### PR TITLE
Obtain the value of constexpr for atomic mask operand

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1635,6 +1635,7 @@ def atomic_cas(pointer, cmp, val, sem=None, scope=None, _builder=None):
 @_add_atomic_docstr("exchange")
 def atomic_xchg(pointer, val, mask=None, sem=None, scope=None, _builder=None):
     val = _to_tensor(val, _builder)
+    mask = _constexpr_to_value(mask)
     sem = _constexpr_to_value(sem)
     scope = _constexpr_to_value(scope)
     return semantic.atomic_xchg(pointer, val, mask, sem, scope, _builder)
@@ -1645,6 +1646,7 @@ def atomic_xchg(pointer, val, mask=None, sem=None, scope=None, _builder=None):
 @_add_atomic_docstr("add")
 def atomic_add(pointer, val, mask=None, sem=None, scope=None, _builder=None):
     val = _to_tensor(val, _builder)
+    mask = _constexpr_to_value(mask)
     sem = _constexpr_to_value(sem)
     scope = _constexpr_to_value(scope)
     return semantic.atomic_add(pointer, val, mask, sem, scope, _builder)
@@ -1655,6 +1657,7 @@ def atomic_add(pointer, val, mask=None, sem=None, scope=None, _builder=None):
 @_add_atomic_docstr("max")
 def atomic_max(pointer, val, mask=None, sem=None, scope=None, _builder=None):
     val = _to_tensor(val, _builder)
+    mask = _constexpr_to_value(mask)
     sem = _constexpr_to_value(sem)
     scope = _constexpr_to_value(scope)
     return semantic.atomic_max(pointer, val, mask, sem, scope, _builder)
@@ -1665,6 +1668,7 @@ def atomic_max(pointer, val, mask=None, sem=None, scope=None, _builder=None):
 @_add_atomic_docstr("min")
 def atomic_min(pointer, val, mask=None, sem=None, scope=None, _builder=None):
     val = _to_tensor(val, _builder)
+    mask = _constexpr_to_value(mask)
     sem = _constexpr_to_value(sem)
     scope = _constexpr_to_value(scope)
     return semantic.atomic_min(pointer, val, mask, sem, scope, _builder)
@@ -1675,6 +1679,7 @@ def atomic_min(pointer, val, mask=None, sem=None, scope=None, _builder=None):
 @_add_atomic_docstr("logical and")
 def atomic_and(pointer, val, mask=None, sem=None, scope=None, _builder=None):
     val = _to_tensor(val, _builder)
+    mask = _constexpr_to_value(mask)
     sem = _constexpr_to_value(sem)
     scope = _constexpr_to_value(scope)
     return semantic.atomic_and(pointer, val, mask, sem, scope, _builder)
@@ -1685,6 +1690,7 @@ def atomic_and(pointer, val, mask=None, sem=None, scope=None, _builder=None):
 @_add_atomic_docstr("logical or")
 def atomic_or(pointer, val, mask=None, sem=None, scope=None, _builder=None):
     val = _to_tensor(val, _builder)
+    mask = _constexpr_to_value(mask)
     sem = _constexpr_to_value(sem)
     scope = _constexpr_to_value(scope)
     return semantic.atomic_or(pointer, val, mask, sem, scope, _builder)
@@ -1695,6 +1701,7 @@ def atomic_or(pointer, val, mask=None, sem=None, scope=None, _builder=None):
 @_add_atomic_docstr("logical xor")
 def atomic_xor(pointer, val, mask=None, sem=None, scope=None, _builder=None):
     val = _to_tensor(val, _builder)
+    mask = _constexpr_to_value(mask)
     sem = _constexpr_to_value(sem)
     scope = _constexpr_to_value(scope)
     return semantic.atomic_xor(pointer, val, mask, sem, scope, _builder)


### PR DESCRIPTION
https://github.com/openai/triton/commit/441d6b10148e313552192ebbd1fbd30d5d93b563 changes some checks from `if mask` to `if mask is not None`. 
`constexpr[None]` is considered as not None, i.e., `if mask` returns true to `if mask is not None` returns false.

We need to get the underlying value for atomic operand `mask` as it is a `constexpr`, so that a proper check can be done.