### PR TITLE
Copy  `libGenISAIntrinsics.a` to packages dir before building Triton

### DIFF
--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -190,12 +190,13 @@ function build {
   if [ "$BUILD_LLVM" = true ]; then
     build_llvm
   fi
-  if [ "$BUILD_TRITON" = true ]; then
-    build_triton
-  fi
 
   # Install libGenISAIntrinsics.a
   cp $LLVM_PROJ/mlir/lib/Target/LLVMIR/Dialect/GENX/libGenISAIntrinsics.a $PACKAGES_DIR/llvm/lib
+
+  if [ "$BUILD_TRITON" = true ]; then
+    build_triton
+  fi
 }
 
 build


### PR DESCRIPTION
https://github.com/intel/intel-xpu-backend-for-triton/pull/480 incorrectly changed the position to copy `libGenISAIntrinsics.a` to `packages` directory. 