### PR TITLE
Use relative tolerance for matmul tutorials.

### DIFF
--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -309,8 +309,7 @@ triton_output = matmul(a, b)
 torch_output = torch.matmul(a, b)
 print(f"triton_output={triton_output}")
 print(f"torch_output={torch_output}")
-# FIXME: reset atol to 1e-2 for xpu
-if torch.allclose(triton_output, torch_output, atol=1e-1, rtol=0):
+if torch.allclose(triton_output, torch_output, atol=1e-2, rtol=1e-3):
     print("✅ Triton and Torch match")
 else:
     print("❌ Triton and Torch differ")

--- a/python/tutorials/08-experimental-block-pointer.py
+++ b/python/tutorials/08-experimental-block-pointer.py
@@ -228,8 +228,7 @@ torch_output = torch.matmul(a, b)
 print(f"triton_output={triton_output}")
 print(f"torch_output={torch_output}")
 
-#FIXME: Once tl.dot is lowered to DPAS instructions put back the precision to (atol=1e-2).
-if torch.allclose(triton_output, torch_output, atol=4e-2, rtol=0):
+if torch.allclose(triton_output, torch_output, atol=1e-2, rtol=1e-3):
     print("✅ Triton and Torch match")
 else:
     print("❌ Triton and Torch differ")

--- a/python/tutorials/11-grouped-gemm.py
+++ b/python/tutorials/11-grouped-gemm.py
@@ -206,8 +206,7 @@ for i in range(group_size):
 tri_out = group_gemm_fn(group_A, group_B)
 ref_out = [torch.matmul(a, b) for a, b in zip(group_A, group_B)]
 for i in range(group_size):
-    # FIXME: tolerance was increased from 1e-2 to 3e-2 to allow test to run
-    assert torch.allclose(ref_out[i], tri_out[i], atol=3e-1, rtol=0)
+    assert torch.allclose(ref_out[i], tri_out[i], atol=1e-2, rtol=1e-3)
 
 
 # only launch the kernel, no tensor preparation here to remove all overhead


### PR DESCRIPTION
When we compare matmul results in tutorials, it's unreasonable to expect complete results match. Used tolerance values should at least consider neighbor FP16 values as matched. FP16 has 10 bits for mantissa, so for normalized values the difference between two consequent values is up to 1/(2^10) which is ~0.001. So I propose to use this value as `rtol` in related tutorials. 

Resolves #468 