### PR TITLE
Merge OpenAI Triton commit `a5ec520`

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -32,7 +32,7 @@ def _path_to_binary(binary: str):
 
 @functools.lru_cache()
 def get_ptxas_version():
-    version = subprocess.check_output([_path_to_binary("ptxas")[0], "--version"])
+    version = subprocess.check_output([_path_to_binary("ptxas")[0], "--version"]).decode("utf-8")
     return version
 
 
@@ -267,5 +267,5 @@ class CUDABackend(BaseBackend):
 
     @functools.lru_cache()
     def hash(self):
-        version = subprocess.check_output([_path_to_binary("ptxas")[0], "--version"]).decode("utf-8")
+        version = get_ptxas_version()
         return f'{version}-{self.capability}'


### PR DESCRIPTION
This PR change the Triton base from a791746de8f49c99c9e4cc2bf21f6eb639dbf07d to a5ec5203aba1efb10f75c0563b410bc948cfb98f (Feb 16).

Please do not squash and merge this PR.