### PR TITLE
Move pre_commit config from upstream triton to local folder.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,41 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+src_paths=python
+
+[*.{yaml,yml}]
+indent_size = 2
+
+[*.md]
+indent_size = 2
+x-soft-wrap-text = true
+
+[*.rst]
+indent_size = 4
+x-soft-wrap-text = true
+
+[CMakeLists.txt,*.cmake]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.{c,cc,cpp,h,hpp,cu,cuh}]
+indent_size = 2
+
+[*.mlir]
+indent_size = 2
+
+[*.td]
+indent_size = 4

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501,E701,E731

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,4 @@
+[settings]
+known_local_folder=intel_xpu_backend
+line_length=88
+py_version=36

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -8,15 +8,15 @@ from pathlib import Path
 
 import setuptools
 import torch
-
 import triton._C.libintel_xpu_backend_for_triton.triton as _triton  # noqa:E402
-from .extensions import SYCLBuildExtension, SYCLExtension  # noqa:E402
 from triton._C.libtriton.triton import add_external_libs  # noqa:E402
 from triton.common.backend import BaseBackend, register_backend  # noqa:E402
 from triton.compiler.make_launcher import make_so_cache_key  # noqa:E402
 from triton.runtime.cache import get_cache_manager  # noqa:E402
 from triton.runtime.driver import DriverBase  # noqa:E402
 from triton.runtime.jit import version_key  # noqa:E402
+
+from .extensions import SYCLBuildExtension, SYCLExtension  # noqa:E402
 
 
 def _add_external_libs(mod, libs):


### PR DESCRIPTION
This PR is to help pre_commit.

Currently, running with the following process is no issue:

```
git clone https://github.com/openai/triton && cd triton
git submodule sync && git submodule update --init
cd third_party/intel_xpu_backend
python3 -m pre_commit run --all-files
```

However, when the user don't first clone the `openai/triton`, and just do the following, because there lack the configs in triton root folder, the following result will not be the same with above:

```
git clone https://github.com/intel/intel-xpu-backend-for-triton
cd intel-xpu-backend-for-triton
python3 -m pre_commit run --all-files
```