### PR TITLE
Use triton-runner-base:0.0.4

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on:
       - glados
       - spr
-      - oneapi-2024.0.1
+      - runner-0.0.4
     strategy:
       matrix:
         python:
@@ -157,13 +157,6 @@ jobs:
         run: |
           pip install pytest pytest-xdist
           pip install torch==2.1.0a0+cxx11.abi intel_extension_for_pytorch==2.1.10+xpu -f https://developer.intel.com/ipex-whl-stable-xpu
-          wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.14828.8/intel-igc-core_1.0.14828.8_amd64.deb
-          wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.14828.8/intel-igc-opencl_1.0.14828.8_amd64.deb
-          sudo dpkg -i ./intel-igc-core_1.0.14828.8_amd64.deb ./intel-igc-opencl_1.0.14828.8_amd64.deb
-          rm ./intel-igc-core_1.0.14828.8_amd64.deb ./intel-igc-opencl_1.0.14828.8_amd64.deb
-          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy unified' | sudo tee -a /etc/apt/sources.list.d/intel-gpu-jammy.list
-          sudo apt update -y
-          sudo apt-get install -y --no-install-recommends --allow-downgrades --fix-missing libigc1=1.0.14828.26-736~22.04
           cd python/test/unit
           python3 -m pytest -n 8 --verbose --device xpu language/ --ignore=language/test_line_info.py --ignore=language/test_subprocess.py
           # run runtime tests serially to avoid race condition with cache handling.


### PR DESCRIPTION
This runner image has downgraded libigc1, so it is no longer required to downgrade it in the workflow.
