### PR TITLE
[SCRIPT] Fix paths for .triton cache directory

### DIFF
--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -164,8 +164,17 @@ fi
 
 if [ ! -d "$TRITON_PROJ_BUILD" ]
 then
-  # Remove the cached triton.
-  rm -fr /iusers/$USERS/.triton
+  # Remove the cached triton (see setup.py, get_triton_cache_path())
+  if [ -n "$HOME" ]
+  then
+    rm -fr "$HOME/.triton/"
+  elif [ -n "$USERPROFILE" ]
+  then
+    rm -fr "$USERPROFILE/.triton/"
+  elif [ -n "$HOMEPATH" ]
+  then
+    rm -fr "$HOMEPATH/.triton/"
+  fi
 fi
 
 build_triton() {


### PR DESCRIPTION
Use the same logic to determine the cache directory as [`get_triton_cache_path()`](https://github.com/intel/intel-xpu-backend-for-triton/blob/7af0717cb08f5d519bab633f6379e502487ed1cf/python/setup.py#L169).