### PR TITLE
Fix dangling pointer in spirv utils and launcher.

### DIFF
--- a/python/triton/compiler/make_launcher.py
+++ b/python/triton/compiler/make_launcher.py
@@ -127,10 +127,10 @@ def generate_launcher(constants, signature, ids):
       if (code != ZE_RESULT_SUCCESS)
       {{
          const char* prefix = "Triton Error [ZE]: ";
-         const char* str = std::to_string(code).c_str();
+         std::string str = std::to_string(code);
          char err[1024] = {{0}};
          strcat(err, prefix);
-         strcat(err, str);
+         strcat(err, str.c_str());
          PyErr_SetString(PyExc_RuntimeError, err);
       }}
     }}

--- a/python/triton/runtime/driver.py
+++ b/python/triton/runtime/driver.py
@@ -249,10 +249,10 @@ class SpirvUtils(object):
            if (code != ZE_RESULT_SUCCESS)
            {
               const char* prefix = "Triton Error [ZE]: ";
-              const char* str = std::to_string(code).c_str();
+              std::string str = std::to_string(code);
               char err[1024] = {0};
               strcat(err, prefix);
-              strcat(err, str);
+              strcat(err, str.c_str());
               PyErr_SetString(PyExc_RuntimeError, err);
            }
         }


### PR DESCRIPTION
This PR fixes dangling pointers (c_str() value of a temporary string objects) in the error handling code generated for SPIRV tools and a launcher.