### PR TITLE
Fix shuffle mode in sub-group shuffle generation for GENX.

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -312,6 +312,20 @@ Value loadShared(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
   llvm_unreachable("unsupported triton::Target");
 }
 
+static GENX::ShflKind toGenXShuffleMode(NVVM::ShflKind mode) {
+  switch (mode) {
+  case NVVM::ShflKind::bfly:
+    return GENX::ShflKind::XOR;
+  case NVVM::ShflKind::up:
+    return GENX::ShflKind::UP;
+  case NVVM::ShflKind::down:
+    return GENX::ShflKind::DOWN;
+  case NVVM::ShflKind::idx:
+    return GENX::ShflKind::IDX;
+  }
+  llvm_unreachable("unsupported NVVM::ShflKind");
+}
+
 static Value commonShflSync(Location loc, ConversionPatternRewriter &rewriter,
                             Value val, Value i, NVVM::ShflKind mode,
                             Value clamp, triton::Target target) {
@@ -352,7 +366,7 @@ static Value commonShflSync(Location loc, ConversionPatternRewriter &rewriter,
   }
   case triton::Target::GENX: {
     return rewriter.create<GENX::SubGroupShuffleOp>(loc, type, val, i,
-                                                    GENX::ShflKind::XOR);
+                                                    toGenXShuffleMode(mode));
   }
   }
   llvm_unreachable("Invalid target");

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1832,8 +1832,6 @@ def get_first_element(a, b):
 def test_scan2d(op, dtype_str, shape, axis, num_warps, device):
     if is_hip():
         pytest.skip("test_scan2d is not supported in HIP")
-    if is_xpu(device) and op in ['cumsum', 'cumprod'] and (axis == 1 or num_warps == 4 or shape in [(1024, 2)]):
-        pytest.skip("FIXME: Incorrect result on XPU")
 
     check_type_supported(dtype_str, device)
 


### PR DESCRIPTION
This PR resolves #153 by emitting proper shuffle mode for sub-group shuffle op. This completely enables `test_scan2d` and probably fixes some other reduction-related tests.