### PR TITLE
Improve E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install required dependencies
         run: |
           sudo apt update -y
-          sudo apt install -y libpng-dev libjpeg-dev pkg-config libgl1 libpango-1.0-0
+          sudo apt install -y libpng-dev libjpeg-dev pkg-config libgl1 libpango-1.0-0 libpangoft2-1.0-0
           pip install wheel
 
       - name: Identify versions

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,9 +40,6 @@ jobs:
           - amp_bf16
           - amp_fp16
           - float32
-#        mode:
-#          - inference
-#          - training
       max-parallel: 2
       fail-fast: false
     timeout-minutes: 720
@@ -277,15 +274,45 @@ jobs:
             $GITHUB_WORKSPACE/scripts/inductor_xpu_test.sh ${{ matrix.model }} ${{ matrix.dtype }} $mode accuracy xpu 0
           done
 
+      - name: Report environment details
+        run: |
+          mkdir -p inductor_log
+          TIMESTAMP=$(date '+%Y%m%d%H%M%S')
+          echo "TIMESTAMP=$TIMESTAMP" >> "${GITHUB_ENV}"
+
+          cat <<EOF | tee inductor_log/.env
+          TIMESTAMP=$TIMESTAMP
+          JOB_NAME=${{ join(matrix.*, '-') }}
+          GITHUB_RUN_ID=$GITHUB_RUN_ID
+          GITHUB_RUN_NUMBER=$GITHUB_RUN_NUMBER
+          GITHUB_RUN_ATTEMPT=$GITHUB_RUN_ATTEMPT
+          PYTHON_VERSION=$PYTHON_VERSION
+          PYTORCH_REPO=$PYTORCH_REPO
+          PYTORCH_COMMIT_ID=$PYTORCH_COMMIT_ID
+          IPEX_REPO=$IPEX_REPO
+          IPEX_COMMIT_ID=$IPEX_COMMIT_ID
+          LLVM_REPO=$LLVM_REPO
+          LLVM_COMMIT_ID=$LLVM_COMMIT_ID
+          BENCHMARK_REPO=$BENCHMARK_REPO
+          BENCHMARK_COMMIT_ID=$BENCHMARK_COMMIT_ID
+          TRITON_REPO=$GITHUB_REPOSITORY
+          TRITON_COMMIT_ID=$GITHUB_SHA
+          TORCHVISION_COMMIT_ID=$TORCHVISION_COMMIT_ID
+          TORCHTEXT_COMMIT_ID=$TORCHTEXT_COMMIT_ID
+          TORCHAUDIO_COMMIT_ID=$TORCHAUDIO_COMMIT_ID
+          TRANSFORMERS_VERSION=$TRANSFORMERS_VERSION
+          TIMM_COMMIT_ID=$TIMM_COMMIT_ID
+          EOF
+
       - name: Copy reports
         run: |
           mkdir -p /cache/reports/e2e
           TMPDIR=$(mktemp -d -p /cache/reports/e2e XXXXXXXXX.tmp)
           cp -r $GITHUB_WORKSPACE/inductor_log/* $TMPDIR
-          mv -T $TMPDIR /cache/reports/e2e/$(date '+%Y%m%d%H%M%S')-${{ matrix.model }}-${{ matrix.dtype }} || rm -rf $TMPDIR
+          mv -T $TMPDIR /cache/reports/e2e/$TIMESTAMP-${{ join(matrix.*, '-') }} || rm -rf $TMPDIR
 
       - name: Upload test logs
         uses: actions/upload-artifact@v4
         with:
-          name: logs-${{ matrix.model }}-${{ matrix.dtype }}
+          name: logs-${{ join(matrix.*, '-') }}
           path: inductor_log

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   build:
-    name: Build
+    name: Test
     runs-on:
       - glados
       - spr
@@ -287,5 +287,5 @@ jobs:
       - name: Upload test logs
         uses: actions/upload-artifact@v4
         with:
-          name: logs-${{ matrix.model }}-${{ matrix.mode }}
+          name: logs-${{ matrix.model }}-${{ matrix.dtype }}
           path: inductor_log

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -209,7 +209,6 @@ jobs:
       - name: Build Triton wheels
         if: ${{ steps.triton-cache.outputs.status == 'miss' }}
         run: |
-          pip install wheel
           cd python
           python setup.py bdist_wheel
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,11 +36,16 @@ jobs:
           - huggingface
           - timm_models
           - torchbench
-        mode:
-          - inference
-          - training
+        dtype:
+          - amp_bf16
+          - amp_fp16
+          - float32
+#        mode:
+#          - inference
+#          - training
       max-parallel: 2
-    timeout-minutes: 240
+      fail-fast: false
+    timeout-minutes: 720
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -268,8 +273,8 @@ jobs:
           source ~/intel/oneapi/setvars.sh
           export WORKSPACE=$GITHUB_WORKSPACE
           cd pytorch
-          for dtype in amp_bf16 amp_fp16 float32; do
-            $GITHUB_WORKSPACE/scripts/inductor_xpu_test.sh ${{ matrix.model }} $dtype ${{ matrix.mode }} accuracy xpu 0
+          for mode in training inference; do
+            $GITHUB_WORKSPACE/scripts/inductor_xpu_test.sh ${{ matrix.model }} ${{ matrix.dtype }} $mode accuracy xpu 0
           done
 
       - name: Copy reports
@@ -277,7 +282,7 @@ jobs:
           mkdir -p /cache/reports/e2e
           TMPDIR=$(mktemp -d -p /cache/reports/e2e XXXXXXXXX.tmp)
           cp -r $GITHUB_WORKSPACE/inductor_log/* $TMPDIR
-          mv -T $TMPDIR /cache/reports/e2e/$(date '+%Y%m%d%H%M%S')-${{ matrix.model }}-${{ matrix.mode }} || rm -rf $TMPDIR
+          mv -T $TMPDIR /cache/reports/e2e/$(date '+%Y%m%d%H%M%S')-${{ matrix.model }}-${{ matrix.dtype }} || rm -rf $TMPDIR
 
       - name: Upload test logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
       - runner-0.0.5
     strategy:
       matrix:
-        model:
+        suite:
           - huggingface
           - timm_models
           - torchbench
@@ -57,7 +57,7 @@ jobs:
 
       # TODO: move to the base image
       # See also https://github.com/weishi-deng/benchmark/blob/main/docker/gcp-a100-runner-dind.dockerfile#L10-L15
-      - name: Install required dependencies
+      - name: Install system dependencies
         run: |
           sudo apt update -y
           sudo apt install -y \
@@ -68,7 +68,9 @@ jobs:
             libpango-1.0-0 libpangoft2-1.0-0 \
             libsdl2-dev libsdl2-2.0-0
 
-          pip install wheel
+      - name: Install Python dependencies
+          pip install wheel \
+            pyyaml pandas scipy psutil pyre_extensions torchrec transformers==$TRANSFORMERS_VERSION
 
       - name: Identify versions
         run: |
@@ -273,15 +275,10 @@ jobs:
           pip install audio/dist/*.whl
           python -c "import torchaudio; print(torchaudio.__version__)"
 
-      - name: Install transformers for huggingface
-        if: ${{ matrix.suite == 'huggingface' }}
-        run: |
-          pip install transformers==$TRANSFORMERS_VERSION
-
       - name: Install PyTorch Benchmarks
         if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
         run: |
-          pip install pyyaml pandas scipy psutil pyre_extensions torchrec
+          pip install
           git clone --single-branch -b $BENCHMARK_BRANCH --recurse-submodules --jobs 8 $BENCHMARK_REPO
           cd benchmark
           python install.py
@@ -292,7 +289,7 @@ jobs:
           source ~/intel/oneapi/setvars.sh
           export WORKSPACE=$GITHUB_WORKSPACE
           cd pytorch
-          $GITHUB_WORKSPACE/scripts/inductor_xpu_test.sh ${{ matrix.model }} ${{ matrix.dtype }} ${{ matrix.mode }} accuracy xpu 0
+          $GITHUB_WORKSPACE/scripts/inductor_xpu_test.sh ${{ matrix.suite }} ${{ matrix.dtype }} ${{ matrix.mode }} accuracy xpu 0
 
       - name: Report environment details
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,6 +36,9 @@ jobs:
           - huggingface
           - timm_models
           - torchbench
+        mode:
+          - inference
+          - training
         dtype:
           - amp_bf16
           - amp_fp16
@@ -270,9 +273,7 @@ jobs:
           source ~/intel/oneapi/setvars.sh
           export WORKSPACE=$GITHUB_WORKSPACE
           cd pytorch
-          for mode in training inference; do
-            $GITHUB_WORKSPACE/scripts/inductor_xpu_test.sh ${{ matrix.model }} ${{ matrix.dtype }} $mode accuracy xpu 0
-          done
+          $GITHUB_WORKSPACE/scripts/inductor_xpu_test.sh ${{ matrix.model }} ${{ matrix.dtype }} ${{ matrix.mode }} accuracy xpu 0
 
       - name: Report environment details
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,11 +68,9 @@ jobs:
             libpango-1.0-0 libpangoft2-1.0-0 \
             libsdl2-dev libsdl2-2.0-0
 
-      - name: Install Python dependencies
+      - name: Install Python build dependencies
         run: |
-          pip install \
-            wheel \
-            pyyaml pandas scipy numpy psutil pyre_extensions torchrec
+          pip install wheel
 
       - name: Identify versions
         run: |
@@ -123,10 +121,6 @@ jobs:
           echo "TORCHAUDIO_COMMIT_ID=$(<.github/ci_commit_pins/audio.txt)" >> "${GITHUB_ENV}"
           echo "TRANSFORMERS_VERSION=$(<.ci/docker/ci_commit_pins/huggingface.txt)" >> "${GITHUB_ENV}"
           echo "TIMM_COMMIT_ID=$(<.ci/docker/ci_commit_pins/timm.txt)" >> "${GITHUB_ENV}"
-
-      - name: Install transformers
-        run: |
-          pip install transformers==$TRANSFORMERS_VERSION
 
       # TIMM depends on torch and torchaudio, so in general, it needs to be installed before
       # installing custom torch and torchaudio.
@@ -238,6 +232,10 @@ jobs:
         with:
           path: ${{ steps.triton-cache.outputs.path }}
           dest: ${{ steps.triton-cache.outputs.dest }}
+
+      - name: Install python test dependencies
+        run: |
+          pip install pyyaml pandas scipy numpy psutil pyre_extensions torchrec transformers==$TRANSFORMERS_VERSION
 
       - name: Build torchvision wheels
         if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -266,9 +266,15 @@ jobs:
           pip install audio/dist/*.whl
           python -c "import torchaudio; print(torchaudio.__version__)"
 
-      - name: Install PyTorch Benchmarks
+      - name: Install transformers for huggingface
+        if: ${{ matrix.suite == 'huggingface' }}
         run: |
-          pip install pyyaml pandas scipy psutil pyre_extensions torchrec transformers==$TRANSFORMERS_VERSION
+          pip install transformers==$TRANSFORMERS_VERSION
+
+      - name: Install PyTorch Benchmarks
+        if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
+        run: |
+          pip install pyyaml pandas scipy psutil pyre_extensions torchrec
           git clone --single-branch -b $BENCHMARK_BRANCH --recurse-submodules --jobs 8 $BENCHMARK_REPO
           cd benchmark
           python install.py

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -70,8 +70,9 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install wheel \
-            pyyaml pandas scipy numpy psutil pyre_extensions torchrec transformers==$TRANSFORMERS_VERSION
+          pip install \
+            wheel \
+            pyyaml pandas scipy numpy psutil pyre_extensions torchrec
 
       - name: Identify versions
         run: |
@@ -122,6 +123,10 @@ jobs:
           echo "TORCHAUDIO_COMMIT_ID=$(<.github/ci_commit_pins/audio.txt)" >> "${GITHUB_ENV}"
           echo "TRANSFORMERS_VERSION=$(<.ci/docker/ci_commit_pins/huggingface.txt)" >> "${GITHUB_ENV}"
           echo "TIMM_COMMIT_ID=$(<.ci/docker/ci_commit_pins/timm.txt)" >> "${GITHUB_ENV}"
+
+      - name: Install transformers
+        run: |
+          pip install transformers==$TRANSFORMERS_VERSION
 
       # TIMM depends on torch and torchaudio, so in general, it needs to be installed before
       # installing custom torch and torchaudio.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,10 +56,18 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       # TODO: move to the base image
+      # See also https://github.com/weishi-deng/benchmark/blob/main/docker/gcp-a100-runner-dind.dockerfile#L10-L15
       - name: Install required dependencies
         run: |
           sudo apt update -y
-          sudo apt install -y libpng-dev libjpeg-dev pkg-config libgl1 libpango-1.0-0 libpangoft2-1.0-0
+          sudo apt install -y \
+            pkg-config \
+            libpng-dev libjpeg-dev \
+            libgl1-mesa-glx libsndfile1-dev libxml2-dev libxslt1-dev \
+            fontconfig libfontconfig1-dev \
+            libpango-1.0-0 libpangoft2-1.0-0 \
+            libsdl2-dev libsdl2-2.0-0
+
           pip install wheel
 
       - name: Identify versions

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -282,7 +282,7 @@ jobs:
       - name: Install PyTorch Benchmarks
         if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
         run: |
-          pip install
+          #pip install
           git clone --single-branch -b $BENCHMARK_BRANCH --recurse-submodules --jobs 8 $BENCHMARK_REPO
           cd benchmark
           python install.py

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -328,7 +328,7 @@ jobs:
         run: |
           mkdir -p /cache/reports/e2e
           TMPDIR=$(mktemp -d -p /cache/reports/e2e XXXXXXXXX.tmp)
-          cp -r $GITHUB_WORKSPACE/inductor_log/* $TMPDIR
+          cp -rT $GITHUB_WORKSPACE/inductor_log $TMPDIR
           mv -T $TMPDIR /cache/reports/e2e/$TIMESTAMP-${{ join(matrix.*, '-') }} || rm -rf $TMPDIR
 
       - name: Upload test logs

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,6 +55,13 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      # TODO: move to the base image
+      - name: Install required dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y libpng-dev libjpeg-dev pkg-config libgl1 libpango-1.0-0
+          pip install wheel
+
       - name: Identify versions
         run: |
           echo "PYTORCH_COMMIT_ID=$(git ls-remote $PYTORCH_REPO refs/heads/$PYTORCH_BRANCH | cut -f1)" >> "${GITHUB_ENV}"
@@ -217,14 +224,8 @@ jobs:
           path: ${{ steps.triton-cache.outputs.path }}
           dest: ${{ steps.triton-cache.outputs.dest }}
 
-      # TODO: move to the base image
-      - name: Install torchvision dependencies
-        run: |
-          sudo apt update -y
-          sudo apt install -y libpng-dev libjpeg-dev pkg-config libgl1 libpango-1.0-0
-          pip install wheel
-
       - name: Build torchvision wheels
+        if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
         run: |
           git clone --single-branch -b main https://github.com/pytorch/vision.git
           cd vision
@@ -232,11 +233,13 @@ jobs:
           python setup.py bdist_wheel
 
       - name: Install torchvision
+        if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
         run: |
           pip install vision/dist/*.whl
           python -c "import torchvision; print(torchvision.__version__)"
 
       - name: Build torchtext wheels
+        if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
         run: |
           git clone --recurse-submodules --jobs 8 --single-branch -b main https://github.com/pytorch/text.git
           cd text
@@ -244,11 +247,13 @@ jobs:
           python setup.py bdist_wheel
 
       - name: Install torchtext
+        if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
         run: |
           pip install text/dist/*.whl
           python -c "import torchtext; print(torchtext.__version__)"
 
       - name: Build torchaudio wheels
+        if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
         run: |
           git clone --single-branch -b main https://github.com/pytorch/audio.git
           cd audio
@@ -256,6 +261,7 @@ jobs:
           python setup.py bdist_wheel
 
       - name: Install torchaudio
+        if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
         run: |
           pip install audio/dist/*.whl
           python -c "import torchaudio; print(torchaudio.__version__)"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,8 +69,9 @@ jobs:
             libsdl2-dev libsdl2-2.0-0
 
       - name: Install Python dependencies
+        run: |
           pip install wheel \
-            pyyaml pandas scipy psutil pyre_extensions torchrec transformers==$TRANSFORMERS_VERSION
+            pyyaml pandas scipy numpy psutil pyre_extensions torchrec transformers==$TRANSFORMERS_VERSION
 
       - name: Identify versions
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -282,7 +282,6 @@ jobs:
       - name: Install PyTorch Benchmarks
         if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
         run: |
-          #pip install
           git clone --single-branch -b $BENCHMARK_BRANCH --recurse-submodules --jobs 8 $BENCHMARK_REPO
           cd benchmark
           python install.py


### PR DESCRIPTION
* Increase job timeout, some jobs are 5+ hours long
* Create .env file in artifacts that contains commit ids for dependencies and other environment information. Specifically, variable `GITHUB_RUN_ID` allows to merge reports from all jobs in the matrix.
* Bigger matrix: 3x2x3 instead of 3x2 to make each individual job smaller.
* Set `fail-fast` to false. Failing jobs should not cancel other running jobs in the matrix.