### PR TITLE
Do not build Triton in CI when building packages

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Build packages
         if: ${{ hashFiles('.packages-cache') == '' }}
         run: |
-          ./scripts/compile-triton.sh
+          ./scripts/compile-triton.sh --skip-triton
 
       - name: Save packages cache
         if: ${{ hashFiles('.packages-cache') == '' }}

--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -23,6 +23,7 @@ function check_rc {
 
 CLEAN=false
 VENV=false
+SKIP_TRITON=false
 for arg in "$@"; do
   case $arg in
     --clean)
@@ -31,6 +32,10 @@ for arg in "$@"; do
       ;;
     --venv)
       VENV=true
+      shift
+      ;;
+    --skip-triton)
+      SKIP_TRITON=true
       shift
       ;;
   esac
@@ -125,6 +130,10 @@ fi
 
 ############################################################################
 ## Configure and build the Triton project.
+
+if [ "$SKIP_TRITON" = true ]; then
+  exit 0
+fi
 
 if [ ! -d "$TRITON_PROJ_BUILD" ]
 then


### PR DESCRIPTION
Triton is being built later in the workflow, there is no need to build it in the script.