### PR TITLE
Fix undefined var usage when CXX env var is set.

### DIFF
--- a/python/triton/common/build.py
+++ b/python/triton/common/build.py
@@ -104,6 +104,7 @@ def _build(name, src, srcdir):
     py_include_dir = sysconfig.get_paths(scheme=scheme)["include"]
 
     if is_spirv():
+        icpx = None
         cxx = os.environ.get("CXX")
         if cxx is None:
             clangpp = shutil.which("clang++")


### PR DESCRIPTION
This PR fixes undefined variable usage for `icpx` var when `CXX` environment variable is defined.
