### PR TITLE
Fix UT failures by removing ptx code check

### DIFF
--- a/.github/scripts/case_update.sh
+++ b/.github/scripts/case_update.sh
@@ -11,6 +11,7 @@ sed -i '/def test_abs_fp8(in_dtype, device):/ a\    pytest.skip("fp8 is not supp
 sed -i 's/MmaLayout(/# &/' ${HOME}/actions-runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/triton/python/test/unit/language/test_core.py
 sed -i 's/f.name/&, device_type=device/' ${HOME}/actions-runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/triton/python/test/unit/language/test_core.py
 sed -i '/pytest.skip("bfloat16 is only supported on NVGPU with cc >= 80")/ a\    if dtype in ["float8e4b15", "float8e4", "float8e5"]:\n        pytest.skip("fp8 is not supported yet")' ${HOME}/actions-runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/triton/python/test/unit/language/test_core.py
+sed -i "/ptx = pgm.asm\['ptx'\]/,/^$/d" ${HOME}/actions-runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/triton/python/test/unit/language/test_core.py
 
 # sed -i '/import torch/ a\import intel_extension_for_pytorch' ${HOME}/actions-runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/triton/python/test/unit/operators/test_blocksparse.py
 # sed -i '/import torch/ a\import intel_extension_for_pytorch' ${HOME}/actions-runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/triton/python/test/unit/operators/test_cross_entropy.py


### PR DESCRIPTION
This PR fixes [UT failures](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/5710075256/job/15469743321?pr=62).
By reproducing these failures, the reason locates in python `Key Error`, where the target case([test_permute](https://github.com/openai/triton/blob/5df904233c11a65bd131ead7268f84cca7804275/python/test/unit/language/test_core.py#L1919)) will check generated `ptx` code as below which we do not have.
```python
    ptx = pgm.asm['ptx']
    assert 'ld.global.v4' in ptx
    assert 'st.global.v4' in ptx
    ptx = pgm_contiguous.asm['ptx']
    assert 'ld.global.v4' in ptx
    assert 'st.global.v4' in ptx
```
The solution is to remove these `ptx` code pieces in `test_core.py` before launching unit test.