### PR TITLE
[NFI] Use `LLVMTypeConverter` instead of `TritonGPUToLLVMTypeConverter` for MMA

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM.cpp
@@ -16,27 +16,27 @@ LogicalResult convertFMADot(triton::DotOp op, triton::DotOp::Adaptor adaptor,
                             ConversionPatternRewriter &rewriter);
 
 LogicalResult convertMMA884(triton::DotOp op, triton::DotOp::Adaptor adaptor,
-                            TritonGPUToLLVMTypeConverter *typeConverter,
+                            const LLVMTypeConverter *typeConverter,
                             ConversionPatternRewriter &rewriter);
 
 LogicalResult convertMMA1688(triton::DotOp op, triton::DotOp::Adaptor adaptor,
-                             TritonGPUToLLVMTypeConverter *typeConverter,
+                             const LLVMTypeConverter *typeConverter,
                              ConversionPatternRewriter &rewriter);
 
 LogicalResult convertMMA16816(triton::DotOp op, triton::DotOp::Adaptor adaptor,
-                              TritonGPUToLLVMTypeConverter *typeConverter,
+                              const LLVMTypeConverter *typeConverter,
                               ConversionPatternRewriter &rewriter);
 
 LogicalResult convertDPAS(triton::DotOp op, triton::DotOp::Adaptor adaptor,
                           TritonGPUToLLVMTypeConverter *typeConverter,
                           ConversionPatternRewriter &rewriter);
 LogicalResult convertWGMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
-                           TritonGPUToLLVMTypeConverter *typeConverter,
+                           const LLVMTypeConverter *typeConverter,
                            ConversionPatternRewriter &rewriter, Value thread);
 
 LogicalResult convertAsyncWGMMA(triton::nvidia_gpu::DotAsyncOp op,
                                 triton::nvidia_gpu::DotAsyncOp::Adaptor adaptor,
-                                TritonGPUToLLVMTypeConverter *typeConverter,
+                                const LLVMTypeConverter *typeConverter,
                                 ConversionPatternRewriter &rewriter,
                                 Value thread);
 namespace {

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv1.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv1.cpp
@@ -16,13 +16,13 @@ static Type getMmaRetType(TensorType operand) {
   return struct_ty(SmallVector<Type>{8, fp32Ty});
 }
 
-static ValueTable
-extractLoadedOperand(Value llStruct, int NK,
-                     ConversionPatternRewriter &rewriter,
-                     TritonGPUToLLVMTypeConverter *typeConverter, Type type) {
+static ValueTable extractLoadedOperand(Value llStruct, int NK,
+                                       ConversionPatternRewriter &rewriter,
+                                       const LLVMTypeConverter *typeConverter,
+                                       Type type) {
   ValueTable rcds;
   SmallVector<Value> elems =
-      typeConverter->unpackLLElements(llStruct.getLoc(), llStruct, rewriter);
+      unpackLLElements(llStruct.getLoc(), llStruct, rewriter);
 
   int offset = 0;
   for (int i = 0; offset < elems.size(); ++i) {
@@ -36,7 +36,7 @@ extractLoadedOperand(Value llStruct, int NK,
 }
 
 LogicalResult convertMMA884(triton::DotOp op, triton::DotOp::Adaptor adaptor,
-                            TritonGPUToLLVMTypeConverter *typeConverter,
+                            const LLVMTypeConverter *typeConverter,
                             ConversionPatternRewriter &rewriter) {
   auto *ctx = op.getContext();
   auto loc = op.getLoc();
@@ -83,8 +83,7 @@ LogicalResult convertMMA884(triton::DotOp op, triton::DotOp::Adaptor adaptor,
   // accumulator value that is shared between the MMA instructions inside a
   // DotOp, we can call the order of the values the accumulator-internal
   // order.
-  SmallVector<Value> acc =
-      typeConverter->unpackLLElements(loc, adaptor.getC(), rewriter);
+  SmallVector<Value> acc = unpackLLElements(loc, adaptor.getC(), rewriter);
   size_t resSize = acc.size();
 
   // The resVals holds the final result of the DotOp.
@@ -155,7 +154,7 @@ LogicalResult convertMMA884(triton::DotOp op, triton::DotOp::Adaptor adaptor,
     resVals[i] = acc[i];
   }
 
-  Value res = typeConverter->packLLElements(loc, resVals, rewriter, DTensorTy);
+  Value res = packLLElements(loc, typeConverter, resVals, rewriter, DTensorTy);
   rewriter.replaceOp(op, res);
   return success();
 }

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv2.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv2.cpp
@@ -10,7 +10,7 @@ using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
 using ValueTableV2 = std::map<std::pair<unsigned, unsigned>, Value>;
 
 Value loadC(Value tensor, Value llTensor,
-            TritonGPUToLLVMTypeConverter *typeConverter, Location loc,
+            const LLVMTypeConverter *typeConverter, Location loc,
             ConversionPatternRewriter &rewriter) {
   MLIRContext *ctx = tensor.getContext();
   auto tensorTy = tensor.getType().cast<RankedTensorType>();
@@ -46,7 +46,7 @@ Value loadC(Value tensor, Value llTensor,
     Type structTy = LLVM::LLVMStructType::getLiteral(
         ctx, SmallVector<Type>(cPack.size(), cPackTy));
     Value result =
-        typeConverter->packLLElements(loc, cPack, rewriter, structTy);
+        packLLElements(loc, typeConverter, cPack, rewriter, structTy);
     return result;
   }
 
@@ -54,11 +54,11 @@ Value loadC(Value tensor, Value llTensor,
 }
 
 ValueTableV2 getValuesFromDotOperandLayoutStruct(
-    TritonGPUToLLVMTypeConverter *typeConverter, Location loc,
+    const LLVMTypeConverter *typeConverter, Location loc,
     ConversionPatternRewriter &rewriter, Value value, int n0, int n1,
     RankedTensorType type) {
 
-  auto elems = typeConverter->unpackLLElements(loc, value, rewriter);
+  auto elems = unpackLLElements(loc, value, rewriter);
   int offset{};
   ValueTableV2 vals;
   for (int i = 0; i < n0; ++i) {
@@ -272,7 +272,7 @@ static void callMmaAmpere(PTXBuilder &builder, unsigned m, unsigned n,
   mma(retArgs, aArgs, bArgs, cArgs);
 }
 
-LogicalResult convertDot(TritonGPUToLLVMTypeConverter *typeConverter,
+LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
                          ConversionPatternRewriter &rewriter, Location loc,
                          Value a, Value b, Value c, Value d, Value loadedA,
                          Value loadedB, Value loadedC, DotOp op,
@@ -303,7 +303,7 @@ LogicalResult convertDot(TritonGPUToLLVMTypeConverter *typeConverter,
   auto hb = getValuesFromDotOperandLayoutStruct(typeConverter, loc, rewriter,
                                                 loadedB, std::max(repN / 2, 1),
                                                 repK, bTensorTy);
-  auto fc = typeConverter->unpackLLElements(loc, loadedC, rewriter);
+  auto fc = unpackLLElements(loc, loadedC, rewriter);
   auto numMmaRets = dTensorTy.getElementType().getIntOrFloatBitWidth() / 8;
   int numCPackedElem = 4 / numMmaRets;
 
@@ -361,7 +361,7 @@ LogicalResult convertDot(TritonGPUToLLVMTypeConverter *typeConverter,
               : bitcast(fc[i], resElemTy);
     }
   }
-  Value res = typeConverter->packLLElements(loc, results, rewriter, structTy);
+  Value res = packLLElements(loc, typeConverter, results, rewriter, structTy);
 
   rewriter.replaceOp(op, res);
 
@@ -369,7 +369,7 @@ LogicalResult convertDot(TritonGPUToLLVMTypeConverter *typeConverter,
 }
 
 LogicalResult convertMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
-                         TritonGPUToLLVMTypeConverter *typeConverter,
+                         const LLVMTypeConverter *typeConverter,
                          ConversionPatternRewriter &rewriter, bool isTuring) {
   auto loc = op.getLoc();
   auto mmaLayout = op.getResult()
@@ -401,14 +401,14 @@ LogicalResult convertMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
 
 // Convert to mma.m16n8k8
 LogicalResult convertMMA1688(triton::DotOp op, triton::DotOp::Adaptor adaptor,
-                             TritonGPUToLLVMTypeConverter *typeConverter,
+                             const LLVMTypeConverter *typeConverter,
                              ConversionPatternRewriter &rewriter) {
   return convertMMA(op, adaptor, typeConverter, rewriter, true /*isTuring*/);
 }
 
 // Convert to mma.m16n8k16
 LogicalResult convertMMA16816(triton::DotOp op, triton::DotOp::Adaptor adaptor,
-                              TritonGPUToLLVMTypeConverter *typeConverter,
+                              const LLVMTypeConverter *typeConverter,
                               ConversionPatternRewriter &rewriter) {
   return convertMMA(op, adaptor, typeConverter, rewriter, false /*isTuring*/);
 }

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -193,7 +193,7 @@ private:
   Value descriptor;
 };
 
-DotOpMmaV3SmemLoader loadA(TritonGPUToLLVMTypeConverter *typeConverter,
+DotOpMmaV3SmemLoader loadA(const LLVMTypeConverter *typeConverter,
                            ConversionPatternRewriter &rewriter, Location loc,
                            const NvidiaMmaEncodingAttr &mmaEncoding,
                            Value tensor, Value smemObjBase, Value thread) {
@@ -230,7 +230,7 @@ DotOpMmaV3SmemLoader loadA(TritonGPUToLLVMTypeConverter *typeConverter,
           loc};
 }
 
-DotOpMmaV3SmemLoader loadB(TritonGPUToLLVMTypeConverter *typeConverter,
+DotOpMmaV3SmemLoader loadB(const LLVMTypeConverter *typeConverter,
                            ConversionPatternRewriter &rewriter, Location loc,
                            NvidiaMmaEncodingAttr &mmaEncoding, Value tensor,
                            Value base, Value thread) {
@@ -367,7 +367,7 @@ static SmallVector<Value> emitWait(ConversionPatternRewriter &rewriter,
   return results;
 }
 
-LogicalResult convertDot(TritonGPUToLLVMTypeConverter *typeConverter,
+LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
                          ConversionPatternRewriter &rewriter, Location loc,
                          Operation *op, Value a, Value b, Value c, Value d,
                          Value loadedA, Value loadedB, Value loadedC,
@@ -415,12 +415,12 @@ LogicalResult convertDot(TritonGPUToLLVMTypeConverter *typeConverter,
     aLoader =
         loadA(typeConverter, rewriter, loc, mmaEncoding, a, baseA, thread);
   } else {
-    structA = typeConverter->unpackLLElements(loc, loadedA, rewriter);
+    structA = unpackLLElements(loc, loadedA, rewriter);
   }
   DotOpMmaV3SmemLoader bLoader =
       loadB(typeConverter, rewriter, loc, mmaEncoding, b, baseB, thread);
 
-  auto fc = typeConverter->unpackLLElements(loc, loadedC, rewriter);
+  auto fc = unpackLLElements(loc, loadedC, rewriter);
 
   triton::nvgpu::WGMMAEltType eltTypeC = getMmaRetType(d);
   triton::nvgpu::WGMMAEltType eltTypeA = getMmaOperandType(a, allowTF32);
@@ -457,7 +457,7 @@ LogicalResult convertDot(TritonGPUToLLVMTypeConverter *typeConverter,
           LLVM::LLVMStructType::getLiteral(rewriter.getContext(), elemTypes);
       Value d;
       if (!zeroAcc)
-        d = typeConverter->packLLElements(loc, mmaOut, rewriter, accTy);
+        d = packLLElements(loc, typeConverter, mmaOut, rewriter, accTy);
       uint32_t numLowPrecisionAcc = 0;
       Value partialAcc;
       for (int k = 0; k < numRepK; ++k) {
@@ -472,7 +472,7 @@ LogicalResult convertDot(TritonGPUToLLVMTypeConverter *typeConverter,
           auto regATy = LLVM::LLVMStructType::getLiteral(
               rewriter.getContext(),
               SmallVector<Type>(regA.size(), regA[0].getType()));
-          a = typeConverter->packLLElements(loc, regA, rewriter, regATy);
+          a = packLLElements(loc, typeConverter, regA, rewriter, regATy);
         }
         auto b = bLoader.smemLoad(n, k, rewriter, loc);
         ValueRange operands{a, b, d};
@@ -498,7 +498,7 @@ LogicalResult convertDot(TritonGPUToLLVMTypeConverter *typeConverter,
           partialAcc = Value();
         }
       }
-      auto acc = typeConverter->unpackLLElements(loc, d, rewriter);
+      auto acc = unpackLLElements(loc, d, rewriter);
       for (int i = 0; i < acc.size(); ++i) {
         mmaResults.push_back(acc[i]);
       }
@@ -516,13 +516,13 @@ LogicalResult convertDot(TritonGPUToLLVMTypeConverter *typeConverter,
   Type structTy = LLVM::LLVMStructType::getLiteral(
       mmaEncoding.getContext(),
       SmallVector<Type>(results.size(), dTensorTy.getElementType()));
-  auto res = typeConverter->packLLElements(loc, results, rewriter, structTy);
+  auto res = packLLElements(loc, typeConverter, results, rewriter, structTy);
   rewriter.replaceOp(op, res);
   return success();
 }
 
 LogicalResult convertWGMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
-                           TritonGPUToLLVMTypeConverter *typeConverter,
+                           const LLVMTypeConverter *typeConverter,
                            ConversionPatternRewriter &rewriter, Value thread) {
   auto loc = op.getLoc();
   Value A = op.getA();
@@ -548,7 +548,7 @@ LogicalResult convertWGMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
 
 LogicalResult convertAsyncWGMMA(triton::nvidia_gpu::DotAsyncOp op,
                                 triton::nvidia_gpu::DotAsyncOp::Adaptor adaptor,
-                                TritonGPUToLLVMTypeConverter *typeConverter,
+                                const LLVMTypeConverter *typeConverter,
                                 ConversionPatternRewriter &rewriter,
                                 Value thread) {
   auto loc = op.getLoc();

--- a/lib/Conversion/TritonGPUToLLVM/Utility.h
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.h
@@ -462,6 +462,58 @@ static Value getSharedMemoryBase(Location loc,
 
 } // namespace LLVM
 
+static SmallVector<Value>
+unpackLLElements(Location loc, Value llvmStruct,
+                 ConversionPatternRewriter &rewriter) {
+  assert(bool(llvmStruct) && "can not unpack null values");
+  if (llvmStruct.getType().isIntOrIndexOrFloat() ||
+      llvmStruct.getType().isa<triton::PointerType>() ||
+      llvmStruct.getType().isa<LLVM::LLVMPointerType>())
+    return {llvmStruct};
+  ArrayRef<Type> types =
+      llvmStruct.getType().cast<LLVM::LLVMStructType>().getBody();
+  SmallVector<Value> results(types.size());
+  for (unsigned i = 0; i < types.size(); ++i) {
+    Type type = types[i];
+    results[i] = extract_val(type, llvmStruct, i);
+  }
+  return results;
+}
+
+static Value packLLElements(Location loc,
+                            const LLVMTypeConverter *typeConverter,
+                            ValueRange resultVals,
+                            ConversionPatternRewriter &rewriter, Type type) {
+  auto structType =
+      typeConverter->convertType(type).dyn_cast<LLVM::LLVMStructType>();
+  if (!structType) {
+    assert(resultVals.size() == 1);
+    return *resultVals.begin();
+  }
+
+  auto elementTypes = structType.getBody();
+  if (elementTypes.size() != resultVals.size()) {
+    emitError(loc) << " size mismatch when packing elements for LLVM struct"
+                   << " expected " << elementTypes.size() << " but got "
+                   << resultVals.size();
+  }
+  Value llvmStruct = rewriter.create<LLVM::UndefOp>(loc, structType);
+  for (const auto &v : llvm::enumerate(resultVals)) {
+    if (!v.value()) {
+      emitError(loc)
+          << "cannot insert null values into struct, but tried to insert"
+          << v.value();
+    }
+    if (v.value().getType() != elementTypes[v.index()]) {
+      emitError(loc) << "invalid element type in packLLEElements. Expected "
+                     << elementTypes[v.index()] << " but got "
+                     << v.value().getType();
+    }
+    llvmStruct = insert_val(structType, llvmStruct, v.value(), v.index());
+  }
+  return llvmStruct;
+}
+
 static Value llGetPid(int axis, Location loc, ModuleOp moduleOp,
                       ConversionPatternRewriter &rewriter,
                       mlir::triton::Target target) {


### PR DESCRIPTION
There are no need to use `TritonGPUToLLVMTypeConverter` for MMA classes, as we don't need to specialize for our target, so changing to use `LLVMTypeConverter`, to make merging from upstream easier.