### PR TITLE
DEBUG=1 when building Triton

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -136,6 +136,7 @@ jobs:
 
       - name: Build Triton
         run: |
+          export DEBUG=1
           cd python
           pip install wheel pytest pytest-xdist pytest-rerunfailures
           pip install --no-build-isolation '.[build,tests,tutorials]'

--- a/.github/workflows/conda_build_and_test.yml
+++ b/.github/workflows/conda_build_and_test.yml
@@ -106,6 +106,7 @@ jobs:
 
       - name: Build Triton
         run: |
+          export DEBUG=1
           cd python
           conda activate triton
           pip install --no-build-isolation '.[build,tests,tutorials]'

--- a/.github/workflows/e2e-performance.yml
+++ b/.github/workflows/e2e-performance.yml
@@ -211,6 +211,7 @@ jobs:
       - name: Build Triton wheels
         if: ${{ steps.triton-cache.outputs.status == 'miss' }}
         run: |
+          export DEBUG=1
           cd python
           python setup.py bdist_wheel
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -211,6 +211,7 @@ jobs:
       - name: Build Triton wheels
         if: ${{ steps.triton-cache.outputs.status == 'miss' }}
         run: |
+          export DEBUG=1
           cd python
           python setup.py bdist_wheel
 

--- a/.github/workflows/nightly_wheels.yml
+++ b/.github/workflows/nightly_wheels.yml
@@ -109,6 +109,7 @@ jobs:
       - name: Build Triton wheels
         if: ${{ steps.triton-cache.outputs.status == 'miss' }}
         run: |
+          export DEBUG=1
           cd python
           python setup.py bdist_wheel
 


### PR DESCRIPTION
Setting `DEBUG=1` translates to `--config Debug` for `cmake`.

In #642 we discovered that `DEBUG=1` is required for building Triton to make the lit tests pass. Use this option for other workflows to make sure Triton is the same.