### PR TITLE
Fix tutorials after `47e7035`

### DIFF
--- a/python/tutorials/01-vector-add.py
+++ b/python/tutorials/01-vector-add.py
@@ -19,6 +19,7 @@ In doing so, you will learn about:
 # --------------
 
 import torch
+import intel_extension_for_pytorch  # type: ignore # noqa: F401
 
 import triton
 import triton.language as tl

--- a/python/tutorials/02-fused-softmax.py
+++ b/python/tutorials/02-fused-softmax.py
@@ -22,6 +22,7 @@ In doing so, you will learn about:
 # Let us consider instead the case of a simple (numerically stabilized) softmax operation:
 
 import torch
+import intel_extension_for_pytorch  # type: ignore # noqa: F401
 
 import triton
 import triton.language as tl

--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -151,6 +151,7 @@ You will specifically learn about:
 # ------------
 
 import torch
+import intel_extension_for_pytorch  # type: ignore # noqa: F401
 
 import triton
 import triton.language as tl


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "intel-xpu-backend-for-triton/python/tutorials/01-vector-add.py", line 23, in <module>
    import triton
  File "intel-xpu-backend-for-triton/python/triton/__init__.py", line 8, in <module>
    from .runtime import (
  File "intel-xpu-backend-for-triton/python/triton/runtime/__init__.py", line 1, in <module>
    from .autotuner import (Autotuner, Config, Heuristics, OutOfResources, autotune, heuristics)
  File "intel-xpu-backend-for-triton/python/triton/runtime/autotuner.py", line 7, in <module>
    from ..testing import do_bench
  File "intel-xpu-backend-for-triton/python/triton/testing.py", line 7, in <module>
    from . import language as tl
  File "intel-xpu-backend-for-triton/python/triton/language/__init__.py", line 6, in <module>
    from .standard import (
  File "intel-xpu-backend-for-triton/python/triton/language/standard.py", line 3, in <module>
    from ..runtime.jit import jit
  File "intel-xpu-backend-for-triton/python/triton/runtime/jit.py", line 13, in <module>
    import intel_extension_for_pytorch as ipex
  File "intel-xpu-backend-for-triton/.venv/lib/python3.10/site-packages/intel_extension_for_pytorch/__init__.py", line 123, in <module>
    from . import _inductor
  File "intel-xpu-backend-for-triton/.venv/lib/python3.10/site-packages/intel_extension_for_pytorch/_inductor/__init__.py", line 1, in <module>
    from . import xpu
  File "intel-xpu-backend-for-triton/.venv/lib/python3.10/site-packages/intel_extension_for_pytorch/_inductor/xpu/__init__.py", line 4, in <module>
    from .codegen.triton import XPUTritonScheduling
  File "intel-xpu-backend-for-triton/.venv/lib/python3.10/site-packages/intel_extension_for_pytorch/_inductor/xpu/codegen/triton.py", line 17, in <module>
    from torch._inductor.codegen.triton import (
  File "intel-xpu-backend-for-triton/.venv/lib/python3.10/site-packages/torch/_inductor/codegen/triton.py", line 26, in <module>
    from ..triton_heuristics import AutotuneHint
  File "intel-xpu-backend-for-triton/.venv/lib/python3.10/site-packages/torch/_inductor/triton_heuristics.py", line 44, in <module>
    from triton import Config
ImportError: cannot import name 'Config' from partially initialized module 'triton' (most likely due to a circular import) (intel-xpu-backend-for-triton/python/triton/__init__.py)
```