### PR TITLE
[DPAS] Fix issue in DPAS caused by latest Triton changes. 

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -44,11 +44,10 @@ Value lowerSharedToDotOperandDPAS(
     const DpasEncodingAttr &dpasLayout,
     const DotOperandEncodingAttr &dotOperandLayout, bool isOuter) {
   auto loc = op.getLoc();
-  Value src = op.getSrc();
+  auto src = op.getSrc();
   Value dst = op.getResult();
 
-  auto llvmElemTy = typeConverter->convertType(
-      src.getType().cast<RankedTensorType>().getElementType());
+  auto llvmElemTy = typeConverter->convertType(src.getType().getElementType());
 
   auto smemObj = getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
                                                  llvmElemTy, rewriter);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandDPAS.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandDPAS.cpp
@@ -240,7 +240,6 @@ getLoadMatrixFn(MemDescType descTy, const SharedMemoryObject &smemObj,
   static_assert(opIdx == 0 || opIdx == 1);
 
   auto shapePerCTA = getShapePerCTA(descTy);
-  //  auto tensorTy = tensor.getType().cast<RankedTensorType>();
   Type eltTy = descTy.getElementType();
 
   auto sharedLayout = descTy.getEncoding().cast<SharedEncodingAttr>();


### PR DESCRIPTION
The latest Triton uses the local alloc to represent the SLM usage. The ConvertLayout on Triton Intel should change accordingly for DPAS.