### PR TITLE
triton-runner-base:0.0.4

### DIFF
--- a/.github/dockerfiles/runner-base/Dockerfile
+++ b/.github/dockerfiles/runner-base/Dockerfile
@@ -16,8 +16,9 @@ RUN set -ex; \
       clinfo \
       intel-level-zero-gpu \
       level-zero \
-      level-zero-dev \
+      level-zero-dev libigc-dev intel-igc-cm libigdfcl-dev libigfxcmrt-dev \
     ; \
+    apt install -y --no-install-recommends --allow-downgrades --fix-missing libigc1=1.0.14828.26-736~22.04; \
     apt-get install -y --no-install-recommends --fix-missing \
       build-essential \
       zlib1g-dev \

--- a/.github/workflows/docker-runner-base.yaml
+++ b/.github/workflows/docker-runner-base.yaml
@@ -5,7 +5,7 @@ on:
 
 env:
   REGISTRY: docker-registry.docker-registry.svc.cluster.local:5000
-  TAG: triton-runner-base:0.0.2
+  TAG: triton-runner-base:0.0.4
 
 jobs:
   build:


### PR DESCRIPTION
GitHub runner image based on Ubuntu 22.04 with oneAPI 2024.0.1 and downgraded libigc1. The downgrade is required for #239.
