### PR TITLE
Use getThreadsPerWarp for SPIRV meta-data settings

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
@@ -1101,14 +1101,14 @@ private:
 
     // Compute the 2-dim coordinates of the first element in the warp operated
     // on by this thread.
-    SmallVector<unsigned> threadPerWarp = getThreadsPerWarp(dpasLayout);
+    SmallVector<unsigned> threadsPerWarp = getThreadsPerWarp(dpasLayout);
     SmallVector<unsigned> contigPerThread = getContigPerThread(dpasLayout);
     SmallVector<Value> multiDimBase = {
         add(mul(i32_val(contigPerThread[0]),
-                udiv(laneId, i32_val(threadPerWarp[1]))),
+                udiv(laneId, i32_val(threadsPerWarp[1]))),
             rowWarpOffset),
         add(mul(i32_val(contigPerThread[1]),
-                urem(laneId, i32_val(threadPerWarp[1]))),
+                urem(laneId, i32_val(threadsPerWarp[1]))),
             colWarpOffset)};
     return multiDimBase;
   }

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
@@ -216,7 +216,8 @@ struct FuncOpConversion : public FuncOpConversionBase {
     case Target::GENX:
       NamedAttrList attrs;
       auto mod = funcOp->getParentOfType<ModuleOp>();
-      int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
+      int threadsPerWarp =
+          triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
       if (allocation.isRoot(funcOp))
         attrs.append(GENX::GENXDialect::getKernelFuncAttrName(),
                      rewriter.getI32IntegerAttr(1));

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
@@ -215,13 +215,15 @@ struct FuncOpConversion : public FuncOpConversionBase {
       break;
     case Target::GENX:
       NamedAttrList attrs;
+      auto mod = funcOp->getParentOfType<ModuleOp>();
+      int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
       if (allocation.isRoot(funcOp))
         attrs.append(GENX::GENXDialect::getKernelFuncAttrName(),
                      rewriter.getI32IntegerAttr(1));
       attrs.append(GENX::GENXDialect::getMaxWorkGroupSizeAttrName(),
-                   rewriter.getI32ArrayAttr({32 * numWarps, 1, 1}));
+                   rewriter.getI32ArrayAttr({threadsPerWarp * numWarps, 1, 1}));
       attrs.append(GENX::GENXDialect::getReqdSubGroupSizeAttrName(),
-                   rewriter.getI32ArrayAttr(32));
+                   rewriter.getI32ArrayAttr(threadsPerWarp));
       newFuncOp->setDialectAttrs(attrs);
       break;
     }

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -928,7 +928,7 @@ SmallVector<unsigned> DpasEncodingAttr::getSizePerThread() const {
 }
 SmallVector<unsigned>
 DpasEncodingAttr::getShapePerCTATile(ArrayRef<int64_t> tensorShape) const {
-  // Given by threadPerWarp ([1,16]) * warpsPerCTA ([8,1]) * warpsPerCTA.
+  // Given by threadsPerWarp ([1,16]) * warpsPerCTA ([8,1]) * warpsPerCTA.
   return {8 * getWarpsPerCTA()[0], 16 * getWarpsPerCTA()[1]};
 }
 


### PR DESCRIPTION
SPIRV kernel reqd_sub_group_size and max_workgroup_siz metadata were using hard coded 32 for threadsPerWarp.  This changeset update it to use module's getThreadsPerWarp() interface function.  Also several minor variable name edits to follow existing Triton variable naming for 'threadsPerWarp'.