### PR TITLE
Avoid hardcoding the location of build compiler in `compile-triton.sh`

### DIFF
--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set +o xtrace
-if [ ! -z "$BASE" ]; then
+if [ -z "$BASE" ]; then
   echo "**** BASE is not given *****"
   BASE=$(cd $(dirname "$0")/../.. && pwd)
   echo "**** Default BASE is set to $BASE ****"
@@ -81,11 +81,11 @@ fi
 ############################################################################
 ## Configure and build the llvm project.
 
-if [ ! -z "$C_COMPILER" ]; then
+if [ -z "$C_COMPILER" ]; then
   C_COMPILER=`which gcc`
   echo "**** C_COMPILER is set to $C_COMPILER ****"
 fi
-if [ ! -z "$CXX_COMPILER" ]; then
+if [ -z "$CXX_COMPILER" ]; then
   CXX_COMPILER=`which g++`
   echo "**** CXX_COMPILER is set to $CXX_COMPILER ****"
 fi

--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set +o xtrace
-if [ ! -d "$BASE" ]; then
+if [ ! -z "$BASE" ]; then
   echo "**** BASE is not given *****"
   BASE=$(cd $(dirname "$0")/../.. && pwd)
   echo "**** Default BASE is set to $BASE ****"
@@ -81,10 +81,12 @@ fi
 ############################################################################
 ## Configure and build the llvm project.
 
-if [ ! -d "$C_COMPILER" ] || [ ! -d "$CXX_COMPILER" ]; then
+if [ ! -z "$C_COMPILER" ]; then
   C_COMPILER=`which gcc`
-  CXX_COMPILER=`which g++`
   echo "**** C_COMPILER is set to $C_COMPILER ****"
+fi
+if [ ! -z "$CXX_COMPILER" ]; then
+  CXX_COMPILER=`which g++`
   echo "**** CXX_COMPILER is set to $CXX_COMPILER ****"
 fi
 

--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -81,8 +81,12 @@ fi
 ############################################################################
 ## Configure and build the llvm project.
 
-C_COMPILER=/usr/bin/gcc
-CXX_COMPILER=/usr/bin/g++
+if [ ! -d "$C_COMPILER" ] || [ ! -d "$CXX_COMPILER" ]; then
+  C_COMPILER=`which gcc`
+  CXX_COMPILER=`which g++`
+  echo "**** C_COMPILER is set to $C_COMPILER ****"
+  echo "**** CXX_COMPILER is set to $CXX_COMPILER ****"
+fi
 
 if [ ! -d "$LLVM_PROJ_BUILD" ]
 then


### PR DESCRIPTION
Addressed post review comment: https://github.com/intel/intel-xpu-backend-for-triton/pull/421#pullrequestreview-1855082914