### PR TITLE
[DPAS] Lower the tt.dot to Intel DPAS instruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,21 +59,6 @@ if(NOT MLIR_DIR)
   set(MLIR_DIR ${LLVM_LIBRARY_DIR}/cmake/mlir)
 endif()
 
-# GenISAIntrinsics
-if (NOT TARGET GenISAIntrinsics)
-  if (EXISTS "${GenISAIntrinsics_LIB_DIR}/libGenISAIntrinsics.a")
-    set(GenISAIntrinsics_LDFLAGS "-L${GenISAIntrinsics_LIB_DIR}")
-  elseif (EXISTS "${LLVM_LIBRARY_DIR}/libGenISAIntrinsics.a")
-    set(GenISAIntrinsics_LDFLAGS "-L${LLVM_LIBRARY_DIR}")
-  else()
-    message(FATAL_ERROR "Can't find libGenISAIntrinsics.a at ${LLVM_LIBRARY_DIR}. Please install it into that directory, or provide explicit path with -DGenISAIntrinsics_LIB_DIR=")
-  endif()
-endif()
-set(GenISAIntrinsics_LIBRARY
-  libGenISAIntrinsics.a
-)
-message(STATUS "GenISAIntrinsics_LDFLAGS: ${GenISAIntrinsics_LDFLAGS}")
-
 # MLIR
 find_package(MLIR REQUIRED CONFIG PATHS ${MLIR_DIR})
 
@@ -263,7 +248,7 @@ if(TRITON_BUILD_PYTHON_MODULE)
   else()
     target_link_libraries(triton PRIVATE z)
   endif()
-  target_link_options(triton PRIVATE ${LLVM_LDFLAGS} ${GenISAIntrinsics_LDFLAGS})
+  target_link_options(triton PRIVATE ${LLVM_LDFLAGS})
 endif()
 
 if(UNIX AND NOT APPLE)

--- a/include/triton/Dialect/TritonIntelGPU/Transforms/Passes.h
+++ b/include/triton/Dialect/TritonIntelGPU/Transforms/Passes.h
@@ -12,8 +12,22 @@
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
+namespace triton {
+namespace gpu {
+namespace intel {
 
-std::unique_ptr<Pass> createTritonIntelGPUAccelerateMatmulPass();
+enum class DeviceArch {
+  ATS = 0,
+  PVC = 1,
+  UNKNOWN,
+};
+
+} // namespace intel
+} // namespace gpu
+} // namespace triton
+
+std::unique_ptr<Pass> createTritonIntelGPUAccelerateMatmulPass(
+    triton::gpu::intel::DeviceArch arch = triton::gpu::intel::DeviceArch::PVC);
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/triton/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -27,6 +27,12 @@ def TritonIntelGPUAccelerateMatmul
     "mlir::triton::gpu::intel::TritonIntelGPUDialect",
     "mlir::triton::TritonDialect"
   ];
+
+  let options = [
+    Option<"deviceArch", "device architecture",
+            "mlir::triton::gpu::intel::DeviceArch", /*default*/" mlir::triton::gpu::intel::DeviceArch::UNKNOWN",
+            "device architecture">
+  ];
 }
 
 #endif // TRITON_INTEL_GPU_PASSES

--- a/include/triton/Dialect/TritonIntelGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonIntelGPU/Transforms/Utility.h
@@ -32,7 +32,7 @@ enum class DPASEngineType : uint8_t {
   NOT_APPLICABLE,
 };
 
-bool supportDPAS(DotOp op);
+bool supportDPAS(DotOp op, DeviceArch arch);
 DPASEngineType getDPASType(DotOp op);
 
 } // namespace intel

--- a/lib/Dialect/TritonIntelGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonIntelGPU/Transforms/AccelerateMatmul.cpp
@@ -10,6 +10,7 @@
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -24,24 +25,152 @@
 using namespace mlir;
 namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
-namespace ttgi = mlir::triton::gpu::intel;
+namespace ttig = mlir::triton::gpu::intel;
 namespace {
 using tt::DotOp;
 using ttg::BlockedEncodingAttr;
 using ttg::ConvertLayoutOp;
 using ttg::DotOperandEncodingAttr;
 using ttg::SliceEncodingAttr;
-using ttgi::DpasEncodingAttr;
+using ttig::DeviceArch;
+using ttig::DpasEncodingAttr;
+
+struct IntelDPASCapability {
+  uint32_t systolicDepth;
+  uint32_t repeatCount;
+  uint32_t executionSize;
+  uint32_t opsChanBitWidths;
+};
+
+static IntelDPASCapability caps[] = {
+    [(uint32_t)DeviceArch::ATS] =
+        {
+            .systolicDepth = 8,
+            .repeatCount = 8,
+            .executionSize = 8,
+            .opsChanBitWidths = 32,
+        },
+
+    [(uint32_t)DeviceArch::PVC] =
+        {
+            .systolicDepth = 8,
+            .repeatCount = 8,
+            .executionSize = 16,
+            .opsChanBitWidths = 32,
+        },
+};
+
+IntelDPASCapability getDPASCapability(DeviceArch arch) {
+  assert(arch <= DeviceArch::UNKNOWN && "Unknown Intel GPU archs");
+  return caps[(uint32_t)arch];
+}
+
+SmallVector<unsigned, 2> getWarpsPerTile(tt::DotOp dotOp,
+                                         struct IntelDPASCapability dpasCap,
+                                         const ArrayRef<int64_t> shape,
+                                         int numWarps) {
+  auto filter = [&dotOp](Operation *op) {
+    return op->getParentRegion() == dotOp->getParentRegion();
+  };
+  auto slices = mlir::getSlice(dotOp, {filter});
+  // TODO: revisit this in flash attention.
+  for (Operation *op : slices)
+    if (isa<DotOp>(op) && (op != dotOp))
+      return {(unsigned)numWarps, 1};
+
+  SmallVector<unsigned, 2> ret = {1, 1};
+  SmallVector<int64_t, 2> shapePerWarp = {dpasCap.repeatCount,
+                                          dpasCap.executionSize};
+  uint32_t rowColRatio =
+      ceil<uint32_t>(dpasCap.repeatCount, dpasCap.executionSize);
+  uint32_t colRowRatio =
+      ceil<uint32_t>(dpasCap.executionSize, dpasCap.repeatCount);
+  do {
+    if (ret[0] * ret[1] >= numWarps)
+      break;
+    if (shape[0] / (shapePerWarp[0] * colRowRatio) / ret[0] >=
+        shape[1] / (shapePerWarp[1] * rowColRatio) / ret[1]) {
+      if (ret[0] < shape[0] / shapePerWarp[0]) {
+        ret[0] *= 2;
+      } else
+        ret[1] *= 2;
+    } else {
+      ret[1] *= 2;
+    }
+  } while (true);
+  return ret;
+}
 
 class BlockedToDPAS : public mlir::RewritePattern {
+  DeviceArch arch;
+
 public:
-  BlockedToDPAS(mlir::MLIRContext *context)
-      : mlir::RewritePattern(tt::DotOp::getOperationName(), 2, context) {}
+  BlockedToDPAS(mlir::MLIRContext *context, DeviceArch arch)
+      : mlir::RewritePattern(tt::DotOp::getOperationName(), 2, context),
+        arch(arch) {}
 
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,
                   mlir::PatternRewriter &rewriter) const override {
-    assert(false && "TODO");
+    auto dotOp = cast<DotOp>(op);
+    auto oldRetType = dotOp.getResult().getType().cast<RankedTensorType>();
+    if (!oldRetType.getEncoding() ||
+        oldRetType.getEncoding().isa<DpasEncodingAttr>())
+      return failure();
+
+    if (!supportDPAS(dotOp, arch))
+      return failure();
+
+    // Create DPAS encoding for the given number of warps
+    auto retShape = oldRetType.getShape();
+    auto mod = op->getParentOfType<mlir::ModuleOp>();
+    int numWarps = ttg::TritonGPUDialect::getNumWarps(mod);
+
+    // operands
+    Value a = dotOp.getA();
+    Value b = dotOp.getB();
+    auto oldAType = a.getType().cast<RankedTensorType>();
+    auto oldBType = b.getType().cast<RankedTensorType>();
+
+    auto dpasCap = getDPASCapability(arch);
+    unsigned dpasElemBitWidths =
+        oldAType.getElementType().getIntOrFloatBitWidth();
+    unsigned opsPerChan = dpasCap.opsChanBitWidths / dpasElemBitWidths;
+
+    auto warpsPerTile = getWarpsPerTile(dotOp, dpasCap, retShape, numWarps);
+
+    int threadsPerWarp = ttg::TritonGPUDialect::getThreadsPerWarp(mod);
+    DpasEncodingAttr dpasEnc = DpasEncodingAttr::get(
+        oldRetType.getContext(), dpasCap.repeatCount, dpasCap.systolicDepth,
+        dpasCap.executionSize, opsPerChan, warpsPerTile, threadsPerWarp);
+
+    auto newRetType =
+        RankedTensorType::get(retShape, oldRetType.getElementType(), dpasEnc);
+
+    // convert accumulator
+    auto oldAcc = dotOp.getOperand(2);
+    auto newAcc = rewriter.create<ttg::ConvertLayoutOp>(oldAcc.getLoc(),
+                                                        newRetType, oldAcc);
+
+    auto newAEncoding = ttg::DotOperandEncodingAttr::get(
+        oldAType.getContext(), 0, newRetType.getEncoding(), opsPerChan);
+    auto newBEncoding = ttg::DotOperandEncodingAttr::get(
+        oldBType.getContext(), 1, newRetType.getEncoding(), opsPerChan);
+
+    auto newAType = RankedTensorType::get(
+        oldAType.getShape(), oldAType.getElementType(), newAEncoding);
+    auto newBType = RankedTensorType::get(
+        oldBType.getShape(), oldBType.getElementType(), newBEncoding);
+
+    a = rewriter.create<ttg::ConvertLayoutOp>(a.getLoc(), newAType, a);
+    b = rewriter.create<ttg::ConvertLayoutOp>(b.getLoc(), newBType, b);
+    auto newDot = rewriter.create<DotOp>(dotOp.getLoc(), newRetType, a, b,
+                                         newAcc, dotOp.getAllowTF32(),
+                                         dotOp.getMaxNumImpreciseAcc());
+
+    rewriter.replaceOpWithNewOp<ttg::ConvertLayoutOp>(op, oldRetType,
+                                                      newDot.getResult());
+    return success();
   }
 };
 } // namespace
@@ -81,12 +210,11 @@ static void decomposeMixedModeDotOp(ModuleOp mod) {
     DpasEncodingAttr dpasLayout =
         D.getType().getEncoding().dyn_cast<DpasEncodingAttr>();
     if (dpasLayout) {
-      // No operands promotion because of DPAS using different packing layout
-      // for MMA.
+      // No operands promotion because of DPAS using different layout
+      // to pack the dot operands for different scalar type.
       return;
     } else {
       // FMA case.
-      Type AElType = dotOp.getA().getType().getElementType();
       Type DElType = D.getType().getElementType();
       if (AElType == DElType)
         return;
@@ -108,21 +236,25 @@ class TritonIntelGPUAccelerateMatmulPass
           TritonIntelGPUAccelerateMatmulPass> {
 public:
   TritonIntelGPUAccelerateMatmulPass() = default;
+  TritonIntelGPUAccelerateMatmulPass(ttig::DeviceArch arch) {
+    this->deviceArch = arch;
+  }
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     ModuleOp m = getOperation();
 
     mlir::RewritePatternSet patterns(context);
-    patterns.add<::BlockedToDPAS>(context);
+    patterns.add<::BlockedToDPAS>(context, deviceArch);
     if (applyPatternsAndFoldGreedily(m, std::move(patterns)).failed()) {
       signalPassFailure();
     }
-    // now that we pick the mma type decompose dot that are not natively
+    // now that we pick the scalar type decompose dot that are not natively
     // supported.
     decomposeMixedModeDotOp(m);
   }
 };
 
-std::unique_ptr<Pass> mlir::createTritonIntelGPUAccelerateMatmulPass() {
-  return std::make_unique<TritonIntelGPUAccelerateMatmulPass>();
+std::unique_ptr<Pass>
+mlir::createTritonIntelGPUAccelerateMatmulPass(ttig::DeviceArch arch) {
+  return std::make_unique<TritonIntelGPUAccelerateMatmulPass>(arch);
 }

--- a/lib/Dialect/TritonIntelGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonIntelGPU/Transforms/Utility.cpp
@@ -14,7 +14,20 @@ namespace triton {
 namespace gpu {
 namespace intel {
 
-bool supportDPAS(DotOp op) {
+bool supportDPAS(DotOp op, DeviceArch arch) {
+  auto mod = op->getParentOfType<mlir::ModuleOp>();
+  int threadsPerWarp = TritonGPUDialect::getThreadsPerWarp(mod);
+
+  if (arch == DeviceArch::PVC && threadsPerWarp != 16) {
+    // Only support threadsPerWarp 16 for PVC now.
+    return false;
+  }
+
+  //  if (arch == DeviceArch::ATS && threadsPerWarp != 8) {
+  //    // Only support threadsPerWarp 8 for ATS now.
+  //    return false;
+  //  }
+
   return getDPASType(op) != DPASEngineType::NOT_APPLICABLE;
 }
 

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -316,7 +316,7 @@ def make_launcher(constants, signature, ids):
 
       sycl::queue stream = *(static_cast<sycl::queue*>(pStream));
       sycl::kernel kernel = *(static_cast<sycl::kernel*>(pKrnl));
-      int threads_per_warp = 32;
+      int threads_per_warp = 16;
       if (PyObject_HasAttrString(compiled_kernel, "threads_per_warp")) {{
         PyObject* _threads_per_warp = PyObject_GetAttrString(compiled_kernel, "threads_per_warp");
         if (PyLong_Check(_threads_per_warp))
@@ -400,8 +400,8 @@ class XPUDriver(DriverBase):
 
     def get_current_target(self):
         device = self.get_current_device()
-        device_arch = self.utils.get_device_properties(device)['device_arch']
-        return ("xpu", device_arch)
+        properties = self.utils.get_device_properties(device)
+        return ("xpu", properties['device_arch'], properties)
 
     @staticmethod
     def is_active():

--- a/third_party/intel/lib/TritonGENToLLVM/CMakeLists.txt
+++ b/third_party/intel/lib/TritonGENToLLVM/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_library(TritonGenISAIntrinsics STATIC IMPORTED)
-set_target_properties(TritonGenISAIntrinsics
+add_library(GenISAIntrinsics STATIC IMPORTED GLOBAL)
+set_target_properties(GenISAIntrinsics
   PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/libGenISAIntrinsics.a
 )
 
@@ -8,8 +8,8 @@ add_triton_library(TritonGENToLLVM
 
   DEPENDS
   TritonGENToLLVMConversionPassIncGen
-  TritonGenISAIntrinsics
+  GenISAIntrinsics
 
   LINK_LIBS PUBLIC
-  TritonGenISAIntrinsics
+  GenISAIntrinsics
 )

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -183,12 +183,19 @@ static LLVM::CallOp createGenISADPAS(TritonGEN::MatrixDPASOp op,
   IntegerType int32Ty = rewriter.getIntegerType(32);
 
   Value a = op.getA();
-  auto aTy = VectorType::get(op.getRc(), int16Ty);
+  auto aOrigTy = cast<VectorType>(a.getType());
+  auto bitWidth = aOrigTy.getNumElements() *
+                  aOrigTy.getElementType().getIntOrFloatBitWidth();
+  auto aTy = VectorType::get(bitWidth / 16, int16Ty);
   if (a.getType() != aTy)
     a = rewriter.create<LLVM::BitcastOp>(loc, aTy, a);
 
   Value b = op.getB();
-  auto bTy = VectorType::get(8, int32Ty);
+
+  auto bOrigTy = cast<VectorType>(b.getType());
+  bitWidth = bOrigTy.getNumElements() *
+             bOrigTy.getElementType().getIntOrFloatBitWidth();
+  auto bTy = VectorType::get(bitWidth / 32, int32Ty);
   if (b.getType() != bTy)
     b = rewriter.create<LLVM::BitcastOp>(loc, bTy, b);
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM/DPAS.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM/DPAS.cpp
@@ -149,6 +149,20 @@ public:
     ValueTable ha = getValuesFromDotOperandLayoutStruct(
         loadedA, repM, repK,
         typeConverter->convertType(ATensorTy.getElementType()), aTy);
+
+//    Value programId =
+//        llGetPid(0, op->getLoc(), op->getParentOfType<ModuleOp>(), rewriter);
+//    Value warpSize = getModuleWarpSize(rewriter, loc);
+//    Value warpId = udiv(getThreadId(rewriter, loc), warpSize);
+//    Value laneId = urem(getThreadId(rewriter, loc), warpSize);
+//    for (auto &valA : ha) {
+//      auto coord = valA.first;
+//      Value p = bitcast(valA.second, vec_ty(type::f16Ty(ctx), 8));
+//      kernel_printf("A pid=%d, sgid=%d, tid=%d, repM=%d, repK=%d, val=%f",
+//                    programId, warpId, laneId, i32_val(coord.first),
+//                    i32_val(coord.second), p);
+//    }
+
     ValueTable hb = getValuesFromDotOperandLayoutStruct(
         loadedB, repN, repK,
         typeConverter->convertType(BTensorTy.getElementType()), bTy);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PrintOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PrintOpToLLVM.cpp
@@ -37,7 +37,8 @@ struct PrintOpConversion
       llvm::raw_string_ostream os(formatStr);
       os << "pid (" << getFormatSubstr(pid[0]) << ", "
          << getFormatSubstr(pid[1]) << ", " << getFormatSubstr(pid[2]) << ")%s";
-      llPrintf(formatStr, {pid[0], pid[1], pid[2], prefixStr}, rewriter);
+      mlir::LLVM::utils::llPrintf(rewriter, formatStr,
+                                  {pid[0], pid[1], pid[2], prefixStr});
     } else {
       for (size_t i = 0; i < op.getNumOperands(); i++) {
         // Elements of the tensor that are resident in this GPU thread.
@@ -157,9 +158,10 @@ struct PrintOpConversion
       // printfOperands.  But we don't want to create BLOCK_SIZE duplicate
       // strings, so we cache the Value.
       if (i == 0) {
-        formatStrValue = llPrintf(formatStr, printfOperands, rewriter);
+        formatStrValue =
+            mlir::LLVM::utils::llPrintf(rewriter, formatStr, printfOperands);
       } else {
-        llPrintf(formatStrValue, printfOperands, rewriter);
+        mlir::LLVM::utils::llPrintf(rewriter, formatStrValue, printfOperands);
       }
     }
   }
@@ -210,121 +212,6 @@ struct PrintOpConversion
     }
     assert(false && "not supported type");
     return "";
-  }
-
-  // declare __spirv_ocl_printf(i8*, ...) as external function
-  static LLVM::LLVMFuncOp
-  getSpirvPrintfDeclaration(ConversionPatternRewriter &rewriter) {
-    auto moduleOp =
-        rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
-    StringRef funcName("_Z18__spirv_ocl_printf");
-    Operation *funcOp = moduleOp.lookupSymbol(funcName);
-    if (funcOp)
-      return cast<LLVM::LLVMFuncOp>(*funcOp);
-
-    MLIRContext *context = rewriter.getContext();
-    auto ptrTy = LLVM::LLVMPointerType::get(
-        context, GENX::GENXMemorySpace::kUniformConstant);
-    SmallVector<Type> argsType{ptrTy};
-    auto retType = i32_ty;
-    auto funcType =
-        LLVM::LLVMFunctionType::get(retType, argsType, /*isVarArg*/ true);
-
-    ConversionPatternRewriter::InsertionGuard guard(rewriter);
-    rewriter.setInsertionPointToStart(moduleOp.getBody());
-
-    auto printFunc = rewriter.create<LLVM::LLVMFuncOp>(
-        UnknownLoc::get(context), funcName, funcType, LLVM::Linkage::External,
-        /*dsoLocal*/ false, LLVM::CConv::SPIR_FUNC, /*comdat=*/SymbolRefAttr{});
-    printFunc->setAttr("nounwind", rewriter.getUnitAttr());
-
-    return printFunc;
-  }
-
-  // declare vprintf(i8*, i8*) as external function
-  static LLVM::LLVMFuncOp
-  getVprintfDeclaration(ConversionPatternRewriter &rewriter) {
-    auto moduleOp =
-        rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
-    StringRef funcName("vprintf");
-    Operation *funcOp = moduleOp.lookupSymbol(funcName);
-    if (funcOp)
-      return cast<LLVM::LLVMFuncOp>(*funcOp);
-
-    auto *context = rewriter.getContext();
-
-    SmallVector<Type> argsType{ptr_ty(context), ptr_ty(context)};
-    auto funcType = LLVM::LLVMFunctionType::get(i32_ty, argsType);
-
-    ConversionPatternRewriter::InsertionGuard guard(rewriter);
-    rewriter.setInsertionPointToStart(moduleOp.getBody());
-
-    return rewriter.create<LLVM::LLVMFuncOp>(UnknownLoc::get(context), funcName,
-                                             funcType);
-  }
-
-  // extend integer to int32, extend float to float64
-  // this comes from vprintf alignment requirements.
-  static std::pair<Type, Value>
-  promoteValue(ConversionPatternRewriter &rewriter, Value value) {
-    auto *context = rewriter.getContext();
-    auto type = value.getType();
-    Value newOp = value;
-    Type newType = type;
-    auto loc = UnknownLoc::get(context);
-
-    bool bUnsigned = type.isUnsignedInteger();
-    if (type.isIntOrIndex() && type.getIntOrFloatBitWidth() < 32) {
-      if (bUnsigned) {
-        newType = ui32_ty;
-        newOp = zext(newType, value);
-      } else {
-        newType = i32_ty;
-        newOp = sext(newType, value);
-      }
-    } else if (type.isBF16() || type.isF16() || type.isF32()) {
-      newType = f64_ty;
-      newOp = fpext(newType, value);
-    }
-
-    return {newType, newOp};
-  }
-
-  // Returns a Value for the format string, which you can reuse.
-  static Value llPrintf(StringRef msg, ValueRange args,
-                        ConversionPatternRewriter &rewriter) {
-    assert(!msg.empty() && "printf with empty string not supported");
-    llvm::SmallString<64> msgNewline(msg);
-    msgNewline.push_back('\n');
-    Value msgValue = LLVM::utils::addStringToModule(
-        UnknownLoc::get(rewriter.getContext()), rewriter, "printfFormat_",
-        msgNewline, GENX::GENXMemorySpace::kUniformConstant);
-    llPrintf(msgValue, args, rewriter);
-    return msgValue;
-  }
-
-  static void llPrintf(Value msg, ValueRange args,
-                       ConversionPatternRewriter &rewriter) {
-    auto *ctx = rewriter.getContext();
-    Type ptr = ptr_ty(ctx);
-    auto moduleOp =
-        rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
-    auto funcOp = getSpirvPrintfDeclaration(rewriter);
-    auto loc = UnknownLoc::get(ctx);
-
-    Value one = i32_val(1);
-    Value zero = i32_val(0);
-
-    Value bufferPtr = null(ptr);
-
-    SmallVector<Value> operands;
-    operands.push_back(msg);
-    // __spirv_ocl_printf expects the value instead of pointer to value
-    for (auto arg : args) {
-      operands.push_back(arg);
-    }
-
-    call(funcOp, operands);
   }
 };
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
@@ -386,6 +386,62 @@ Value addStringToModule(Location loc, ConversionPatternRewriter &rewriter,
   return stringStart;
 }
 
+// declare __spirv_ocl_printf(i8*, ...) as external function
+LLVM::LLVMFuncOp
+getSpirvPrintfDeclaration(ConversionPatternRewriter &rewriter) {
+  auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
+  StringRef funcName("_Z18__spirv_ocl_printf");
+  Operation *funcOp = moduleOp.lookupSymbol(funcName);
+  if (funcOp)
+    return cast<LLVM::LLVMFuncOp>(*funcOp);
+
+  MLIRContext *context = rewriter.getContext();
+  auto ptrTy = LLVM::LLVMPointerType::get(
+      context, GENX::GENXMemorySpace::kUniformConstant);
+  SmallVector<Type> argsType{ptrTy};
+  auto retType = i32_ty;
+  auto funcType =
+      LLVM::LLVMFunctionType::get(retType, argsType, /*isVarArg*/ true);
+
+  ConversionPatternRewriter::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointToStart(moduleOp.getBody());
+
+  auto printFunc = rewriter.create<LLVM::LLVMFuncOp>(
+      UnknownLoc::get(context), funcName, funcType, LLVM::Linkage::External,
+      /*dsoLocal*/ false, LLVM::CConv::SPIR_FUNC, /*comdat=*/SymbolRefAttr{});
+  printFunc->setAttr("nounwind", rewriter.getUnitAttr());
+
+  return printFunc;
+}
+
+void llPrintf(ConversionPatternRewriter &rewriter, Value msg, ValueRange args) {
+  auto *ctx = rewriter.getContext();
+  Type ptr = ptr_ty(ctx);
+  auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
+  auto funcOp = getSpirvPrintfDeclaration(rewriter);
+  auto loc = UnknownLoc::get(ctx);
+
+  SmallVector<Value> operands;
+  operands.push_back(msg);
+  for (auto arg : args) {
+    operands.push_back(arg);
+  }
+  call(funcOp, operands);
+}
+
+// Returns a Value for the format string, which you can reuse.
+Value llPrintf(ConversionPatternRewriter &rewriter, StringRef msg,
+               ValueRange args) {
+  assert(!msg.empty() && "printf with empty string not supported");
+  llvm::SmallString<64> msgNewline(msg);
+  msgNewline.push_back('\n');
+  Value msgValue = LLVM::utils::addStringToModule(
+      UnknownLoc::get(rewriter.getContext()), rewriter, "printfFormat_",
+      msgNewline, GENX::GENXMemorySpace::kUniformConstant);
+  llPrintf(rewriter, msgValue, args);
+  return msgValue;
+}
+
 } // namespace utils
 } // namespace LLVM
 } // namespace mlir

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
@@ -142,6 +142,10 @@ using namespace mlir::triton;
 #define i32_arr_attr(...) rewriter.getI32ArrayAttr({__VA_ARGS__})
 #define i64_arr_attr(...) rewriter.getI64ArrayAttr({__VA_ARGS__})
 
+// Kernel printf
+#define kernel_printf(fmt, ...)                                                \
+  LLVM::utils::llPrintf(rewriter, fmt, ValueRange{__VA_ARGS__})
+
 namespace mlir {
 namespace triton {
 // namespace intel {
@@ -463,6 +467,12 @@ static Value getSharedMemoryBase(Location loc,
       gep(ptrTy, i8_ty, LLVM::utils::getStackPointer(rewriter, func), offVal);
   return base;
 }
+
+// Returns a Value for the format string, which you can reuse.
+Value llPrintf(ConversionPatternRewriter &rewriter, StringRef msg,
+               ValueRange args);
+
+void llPrintf(ConversionPatternRewriter &rewriter, Value msg, ValueRange args);
 
 } // namespace utils
 } // namespace LLVM

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -24,9 +24,10 @@ void init_triton_intel_passes_ttgpuir(py::module &&m) {
   m.def("add_to_llvmir", [](mlir::PassManager &pm, int32_t capability) {
     pm.addPass(mlir::triton::createConvertTritonIntelGPUToLLVMPass(capability));
   });
-  m.def("add_accelerate_matmul", [](mlir::PassManager &self) {
-    self.addPass(mlir::createTritonIntelGPUAccelerateMatmulPass());
-  });
+  m.def("add_accelerate_matmul",
+        [](mlir::PassManager &self, mlir::triton::gpu::intel::DeviceArch arch) {
+          self.addPass(mlir::createTritonIntelGPUAccelerateMatmulPass(arch));
+        });
   m.def("add_decompose_unsupported_conversions", [](mlir::PassManager &pm) {
     pm.addPass(createIntelDecomposeUnsupportedConversionsPass());
   });
@@ -48,6 +49,14 @@ void init_triton_intel(py::module &&m) {
   auto passes = m.def_submodule("passes");
   init_triton_intel_passes_ttgpuir(passes.def_submodule("ttgpuir"));
   init_triton_intel_passes_ttnvgpuir(passes.def_submodule("ttnvgpuir"));
+
+  // Device arch
+  py::enum_<mlir::triton::gpu::intel::DeviceArch>(m, "DEVICE_ARCH",
+                                                  py::module_local())
+      .value("ATS", mlir::triton::gpu::intel::DeviceArch::ATS)
+      .value("PVC", mlir::triton::gpu::intel::DeviceArch::PVC)
+      .value("UNKNOWN", mlir::triton::gpu::intel::DeviceArch::UNKNOWN)
+      .export_values();
 
   // cluster info
   py::class_<mlir::triton::nvidia_gpu::ClusterInfo>(m, "ClusterInfo")


### PR DESCRIPTION
Lower the tt.dot to Intel DPAS instruction.

- Modify the DpasEncodingAttr.
- Add a pass to accelerate matmul for Intel GPU.
- Add the TritonIntelGPU dialect for Intel ops/attr/passes on ttgir.
