### PR TITLE
Top level permissions for workflows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - llvm-target
 
+permissions: read-all
+
 env:
   BASE: /home/runner
   LLVM_SYSPATH: /home/runner/packages/llvm

--- a/.github/workflows/docker-runner-base.yaml
+++ b/.github/workflows/docker-runner-base.yaml
@@ -3,6 +3,8 @@ name: Docker image runner-base
 on:
   workflow_dispatch:
 
+permissions: read-all
+
 env:
   REGISTRY: docker-registry.docker-registry.svc.cluster.local:5000
   TAG: triton-runner-base:0.0.4


### PR DESCRIPTION
To fix the following warnings from OpenSSF Scorecard Report:

```
Warn: no topLevel permission defined: .github/workflows/build_and_test.yml:1
Warn: no topLevel permission defined: .github/workflows/docker-runner-base.yaml:1
```

Partially fixes #300.