### PR TITLE
Enhance the launcher

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -249,7 +249,7 @@ PYBIND11_MODULE(__triton_launcher, m) {{
                        py::object &launch_exit_hook,
                        py::object &compiled_kernel,
                        {', '.join([f"{_extracted_type_pybind11(ty)} _arg{i}" for i, ty in signature.items()])}){{
-      int threads_per_warp = 32;
+      int threads_per_warp = compiled_kernel.attr("threads_per_warp").cast<int>();
       sycl::queue* stream = static_cast<sycl::queue*>(_stream);
       sycl::kernel* kernel = static_cast<sycl::kernel*>(_kernel);
       sycl_kernel_launch(grid_x, grid_y, grid_z, num_warps, threads_per_warp, shared_memory, *stream, *kernel,
@@ -431,7 +431,7 @@ class XPUBackend(BaseBackend):
         if cache_path is None:
             with tempfile.TemporaryDirectory() as tmpdir:
                 src = generate_launcher(constants, signature)
-                src_path = os.path.join(tmpdir, "main.c")
+                src_path = os.path.join(tmpdir, "main.cpp")
                 with open(src_path, "w") as f:
                     f.write(src)
                 so = _build_xpu_ext(name, src_path, tmpdir)


### PR DESCRIPTION
1. Use the threads per warp from the JIT kernel attribute.
2. Make the suffix to "cpp" to use the c++ compiler to build the launcher.