### PR TITLE
Remove Triton dependency on downstream LLVM/MLIR - part 1

### DIFF
--- a/include/triton/Dialect/TritonGEN/IR/TritonGENOps.td
+++ b/include/triton/Dialect/TritonGEN/IR/TritonGENOps.td
@@ -172,30 +172,6 @@ def TritonGEN_SubGroupShuffleOp : TritonGEN_Op<"sub_group_shuffle", [
 }
 
 //===----------------------------------------------------------------------===//
-// Type Conversions
-//===----------------------------------------------------------------------===//
-
-def TritonGEN_FpToFpOp : TritonGEN_Op<"fptofp">,
-  Results<(outs AnyFloat:$res)>,
-  Arguments<(ins
-    AnyFloat:$arg,
-    OptionalAttr<TritonGEN_RoundingModeAttr>:$roundingMode
-  )> {
-  let summary = "Convert between floating point types";
-
-  string baseDescription = [{
-    Convert `$arg` to the type of the result `$res`. If necessary, round the
-    result according to `$roundingMode`.
-  }];
-
-  let assemblyFormat = [{
-    $arg (` ` `{` `roundingMode` `=` $roundingMode^ `}`)? attr-dict `:` type($arg) `to` type($res)
-  }];
-
-  let hasVerifier = 1;
-}
-
-//===----------------------------------------------------------------------===//
 // Matrix operations
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TritonGEN/IR/TritonGENOps.cpp
+++ b/lib/Dialect/TritonGEN/IR/TritonGENOps.cpp
@@ -14,21 +14,6 @@ using namespace mlir;
 using namespace mlir::triton;
 
 //===----------------------------------------------------------------------===//
-// gen.fptofp
-//===----------------------------------------------------------------------===//
-
-LogicalResult TritonGEN::FpToFpOp::verify() {
-  unsigned srcTySizeInBits = getArg().getType().getWidth();
-  unsigned resTySizeInBits = getRes().getType().getWidth();
-  if (srcTySizeInBits == resTySizeInBits)
-    return this->emitOpError(
-        "expecting first argument and result size to be different");
-  if (!getRoundingMode() && srcTySizeInBits >= resTySizeInBits)
-    return this->emitOpError("expecting rounding mode for truncation");
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
 // gen.matrix.dpas
 //===----------------------------------------------------------------------===//
 

--- a/test/TritonGEN/tritongen-invalid.mlir
+++ b/test/TritonGEN/tritongen-invalid.mlir
@@ -1,29 +1,5 @@
 // RUN: triton-opt -split-input-file -verify-diagnostics %s
 
-llvm.func @triton_gen.fptofp(%a : i32) {
-  // expected-error @+1 {{custom op 'triton_gen.fptofp' invalid kind of type specified}}
-  %0 = triton_gen.fptofp %a {roundingMode = rte} : i32 to i16
-  llvm.return
-}
-
-// -----
-
-llvm.func @triton_gen.fptofp(%a : f32) {
-  // expected-error @+1 {{'triton_gen.fptofp' op expecting first argument and result size to be different}}
-  %0 = triton_gen.fptofp %a {roundingMode = rte} : f32 to f32
-  llvm.return
-}
-
-// -----
-
-llvm.func @triton_gen.fptofp(%a : f32) {
-  // expected-error @+1 {{'triton_gen.fptofp' op expecting rounding mode for truncation}}
-  %0 = triton_gen.fptofp %a : f32 to f16
-  llvm.return
-}
-
-// -----
-
 llvm.func @triton_gen.dpas(%c : vector<8xi32>, %a : vector<16xi8>, %b : vector<32xi8>) {
   // expected-error @+1 {{'triton_gen.dpas' op expecting repeat count to be 1, 2, 4, or 8}}
   %0 = triton_gen.dpas %c, %a, %b {pa=s8, pb=s8, rc=6} : (vector<8xi32>, vector<16xi8>, vector<32xi8>) -> vector<8xi32>

--- a/test/TritonGEN/tritongen.mlir
+++ b/test/TritonGEN/tritongen.mlir
@@ -68,29 +68,6 @@ llvm.func @triton_gen.sub_group_shuffle() {
   llvm.return
 }
 
-llvm.func @triton_gen.fptofp(%a: f32, %b: f16) {
-  // CHECK-LABEL: triton_gen.fptofp
-  // CHECK:      %0 = triton_gen.fptofp %arg0 {roundingMode = rte} : f32 to f16
-  // CHECK-NEXT: %1 = triton_gen.fptofp %arg0 {roundingMode = rtn} : f32 to f16
-  // CHECK-NEXT: %2 = triton_gen.fptofp %arg0 {roundingMode = rtp} : f32 to f16
-  // CHECK-NEXT: %3 = triton_gen.fptofp %arg0 {roundingMode = rtz} : f32 to f16
-  // CHECK-NEXT: %4 = triton_gen.fptofp %arg1 {roundingMode = rte} : f16 to f32
-  // CHECK-NEXT: %5 = triton_gen.fptofp %arg1 {roundingMode = rtn} : f16 to f32
-  // CHECK-NEXT: %6 = triton_gen.fptofp %arg1 {roundingMode = rtp} : f16 to f32
-  // CHECK-NEXT: %7 = triton_gen.fptofp %arg1 {roundingMode = rtz} : f16 to f32
-  // CHECK-NEXT: %8 = triton_gen.fptofp %arg1 : f16 to f32
-  %0 = triton_gen.fptofp %a {roundingMode = rte} : f32 to f16
-  %1 = triton_gen.fptofp %a {roundingMode = rtn} : f32 to f16
-  %2 = triton_gen.fptofp %a {roundingMode = rtp} : f32 to f16
-  %3 = triton_gen.fptofp %a {roundingMode = rtz} : f32 to f16
-  %4 = triton_gen.fptofp %b {roundingMode = rte} : f16 to f32
-  %5 = triton_gen.fptofp %b {roundingMode = rtn} : f16 to f32
-  %6 = triton_gen.fptofp %b {roundingMode = rtp} : f16 to f32
-  %7 = triton_gen.fptofp %b {roundingMode = rtz} : f16 to f32
-  %8 = triton_gen.fptofp %b : f16 to f32
-  llvm.return
-}
-
 llvm.func @triton_gen.dpas(%c : vector<8xi32>, %a : vector<16xi8>, %b : vector<32xi8>) {
   // CHECK:      llvm.func @triton_gen.dpas(%arg0: vector<8xi32>, %arg1: vector<16xi8>, %arg2: vector<32xi8>) {
   // CHECK-NEXT:   %0 = triton_gen.dpas %arg0, %arg1, %arg2 {pa = s8, pb = s8, rc = 8} : (vector<8xi32>, vector<16xi8>, vector<32xi8>) -> vector<8xi32>

--- a/third_party/intel/include/TritonIntelGPUToLLVM/Passes.td
+++ b/third_party/intel/include/TritonIntelGPUToLLVM/Passes.td
@@ -30,7 +30,6 @@ def ConvertTritonIntelGPUToLLVM : Pass<"convert-triton-intel-gpu-to-llvm", "mlir
                              "mlir::triton::gpu::TritonGPUDialect",
                              "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
                              "mlir::triton::TritonGEN::TritonGENDialect",
-                             "mlir::GENX::GENXDialect",
                              "mlir::NVVM::NVVMDialect"];
 
     let options = [

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -120,56 +120,6 @@ static LLVM::CallOp createSubGroupShuffle(ConversionPatternRewriter &rewriter,
                                   {value, mask}, true /*convergent*/);
 }
 
-static LLVM::CallIntrinsicOp createFpToFp(TritonGEN::FpToFpOp op,
-                                          ConversionPatternRewriter &rewriter) {
-  MLIRContext *context = rewriter.getContext();
-  Location loc = UnknownLoc::get(context);
-
-  // TODO: MLIR offers a mechanism to convert attributes to different dialects,
-  // we should replace this switch with it.
-  std::optional<int32_t> rounding = std::nullopt;
-  if (op.getRoundingMode())
-    switch (*op.getRoundingMode()) {
-    case TritonGEN::RoundingMode::RTE:
-      rounding = static_cast<int32_t>(llvm::RoundingMode::NearestTiesToEven);
-      break;
-    case TritonGEN::RoundingMode::RTN:
-      rounding = static_cast<int32_t>(llvm::RoundingMode::TowardNegative);
-      break;
-    case TritonGEN::RoundingMode::RTP:
-      rounding = static_cast<int32_t>(llvm::RoundingMode::TowardPositive);
-      break;
-    case TritonGEN::RoundingMode::RTZ:
-      rounding = static_cast<int32_t>(llvm::RoundingMode::TowardZero);
-      break;
-    default:
-      llvm_unreachable("Unhandled rounding mode");
-    }
-
-  Type argType = op.getArg().getType();
-  Type resType = op.getResult().getType();
-  unsigned resTySizeInBits = resType.getIntOrFloatBitWidth();
-  unsigned srcTySizeInBits = argType.getIntOrFloatBitWidth();
-  // TODO: add these intrinsics to the llvm dialect as first class operations.
-  auto stringAttr =
-      (srcTySizeInBits > resTySizeInBits)
-          ? rewriter.getStringAttr(llvm::Intrinsic::getBaseName(
-                llvm::Intrinsic::experimental_constrained_fptrunc))
-          : rewriter.getStringAttr(llvm::Intrinsic::getBaseName(
-                llvm::Intrinsic::experimental_constrained_fpext));
-
-  if (rounding.has_value()) {
-    auto namedAttr = rewriter.getNamedAttr(
-        "roundingMode",
-        IntegerAttr::get(IntegerType::get(context, 32), rounding.value()));
-  }
-
-  // TODO: currently the LLVM dialect is unable to translate an intrinsic call
-  // with metadata correctly.
-  return rewriter.create<LLVM::CallIntrinsicOp>(loc, resType, stringAttr,
-                                                op.getArg());
-}
-
 static LLVM::CallOp createGenISADPAS(TritonGEN::MatrixDPASOp op,
                                      ConversionPatternRewriter &rewriter) {
   auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
@@ -582,23 +532,6 @@ struct TritonSubGroupShuffleLowering
 };
 
 //===----------------------------------------------------------------------===//
-// Type Conversion Ops Lowerings
-//===----------------------------------------------------------------------===//
-
-struct TritonGENFpToFpLowering
-    : public ConvertOpToLLVMPattern<TritonGEN::FpToFpOp> {
-  using ConvertOpToLLVMPattern<TritonGEN::FpToFpOp>::ConvertOpToLLVMPattern;
-
-  LogicalResult
-  matchAndRewrite(TritonGEN::FpToFpOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    LLVM::CallIntrinsicOp callOp = createFpToFp(op, rewriter);
-    rewriter.replaceOp(op, callOp);
-    return success();
-  }
-};
-
-//===----------------------------------------------------------------------===//
 // Matrix operations
 //===----------------------------------------------------------------------===//
 
@@ -705,10 +638,9 @@ void mlir::triton::populateTritonGENToLLVMConversionPatterns(
                TritonGENBlockIdYLowering, TritonGENBlockIdZLowering,
                TritonGENBlockDimXLowering, TritonGENBlockDimYLowering,
                TritonGENBlockDimZLowering, TritonGENGridDimXLowering,
-               TritonGENGridDimYLowering, TritonGENGridDimZLowering>(converter);
-  patterns.add<TritonGENBarrierLowering, TritonSubGroupShuffleLowering,
-               TritonGENFpToFpLowering>(converter);
-  patterns.add<TritonMatrixDPASLowering, TritonMatrix2DBlockLoadLowering,
+               TritonGENGridDimYLowering, TritonGENGridDimZLowering,
+               TritonGENBarrierLowering, TritonSubGroupShuffleLowering,
+               TritonMatrixDPASLowering, TritonMatrix2DBlockLoadLowering,
                TritonMatrix2DBlockStoreLowering>(converter);
 }
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/CMakeLists.txt
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/CMakeLists.txt
@@ -30,11 +30,9 @@ add_triton_library(TritonIntelGPUToLLVM
 
     LINK_LIBS PUBLIC
     TritonNvidiaGPUTransforms
-    MLIRGPUToGENXTransforms
     NVGPUIR
     TritonGENIR
     TritonGENToLLVM
     TritonIntelGPUIR
-    MLIRGENXDialect
     GPUToTritonGEN
 )

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1709,6 +1709,9 @@ struct FpToFpOpConversion
     MLIRContext *ctx = rewriter.getContext();
     auto moduleOp =
         rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
+
+    // FIXME: Avoid using `llvm.genx.GenISA` calls (use arith dialect instead
+    // once it has been enhanced).
     std::string funcName = "llvm.genx.GenISA.ftof.";
 
     switch (rounding) {

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVM.cpp
@@ -10,7 +10,6 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/Index/IR/IndexOps.h"
-#include "mlir/Dialect/LLVMIR/GENXDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/Pass/Pass.h"
@@ -175,7 +174,6 @@ public:
   explicit TritonLLVMConversionTarget(MLIRContext &ctx)
       : ConversionTarget(ctx) {
     addLegalDialect<LLVM::LLVMDialect>();
-    addLegalDialect<GENX::GENXDialect>();
     addIllegalDialect<triton::TritonDialect>();
     addIllegalDialect<triton::gpu::TritonGPUDialect>();
     addIllegalDialect<triton::nvidia_gpu::TritonNvidiaGPUDialect>();
@@ -192,8 +190,7 @@ struct ConvertTritonGPUToLLVM
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<triton::nvgpu::NVGPUDialect, LLVM::LLVMDialect,
-                    NVVM::NVVMDialect, TritonGEN::TritonGENDialect,
-                    GENX::GENXDialect>();
+                    NVVM::NVVMDialect, TritonGEN::TritonGENDialect>();
   }
 
   ConvertTritonGPUToLLVM(int32_t computeCapability)


### PR DESCRIPTION
Remove TritonGEN fptofp operation and adjust convertFp32ToFp16 to remove dep. on GENX dialect