### PR TITLE
Remove NVVM-specific pass from XPU pipeline.

### DIFF
--- a/third_party/xpu/backend/compiler.py
+++ b/third_party/xpu/backend/compiler.py
@@ -404,7 +404,6 @@ class XPUBackend(BaseBackend):
         xpu.passes.ttnvgpuir.add_plan_cta(pm, cluster_info)
         passes.ttgpuir.add_remove_layout_conversions(pm)
         passes.ttgpuir.add_optimize_thread_locality(pm)
-        passes.ttgpuir.add_accelerate_matmul(pm, capability)
         passes.ttgpuir.add_remove_layout_conversions(pm)
         if opt.optimize_epilogue:
             passes.ttgpuir.add_optimize_epilogue(pm)


### PR DESCRIPTION
We run `tritongpu-accelerate-matmul` pass with `capability=0` executing transformations that are specific to Nvidia's MMA op version 1. This adds bf16-to-f32 conversion ops for XPU target causing compilation failure due to missing conversion patterns.

Supporting such conversion makes the `test_masked_load_shared_memory` test pass (#279) but DPAS supports BF16 type and we want it to be used in the end. So I propose to remove this pass from our pipeline. It doesn't seem to have anything useful for us (DPAS-related code there doesn't seem to make any transformations). DPAS-specific transformations should be done in a separate XPU-specific pass rather than added to the existing NVVM-specific one.

This PR transforms compilation failure (#158) into runtime failure (incorrect kernel results) and causes no new failures in core tests.