### PR TITLE
Use 4 workers for operators tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Run partial operators tests
         run: |
           cd python/test/unit
-          python3 -m pytest -n 8 --verbose operators
+          python3 -m pytest -n 4 --maxfail=1 --verbose operators
 
       - name: Regression tests
         run: |


### PR DESCRIPTION
We had several failures for operators tests when running on 8 workers. Decreasing the number of workers to 4, also adding `--maxfail=1` to fail fast.