### PR TITLE
GitHub workflow for new runners

### DIFF
--- a/.github/dockerfiles/runner-base/Dockerfile
+++ b/.github/dockerfiles/runner-base/Dockerfile
@@ -1,0 +1,47 @@
+ARG INSTALLER_IMAGE=docker-registry.docker-registry.svc.cluster.local:5000/oneapi-basekit:2023.2.0
+
+FROM $INSTALLER_IMAGE as installer
+
+FROM summerwind/actions-runner:ubuntu-22.04
+
+USER root
+
+RUN set -ex; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/graphics/ubuntu jammy max' > /etc/apt/sources.list.d/intel-graphics.list; \
+    curl -s https://repositories.intel.com/graphics/intel-graphics.key | gpg --dearmor --output /usr/share/keyrings/intel-graphics.gpg; \
+    apt-get update -y; \
+    apt-get install -y --no-install-recommends --fix-missing \
+      intel-opencl-icd \
+      clinfo \
+    ; \
+    echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" > /etc/apt/sources.list.d/intel-oneapi.list; \
+    curl -s https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor --output /usr/share/keyrings/oneapi-archive-keyring.gpg; \
+    apt-get update -y; \
+    apt-get install -y --no-install-recommends --fix-missing \
+      intel-level-zero-gpu \
+      level-zero \
+      level-zero-dev \
+    ; \
+    apt-get install -y --no-install-recommends --fix-missing \
+      build-essential \
+      zlib1g-dev \
+      cmake \
+      ninja-build \
+      ncurses-term \
+      wget \
+    ; \
+    rm -rf /var/lib/apt/lists/*
+
+USER runner
+SHELL ["/bin/bash", "-xec"]
+ENV BASE=$HOME
+
+COPY --from=installer /l_BaseKit*.sh $HOME/
+
+# TODO: install only necessary components
+
+RUN \
+  cd $HOME; \
+  /bin/sh l_BaseKit*.sh -a --silent --eula accept; \
+  rm l_BaseKit*.sh

--- a/.github/dockerfiles/runner-base/Dockerfile
+++ b/.github/dockerfiles/runner-base/Dockerfile
@@ -44,4 +44,6 @@ COPY --from=installer /l_BaseKit*.sh $HOME/
 RUN \
   cd $HOME; \
   /bin/sh l_BaseKit*.sh -a --silent --eula accept; \
-  rm l_BaseKit*.sh
+  rm l_BaseKit*.sh; \
+  echo "source $HOME/intel/oneapi/setvars.sh --force > /dev/null" > $HOME/.bashrc
+

--- a/.github/dockerfiles/runner-base/Dockerfile
+++ b/.github/dockerfiles/runner-base/Dockerfile
@@ -44,5 +44,4 @@ COPY --from=installer /l_BaseKit*.sh $HOME/
 RUN \
   cd $HOME; \
   /bin/sh l_BaseKit*.sh -a --silent --eula accept; \
-  rm l_BaseKit*.sh; \
-  echo "source $HOME/intel/oneapi/setvars.sh --force > /dev/null" > $HOME/.bashrc
+  rm l_BaseKit*.sh

--- a/.github/dockerfiles/runner-base/Dockerfile
+++ b/.github/dockerfiles/runner-base/Dockerfile
@@ -46,4 +46,3 @@ RUN \
   /bin/sh l_BaseKit*.sh -a --silent --eula accept; \
   rm l_BaseKit*.sh; \
   echo "source $HOME/intel/oneapi/setvars.sh --force > /dev/null" > $HOME/.bashrc
-

--- a/.github/dockerfiles/runner-base/README.md
+++ b/.github/dockerfiles/runner-base/README.md
@@ -1,0 +1,5 @@
+Dockerfile for GitHub runner with oneAPI BaseKit..
+
+Links:
+
+* https://github.com/actions/actions-runner-controller

--- a/.github/workflows/build_and_test_2.yaml
+++ b/.github/workflows/build_and_test_2.yaml
@@ -46,7 +46,7 @@ jobs:
       - pvc
     defaults:
       run:
-        shell: bash -noprofile --norc -eo pipefail -c "source /home/runner/intel/oneapi/setvars.sh; {0}"
+        shell: bash -noprofile --norc -eo pipefail -c "source /home/runner/intel/oneapi/setvars.sh > /dev/null; source {0}"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build_and_test_2.yaml
+++ b/.github/workflows/build_and_test_2.yaml
@@ -50,6 +50,8 @@ jobs:
       - name: Run pre-commit checks
         run: |
           pip install --upgrade pre-commit
+          # TODO: ignore the first yapf failure until https://github.com/google/yapf/issues/1164 is fixed
+          python3 -m pre_commit run --all-files --verbose yapf || true
           python3 -m pre_commit run --all-files --verbose
 
       - name: Build Triton

--- a/.github/workflows/build_and_test_2.yaml
+++ b/.github/workflows/build_and_test_2.yaml
@@ -44,6 +44,9 @@ jobs:
       - glados
       - spr
       - pvc
+    defaults:
+      run:
+        shell: bash -noprofile --norc -eo pipefail -c 'source /home/runner/intel/oneapi/setvars.sh --force > /dev/null; {0}'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build_and_test_2.yaml
+++ b/.github/workflows/build_and_test_2.yaml
@@ -1,0 +1,94 @@
+name: Build and test
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - llvm-target
+
+env:
+  BASE: /home/runner
+  LLVM_SYSPATH: /home/runner/packages/llvm
+  BACKEND: XPU
+  TRITON_DISABLE_LINE_INFO: 1
+
+jobs:
+  build:
+    runs-on:
+      - glados
+      - spr
+      - pvc
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+          cache-dependency-path: |
+            python/pyproject.toml
+            python/setup.py
+
+      - name: Read packages from cache
+        id: packages-cache
+        uses: actions/cache@v3
+        env:
+          # Increase this value to reset cache
+          CACHE_NUMBER: 1
+        with:
+          path: /home/runner/packages
+          key: ${{ hashFiles('scripts/compile-triton.sh') }}
+
+      - name: Build packages
+        if: steps.packages-cache.outputs.cache-hit != 'true'
+        run: |
+          source ~/intel/oneapi/setvars.sh
+          ./scripts/compile-triton.sh
+
+      - name: Run pre-commit checks
+        run: |
+          pip install --upgrade pre-commit
+          python3 -m pre_commit run --all-files --verbose
+
+      - name: Build Triton
+        run: |
+          source ~/intel/oneapi/setvars.sh
+          cd python
+          pip install wheel
+          pip install --no-build-isolation '.[tests]'
+
+      - name: Run lit tests
+        run: |
+          source ~/intel/oneapi/setvars.sh
+          pip install lit
+          cd python
+          lit -v build/*/test
+
+      - name: Run core tests
+        run: |
+          source ~/intel/oneapi/setvars.sh
+          pip install pytest pytest-xdist
+          pip install torch==1.13.0a0+git6c9b55e intel_extension_for_pytorch==1.13.120+xpu -f https://developer.intel.com/ipex-whl-stable-xpu
+          cd python/test/unit/language
+          python3 -m pytest -n auto --verbose --device xpu --ignore=test_line_info.py --ignore=test_block_pointer.py --ignore=test_subprocess.py
+
+      - name: Run assert/print tests
+        run: |
+          source ~/intel/oneapi/setvars.sh
+          cd python/test/unit/language
+          python3 assert_helper.py device_assert
+          python3 print_helper.py device_print float 1> /dev/null
+
+      - name: Run XPU python tests
+        run: |
+          source ~/intel/oneapi/setvars.sh
+          cd python/test/backend/third_party_backends
+          python3 -m pytest -n auto --verbose test_xpu_backend.py
+
+      - name: Run CXX unittests
+        run: |
+          source ~/intel/oneapi/setvars.sh
+          cd python/build/*cmake*
+          ctest

--- a/.github/workflows/build_and_test_2.yaml
+++ b/.github/workflows/build_and_test_2.yaml
@@ -74,7 +74,9 @@ jobs:
           pip install pytest pytest-xdist
           pip install torch==1.13.0a0+git6c9b55e intel_extension_for_pytorch==1.13.120+xpu -f https://developer.intel.com/ipex-whl-stable-xpu
           cd python/test/unit/language
-          python3 -m pytest -n auto --verbose --device xpu --ignore=test_line_info.py --ignore=test_block_pointer.py --ignore=test_subprocess.py
+          python3 -m pytest -n auto --verbose --device xpu --ignore=test_line_info.py --ignore=test_subprocess.py
+          # run test_line_info.py separately with TRITON_DISABLE_LINE_INFO=0
+          TRITON_DISABLE_LINE_INFO=0 python3 -m pytest -n auto test_line_info.py
 
       - name: Run assert/print tests
         run: |

--- a/.github/workflows/build_and_test_2.yaml
+++ b/.github/workflows/build_and_test_2.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           pip install --upgrade pre-commit
           # TODO: ignore the first yapf failure until https://github.com/google/yapf/issues/1164 is fixed
-          python3 -m pre_commit run --all-files --verbose yapf || true
+          python3 -m pre_commit run --all-files --verbose yapf &> /dev/null || true
           python3 -m pre_commit run --all-files --verbose
 
   integration-tests:

--- a/.github/workflows/build_and_test_2.yaml
+++ b/.github/workflows/build_and_test_2.yaml
@@ -13,7 +13,27 @@ env:
   TRITON_DISABLE_LINE_INFO: 1
 
 jobs:
-  build:
+  pre-commit:
+    name: Pre-commit checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Run pre-commit checks
+        run: |
+          pip install --upgrade pre-commit
+          # TODO: ignore the first yapf failure until https://github.com/google/yapf/issues/1164 is fixed
+          python3 -m pre_commit run --all-files --verbose yapf || true
+          python3 -m pre_commit run --all-files --verbose
+
+  integration-tests:
+    name: Integration tests
     runs-on:
       - glados
       - spr
@@ -46,13 +66,6 @@ jobs:
         run: |
           source ~/intel/oneapi/setvars.sh
           ./scripts/compile-triton.sh
-
-      - name: Run pre-commit checks
-        run: |
-          pip install --upgrade pre-commit
-          # TODO: ignore the first yapf failure until https://github.com/google/yapf/issues/1164 is fixed
-          python3 -m pre_commit run --all-files --verbose yapf || true
-          python3 -m pre_commit run --all-files --verbose
 
       - name: Build Triton
         run: |

--- a/.github/workflows/build_and_test_2.yaml
+++ b/.github/workflows/build_and_test_2.yaml
@@ -15,7 +15,10 @@ env:
 jobs:
   pre-commit:
     name: Pre-commit checks
-    runs-on: ubuntu-latest
+    runs-on:
+      - glados
+      - spr
+      - cpu
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -24,6 +27,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+          cache: 'pip'
+          cache-dependency-path: |
+            .pre-commit-config.yaml
 
       - name: Run pre-commit checks
         run: |

--- a/.github/workflows/build_and_test_2.yaml
+++ b/.github/workflows/build_and_test_2.yaml
@@ -46,7 +46,7 @@ jobs:
       - pvc
     defaults:
       run:
-        shell: bash -noprofile --norc -eo pipefail -c 'source /home/runner/intel/oneapi/setvars.sh --force > /dev/null; {0}'
+        shell: bash -noprofile --norc -eo pipefail -c "source /home/runner/intel/oneapi/setvars.sh; {0}"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build_and_test_2.yaml
+++ b/.github/workflows/build_and_test_2.yaml
@@ -70,26 +70,22 @@ jobs:
       - name: Build packages
         if: steps.packages-cache.outputs.cache-hit != 'true'
         run: |
-          source ~/intel/oneapi/setvars.sh
           ./scripts/compile-triton.sh
 
       - name: Build Triton
         run: |
-          source ~/intel/oneapi/setvars.sh
           cd python
           pip install wheel
           pip install --no-build-isolation '.[tests]'
 
       - name: Run lit tests
         run: |
-          source ~/intel/oneapi/setvars.sh
           pip install lit
           cd python
           lit -v build/*/test
 
       - name: Run core tests
         run: |
-          source ~/intel/oneapi/setvars.sh
           pip install pytest pytest-xdist
           pip install torch==1.13.0a0+git6c9b55e intel_extension_for_pytorch==1.13.120+xpu -f https://developer.intel.com/ipex-whl-stable-xpu
           cd python/test/unit/language
@@ -99,19 +95,16 @@ jobs:
 
       - name: Run assert/print tests
         run: |
-          source ~/intel/oneapi/setvars.sh
           cd python/test/unit/language
           python3 assert_helper.py device_assert
           python3 print_helper.py device_print float 1> /dev/null
 
       - name: Run XPU python tests
         run: |
-          source ~/intel/oneapi/setvars.sh
           cd python/test/backend/third_party_backends
           python3 -m pytest -n auto --verbose test_xpu_backend.py
 
       - name: Run CXX unittests
         run: |
-          source ~/intel/oneapi/setvars.sh
           cd python/build/*cmake*
           ctest

--- a/.github/workflows/build_and_test_2.yaml
+++ b/.github/workflows/build_and_test_2.yaml
@@ -39,7 +39,7 @@ jobs:
           CACHE_NUMBER: 1
         with:
           path: /home/runner/packages
-          key: ${{ hashFiles('scripts/compile-triton.sh') }}
+          key: packages-${{ hashFiles('scripts/compile-triton.sh', 'cmake/llvm-hash.txt') }}-${{ env.CACHE_NUMBER }}
 
       - name: Build packages
         if: steps.packages-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/docker-runner-base.yaml
+++ b/.github/workflows/docker-runner-base.yaml
@@ -25,4 +25,3 @@ jobs:
       - name: Push image
         run: |
           docker push $REGISTRY/$TAG
-

--- a/.github/workflows/docker-runner-base.yaml
+++ b/.github/workflows/docker-runner-base.yaml
@@ -1,0 +1,26 @@
+name: Docker image runner-base
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: docker-registry.docker-registry.svc.cluster.local:5000
+
+jobs:
+  build:
+    runs-on:
+      - glados
+      - docker
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build image
+        run: |
+          docker build .github/dockerfiles/runner-base/ \
+            --tag $REGISTRY/triton-runner-base:0.0.1 \
+            --build-arg INSTALLER_IMAGE=$REGISTRY/oneapi-basekit:2023.2.0
+
+      - name: Push image
+        run: |
+          docker push $REGISTRY/triton-runner-base:0.0.1

--- a/.github/workflows/docker-runner-base.yaml
+++ b/.github/workflows/docker-runner-base.yaml
@@ -5,6 +5,7 @@ on:
 
 env:
   REGISTRY: docker-registry.docker-registry.svc.cluster.local:5000
+  TAG: triton-runner-base:0.0.2
 
 jobs:
   build:
@@ -18,9 +19,10 @@ jobs:
       - name: Build image
         run: |
           docker build .github/dockerfiles/runner-base/ \
-            --tag $REGISTRY/triton-runner-base:0.0.1 \
+            --tag $REGISTRY/$TAG \
             --build-arg INSTALLER_IMAGE=$REGISTRY/oneapi-basekit:2023.2.0
 
       - name: Push image
         run: |
-          docker push $REGISTRY/triton-runner-base:0.0.1
+          docker push $REGISTRY/$TAG
+


### PR DESCRIPTION
New GitHub workflows:
* `docker-runner-base.yaml` builds a GitHub runner image with oneAPI BaseKit and pushes it to a local registry.
* `build_and_test_2.yaml` is similar to  `build_and_test.yml` but uses new hosted runners and leverages GitHub cache.

Note that new runners are containerized and ephemeral. They are re-created from the base image for each run.