### PR TITLE
Fix sycl warnings

### DIFF
--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -90,7 +90,7 @@ static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
       gpu_arch = 1; // PVC
       break;
     default:
-      // fall through
+      ; // fall through
   }
 
   ze_device_compute_properties_t compute_properties = {};
@@ -302,15 +302,15 @@ bool update(sycl::queue sycl_queue) {
   // Get l0-context
   auto sycl_context = sycl_queue.get_context();
   ze_context_handle_t hCtxt =
-      get_native<sycl::backend::ext_oneapi_level_zero>(sycl_context);
+      sycl::get_native<sycl::backend::ext_oneapi_level_zero>(sycl_context);
   // Get l0-device
   std::vector<sycl::device> sycl_devices = sycl_context.get_devices();
   ze_device_handle_t hDev =
-      get_native<sycl::backend::ext_oneapi_level_zero>(sycl_devices[0]);
+      sycl::get_native<sycl::backend::ext_oneapi_level_zero>(sycl_devices[0]);
   // Get l0-queue
   bool immediate_cmd_list = false;
   std::variant<ze_command_queue_handle_t, ze_command_list_handle_t> queue_var =
-      get_native<sycl::backend::ext_oneapi_level_zero>(sycl_queue);
+      sycl::get_native<sycl::backend::ext_oneapi_level_zero>(sycl_queue);
   auto l0_queue = std::get_if<ze_command_queue_handle_t>(&queue_var);
   if (l0_queue == nullptr) {
     auto imm_cmd_list = std::get_if<ze_command_list_handle_t>(&queue_var);

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -355,7 +355,7 @@ def make_launcher(constants, signature, ids):
     auto cgf = [&](sycl::handler &cgh) {{
       {" ".join(f'set_scalar_arg(cgh, {idx}, sizeof({ty_to_cpp(item)}), params[{idx}]);' for idx, item in enumerate([signature[i] for i in signature if i not in constants]))}
       if (shared_memory) {{
-          using share_mem_t = sycl::accessor<int8_t, 1, sycl::access::mode::read_write, sycl::access::target::local>;
+          using share_mem_t = sycl::local_accessor<int8_t, 1>;
           share_mem_t local_buffer = share_mem_t(shared_memory, cgh);
           cgh.set_arg(num_params, local_buffer);
           //cgh.parallel_for(sycl::nd_range{{sycl::range{{(uint32_t)gridX*threads_per_warp*num_warps}}, sycl::range{{work_group_size}}}}, kernel_ptr);


### PR DESCRIPTION
There are some runtime warning from sycl version change, like

```
/tmp/tmpvi6hoaq1/main.cpp:206:111: warning: 'local' is deprecated: use `local_accessor` instead [-Wdeprecated-declarations]
  206 |           using share_mem_t = sycl::accessor<int8_t, 1, sycl::access::mode::read_write, sycl::access::target::local>; 
```
```
/tmp/tmpj_mb82xa/main.cpp:313:7: warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension [-Wc++20-extensions]
  313 |       get_native<sycl::backend::ext_oneapi_level_zero>(sycl_queue);
      |       ^
```
Fix these based on the warning message.