### PR TITLE
Use latest llvm genx commit for packages cache key

### DIFF
--- a/.github/workflows/build_and_test_2.yaml
+++ b/.github/workflows/build_and_test_2.yaml
@@ -104,7 +104,10 @@ jobs:
           # Increase this value to reset cache
           CACHE_NUMBER: 1
         run: |
-          PACKAGES_CACHE_KEY="packages-${{ hashFiles('scripts/compile-triton.sh', 'cmake/llvm-hash.txt') }}-${{ env.CACHE_NUMBER }}"
+          LLVM_COMMIT_ID=$(git ls-remote https://github.com/intel/llvm.git refs/heads/genx | cut -f1)
+          echo "Latest llvm genx commit id: $LLVM_COMMIT_ID"
+          COMPOSITE_KEY=$(echo $LLVM_COMMIT_ID ${{ hashFiles('scripts/compile-triton.sh', 'cmake/llvm-hash.txt') }} | sha256sum - | cut -d\  -f1)
+          PACKAGES_CACHE_KEY="packages-$COMPOSITE_KEY-${{ env.CACHE_NUMBER }}"
           PACKAGES_CACHE="/cache/$PACKAGES_CACHE_KEY"
           echo "PACKAGES_CACHE=$PACKAGES_CACHE" >> "${GITHUB_ENV}"
           if [[ -d $PACKAGES_CACHE ]]; then

--- a/.github/workflows/build_and_test_2.yaml
+++ b/.github/workflows/build_and_test_2.yaml
@@ -106,7 +106,7 @@ jobs:
         run: |
           LLVM_COMMIT_ID=$(git ls-remote https://github.com/intel/llvm.git refs/heads/genx | cut -f1)
           echo "Latest llvm genx commit id: $LLVM_COMMIT_ID"
-          COMPOSITE_KEY=$(echo $LLVM_COMMIT_ID ${{ hashFiles('scripts/compile-triton.sh', 'cmake/llvm-hash.txt') }} | sha256sum - | cut -d\  -f1)
+          COMPOSITE_KEY=$(echo $LLVM_COMMIT_ID ${{ hashFiles('scripts/compile-triton.sh') }} | sha256sum - | cut -d\  -f1)
           PACKAGES_CACHE_KEY="packages-$COMPOSITE_KEY-${{ env.CACHE_NUMBER }}"
           PACKAGES_CACHE="/cache/$PACKAGES_CACHE_KEY"
           echo "PACKAGES_CACHE=$PACKAGES_CACHE" >> "${GITHUB_ENV}"


### PR DESCRIPTION
Previously we used only hash of `compile-triton.sh` and `llvm-hash.txt` to trigger cache re-generation. With this PR a new
packages cache will be generated for a new latest commit id to llvm genx branch.