### PR TITLE
Support for python virtualenv in compile/test scripts

### DIFF
--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -21,7 +21,23 @@ function check_rc {
   fi
 }
 
-if [[ "$1" == "--clean" ]]; then
+CLEAN=false
+VENV=false
+for arg in "$@"; do
+  case $arg in
+    --clean)
+      CLEAN=true
+      shift
+      ;;
+    --venv)
+      VENV=true
+      shift
+      ;;
+  esac
+done
+
+if [ "$CLEAN" = true ]; then
+  echo "**** Cleaning $PACKAGES_DIR , $LLVM_PROJ , and $TRITON_PROJ_BUILD before build ****"
   rm -rf $PACKAGES_DIR $LLVM_PROJ $TRITON_PROJ_BUILD
 fi
 
@@ -119,6 +135,14 @@ fi
 function build_triton {
   echo "**** Configuring $TRITON_PROJ ****"
   cd $TRITON_PROJ
+  
+  if [ "$VENV" = true ]; then
+    echo "**** Creating Python virtualenv ****"
+    python3 -m venv .venv --prompt triton
+    source .venv/bin/activate
+    pip install ninja cmake wheel
+  fi
+
   export LLVM_SYSPATH=$PACKAGES_DIR/llvm
   export DEBUG=1
   cd python

--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -135,7 +135,7 @@ fi
 function build_triton {
   echo "**** Configuring $TRITON_PROJ ****"
   cd $TRITON_PROJ
-  
+
   if [ "$VENV" = true ]; then
     echo "**** Creating Python virtualenv ****"
     python3 -m venv .venv --prompt triton

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -4,6 +4,7 @@
 TEST_CORE=false
 TEST_TUTORIAL=false
 TEST_UNIT=false
+VENV=false
 for arg in "$@"; do
   case $arg in
     --core)
@@ -18,8 +19,12 @@ for arg in "$@"; do
       TEST_UNIT=true
       shift
       ;;
+    --venv)
+      VENV=true
+      shift
+      ;;
     --help)
-      echo "Example usage: ./test-triton.sh [--core | --tutorial | --unit]"
+      echo "Example usage: ./test-triton.sh [--core | --tutorial | --unit | --venv]"
       exit 1
       ;;
     *)
@@ -41,6 +46,10 @@ if [ ! -d "$BASE" ]; then
   echo "**** Default BASE is set to /iusers/$USER ****"
   BASE=/iusers/$USER
 fi
+
+if [ "$VENV" = true ]; then
+  source .venv/bin/activate
+fi 
 
 export TRITON_PROJ=$BASE/intel-xpu-backend-for-triton
 export TRITON_PROJ_BUILD=$TRITON_PROJ/python/build

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -49,7 +49,7 @@ fi
 
 if [ "$VENV" = true ]; then
   source .venv/bin/activate
-fi 
+fi
 
 export TRITON_PROJ=$BASE/intel-xpu-backend-for-triton
 export TRITON_PROJ_BUILD=$TRITON_PROJ/python/build


### PR DESCRIPTION
I switched from conda to virtualenv on the PVC lab machine due to include errors w/ system libraries for level0. These changes allow me to continue using the repo build and test scripts w/out breaking existing workflows. 