### PR TITLE
[CI] Migrate action runners to dedicated one

### DIFF
--- a/.github/workflows/triton_xpu_backend_ci.yml
+++ b/.github/workflows/triton_xpu_backend_ci.yml
@@ -48,7 +48,7 @@ jobs:
 
   Integration-Tests:
 
-    runs-on: [self-hosted, PVC]
+    runs-on: [self-hosted, PVC_TEST]
 
     steps:
 

--- a/.github/workflows/triton_xpu_backend_ci.yml
+++ b/.github/workflows/triton_xpu_backend_ci.yml
@@ -36,9 +36,6 @@ on:
   merge_group:
     branches: [main]
     types: [checks_requested]
-  push:
-    branches:
-      - yudong/ci_on_onerunner
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -51,7 +48,7 @@ jobs:
 
   Integration-Tests:
 
-    runs-on: [self-hosted, PVC_TEST]
+    runs-on: [self-hosted, PVC]
 
     steps:
 

--- a/.github/workflows/triton_xpu_backend_ci.yml
+++ b/.github/workflows/triton_xpu_backend_ci.yml
@@ -38,7 +38,7 @@ on:
     types: [checks_requested]
   push:
     branches:
-      - yudong/ci_on_onerunner  
+      - yudong/ci_on_onerunner
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/triton_xpu_backend_ci.yml
+++ b/.github/workflows/triton_xpu_backend_ci.yml
@@ -36,6 +36,9 @@ on:
   merge_group:
     branches: [main]
     types: [checks_requested]
+  push:
+    branches:
+      - yudong/ci_on_onerunner  
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/triton_xpu_backend_e2e_ci.yml
+++ b/.github/workflows/triton_xpu_backend_e2e_ci.yml
@@ -36,9 +36,6 @@ on:
   merge_group:
     branches: [main]
     types: [checks_requested]
-  push:
-    branches:
-      - yudong/ci_on_onerunner
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -48,7 +45,7 @@ jobs:
 
   Inductor-E2E-CI-Tests:
 
-    runs-on: [self-hosted, PVC_E2E_TEST]
+    runs-on: [self-hosted, PVC_E2E]
 
     steps:
 

--- a/.github/workflows/triton_xpu_backend_e2e_ci.yml
+++ b/.github/workflows/triton_xpu_backend_e2e_ci.yml
@@ -36,6 +36,9 @@ on:
   merge_group:
     branches: [main]
     types: [checks_requested]
+  push:
+    branches:
+      - yudong/ci_on_onerunner      
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/triton_xpu_backend_e2e_ci.yml
+++ b/.github/workflows/triton_xpu_backend_e2e_ci.yml
@@ -38,7 +38,7 @@ on:
     types: [checks_requested]
   push:
     branches:
-      - yudong/ci_on_onerunner      
+      - yudong/ci_on_onerunner
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/triton_xpu_backend_e2e_ci.yml
+++ b/.github/workflows/triton_xpu_backend_e2e_ci.yml
@@ -45,7 +45,7 @@ jobs:
 
   Inductor-E2E-CI-Tests:
 
-    runs-on: [self-hosted, PVC_E2E]
+    runs-on: [self-hosted, PVC_E2E_TEST]
 
     steps:
 
@@ -130,14 +130,13 @@ jobs:
           source ${HOME}/env_triton.sh ${{ github.event.inputs.oneapi }}
           pip install pandas
           cd ${HOME}/triton-preci
-          bash set_proxy.sh
           cp ${HOME}/triton-preci/triton_src/third_party/intel_xpu_backend/.github/scripts/inductor_xpu_test.sh ${HOME}/triton-preci/pytorch
           cd ${HOME}/triton-preci/pytorch
           rm -rf inductor_log
           bash inductor_xpu_test.sh huggingface amp_bf16 inference accuracy xpu 0 static 2 0 & \
-          bash inductor_xpu_test.sh huggingface amp_bf16 inference accuracy xpu 1 static 2 1 & \
-          bash inductor_xpu_test.sh huggingface amp_fp16 inference accuracy xpu 2 static 2 0 & \
-          bash inductor_xpu_test.sh huggingface amp_fp16 inference accuracy xpu 3 static 2 1 & wait
+          bash inductor_xpu_test.sh huggingface amp_bf16 inference accuracy xpu 2 static 2 1 & \
+          bash inductor_xpu_test.sh huggingface amp_fp16 inference accuracy xpu 3 static 2 0 & wait
+          bash inductor_xpu_test.sh huggingface amp_fp16 inference accuracy xpu 0 static 2 1 & wait
           cp ${HOME}/triton-preci/triton_src/sw_info.log inductor_log/
 
       - name: Test Results Overview

--- a/.github/workflows/triton_xpu_backend_e2e_nightly.yml
+++ b/.github/workflows/triton_xpu_backend_e2e_nightly.yml
@@ -38,7 +38,7 @@ jobs:
 
   Tests-Env-Prepare:
 
-    runs-on: [self-hosted, PVC_E2E]
+    runs-on: [self-hosted, PVC_E2E_TEST]
 
     steps:
 
@@ -129,13 +129,12 @@ jobs:
           source ${HOME}/miniconda3/bin/activate triton-nightly-test
           source ${HOME}/env_triton.sh ${{ github.event.inputs.oneapi }}
           cd ${HOME}/triton-nightly
-          bash set_proxy.sh
           cd ${HOME}/triton-nightly/pytorch
           rm -rf inductor_log
           bash inductor_xpu_test.sh huggingface amp_bf16 inference accuracy xpu 0 & \
-          bash inductor_xpu_test.sh huggingface amp_bf16 training accuracy xpu 1 & \
-          bash inductor_xpu_test.sh huggingface amp_fp16 inference accuracy xpu 2 & \
-          bash inductor_xpu_test.sh huggingface amp_fp16 training accuracy xpu 3 & wait
+          bash inductor_xpu_test.sh huggingface amp_bf16 training accuracy xpu 2 & \
+          bash inductor_xpu_test.sh huggingface amp_fp16 inference accuracy xpu 3 & wait
+          bash inductor_xpu_test.sh huggingface amp_fp16 training accuracy xpu 0 & wait
           cp ${HOME}/triton-nightly/triton_src/sw_info.log inductor_log/
 
       - name: ACC Test Results Overview
@@ -226,12 +225,11 @@ jobs:
           source ${HOME}/miniconda3/bin/activate triton-nightly-test
           source ${HOME}/env_triton.sh ${{ github.event.inputs.oneapi }}
           cd ${HOME}/triton-nightly
-          bash set_proxy.sh
           cd ${HOME}/triton-nightly/pytorch
           bash inductor_xpu_test.sh huggingface amp_bf16 inference performance xpu 0 & \
-          bash inductor_xpu_test.sh huggingface amp_bf16 training performance xpu 1 & \
-          bash inductor_xpu_test.sh huggingface amp_fp16 inference performance xpu 2 & \
-          bash inductor_xpu_test.sh huggingface amp_fp16 training performance xpu 3 & wait
+          bash inductor_xpu_test.sh huggingface amp_bf16 training performance xpu 2 & \
+          bash inductor_xpu_test.sh huggingface amp_fp16 inference performance xpu 3 & wait
+          bash inductor_xpu_test.sh huggingface amp_fp16 training performance xpu 0 & wait
 
       - name: Perf Test Results Generate and Overview
         run: |

--- a/.github/workflows/triton_xpu_backend_e2e_nightly.yml
+++ b/.github/workflows/triton_xpu_backend_e2e_nightly.yml
@@ -38,7 +38,7 @@ jobs:
 
   Tests-Env-Prepare:
 
-    runs-on: [self-hosted, PVC_E2E_TEST]
+    runs-on: [self-hosted, PVC_E2E]
 
     steps:
 
@@ -258,4 +258,4 @@ jobs:
           repo="${{ github.repository }}"
           gh --repo $repo issue comment 123  \
               --body "E2E Nightly Failed $(date +'%Y-%m-%d'),See: $build_url
-                      cc $notificiation_list"
+                      cc $notification_list"

--- a/.github/workflows/triton_xpu_backend_nightly.yml
+++ b/.github/workflows/triton_xpu_backend_nightly.yml
@@ -38,7 +38,7 @@ jobs:
 
   Nightly-Tests:
 
-    runs-on: [self-hosted, PVC_TEST]
+    runs-on: [self-hosted, PVC]
 
     steps:
 
@@ -214,4 +214,4 @@ jobs:
           repo="${{ github.repository }}"
           gh --repo $repo issue comment 123  \
               --body "UT Nightly Failed $(date +'%Y-%m-%d'),See: $build_url
-                      cc $notificiation_list"
+                      cc $notification_list"

--- a/.github/workflows/triton_xpu_backend_nightly.yml
+++ b/.github/workflows/triton_xpu_backend_nightly.yml
@@ -38,7 +38,7 @@ jobs:
 
   Nightly-Tests:
 
-    runs-on: [self-hosted, PVC]
+    runs-on: [self-hosted, PVC_TEST]
 
     steps:
 


### PR DESCRIPTION
As the title, now we have to use one machine for CI, UT workload will only runs on card 1, others for E2E. Now actually one machine roles as two runners.
