### PR TITLE
Fix the  processReplica function does not support on i1 type and ptr type

### DIFF
--- a/lib/Conversion/TritonGPUToSPIRV/ConvertLayoutOpToSPIRV.cpp
+++ b/lib/Conversion/TritonGPUToSPIRV/ConvertLayoutOpToSPIRV.cpp
@@ -205,19 +205,15 @@ private:
             linearize(rewriter, loc, multiDimOffset, paddedRepShape, outOrd);
 
         auto elemPtrTy = ptr_ty(llvmElemTy, spirv::StorageClass::Workgroup);
-        Value ptr = gep(elemPtrTy, smemBase, offset);
+
+        Value ptr = gep(elemPtrTy, bitcast(smemBase, elemPtrTy), offset);
+
         if (vec == 1) {
           if (stNotRd) {
             auto currVal = vals[elemId + linearCTAId * accumSizePerThread];
             if (isInt1) {
-              // If it is i1, then convert val into the i8
-              // Because the spirv::BitCastOp does not support i1, we use the
-              // select to create i8.
-              Value mask = int_val(1, 1);
-              Value maskedSrc = logic_and(currVal, mask);
-              Value isOne = logic_cmp_eq(maskedSrc, mask);
-
-              currVal = select(isOne, int_val(8, 1), int_val(8, 0));
+              // spriv::UConvert doesn't support i1
+              currVal = select(currVal, int_val(8, 1), int_val(8, 0));
             }
             store(currVal, ptr);
           } else {
@@ -237,14 +233,8 @@ private:
               auto currVal =
                   vals[elemId + linearCTAId * accumSizePerThread + v];
               if (isInt1) {
-                // If it is i1, then convert val into the i8
-                // Because the spirv::BitCastOp does not support i1, we use the
-                // select to create i8.
-                Value mask = int_val(1, 1);
-                Value maskedSrc = logic_and(currVal, mask);
-                Value isOne = logic_cmp_eq(maskedSrc, mask);
-
-                currVal = select(isOne, int_val(8, 1), int_val(8, 0));
+                // spriv::UConvert doesn't support i1
+                currVal = select(currVal, int_val(8, 1), int_val(8, 0));
               }
               valVec = insert_element(vecTy, valVec, currVal, idx_val(v));
             }
@@ -295,10 +285,7 @@ private:
     auto llvmElemTy = getTypeConverter()->convertType(dstTy.getElementType());
     Value smemBase = getSharedMemoryBase(loc, rewriter, op.getOperation());
     auto elemPtrTy = ptr_ty(llvmElemTy, spirv::StorageClass::Workgroup);
-    if (!llvmElemTy.isInteger(1)) {
-      // avoid unecessary bitcast. Since the i1 will be stored in i8.
-      smemBase = bitcast(smemBase, elemPtrTy);
-    }
+    smemBase = bitcast(smemBase, elemPtrTy);
     auto shape = dstTy.getShape();
     unsigned rank = dstTy.getRank();
     SmallVector<unsigned> numReplicates(rank);

--- a/lib/Conversion/TritonGPUToSPIRV/Utility.h
+++ b/lib/Conversion/TritonGPUToSPIRV/Utility.h
@@ -7,8 +7,8 @@
 
 // Shortcuts for some commonly used LLVM ops to keep code simple and intuitive
 // Operators
-#define inttoptr(...) rewriter.create<spirv::BitcastOp>(loc, __VA_ARGS__)
-#define ptrtoint(...) rewriter.create<spirv::BitcastOp>(loc, __VA_ARGS__)
+#define inttoptr(...) rewriter.create<spirv::ConvertUToPtrOp>(loc, __VA_ARGS__)
+#define ptrtoint(...) rewriter.create<spirv::ConvertPtrToUOp>(loc, __VA_ARGS__)
 #define zext(...) rewriter.create<spirv::UConvertOp>(loc, __VA_ARGS__)
 #define sext(...) rewriter.create<spirv::SConvertOp>(loc, __VA_ARGS__)
 #define fpext(...) rewriter.create<spirv::FConvertOp>(loc, __VA_ARGS__)


### PR DESCRIPTION
This PR helps to solve the following problem:

```
error: 'spirv.PtrAccessChain' op invalid result type: expected '!spirv.ptr<i1, Workgroup>', but provided '!spirv.ptr<i8, Workgroup>'


loc("-":71:11): error: 'spirv.Load' op result #0 must be void or bool or 8/16/32/64-bit integer or 16/32/64-bit float or vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float values of length 2/3/4/8/16 or any SPIR-V pointer type or any SPIR-V array type or any SPIR-V runtime array type or any SPIR-V struct type or any SPIR-V cooperative matrix type or any SPIR-V joint matrix type or any SPIR-V matrix type or any SPIR-V sampled image type, but got 'vector<2x!spirv.ptr<f32, CrossWorkgroup>>'
 
```