### PR TITLE
Temporarily remove `Quick Installation` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,6 @@ The foundations of this project are described in the following MAPL2019 publicat
 
 The [official documentation](https://triton-lang.org) contains installation instructions and tutorials.
 
-# Quick Installation
-
-You can install the latest stable release of Triton from pip:
-
-```bash
-pip install triton
-```
-Binary wheels are available for CPython 3.7-3.11 and PyPy 3.8-3.9.
-
-And the latest nightly release:
-
-```bash
-pip install -U --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/ triton-nightly
-```
-
 # Install from source
 
 ```


### PR DESCRIPTION
Address code review comment: https://github.com/intel/intel-xpu-backend-for-triton/pull/437#pullrequestreview-1860383398

Temporarily remove `Quick Installation` section and bring it back when we publish new triton-xpu wheel with llvm-target branch in PyPI.