### PR TITLE
Reduce workload size for tutorials `09-experimental-tma-matrix-multiplication.py` and `10-experimental-tma-store-matrix-multiplication.py`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -196,6 +196,8 @@ jobs:
           python3 05-layer-norm.py
           python3 06-fused-attention.py
           python3 07-math-functions.py
+          python3 09-experimental-tma-matrix-multiplication.py
+          python3 10-experimental-tma-store-matrix-multiplication.py
           python3 11-grouped-gemm.py
 
       - name: Run CXX unittests

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -5,7 +5,7 @@ import sys
 from contextlib import contextmanager
 from typing import Any, Dict, List
 from . import language as tl
-
+from datetime import datetime, timedelta
 
 def nvsmi(attrs):
     attrs = ','.join(attrs)
@@ -109,21 +109,20 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fast_flu
         cache = torch.empty(int(256e6), dtype=torch.int8, device='xpu')
 
     # Estimate the runtime of the function
-    start_event = torch.xpu.Event(enable_timing=True)
-    end_event = torch.xpu.Event(enable_timing=True)
-    start_event.record()
+    start_time = datetime.now()
     for _ in range(5):
         cache.zero_()
         fn()
-    end_event.record()
+    end_time = datetime.now()    
     torch.xpu.synchronize()
-    estimate_ms = start_event.elapsed_time(end_event) / 5
+    estimate_ms = ((end_time.timestamp() - start_time.timestamp()) * 1000) / 5
 
     # compute number of warmup and repeat
     n_warmup = max(1, int(warmup / estimate_ms))
     n_repeat = max(1, int(rep / estimate_ms))
-    start_event = [torch.xpu.Event(enable_timing=True) for i in range(n_repeat)]
-    end_event = [torch.xpu.Event(enable_timing=True) for i in range(n_repeat)]
+    start_times = [datetime for i in range(n_repeat)]
+    end_times =  [datetime for i in range(n_repeat)]
+
     # Warm-up
     for _ in range(n_warmup):
         fn()
@@ -138,12 +137,12 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fast_flu
         # we clear the L2 cache before each run
         cache.zero_()
         # record time of `fn`
-        start_event[i].record()
+        start_times[i] = datetime.now()
         fn()
-        end_event[i].record()
+        end_times[i] = datetime.now()
     # Record clocks
     torch.xpu.synchronize()
-    times = torch.tensor([s.elapsed_time(e) for s, e in zip(start_event, end_event)], dtype=torch.float)
+    times = torch.tensor([(e.timestamp() - s.timestamp()) * 1000 for s, e in zip(start_times, end_times)], dtype=torch.float)
     if quantiles is not None:
         ret = torch.quantile(times, torch.tensor(quantiles, dtype=torch.float)).tolist()
         if len(ret) == 1:

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -5,7 +5,8 @@ import sys
 from contextlib import contextmanager
 from typing import Any, Dict, List
 from . import language as tl
-from datetime import datetime, timedelta
+from datetime import datetime
+
 
 def nvsmi(attrs):
     attrs = ','.join(attrs)
@@ -113,7 +114,7 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fast_flu
     for _ in range(5):
         cache.zero_()
         fn()
-    end_time = datetime.now()    
+    end_time = datetime.now()
     torch.xpu.synchronize()
     estimate_ms = ((end_time.timestamp() - start_time.timestamp()) * 1000) / 5
 
@@ -121,7 +122,7 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fast_flu
     n_warmup = max(1, int(warmup / estimate_ms))
     n_repeat = max(1, int(rep / estimate_ms))
     start_times = [datetime for i in range(n_repeat)]
-    end_times =  [datetime for i in range(n_repeat)]
+    end_times = [datetime for i in range(n_repeat)]
 
     # Warm-up
     for _ in range(n_warmup):
@@ -142,7 +143,8 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fast_flu
         end_times[i] = datetime.now()
     # Record clocks
     torch.xpu.synchronize()
-    times = torch.tensor([(e.timestamp() - s.timestamp()) * 1000 for s, e in zip(start_times, end_times)], dtype=torch.float)
+    times = torch.tensor([(e.timestamp() - s.timestamp()) * 1000 for s, e in zip(start_times, end_times)],
+                         dtype=torch.float)
     if quantiles is not None:
         ret = torch.quantile(times, torch.tensor(quantiles, dtype=torch.float)).tolist()
         if len(ret) == 1:

--- a/python/tutorials/09-experimental-tma-matrix-multiplication.py
+++ b/python/tutorials/09-experimental-tma-matrix-multiplication.py
@@ -39,8 +39,9 @@ torch.xpu.enable_sync_mode()
 
 @triton.autotune(
     configs=[
-        # FIXME: Put back the original problem size once tl.dot is lowered using DPAS instructions.            
-        triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8}, num_stages=7, num_warps=4),
+        # FIXME: Put back the original problem size once tl.dot is lowered using DPAS instructions.
+        triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8}, num_stages=7,
+                      num_warps=4),
         # PUT BACK: triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8}, num_stages=7,
         #                        num_warps=4),
         # triton.Config({'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8}, num_stages=7, num_warps=4, num_ctas=2),

--- a/python/tutorials/09-experimental-tma-matrix-multiplication.py
+++ b/python/tutorials/09-experimental-tma-matrix-multiplication.py
@@ -39,8 +39,10 @@ torch.xpu.enable_sync_mode()
 
 @triton.autotune(
     configs=[
-        triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8}, num_stages=7,
-                      num_warps=4),
+        # FIXME: Put back the original problem size once tl.dot is lowered using DPAS instructions.            
+        triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8}, num_stages=7, num_warps=4),
+        # PUT BACK: triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8}, num_stages=7,
+        #                        num_warps=4),
         # triton.Config({'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8}, num_stages=7, num_warps=4, num_ctas=2),
         # triton.Config({'BLOCK_SIZE_M': 512, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8}, num_stages=7, num_warps=4, num_ctas=4),
     ],

--- a/python/tutorials/10-experimental-tma-store-matrix-multiplication.py
+++ b/python/tutorials/10-experimental-tma-store-matrix-multiplication.py
@@ -37,8 +37,11 @@ import triton.language as tl
 
 @triton.autotune(
     configs=[
+        # FIXME: Put back the original problem size once tl.dot is lowered using DPAS instructions.
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8}, num_stages=7,
-                      num_warps=4),
+                      num_warps=8),
+        #PUT BACK: triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8}, num_stages=7,
+        #                         num_warps=4),
         # triton.Config({'BLOCK_SIZE_M': 512, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8}, num_stages=7, num_warps=4, num_ctas=4),
     ],
     key=['M', 'N', 'K'],

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -166,6 +166,8 @@ function run_tutorial_tests {
   run_tutorial_test "05-layer-norm" 05-layer-norm.py
   run_tutorial_test "06-fused-attention.py" 06-fused-attention.py
   run_tutorial_test "07-math-functions" 07-math-functions.py
+  run_tutorial_test "09-experimental-tma-matrix-multiplication" 09-experimental-tma-matrix-multiplication.py 
+  run_tutorial_test "10-experimental-tma-store-matrix-multiplication" 10-experimental-tma-store-matrix-multiplication.py
   run_tutorial_test "11-grouped-gemm" 11-grouped-gemm.py
 }
 

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -166,7 +166,7 @@ function run_tutorial_tests {
   run_tutorial_test "05-layer-norm" 05-layer-norm.py
   run_tutorial_test "06-fused-attention.py" 06-fused-attention.py
   run_tutorial_test "07-math-functions" 07-math-functions.py
-  run_tutorial_test "09-experimental-tma-matrix-multiplication" 09-experimental-tma-matrix-multiplication.py 
+  run_tutorial_test "09-experimental-tma-matrix-multiplication" 09-experimental-tma-matrix-multiplication.py
   run_tutorial_test "10-experimental-tma-store-matrix-multiplication" 10-experimental-tma-store-matrix-multiplication.py
   run_tutorial_test "11-grouped-gemm" 11-grouped-gemm.py
 }


### PR DESCRIPTION
Currently `tl.dot` is lowered to a loop containing scalar instructions. Large workload size do not work with this approach and we will lower `tl.dot` to use DPAS instructions soon.  This PR reduces the workload used by the benchmark temporarily, to make the tutorial run correctly.