### PR TITLE
Disable default build for pytorch and ipex

### DIFF
--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -51,8 +51,6 @@ done
 
 if [ "$BUILD_PYTORCH" = false ] && [ "$BUILD_IPEX" = false ] \
    && [ "$BUILD_LLVM" = false ] && [ "$BUILD_TRITON" = false ]; then
-  BUILD_PYTORCH=false
-  BUILD_IPEX=false
   BUILD_LLVM=true
   BUILD_TRITON=true
 fi

--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -51,8 +51,8 @@ done
 
 if [ "$BUILD_PYTORCH" = false ] && [ "$BUILD_IPEX" = false ] \
    && [ "$BUILD_LLVM" = false ] && [ "$BUILD_TRITON" = false ]; then
-  BUILD_PYTORCH=true
-  BUILD_IPEX=true
+  BUILD_PYTORCH=false
+  BUILD_IPEX=false
   BUILD_LLVM=true
   BUILD_TRITON=true
 fi


### PR DESCRIPTION
For the Triton side's build script, the pytorch/ipex build is preferable to be enabled by the user explicitly. Otherwise, this would override the user's existing one.

An example is that when the user has a debug version of PyTorch, this script will automatically uninstall the original torch and replace it with a release version.