### PR TITLE
Reduce workload size for `test_flash_attention.py`

### DIFF
--- a/python/test/unit/operators/test_flash_attention.py
+++ b/python/test/unit/operators/test_flash_attention.py
@@ -5,6 +5,9 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.ops
 
+# FIXME remove this once Triton L0 queue and IPEX SYCL queue can be synchronized through events
+torch.xpu.enable_sync_mode()
+
 
 # FIXME: Enable larger problem sizes when tl.dot uses DPAS.
 @pytest.mark.parametrize('Z, H, N_CTX, D_HEAD', [  #

--- a/python/test/unit/operators/test_flash_attention.py
+++ b/python/test/unit/operators/test_flash_attention.py
@@ -5,12 +5,13 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.ops
 
+
 # FIXME: Enable larger problem sizes when tl.dot uses DPAS.
 @pytest.mark.parametrize('Z, H, N_CTX, D_HEAD', [  #
     (2, 4, 512, 16),
-#    (2, 4, 512, 32),
-#    (2, 4, 512, 64),
-#    (2, 4, 512, 128),
+    #    (2, 4, 512, 32),
+    #    (2, 4, 512, 64),
+    #    (2, 4, 512, 128),
 ])
 @pytest.mark.parametrize('dtype', [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize('causal', [True, False])
@@ -23,11 +24,11 @@ def test_op(Z, H, N_CTX, D_HEAD, dtype, causal, seq_par):
             pytest.xfail('bfloat16 tma not support currently')
 
     capability = 0
-    if torch.cuda.is_available():            
+    if torch.cuda.is_available():
         capability = torch.cuda.get_device_capability()
 
     interpreter = os.environ.get("TRITON_INTERPRET", 'not found') in ["on", "true", "1"]
-    if torch.cuda.is_available():            
+    if torch.cuda.is_available():
         if not interpreter and capability[0] < 8:
             pytest.xfail("Flash attention only supported for compute capability >= 80")
     torch.manual_seed(20)

--- a/python/test/unit/operators/test_flash_attention.py
+++ b/python/test/unit/operators/test_flash_attention.py
@@ -5,15 +5,12 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.ops
 
-# FIXME remove this once Triton L0 queue and IPEX SYCL queue can be synchronized through events
-torch.xpu.enable_sync_mode()
-
-
+# FIXME: Enable larger problem sizes when tl.dot uses DPAS.
 @pytest.mark.parametrize('Z, H, N_CTX, D_HEAD', [  #
     (2, 4, 512, 16),
-    (2, 4, 512, 32),
-    (2, 4, 512, 64),
-    (2, 4, 512, 128),
+#    (2, 4, 512, 32),
+#    (2, 4, 512, 64),
+#    (2, 4, 512, 128),
 ])
 @pytest.mark.parametrize('dtype', [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize('causal', [True, False])
@@ -23,20 +20,24 @@ def test_op(Z, H, N_CTX, D_HEAD, dtype, causal, seq_par):
     enable_tma = os.environ.get('ENABLE_TMA', 'not found').lower()
     if enable_tma in ["on", "true", "1"]:
         if dtype == torch.bfloat16:
-            pytest.skip('bfloat16 tma not support currently')
-    pytest.skip("FIXME: Port get_device_capability to XPU")
-    capability = torch.cuda.get_device_capability()
+            pytest.xfail('bfloat16 tma not support currently')
+
+    capability = 0
+    if torch.cuda.is_available():            
+        capability = torch.cuda.get_device_capability()
+
     interpreter = os.environ.get("TRITON_INTERPRET", 'not found') in ["on", "true", "1"]
-    if not interpreter and capability[0] < 8:
-        pytest.skip("Flash attention only supported for compute capability >= 80")
+    if torch.cuda.is_available():            
+        if not interpreter and capability[0] < 8:
+            pytest.xfail("Flash attention only supported for compute capability >= 80")
     torch.manual_seed(20)
-    q = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0., std=0.5).requires_grad_()
-    k = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0., std=0.5).requires_grad_()
-    v = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0., std=0.5).requires_grad_()
+    q = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="xpu").normal_(mean=0., std=0.5).requires_grad_()
+    k = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="xpu").normal_(mean=0., std=0.5).requires_grad_()
+    v = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="xpu").normal_(mean=0., std=0.5).requires_grad_()
     sm_scale = 0.5
     dout = torch.randn_like(q)
     # reference implementation
-    M = torch.tril(torch.ones((N_CTX, N_CTX), device="cuda"))
+    M = torch.tril(torch.ones((N_CTX, N_CTX), device="xpu"))
     p = torch.matmul(q, k.transpose(2, 3)) * sm_scale
     if causal:
         p[:, :, M == 0] = float("-inf")

--- a/python/test/unit/operators/test_inductor.py
+++ b/python/test/unit/operators/test_inductor.py
@@ -164,7 +164,7 @@ def test_avg_pool_bw():
 @pytest.mark.parametrize("RBLOCK", [1, 16, 32, 64, 128])
 @pytest.mark.parametrize("num_warps", [1, 4])
 def test_scan2d_broadcast(RBLOCK, num_warps):
-    pytest.skip("FIXME: worker crashed cases")
+    pytest.skip("FIXME: device_assert not working on XPU yet")
 
     @triton.jit(debug=True)
     def fn(in_ptr, out_ptr, XBLOCK: tl.constexpr, RBLOCK: tl.constexpr):

--- a/python/triton/ops/flash_attention.py
+++ b/python/triton/ops/flash_attention.py
@@ -406,7 +406,7 @@ class _attention(torch.autograd.Function):
     @staticmethod
     def backward(ctx, do):
         MMA_V3 = False
-        if torch.cuda.is_available():        
+        if torch.cuda.is_available():
             capability = torch.cuda.get_device_capability()
             MMA_V3 = capability[0] >= 9
         BLOCK = 128


### PR DESCRIPTION
Currently `tl.dot` is lowered to a loop containing scalar instructions. Large workload size do not work with this approach and we will lower `tl.dot` to use DPAS instructions soon. This PR reduces the workload used by the benchmark temporarily, to make it run correctly.