### PR TITLE
Delete duplicate CMP0135 setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ else()
     else()
       include(FetchContent)
       function(download_file url)
-        cmake_policy(SET CMP0135 NEW)
 
         FetchContent_Declare(intel-llvm URL ${url} SOURCE_DIR
                                             ${TRITON_INTEL_LLVM_DIR})


### PR DESCRIPTION
The `download_file_url` has one duplicate CMP0135 settings, which would cause error when cmake version is low.