### PR TITLE
[NFC] Added comments for the result of test_attention_fwd_bwd

### DIFF
--- a/python/test/unit/operators/test_blocksparse.py
+++ b/python/test/unit/operators/test_blocksparse.py
@@ -150,7 +150,8 @@ def test_attention_fwd_bwd(block, dtype, device, input_scale=1.0, scale=1 / 8.0,
         if capability[0] < 7:
             pytest.skip("Only test tl.dot() on devices with sm >= 70")
 
-    pytest.skip("FIXME: AssertionError: Scalars are not close!")
+    # Note: Triton result on XPU is correct compared to the result on CUDA.
+    pytest.skip("FIXME: Torch produces incorrect nan values")
 
     # inputs
     qkv_shape = (batch_size, n_heads, n_ctx, 64)


### PR DESCRIPTION
Triton side of test_attention_fwd_bwd in test_blocksparse.py is no longer failing after https://github.com/intel/llvm/pull/12709. Updated function to include comments of current result of the function.