### PR TITLE
Ported tutorial tests

### DIFF
--- a/python/tutorials/08-experimental-block-pointer.py
+++ b/python/tutorials/08-experimental-block-pointer.py
@@ -91,9 +91,12 @@ Note that this feature is still experimental and may change in the future.
 # ------------
 
 import torch
+import intel_extension_for_pytorch  # type: ignore # noqa: F401
 
 import triton
 import triton.language as tl
+
+torch.xpu.enable_sync_mode()
 
 
 @triton.autotune(
@@ -219,8 +222,8 @@ def matmul(a, b):
 # Still we can test our matrix multiplication with block pointers against a native torch implementation (i.e., cuBLAS).
 
 torch.manual_seed(0)
-a = torch.randn((512, 512), device='cuda', dtype=torch.float16)
-b = torch.randn((512, 512), device='cuda', dtype=torch.float16)
+a = torch.randn((512, 512), device='xpu', dtype=torch.float16)
+b = torch.randn((512, 512), device='xpu', dtype=torch.float16)
 triton_output = matmul(a, b)
 torch_output = torch.matmul(a, b)
 print(f"triton_output={triton_output}")

--- a/python/tutorials/09-experimental-tma-matrix-multiplication.py
+++ b/python/tutorials/09-experimental-tma-matrix-multiplication.py
@@ -29,13 +29,12 @@ performance on parallel with cuBLAS.
 import torch
 from torch.testing import assert_close
 
+import intel_extension_for_pytorch  # type: ignore # noqa: F401
+
 import triton
 import triton.language as tl
 
-if torch.cuda.get_device_capability()[0] < 9:
-    import sys
-    print("Skipping TMA benchmark for GPU with compute capability < 9")
-    sys.exit(0)
+torch.xpu.enable_sync_mode()
 
 
 @triton.autotune(
@@ -131,17 +130,17 @@ def test_matmul():
         M, N, K, TRANS_A, TRANS_B = case
         print(M, N, K, TRANS_A, TRANS_B)
         if (TRANS_A):
-            a = torch.randn((K, M), device='cuda', dtype=torch.float16).T
+            a = torch.randn((K, M), device='xpu', dtype=torch.float16).T
             a_order = [0, 1]
         else:
-            a = torch.randn((M, K), device='cuda', dtype=torch.float16)
+            a = torch.randn((M, K), device='xpu', dtype=torch.float16)
             a_order = [1, 0]
 
         if (TRANS_B):
-            b = torch.randn((N, K), device='cuda', dtype=torch.float16).T
+            b = torch.randn((N, K), device='xpu', dtype=torch.float16).T
             b_order = [0, 1]
         else:
-            b = torch.randn((K, N), device='cuda', dtype=torch.float16)
+            b = torch.randn((K, N), device='xpu', dtype=torch.float16)
             b_order = [1, 0]
 
         golden = torch.matmul(a, b)
@@ -173,17 +172,17 @@ def test_matmul():
     ))
 def benchmark(M, N, K, TRANS_A, TRANS_B, provider):
     if (TRANS_A):
-        a = torch.randn((K, M), device='cuda', dtype=torch.float16).T
+        a = torch.randn((K, M), device='xpu', dtype=torch.float16).T
         a_order = [0, 1]
     else:
-        a = torch.randn((M, K), device='cuda', dtype=torch.float16)
+        a = torch.randn((M, K), device='xpu', dtype=torch.float16)
         a_order = [1, 0]
 
     if (TRANS_B):
-        b = torch.randn((N, K), device='cuda', dtype=torch.float16).T
+        b = torch.randn((N, K), device='xpu', dtype=torch.float16).T
         b_order = [0, 1]
     else:
-        b = torch.randn((K, N), device='cuda', dtype=torch.float16)
+        b = torch.randn((K, N), device='xpu', dtype=torch.float16)
         b_order = [1, 0]
 
     quantiles = [0.5, 0.2, 0.8]

--- a/python/tutorials/10-experimental-tma-store-matrix-multiplication.py
+++ b/python/tutorials/10-experimental-tma-store-matrix-multiplication.py
@@ -29,13 +29,10 @@ performance on parallel with cuBLAS.
 import torch
 from torch.testing import assert_close
 
+import intel_extension_for_pytorch  # type: ignore # noqa: F401
+
 import triton
 import triton.language as tl
-
-if torch.cuda.get_device_capability()[0] < 9:
-    import sys
-    print("Skipping TMA benchmark for GPU with compute capability < 9")
-    sys.exit(0)
 
 
 @triton.autotune(
@@ -108,8 +105,8 @@ def matmul(a, b):
     return c
 
 
-a = torch.randn((512, 512), device='cuda', dtype=torch.float16)
-b = torch.randn((512, 512), device='cuda', dtype=torch.float16).T
+a = torch.randn((512, 512), device='xpu', dtype=torch.float16)
+b = torch.randn((512, 512), device='xpu', dtype=torch.float16).T
 c = matmul(a, b)
 c = torch.nn.functional.normalize(c)
 
@@ -144,8 +141,8 @@ assert_close(c, golden, rtol=1e-2, atol=1e-3, check_dtype=False)
         args={},
     ))
 def benchmark(M, N, K, provider):
-    a = torch.randn((M, K), device='cuda', dtype=torch.float16)
-    b = torch.randn((N, K), device='cuda', dtype=torch.float16).T
+    a = torch.randn((M, K), device='xpu', dtype=torch.float16)
+    b = torch.randn((N, K), device='xpu', dtype=torch.float16).T
     quantiles = [0.5, 0.2, 0.8]
     if provider == 'cublas':
         ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), rep=100, quantiles=quantiles,


### PR DESCRIPTION
These changes are necessary to compile the tutorial tests on xpu, however it does not address the test failures.

Currently tests 03, 08, 09, 10 all fail for the same reason: 
```
    self.module, self.function, self.n_regs, self.n_spills = driver.utils.load_binary(
RuntimeError: Triton Error [ZE]: 2013265937
```

could be resolved by #324 

test 11 compiles and runs but has a huge discrepancy in the benchmark:
```
group-gemm-performance:
        N   cuBLAS        Triton
0   128.0  0.11488  276574.06250
1   256.0  0.12080  276332.68750
2   512.0  0.14360  276066.46875
3  1024.0  0.21360  275607.40625
```

Also the tolerance for the assertion related to the weight had to be relaxed in order to run.

Test 06 simply hangs and fails to complete

