### PR TITLE
Revert fix for #582

### DIFF
--- a/.github/actions/setup-ipex/action.yml
+++ b/.github/actions/setup-ipex/action.yml
@@ -65,8 +65,7 @@ runs:
       run: |
         source ${{ inputs.oneapi }}/setvars.sh
         pip install intel-extension-for-pytorch/dist/*.whl
-        # Temporary disable import check until https://github.com/intel/intel-xpu-backend-for-triton/issues/582 is fixed
-        # python -c "import torch;import intel_extension_for_pytorch as ipex;print(ipex.__version__)"
+        python -c "import torch;import intel_extension_for_pytorch as ipex;print(ipex.__version__)"
 
     - name: Save IPEX wheels to a cache
       if: ${{ steps.ipex-cache.outputs.status == 'miss' }}


### PR DESCRIPTION
IPEX can be imported again (as a minimal sanity check) before building Triton.