### PR TITLE
Remove redundant local target-dependent code

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/AllocateSharedMemory.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/AllocateSharedMemory.cpp
@@ -30,8 +30,7 @@ struct AllocateSharedMemory
     ModuleAllocation allocation(mod);
 
     mod.walk([&](FunctionOpInterface funcOp) {
-      if (target == Target::GENX && allocation.isRoot(funcOp) &&
-          allocation.getSharedMemorySize()) {
+      if (allocation.isRoot(funcOp) && allocation.getSharedMemorySize()) {
         LLVM::LLVMPointerType ptrTy =
             LLVM::LLVMPointerType::get(ctx, GENX::GENXMemorySpace::kWorkgroup);
         funcOp.insertArgument(funcOp.getNumArguments(), ptrTy, {},

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/AssertOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/AssertOpToLLVM.cpp
@@ -33,7 +33,7 @@ struct AssertOpConversion
       }
     }
     llAssert(op, condition, adaptor.getMessage(), adaptor.getFile(),
-             adaptor.getFunc(), adaptor.getLine(), rewriter, target);
+             adaptor.getFunc(), adaptor.getLine(), rewriter);
     rewriter.eraseOp(op);
     return success();
   }
@@ -42,7 +42,7 @@ struct AssertOpConversion
   // know about the op to split the block.
   static void llAssert(Operation *op, Value condition, StringRef message,
                        StringRef file, StringRef func, int line,
-                       ConversionPatternRewriter &rewriter, Target target) {
+                       ConversionPatternRewriter &rewriter) {
     ConversionPatternRewriter::InsertionGuard guard(rewriter);
     auto ctx = rewriter.getContext();
     auto loc = op->getLoc();
@@ -57,11 +57,10 @@ struct AssertOpConversion
     Block *ifBlock = rewriter.splitBlock(prevBlock, op->getIterator());
     rewriter.setInsertionPointToStart(ifBlock);
 
-    auto funcOp = getAssertfailDeclaration(rewriter, target);
+    auto funcOp = getAssertfailDeclaration(rewriter);
     auto moduleOp =
         rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
-    unsigned addrSpace =
-        (target == Target::GENX) ? GENX::GENXMemorySpace::kCrossWorkgroup : 0;
+    unsigned addrSpace = GENX::GENXMemorySpace::kCrossWorkgroup;
     Value messageString = LLVM::utils::addStringToModule(
         loc, rewriter, "assertMessage_", message, addrSpace);
     Value fileString = LLVM::utils::addStringToModule(
@@ -71,24 +70,16 @@ struct AssertOpConversion
     Value lineNumber = i32_val(line);
 
     SmallVector<Value> operands;
-    if (target == Target::GENX) {
-      Value messageStringPtr = addrspacecast(
-          ptr_ty(ctx, GENX::GENXMemorySpace::kGeneric), messageString);
-      Value fileStringPtr = addrspacecast(
-          ptr_ty(ctx, GENX::GENXMemorySpace::kGeneric), fileString);
-      Value funcStringPtr = addrspacecast(
-          ptr_ty(ctx, GENX::GENXMemorySpace::kGeneric), funcString);
-      operands = {messageStringPtr, fileStringPtr, lineNumber, funcStringPtr};
-    } else {
-      Value charSize = int_val(sizeof(size_t) * 8, sizeof(char));
-      operands = {messageString, fileString, lineNumber, funcString,
-                  int_val(sizeof(size_t) * 8, sizeof(char))};
-    }
+    Value messageStringPtr = addrspacecast(
+        ptr_ty(ctx, GENX::GENXMemorySpace::kGeneric), messageString);
+    Value fileStringPtr =
+        addrspacecast(ptr_ty(ctx, GENX::GENXMemorySpace::kGeneric), fileString);
+    Value funcStringPtr =
+        addrspacecast(ptr_ty(ctx, GENX::GENXMemorySpace::kGeneric), funcString);
+    operands = {messageStringPtr, fileStringPtr, lineNumber, funcStringPtr};
     auto ret = call(funcOp, operands);
 
-    if (target == Target::GENX) {
-      ret.setCConv(LLVM::cconv::CConv::SPIR_FUNC);
-    }
+    ret.setCConv(LLVM::cconv::CConv::SPIR_FUNC);
 
     // Split a block after the call.
     Block *thenBlock = rewriter.splitBlock(ifBlock, op->getIterator());
@@ -99,11 +90,10 @@ struct AssertOpConversion
   }
 
   static LLVM::LLVMFuncOp
-  getAssertfailDeclaration(ConversionPatternRewriter &rewriter, Target target) {
+  getAssertfailDeclaration(ConversionPatternRewriter &rewriter) {
     auto moduleOp =
         rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
-    StringRef funcName =
-        (target == Target::GENX) ? "__assert_fail" : "__assertfail";
+    StringRef funcName = "__assert_fail";
     Operation *funcOp = moduleOp.lookupSymbol(funcName);
     if (funcOp)
       return cast<LLVM::LLVMFuncOp>(*funcOp);
@@ -112,14 +102,9 @@ struct AssertOpConversion
     // int line, const char * function);
     auto *ctx = rewriter.getContext();
     SmallVector<Type> argsType;
-    if (target == Target::GENX) {
-      argsType = {ptr_ty(ctx, GENX::GENXMemorySpace::kGeneric),
-                  ptr_ty(ctx, GENX::GENXMemorySpace::kGeneric), i32_ty,
-                  ptr_ty(ctx, GENX::GENXMemorySpace::kGeneric)};
-    } else {
-      argsType = {ptr_ty(ctx), ptr_ty(ctx), i32_ty, ptr_ty(ctx),
-                  rewriter.getIntegerType(sizeof(size_t) * 8)};
-    }
+    argsType = {ptr_ty(ctx, GENX::GENXMemorySpace::kGeneric),
+                ptr_ty(ctx, GENX::GENXMemorySpace::kGeneric), i32_ty,
+                ptr_ty(ctx, GENX::GENXMemorySpace::kGeneric)};
     auto funcType = LLVM::LLVMFunctionType::get(void_ty(ctx), argsType);
 
     ConversionPatternRewriter::InsertionGuard guard(rewriter);
@@ -127,9 +112,7 @@ struct AssertOpConversion
 
     auto func = rewriter.create<LLVM::LLVMFuncOp>(UnknownLoc::get(ctx),
                                                   funcName, funcType);
-    if (target == Target::GENX) {
-      func.setCConv(LLVM::cconv::CConv::SPIR_FUNC);
-    }
+    func.setCConv(LLVM::cconv::CConv::SPIR_FUNC);
     return func;
   }
 };

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ControlFlowOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ControlFlowOpToLLVM.cpp
@@ -85,12 +85,12 @@ private:
         callOp.getLoc(), /*opOperands=*/callOp->getOperands(),
         adaptor.getOperands(), rewriter);
     if (!caller->hasAttr("allocation.offset")) {
-      auto base = LLVM::utils::getStackPointer(rewriter, caller, target);
+      auto base = LLVM::utils::getStackPointer(rewriter, caller);
       promotedOperands.push_back(base);
       return promotedOperands;
     }
-    promotedOperands.push_back(LLVM::utils::getSharedMemoryBase(
-        callOp->getLoc(), rewriter, callOp, target));
+    promotedOperands.push_back(
+        LLVM::utils::getSharedMemoryBase(callOp->getLoc(), rewriter, callOp));
     return promotedOperands;
   }
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -528,8 +528,8 @@ private:
     auto llvmElemTy = getTypeConverter()->convertType(dstTy.getElementType());
     auto elemPtrTy = ptr_ty(rewriter.getContext(), 3);
 
-    Value smemBase = LLVM::utils::getSharedMemoryBase(
-        loc, rewriter, op.getOperation(), target);
+    Value smemBase =
+        LLVM::utils::getSharedMemoryBase(loc, rewriter, op.getOperation());
     smemBase = bitcast(smemBase, elemPtrTy);
     auto smemShape = convertType<unsigned, int64_t>(srcShapePerCTA);
 
@@ -608,8 +608,8 @@ private:
 
     if (shouldUseDistSmem(srcLayout, dstLayout))
       return lowerDistToDistWithDistSmem(op, adaptor, rewriter);
-    Value smemBase = LLVM::utils::getSharedMemoryBase(
-        loc, rewriter, op.getOperation(), target);
+    Value smemBase =
+        LLVM::utils::getSharedMemoryBase(loc, rewriter, op.getOperation());
     auto elemPtrTy = ptr_ty(rewriter.getContext(), 3);
     smemBase = bitcast(smemBase, elemPtrTy);
     auto shape = dstTy.getShape();
@@ -874,8 +874,8 @@ private:
     assert(srcTy.getShape().size() == 2 ||
            (srcTy.getShape().size() <= 3 && outOrd[2] == 0) &&
                "Unexpected rank of ConvertLayout(blocked->shared)");
-    Value smemBase = LLVM::utils::getSharedMemoryBase(
-        loc, rewriter, op.getOperation(), target);
+    Value smemBase =
+        LLVM::utils::getSharedMemoryBase(loc, rewriter, op.getOperation());
     auto elemTy = getTypeConverter()->convertType(srcTy.getElementType());
     auto elemPtrTy = ptr_ty(rewriter.getContext(), 3);
     smemBase = bitcast(smemBase, elemPtrTy);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -216,8 +216,7 @@ DotOpMmaV3SmemLoader loadA(const LLVMTypeConverter *typeConverter,
   // Workaround for a bug in ptxas 12.3 that cause a failure in
   // test_core.py::test_dot. The shuffle will force the compiler to treat the
   // value as uniform and prevent wrong optimizations.
-  warp = mlir::LLVM::utils::shflIdxSync(loc, rewriter, warp, 0,
-                                        mlir::triton::NVVM);
+  warp = mlir::LLVM::utils::shflIdxSync(loc, rewriter, warp, 0);
   Value warpM = urem(warp, i32_val(wpt[0]));
   Value warpId = urem(warpM, i32_val(shapePerCTA[0] / instrShape[0]));
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -221,187 +221,71 @@ struct LoadOpConversion
 
       Value pred = mask ? maskElems[vecStart] : int_val(1, 1);
 
-      if (target == triton::Target::GENX) {
-        SmallVector<Type> retTys(nWords, IntegerType::get(getContext(), width));
-        Type retTy = retTys.size() > 1
-                         ? vec_ty(IntegerType::get(ctx, width), nWords)
-                         : retTys[0];
+      SmallVector<Type> retTys(nWords, IntegerType::get(getContext(), width));
+      Type retTy = retTys.size() > 1
+                       ? vec_ty(IntegerType::get(ctx, width), nWords)
+                       : retTys[0];
 
-        Value other_ = undef(retTy);
-        if (other) {
-          for (size_t ii = 0; ii < nWords; ++ii) {
-            size_t size = width / valueElemNBits;
+      Value other_ = undef(retTy);
+      if (other) {
+        for (size_t ii = 0; ii < nWords; ++ii) {
+          size_t size = width / valueElemNBits;
 
-            auto vecTy = vec_ty(valueElemTy, size);
-            Value v = undef(vecTy);
-            for (size_t s = 0; s < size; ++s) {
-              Value falseVal = otherElems[vecStart + ii * size + s];
-              Value sVal = createIndexAttrConstant(
-                  rewriter, loc, this->getTypeConverter()->getIndexType(), s);
-              v = insert_element(vecTy, v, falseVal, sVal);
-            }
-            v = bitcast(v, IntegerType::get(ctx, width));
-
-            if (otherIsSplatConstInt) {
-              for (size_t s = 0; s < 32; s += valueElemNBits)
-                splatVal |= splatVal << valueElemNBits;
-              v = int_val(width, splatVal);
-            }
-
-            Value iiVal = createIndexAttrConstant(
-                rewriter, loc, this->getTypeConverter()->getIndexType(), ii);
-            if (nWords > 1) {
-              other_ = insert_element(retTy, other_, v, iiVal);
-            } else {
-              other_ = v;
-            }
+          auto vecTy = vec_ty(valueElemTy, size);
+          Value v = undef(vecTy);
+          for (size_t s = 0; s < size; ++s) {
+            Value falseVal = otherElems[vecStart + ii * size + s];
+            Value sVal = createIndexAttrConstant(
+                rewriter, loc, this->getTypeConverter()->getIndexType(), s);
+            v = insert_element(vecTy, v, falseVal, sVal);
           }
-        }
+          v = bitcast(v, IntegerType::get(ctx, width));
 
-        // Create a predicated load operation.
-        Block &endBlock = LLVM::utils::createPredicatedBlock(
-            rewriter, loc, pred, SmallVector<Value, 1>{other_}, [&]() {
-              Value addrElem =
-                  bitcast(ptrElems[vecStart], ptr_ty(ctx, 1 /*global*/));
-              Value ret = load(retTy, addrElem);
-              return SmallVector<Value, 1>{ret};
-            });
-        Value ret = *endBlock.args_begin();
+          if (otherIsSplatConstInt) {
+            for (size_t s = 0; s < 32; s += valueElemNBits)
+              splatVal |= splatVal << valueElemNBits;
+            v = int_val(width, splatVal);
+          }
 
-        // Extract and store return values
-        SmallVector<Value> rets;
-        for (unsigned int ii = 0; ii < nWords; ++ii) {
-          Value curr;
-          if (retTy.isa<VectorType>()) {
-            curr =
-                extract_element(IntegerType::get(ctx, width), ret, i32_val(ii));
+          Value iiVal = createIndexAttrConstant(
+              rewriter, loc, this->getTypeConverter()->getIndexType(), ii);
+          if (nWords > 1) {
+            other_ = insert_element(retTy, other_, v, iiVal);
           } else {
-            curr = ret;
-          }
-          curr = bitcast(curr, LLVM::getFixedVectorType(
-                                   valueElemTy, width / valueElemNBits));
-          rets.push_back(curr);
-        }
-        int tmp = width / valueElemNBits;
-        for (size_t ii = 0; ii < vec; ++ii) {
-          Value loaded =
-              extract_element(valueElemTy, rets[ii / tmp], i32_val(ii % tmp));
-          loadedVals.push_back(loaded);
-        }
-      } else { // Not target::SPIRV || target::GENX
-
-        // TODO(Superjomn) Add cache policy fields to StoreOp.
-        // TODO(Superjomn) Deal with cache policy here.
-        const bool hasL2EvictPolicy = false;
-
-        PTXBuilder ptxBuilder;
-
-        const std::string readConstraint =
-            (width == 64) ? "l" : ((width == 32) ? "r" : "c");
-        const std::string writeConstraint =
-            (width == 64) ? "=l" : ((width == 32) ? "=r" : "=c");
-
-        // prepare asm operands
-        auto *dstsOpr = ptxBuilder.newListOperand();
-        for (size_t wordIdx = 0; wordIdx < nWords; ++wordIdx) {
-          auto *opr = ptxBuilder.newOperand(writeConstraint,
-                                            /*init=*/true); // =r operations
-          dstsOpr->listAppend(opr);
-        }
-
-        auto *addrOpr =
-            ptxBuilder.newAddrOperand(ptrElems[vecStart], "l", in_off);
-
-        // Define the instruction opcode
-        auto &ld = ptxBuilder.create<>("ld")
-                       ->o("volatile", op.getIsVolatile())
-                       .global()
-                       .o("ca", op.getCache() == triton::CacheModifier::CA)
-                       .o("cg", op.getCache() == triton::CacheModifier::CG)
-                       .o("L1::evict_first",
-                          op.getEvict() == triton::EvictionPolicy::EVICT_FIRST)
-                       .o("L1::evict_last",
-                          op.getEvict() == triton::EvictionPolicy::EVICT_LAST)
-                       .o("L1::cache_hint", hasL2EvictPolicy)
-                       .v(nWords)
-                       .b(width);
-
-        PTXBuilder::Operand *evictOpr{};
-
-        // Here lack a mlir::Value to bind to this operation, so disabled.
-        // if (has_l2_evict_policy)
-        //   evictOpr = ptxBuilder.newOperand(l2Evict, "l");
-
-        if (!evictOpr)
-          ld(dstsOpr, addrOpr).predicate(pred, "b");
-        else
-          ld(dstsOpr, addrOpr, evictOpr).predicate(pred, "b");
-
-        if (other) {
-          for (size_t ii = 0; ii < nWords; ++ii) {
-            // PTX doesn't support mov.u8, so we need to use mov.u16
-            PTXInstr &mov =
-                ptxBuilder.create<>("mov")->o("u" + std::to_string(movWidth));
-
-            size_t size = width / valueElemNBits;
-
-            auto vecTy = LLVM::getFixedVectorType(valueElemTy, size);
-            Value v = undef(vecTy);
-            for (size_t s = 0; s < size; ++s) {
-              Value falseVal = otherElems[vecStart + ii * size + s];
-              Value sVal = createIndexAttrConstant(
-                  rewriter, loc, this->getTypeConverter()->getIndexType(), s);
-              v = insert_element(vecTy, v, falseVal, sVal);
-            }
-            v = bitcast(v, IntegerType::get(getContext(), width));
-
-            PTXInstr::Operand *opr{};
-
-            if (otherIsSplatConstInt) {
-              for (size_t s = 0; s < 32; s += valueElemNBits)
-                splatVal |= splatVal << valueElemNBits;
-              opr = ptxBuilder.newConstantOperand(splatVal);
-            } else
-              opr = ptxBuilder.newOperand(v, readConstraint);
-
-            mov(dstsOpr->listGet(ii), opr).predicateNot(pred, "b");
+            other_ = v;
           }
         }
+      }
 
-        // Create inline ASM signature
-        SmallVector<Type> retTys(nWords, IntegerType::get(getContext(), width));
-        Type retTy =
-            retTys.size() > 1
-                ? LLVM::LLVMStructType::getLiteral(getContext(), retTys)
-                : retTys[0];
+      // Create a predicated load operation.
+      Block &endBlock = LLVM::utils::createPredicatedBlock(
+          rewriter, loc, pred, SmallVector<Value, 1>{other_}, [&]() {
+            Value addrElem =
+                bitcast(ptrElems[vecStart], ptr_ty(ctx, 1 /*global*/));
+            Value ret = load(retTy, addrElem);
+            return SmallVector<Value, 1>{ret};
+          });
+      Value ret = *endBlock.args_begin();
 
-        // TODO: if (has_l2_evict_policy)
-        // auto asmDialectAttr =
-        // LLVM::AsmDialectAttr::get(rewriter.getContext(),
-        //                                                 LLVM::AsmDialect::AD_ATT);
-        Value ret = ptxBuilder.launch(rewriter, loc, retTy);
-
-        // Extract and store return values
-        SmallVector<Value> rets;
-        for (unsigned int ii = 0; ii < nWords; ++ii) {
-          Value curr;
-          if (retTy.isa<LLVM::LLVMStructType>()) {
-            curr = extract_val(IntegerType::get(getContext(), width), ret, ii);
-          } else {
-            curr = ret;
-          }
-          curr = bitcast(curr, LLVM::getFixedVectorType(
-                                   valueElemTy, width / valueElemNBits));
-          rets.push_back(curr);
+      // Extract and store return values
+      SmallVector<Value> rets;
+      for (unsigned int ii = 0; ii < nWords; ++ii) {
+        Value curr;
+        if (retTy.isa<VectorType>()) {
+          curr =
+              extract_element(IntegerType::get(ctx, width), ret, i32_val(ii));
+        } else {
+          curr = ret;
         }
-        int tmp = width / valueElemNBits;
-        for (size_t ii = 0; ii < vec; ++ii) {
-          Value vecIdx = createIndexAttrConstant(
-              rewriter, loc, this->getTypeConverter()->getIndexType(),
-              ii % tmp);
-          Value loaded = extract_element(valueElemTy, rets[ii / tmp], vecIdx);
-          loadedVals.push_back(loaded);
-        }
+        curr = bitcast(curr, LLVM::getFixedVectorType(valueElemTy,
+                                                      width / valueElemNBits));
+        rets.push_back(curr);
+      }
+      int tmp = width / valueElemNBits;
+      for (size_t ii = 0; ii < vec; ++ii) {
+        Value loaded =
+            extract_element(valueElemTy, rets[ii / tmp], i32_val(ii % tmp));
+        loadedVals.push_back(loaded);
       }
     } // end vec
 
@@ -507,53 +391,19 @@ struct StoreOpConversion
 
       Value maskVal = llMask ? and_(mask, maskElems[vecStart]) : mask;
 
-      if (target == triton::Target::GENX) {
-        auto vecTy = vec_ty(valArgTy, nWords);
-        Value vecWord = undef(vecTy);
-        for (int index = 0; index < asmArgs.size(); ++index) {
-          auto llWord = asmArgs[index].first;
-          vecWord = insert_element(vecTy, vecWord, llWord, i32_val(index));
-        }
-
-        // Create a predicated store operation.
-        mlir::LLVM::utils::createPredicatedBlock(rewriter, loc, maskVal, [&] {
-          Value addrElem =
-              bitcast(ptrElems[vecStart], ptr_ty(ctx, 1 /*global*/));
-          store(vecWord, addrElem);
-          return ArrayRef<Value>();
-        });
-      } else {
-        // Prepare the PTX inline asm.
-        PTXBuilder ptxBuilder;
-        auto *asmArgList = ptxBuilder.newListOperand(asmArgs);
-
-        auto *asmAddr =
-            ptxBuilder.newAddrOperand(ptrElems[vecStart], "l", in_off);
-
-        auto &ptxStoreInstr =
-            ptxBuilder.create<>("st")
-                ->global()
-                .o("wb", op.getCache() == triton::CacheModifier::WB)
-                .o("cg", op.getCache() == triton::CacheModifier::CG)
-                .o("cs", op.getCache() == triton::CacheModifier::CS)
-                .o("wt", op.getCache() == triton::CacheModifier::WT)
-                .o("L1::evict_first",
-                   op.getEvict() == triton::EvictionPolicy::EVICT_FIRST)
-                .o("L1::evict_last",
-                   op.getEvict() == triton::EvictionPolicy::EVICT_LAST)
-                .v(nWords)
-                .b(width);
-        ptxStoreInstr(asmAddr, asmArgList).predicate(maskVal, "b");
-
-        Type boolTy =
-            getTypeConverter()->convertType(rewriter.getIntegerType(1));
-        llvm::SmallVector<Type> argTys({boolTy, ptr.getType()});
-        argTys.insert(argTys.end(), nWords, valArgTy);
-
-        auto asmReturnTy = void_ty(ctx);
-
-        ptxBuilder.launch(rewriter, loc, asmReturnTy);
+      auto vecTy = vec_ty(valArgTy, nWords);
+      Value vecWord = undef(vecTy);
+      for (int index = 0; index < asmArgs.size(); ++index) {
+        auto llWord = asmArgs[index].first;
+        vecWord = insert_element(vecTy, vecWord, llWord, i32_val(index));
       }
+
+      // Create a predicated store operation.
+      mlir::LLVM::utils::createPredicatedBlock(rewriter, loc, maskVal, [&] {
+        Value addrElem = bitcast(ptrElems[vecStart], ptr_ty(ctx, 1 /*global*/));
+        store(vecWord, addrElem);
+        return ArrayRef<Value>();
+      });
     } // for
     rewriter.eraseOp(op);
     return success();
@@ -631,98 +481,43 @@ struct AtomicCASOpConversion
       Value casCmp = cmpElements[i];
       casVal = valElements[i];
 
-      switch (target) {
-      case triton::Target::ROCDL:
-      case triton::Target::NVVM: {
-        PTXBuilder ptxBuilderAtomicCAS;
-        std::string tyId = valueElemNBits * vec == 64
-                               ? "l"
-                               : (valueElemNBits * vec == 32 ? "r" : "h");
-        auto *dstOpr =
-            ptxBuilderAtomicCAS.newOperand("=" + tyId, /*init=*/true);
-        auto *ptrOpr = ptxBuilderAtomicCAS.newAddrOperand(casPtr, "l");
-        auto *cmpOpr = ptxBuilderAtomicCAS.newOperand(casCmp, tyId);
-        auto *valOpr = ptxBuilderAtomicCAS.newOperand(casVal, tyId);
-        auto &atom = *ptxBuilderAtomicCAS.create<PTXInstr>("atom");
-        auto sTy = "b" + std::to_string(valueElemNBits);
-        std::string semStr;
-        llvm::raw_string_ostream os(semStr);
-        os << op.getSem();
-        auto scope = stringifyMemSyncScope(op.getScope()).str();
-        atom.global().o(semStr).o(scope).o("cas").o(sTy);
-        atom(dstOpr, ptrOpr, cmpOpr, valOpr).predicate(mask);
+      assert((valueElemNBits == 32 || valueElemNBits == 64) &&
+             "Unexpected width");
 
-        if (tensorTy) {
-          auto retType = vec == 1 ? valueElemTy : vecTy;
-          auto ret = ptxBuilderAtomicCAS.launch(rewriter, loc, retType);
-          for (int ii = 0; ii < vec; ++ii) {
-            resultVals[i + ii] =
-                vec == 1 ? ret : extract_element(valueElemTy, ret, i32_val(ii));
-          }
-        } else {
-          auto old = ptxBuilderAtomicCAS.launch(rewriter, loc, valueElemTy);
-          createBarrier(rewriter, loc, numCTAs);
-          Value atomPtr = LLVM::utils::getSharedMemoryBase(
-              loc, rewriter, op.getOperation(), target);
-          atomPtr = bitcast(atomPtr, ptr_ty(ctx, 3));
-          // Only threads with mask = True store the result
-          PTXBuilder ptxBuilderStore;
-          auto *dstOprStore = ptxBuilderStore.newAddrOperand(atomPtr, "r");
-          auto *valOprStore = ptxBuilderStore.newOperand(old, "r");
-          auto &st = *ptxBuilderStore.create<PTXInstr>("st");
-          st.shared().o(sTy);
-          st(dstOprStore, valOprStore).predicate(mask);
-          auto ASMReturnTy = void_ty(ctx);
-          ptxBuilderStore.launch(rewriter, loc, ASMReturnTy);
-          createBarrier(rewriter, loc, numCTAs);
-          Value ret = load(valueElemTy, atomPtr);
-          createBarrier(rewriter, loc, numCTAs);
-          rewriter.replaceOp(op, {ret});
+      Value zero = (valueElemNBits == 32) ? i32_val(0) : i64_val(0);
+      Block &endBlock = mlir::LLVM::utils::createPredicatedBlock(
+          rewriter, loc, mask, {zero}, [&] {
+            // casPtr = bitcast(casPtr, ptr_ty(ctx, 1));
+            casCmp = bitcast(casCmp, zero.getType());
+            casVal = bitcast(casVal, zero.getType());
+
+            auto cmpxchg = rewriter.create<LLVM::AtomicCmpXchgOp>(
+                loc, casPtr, casCmp, casVal, LLVM::AtomicOrdering::acq_rel,
+                LLVM::AtomicOrdering::monotonic);
+            Value newLoaded =
+                rewriter.create<LLVM::ExtractValueOp>(loc, cmpxchg, 0);
+            return SmallVector<Value, 1>{newLoaded};
+          });
+
+      Value ret = endBlock.getArgument(0);
+      Type retType = (!tensorTy || vec == 1) ? valueElemTy : vecTy;
+      ret = bitcast(ret, retType);
+
+      if (tensorTy) {
+        for (int ii = 0; ii < vec; ++ii) {
+          resultVals[i + ii] =
+              vec == 1 ? ret : extract_element(valueElemTy, ret, i32_val(ii));
         }
-      } break;
-      case triton::Target::GENX: {
-        assert((valueElemNBits == 32 || valueElemNBits == 64) &&
-               "Unexpected width");
-
-        Value zero = (valueElemNBits == 32) ? i32_val(0) : i64_val(0);
-        Block &endBlock = mlir::LLVM::utils::createPredicatedBlock(
-            rewriter, loc, mask, {zero}, [&] {
-              // casPtr = bitcast(casPtr, ptr_ty(ctx, 1));
-              casCmp = bitcast(casCmp, zero.getType());
-              casVal = bitcast(casVal, zero.getType());
-
-              auto cmpxchg = rewriter.create<LLVM::AtomicCmpXchgOp>(
-                  loc, casPtr, casCmp, casVal, LLVM::AtomicOrdering::acq_rel,
-                  LLVM::AtomicOrdering::monotonic);
-              Value newLoaded =
-                  rewriter.create<LLVM::ExtractValueOp>(loc, cmpxchg, 0);
-              return SmallVector<Value, 1>{newLoaded};
-            });
-
-        Value ret = endBlock.getArgument(0);
-        Type retType = (!tensorTy || vec == 1) ? valueElemTy : vecTy;
-        ret = bitcast(ret, retType);
-
-        if (tensorTy) {
-          for (int ii = 0; ii < vec; ++ii) {
-            resultVals[i + ii] =
-                vec == 1 ? ret : extract_element(valueElemTy, ret, i32_val(ii));
-          }
-        } else {
-          createBarrier(rewriter, loc, numCTAs);
-          Value atomPtr = LLVM::utils::getSharedMemoryBase(
-              loc, rewriter, op.getOperation(), target);
-          atomPtr = bitcast(atomPtr, ptr_ty(ctx, 3));
-          mlir::LLVM::utils::storeShared(rewriter, loc, atomPtr, ret, mask,
-                                         target);
-          createBarrier(rewriter, loc, numCTAs);
-          Value ret = load(valueElemTy, atomPtr);
-          createBarrier(rewriter, loc, numCTAs);
-          rewriter.replaceOp(op, {ret});
-        }
-      } break;
-      default:
-        llvm_unreachable("Unhandled target");
+      } else {
+        createBarrier(rewriter, loc, numCTAs);
+        Value atomPtr =
+            LLVM::utils::getSharedMemoryBase(loc, rewriter, op.getOperation());
+        atomPtr = bitcast(atomPtr, ptr_ty(ctx, 3));
+        mlir::LLVM::utils::storeShared(rewriter, loc, atomPtr, ret, mask);
+        createBarrier(rewriter, loc, numCTAs);
+        Value ret = load(valueElemTy, atomPtr);
+        createBarrier(rewriter, loc, numCTAs);
+        rewriter.replaceOp(op, {ret});
       }
     }
 
@@ -806,178 +601,79 @@ struct AtomicRMWOpConversion
       Value rmwPtr = ptrElements[i];
       Value rmwMask = llMask ? and_(mask, maskElements[i]) : mask;
 
-      switch (target) {
-      case triton::Target::ROCDL:
-      case triton::Target::NVVM: {
-        std::string sTy;
-        PTXBuilder ptxBuilderAtomicRMW;
-        std::string tyId = valueElemNBits * vec == 64
-                               ? "l"
-                               : (valueElemNBits * vec == 32 ? "r" : "h");
-        auto *dstOpr =
-            ptxBuilderAtomicRMW.newOperand("=" + tyId, /*init=*/true);
-        auto *ptrOpr = ptxBuilderAtomicRMW.newAddrOperand(rmwPtr, "l");
-        auto *valOpr = ptxBuilderAtomicRMW.newOperand(rmwVal, tyId);
+      assert((valueElemNBits == 16 || valueElemNBits == 32 ||
+              valueElemNBits == 64) &&
+             "Unexpected width");
 
-        auto scope = stringifyMemSyncScope(op.getScope()).str();
-        auto &atom = ptxBuilderAtomicRMW.create<>("atom")->global().o(scope);
-        auto rmwOp = stringifyRMWOp(atomicRmwAttr).str();
-        auto sBits = std::to_string(valueElemNBits);
-        switch (atomicRmwAttr) {
-        case RMWOp::AND:
-          sTy = "b" + sBits;
-          break;
-        case RMWOp::OR:
-          sTy = "b" + sBits;
-          break;
-        case RMWOp::XOR:
-          sTy = "b" + sBits;
-          break;
-        case RMWOp::ADD:
-          sTy = "u" + sBits;
-          break;
-        case RMWOp::FADD:
-          rmwOp = "add";
-          rmwOp += (valueElemNBits == 16 ? ".noftz" : "");
-          sTy = "f" + sBits;
-          sTy += (vec == 2 && valueElemNBits == 16) ? "x2" : "";
-          break;
-        case RMWOp::MAX:
-          sTy = "s" + sBits;
-          break;
-        case RMWOp::MIN:
-          sTy = "s" + sBits;
-          break;
-        case RMWOp::UMAX:
-          rmwOp = "max";
-          sTy = "u" + sBits;
-          break;
-        case RMWOp::UMIN:
-          rmwOp = "min";
-          sTy = "u" + sBits;
-          break;
-        case RMWOp::XCHG:
-          sTy = "b" + sBits;
-          break;
-        default:
-          return failure();
+      Value zero;
+      llvm::TypeSwitch<mlir::Type>(valueElemTy)
+          .Case<mlir::IntegerType>(
+              [&](auto ty) { zero = int_val(valueElemNBits, 0); })
+          .Case<mlir::Float16Type>([&](auto ty) { zero = f16_val(0); })
+          .Case<mlir::Float32Type>([&](auto ty) { zero = f32_val(0); })
+          .Case<mlir::Float64Type>([&](auto ty) { zero = f64_val(0); });
+
+      Block &endBlock = mlir::LLVM::utils::createPredicatedBlock(
+          rewriter, loc, rmwMask, {zero}, [&] {
+            mlir::LLVM::AtomicBinOp rmwKind;
+            switch (atomicRmwAttr) {
+            case RMWOp::AND:
+              rmwKind = LLVM::AtomicBinOp::_and;
+              break;
+            case RMWOp::OR:
+              rmwKind = LLVM::AtomicBinOp::_or;
+              break;
+            case RMWOp::XOR:
+              rmwKind = LLVM::AtomicBinOp::_xor;
+              break;
+            case RMWOp::ADD:
+              rmwKind = LLVM::AtomicBinOp::add;
+              break;
+            case RMWOp::FADD:
+              rmwKind = LLVM::AtomicBinOp::fadd;
+              break;
+            case RMWOp::MAX:
+              rmwKind = LLVM::AtomicBinOp::max;
+              break;
+            case RMWOp::UMAX:
+              rmwKind = LLVM::AtomicBinOp::umax;
+              break;
+            case RMWOp::MIN:
+              rmwKind = LLVM::AtomicBinOp::min;
+              break;
+            case RMWOp::UMIN:
+              rmwKind = LLVM::AtomicBinOp::umin;
+              break;
+            case RMWOp::XCHG:
+              rmwKind = LLVM::AtomicBinOp::xchg;
+              break;
+            }
+
+            rmwVal = bitcast(rmwVal, valueElemTy);
+            auto atomRMW = rewriter.create<LLVM::AtomicRMWOp>(
+                loc, rmwKind, rmwPtr, rmwVal, LLVM::AtomicOrdering::acq_rel);
+            return SmallVector<Value, 1>{atomRMW.getRes()};
+          });
+
+      Value ret = endBlock.getArgument(0);
+      Type retType = (!tensorTy || vec == 1) ? valueElemTy : vecTy;
+      ret = bitcast(ret, retType);
+
+      if (tensorTy) {
+        for (int ii = 0; ii < vec; ++ii) {
+          resultVals[i + ii] =
+              vec == 1 ? ret : extract_element(valueElemTy, ret, i32_val(ii));
         }
-        std::string semStr;
-        llvm::raw_string_ostream os(semStr);
-        os << op.getSem();
-        atom.o(semStr).o(rmwOp).o(sTy);
-        if (tensorTy) {
-          atom(dstOpr, ptrOpr, valOpr).predicate(rmwMask);
-          auto retType = vec == 1 ? valueElemTy : vecTy;
-          auto ret = ptxBuilderAtomicRMW.launch(rewriter, loc, retType);
-          for (int ii = 0; ii < vec; ++ii) {
-            resultVals[i + ii] =
-                vec == 1 ? ret : extract_element(valueElemTy, ret, i32_val(ii));
-          }
-        } else {
-          auto ASMReturnTy = void_ty(ctx);
-          atom(dstOpr, ptrOpr, valOpr).predicate(rmwMask);
-          auto old = ptxBuilderAtomicRMW.launch(rewriter, loc, valueElemTy);
-          if (op->user_begin() == op->user_end()) {
-            rewriter.replaceOp(op, {old});
-            return success();
-          }
-          Value atomPtr = LLVM::utils::getSharedMemoryBase(
-              loc, rewriter, op.getOperation(), target);
-          atomPtr = bitcast(atomPtr, ptr_ty(ctx, 3));
-          // Only threads with rmwMask = True store the result
-          PTXBuilder ptxBuilderStore;
-          auto &storeShared =
-              ptxBuilderStore.create<>("st")->shared().o("b" + sBits);
-          auto *ptrOpr = ptxBuilderStore.newAddrOperand(atomPtr, "r");
-          auto *valOpr = ptxBuilderStore.newOperand(old, tyId);
-          storeShared(ptrOpr, valOpr).predicate(rmwMask);
-          ptxBuilderStore.launch(rewriter, loc, void_ty(ctx));
-          createBarrier(rewriter, loc, numCTAs);
-          Value ret = load(valueElemTy, atomPtr);
-          createBarrier(rewriter, loc, numCTAs);
-          rewriter.replaceOp(op, {ret});
-        }
-      } break;
-      case triton::Target::GENX: {
-        assert((valueElemNBits == 16 || valueElemNBits == 32 ||
-                valueElemNBits == 64) &&
-               "Unexpected width");
-
-        Value zero;
-        llvm::TypeSwitch<mlir::Type>(valueElemTy)
-            .Case<mlir::IntegerType>(
-                [&](auto ty) { zero = int_val(valueElemNBits, 0); })
-            .Case<mlir::Float16Type>([&](auto ty) { zero = f16_val(0); })
-            .Case<mlir::Float32Type>([&](auto ty) { zero = f32_val(0); })
-            .Case<mlir::Float64Type>([&](auto ty) { zero = f64_val(0); });
-
-        Block &endBlock = mlir::LLVM::utils::createPredicatedBlock(
-            rewriter, loc, rmwMask, {zero}, [&] {
-              mlir::LLVM::AtomicBinOp rmwKind;
-              switch (atomicRmwAttr) {
-              case RMWOp::AND:
-                rmwKind = LLVM::AtomicBinOp::_and;
-                break;
-              case RMWOp::OR:
-                rmwKind = LLVM::AtomicBinOp::_or;
-                break;
-              case RMWOp::XOR:
-                rmwKind = LLVM::AtomicBinOp::_xor;
-                break;
-              case RMWOp::ADD:
-                rmwKind = LLVM::AtomicBinOp::add;
-                break;
-              case RMWOp::FADD:
-                rmwKind = LLVM::AtomicBinOp::fadd;
-                break;
-              case RMWOp::MAX:
-                rmwKind = LLVM::AtomicBinOp::max;
-                break;
-              case RMWOp::UMAX:
-                rmwKind = LLVM::AtomicBinOp::umax;
-                break;
-              case RMWOp::MIN:
-                rmwKind = LLVM::AtomicBinOp::min;
-                break;
-              case RMWOp::UMIN:
-                rmwKind = LLVM::AtomicBinOp::umin;
-                break;
-              case RMWOp::XCHG:
-                rmwKind = LLVM::AtomicBinOp::xchg;
-                break;
-              }
-
-              rmwVal = bitcast(rmwVal, valueElemTy);
-              auto atomRMW = rewriter.create<LLVM::AtomicRMWOp>(
-                  loc, rmwKind, rmwPtr, rmwVal, LLVM::AtomicOrdering::acq_rel);
-              return SmallVector<Value, 1>{atomRMW.getRes()};
-            });
-
-        Value ret = endBlock.getArgument(0);
-        Type retType = (!tensorTy || vec == 1) ? valueElemTy : vecTy;
-        ret = bitcast(ret, retType);
-
-        if (tensorTy) {
-          for (int ii = 0; ii < vec; ++ii) {
-            resultVals[i + ii] =
-                vec == 1 ? ret : extract_element(valueElemTy, ret, i32_val(ii));
-          }
-        } else {
-          Value atomPtr = LLVM::utils::getSharedMemoryBase(
-              loc, rewriter, op.getOperation(), target);
-          atomPtr = bitcast(atomPtr, ptr_ty(ctx, 3));
-          // Only threads with rmwMask = True store the result
-          mlir::LLVM::utils::storeShared(rewriter, loc, atomPtr, ret, rmwMask,
-                                         target);
-          createBarrier(rewriter, loc, numCTAs);
-          Value loadVal = load(valueElemTy, atomPtr);
-          createBarrier(rewriter, loc, numCTAs);
-          rewriter.replaceOp(op, {loadVal});
-        }
-      } break;
-      default:
-        llvm_unreachable("Unhandled target");
+      } else {
+        Value atomPtr =
+            LLVM::utils::getSharedMemoryBase(loc, rewriter, op.getOperation());
+        atomPtr = bitcast(atomPtr, ptr_ty(ctx, 3));
+        // Only threads with rmwMask = True store the result
+        mlir::LLVM::utils::storeShared(rewriter, loc, atomPtr, ret, rmwMask);
+        createBarrier(rewriter, loc, numCTAs);
+        Value loadVal = load(valueElemTy, atomPtr);
+        createBarrier(rewriter, loc, numCTAs);
+        rewriter.replaceOp(op, {loadVal});
       }
     }
 
@@ -999,10 +695,6 @@ struct InsertSliceOpConversion
   LogicalResult
   matchAndRewrite(tensor::InsertSliceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-
-    // This function has been removed upstream and should only exist for genx
-    assert(target == triton::Target::GENX &&
-           "InsertSliceOpConversion: genx target not supported yet");
 
     // %dst = insert_slice %src into %dst[%offsets]
     Location loc = op->getLoc();
@@ -1084,152 +776,8 @@ struct InsertSliceAsyncOpConversion
     // decomposeInsertSliceAsyncOp function.
     // FIXME: remove this assertion once a suitable replacement instruction
     // exists for the generated PTX in this function (cp.async.cg.shared.global)
-    assert(target != triton::Target::GENX &&
+    assert(false &&
            "InsertSliceAsyncOpConversion: genx target not supported yet");
-
-    // insert_slice_async %src, %dst, %index, %mask, %other
-    auto loc = op.getLoc();
-    Value res = op.getResult();
-    Value mask = op.getMask();
-    Value other = op.getOther();
-    auto funcOp = op->getParentOfType<FunctionOpInterface>();
-
-    auto srcTy = op.getSrc().getType();
-    auto dstTy = op.getDst().getType();
-    auto resElemTy = getTypeConverter()->convertType(dstTy.getElementType());
-    auto srcLayout = srcTy.getEncoding();
-    assert((srcLayout.isa<BlockedEncodingAttr, SliceEncodingAttr>() &&
-            "Unexpected srcLayout in InsertSliceAsyncOpConversion"));
-    auto resSharedLayout = dstTy.getEncoding().cast<SharedEncodingAttr>();
-    auto srcShape = srcTy.getShape();
-    assert((srcShape.size() <= 3) &&
-           "insert_slice_async: Unexpected rank of %src");
-
-    Value llDst = adaptor.getDst();
-    Value llSrc = adaptor.getSrc();
-    Value llMask = adaptor.getMask();
-    Value llOther = adaptor.getOther();
-    Value llIndex = adaptor.getIndex();
-
-    // %src
-    auto srcElems = unpackLLElements(loc, llSrc, rewriter);
-
-    // %dst
-    auto smemObj =
-        getSharedMemoryObjectFromStruct(loc, llDst, resElemTy, rewriter);
-    auto axis = op->getAttrOfType<IntegerAttr>("axis").getInt();
-    SmallVector<Value, 4> offsetVals;
-    SmallVector<Value, 4> srcStrides;
-    for (auto i = 0; i < dstTy.getShape().size(); ++i) {
-      if (i == axis) {
-        offsetVals.emplace_back(llIndex);
-      } else {
-        offsetVals.emplace_back(i32_val(0));
-        srcStrides.emplace_back(smemObj.strides[i]);
-      }
-    }
-    // Compute the offset based on the original dimensions of the shared
-    // memory object
-    auto dstOffset = dot(rewriter, loc, offsetVals, smemObj.strides);
-    auto dstPtrTy = ptr_ty(rewriter.getContext(), 3);
-    Value dstPtrBase = gep(dstPtrTy, resElemTy, smemObj.base, dstOffset);
-
-    // %mask
-    SmallVector<Value> maskElems;
-    if (llMask) {
-      maskElems = unpackLLElements(loc, llMask, rewriter);
-      assert(srcElems.size() == maskElems.size());
-    }
-
-    // %other
-    SmallVector<Value> otherElems;
-    if (llOther) {
-      // FIXME(Keren): always assume other is 0 for now
-      // It's not necessary for now because the pipeline pass will skip
-      // generating insert_slice_async if the load op has any "other" tensor.
-      // assert(false && "insert_slice_async: Other value not supported yet");
-      otherElems = unpackLLElements(loc, llOther, rewriter);
-      assert(srcElems.size() == otherElems.size());
-    }
-
-    // We don't use getVec() here because we are copying from memory to memory.
-    // If contiguity > vector size, we can have one pointer maintaining the
-    // start of the vector and the other pointer moving to the next vector.
-    unsigned inVec = getContiguity(op.getSrc());
-    unsigned outVec = resSharedLayout.getVec();
-    unsigned minVec = inVec;
-    if (outVec > 1)
-      minVec = std::min(outVec, inVec);
-    unsigned numElems = getTotalElemsPerThread(srcTy);
-    unsigned perPhase = resSharedLayout.getPerPhase();
-    unsigned maxPhase = resSharedLayout.getMaxPhase();
-    DenseMap<unsigned, Value> sharedPtrs =
-        getSwizzledSharedPtrs(loc, inVec, srcTy, resSharedLayout, resElemTy,
-                              smemObj, rewriter, offsetVals, srcStrides);
-
-    // A sharedLayout encoding has a "vec" parameter.
-    // On the column dimension, if inVec > outVec, it means we have to divide
-    // single vector read into multiple ones
-    auto numVecCols = std::max<unsigned>(inVec / outVec, 1);
-
-    for (unsigned elemIdx = 0; elemIdx < numElems; elemIdx += minVec) {
-      // 16 * 8 = 128bits
-      auto maxBitWidth =
-          std::max<unsigned>(128, resElemTy.getIntOrFloatBitWidth());
-      auto vecBitWidth = resElemTy.getIntOrFloatBitWidth() * minVec;
-      auto bitWidth = std::min<unsigned>(maxBitWidth, vecBitWidth);
-      auto numWords = vecBitWidth / bitWidth;
-      auto numWordElems = bitWidth / resElemTy.getIntOrFloatBitWidth();
-
-      // Tune CG and CA here.
-      auto byteWidth = bitWidth / 8;
-      CacheModifier srcCacheModifier =
-          byteWidth == 16 ? CacheModifier::CG : CacheModifier::CA;
-      assert(byteWidth == 16 || byteWidth == 8 || byteWidth == 4);
-      auto resByteWidth = resElemTy.getIntOrFloatBitWidth() / 8;
-
-      Value basePtr = sharedPtrs[elemIdx];
-      for (size_t wordIdx = 0; wordIdx < numWords; ++wordIdx) {
-        PTXBuilder ptxBuilder;
-        auto wordElemIdx = wordIdx * numWordElems;
-        auto &copyAsyncOp =
-            *ptxBuilder.create<PTXCpAsyncLoadInstr>(srcCacheModifier);
-        auto *dstOperand =
-            ptxBuilder.newAddrOperand(basePtr, "r", wordElemIdx * resByteWidth);
-        auto *srcOperand =
-            ptxBuilder.newAddrOperand(srcElems[elemIdx + wordElemIdx], "l");
-        auto *copySize = ptxBuilder.newConstantOperand(byteWidth);
-        auto *srcSize = copySize;
-        if (op.getMask()) {
-          // We don't use predicate in this case, setting src-size to 0
-          // if there's any mask. cp.async will automatically fill the
-          // remaining slots with 0 if cp-size > src-size.
-          // XXX(Keren): Always assume other = 0 for now.
-          auto selectOp = select(maskElems[elemIdx + wordElemIdx],
-                                 i32_val(byteWidth), i32_val(0));
-          srcSize = ptxBuilder.newOperand(selectOp, "r");
-        }
-
-        // When 'other != 0' is supported, we will need to fold the op.getMask()
-        // and redundantDataMask() into the same predicate, the way it is done
-        // for LoadOp.
-        Value maskVal = redundantDataMask(srcTy, rewriter, loc);
-
-        // TODO: Masking does not work for CTA multicast with cp.async. This is
-        // a quick and dirty workaround to avoid the issue.
-        bool skipMaskForMultiCTA = triton::gpu::getNumCTAs(srcLayout) > 1;
-        if (!skipMaskForMultiCTA) {
-          copyAsyncOp(dstOperand, srcOperand, copySize, srcSize)
-              .predicate(maskVal);
-        } else {
-          copyAsyncOp(dstOperand, srcOperand, copySize, srcSize);
-        }
-        ptxBuilder.launch(rewriter, loc, void_ty(getContext()));
-      }
-    }
-
-    rewriter.replaceOp(op, llDst);
-    return success();
   }
 };
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/MemoryOpToLLVM.cpp
@@ -15,8 +15,8 @@ struct AllocTensorOpConversion
   matchAndRewrite(triton::gpu::AllocTensorOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
-    Value smemBase = LLVM::utils::getSharedMemoryBase(
-        loc, rewriter, op.getOperation(), target);
+    Value smemBase =
+        LLVM::utils::getSharedMemoryBase(loc, rewriter, op.getOperation());
     auto resultTy = op.getType().dyn_cast<RankedTensorType>();
     auto elemPtrTy = ptr_ty(rewriter.getContext(), 3);
     auto typeConverter = getTypeConverter();

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceOpToLLVM.cpp
@@ -41,7 +41,7 @@ public:
     reduceWithinThreads(helper, srcValues, accs, indices, rewriter);
 
     // Then reduce across threads within a warp.
-    reduceWithinWarps(helper, accs, rewriter, target);
+    reduceWithinWarps(helper, accs, rewriter);
 
     if (helper.isWarpSynchronous()) {
       // If all the values to be reduced are within the same warp there is
@@ -54,7 +54,7 @@ public:
     auto smemShape = helper.getScratchConfig();
 
     SmallVector<Value> smemBases =
-        getSmemBases(op, product<unsigned>(smemShape), rewriter, target);
+        getSmemBases(op, product<unsigned>(smemShape), rewriter);
 
     storeWarpReduceToSharedMemory(helper, accs, indices, smemBases, rewriter);
 
@@ -66,7 +66,7 @@ public:
     //
     // Each thread needs to process:
     //   elemsPerThread = sizeInterWarps * s1 * s2 .. Sn / numThreads
-    accumulatePartialReductions(helper, smemBases, rewriter, target);
+    accumulatePartialReductions(helper, smemBases, rewriter);
 
     // We could avoid this barrier in some of the layouts, however this is not
     // the general case.
@@ -205,51 +205,11 @@ private:
   // region and the accumulator values as source.
   void warpReduce(ConversionPatternRewriter &rewriter, Location loc,
                   SmallVector<Value> &acc, triton::ReduceOp op,
-                  unsigned numLaneToReduce, unsigned interleave,
-                  Target target) const {
-    if (target != Target::GENX) {
-      if (auto kind = matchReduxKind(op)) {
-        // Based on benchmarking on A100 redux op gives a speed up only when
-        // doing a single reduction (not partitioned) and when the mask is
-        // static. Therefore we currently only enable it to reduce across all
-        // the lanes.
-        if (numLaneToReduce == 32) {
-          assert(acc.size() == 1);
-          Value mask = i32_val(0xFFFFFFFF);
-          // Even though we currently don't use redux for partitioned reduction
-          // the code below supports it in case we want to tweak the heuristic.
-          if (numLaneToReduce < 32) {
-            // For partitioned reduction we need to calculate the mask so that
-            // each group of numLaneToReduce threads has the correct mask.
-            unsigned bitmask = (1 << numLaneToReduce) - 1;
-            Value threadId = getThreadId(rewriter, loc);
-            Value laneId = urem(threadId, i32_val(32));
-            mask = shl(i32_val(bitmask),
-                       and_(laneId, i32_val(~(numLaneToReduce - 1))));
-          }
-          for (unsigned i = 0; i < acc.size(); ++i) {
-            unsigned bitwidth = acc[i].getType().cast<IntegerType>().getWidth();
-            if (bitwidth < 32) {
-              if (*kind == NVVM::ReduxKind::MIN ||
-                  *kind == NVVM::ReduxKind::MAX)
-                acc[i] = sext(i32_ty, acc[i]);
-              else
-                acc[i] = zext(i32_ty, acc[i]);
-            }
-            acc[i] = rewriter.create<NVVM::ReduxOp>(loc, acc[i].getType(),
-                                                    acc[0], *kind, mask);
-            if (bitwidth < 32)
-              acc[i] = trunc(int_ty(bitwidth), acc[i]);
-          }
-          return;
-        }
-      }
-    }
-
+                  unsigned numLaneToReduce, unsigned interleave) const {
     for (unsigned N = numLaneToReduce / 2; N > 0; N >>= 1) {
       SmallVector<Value> shfl(acc.size());
       for (unsigned i = 0; i < acc.size(); ++i) {
-        shfl[i] = shflSync(loc, rewriter, acc[i], N * interleave, target);
+        shfl[i] = shflSync(loc, rewriter, acc[i], N * interleave);
       }
       accumulate(rewriter, op.getCombineOp(), acc, shfl, false);
     }
@@ -259,7 +219,7 @@ private:
   void
   reduceWithinWarps(ReduceOpHelper &helper,
                     std::map<SmallVector<unsigned>, SmallVector<Value>> &accs,
-                    ConversionPatternRewriter &rewriter, Target target) const {
+                    ConversionPatternRewriter &rewriter) const {
     triton::ReduceOp op = helper.getOperation();
     unsigned sizeIntraWarps = helper.getIntraWarpSizeWithUniqueData();
     unsigned threadOffsetOnReductionAxis =
@@ -268,7 +228,7 @@ private:
       const SmallVector<unsigned> &key = it.first;
       SmallVector<Value> &acc = accs[key];
       warpReduce(rewriter, op.getLoc(), acc, op, sizeIntraWarps,
-                 threadOffsetOnReductionAxis, target);
+                 threadOffsetOnReductionAxis);
     }
   }
 
@@ -370,7 +330,7 @@ private:
         auto elemTy = getElementType(op, i);
         Value writePtr = gep(ptr_ty(rewriter.getContext(), 3), elemTy,
                              smemBases[i], writeOffset);
-        storeShared(rewriter, loc, writePtr, acc[i], laneZero, target);
+        storeShared(rewriter, loc, writePtr, acc[i], laneZero);
       }
     }
   }
@@ -379,8 +339,7 @@ private:
   // store back to shared memory.
   void accumulatePartialReductions(ReduceOpHelper &helper,
                                    SmallVector<Value> &smemBases,
-                                   ConversionPatternRewriter &rewriter,
-                                   Target target) const {
+                                   ConversionPatternRewriter &rewriter) const {
     triton::ReduceOp op = helper.getOperation();
     auto srcLayout = helper.getSrcLayout();
     auto smemShape = helper.getScratchConfig();
@@ -406,11 +365,9 @@ private:
         auto elemTy = getElementType(op, i);
         Value readPtr = gep(ptr_ty(rewriter.getContext(), 3), elemTy,
                             smemBases[i], readOffset);
-        acc[i] =
-            loadShared(rewriter, loc, readPtr, elemTy, threadIsNeeded, target);
+        acc[i] = loadShared(rewriter, loc, readPtr, elemTy, threadIsNeeded);
       }
-      warpReduce(rewriter, loc, acc, op, sizeInterWarps, 1 /* interleave */,
-                 target);
+      warpReduce(rewriter, loc, acc, op, sizeInterWarps, 1 /* interleave */);
       // only the first thread in each sizeInterWarps is writing
       Value writeOffset = readOffset;
       SmallVector<Value> writePtrs(op.getNumOperands());
@@ -426,7 +383,7 @@ private:
       Value pred = and_(threadIsNeeded, laneIdModSizeInterWarpsIsZero);
 
       for (unsigned i = 0; i < op.getNumOperands(); ++i) {
-        storeShared(rewriter, loc, writePtrs[i], acc[i], pred, target);
+        storeShared(rewriter, loc, writePtrs[i], acc[i], pred);
       }
 
       if (round != elemsPerThread - 1) {

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceScanCommon.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceScanCommon.h
@@ -57,8 +57,7 @@ public:
 
   // Helper to compute the smem bases in both reductions and scans
   SmallVector<Value> getSmemBases(SourceOp op, unsigned elems,
-                                  ConversionPatternRewriter &rewriter,
-                                  Target target) const {
+                                  ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
     // indices will store the index of the op operands in descending order
     // of their bitwidths
@@ -71,8 +70,8 @@ public:
     });
     // Assign base index to each operand in their order in indices
     std::map<unsigned, Value> indexToBase;
-    indexToBase[indices[0]] = LLVM::utils::getSharedMemoryBase(
-        loc, rewriter, op.getOperation(), target);
+    indexToBase[indices[0]] =
+        LLVM::utils::getSharedMemoryBase(loc, rewriter, op.getOperation());
     for (unsigned i = 1; i < op.getNumOperands(); ++i) {
       indexToBase[indices[i]] = gep(
           ptr_ty(rewriter.getContext(), 3), getElementType(op, indices[i - 1]),

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
@@ -264,64 +264,25 @@ Value linearize(ConversionPatternRewriter &rewriter, Location loc,
 }
 
 Value storeShared(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
-                  Value val, Value pred, triton::Target target) {
-  switch (target) {
-  case triton::Target::ROCDL:
-  case triton::Target::NVVM: {
-    MLIRContext *ctx = rewriter.getContext();
-    unsigned bits = std::max(8u, val.getType().getIntOrFloatBitWidth());
-    const char *c = bits == 64 ? "l" : (bits == 16 ? "h" : "r");
-
-    PTXBuilder builder;
-    auto *ptrOpr = builder.newAddrOperand(ptr, "r");
-    auto *valOpr = builder.newOperand(val, c);
-    auto &st = builder.create<>("st")->shared().b(bits);
-    st(ptrOpr, valOpr).predicate(pred, "b");
-    return builder.launch(rewriter, loc, void_ty(ctx));
-  } break;
-  case triton::Target::GENX: {
-    createPredicatedBlock(rewriter, loc, pred, [&] {
-      store(val, ptr);
-      return ArrayRef<Value>();
-    });
-    return Value();
-  } break;
-  }
-  llvm_unreachable("unsupported triton::Target");
+                  Value val, Value pred) {
+  createPredicatedBlock(rewriter, loc, pred, [&] {
+    store(val, ptr);
+    return ArrayRef<Value>();
+  });
+  return Value();
 }
 
 Value loadShared(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
-                 Type elemTy, Value pred, triton::Target target) {
-  switch (target) {
-  case triton::Target::ROCDL:
-  case triton::Target::NVVM: {
-    MLIRContext *ctx = rewriter.getContext();
-    auto ptrTy = ptr.getType().cast<LLVMPointerType>();
-    assert(ptrTy.getAddressSpace() == 3 && "Invalid addr space for loadShared");
-    unsigned bitwidth = std::max(8u, elemTy.getIntOrFloatBitWidth());
-
-    const char *c = bitwidth == 64 ? "=l" : (bitwidth == 16 ? "=h" : "=r");
-
-    PTXBuilder builder;
-    auto *dOpr = builder.newOperand(c);
-    auto *ptrOpr = builder.newAddrOperand(ptr, "r");
-    auto &ld = builder.create<>("ld")->shared().b(bitwidth);
-    ld(dOpr, ptrOpr).predicate(pred, "b");
-    return builder.launch(rewriter, loc, elemTy);
-  } break;
-  case triton::Target::GENX: {
-    assert(ptr.getType().cast<LLVMPointerType>().getAddressSpace() == 3 &&
-           "Invalid addr space for loadShared");
-    Value undef = undef(elemTy);
-    Block &endBlock = createPredicatedBlock(rewriter, loc, pred,
-                                            SmallVector<Value, 1>{undef}, [&] {
-                                              Value ret = load(elemTy, ptr);
-                                              return SmallVector<Value, 1>{ret};
-                                            });
-    return *endBlock.args_begin();
-  } break;
-  }
-  llvm_unreachable("unsupported triton::Target");
+                 Type elemTy, Value pred) {
+  assert(ptr.getType().cast<LLVMPointerType>().getAddressSpace() == 3 &&
+         "Invalid addr space for loadShared");
+  Value undef = undef(elemTy);
+  Block &endBlock = createPredicatedBlock(rewriter, loc, pred,
+                                          SmallVector<Value, 1>{undef}, [&] {
+                                            Value ret = load(elemTy, ptr);
+                                            return SmallVector<Value, 1>{ret};
+                                          });
+  return *endBlock.args_begin();
 }
 
 static GENX::ShflKind toGenXShuffleMode(NVVM::ShflKind mode) {
@@ -340,7 +301,7 @@ static GENX::ShflKind toGenXShuffleMode(NVVM::ShflKind mode) {
 
 static Value commonShflSync(Location loc, ConversionPatternRewriter &rewriter,
                             Value val, Value i, NVVM::ShflKind mode,
-                            Value clamp, triton::Target target) {
+                            Value clamp) {
   unsigned bits = val.getType().getIntOrFloatBitWidth();
 
   if (bits == 64) {
@@ -348,8 +309,8 @@ static Value commonShflSync(Location loc, ConversionPatternRewriter &rewriter,
     Value vec = bitcast(val, vecTy);
     Value val0 = extract_element(f32_ty, vec, i32_val(0));
     Value val1 = extract_element(f32_ty, vec, i32_val(1));
-    val0 = commonShflSync(loc, rewriter, val0, i, mode, clamp, target);
-    val1 = commonShflSync(loc, rewriter, val1, i, mode, clamp, target);
+    val0 = commonShflSync(loc, rewriter, val0, i, mode, clamp);
+    val1 = commonShflSync(loc, rewriter, val1, i, mode, clamp);
     vec = undef(vecTy);
     vec = insert_element(vecTy, vec, val0, i32_val(0));
     vec = insert_element(vecTy, vec, val1, i32_val(1));
@@ -357,54 +318,31 @@ static Value commonShflSync(Location loc, ConversionPatternRewriter &rewriter,
   }
   Type type = val.getType();
 
-  switch (target) {
-  case triton::Target::ROCDL:
-  case triton::Target::NVVM: {
-    if (type != i32_ty) {
-      val = bitcast(val, int_ty(bits));
-      if (bits < 32)
-        val = zext(i32_ty, val);
-    }
-    Value mask = i32_val(0xFFFFFFFF);
-    Value result = rewriter.create<NVVM::ShflOp>(loc, i32_ty, mask, val, i,
-                                                 clamp, mode, UnitAttr());
-    if (type != i32_ty) {
-      if (bits < 32)
-        result = trunc(int_ty(bits), result);
-      result = bitcast(result, type);
-    }
-
-    return result;
-  }
-  case triton::Target::GENX: {
-    return rewriter.create<GENX::SubGroupShuffleOp>(loc, type, val, i,
-                                                    toGenXShuffleMode(mode));
-  }
-  }
-  llvm_unreachable("Invalid target");
+  return rewriter.create<GENX::SubGroupShuffleOp>(loc, type, val, i,
+                                                  toGenXShuffleMode(mode));
 }
 
 Value shflSync(Location loc, ConversionPatternRewriter &rewriter, Value val,
-               int i, Target target) {
+               int i) {
   return commonShflSync(loc, rewriter, val, i32_val(i), NVVM::ShflKind::bfly,
-                        i32_val(0x1f), target);
+                        i32_val(0x1f));
 }
 
 Value shflUpSync(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                 int i, Target target) {
+                 int i) {
   return commonShflSync(loc, rewriter, val, i32_val(i), NVVM::ShflKind::up,
-                        i32_val(0x0), target);
+                        i32_val(0x0));
 }
 
 Value shflIdxSync(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                  int i, Target target) {
-  return shflIdxSync(loc, rewriter, val, i32_val(i), target);
+                  int i) {
+  return shflIdxSync(loc, rewriter, val, i32_val(i));
 }
 
 Value shflIdxSync(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                  Value i, Target target) {
+                  Value i) {
   return commonShflSync(loc, rewriter, val, i, NVVM::ShflKind::idx,
-                        i32_val(0x1f), target);
+                        i32_val(0x1f));
 }
 
 Value getSRegValue(OpBuilder &b, Location loc, const std::string &sRegStr) {

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
@@ -415,19 +415,19 @@ Value linearize(ConversionPatternRewriter &rewriter, Location loc,
                 ArrayRef<Value> multiDim, ArrayRef<unsigned> shape);
 
 Value storeShared(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
-                  Value val, Value pred, triton::Target target);
+                  Value val, Value pred);
 
 Value loadShared(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
-                 Type elemTy, Value pred, triton::Target target);
+                 Type elemTy, Value pred);
 
 Value shflSync(Location loc, ConversionPatternRewriter &rewriter, Value val,
-               int i, triton::Target target);
+               int i);
 Value shflUpSync(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                 int i, triton::Target target);
+                 int i);
 Value shflIdxSync(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                  int i, triton::Target target);
+                  int i);
 Value shflIdxSync(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                  Value i, triton::Target target);
+                  Value i);
 Value getSRegValue(OpBuilder &b, Location loc, const std::string &sRegStr);
 
 Value addStringToModule(Location loc, ConversionPatternRewriter &rewriter,
@@ -439,30 +439,18 @@ static bool isKernel(FunctionOpInterface funcOp) {
 }
 
 static Value getStackPointer(PatternRewriter &rewriter,
-                             FunctionOpInterface funcOp, Target target) {
+                             FunctionOpInterface funcOp) {
   auto mod = funcOp->getParentOfType<ModuleOp>();
-  if (target == triton::Target::GENX) {
-    LLVM::LLVMPointerType ptrTy =
-        ptr_ty(rewriter.getContext(), GENX::GENXMemorySpace::kWorkgroup);
-    if (mod->getAttrOfType<IntegerAttr>("triton_gpu.shared").getInt() == 0)
-      return rewriter.create<LLVM::UndefOp>(funcOp.getLoc(), ptrTy);
-    return funcOp.getArgument(funcOp.getNumArguments() - 1);
-  }
-  LLVM::GlobalOp globalBase = nullptr;
-  mod.walk([&](LLVM::GlobalOp op) {
-    if (op.getSymName() == "global_smem")
-      globalBase = op;
-  });
-  assert(globalBase);
-  if (isKernel(funcOp))
-    return rewriter.create<LLVM::AddressOfOp>(funcOp.getLoc(), globalBase);
-  else
-    return funcOp.getArgument(funcOp.getNumArguments() - 1);
+  LLVM::LLVMPointerType ptrTy =
+      ptr_ty(rewriter.getContext(), GENX::GENXMemorySpace::kWorkgroup);
+  if (mod->getAttrOfType<IntegerAttr>("triton_gpu.shared").getInt() == 0)
+    return rewriter.create<LLVM::UndefOp>(funcOp.getLoc(), ptrTy);
+  return funcOp.getArgument(funcOp.getNumArguments() - 1);
 }
 
 static Value getSharedMemoryBase(Location loc,
                                  ConversionPatternRewriter &rewriter,
-                                 Operation *op, Target target) {
+                                 Operation *op) {
   auto ptrTy = LLVM::LLVMPointerType::get(rewriter.getContext(), 3);
   FunctionOpInterface func =
       op->template getParentOfType<FunctionOpInterface>();
@@ -473,8 +461,7 @@ static Value getSharedMemoryBase(Location loc,
                       .getZExtValue();
   Value offVal = i32_val(offset);
   Value base =
-      gep(ptrTy, i8_ty, LLVM::utils::getStackPointer(rewriter, func, target),
-          offVal);
+      gep(ptrTy, i8_ty, LLVM::utils::getStackPointer(rewriter, func), offVal);
   return base;
 }
 
@@ -1409,30 +1396,17 @@ static Value packLLElements(Location loc,
 }
 
 static Value llGetPid(int axis, Location loc, ModuleOp moduleOp,
-                      ConversionPatternRewriter &rewriter,
-                      mlir::triton::Target target) {
+                      ConversionPatternRewriter &rewriter) {
   assert(axis >= 0);
   assert(axis < 3);
   assert(moduleOp);
 
-  if (target == triton::Target::GENX) {
-    constexpr mlir::gpu::Dimension dims[] = {mlir::gpu::Dimension::x,
-                                             mlir::gpu::Dimension::y,
-                                             mlir::gpu::Dimension::z};
+  constexpr mlir::gpu::Dimension dims[] = {mlir::gpu::Dimension::x,
+                                           mlir::gpu::Dimension::y,
+                                           mlir::gpu::Dimension::z};
 
-    Value blockId = rewriter.create<::mlir::gpu::BlockIdOp>(loc, dims[axis]);
-    return rewriter.create<arith::IndexCastOp>(loc, i32_ty, blockId);
-  }
-
-  // It is not easy to get the compute capability here, so we use numCTAs to
-  // decide the semantic of GetProgramIdOp. If numCTAs = 1, then
-  // GetProgramIdOp is converted to "%ctaid", otherwise it is converted to
-  // "%clusterid".
-  int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(moduleOp);
-
-  std::string sreg = numCTAs == 1 ? "%ctaid." : "%clusterid.";
-  sreg.append(1, 'x' + axis); // 0 -> 'x', 1 -> 'y', 2 -> 'z'
-  return LLVM::utils::getSRegValue(rewriter, loc, sreg);
+  Value blockId = rewriter.create<::mlir::gpu::BlockIdOp>(loc, dims[axis]);
+  return rewriter.create<arith::IndexCastOp>(loc, i32_ty, blockId);
 }
 
 } // namespace mlir


### PR DESCRIPTION
This one deals with all the switches on target. Will do patterns separately.