### PR TITLE
Add tensor pointer checks to XPU launcher to detect CPU tensors.

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3188,7 +3188,7 @@ def test_noop(device):
 @pytest.mark.parametrize("device", ['xpu', 'cpu', 'cpu_pinned'])
 def test_pointer_arguments(device):
     if is_xpu() and device in ['cpu_pinned']:
-        pytest.skip("RuntimeError: Pinned memory requires CUDA.")
+        pytest.xfail("RuntimeError: Pinned memory requires CUDA.")
 
     @triton.jit
     def kernel(x):

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3187,8 +3187,8 @@ def test_noop(device):
 
 @pytest.mark.parametrize("device", ['xpu', 'cpu', 'cpu_pinned'])
 def test_pointer_arguments(device):
-    if is_xpu() and device in ['cpu', 'cpu_pinned']:
-        pytest.skip("FIXME: Incorrect result on XPU")
+    if is_xpu() and device in ['cpu_pinned']:
+        pytest.skip("RuntimeError: Pinned memory requires CUDA.")
 
     @triton.jit
     def kernel(x):


### PR DESCRIPTION
This patch checks that the tensors passed to the launcher are in the device memory. This prevents kernel launch on tensors located on CPU and raises ValueError.

Resolves #457 