### PR TITLE
Reduce workload size temporarily for tutorial `03-matrix-multiplication.py`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -192,6 +192,7 @@ jobs:
           cd python/tutorials
           python3 01-vector-add.py
           python3 02-fused-softmax.py
+          python3 03-matrix-multiplication.py
           python3 04-low-memory-dropout.py
           python3 05-layer-norm.py
           python3 07-math-functions.py

--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -166,8 +166,9 @@ torch.xpu.enable_sync_mode()
 #       provided configs
 @triton.autotune(
     configs=[
-        triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8}, num_stages=3,
-                      num_warps=8),
+        # FIXME: Once tl.dot uses DPAS put back the workload commented out.
+        # triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8}, num_stages=3,
+        #               num_warps=8),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 32, 'GROUP_SIZE_M': 8}, num_stages=4,
                       num_warps=4),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'GROUP_SIZE_M': 8}, num_stages=4,

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -162,6 +162,7 @@ function run_tutorial_tests {
 
   run_tutorial_test "01-vector-add" 01-vector-add.py
   run_tutorial_test "02-fused-softmax" 02-fused-softmax.py
+  run_tutorial_test "03-matrix-multiplication" 03-matrix-multiplication.py  
   run_tutorial_test "04-low-memory-dropout" 04-low-memory-dropout.py
   run_tutorial_test "05-layer-norm" 05-layer-norm.py
   run_tutorial_test "07-math-functions" 07-math-functions.py

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -162,7 +162,7 @@ function run_tutorial_tests {
 
   run_tutorial_test "01-vector-add" 01-vector-add.py
   run_tutorial_test "02-fused-softmax" 02-fused-softmax.py
-  run_tutorial_test "03-matrix-multiplication" 03-matrix-multiplication.py  
+  run_tutorial_test "03-matrix-multiplication" 03-matrix-multiplication.py
   run_tutorial_test "04-low-memory-dropout" 04-low-memory-dropout.py
   run_tutorial_test "05-layer-norm" 05-layer-norm.py
   run_tutorial_test "06-fused-attention.py" 06-fused-attention.py


### PR DESCRIPTION
Currently `tl.dot` is lowered to a loop containing scalar instructions. Large workload size do not work with this approach and we will lower `tl.dot` to use DPAS instructions soon.  This PR reduces the workload used by the benchmark temporarily, to make the tutorial run correctly.