### PR TITLE
Always initialize oneAPI in CI workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -102,6 +102,9 @@ jobs:
       max-parallel: 2
       fail-fast: false
     timeout-minutes: 720
+    defaults:
+      run:
+        shell: bash -noprofile --norc -eo pipefail -c "source /home/runner/intel/oneapi/setvars.sh > /dev/null; source {0}"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -333,7 +336,6 @@ jobs:
         env:
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
         run: |
-          source ~/intel/oneapi/setvars.sh
           export WORKSPACE=$GITHUB_WORKSPACE
           if [[ "${{ inputs.TORCH_COMPILE_DEBUG }}" == "1" ]] ; then
             export TORCH_COMPILE_DEBUG="1"

--- a/.github/workflows/nightly_wheels.yml
+++ b/.github/workflows/nightly_wheels.yml
@@ -26,6 +26,9 @@ jobs:
         python:
           - "3.9"
           - "3.10"
+    defaults:
+      run:
+        shell: bash -noprofile --norc -eo pipefail -c "source /home/runner/intel/oneapi/setvars.sh > /dev/null; source {0}"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
It's simpler to initialize oneAPI for each step in CI workflows by default than do it for each individual step that requires it. Also it brings the CI environment in sync with development environments where oneAPI, usually, is initialized in the very begining,