### PR TITLE
Re-disable assert tests

### DIFF
--- a/python/test/unit/language/test_subprocess.py
+++ b/python/test/unit/language/test_subprocess.py
@@ -69,6 +69,9 @@ def test_print(func_type: str, data_type: str):
 
 @pytest.mark.parametrize("func_type", assert_types)
 def test_assert(func_type: str):
+    if (func_type in ["device_assert", "assert", "no_debug", "double_assert"]):
+        pytest.skip("FIXME: Require new IGC")
+
     os.environ["TRITON_DEBUG"] = "1"
     proc = subprocess.Popen([sys.executable, assert_path, func_type], stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                             shell=False)
@@ -91,6 +94,8 @@ def test_assert(func_type: str):
 
 @pytest.mark.parametrize("caller_type, callee_type", nested_types)
 def test_assert_nested(caller_type, callee_type):
+    pytest.skip("FIXME: Require new IGC")
+
     proc = subprocess.Popen([sys.executable, assert_path, caller_type, callee_type], stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE, shell=False)
     _, errs = proc.communicate()


### PR DESCRIPTION
The `pytest.skip` were removed in https://github.com/intel/intel-xpu-backend-for-triton/pull/362, which cause `test_triton.sh` to fail.
We cannot enable the assert tests yet, as they require a newer version of IGC to pass, and that is still WIP.