### PR TITLE
Reset git tree after first yapf failure

### DIFF
--- a/.github/workflows/build_and_test_2.yaml
+++ b/.github/workflows/build_and_test_2.yaml
@@ -48,8 +48,12 @@ jobs:
       - name: Run pre-commit checks
         run: |
           pip install --upgrade pre-commit
+
           # TODO: ignore the first yapf failure until https://github.com/google/yapf/issues/1164 is fixed
           python3 -m pre_commit run --all-files --verbose yapf &> /dev/null || true
+          # If first run of yapf worked and made changes reset the tree to the original state
+          git reset --hard
+
           python3 -m pre_commit run --all-files --verbose
 
       - name: Save pip cache


### PR DESCRIPTION
We have to run yapf twice because in a clean environment the first run most likely fails because of the race condition in yapf, see https://github.com/google/yapf/issues/1164. If, however, the first run was successful and yapf has modified files, then we need to reset the changes, so the second run can detect them again.

Note that the whole block (ignore the first run and reset the tree) will not be necessary and will be removed after fixed
https://github.com/google/yapf/issues/1164.
