### PR TITLE
[E2E] Cache for pip cache, torch vision, text, audio

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -106,15 +106,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install Python build dependencies
-        run: |
-          pip install wheel
-
       - name: Identify versions
         run: |
           echo "PYTORCH_COMMIT_ID=$(git ls-remote $PYTORCH_REPO refs/heads/$PYTORCH_BRANCH | cut -f1)" >> "${GITHUB_ENV}"
@@ -128,6 +119,23 @@ jobs:
           echo "$IPEX_REPO: $IPEX_COMMIT_ID"
           echo "$LLVM_REPO: $LLVM_COMMIT_ID"
           echo "$GITHUB_REPOSITORY: $GITHUB_SHA"
+
+      - name: Load pip cache
+        id: pip-cache
+        uses: ./.github/actions/load
+        with:
+          path: $HOME/.cache/pip
+          # pip cache per commit id just to minimize network traffic
+          key: pip-$PYTHON_VERSION-$GITHUB_SHA
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Python build dependencies
+        run: |
+          pip install wheel
 
       - name: Create environment file for building PyTorch
         run: |
@@ -280,8 +288,16 @@ jobs:
         run: |
           pip install pyyaml pandas scipy numpy psutil pyre_extensions torchrec transformers==$TRANSFORMERS_VERSION
 
-      - name: Build torchvision wheels
+      - name: Load torchvision from a cache
         if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
+        id: torchvision-cache
+        uses: ./.github/actions/load
+        with:
+          path: vision
+          key: torchvision-$PYTHON_VERSION-$TORCHVISION_COMMIT_ID
+
+      - name: Build torchvision wheels
+        if: ${{ (matrix.suite == 'timm_models' || matrix.suite == 'torchbench') && steps.torchvision-cache.outputs.status == 'miss' }}
         run: |
           git clone --single-branch -b main https://github.com/pytorch/vision.git
           cd vision
@@ -294,8 +310,23 @@ jobs:
           pip install vision/dist/*.whl
           python -c "import torchvision; print(torchvision.__version__)"
 
-      - name: Build torchtext wheels
+      - name: Save torchvision to a cache
+        if: ${{ (matrix.suite == 'timm_models' || matrix.suite == 'torchbench') && steps.torchvision-cache.outputs.status == 'miss' }}
+        uses: ./.github/actions/save
+        with:
+          path: ${{ steps.torchvision-cache.outputs.path }}
+          dest: ${{ steps.torchvision-cache.outputs.dest }}
+
+      - name: Load torchtext from a cache
         if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
+        id: torchtext-cache
+        uses: ./.github/actions/load
+        with:
+          path: text
+          key: torchtext-$PYTHON_VERSION-$TORCHTEXT_COMMIT_ID
+
+      - name: Build torchtext wheels
+        if: ${{ (matrix.suite == 'timm_models' || matrix.suite == 'torchbench') && steps.torchtext-cache.outputs.status == 'miss'}}
         run: |
           git clone --recurse-submodules --jobs 8 --single-branch -b main https://github.com/pytorch/text.git
           cd text
@@ -308,8 +339,23 @@ jobs:
           pip install text/dist/*.whl
           python -c "import torchtext; print(torchtext.__version__)"
 
-      - name: Build torchaudio wheels
+      - name: Save torchtext to a cache
+        if: ${{ (matrix.suite == 'timm_models' || matrix.suite == 'torchbench') && steps.torchtext-cache.outputs.status == 'miss' }}
+        uses: ./.github/actions/save
+        with:
+          path: ${{ steps.torchtext-cache.outputs.path }}
+          dest: ${{ steps.torchtext-cache.outputs.dest }}
+
+      - name: Load torchaudio from a cache
         if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
+        id: torchaudio-cache
+        uses: ./.github/actions/load
+        with:
+          path: audio
+          key: torchaudio-$PYTHON_VERSION-$TORCHAUDIO_COMMIT_ID
+
+      - name: Build torchaudio wheels
+        if: ${{ (matrix.suite == 'timm_models' || matrix.suite == 'torchbench') && steps.torchaudio-cache.outputs.status == 'miss' }}
         run: |
           git clone --single-branch -b main https://github.com/pytorch/audio.git
           cd audio
@@ -322,8 +368,15 @@ jobs:
           pip install audio/dist/*.whl
           python -c "import torchaudio; print(torchaudio.__version__)"
 
-      - name: Install PyTorch Benchmarks
-        if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
+      - name: Save torchaudio to a cache
+        if: ${{ (matrix.suite == 'timm_models' || matrix.suite == 'torchbench') && steps.torchaudio-cache.outputs.status == 'miss' }}
+        uses: ./.github/actions/save
+        with:
+          path: ${{ steps.torchaudio-cache.outputs.path }}
+          dest: ${{ steps.torchaudio-cache.outputs.dest }}
+
+      - name: Install pytorch benchmark
+        if: ${{ matrix.suite == 'torchbench' }}
         run: |
           git clone --single-branch -b $BENCHMARK_BRANCH --recurse-submodules --jobs 8 $BENCHMARK_REPO
           cd benchmark
@@ -381,3 +434,10 @@ jobs:
         with:
           name: logs-${{ join(matrix.*, '-') }}
           path: inductor_log
+
+      - name: Save pip cache
+        if: ${{ steps.pip-cache.outputs.status == 'miss' }}
+        uses: ./.github/actions/save
+        with:
+          path: ${{ steps.pip-cache.outputs.path }}
+          dest: ${{ steps.pip-cache.outputs.dest }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -318,7 +318,7 @@ jobs:
           dest: ${{ steps.torchvision-cache.outputs.dest }}
 
       - name: Load torchtext from a cache
-        if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
+        if: ${{ matrix.suite == 'torchbench' }}
         id: torchtext-cache
         uses: ./.github/actions/load
         with:
@@ -326,7 +326,7 @@ jobs:
           key: torchtext-$PYTHON_VERSION-$TORCHTEXT_COMMIT_ID
 
       - name: Build torchtext wheels
-        if: ${{ (matrix.suite == 'timm_models' || matrix.suite == 'torchbench') && steps.torchtext-cache.outputs.status == 'miss'}}
+        if: ${{ matrix.suite == 'torchbench' && steps.torchtext-cache.outputs.status == 'miss'}}
         run: |
           git clone --recurse-submodules --jobs 8 --single-branch -b main https://github.com/pytorch/text.git
           cd text
@@ -334,20 +334,20 @@ jobs:
           python setup.py bdist_wheel
 
       - name: Install torchtext
-        if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
+        if: ${{ matrix.suite == 'torchbench' }}
         run: |
           pip install text/dist/*.whl
           python -c "import torchtext; print(torchtext.__version__)"
 
       - name: Save torchtext to a cache
-        if: ${{ (matrix.suite == 'timm_models' || matrix.suite == 'torchbench') && steps.torchtext-cache.outputs.status == 'miss' }}
+        if: ${{ matrix.suite == 'torchbench' && steps.torchtext-cache.outputs.status == 'miss' }}
         uses: ./.github/actions/save
         with:
           path: ${{ steps.torchtext-cache.outputs.path }}
           dest: ${{ steps.torchtext-cache.outputs.dest }}
 
       - name: Load torchaudio from a cache
-        if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
+        if: ${{ matrix.suite == 'torchbench' }}
         id: torchaudio-cache
         uses: ./.github/actions/load
         with:
@@ -355,7 +355,7 @@ jobs:
           key: torchaudio-$PYTHON_VERSION-$TORCHAUDIO_COMMIT_ID
 
       - name: Build torchaudio wheels
-        if: ${{ (matrix.suite == 'timm_models' || matrix.suite == 'torchbench') && steps.torchaudio-cache.outputs.status == 'miss' }}
+        if: ${{ matrix.suite == 'torchbench' && steps.torchaudio-cache.outputs.status == 'miss' }}
         run: |
           git clone --single-branch -b main https://github.com/pytorch/audio.git
           cd audio
@@ -363,13 +363,13 @@ jobs:
           python setup.py bdist_wheel
 
       - name: Install torchaudio
-        if: ${{ matrix.suite == 'timm_models' || matrix.suite == 'torchbench' }}
+        if: ${{ matrix.suite == 'torchbench' }}
         run: |
           pip install audio/dist/*.whl
           python -c "import torchaudio; print(torchaudio.__version__)"
 
       - name: Save torchaudio to a cache
-        if: ${{ (matrix.suite == 'timm_models' || matrix.suite == 'torchbench') && steps.torchaudio-cache.outputs.status == 'miss' }}
+        if: ${{ matrix.suite == 'torchbench' && steps.torchaudio-cache.outputs.status == 'miss' }}
         uses: ./.github/actions/save
         with:
           path: ${{ steps.torchaudio-cache.outputs.path }}


### PR DESCRIPTION
A single E2E workflow currently launches 30 jobs in matrix. Adding cache for pip cache,  torch vision, text, audio. The key for pip cache is per commit id, so the first finished job will populate the cache, others will use it. This is to minimize network traffic, since there is no need for each job to download the same pip packages, clone the same git repos, and build the same wheels. This should help with the random network failures that happened in the past.