### PR TITLE
Check errors before using l0 kernel pointer

### DIFF
--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -43,7 +43,10 @@ static inline void gpuAssert(ze_result_t code, const char *file, int line) {
     char err[1024] = {0};
     strcat(err, prefix);
     strcat(err, str.c_str());
+    PyGILState_STATE gil_state;
+    gil_state = PyGILState_Ensure();
     PyErr_SetString(PyExc_RuntimeError, err);
+    PyGILState_Release(gil_state);
   }
 }
 
@@ -226,8 +229,14 @@ static PyObject *loadSyclBinary(PyObject *self, PyObject *args) {
   auto l0_context = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(ctx);
   auto l0_module =
       create_module(l0_context, l0_device, binary_ptr, binary_size);
-
+      
   auto l0_kernel = create_function(l0_module, kernel_name);
+
+  if (PyErr_Occurred()) {
+    // check for errors from module/kernel creation
+    return NULL;
+  }
+
   ze_kernel_properties_t props;
   props.stype = ZE_STRUCTURE_TYPE_KERNEL_PROPERTIES;
   props.pNext = nullptr;

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -229,7 +229,6 @@ static PyObject *loadSyclBinary(PyObject *self, PyObject *args) {
   auto l0_context = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(ctx);
   auto l0_module =
       create_module(l0_context, l0_device, binary_ptr, binary_size);
-      
   auto l0_kernel = create_function(l0_module, kernel_name);
 
   if (PyErr_Occurred()) {


### PR DESCRIPTION
Checks for stored runtime error before using l0 kernel call. I suppose we could also check for a nullptr in the l0 kernel handle but it seems redundant - an assert would be nice, but I did not see other c code using asserts. I copied the additional lines around the GIL from upstream nvidia backend - it appears that was added as part of a recent bug fix. 

After this call we are once again properly surfacing L0 errors:
``` 
FAILED test_core.py::test_locality[4-2048-64-sum] - RuntimeError: Triton Error [ZE]: 2013265944
```

Closes #428 