### PR TITLE
Enable `test_atomic_rmw` tests scenarios for PVC

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1143,7 +1143,7 @@ def test_atomic_rmw(op, dtype_x_str, mode, sem, device):
 
     if is_xpu():
         capability = 0
-        if dtype_x_str == 'float16':        
+        if dtype_x_str == 'float16':
             pytest.skip("FIXME: Atomic RMW for float16 not yet supported by IGC")
 
     n_programs = 5

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1135,12 +1135,17 @@ def test_atomic_rmw(op, dtype_x_str, mode, sem, device):
             'test_atomic_rmw for HIP currently broken in https://github.com/openai/triton. Use https://github.com/ROCmSoftwarePlatform/triton'
         )
 
-    check_cuda_only(device)
+    if is_cuda():
+        capability = torch.cuda.get_device_capability()
+        if capability[0] < 7:
+            if dtype_x_str == 'float16':
+                pytest.skip("Only test atomic float16 ops on devices with sm >= 70")
 
-    capability = torch.cuda.get_device_capability()
-    if capability[0] < 7:
-        if dtype_x_str == 'float16':
-            pytest.skip("Only test atomic float16 ops on devices with sm >= 70")
+    if is_xpu():
+        capability = 0
+        if dtype_x_str == 'float16':        
+            pytest.skip("FIXME: Atomic RMW for float16 not yet supported by IGC")
+
     n_programs = 5
 
     # triton kernel


### PR DESCRIPTION
Enable `test_atomic_rmw` tests in `test_core.py` (361 additional tests pass). Note that the tests for fp16 are still disabled.