### PR TITLE
[Backend]Removed forced sync call from tests

### DIFF
--- a/python/test/unit/language/assert_helper.py
+++ b/python/test/unit/language/assert_helper.py
@@ -7,9 +7,6 @@ from torch.testing import assert_close
 import triton
 import triton.language as tl
 
-#FIXME
-torch.xpu.enable_sync_mode()
-
 
 @triton.jit
 def kernel_device_assert(X, Y, BLOCK: tl.constexpr):

--- a/python/test/unit/language/print_helper.py
+++ b/python/test/unit/language/print_helper.py
@@ -8,9 +8,6 @@ from torch.testing import assert_close
 import triton
 import triton.language as tl
 
-#FIXME
-torch.xpu.enable_sync_mode()
-
 
 @triton.jit
 def kernel_device_print(X, Y, BLOCK: tl.constexpr):

--- a/python/test/unit/language/test_block_pointer.py
+++ b/python/test/unit/language/test_block_pointer.py
@@ -5,9 +5,6 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.language as tl
 
-# FIXME remove this once Triton L0 queue and IPEX SYCL queue can be synchronized through events
-torch.xpu.enable_sync_mode()
-
 
 @triton.jit
 def block_copy_kernel(a_ptr, b_ptr, N, BLOCK_SIZE: tl.constexpr, padding_option: tl.constexpr):

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -40,10 +40,6 @@ if is_hip():
 else:
     THREADS_PER_WARP = 32
 
-if is_spirv():
-    # FIXME remove this once Triton L0 queue and IPEX SYCL queue can be synchronized through events
-    torch.xpu.enable_sync_mode()
-
 
 def _bitwidth(dtype: str) -> int:
     # ex.: "int64" -> 64

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -18,7 +18,6 @@ def is_hip():
     return triton.runtime.driver.active.get_current_target()[0] == "hip"
 
 
-
 int_dtypes = ['int8', 'int16', 'int32', 'int64']
 uint_dtypes = ['uint8', 'uint16', 'uint32', 'uint64']
 float_dtypes = ['float16', 'float32', 'float64']

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -18,9 +18,6 @@ def is_hip():
     return triton.runtime.driver.active.get_current_target()[0] == "hip"
 
 
-def is_spirv():
-    return triton.runtime.driver.active.get_current_target()[0] == "xpu"
-
 
 int_dtypes = ['int8', 'int16', 'int32', 'int64']
 uint_dtypes = ['uint8', 'uint16', 'uint32', 'uint64']

--- a/python/test/unit/operators/test_blocksparse.py
+++ b/python/test/unit/operators/test_blocksparse.py
@@ -5,9 +5,6 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.ops
 
-# FIXME remove this once Triton L0 queue and IPEX SYCL queue can be synchronized through events
-torch.xpu.enable_sync_mode()
-
 
 def sparsify_tensor(x, mask, block):
     ret = torch.empty((x.size(0), mask.sum(), block, block), dtype=x.dtype, device=x.device)

--- a/python/test/unit/operators/test_cross_entropy.py
+++ b/python/test/unit/operators/test_cross_entropy.py
@@ -5,9 +5,6 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.ops
 
-# FIXME remove this once Triton L0 queue and IPEX SYCL queue can be synchronized through events
-torch.xpu.enable_sync_mode()
-
 
 @pytest.mark.parametrize("M, N, dtype, mode", [  #
     (M, N, dtype, mode)

--- a/python/test/unit/operators/test_flash_attention.py
+++ b/python/test/unit/operators/test_flash_attention.py
@@ -5,9 +5,6 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.ops
 
-# FIXME remove this once Triton L0 queue and IPEX SYCL queue can be synchronized through events
-torch.xpu.enable_sync_mode()
-
 
 @pytest.mark.parametrize('Z, H, N_CTX, D_HEAD', [  #
     (2, 4, 512, 16),

--- a/python/test/unit/operators/test_inductor.py
+++ b/python/test/unit/operators/test_inductor.py
@@ -5,9 +5,6 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.language as tl
 
-# FIXME remove this once Triton L0 queue and IPEX SYCL queue can be synchronized through events
-torch.xpu.enable_sync_mode()
-
 
 def test_normalization_with_remat(device):
 

--- a/python/test/unit/operators/test_matmul.py
+++ b/python/test/unit/operators/test_matmul.py
@@ -8,9 +8,6 @@ import triton
 import triton.language as tl
 import triton.ops
 
-# FIXME remove this once Triton L0 queue and IPEX SYCL queue can be synchronized through events
-torch.xpu.enable_sync_mode()
-
 
 @pytest.mark.parametrize(
     "BLOCK_M, BLOCK_N, BLOCK_K, SPLIT_K, NWARP, NSTAGE, M, N, K, AT, BT, ADTYPE, BDTYPE, ALLOW_TF32, F8_FASTACCUM, ACC_DTYPE, OUTPUT_DTYPE",

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -5,9 +5,6 @@ import triton
 import triton.language as tl
 import pytest
 
-# FIXME remove this once Triton L0 queue and IPEX SYCL queue can be synchronized through events
-torch.xpu.enable_sync_mode()
-
 
 def test_kwargs():
     N = 1024

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -11,9 +11,6 @@ import triton
 import triton.language as tl
 from triton.runtime.jit import JITFunction
 
-# FIXME remove this once Triton L0 queue and IPEX SYCL queue can be synchronized through events
-torch.xpu.enable_sync_mode()
-
 tmpdir = ".tmp"
 
 

--- a/python/test/unit/runtime/test_launch.py
+++ b/python/test/unit/runtime/test_launch.py
@@ -30,22 +30,16 @@ def test_memory_leak() -> None:
 
     tracemalloc.start()
     try:
-        print("Hello Sarbojit")
         inp = torch.randn(10, device='xpu')
         out = torch.randn(10, device='xpu')
-        begin, _ = tracemalloc.get_traced_memory()
         kernel[(10, )](inp, out, 10, XBLOCK=16)
         gc.collect()
-        end, _ = tracemalloc.get_traced_memory()
-        print("Memory used : " + str(end - begin))
         begin, _ = tracemalloc.get_traced_memory()
         for _ in range(100):
             kernel[(10, )](inp, out, 10, XBLOCK=16)
         gc.collect()
         end, _ = tracemalloc.get_traced_memory()
-        print("Memory used after 100 iteration: " + str(end - begin))
         assert end - begin < 30000
-        #assert(False)
     finally:
         tracemalloc.stop()
 

--- a/python/test/unit/runtime/test_launch.py
+++ b/python/test/unit/runtime/test_launch.py
@@ -30,16 +30,22 @@ def test_memory_leak() -> None:
 
     tracemalloc.start()
     try:
+        print("Hello Sarbojit")
         inp = torch.randn(10, device='xpu')
         out = torch.randn(10, device='xpu')
+        begin, _ = tracemalloc.get_traced_memory()
         kernel[(10, )](inp, out, 10, XBLOCK=16)
         gc.collect()
+        end, _ = tracemalloc.get_traced_memory()
+        print("Memory used : " + str(end - begin))
         begin, _ = tracemalloc.get_traced_memory()
         for _ in range(100):
             kernel[(10, )](inp, out, 10, XBLOCK=16)
         gc.collect()
         end, _ = tracemalloc.get_traced_memory()
+        print("Memory used after 100 iteration: " + str(end - begin))
         assert end - begin < 30000
+        #assert(False)
     finally:
         tracemalloc.stop()
 

--- a/python/test/unit/runtime/test_subproc.py
+++ b/python/test/unit/runtime/test_subproc.py
@@ -9,9 +9,6 @@ import triton
 import triton.language as tl
 from triton.compiler import ASTSource
 
-# FIXME remove this once Triton L0 queue and IPEX SYCL queue can be synchronized through events
-torch.xpu.enable_sync_mode()
-
 tmpdir = ".tmp"
 
 

--- a/python/tutorials/01-vector-add.py
+++ b/python/tutorials/01-vector-add.py
@@ -24,8 +24,6 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.language as tl
 
-torch.xpu.enable_sync_mode()
-
 
 @triton.jit
 def add_kernel(x_ptr,  # *Pointer* to first input vector.

--- a/python/tutorials/02-fused-softmax.py
+++ b/python/tutorials/02-fused-softmax.py
@@ -27,8 +27,6 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.language as tl
 
-torch.xpu.enable_sync_mode()
-
 
 @torch.jit.script
 def naive_softmax(x):

--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -156,8 +156,6 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.language as tl
 
-torch.xpu.enable_sync_mode()
-
 
 # `triton.jit`'ed functions can be auto-tuned by using the `triton.autotune` decorator, which consumes:
 #   - A list of `triton.Config` objects that define different configurations of

--- a/python/tutorials/04-low-memory-dropout.py
+++ b/python/tutorials/04-low-memory-dropout.py
@@ -39,8 +39,6 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.language as tl
 
-torch.xpu.enable_sync_mode()
-
 
 @triton.jit
 def _dropout(

--- a/python/tutorials/05-layer-norm.py
+++ b/python/tutorials/05-layer-norm.py
@@ -35,8 +35,6 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.language as tl
 
-torch.xpu.enable_sync_mode()
-
 try:
     # This is https://github.com/NVIDIA/apex, NOT the apex on PyPi, so it
     # should not be added to extras_require in setup.py.

--- a/python/tutorials/06-fused-attention.py
+++ b/python/tutorials/06-fused-attention.py
@@ -18,8 +18,6 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.language as tl
 
-torch.xpu.enable_sync_mode()
-
 
 @triton.jit
 def _attn_fwd_inner(acc, l_i, m_i, q,  #

--- a/python/tutorials/07-math-functions.py
+++ b/python/tutorials/07-math-functions.py
@@ -20,8 +20,6 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.language as tl
 
-torch.xpu.enable_sync_mode()
-
 
 @triton.jit
 def asin_kernel(

--- a/python/tutorials/08-experimental-block-pointer.py
+++ b/python/tutorials/08-experimental-block-pointer.py
@@ -96,8 +96,6 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.language as tl
 
-torch.xpu.enable_sync_mode()
-
 
 @triton.autotune(
     configs=[

--- a/python/tutorials/09-experimental-tma-matrix-multiplication.py
+++ b/python/tutorials/09-experimental-tma-matrix-multiplication.py
@@ -34,8 +34,6 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.language as tl
 
-torch.xpu.enable_sync_mode()
-
 
 @triton.autotune(
     configs=[

--- a/python/tutorials/11-grouped-gemm.py
+++ b/python/tutorials/11-grouped-gemm.py
@@ -32,8 +32,6 @@ import intel_extension_for_pytorch  # type: ignore # noqa: F401
 import triton
 import triton.language as tl
 
-torch.xpu.enable_sync_mode()
-
 
 @triton.autotune(
     configs=[

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -80,17 +80,16 @@ static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
   // Extract triton::gpu::intel::DeviceArch from pci_device_id
   // https://dgpu-docs.intel.com/devices/hardware-table.html
   int pci_device_id = device_properties.deviceId;
-  int gpu_arch = 3;  // triton::gpu::intel::DeviceArch::UNKNOWN
-  switch ((pci_device_id >> 8) & 0xFF)
-  {
-    case 0x56:
-      gpu_arch = 0; // Arc GPUs 56xx
-      break;
-    case 0x0B: // PVC GPUs 0Bxx
-      gpu_arch = 1; // PVC
-      break;
-    default:
-      // fall through
+  int gpu_arch = 3; // triton::gpu::intel::DeviceArch::UNKNOWN
+  switch ((pci_device_id >> 8) & 0xFF) {
+  case 0x56:
+    gpu_arch = 0; // Arc GPUs 56xx
+    break;
+  case 0x0B:      // PVC GPUs 0Bxx
+    gpu_arch = 1; // PVC
+    break;
+  default:
+    // fall through
   }
 
   ze_device_compute_properties_t compute_properties = {};
@@ -350,19 +349,6 @@ static PyObject *initContext(PyObject *self, PyObject *args) {
   return Py_BuildValue("(K)", (uint64_t)context);
 }
 
-static PyObject *initEventPool(PyObject *self, PyObject *args) {
-  // Create event pool
-  ze_event_pool_desc_t tsEventPoolDesc = {
-      ZE_STRUCTURE_TYPE_EVENT_POOL_DESC, nullptr,
-      ZE_EVENT_POOL_FLAG_HOST_VISIBLE, // all events in pool are visible to Host
-      1                                // count
-  };
-  ZE_CHECK(zeEventPoolCreate(context, &tsEventPoolDesc, 0, nullptr,
-                             &eventPoolHandle));
-
-  return Py_BuildValue("(K)", (uint64_t)eventPoolHandle);
-}
-
 static PyObject *initDevices(PyObject *self, PyObject *args) {
   PyObject *cap;
   void *queue = NULL;
@@ -390,21 +376,6 @@ static PyObject *initDevices(PyObject *self, PyObject *args) {
   return Py_BuildValue("(i)", deviceCount);
 }
 
-static PyObject *getL0ImmCommandList(PyObject *self, PyObject *args) {
-  PyObject *cap;
-  void *queue = NULL;
-  if (!PyArg_ParseTuple(args, "O", &cap))
-    return NULL;
-  if (!(queue = PyCapsule_GetPointer(cap, PyCapsule_GetName(cap))))
-    return NULL;
-  sycl::queue *sycl_queue = static_cast<sycl::queue *>(queue);
-
-  if (sycl_queue_map.find(*sycl_queue) == sycl_queue_map.end()) {
-    update(*sycl_queue);
-  }
-  return Py_BuildValue("(K)", (uint64_t)(sycl_queue_map[*sycl_queue].cmd_list));
-}
-
 static PyObject *getL0Queue(PyObject *self, PyObject *args) {
   PyObject *cap;
   void *queue = NULL;
@@ -417,20 +388,6 @@ static PyObject *getL0Queue(PyObject *self, PyObject *args) {
     update(*sycl_queue);
   }
   return Py_BuildValue("(K)", (uint64_t)(sycl_queue_map[*sycl_queue].queue));
-}
-
-static PyObject *getL0DevPtr(PyObject *self, PyObject *args) {
-  PyObject *cap;
-  void *queue = NULL;
-  if (!PyArg_ParseTuple(args, "O", &cap))
-    return NULL;
-  if (!(queue = PyCapsule_GetPointer(cap, PyCapsule_GetName(cap))))
-    return NULL;
-  sycl::queue *sycl_queue = static_cast<sycl::queue *>(queue);
-  if (sycl_queue_map.find(*sycl_queue) == sycl_queue_map.end()) {
-    update(*sycl_queue);
-  }
-  return Py_BuildValue("(K)", (uint64_t)(sycl_queue_map[*sycl_queue].device));
 }
 
 static PyObject *getL0CtxtPtr(PyObject *self, PyObject *args) {
@@ -458,13 +415,7 @@ static PyMethodDef ModuleMethods[] = {
      "Initialize the ZE GPU context"},
     {"init_devices", initDevices, METH_VARARGS,
      "Initialize the ZE GPU devices and return device count"},
-    {"init_event_pool", initEventPool, METH_VARARGS,
-     "Initialize ZE event pool"},
-    {"get_l0_imm_cmd_list", getL0ImmCommandList, METH_VARARGS,
-     "Get l0 command list in case of immediate command list"},
     {"get_l0_queue", getL0Queue, METH_VARARGS, "Get l0 queue from sycl queue"},
-    {"get_l0_dev_ptr", getL0DevPtr, METH_VARARGS,
-     "Extract l0 device pointer from sycl queue"},
     {"get_l0_ctxt_ptr", getL0CtxtPtr, METH_VARARGS,
      "Extract l0 context pointer from sycl queue"},
     {NULL, NULL, 0, NULL} // sentinel

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -54,12 +54,9 @@ class XPUUtils(object):
         self.load_sycl_binary = mod.load_sycl_binary
         self.get_device_properties = mod.get_device_properties
         self.get_l0_queue = mod.get_l0_queue
-        self.get_l0_imm_cmd_list = mod.get_l0_imm_cmd_list
-        self.get_l0_dev_ptr = mod.get_l0_dev_ptr
         self.get_l0_ctxt_ptr = mod.get_l0_ctxt_ptr
         self.context = mod.init_context(self.get_sycl_queue())
         self.device_count = mod.init_devices(self.get_sycl_queue())
-        self.event_pool = mod.init_event_pool()[0]
         self.current_device = 0 if self.device_count[0] > 0 else -1
 
     def get_current_device(self):
@@ -177,98 +174,6 @@ def make_launcher(constants, signature, ids):
     }}
 
     #define ZE_CHECK(ans) {{ gpuAssert((ans), __FILE__, __LINE__); }}
-
-    static void _regular_launch(uint32_t gridX, uint32_t gridY, uint32_t gridZ, int num_warps, int shared_memory,
-                                ze_command_queue_handle_t queue, ze_device_handle_t _dev, ze_context_handle_t _ctxt,
-                                ze_kernel_handle_t function, ze_event_pool_handle_t event_pool
-                                {', ' + arg_decls if len(arg_decls) > 0 else ''}) {{
-      void *params[] = {{ {', '.join(f"&arg{i}" for i in signature.keys() if i not in constants)} }};
-
-      if (gridX*gridY*gridZ > 0) {{
-        {" ".join(f'zeKernelSetArgumentValue(function, {idx}, sizeof({ty_to_cpp(item)}), params[{idx}]);' for idx, item in enumerate([signature[i] for i in signature if i not in constants]))}
-        if (shared_memory) {{
-          uint32_t num_params = sizeof(params)/sizeof(params[0]);
-          zeKernelSetArgumentValue(function, num_params, shared_memory, NULL);
-        }}
-        zeKernelSetGroupSize(function, 32*num_warps, 1, 1);
-
-        ze_group_count_t grpCount = {{gridX, gridY, gridZ}};
-
-        // Create command list
-        ze_command_list_handle_t CmdList;
-        ze_command_list_desc_t CommandListDesc_ = {{
-            ZE_STRUCTURE_TYPE_COMMAND_LIST_DESC,
-            nullptr,
-            0,
-            0,
-        }};
-
-        ZE_CHECK(zeCommandListCreate(_ctxt, _dev, &CommandListDesc_, &CmdList));
-
-        ze_event_desc_t eventDesc = {{
-            ZE_STRUCTURE_TYPE_EVENT_DESC,
-            nullptr,
-            0,
-            0,
-            ZE_EVENT_SCOPE_FLAG_HOST
-        }};
-        ze_event_handle_t hEvent;
-        ZE_CHECK(zeEventCreate(event_pool, &eventDesc, &hEvent));
-
-        // Append a signal of an event into the command list after the kernel executes
-        ZE_CHECK(zeCommandListAppendLaunchKernel(CmdList, function, &grpCount, hEvent, 0, nullptr));
-
-        // close command list
-        ZE_CHECK(zeCommandListClose(CmdList));
-
-        // FIXME: The following statement currently doesn't synchronize all IPEX SYCL queues.
-        //        Needs to find all IPEX SYCL queues
-        // Synchronize the command queue to ensure previous IPEX SYCL commands complete before Triton kernel starts
-        // ZE_CHECK(zeCommandQueueSynchronize(queue, std::numeric_limits<uint64_t>::max()));
-
-        // execute command list
-        ZE_CHECK(zeCommandQueueExecuteCommandLists(queue, 1, &CmdList, nullptr));
-
-        // Wait on event to complete
-        ZE_CHECK(zeEventHostSynchronize(hEvent, std::numeric_limits<uint64_t>::max()));
-      }}
-    }}
-
-    static void _launch(uint32_t gridX, uint32_t gridY, uint32_t gridZ, int num_warps, int shared_memory,
-                        ze_command_list_handle_t queue, ze_kernel_handle_t function, ze_event_pool_handle_t event_pool
-                        {', ' + arg_decls if len(arg_decls) > 0 else ''}) {{
-      void *params[] = {{ {', '.join(f"&arg{i}" for i in signature.keys() if i not in constants)} }};
-
-      if (gridX*gridY*gridZ > 0) {{
-        {" ".join(f'zeKernelSetArgumentValue(function, {idx}, sizeof({ty_to_cpp(item)}), params[{idx}]);' for idx, item in enumerate([signature[i] for i in signature if i not in constants]))}
-        if (shared_memory) {{
-          uint32_t num_params = sizeof(params)/sizeof(params[0]);
-          zeKernelSetArgumentValue(function, num_params, shared_memory, NULL);
-        }}
-        zeKernelSetGroupSize(function, 32*num_warps, 1, 1);
-        ze_group_count_t grpCount = {{gridX, gridY, gridZ}};
-
-        ze_event_desc_t eventDesc = {{
-            ZE_STRUCTURE_TYPE_EVENT_DESC,
-            nullptr,
-            0,
-            0,
-            ZE_EVENT_SCOPE_FLAG_HOST
-        }};
-        ze_event_handle_t hEvent;
-        ZE_CHECK(zeEventCreate(event_pool, &eventDesc, &hEvent));
-
-        // FIXME: The following statement currently doesn't synchronize all IPEX SYCL queues.
-        //        Needs to find all IPEX SYCL queues
-        // Synchronize to ensure previous IPEX SYCL commands complete before Triton kernel starts
-        ZE_CHECK(zeCommandListHostSynchronize(queue, std::numeric_limits<uint64_t>::max()));
-
-        // Append a signal of an event into the command list after the kernel executes
-        ZE_CHECK(zeCommandListAppendLaunchKernel(queue, function, &grpCount, hEvent, 0, nullptr));
-        // Wait on event to complete
-        ZE_CHECK(zeEventHostSynchronize(hEvent, std::numeric_limits<uint64_t>::max()));
-      }}
-    }}
 
     typedef struct _DevicePtrInfo {{
       void* dev_ptr;


### PR DESCRIPTION
1. Removed torch sync mode call from all the tests. It is not required as new change is using sycl queue from torch.
2. Cleaned some of L0 code which are no longer needed as Triton now uses sycl runtime instead.