### PR TITLE
Revert downgrading libigc1 in the runner image

### DIFF
--- a/.github/dockerfiles/runner-base/Dockerfile
+++ b/.github/dockerfiles/runner-base/Dockerfile
@@ -18,7 +18,6 @@ RUN set -ex; \
       level-zero \
       level-zero-dev libigc-dev intel-igc-cm libigdfcl-dev libigfxcmrt-dev \
     ; \
-    apt install -y --no-install-recommends --allow-downgrades --fix-missing libigc1=1.0.14828.26-736~22.04; \
     apt-get install -y --no-install-recommends --fix-missing \
       build-essential \
       zlib1g-dev \

--- a/.github/workflows/docker-runner-base.yaml
+++ b/.github/workflows/docker-runner-base.yaml
@@ -7,7 +7,7 @@ permissions: read-all
 
 env:
   REGISTRY: docker-registry.docker-registry.svc.cluster.local:5000
-  TAG: triton-runner-base:0.0.4
+  TAG: triton-runner-base:0.0.5
 
 jobs:
   build:


### PR DESCRIPTION
Docker image triton-runner-base:0.0.5 will have libigc1 that installed by L0 by default.