### PR TITLE
[BACKEND][TRANSFORM] add a pass to decompose tritongpu to match target IR size

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -207,6 +207,24 @@ def TT_LoadOp : TT_Op<"load",
     let hasCanonicalizer = 1;
 }
 
+def TT_PrefetchOp : TT_Op<"prefetch",
+                      [MemoryEffects<[MemWrite, MemRead]>
+                                      ]> {
+    let summary = "prefetch  from a tensor pointer";
+
+    let arguments = (ins AnyTypeOf<[TT_TensorPtr]>:$ptr, TT_CacheModifierAttr:$cache,
+                         TT_EvictionPolicyAttr:$evict, BoolAttr:$isVolatile);
+
+    let results = (outs);
+
+    let assemblyFormat = [{
+      $ptr attr-dict `:` type($ptr)
+    }];
+
+    let hasCanonicalizer = 0;
+}
+
+
 def TT_StoreOp : TT_Op<"store",
                        [SameLoadStoreOperandsShape,
                         SameLoadStoreOperandsEncoding,
@@ -947,6 +965,29 @@ def ReturnOp : TT_Op<"return", [Pure, HasParent<"FuncOp">, /*MemRefsNormalizable
 
   let assemblyFormat = "attr-dict ($srcs^ `:` type($srcs))?";
   let hasVerifier = 1;
+}
+
+def TT_TensorRelated : AnyTypeOf<[TT_Tensor, TT_TensorPtr]>;
+
+def TT_GlueOp : TT_Op<"glue", [// operands have same type: SameOperandsType,
+                               Pure]> {
+    let summary = "glue/concat opearands to a larger size";
+
+    let arguments = (ins Variadic<TT_TensorRelated>:$operands);
+
+    let results = (outs TT_TensorRelated:$result);
+
+    let assemblyFormat = "$operands attr-dict `:` type($operands) `->` type($result)";
+}
+
+def TT_ExtractOp : TT_Op<"extract", [Pure]> {
+    let summary = "extract a sub value from base at idx";
+
+    let arguments = (ins TT_TensorRelated:$base, I32Attr:$idx);
+
+    let results = (outs TT_TensorRelated:$result);
+
+    let assemblyFormat = "$base `,` $idx attr-dict `:` type($base) `->` type($result)";
 }
 
 #endif // Triton_OPS

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -62,6 +62,34 @@ Right now, Triton implements two classes of layouts: shared, and distributed.
 }
 
 //===----------------------------------------------------------------------===//
+// Warp Encoding
+//===----------------------------------------------------------------------===//
+
+def WarpEncodingAttr : TritonGPU_Attr<"WarpEncoding", "warp_encoding"> {
+  let mnemonic = "warp";
+
+  let description = [{
+only have 3 items: sizePerThread, threadsPerWarp, order
+all their meaning remain the same as above blocked encoding
+  }];
+
+  let parameters = (
+    ins
+    ArrayRefParameter<"unsigned">:$sizePerThread,
+    ArrayRefParameter<"unsigned">:$threadsPerWarp,
+    ArrayRefParameter<"unsigned">:$order // the fastest-changing axis first
+  );
+
+  let extraClassDeclaration = [{
+    unsigned getTotalElemsPerThread(ArrayRef<int64_t> shape, Type eltTy) const;
+    SmallVector<unsigned> getElemsPerThread(ArrayRef<int64_t> shape, Type eltTy) const;
+  }];
+
+  let hasCustomAssemblyFormat = 1;
+}
+
+
+//===----------------------------------------------------------------------===//
 // CTA Layout
 //===----------------------------------------------------------------------===//
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -256,6 +256,20 @@ def TTG_AllocTensorOp : TTG_Op<"alloc_tensor", [MemoryEffects<[MemAlloc<SharedMe
   let results = (outs TT_Tensor:$result);
 }
 
+def TTG_AllocOp : TTG_Op<"alloc", [MemoryEffects<[MemAlloc]>  // Allocate shared memory
+                                                ]> {
+  let summary = "allocate tensor in memory, return the pointer";
+
+  let description = [{
+    This operation defines a tensor of a particular shape.
+    The contents of the tensor are supposed to be in shared memory.
+  }];
+
+  let assemblyFormat = [{attr-dict `:` type($result)}];
+
+  let results = (outs TT_Ptr:$result);
+}
+
 def TTG_DeallocTensorOp : TTG_Op<"dealloc_tensor", [MemoryEffects<[MemFree<SharedMemory>]>,  // Deallocate shared memory
                                                     OperandsAreSharedEncoding]> {
   let summary = "dealloc tensor";

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.h
@@ -16,6 +16,8 @@ std::unique_ptr<Pass> createAccelerateMatmulPass(int computeCapability = 80);
 
 std::unique_ptr<Pass> createPrefetchPass();
 
+std::unique_ptr<Pass> createTritonGPUDistributeToWarpsPass();
+
 std::unique_ptr<Pass> createCoalescePass();
 
 std::unique_ptr<Pass> createReorderInstructionsPass();

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.h
@@ -18,6 +18,8 @@ std::unique_ptr<Pass> createPrefetchPass();
 
 std::unique_ptr<Pass> createTritonGPUDistributeToWarpsPass();
 
+std::unique_ptr<Pass> createTritonGPUMatchTargetSizePass();
+
 std::unique_ptr<Pass> createCoalescePass();
 
 std::unique_ptr<Pass> createReorderInstructionsPass();

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -66,6 +66,26 @@ def TritonGPUDistributeToWarps : Pass<"tritongpu-distribute-to-warps", "mlir::Mo
                            "mlir::arith::ArithDialect"];
 }
 
+def TritonGPUMatchTargetSize : Pass<"tritongpu-match-target-size", "mlir::ModuleOp"> {
+  let summary = "match the target size of specific op (dot, load, store)";
+
+  let description = [{
+    this pass should be run after tritongpu-distribute-to-warps
+  }];
+
+  let constructor = "mlir::triton::gpu::createTritonGPUMatchTargetSizePass()";
+
+  let dependentDialects = ["mlir::triton::TritonDialect",
+                           "mlir::triton::gpu::TritonGPUDialect"];
+
+  let options = [
+    ListOption<"dotSize", "dot-size",
+           "int64_t", "target LLVM IR dot operation size">
+    // fixme : add operate-size load-size, store-size
+    // load-operate-store-size 256DW which is 16x16xf32, 32x16xf16
+  ];
+}
+
 
 
 def TritonGPUAccelerateMatmul : Pass<"tritongpu-accelerate-matmul", "mlir::ModuleOp"> {

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -51,6 +51,23 @@ def TritonGPUPrefetch : Pass<"tritongpu-prefetch", "mlir::ModuleOp"> {
                            "mlir::arith::ArithDialect"];
 }
 
+def TritonGPUDistributeToWarps : Pass<"tritongpu-distribute-to-warps", "mlir::ModuleOp"> {
+  let summary = "distribute the thread block workload to the warps";
+
+  let description = [{
+  }];
+
+  let constructor = "mlir::triton::gpu::createTritonGPUDistributeToWarpsPass()";
+
+  let dependentDialects = ["mlir::triton::TritonDialect",
+                           "mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::scf::SCFDialect",
+                           "mlir::gpu::GPUDialect",
+                           "mlir::arith::ArithDialect"];
+}
+
+
+
 def TritonGPUAccelerateMatmul : Pass<"tritongpu-accelerate-matmul", "mlir::ModuleOp"> {
   let summary = "accelerate matmul";
 

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -118,6 +118,9 @@ getThreadsPerWarpWithUniqueData(Attribute layout,
 }
 
 SmallVector<unsigned> getWarpsPerCTA(Attribute layout) {
+  if (auto dotLayout = layout.dyn_cast<DotOperandEncodingAttr>()) {
+    return getWarpsPerCTA(dotLayout.getParent());
+  }
   if (auto distributedLayout = layout.dyn_cast<DistributedEncodingTrait>()) {
     return distributedLayout.getWarpsPerCTA();
   }
@@ -638,6 +641,25 @@ BlockedEncodingAttr::getShapePerCTATile(ArrayRef<int64_t> tensorShape) const {
   return shape;
 }
 
+SmallVector<unsigned>
+WarpEncodingAttr::getElemsPerThread(ArrayRef<int64_t> shape, Type eltTy) const {
+  size_t rank = shape.size();
+  auto sizePerThread = getSizePerThread();
+  auto threadsPerWarp = getThreadsPerWarp();
+  assert(rank == sizePerThread.size() &&
+         "unexpected rank in WarpEncodingAttr::getElemsPerThread");
+  SmallVector<unsigned> elemsPerThread(rank);
+  for (size_t i = 0; i < rank; ++i) {
+    unsigned t = sizePerThread[i] * threadsPerWarp[i];
+    elemsPerThread[i] = t;
+  }
+  return elemsPerThread;
+}
+unsigned WarpEncodingAttr::getTotalElemsPerThread(ArrayRef<int64_t> shape,
+                                                  Type eltTy) const {
+  return product<unsigned>(getElemsPerThread(shape, eltTy));
+}
+
 template <class T>
 SmallVector<T> SliceEncodingAttr::paddedShape(ArrayRef<T> shape) const {
   size_t rank = shape.size();
@@ -1058,6 +1080,60 @@ void BlockedEncodingAttr::print(mlir::AsmPrinter &printer) const {
                       /*rank=*/getSizePerThread().size());
 
   printer << "}>";
+}
+
+//===----------------------------------------------------------------------===//
+// Warp encoding
+//===----------------------------------------------------------------------===//
+
+Attribute WarpEncodingAttr::parse(AsmParser &parser, Type type) {
+  if (parser.parseLess().failed())
+    return {};
+  // Parse the data as a dictionary
+  DictionaryAttr dict;
+  if (parser.parseAttribute(dict).failed())
+    return {};
+  if (parser.parseGreater().failed())
+    return {};
+
+  SmallVector<unsigned> sizePerThread;
+  SmallVector<unsigned> threadsPerWarp;
+  SmallVector<unsigned> order;
+
+  for (const NamedAttribute &attr : dict) {
+    if (attr.getName() == "sizePerThread") {
+      if (parseIntArrayAttr(parser, attr, sizePerThread,
+                            "number of elements per thread")
+              .failed())
+        return {};
+    } else if (attr.getName() == "threadsPerWarp") {
+      if (parseIntArrayAttr(parser, attr, threadsPerWarp,
+                            "number of threads per warp")
+              .failed())
+        return {};
+    } else if (attr.getName() == "order") {
+      if (parseIntArrayAttr(parser, attr, order, "order").failed())
+        return {};
+    } else {
+      parser.emitError(parser.getNameLoc(), "unexpected key: ")
+          << attr.getName().strref();
+      return {};
+    }
+  }
+  return parser.getChecked<WarpEncodingAttr>(parser.getContext(), sizePerThread,
+                                             threadsPerWarp, order);
+}
+
+void WarpEncodingAttr::print(mlir::AsmPrinter &printer) const {
+  auto threadsPerWarp = getThreadsPerWarp();
+  auto sizePerThread = getSizePerThread();
+  printer << "<{"
+          << "sizePerThread = [" << llvm::ArrayRef<unsigned>(sizePerThread)
+          << "]"
+          << ", threadsPerWarp = [" << llvm::ArrayRef<unsigned>(threadsPerWarp)
+          << "]"
+          << ", order = [" << getOrder() << "]"
+          << "}>";
 }
 
 //===----------------------------------------------------------------------===//
@@ -1876,6 +1952,9 @@ public:
       return AliasResult::FinalAlias;
     } else if (auto blockedAttr = attr.dyn_cast<BlockedEncodingAttr>()) {
       os << "blocked";
+      return AliasResult::FinalAlias;
+    } else if (auto warpAttr = attr.dyn_cast<WarpEncodingAttr>()) {
+      os << "warp";
       return AliasResult::FinalAlias;
     } /* else if (auto sliceAttr = attr.dyn_cast<SliceEncodingAttr>()) {
       os << "slice";

--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_triton_library(TritonGPUTransforms
   AccelerateMatmul.cpp
   Coalesce.cpp
   DistributeToWarps.cpp
+  MatchTargetSize.cpp
   ReduceDataDuplication.cpp
   OptimizeDotOperands.cpp
   OptimizeThreadLocality.cpp

--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_triton_library(TritonGPUTransforms
   AccelerateMatmul.cpp
   Coalesce.cpp
+  DistributeToWarps.cpp
   ReduceDataDuplication.cpp
   OptimizeDotOperands.cpp
   OptimizeThreadLocality.cpp

--- a/lib/Dialect/TritonGPU/Transforms/DistributeToWarps.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DistributeToWarps.cpp
@@ -1,0 +1,321 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
+#include "llvm/Support/Debug.h"
+#include <memory>
+
+using namespace mlir;
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+namespace {
+// pass named attrs (e.g., tt.contiguity) from Triton to Triton
+static void addNamedAttrs(Operation *op, DictionaryAttr dictAttrs) {
+  for (const NamedAttribute attr : dictAttrs.getValue())
+    if (!op->hasAttr(attr.getName()))
+      op->setAttr(attr.getName(), attr.getValue());
+}
+
+// fixme: maybe set sizePerWarp in the attr directly
+SmallVector<long> getSizePerWarp(RankedTensorType type, Attribute layout) {
+  llvm::SmallVector<long> sizePerWarp;
+  if (auto blockedLayout = dyn_cast<ttg::BlockedEncodingAttr>(layout)) {
+    auto sizePerThread = blockedLayout.getSizePerThread();
+    auto threadsPerWarp = blockedLayout.getThreadsPerWarp();
+    for (auto [lhs, rhs] : llvm::zip(sizePerThread, threadsPerWarp)) {
+      sizePerWarp.push_back(lhs * rhs);
+    }
+  } else if (auto dotLayout = dyn_cast<ttg::DotOperandEncodingAttr>(layout)) {
+    auto idx = dotLayout.getOpIdx();
+    assert(isa<ttg::BlockedEncodingAttr>(dotLayout.getParent()) &&
+           "at this stage, parent layout should be blocked layout.");
+    auto parentSizePerWarp = getSizePerWarp(
+        type, cast<ttg::BlockedEncodingAttr>(dotLayout.getParent()));
+    if (idx == 0) { // dot operand A
+      sizePerWarp.assign({parentSizePerWarp[0], type.getShape()[1]});
+    } else { // idx == 1, dot operand B
+      sizePerWarp.assign({type.getShape()[0], parentSizePerWarp[1]});
+    }
+  } else {
+    llvm::report_fatal_error(
+        "getSizePerWarp not implemented for this attribute");
+  }
+  return sizePerWarp;
+}
+
+Attribute getWarpLayout(Attribute layout) {
+  auto *ctx = layout.getContext();
+  if (auto blockedLayout = dyn_cast<ttg::BlockedEncodingAttr>(layout)) {
+    auto warpLayout = ttg::WarpEncodingAttr::get(
+        ctx, blockedLayout.getSizePerThread(),
+        blockedLayout.getThreadsPerWarp(), blockedLayout.getOrder());
+    return warpLayout;
+  } else if (auto dotLayout = dyn_cast<ttg::DotOperandEncodingAttr>(layout)) {
+    auto parentLayout = getWarpLayout(dotLayout.getParent());
+    auto newDotLayout = ttg::DotOperandEncodingAttr::get(
+        ctx, dotLayout.getOpIdx(), parentLayout, dotLayout.getKWidth());
+    return newDotLayout;
+  }
+  return layout;
+}
+
+template <typename T> static T convertType(T type) { return type; }
+
+template <>
+RankedTensorType convertType<RankedTensorType>(RankedTensorType type) {
+  auto layout = type.getEncoding();
+  auto sizePerWarp = getSizePerWarp(type, layout);
+  auto warpLayout = getWarpLayout(layout);
+  auto newType =
+      RankedTensorType::get(sizePerWarp, type.getElementType(), warpLayout);
+  return newType;
+}
+
+template <> tt::PointerType convertType<tt::PointerType>(tt::PointerType type) {
+  auto pointeeType = type.getPointeeType();
+  auto tensorType = dyn_cast<RankedTensorType>(pointeeType);
+  if (!tensorType)
+    return type;
+  auto newTensorType = convertType(tensorType);
+  auto newType = tt::PointerType::get(newTensorType, type.getAddressSpace());
+  return newType;
+}
+
+/// @brief get each warp's offset
+/// warpsPerDim = blockShape / warpShape
+/// assert(warpsPerDim <= warpsPerCTA)
+/// warpId.x = warpId % warpPerCTA.x
+/// warpId.y = warpId / warpPerCTA.x
+/// incX = (warpId.x % warpsPerDim.x) * SizePerWarp.x
+/// incY = (warpId.y % warpsPerDim.y) * SizePerWarp.y
+/// newX = oldX + incX
+/// newY = oldY + incY
+SmallVector<Value> distributeOffset(SmallVector<Value> oldOffsets,
+                                    RankedTensorType tensorType, Value warpId,
+                                    OpBuilder b, Location loc) {
+  auto layout = tensorType.getEncoding();
+  auto warpsPerCTA = ttg::getWarpsPerCTA(layout);
+  auto dims = warpsPerCTA.size();
+  assert(dims <= 2 && "no more than 2D shape");
+  // same to the module attribute num-warps
+  auto numWarps = product<unsigned>(warpsPerCTA);
+  auto newTensorType = convertType(tensorType);
+  auto blockShape = tensorType.getShape();
+  auto warpShape = newTensorType.getShape();
+  SmallVector<unsigned> warpsPerDim;
+  for (auto [lhs, rhs] : llvm::zip(blockShape, warpShape)) {
+    if (lhs % rhs != 0)
+      return oldOffsets;
+    warpsPerDim.push_back(lhs / rhs);
+  }
+  SmallVector<Value> newOffsets;
+  for (auto i = 0; i < dims; i++) {
+    auto oldOffset = oldOffsets[i];
+    Value warpIdPerDim;
+    if (i == 1) { // warpId.x
+      if (warpsPerCTA[dims - 1] == 1) {
+        newOffsets.push_back(oldOffset);
+        continue;
+      } else if (warpsPerCTA[dims - 1] == numWarps) {
+        warpIdPerDim = warpId;
+      } else {
+        warpIdPerDim = b.create<arith::RemSIOp>(
+            loc, warpId,
+            b.create<arith::ConstantIntOp>(loc, warpsPerCTA[dims - 1], 32));
+      }
+    } else { // i == 0, warpId.y
+      if (warpsPerCTA[dims - 1] == 1) {
+        warpIdPerDim = warpId;
+      } else if (warpsPerCTA[dims - 1] == numWarps) {
+        newOffsets.push_back(oldOffset);
+        continue;
+      } else {
+        warpIdPerDim = b.create<arith::DivSIOp>(
+            loc, warpId,
+            b.create<arith::ConstantIntOp>(loc, warpsPerCTA[dims - 1], 32));
+      }
+    }
+    Value step;
+    if (warpsPerDim[i] == 1) {
+      newOffsets.push_back(oldOffset);
+      continue;
+    } else if (warpsPerDim[i] == numWarps) {
+      step = warpIdPerDim;
+    } else {
+      step = b.create<arith::RemSIOp>(
+          loc, warpIdPerDim,
+          b.create<arith::ConstantIntOp>(loc, warpsPerDim[i], 32));
+    }
+    auto inc = b.create<arith::MulIOp>(
+        loc, step, b.create<arith::ConstantIntOp>(loc, warpShape[i], 32));
+    auto newOffset = b.create<arith::AddIOp>(loc, inc, oldOffset);
+    newOffsets.push_back(newOffset);
+  }
+  return newOffsets;
+}
+
+void distributeGenericOp(Operation *op) {
+  OpBuilder b(op);
+  auto newOp = b.clone(*op);
+  for (auto result : newOp->getResults()) {
+    if (auto castType = dyn_cast<RankedTensorType>(result.getType()))
+      result.setType(convertType(castType));
+    else if (auto castType = dyn_cast<tt::PointerType>(result.getType()))
+      result.setType(convertType(castType));
+  }
+  op->replaceAllUsesWith(newOp->getResults());
+  op->erase();
+  return;
+}
+
+void distributeArithConstantOp(arith::ConstantOp op) {
+  auto type = dyn_cast<RankedTensorType>(op.getType());
+  if (!type)
+    return;
+  auto newType = convertType(type);
+  auto value = cast<DenseElementsAttr>(op.getValue());
+  value = value.resizeSplat(newType);
+  OpBuilder b(op);
+  auto newOp = b.create<arith::ConstantOp>(op.getLoc(), newType, value);
+  addNamedAttrs(newOp, op->getAttrDictionary());
+  op->replaceAllUsesWith(newOp->getResults());
+  op->erase();
+  return;
+}
+
+void distributeMakeTensorPtrOp(tt::MakeTensorPtrOp op, Value warpId) {
+  auto loc = op.getLoc();
+  tt::PointerType type = op.getType();
+  OpBuilder b(op);
+  auto tensorType = dyn_cast<RankedTensorType>(type.getPointeeType());
+  if (!tensorType)
+    return;
+  auto newOffsets =
+      distributeOffset(op.getOffsets(), tensorType, warpId, b, loc);
+  auto newOp = b.clone(*op.getOperation());
+  auto newType = convertType(type);
+  auto newPtrOp = cast<tt::MakeTensorPtrOp>(newOp);
+  newPtrOp.getOffsetsMutable().assign(newOffsets);
+  newPtrOp.getResult().setType(newType);
+  op->replaceAllUsesWith(newPtrOp->getResults());
+  op->erase();
+  return;
+}
+
+void distributeConvertLayoutOp(ttg::ConvertLayoutOp op, Value warpId,
+                               RankedTensorType oldSrcType) {
+  auto loc = op.getLoc();
+  OpBuilder b(op);
+  auto dstType = cast<RankedTensorType>(op.getResult().getType());
+  auto convertedDstType = convertType(dstType);
+  auto dstPtrType = tt::PointerType::get(convertedDstType, 3 /* shared mem*/);
+  auto srcPtrType =
+      tt::PointerType::get(op.getSrc().getType(), 3 /* shared mem*/);
+
+  // fixme: allocOp may carry the size info, tt::PointerType::get(oldSrcType)
+  // fixme: set addrspace 1 instead of 3 to avoid makeTensorOp type match
+  // error
+  auto baseType = tt::PointerType::get(oldSrcType.getElementType(), 1);
+  auto base = b.create<ttg::AllocOp>(loc, baseType);
+  SmallVector<Value> shape;
+  shape.push_back(
+      b.create<arith::ConstantIntOp>(loc, oldSrcType.getShape()[0], 64));
+  shape.push_back(
+      b.create<arith::ConstantIntOp>(loc, oldSrcType.getShape()[1], 64));
+  SmallVector<Value> strides;
+  strides.push_back(
+      b.create<arith::ConstantIntOp>(loc, oldSrcType.getShape()[1], 64));
+  strides.push_back(b.create<arith::ConstantIntOp>(loc, 1, 64));
+  SmallVector<Value> offsets;
+  offsets.push_back(b.create<arith::ConstantIntOp>(loc, 0, 32));
+  offsets.push_back(b.create<arith::ConstantIntOp>(loc, 0, 32));
+  auto srcOffsets = distributeOffset(offsets, oldSrcType, warpId, b, loc);
+  Value storePtr =
+      b.create<tt::MakeTensorPtrOp>(loc, srcPtrType, base, shape, strides,
+                                    srcOffsets, b.getDenseI32ArrayAttr({1, 0}));
+  b.create<tt::StoreOp>(loc, storePtr, op.getSrc(), tt::CacheModifier::NONE,
+                        tt::EvictionPolicy::NORMAL);
+  b.create<gpu::BarrierOp>(loc);
+  auto dstOffsets = distributeOffset(offsets, dstType, warpId, b, loc);
+  Value loadPtr =
+      b.create<tt::MakeTensorPtrOp>(loc, dstPtrType, base, shape, strides,
+                                    dstOffsets, b.getDenseI32ArrayAttr({1, 0}));
+  auto load = b.create<tt::LoadOp>(loc, loadPtr, tt::CacheModifier::NONE,
+                                   tt::EvictionPolicy::NORMAL, false);
+  op->replaceAllUsesWith(load->getResults());
+  op->erase();
+  return;
+}
+
+void distributeScfForOp(scf::ForOp op) {
+  auto body = op.getBody();
+  for (auto [lhs, rhs] :
+       llvm::zip(body->getArguments().drop_front(1), op.getInitArgs()))
+    lhs.setType(rhs.getType());
+  for (auto result : op->getResults()) {
+    if (auto castType = dyn_cast<RankedTensorType>(result.getType()))
+      result.setType(convertType(castType));
+    else if (auto castType = dyn_cast<tt::PointerType>(result.getType()))
+      result.setType(convertType(castType));
+  }
+  return;
+}
+
+} // namespace
+
+#define GEN_PASS_CLASSES
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
+
+class TritonGPUDistributeToWarpsPass
+    : public TritonGPUDistributeToWarpsBase<TritonGPUDistributeToWarpsPass> {
+public:
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp m = getOperation();
+    for (auto func : m.getOps<tt::FuncOp>()) {
+      auto b = OpBuilder::atBlockBegin(&func.getBody().front());
+      auto loc = func.getLoc();
+      auto subgroupId = b.create<gpu::SubgroupIdOp>(loc);
+      auto warpId =
+          b.create<arith::IndexCastOp>(loc, b.getI32Type(), subgroupId);
+      // record old type before transform
+      DenseMap<Operation *, RankedTensorType> typeMap;
+      func.walk([&](ttg::ConvertLayoutOp op) {
+        typeMap[op] = op.getSrc().getType().cast<RankedTensorType>();
+      });
+      func.walk<WalkOrder::PreOrder>([&](Operation *op) {
+        if (llvm::all_of(op->getResultTypes(), [&](Type type) {
+              return !isa<RankedTensorType>(type) &&
+                     !isa<tt::PointerType>(type);
+            }))
+          ;
+        else if (auto forOp = dyn_cast<scf::ForOp>(op))
+          distributeScfForOp(forOp);
+        else if (auto ptrOp = dyn_cast<tt::MakeTensorPtrOp>(op))
+          distributeMakeTensorPtrOp(ptrOp, warpId);
+        else if (auto cstOp = dyn_cast<arith::ConstantOp>(op))
+          distributeArithConstantOp(cstOp);
+        else if (auto convertOp = dyn_cast<ttg::ConvertLayoutOp>(op))
+          distributeConvertLayoutOp(convertOp, warpId, typeMap[convertOp]);
+        else if (isa<tt::LoadOp, tt::DotOp, tt::AdvanceOp, arith::TruncFOp>(op))
+          distributeGenericOp(op);
+        else
+          assert(0 && "op not considered");
+        return WalkResult::advance();
+      });
+    }
+  }
+};
+
+std::unique_ptr<Pass>
+mlir::triton::gpu::createTritonGPUDistributeToWarpsPass() {
+  return std::make_unique<TritonGPUDistributeToWarpsPass>();
+}

--- a/lib/Dialect/TritonGPU/Transforms/MatchTargetSize.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/MatchTargetSize.cpp
@@ -1,0 +1,489 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
+#include "llvm/Support/Debug.h"
+#include <memory>
+
+using namespace mlir;
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+
+#define GEN_PASS_CLASSES
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
+
+class TritonGPUMatchTargetSizePass
+    : public TritonGPUMatchTargetSizeBase<TritonGPUMatchTargetSizePass> {
+public:
+  void runOnOperation() override {
+    auto *ctx = &getContext();
+    ModuleOp m = getOperation();
+    sizePerAttrMap.clear();
+    if (!dotSize.hasValue()) {
+      dotSize.addValue(8);
+      dotSize.addValue(16);
+      dotSize.addValue(16);
+    }
+    /// split op to match target llvm/spirv size
+    // try to use callback to handle different cases
+    m.walk<WalkOrder::PreOrder>([&](Operation *op) {
+      SmallVector<Type> types(op->getOperandTypes().begin(),
+                              op->getOperandTypes().end());
+      SmallVector<Type> resultTypes(op->getResultTypes().begin(),
+                                    op->getResultTypes().end());
+      types.append(resultTypes);
+      if (!llvm::any_of(types, [&](Type type) {
+            if (isa<RankedTensorType>(type)) {
+              return true;
+            } else if (auto ptrType = dyn_cast<tt::PointerType>(type)) {
+              auto pointeeType = ptrType.getPointeeType();
+              return isa<RankedTensorType>(pointeeType) ? true : false;
+            } else {
+              return false;
+            }
+          }))
+        ;
+      else if (isa<scf::ForOp, scf::YieldOp>(op))
+        ;
+      else if (auto cstOp = dyn_cast<arith::ConstantOp>(op)) {
+        recordRootSubSize(op->getResultTypes()[0]);
+        transformArithConstantOp(cstOp);
+      } else if (auto dot = dyn_cast<tt::DotOp>(op))
+        transformDotOp(dot);
+      else if (auto ptrOp = dyn_cast<tt::MakeTensorPtrOp>(op)) {
+        recordRootSubSize(op->getResultTypes()[0]);
+        transformMakeTensorPtrOp(ptrOp);
+      }
+      // arith,math,tt.advance,tt.load,tt.store,tt.prefetch
+      else
+        transformGenericOp(op);
+      return WalkResult::advance();
+    });
+
+    m.dump();
+    /// canonicalize ops(remove redundant tt.extract, tt.glue)
+    RewritePatternSet patterns(ctx);
+    patterns.add<ScfPattern>(ctx);
+    patterns.add<ExtractPattern>(ctx);
+    patterns.add<ArithRemPattern>(ctx);
+    if (failed(applyPatternsAndFoldGreedily(m, std::move(patterns))))
+      signalPassFailure();
+  }
+
+private:
+  DenseMap<Attribute, SmallVector<int64_t>> sizePerAttrMap;
+  void recordRootSubSize(Type type) {
+    if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
+      auto layout = tensorType.getEncoding();
+      if (sizePerAttrMap.count(layout) == 0)
+        sizePerAttrMap[layout] = getSubOpSize(tensorType);
+    } else if (auto ptrType = dyn_cast<tt::PointerType>(type)) {
+      recordRootSubSize(ptrType.getPointeeType());
+    }
+  }
+  // assume
+  // all lsc size max is 256 DW
+  // lsc 2d limit is 32
+  //  bool isLsc = false)
+  SmallVector<int64_t> getSubOpSize(RankedTensorType type) {
+    auto mStep = dotSize[0];
+    auto nStep = dotSize[1];
+    auto kStep = dotSize[2];
+    auto layout = type.getEncoding();
+    int64_t colLimit = 0;
+    if (auto warpAttr = dyn_cast<ttg::WarpEncodingAttr>(layout)) {
+      colLimit = 32;
+      colLimit = 16;
+      // if (warpAttr.getIsDotC())
+      if (warpAttr.getSizePerThread()[1] == 64)
+        colLimit = nStep;
+    } else if (auto dotAttr = dyn_cast<ttg::DotOperandEncodingAttr>(layout)) {
+      colLimit = dotAttr.getOpIdx() == 0 ? kStep : nStep;
+    }
+    auto shape = type.getShape();
+    SmallVector<int64_t> subSize(shape.size());
+    auto sizeInByte = type.getElementTypeBitWidth() / 8;
+    if (shape.size() == 2) {
+      subSize[1] = (shape[1] > colLimit) ? colLimit : shape[1];
+      auto max = 256 * 4 / sizeInByte / subSize[1];
+      subSize[0] = std::min(max, shape[0]);
+    } else if (shape.size() == 1) {
+      int64_t max = 256 * 4 / sizeInByte;
+      subSize[0] = std::min(max, shape[0]);
+    }
+    return subSize;
+  }
+
+  std::tuple<SmallVector<int64_t>, Type, SmallVector<int64_t>>
+  getSubTypeAndShape(Type type) {
+    if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
+      auto shape = llvm::to_vector(tensorType.getShape());
+      auto attr = tensorType.getEncoding();
+      auto subSize = sizePerAttrMap[attr];
+      auto subType = RankedTensorType::get(
+          subSize, tensorType.getElementType() /*no encoding*/);
+      return std::make_tuple(shape, subType, subSize);
+    } else if (auto ptrType = dyn_cast<tt::PointerType>(type)) {
+      auto pointeeType = ptrType.getPointeeType();
+      auto [shape, subType, subSize] = getSubTypeAndShape(pointeeType);
+      auto newType = tt::PointerType::get(subType, ptrType.getAddressSpace());
+      return std::make_tuple(shape, newType, subSize);
+    }
+    return {{0}, type, {0}};
+  }
+
+  void transformMakeTensorPtrOp(tt::MakeTensorPtrOp op) {
+    auto type = op.getType();
+    auto [shape, subType, subSize] = getSubTypeAndShape(type);
+    // // early return
+    // if (shape == subSize)
+    //   return;
+    auto dim = shape.size();
+    OpBuilder b(op);
+    auto loc = op.getLoc();
+    auto idx = 0;
+    SmallVector<Value> subOps;
+    for (auto i = 0; i < shape[dim - 1]; i += subSize[dim - 1]) {
+      if (dim == 2) {
+        for (auto j = 0; j < shape[0]; j += subSize[0]) {
+          auto offsets = op.getOffsets();
+          // auto newOffsets = offsets += [i, j]
+          SmallVector<Value> newOffsets(2);
+          if (j == 0)
+            newOffsets[0] = offsets[0];
+          else {
+            auto step = b.create<arith::ConstantIntOp>(loc, j, 32);
+            newOffsets[0] = b.create<arith::AddIOp>(loc, offsets[0], step);
+          }
+          if (i == 0)
+            newOffsets[1] = offsets[1];
+          else {
+            auto step = b.create<arith::ConstantIntOp>(loc, i, 32);
+            newOffsets[1] = b.create<arith::AddIOp>(loc, offsets[1], step);
+          }
+          SmallVector<int32_t> subShape;
+          for (auto sub : subSize)
+            subShape.push_back(sub);
+          auto subOp = b.create<tt::MakeTensorPtrOp>(
+              loc, op.getBase(), op.getShape(), op.getStrides(), newOffsets,
+              subShape, op.getOrder());
+          subOps.push_back(subOp);
+        }
+      }
+    }
+    auto glue = b.create<tt::GlueOp>(loc, type, subOps);
+    op->replaceAllUsesWith(glue->getResults());
+    op->erase();
+    return;
+  }
+
+  void transformArithConstantOp(arith::ConstantOp op) {
+    auto type = cast<RankedTensorType>(op.getResult().getType());
+    auto [shape, subType, subSize] = getSubTypeAndShape(type);
+    // // early return
+    // if (shape == subSize)
+    //   return;
+    auto dim = shape.size();
+    OpBuilder b(op);
+    auto loc = op.getLoc();
+    auto idx = 0;
+    // these 2 lines are specific
+    auto value = cast<DenseElementsAttr>(op.getValue());
+    value = value.resizeSplat(subType.cast<ShapedType>());
+    SmallVector<Value> subOps;
+    for (auto i = 0; i < shape[dim - 1]; i += subSize[dim - 1]) {
+      if (dim == 2) {
+        for (auto j = 0; j < shape[0]; j += subSize[0]) {
+          auto subOp = b.create<arith::ConstantOp>(loc, subType, value);
+          subOps.push_back(subOp);
+        }
+      }
+    }
+    auto glue = b.create<tt::GlueOp>(loc, type, subOps);
+    op->replaceAllUsesWith(glue->getResults());
+    op->erase();
+    return;
+  }
+
+  void transformGenericOp(Operation *op) {
+    auto numResults = op->getResults().size();
+    Type type;
+    // prefetch/store
+    if (numResults == 0)
+      type = op->getOperand(0).getType();
+    // arith/math/advanceOp
+    else {
+      assert(numResults == 1);
+      type = op->getResultTypes()[0];
+    }
+    auto [shape, subType, subSize] = getSubTypeAndShape(type);
+    // // early return
+    // if (shape == subSize)
+    //   return;
+    auto dim = shape.size();
+    OpBuilder b(op);
+    auto loc = op->getLoc();
+    auto idx = 0;
+    SmallVector<Value> subOps;
+    for (auto i = 0; i < shape[dim - 1]; i += subSize[dim - 1]) {
+      if (dim == 2) {
+        for (auto j = 0; j < shape[0]; j += subSize[0]) {
+          SmallVector<Value> newOperands;
+          llvm::transform(op->getOperands(), std::back_inserter(newOperands),
+                          [&](Value operand) {
+                            auto type = operand.getType();
+                            if (isa<tt::PointerType, RankedTensorType>(type)) {
+                              auto subOpndType =
+                                  std::get<1>(getSubTypeAndShape(type));
+                              Value newOp = b.create<tt::ExtractOp>(
+                                  loc, subOpndType, operand, idx);
+                              return newOp;
+                            } else
+                              return operand;
+                          });
+          // auto subOp = b.create<op->getName().getTypeID()>(loc, newOperands,
+          //                                                  op->getAttrs());
+          // subOps.push_back(subOp);
+          Operation *subOp;
+          if (numResults == 0)
+            subOp = b.create(loc, op->getName().getIdentifier(), newOperands,
+                             {}, op->getAttrs());
+          else {
+            subOp = b.create(loc, op->getName().getIdentifier(), newOperands,
+                             subType, op->getAttrs());
+            subOps.push_back(subOp->getResults()[0]);
+          }
+          idx++;
+        }
+      }
+    }
+    if (numResults == 1) {
+      auto glue = b.create<tt::GlueOp>(loc, type, subOps);
+      op->replaceAllUsesWith(glue);
+    }
+    op->erase();
+  }
+
+  // for dot split k, n to make the inner register contiguous
+  void transformDotOp(tt::DotOp dot) {
+    assert(dotSize.size() == 3 && "target-size should have m, n ,k");
+    auto aType = dot.getA().getType().cast<RankedTensorType>();
+    auto bType = dot.getB().getType().cast<RankedTensorType>();
+    auto cType = dot.getC().getType().cast<RankedTensorType>();
+    auto aShape = aType.getShape();
+    auto bShape = bType.getShape();
+    auto cShape = cType.getShape();
+    auto m = aShape[0];
+    auto n = bShape[1];
+    auto k = aShape[1];
+    auto mStep = dotSize[0];
+    auto nStep = dotSize[1];
+    auto kStep = dotSize[2];
+    OpBuilder b(dot);
+    auto loc = dot.getLoc();
+    auto packValues = [&](ArrayRef<int64_t> values) {
+      SmallVector<OpFoldResult> newValues = llvm::to_vector<4>(
+          llvm::map_range(values, [&](int64_t v) -> OpFoldResult {
+            return b.getI64IntegerAttr(v);
+          }));
+      return newValues;
+    };
+    auto getSubDotVal = [&](Value val, int64_t mm, int64_t kk, int64_t mStep,
+                            int64_t kStep) {
+      auto [shape, subType, subSize] = getSubTypeAndShape(val.getType());
+      auto subIdx =
+          (kk / subSize[1]) * (shape[0] / subSize[0]) + mm / subSize[0];
+      auto subVal = b.create<tt::ExtractOp>(loc, subType, val, subIdx);
+      auto subDotType = RankedTensorType::get(
+          {mStep, kStep},
+          val.getType().cast<RankedTensorType>().getElementType());
+      auto subDotIdx = ((kk % subSize[1]) / kStep) * (subSize[0] / mStep) +
+                       (mm % subSize[0]) / mStep;
+      auto subDotVal =
+          b.create<tt::ExtractOp>(loc, subDotType, subVal, subDotIdx);
+      return subDotVal;
+    };
+
+    // n first, so that we can use larger store
+    auto [shape, subType, subSize] = getSubTypeAndShape(cType);
+    SmallVector<Value> subCs;
+    SmallVector<Value> subOps;
+    for (auto nn = 0; nn < n; nn += nStep) {
+      for (auto mm = 0; mm < m; mm += mStep) {
+        if (mm % subSize[0] == 0) {
+          subOps.clear();
+        }
+        Value subDotC = getSubDotVal(dot.getC(), mm, nn, mStep, nStep);
+        for (auto kk = 0; kk < k; kk += kStep) {
+          auto subDotA = getSubDotVal(dot.getA(), mm, kk, mStep, kStep);
+          auto subDotB = getSubDotVal(dot.getB(), kk, nn, kStep, nStep);
+          subDotC = b.create<tt::DotOp>(loc, subDotA, subDotB, subDotC,
+                                        dot.getAllowTF32Attr(),
+                                        dot.getMaxNumImpreciseAccAttr());
+        }
+        subOps.push_back(subDotC);
+        if ((mm % subSize[0]) == (subSize[0] - mStep)) {
+          Value glue = b.create<tt::GlueOp>(loc, subType, subOps);
+          subCs.push_back(glue);
+        }
+      }
+    }
+    auto newC = b.create<tt::GlueOp>(loc, dot.getType(), subCs);
+    dot->replaceAllUsesWith(newC->getResults());
+    dot->erase();
+  }
+
+  class ArithRemPattern : public OpRewritePattern<arith::RemSIOp> {
+  public:
+    using OpRewritePattern<arith::RemSIOp>::OpRewritePattern;
+    LogicalResult matchAndRewrite(arith::RemSIOp op,
+                                  PatternRewriter &rewriter) const final {
+      auto loc = op.getLoc();
+      auto type = op.getType();
+      auto rhs = op.getRhs();
+      APInt value;
+      if (!matchPattern(rhs, m_ConstantInt(&value)))
+        return failure();
+      if (value.isOne()) {
+        auto attr = rewriter.getIntegerAttr(type, 0);
+        auto zero = rewriter.create<arith::ConstantOp>(loc, attr);
+        rewriter.replaceOp(op, zero);
+        return success();
+      } else if (value.popcount() == 1) {
+        auto attr = rewriter.getIntegerAttr(type, value.getSExtValue() - 1);
+        auto mask = rewriter.create<arith::ConstantOp>(loc, attr);
+        auto result = rewriter.create<arith::AndIOp>(loc, op.getLhs(), mask);
+        rewriter.replaceOp(op, result);
+        return success();
+      }
+      return failure();
+    }
+  };
+
+  // assume that no sideEffect op in between
+  class ExtractPattern : public OpRewritePattern<tt::ExtractOp> {
+  public:
+    using OpRewritePattern<tt::ExtractOp>::OpRewritePattern;
+    LogicalResult matchAndRewrite(tt::ExtractOp op,
+                                  PatternRewriter &rewriter) const final {
+      auto base = op.getBase();
+      if (auto def = base.getDefiningOp()) {
+        if (auto glue = dyn_cast<tt::GlueOp>(def)) {
+          auto sub = glue->getOperand(op.getIdx());
+          rewriter.replaceOp(op, sub);
+          return success();
+        }
+      }
+      if (base.getType() == op.getType() && op.getIdx() == 0) {
+        rewriter.replaceOp(op, base);
+        return success();
+      }
+      return failure();
+    }
+  };
+  class ScfPattern : public OpRewritePattern<scf::ForOp> {
+  public:
+    using OpRewritePattern<scf::ForOp>::OpRewritePattern;
+    LogicalResult matchAndRewrite(scf::ForOp op,
+                                  PatternRewriter &rewriter) const final {
+      SmallVector<Operation *> deleteList;
+      SmallVector<Value> newInits;
+      DenseMap<Value, int> userIndexMap;
+      auto idx = 0;
+      for (auto [arg, init] :
+           llvm::zip(op.getRegionIterArgs(), op.getInits())) {
+        auto glue = dyn_cast<tt::GlueOp>(init.getDefiningOp());
+        if (!glue) {
+          newInits.push_back(init);
+          userIndexMap[arg] = idx;
+          idx++;
+          continue;
+        }
+        auto numSplit = glue->getOperands().size();
+        for (auto i = 0; i < numSplit; i++) {
+          newInits.push_back(glue->getOperand(i));
+        }
+        for (auto user : arg.getUsers()) {
+          auto extract = dyn_cast<tt::ExtractOp>(user);
+          if (extract) {
+            userIndexMap[extract] = idx + extract.getIdx();
+            deleteList.push_back(extract.getOperation());
+          }
+        }
+        idx += numSplit;
+      }
+      if (newInits.size() == op.getInits().size())
+        return failure();
+      auto newOp = rewriter.create<scf::ForOp>(op.getLoc(), op.getLowerBound(),
+                                               op.getUpperBound(), op.getStep(),
+                                               newInits);
+
+      for (auto [user, idx] : userIndexMap)
+        user.replaceAllUsesWith(newOp.getRegionIterArgs()[idx]);
+      op.getInductionVar().replaceAllUsesWith(newOp.getInductionVar());
+      // splice operations
+      auto *body = newOp.getBody();
+      body->getOperations().splice(body->begin(),
+                                   op.getBody()->getOperations());
+      // yield op
+      auto yield = cast<scf::YieldOp>(body->getTerminator());
+      SmallVector<Value> newValues;
+      for (auto result : yield.getResults()) {
+        auto def = result.getDefiningOp();
+        if (def) {
+          if (auto glue = dyn_cast<tt::GlueOp>(def)) {
+            newValues.append(glue->getOperands().begin(),
+                             glue->getOperands().end());
+          } else {
+            newValues.push_back(result);
+          }
+        }
+      }
+      {
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPoint(yield);
+        rewriter.create<scf::YieldOp>(yield.getLoc(), newValues);
+        rewriter.eraseOp(yield);
+      }
+
+      // replaceResults
+      userIndexMap.clear();
+      idx = 0;
+      for (auto [result, init] : llvm::zip(op.getResults(), op.getInits())) {
+        auto glue = dyn_cast<tt::GlueOp>(init.getDefiningOp());
+        if (!glue) {
+          userIndexMap[result] = idx;
+          idx++;
+          continue;
+        }
+        for (auto user : result.getUsers()) {
+          auto extract = dyn_cast<tt::ExtractOp>(user);
+          if (extract) {
+            userIndexMap[extract] = idx + extract.getIdx();
+            deleteList.push_back(extract.getOperation());
+          }
+        }
+        idx += glue->getOperands().size();
+      }
+      for (auto [user, idx] : userIndexMap)
+        user.replaceAllUsesWith(newOp.getResults()[idx]);
+      // rewriter.replaceAllUsesWith()
+      for (auto op : deleteList)
+        rewriter.eraseOp(op);
+      rewriter.eraseOp(op);
+      return success();
+    }
+  };
+};
+
+std::unique_ptr<Pass> mlir::triton::gpu::createTritonGPUMatchTargetSizePass() {
+  return std::make_unique<TritonGPUMatchTargetSizePass>();
+}

--- a/test/TritonGPU/distribute-to-warps.mlir
+++ b/test/TritonGPU/distribute-to-warps.mlir
@@ -1,0 +1,107 @@
+// RUN: triton-opt %s -split-input-file -tritongpu-distribute-to-warps -canonicalize -cse | FileCheck %s
+
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [32, 32], threadsPerWarp = [1, 1], warpsPerCTA = [4, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#blocked2 = #triton_gpu.blocked<{sizePerThread = [32, 32], threadsPerWarp = [1, 1], warpsPerCTA = [1, 4], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#blockedC = #triton_gpu.blocked<{sizePerThread = [64, 64], threadsPerWarp = [1, 1], warpsPerCTA = [2, 2], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#blockedA = #triton_gpu.dot_op<{opIdx = 0, parent = #blockedC}>
+#blockedB = #triton_gpu.dot_op<{opIdx = 1, parent = #blockedC}>
+
+//       CHECK: gpu.subgroup_id : index
+// in the loop body:
+// thread block works on 128x128xf32 = 128x32xf16 * 32x128xf16
+//    each warp works on   64x64xf32 =  64x32xf16 *  32x64xf16
+module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 1 : i32} {
+  tt.func public @matmul_kernel_with_block_pointers_with_convertlayout(%arg0: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg4: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg5: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg6: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg7: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg8: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blockedC>
+    %c8_i32 = arith.constant 8 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c127_i32 = arith.constant 127 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.addi %arg3, %c127_i32 : i32
+    %2 = arith.divsi %1, %c128_i32 : i32
+    %3 = arith.addi %arg4, %c127_i32 : i32
+    %4 = arith.divsi %3, %c128_i32 : i32
+    %5 = arith.muli %4, %c8_i32 : i32
+    %6 = arith.divsi %0, %5 : i32
+    %7 = arith.muli %6, %c8_i32 : i32
+    %8 = arith.subi %2, %7 : i32
+    %9 = arith.minsi %8, %c8_i32 : i32
+    %10 = arith.remsi %0, %9 : i32
+    %11 = arith.addi %7, %10 : i32
+    %12 = arith.remsi %0, %5 : i32
+    %13 = arith.divsi %12, %9 : i32
+    %14 = arith.muli %11, %c128_i32 : i32
+    %15 = arith.extsi %arg3 : i32 to i64
+    %16 = arith.extsi %arg5 : i32 to i64
+    %17 = arith.extsi %arg6 : i32 to i64
+    %18 = tt.make_tensor_ptr %arg0, [%15, %16], [%17, %c1_i64], [%14, %c0_i32] {order = array<i32: 1, 0>} : <tensor<128x32xf16, #blocked1>, 1>
+    %19 = arith.muli %13, %c128_i32 : i32
+    %20 = arith.extsi %arg4 : i32 to i64
+    %21 = arith.extsi %arg7 : i32 to i64
+    %22 = tt.make_tensor_ptr %arg1, [%16, %20], [%21, %c1_i64], [%c0_i32, %19] {order = array<i32: 1, 0>} : <tensor<32x128xf16, #blocked2>, 1>
+    %23:3 = scf.for %arg9 = %c0_i32 to %arg5 step %c32_i32 iter_args(%arg10 = %cst, %arg11 = %18, %arg12 = %22) -> (tensor<128x128xf32, #blockedC>, !tt.ptr<tensor<128x32xf16, #blocked1>, 1>, !tt.ptr<tensor<32x128xf16, #blocked2>, 1>)  : i32 {
+      %28 = tt.load %arg11 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<128x32xf16, #blocked1>, 1> -> tensor<128x32xf16, #blocked1>
+      %29 = tt.load %arg12 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<32x128xf16, #blocked2>, 1> -> tensor<32x128xf16, #blocked2>
+      %30 = triton_gpu.convert_layout %28 : tensor<128x32xf16, #blocked1> -> tensor<128x32xf16, #blockedA>
+      %31 = triton_gpu.convert_layout %29 : tensor<32x128xf16, #blocked2> -> tensor<32x128xf16, #blockedB>
+      %32 = tt.dot %30, %31, %arg10 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<128x32xf16, #blockedA> * tensor<32x128xf16, #blockedB> -> tensor<128x128xf32, #blockedC>
+      %33 = tt.advance %arg11, [%c0_i32, %c32_i32] : <tensor<128x32xf16, #blocked1>, 1>
+      %34 = tt.advance %arg12, [%c32_i32, %c0_i32] : <tensor<32x128xf16, #blocked2>, 1>
+      scf.yield %32, %33, %34 : tensor<128x128xf32, #blockedC>, !tt.ptr<tensor<128x32xf16, #blocked1>, 1>, !tt.ptr<tensor<32x128xf16, #blocked2>, 1>
+    }
+    %24 = arith.truncf %23#0 : tensor<128x128xf32, #blockedC> to tensor<128x128xf16, #blockedC>
+    %25 = arith.extsi %arg8 : i32 to i64
+    %26 = tt.make_tensor_ptr %arg2, [%15, %20], [%25, %c1_i64], [%14, %19] {order = array<i32: 1, 0>} : <tensor<128x128xf16, #blockedC>, 1>
+    tt.store %26, %24 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<128x128xf16, #blockedC>, 1>, tensor<128x128xf16, #blockedC>
+    tt.return
+  }
+
+  tt.func public @matmul_kernel_with_block_pointers_without_convertlayout(%arg0: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg4: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg5: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg6: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg7: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg8: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blockedC>
+    %c8_i32 = arith.constant 8 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c127_i32 = arith.constant 127 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.addi %arg3, %c127_i32 : i32
+    %2 = arith.divsi %1, %c128_i32 : i32
+    %3 = arith.addi %arg4, %c127_i32 : i32
+    %4 = arith.divsi %3, %c128_i32 : i32
+    %5 = arith.muli %4, %c8_i32 : i32
+    %6 = arith.divsi %0, %5 : i32
+    %7 = arith.muli %6, %c8_i32 : i32
+    %8 = arith.subi %2, %7 : i32
+    %9 = arith.minsi %8, %c8_i32 : i32
+    %10 = arith.remsi %0, %9 : i32
+    %11 = arith.addi %7, %10 : i32
+    %12 = arith.remsi %0, %5 : i32
+    %13 = arith.divsi %12, %9 : i32
+    %14 = arith.muli %11, %c128_i32 : i32
+    %15 = arith.extsi %arg3 : i32 to i64
+    %16 = arith.extsi %arg5 : i32 to i64
+    %17 = arith.extsi %arg6 : i32 to i64
+    %18 = tt.make_tensor_ptr %arg0, [%15, %16], [%17, %c1_i64], [%14, %c0_i32] {order = array<i32: 1, 0>} : <tensor<128x32xf16, #blockedA>, 1>
+    %19 = arith.muli %13, %c128_i32 : i32
+    %20 = arith.extsi %arg4 : i32 to i64
+    %21 = arith.extsi %arg7 : i32 to i64
+    %22 = tt.make_tensor_ptr %arg1, [%16, %20], [%21, %c1_i64], [%c0_i32, %19] {order = array<i32: 1, 0>} : <tensor<32x128xf16, #blockedB>, 1>
+    %23:3 = scf.for %arg9 = %c0_i32 to %arg5 step %c32_i32 iter_args(%arg10 = %cst, %arg11 = %18, %arg12 = %22) -> (tensor<128x128xf32, #blockedC>, !tt.ptr<tensor<128x32xf16, #blockedA>, 1>, !tt.ptr<tensor<32x128xf16, #blockedB>, 1>)  : i32 {
+      %28 = tt.load %arg11 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<128x32xf16, #blockedA>, 1> -> tensor<128x32xf16, #blockedA>
+      %29 = tt.load %arg12 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<32x128xf16, #blockedB>, 1> -> tensor<32x128xf16, #blockedB>
+      %32 = tt.dot %28, %29, %arg10 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<128x32xf16, #blockedA> * tensor<32x128xf16, #blockedB> -> tensor<128x128xf32, #blockedC>
+      %33 = tt.advance %arg11, [%c0_i32, %c32_i32] : <tensor<128x32xf16, #blockedA>, 1>
+      %34 = tt.advance %arg12, [%c32_i32, %c0_i32] : <tensor<32x128xf16, #blockedB>, 1>
+      scf.yield %32, %33, %34 : tensor<128x128xf32, #blockedC>, !tt.ptr<tensor<128x32xf16, #blockedA>, 1>, !tt.ptr<tensor<32x128xf16, #blockedB>, 1>
+    }
+    %24 = arith.truncf %23#0 : tensor<128x128xf32, #blockedC> to tensor<128x128xf16, #blockedC>
+    %25 = arith.extsi %arg8 : i32 to i64
+    %26 = tt.make_tensor_ptr %arg2, [%15, %20], [%25, %c1_i64], [%14, %19] {order = array<i32: 1, 0>} : <tensor<128x128xf16, #blockedC>, 1>
+    tt.store %26, %24 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<128x128xf16, #blockedC>, 1>, tensor<128x128xf16, #blockedC>
+    tt.return
+  }
+}

--- a/test/TritonGPU/distribute-to-warps.output.mlir
+++ b/test/TritonGPU/distribute-to-warps.output.mlir
@@ -1,0 +1,144 @@
+// RUN: triton-opt %s -split-input-file | FileCheck %s
+
+#warp = #triton_gpu.warp<{sizePerThread = [64, 64], threadsPerWarp = [1, 1], order = [1, 0]}>
+#warp1 = #triton_gpu.warp<{sizePerThread = [32, 32], threadsPerWarp = [1, 1], order = [1, 0]}>
+//       CHECK: gpu.subgroup_id : index
+module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 1 : i32} {
+  tt.func public @matmul_kernel_with_block_pointers_with_convertlayout(%arg0: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg4: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg5: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg6: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg7: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg8: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}) attributes {noinline = false} {
+    %c64_i32 = arith.constant 64 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c32_i64 = arith.constant 32 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c127_i32 = arith.constant 127 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #warp>
+    %0 = gpu.subgroup_id : index
+    %1 = arith.index_cast %0 : index to i32
+    %2 = tt.get_program_id x : i32
+    %3 = arith.addi %arg3, %c127_i32 : i32
+    %4 = arith.divsi %3, %c128_i32 : i32
+    %5 = arith.addi %arg4, %c127_i32 : i32
+    %6 = arith.divsi %5, %c128_i32 : i32
+    %7 = arith.muli %6, %c8_i32 : i32
+    %8 = arith.divsi %2, %7 : i32
+    %9 = arith.muli %8, %c8_i32 : i32
+    %10 = arith.subi %4, %9 : i32
+    %11 = arith.minsi %10, %c8_i32 : i32
+    %12 = arith.remsi %2, %11 : i32
+    %13 = arith.addi %9, %12 : i32
+    %14 = arith.remsi %2, %7 : i32
+    %15 = arith.divsi %14, %11 : i32
+    %16 = arith.muli %13, %c128_i32 : i32
+    %17 = arith.extsi %arg3 : i32 to i64
+    %18 = arith.extsi %arg5 : i32 to i64
+    %19 = arith.extsi %arg6 : i32 to i64
+    %20 = arith.muli %1, %c32_i32 : i32
+    %21 = arith.addi %20, %16 : i32
+    %22 = tt.make_tensor_ptr %arg0, [%17, %18], [%19, %c1_i64], [%21, %c0_i32] {order = array<i32: 1, 0>} : <tensor<32x32xf16, #warp1>, 1>
+    %23 = arith.muli %15, %c128_i32 : i32
+    %24 = arith.extsi %arg4 : i32 to i64
+    %25 = arith.extsi %arg7 : i32 to i64
+    %26 = arith.addi %20, %23 : i32
+    %27 = tt.make_tensor_ptr %arg1, [%18, %24], [%25, %c1_i64], [%c0_i32, %26] {order = array<i32: 1, 0>} : <tensor<32x32xf16, #warp1>, 1>
+    %28:3 = scf.for %arg9 = %c0_i32 to %arg5 step %c32_i32 iter_args(%arg10 = %cst, %arg11 = %22, %arg12 = %27) -> (tensor<64x64xf32, #warp>, !tt.ptr<tensor<32x32xf16, #warp1>, 1>, !tt.ptr<tensor<32x32xf16, #warp1>, 1>)  : i32 {
+      %40 = tt.load %arg11 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<32x32xf16, #warp1>, 1> -> tensor<32x32xf16, #warp1>
+      %41 = tt.load %arg12 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<32x32xf16, #warp1>, 1> -> tensor<32x32xf16, #warp1>
+      %42 = triton_gpu.alloc : <f16, 1>
+      %43 = tt.make_tensor_ptr %42, [%c128_i64, %c32_i64], [%c32_i64, %c1_i64], [%20, %c0_i32] {order = array<i32: 1, 0>} : <tensor<32x32xf16, #warp1>, 3>
+      tt.store %43, %40 {cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<32x32xf16, #warp1>, 3>, tensor<32x32xf16, #warp1>
+      gpu.barrier
+      %44 = arith.divsi %1, %c2_i32 : i32
+      %45 = arith.remsi %44, %c2_i32 : i32
+      %46 = arith.muli %45, %c64_i32 : i32
+      %47 = tt.make_tensor_ptr %42, [%c128_i64, %c32_i64], [%c32_i64, %c1_i64], [%46, %c0_i32] {order = array<i32: 1, 0>} : <tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #warp}>>, 3>
+      %48 = tt.load %47 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #warp}>>, 3> -> tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #warp}>>
+      %49 = triton_gpu.alloc : <f16, 1>
+      %50 = tt.make_tensor_ptr %49, [%c32_i64, %c128_i64], [%c128_i64, %c1_i64], [%c0_i32, %20] {order = array<i32: 1, 0>} : <tensor<32x32xf16, #warp1>, 3>
+      tt.store %50, %41 {cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<32x32xf16, #warp1>, 3>, tensor<32x32xf16, #warp1>
+      gpu.barrier
+      %51 = arith.remsi %1, %c2_i32 : i32
+      %52 = arith.remsi %51, %c2_i32 : i32
+      %53 = arith.muli %52, %c64_i32 : i32
+      %54 = tt.make_tensor_ptr %49, [%c32_i64, %c128_i64], [%c128_i64, %c1_i64], [%c0_i32, %53] {order = array<i32: 1, 0>} : <tensor<32x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #warp}>>, 3>
+      %55 = tt.load %54 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<32x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #warp}>>, 3> -> tensor<32x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #warp}>>
+      %56 = tt.dot %48, %55, %arg10 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #warp}>> * tensor<32x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #warp}>> -> tensor<64x64xf32, #warp>
+      %57 = tt.advance %arg11, [%c0_i32, %c32_i32] : <tensor<32x32xf16, #warp1>, 1>
+      %58 = tt.advance %arg12, [%c32_i32, %c0_i32] : <tensor<32x32xf16, #warp1>, 1>
+      scf.yield %56, %57, %58 : tensor<64x64xf32, #warp>, !tt.ptr<tensor<32x32xf16, #warp1>, 1>, !tt.ptr<tensor<32x32xf16, #warp1>, 1>
+    }
+    %29 = arith.truncf %28#0 : tensor<64x64xf32, #warp> to tensor<64x64xf16, #warp>
+    %30 = arith.extsi %arg8 : i32 to i64
+    %31 = arith.divsi %1, %c2_i32 : i32
+    %32 = arith.remsi %31, %c2_i32 : i32
+    %33 = arith.muli %32, %c64_i32 : i32
+    %34 = arith.addi %33, %16 : i32
+    %35 = arith.remsi %1, %c2_i32 : i32
+    %36 = arith.remsi %35, %c2_i32 : i32
+    %37 = arith.muli %36, %c64_i32 : i32
+    %38 = arith.addi %37, %23 : i32
+    %39 = tt.make_tensor_ptr %arg2, [%17, %24], [%30, %c1_i64], [%34, %38] {order = array<i32: 1, 0>} : <tensor<64x64xf16, #warp>, 1>
+    tt.store %39, %29 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<64x64xf16, #warp>, 1>, tensor<64x64xf16, #warp>
+    tt.return
+  }
+  tt.func public @matmul_kernel_with_block_pointers_without_convertlayout(%arg0: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg4: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg5: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg6: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg7: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg8: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}) attributes {noinline = false} {
+    %c64_i32 = arith.constant 64 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c127_i32 = arith.constant 127 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #warp>
+    %0 = gpu.subgroup_id : index
+    %1 = arith.index_cast %0 : index to i32
+    %2 = tt.get_program_id x : i32
+    %3 = arith.addi %arg3, %c127_i32 : i32
+    %4 = arith.divsi %3, %c128_i32 : i32
+    %5 = arith.addi %arg4, %c127_i32 : i32
+    %6 = arith.divsi %5, %c128_i32 : i32
+    %7 = arith.muli %6, %c8_i32 : i32
+    %8 = arith.divsi %2, %7 : i32
+    %9 = arith.muli %8, %c8_i32 : i32
+    %10 = arith.subi %4, %9 : i32
+    %11 = arith.minsi %10, %c8_i32 : i32
+    %12 = arith.remsi %2, %11 : i32
+    %13 = arith.addi %9, %12 : i32
+    %14 = arith.remsi %2, %7 : i32
+    %15 = arith.divsi %14, %11 : i32
+    %16 = arith.muli %13, %c128_i32 : i32
+    %17 = arith.extsi %arg3 : i32 to i64
+    %18 = arith.extsi %arg5 : i32 to i64
+    %19 = arith.extsi %arg6 : i32 to i64
+    %20 = arith.divsi %1, %c2_i32 : i32
+    %21 = arith.remsi %20, %c2_i32 : i32
+    %22 = arith.muli %21, %c64_i32 : i32
+    %23 = arith.addi %22, %16 : i32
+    %24 = tt.make_tensor_ptr %arg0, [%17, %18], [%19, %c1_i64], [%23, %c0_i32] {order = array<i32: 1, 0>} : <tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #warp}>>, 1>
+    %25 = arith.muli %15, %c128_i32 : i32
+    %26 = arith.extsi %arg4 : i32 to i64
+    %27 = arith.extsi %arg7 : i32 to i64
+    %28 = arith.remsi %1, %c2_i32 : i32
+    %29 = arith.remsi %28, %c2_i32 : i32
+    %30 = arith.muli %29, %c64_i32 : i32
+    %31 = arith.addi %30, %25 : i32
+    %32 = tt.make_tensor_ptr %arg1, [%18, %26], [%27, %c1_i64], [%c0_i32, %31] {order = array<i32: 1, 0>} : <tensor<32x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #warp}>>, 1>
+    %33:3 = scf.for %arg9 = %c0_i32 to %arg5 step %c32_i32 iter_args(%arg10 = %cst, %arg11 = %24, %arg12 = %32) -> (tensor<64x64xf32, #warp>, !tt.ptr<tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #warp}>>, 1>, !tt.ptr<tensor<32x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #warp}>>, 1>)  : i32 {
+      %37 = tt.load %arg11 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #warp}>>, 1> -> tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #warp}>>
+      %38 = tt.load %arg12 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<32x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #warp}>>, 1> -> tensor<32x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #warp}>>
+      %39 = tt.dot %37, %38, %arg10 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #warp}>> * tensor<32x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #warp}>> -> tensor<64x64xf32, #warp>
+      %40 = tt.advance %arg11, [%c0_i32, %c32_i32] : <tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #warp}>>, 1>
+      %41 = tt.advance %arg12, [%c32_i32, %c0_i32] : <tensor<32x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #warp}>>, 1>
+      scf.yield %39, %40, %41 : tensor<64x64xf32, #warp>, !tt.ptr<tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #warp}>>, 1>, !tt.ptr<tensor<32x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #warp}>>, 1>
+    }
+    %34 = arith.truncf %33#0 : tensor<64x64xf32, #warp> to tensor<64x64xf16, #warp>
+    %35 = arith.extsi %arg8 : i32 to i64
+    %36 = tt.make_tensor_ptr %arg2, [%17, %26], [%35, %c1_i64], [%23, %31] {order = array<i32: 1, 0>} : <tensor<64x64xf16, #warp>, 1>
+    tt.store %36, %34 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<64x64xf16, #warp>, 1>, tensor<64x64xf16, #warp>
+    tt.return
+  }
+}

--- a/test/TritonGPU/match-target-size.mlir
+++ b/test/TritonGPU/match-target-size.mlir
@@ -1,0 +1,66 @@
+// RUN: triton-opt %s -split-input-file -tritongpu-match-target-size -canonicalize -cse | FileCheck %s
+
+#warp = #triton_gpu.warp<{sizePerThread = [32, 64], threadsPerWarp = [1, 1], order = [1, 0]}>
+#dot0_ = #triton_gpu.dot_op<{opIdx = 0, parent = #warp}>
+#dot1_ = #triton_gpu.dot_op<{opIdx = 1, parent = #warp}>
+module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 32 : i32, "triton_gpu.threads-per-warp" = 1 : i32} {
+  tt.func public @matmul_kernel_with_block_pointers_without_convertlayout(%arg0: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg4: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg5: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg6: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg7: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg8: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}) attributes {noinline = false} {
+    %c64_i32 = arith.constant 64 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c127_i32 = arith.constant 127 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x64xf32, #warp>
+    %0 = gpu.subgroup_id : index
+    %1 = arith.index_cast %0 : index to i32
+    %2 = tt.get_program_id x : i32
+    %3 = arith.addi %arg3, %c127_i32 : i32
+    %4 = arith.divsi %3, %c128_i32 : i32
+    %5 = arith.addi %arg4, %c127_i32 : i32
+    %6 = arith.divsi %5, %c128_i32 : i32
+    %7 = arith.muli %6, %c8_i32 : i32
+    %8 = arith.divsi %2, %7 : i32
+    %9 = arith.muli %8, %c8_i32 : i32
+    %10 = arith.subi %4, %9 : i32
+    %11 = arith.minsi %10, %c8_i32 : i32
+    %12 = arith.remsi %2, %11 : i32
+    %13 = arith.addi %9, %12 : i32
+    %14 = arith.remsi %2, %7 : i32
+    %15 = arith.divsi %14, %11 : i32
+    %16 = arith.muli %13, %c128_i32 : i32
+    %17 = arith.extsi %arg3 : i32 to i64
+    %18 = arith.extsi %arg5 : i32 to i64
+    %19 = arith.extsi %arg6 : i32 to i64
+    %20 = arith.divsi %1, %c4_i32 : i32
+    %21 = arith.remsi %20, %c8_i32 : i32
+    %22 = arith.muli %21, %c32_i32 : i32
+    %23 = arith.addi %22, %16 : i32
+    %24 = tt.make_tensor_ptr %arg0, [%17, %18], [%19, %c1_i64], [%23, %c0_i32] {order = array<i32: 1, 0>} : <tensor<32x32xf16, #dot0_>, 1>
+    %25 = arith.muli %15, %c128_i32 : i32
+    %26 = arith.extsi %arg4 : i32 to i64
+    %27 = arith.extsi %arg7 : i32 to i64
+    %28 = arith.remsi %1, %c4_i32 : i32
+    %29 = arith.remsi %28, %c4_i32 : i32
+    %30 = arith.muli %29, %c64_i32 : i32
+    %31 = arith.addi %30, %25 : i32
+    %32 = tt.make_tensor_ptr %arg1, [%18, %26], [%27, %c1_i64], [%c0_i32, %31] {order = array<i32: 1, 0>} : <tensor<32x64xf16, #dot1_>, 1>
+    %33:3 = scf.for %arg9 = %c0_i32 to %arg5 step %c32_i32 iter_args(%arg10 = %cst, %arg11 = %24, %arg12 = %32) -> (tensor<32x64xf32, #warp>, !tt.ptr<tensor<32x32xf16, #dot0_>, 1>, !tt.ptr<tensor<32x64xf16, #dot1_>, 1>)  : i32 {
+      %37 = tt.load %arg11 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<32x32xf16, #dot0_>, 1> -> tensor<32x32xf16, #dot0_>
+      %38 = tt.load %arg12 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<32x64xf16, #dot1_>, 1> -> tensor<32x64xf16, #dot1_>
+      // CHECK: tt.dot
+      // CHECK-SAME: tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %39 = tt.dot %37, %38, %arg10 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<32x32xf16, #dot0_> * tensor<32x64xf16, #dot1_> -> tensor<32x64xf32, #warp>
+      %40 = tt.advance %arg11, [%c0_i32, %c32_i32] : <tensor<32x32xf16, #dot0_>, 1>
+      %41 = tt.advance %arg12, [%c32_i32, %c0_i32] : <tensor<32x64xf16, #dot1_>, 1>
+      scf.yield %39, %40, %41 : tensor<32x64xf32, #warp>, !tt.ptr<tensor<32x32xf16, #dot0_>, 1>, !tt.ptr<tensor<32x64xf16, #dot1_>, 1>
+    }
+    %34 = arith.truncf %33#0 : tensor<32x64xf32, #warp> to tensor<32x64xf16, #warp>
+    %35 = arith.extsi %arg8 : i32 to i64
+    %36 = tt.make_tensor_ptr %arg2, [%17, %26], [%35, %c1_i64], [%23, %31] {order = array<i32: 1, 0>} : <tensor<32x64xf16, #warp>, 1>
+    tt.store %36, %34 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<32x64xf16, #warp>, 1>, tensor<32x64xf16, #warp>
+    tt.return
+  }
+}

--- a/test/TritonGPU/match-target-size.output.mlir
+++ b/test/TritonGPU/match-target-size.output.mlir
@@ -1,0 +1,173 @@
+// RUN: triton-opt %s -split-input-file | FileCheck %s
+
+// CHECK: tt.dot
+module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 32 : i32, "triton_gpu.threads-per-warp" = 1 : i32} {
+  tt.func public @matmul_kernel_with_block_pointers_without_convertlayout(%arg0: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg4: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg5: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg6: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg7: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}, %arg8: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}) attributes {noinline = false} {
+    %c3_i32 = arith.constant 3 : i32
+    %c7_i32 = arith.constant 7 : i32
+    %c48_i32 = arith.constant 48 : i32
+    %c16_i32 = arith.constant 16 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c127_i32 = arith.constant 127 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32>
+    %0 = gpu.subgroup_id : index
+    %1 = arith.index_cast %0 : index to i32
+    %2 = tt.get_program_id x : i32
+    %3 = arith.addi %arg3, %c127_i32 : i32
+    %4 = arith.divsi %3, %c128_i32 : i32
+    %5 = arith.addi %arg4, %c127_i32 : i32
+    %6 = arith.divsi %5, %c128_i32 : i32
+    %7 = arith.muli %6, %c8_i32 : i32
+    %8 = arith.divsi %2, %7 : i32
+    %9 = arith.muli %8, %c8_i32 : i32
+    %10 = arith.subi %4, %9 : i32
+    %11 = arith.minsi %10, %c8_i32 : i32
+    %12 = arith.remsi %2, %11 : i32
+    %13 = arith.addi %9, %12 : i32
+    %14 = arith.remsi %2, %7 : i32
+    %15 = arith.divsi %14, %11 : i32
+    %16 = arith.muli %13, %c128_i32 : i32
+    %17 = arith.extsi %arg3 : i32 to i64
+    %18 = arith.extsi %arg5 : i32 to i64
+    %19 = arith.extsi %arg6 : i32 to i64
+    %20 = arith.divsi %1, %c4_i32 : i32
+    %21 = arith.andi %20, %c7_i32 : i32
+    %22 = arith.muli %21, %c32_i32 : i32
+    %23 = arith.addi %22, %16 : i32
+    %24 = tt.make_tensor_ptr %arg0, [%17, %18], [%19, %c1_i64], [%23, %c0_i32] {order = array<i32: 1, 0>} : <tensor<32x16xf16>, 1>
+    %25 = tt.make_tensor_ptr %arg0, [%17, %18], [%19, %c1_i64], [%23, %c16_i32] {order = array<i32: 1, 0>} : <tensor<32x16xf16>, 1>
+    %26 = arith.muli %15, %c128_i32 : i32
+    %27 = arith.extsi %arg4 : i32 to i64
+    %28 = arith.extsi %arg7 : i32 to i64
+    %29 = arith.andi %1, %c3_i32 : i32
+    %30 = arith.muli %29, %c64_i32 : i32
+    %31 = arith.addi %30, %26 : i32
+    %32 = tt.make_tensor_ptr %arg1, [%18, %27], [%28, %c1_i64], [%c0_i32, %31] {order = array<i32: 1, 0>} : <tensor<32x16xf16>, 1>
+    %33 = arith.addi %31, %c16_i32 : i32
+    %34 = tt.make_tensor_ptr %arg1, [%18, %27], [%28, %c1_i64], [%c0_i32, %33] {order = array<i32: 1, 0>} : <tensor<32x16xf16>, 1>
+    %35 = arith.addi %31, %c32_i32 : i32
+    %36 = tt.make_tensor_ptr %arg1, [%18, %27], [%28, %c1_i64], [%c0_i32, %35] {order = array<i32: 1, 0>} : <tensor<32x16xf16>, 1>
+    %37 = arith.addi %31, %c48_i32 : i32
+    %38 = tt.make_tensor_ptr %arg1, [%18, %27], [%28, %c1_i64], [%c0_i32, %37] {order = array<i32: 1, 0>} : <tensor<32x16xf16>, 1>
+    %39:14 = scf.for %arg9 = %c0_i32 to %arg5 step %c32_i32 iter_args(%arg10 = %cst, %arg11 = %cst, %arg12 = %cst, %arg13 = %cst, %arg14 = %cst, %arg15 = %cst, %arg16 = %cst, %arg17 = %cst, %arg18 = %24, %arg19 = %25, %arg20 = %32, %arg21 = %34, %arg22 = %36, %arg23 = %38) -> (tensor<16x16xf32>, tensor<16x16xf32>, tensor<16x16xf32>, tensor<16x16xf32>, tensor<16x16xf32>, tensor<16x16xf32>, tensor<16x16xf32>, tensor<16x16xf32>, !tt.ptr<tensor<32x16xf16>, 1>, !tt.ptr<tensor<32x16xf16>, 1>, !tt.ptr<tensor<32x16xf16>, 1>, !tt.ptr<tensor<32x16xf16>, 1>, !tt.ptr<tensor<32x16xf16>, 1>, !tt.ptr<tensor<32x16xf16>, 1>)  : i32 {
+      %58 = tt.load %arg18 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<32x16xf16>, 1> -> tensor<32x16xf16>
+      %59 = tt.load %arg19 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<32x16xf16>, 1> -> tensor<32x16xf16>
+      %60 = tt.load %arg20 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<32x16xf16>, 1> -> tensor<32x16xf16>
+      %61 = tt.load %arg21 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<32x16xf16>, 1> -> tensor<32x16xf16>
+      %62 = tt.load %arg22 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<32x16xf16>, 1> -> tensor<32x16xf16>
+      %63 = tt.load %arg23 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<32x16xf16>, 1> -> tensor<32x16xf16>
+      %64 = tt.extract %arg10, 0 : tensor<16x16xf32> -> tensor<8x16xf32>
+      %65 = tt.extract %58, 0 : tensor<32x16xf16> -> tensor<8x16xf16>
+      %66 = tt.extract %60, 0 : tensor<32x16xf16> -> tensor<16x16xf16>
+      %67 = tt.dot %65, %66, %64 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %68 = tt.extract %59, 0 : tensor<32x16xf16> -> tensor<8x16xf16>
+      %69 = tt.extract %60, 1 : tensor<32x16xf16> -> tensor<16x16xf16>
+      %70 = tt.dot %68, %69, %67 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %71 = tt.extract %arg10, 1 : tensor<16x16xf32> -> tensor<8x16xf32>
+      %72 = tt.extract %58, 1 : tensor<32x16xf16> -> tensor<8x16xf16>
+      %73 = tt.dot %72, %66, %71 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %74 = tt.extract %59, 1 : tensor<32x16xf16> -> tensor<8x16xf16>
+      %75 = tt.dot %74, %69, %73 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %76 = tt.glue %70, %75 : tensor<8x16xf32>, tensor<8x16xf32> -> tensor<16x16xf32>
+      %77 = tt.extract %arg11, 0 : tensor<16x16xf32> -> tensor<8x16xf32>
+      %78 = tt.extract %58, 2 : tensor<32x16xf16> -> tensor<8x16xf16>
+      %79 = tt.dot %78, %66, %77 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %80 = tt.extract %59, 2 : tensor<32x16xf16> -> tensor<8x16xf16>
+      %81 = tt.dot %80, %69, %79 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %82 = tt.extract %arg11, 1 : tensor<16x16xf32> -> tensor<8x16xf32>
+      %83 = tt.extract %58, 3 : tensor<32x16xf16> -> tensor<8x16xf16>
+      %84 = tt.dot %83, %66, %82 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %85 = tt.extract %59, 3 : tensor<32x16xf16> -> tensor<8x16xf16>
+      %86 = tt.dot %85, %69, %84 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %87 = tt.glue %81, %86 : tensor<8x16xf32>, tensor<8x16xf32> -> tensor<16x16xf32>
+      %88 = tt.extract %arg12, 0 : tensor<16x16xf32> -> tensor<8x16xf32>
+      %89 = tt.extract %61, 0 : tensor<32x16xf16> -> tensor<16x16xf16>
+      %90 = tt.dot %65, %89, %88 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %91 = tt.extract %61, 1 : tensor<32x16xf16> -> tensor<16x16xf16>
+      %92 = tt.dot %68, %91, %90 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %93 = tt.extract %arg12, 1 : tensor<16x16xf32> -> tensor<8x16xf32>
+      %94 = tt.dot %72, %89, %93 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %95 = tt.dot %74, %91, %94 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %96 = tt.glue %92, %95 : tensor<8x16xf32>, tensor<8x16xf32> -> tensor<16x16xf32>
+      %97 = tt.extract %arg13, 0 : tensor<16x16xf32> -> tensor<8x16xf32>
+      %98 = tt.dot %78, %89, %97 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %99 = tt.dot %80, %91, %98 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %100 = tt.extract %arg13, 1 : tensor<16x16xf32> -> tensor<8x16xf32>
+      %101 = tt.dot %83, %89, %100 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %102 = tt.dot %85, %91, %101 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %103 = tt.glue %99, %102 : tensor<8x16xf32>, tensor<8x16xf32> -> tensor<16x16xf32>
+      %104 = tt.extract %arg14, 0 : tensor<16x16xf32> -> tensor<8x16xf32>
+      %105 = tt.extract %62, 0 : tensor<32x16xf16> -> tensor<16x16xf16>
+      %106 = tt.dot %65, %105, %104 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %107 = tt.extract %62, 1 : tensor<32x16xf16> -> tensor<16x16xf16>
+      %108 = tt.dot %68, %107, %106 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %109 = tt.extract %arg14, 1 : tensor<16x16xf32> -> tensor<8x16xf32>
+      %110 = tt.dot %72, %105, %109 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %111 = tt.dot %74, %107, %110 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %112 = tt.glue %108, %111 : tensor<8x16xf32>, tensor<8x16xf32> -> tensor<16x16xf32>
+      %113 = tt.extract %arg15, 0 : tensor<16x16xf32> -> tensor<8x16xf32>
+      %114 = tt.dot %78, %105, %113 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %115 = tt.dot %80, %107, %114 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %116 = tt.extract %arg15, 1 : tensor<16x16xf32> -> tensor<8x16xf32>
+      %117 = tt.dot %83, %105, %116 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %118 = tt.dot %85, %107, %117 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %119 = tt.glue %115, %118 : tensor<8x16xf32>, tensor<8x16xf32> -> tensor<16x16xf32>
+      %120 = tt.extract %arg16, 0 : tensor<16x16xf32> -> tensor<8x16xf32>
+      %121 = tt.extract %63, 0 : tensor<32x16xf16> -> tensor<16x16xf16>
+      %122 = tt.dot %65, %121, %120 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %123 = tt.extract %63, 1 : tensor<32x16xf16> -> tensor<16x16xf16>
+      %124 = tt.dot %68, %123, %122 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %125 = tt.extract %arg16, 1 : tensor<16x16xf32> -> tensor<8x16xf32>
+      %126 = tt.dot %72, %121, %125 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %127 = tt.dot %74, %123, %126 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %128 = tt.glue %124, %127 : tensor<8x16xf32>, tensor<8x16xf32> -> tensor<16x16xf32>
+      %129 = tt.extract %arg17, 0 : tensor<16x16xf32> -> tensor<8x16xf32>
+      %130 = tt.dot %78, %121, %129 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %131 = tt.dot %80, %123, %130 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %132 = tt.extract %arg17, 1 : tensor<16x16xf32> -> tensor<8x16xf32>
+      %133 = tt.dot %83, %121, %132 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %134 = tt.dot %85, %123, %133 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %135 = tt.glue %131, %134 : tensor<8x16xf32>, tensor<8x16xf32> -> tensor<16x16xf32>
+      %136 = tt.advance %arg18, [%c0_i32, %c32_i32] : <tensor<32x16xf16>, 1>
+      %137 = tt.advance %arg19, [%c0_i32, %c32_i32] : <tensor<32x16xf16>, 1>
+      %138 = tt.advance %arg20, [%c32_i32, %c0_i32] : <tensor<32x16xf16>, 1>
+      %139 = tt.advance %arg21, [%c32_i32, %c0_i32] : <tensor<32x16xf16>, 1>
+      %140 = tt.advance %arg22, [%c32_i32, %c0_i32] : <tensor<32x16xf16>, 1>
+      %141 = tt.advance %arg23, [%c32_i32, %c0_i32] : <tensor<32x16xf16>, 1>
+      scf.yield %76, %87, %96, %103, %112, %119, %128, %135, %136, %137, %138, %139, %140, %141 : tensor<16x16xf32>, tensor<16x16xf32>, tensor<16x16xf32>, tensor<16x16xf32>, tensor<16x16xf32>, tensor<16x16xf32>, tensor<16x16xf32>, tensor<16x16xf32>, !tt.ptr<tensor<32x16xf16>, 1>, !tt.ptr<tensor<32x16xf16>, 1>, !tt.ptr<tensor<32x16xf16>, 1>, !tt.ptr<tensor<32x16xf16>, 1>, !tt.ptr<tensor<32x16xf16>, 1>, !tt.ptr<tensor<32x16xf16>, 1>
+    }
+    %40 = arith.truncf %39#0 : tensor<16x16xf32> to tensor<16x16xf16>
+    %41 = arith.truncf %39#1 : tensor<16x16xf32> to tensor<16x16xf16>
+    %42 = arith.truncf %39#2 : tensor<16x16xf32> to tensor<16x16xf16>
+    %43 = arith.truncf %39#3 : tensor<16x16xf32> to tensor<16x16xf16>
+    %44 = arith.truncf %39#4 : tensor<16x16xf32> to tensor<16x16xf16>
+    %45 = arith.truncf %39#5 : tensor<16x16xf32> to tensor<16x16xf16>
+    %46 = arith.truncf %39#6 : tensor<16x16xf32> to tensor<16x16xf16>
+    %47 = arith.truncf %39#7 : tensor<16x16xf32> to tensor<16x16xf16>
+    %48 = arith.extsi %arg8 : i32 to i64
+    %49 = tt.make_tensor_ptr %arg2, [%17, %27], [%48, %c1_i64], [%23, %31] {order = array<i32: 1, 0>} : <tensor<16x16xf16>, 1>
+    %50 = arith.addi %23, %c16_i32 : i32
+    %51 = tt.make_tensor_ptr %arg2, [%17, %27], [%48, %c1_i64], [%50, %31] {order = array<i32: 1, 0>} : <tensor<16x16xf16>, 1>
+    %52 = tt.make_tensor_ptr %arg2, [%17, %27], [%48, %c1_i64], [%23, %33] {order = array<i32: 1, 0>} : <tensor<16x16xf16>, 1>
+    %53 = tt.make_tensor_ptr %arg2, [%17, %27], [%48, %c1_i64], [%50, %33] {order = array<i32: 1, 0>} : <tensor<16x16xf16>, 1>
+    %54 = tt.make_tensor_ptr %arg2, [%17, %27], [%48, %c1_i64], [%23, %35] {order = array<i32: 1, 0>} : <tensor<16x16xf16>, 1>
+    %55 = tt.make_tensor_ptr %arg2, [%17, %27], [%48, %c1_i64], [%50, %35] {order = array<i32: 1, 0>} : <tensor<16x16xf16>, 1>
+    %56 = tt.make_tensor_ptr %arg2, [%17, %27], [%48, %c1_i64], [%23, %37] {order = array<i32: 1, 0>} : <tensor<16x16xf16>, 1>
+    %57 = tt.make_tensor_ptr %arg2, [%17, %27], [%48, %c1_i64], [%50, %37] {order = array<i32: 1, 0>} : <tensor<16x16xf16>, 1>
+    tt.store %49, %40 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<16x16xf16>, 1>, tensor<16x16xf16>
+    tt.store %51, %41 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<16x16xf16>, 1>, tensor<16x16xf16>
+    tt.store %52, %42 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<16x16xf16>, 1>, tensor<16x16xf16>
+    tt.store %53, %43 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<16x16xf16>, 1>, tensor<16x16xf16>
+    tt.store %54, %44 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<16x16xf16>, 1>, tensor<16x16xf16>
+    tt.store %55, %45 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<16x16xf16>, 1>, tensor<16x16xf16>
+    tt.store %56, %46 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<16x16xf16>, 1>, tensor<16x16xf16>
+    tt.store %57, %47 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<16x16xf16>, 1>, tensor<16x16xf16>
+    tt.return
+  }
+}


### PR DESCRIPTION
add a pass: tritongpu-match-target-size which decompose tritongpu ops(dot, load, store) to match the target IR size.
for example,
```mlir
32x64xf32 = tt.dot 32x32xf16, 32x64xf16
```
Can split to multiple tt.dot to match the dpas size(8x16)
```mlir
8x16xf32 = tt.dot 8x16xf16, 16x16xf16
```

this pr is based on https://github.com/intel/intel-xpu-backend-for-triton/pull/529, so we can only review [commit2](https://github.com/intel/intel-xpu-backend-for-triton/pull/530/commits/e0ed2b073d8815c6c77547cb01297cccc934e498)