### PR TITLE
Enable `test_subprocess` again

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -158,7 +158,7 @@ jobs:
           pip install pytest pytest-xdist
           pip install torch==2.1.0a0+cxx11.abi intel_extension_for_pytorch==2.1.10+xpu -f https://developer.intel.com/ipex-whl-stable-xpu
           cd python/test/unit
-          python3 -m pytest -n 8 --verbose --device xpu language/ --ignore=language/test_line_info.py --ignore=language/test_subprocess.py
+          python3 -m pytest -n 8 --verbose --device xpu language/ --ignore=language/test_line_info.py
           # run runtime tests serially to avoid race condition with cache handling.
           python3 -m pytest runtime/
           # run test_line_info.py separately with TRITON_DISABLE_LINE_INFO=0

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -105,13 +105,7 @@ function run_core_tests {
   fi
   cd ${CORE_TEST_DIR}
 
-  TRITON_DISABLE_LINE_INFO=1 python3 -m pytest -n 8 --verbose --device xpu language/ --ignore=language/test_line_info.py --ignore=language/test_subprocess.py
-  if [ $? -ne 0 ]; then
-    echo "FAILED: return code $?" ; exit $?
-  fi
-
-  # run test_subprocess serially to avoid issues with print buffer handling.
-  TRITON_DISABLE_LINE_INFO=1 python3 -m pytest --verbose --device xpu language/test_subprocess.py
+  TRITON_DISABLE_LINE_INFO=1 python3 -m pytest -n 8 --verbose --device xpu language/ --ignore=language/test_line_info.py
   if [ $? -ne 0 ]; then
     echo "FAILED: return code $?" ; exit $?
   fi


### PR DESCRIPTION
Now that we are using the SYCL RT these tests pass even when running them in parallel. Putting the tests back into CI.