### PR TITLE
Remove dependency on custom LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,6 @@ if(TRITON_BUILD_PYTHON_MODULE)
     MLIRTargetLLVMIRExport
     MLIRMathToLLVM
     MLIRROCDLToLLVMIRTranslation
-    MLIRGENXToLLVMIRTranslation
     MLIRGPUDialect
     MLIRSCFToControlFlow
     MLIRIndexToLLVM

--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ downloads a prebuilt LLVM, but you can also build LLVM from source and use that.
 LLVM does not have a stable API, so the Triton build will not work at an
 arbitrary LLVM version.
 
-1. `git checkout` LLVM at https://github.com/intel/llvm/tree/genx.  Optionally,
-   make additional modifications to LLVM.
+Find the version of LLVM that Triton builds against. Check cmake/llvm-hash.txt to 
+see the current version. For example, if it says: 49af6502c6dcb4a7f7520178bd14df396f78240c 
+checkout that version:
+
+1. `git checkout 49af6502c6dcb4a7f7520178bd14df396f78240c ` LLVM at https://github.com/llvm/llvm-project
 
 2. [Build LLVM](https://llvm.org/docs/CMake.html).  For example, you might run
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ downloads a prebuilt LLVM, but you can also build LLVM from source and use that.
 LLVM does not have a stable API, so the Triton build will not work at an
 arbitrary LLVM version.
 
-Find the version of LLVM that Triton builds against. Check cmake/llvm-hash.txt to 
-see the current version. For example, if it says: 49af6502c6dcb4a7f7520178bd14df396f78240c 
+Find the version of LLVM that Triton builds against. Check cmake/llvm-hash.txt to
+see the current version. For example, if it says: 49af6502c6dcb4a7f7520178bd14df396f78240c
 checkout that version:
 
 1. `git checkout 49af6502c6dcb4a7f7520178bd14df396f78240c ` LLVM at https://github.com/llvm/llvm-project

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -482,8 +482,8 @@ The modes are mostly separate within IGC and make different assumptions about th
 
 From the execution point of view the two modes are incompatible (in the driver), however, there’s a feature to allow for kernels to do cross-context calls (in dpc++ these are invoke_simd and invoke_spmd, e.g., [34]). Those have an overhead and are tricky to use.
 Intel GPU backed has thus two paths for Triton kernels compilation:
-* SIMT – the default approach (same as AMD/Nvidia) that lowers TritonGPU IR using the layouts described above, through GenX dialect [35]. The GenX dialect in turn is lowered to either OpenCL built-ins or GenISA instrinsics.
-* SIMD – an approach suitable for dense operations that transforms TritonGPU to “warp-level” IR (similar to auto-vectorization), adjusts operator argument sizes and maps the result to XeGPU dialect [36].
+* SIMT – the default approach (same as AMD/Nvidia) that lowers TritonGPU IR using the layouts described above.
+* SIMD – an approach suitable for dense operations that transforms TritonGPU to “warp-level” IR (similar to auto-vectorization), adjusts operator argument sizes and maps the result to XeGPU dialect [35].
 
 At a higher level, the two approaches represent only the way the IR is looked at (e.g., Triton IR can be thought of "SIMD" in a way that it operates on tensors; and autovectorization converts initial sizes to appropriate hardware-defined vector widths for actual instructions).
 
@@ -571,5 +571,4 @@ Triton will have an opportunity to be used without PyTorch while not having a re
 [32] GenISA intrinsics: https://github.com/intel/intel-graphics-compiler/blob/4a1798982e29564baba0265b19a4752f8f458219/IGC/GenISAIntrinsics/Intrinsic_definitions.py<br>
 [33] GenX intrinsics: https://github.com/intel/vc-intrinsics<br>
 [34] Sycl ext invoke_simd: https://github.com/intel/llvm/blob/d3c8a7e621ba41be5c11ebad1bce8cd1af216117/sycl/doc/extensions/experimental/sycl_ext_oneapi_invoke_simd.asciidoc<br>
-[35] GenX dialect: https://github.com/intel/llvm/tree/genx<br>
-[36] XeGPU dialect: https://github.com/intel/mlir-extensions<br>
+[35] XeGPU dialect: https://github.com/intel/mlir-extensions<br>

--- a/docs/getting-started/architecture.rst
+++ b/docs/getting-started/architecture.rst
@@ -29,7 +29,7 @@ The Triton structure can be broken down into three major parts, following the cl
 2. The middle-end consumes the IR and progressively lowers it to the TritonGPU dialect applying optimizations.
 3. The backend lowers TritonGPU dialect to LLVM dialect, then converts it to LLVM IR and an appropriate format depending on the target (e.g., ptx/cubin in Nvidia case).
 
-There are three main IR stages on which most of the optimizations are done: Triton dialect, TritonGPU dialect [c8]_, and LLVM IR. Note: Vendor-specific backends introduce additional dialects (e.g., GenX for Intel) to help with TritonGPU lowering.
+There are three main IR stages on which most of the optimizations are done: Triton dialect, TritonGPU dialect [c8]_, and LLVM IR. Note: Vendor-specific backends introduce additional dialects to help with TritonGPU lowering.
 
 .. image :: ../pics/triton.png
 
@@ -538,7 +538,6 @@ Components
 ==========
 The Intel GPU backend consists of three major components:
 
-* LLVM fork for the GenX dialect -> move to the backend
 * Triton fork for upstream work
 * Intel GPU backend (plugin)
 
@@ -553,8 +552,8 @@ The modes are mostly separate within IGC and make different assumptions about th
 From the execution point of view the two modes are incompatible (in the driver), however, there’s a feature to allow for kernels to do cross-context calls (in dpc++ these are invoke_simd and invoke_spmd, e.g., [c34]_). Those have an overhead and are tricky to use.
 Intel GPU backed has thus two paths for Triton kernels compilation:
 
-* SIMT – the default approach (same as AMD/Nvidia) that lowers TritonGPU IR using the layouts described above, through GenX dialect [c35]_. The GenX dialect in turn is lowered to either OpenCL built-ins or GenISA instrinsics.
-* SIMD – an approach suitable for dense operations that transforms TritonGPU to “warp-level” IR (similar to auto-vectorization), adjusts operator argument sizes and maps the result to XeGPU dialect [c36]_.
+* SIMT – the default approach (same as AMD/Nvidia) that lowers TritonGPU IR using the layouts described above.
+* SIMD – an approach suitable for dense operations that transforms TritonGPU to “warp-level” IR (similar to auto-vectorization), adjusts operator argument sizes and maps the result to XeGPU dialect [c35]_.
 
 At a higher level, the two approaches represent only the way the IR is looked at (e.g., Triton IR can be thought of "SIMD" in a way that it operates on tensors; and autovectorization converts initial sizes to appropriate hardware-defined vector widths for actual instructions).
 
@@ -649,5 +648,4 @@ Links and materials
 .. [c32] GenISA intrinsics: https://github.com/intel/intel-graphics-compiler/blob/4a1798982e29564baba0265b19a4752f8f458219/IGC/GenISAIntrinsics/Intrinsic_definitions.py
 .. [c33] GenX intrinsics: https://github.com/intel/vc-intrinsics
 .. [c34] Sycl ext invoke_simd: https://github.com/intel/llvm/blob/d3c8a7e621ba41be5c11ebad1bce8cd1af216117/sycl/doc/extensions/experimental/sycl_ext_oneapi_invoke_simd.asciidoc
-.. [c35] GenX dialect: https://github.com/intel/llvm/tree/genx
-.. [c36] XeGPU dialect: https://github.com/intel/mlir-extensions
+.. [c35] XeGPU dialect: https://github.com/intel/mlir-extensions

--- a/include/triton/Dialect/TritonGEN/IR/TritonGENDialect.td
+++ b/include/triton/Dialect/TritonGEN/IR/TritonGENDialect.td
@@ -23,25 +23,22 @@ def TritonGEN_Dialect : Dialect {
   let dependentDialects = ["mlir::LLVM::LLVMDialect"];
 
   let extraClassDeclaration = [{
-    /// Get the name of the attribute used to annotate kernels.
-    static StringRef getKernelFuncAttrName() { return "genx.kernel"; }
-
     /// Get the name of the attribute used to annotate max work group size
     /// required for kernels.
     static constexpr ::llvm::StringLiteral getMaxWorkGroupSizeAttrName() {
-      return ::llvm::StringLiteral("genx.max_work_group_size");
+      return ::llvm::StringLiteral("gen.max_work_group_size");
     }
 
     /// Get the name of the attribute used to annotate exact work group size
     /// required for kernels.
     static constexpr ::llvm::StringLiteral getReqdWorkGroupSizeAttrName() {
-      return ::llvm::StringLiteral("genx.reqd_work_group_size");
+      return ::llvm::StringLiteral("gen.reqd_work_group_size");
     }
 
     /// Get the name for the attribute used to annotate the exact sub group
     /// size required for kernels.
     static constexpr ::llvm::StringLiteral getReqdSubGroupSizeAttrName() {
-      return ::llvm::StringLiteral("genx.intel_reqd_sub_group_size");
+      return ::llvm::StringLiteral("gen.intel_reqd_sub_group_size");
     }
   }];
 }

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -111,7 +111,7 @@ static uint32_t findKernels(llvm::Module &M,
   for (llvm::Function &function : M.functions())
     if (function.getCallingConv() == CallingConv::SPIR_KERNEL) {
       functions.insert(&function);
-      numKernels++;
+      ++numKernels;
     }
   return numKernels;
 }

--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -117,7 +117,7 @@ fi
 if [ ! -d "$LLVM_PROJ" ]; then
   echo "**** Cloning $LLVM_PROJ ****"
   cd $BASE
-  git clone --recursive https://github.com/llvm/llvm-project.git 
+  git clone --recursive https://github.com/llvm/llvm-project.git
 
   TRITON_LLVM_COMMIT_FILE="$TRITON_PROJ/cmake/llvm-hash.txt"
   if [ ! -f "$TRITON_LLVM_COMMIT_FILE" ]; then

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -60,11 +60,11 @@ export SCRIPTS_DIR=$(dirname "$0")
 python3 -m pip install lit
 python3 -m pip install pytest pytest-xdist pytest-rerunfailures
 
-#$SCRIPTS_DIR/compile-pytorch-ipex.sh --pinned $ARGS
-#if [ $? -ne 0 ]; then
-#  echo "FAILED: return code $?"
-#  exit $?
-#fi
+$SCRIPTS_DIR/compile-pytorch-ipex.sh --pinned $ARGS
+if [ $? -ne 0 ]; then
+  echo "FAILED: return code $?"
+  exit $?
+fi
 
 if [ ! -d "$TRITON_PROJ_BUILD" ]
 then

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -60,11 +60,11 @@ export SCRIPTS_DIR=$(dirname "$0")
 python3 -m pip install lit
 python3 -m pip install pytest pytest-xdist pytest-rerunfailures
 
-$SCRIPTS_DIR/compile-pytorch-ipex.sh --pinned $ARGS
-if [ $? -ne 0 ]; then
-  echo "FAILED: return code $?"
-  exit $?
-fi
+#$SCRIPTS_DIR/compile-pytorch-ipex.sh --pinned $ARGS
+#if [ $? -ne 0 ]; then
+#  echo "FAILED: return code $?"
+#  exit $?
+#fi
 
 if [ ! -d "$TRITON_PROJ_BUILD" ]
 then

--- a/test/Conversion/tritongpu_to_gen.mlir
+++ b/test/Conversion/tritongpu_to_gen.mlir
@@ -1,9 +1,9 @@
 // RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory  --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm
 
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32} {
-  // CHECK: llvm.func @test_empty_kernel(%arg0: i64, %arg1: !llvm.ptr<1>)
+  // CHECK: llvm.func spir_kernelcc @test_empty_kernel(%arg0: i64, %arg1: !llvm.ptr<1>)
   // Here the 128 comes from the 4 in module attribute multiples 32
-  // CHECK-SAME: attributes {genx.intel_reqd_sub_group_size = [32 : i32], genx.kernel = 1 : i32, genx.max_work_group_size = [128 : i32, 1 : i32, 1 : i32]} {
+  // CHECK-SAME: attributes {passthrough = {{.*}}"gen.intel_reqd_sub_group_size", "32"{{.*}}"gen.max_work_group_size", "128,1,1"{{.*}}} { 
   tt.func @test_empty_kernel(%lb : index, %A : !tt.ptr<f16>) {
     // CHECK:  llvm.return
     tt.return

--- a/test/Conversion/tritongpu_to_gen.mlir
+++ b/test/Conversion/tritongpu_to_gen.mlir
@@ -3,7 +3,7 @@
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32} {
   // CHECK: llvm.func spir_kernelcc @test_empty_kernel(%arg0: i64, %arg1: !llvm.ptr<1>)
   // Here the 128 comes from the 4 in module attribute multiples 32
-  // CHECK-SAME: attributes {passthrough = {{.*}}"gen.intel_reqd_sub_group_size", "32"{{.*}}"gen.max_work_group_size", "128,1,1"{{.*}}} { 
+  // CHECK-SAME: attributes {passthrough = {{.*}}"gen.intel_reqd_sub_group_size", "32"{{.*}}"gen.max_work_group_size", "128,1,1"{{.*}}} {
   tt.func @test_empty_kernel(%lb : index, %A : !tt.ptr<f16>) {
     // CHECK:  llvm.return
     tt.return

--- a/third_party/intel/lib/GPUToTritonGEN/GPUOpsLowering.h
+++ b/third_party/intel/lib/GPUToTritonGEN/GPUOpsLowering.h
@@ -39,12 +39,11 @@ private:
 struct GPUFuncOpLowering : ConvertOpToLLVMPattern<gpu::GPUFuncOp> {
   GPUFuncOpLowering(
       const LLVMTypeConverter &converter, unsigned allocaAddrSpace,
-      unsigned workgroupAddrSpace, StringAttr kernelAttributeName,
+      unsigned workgroupAddrSpace,
       std::optional<StringAttr> kernelBlockSizeAttributeName = std::nullopt)
       : ConvertOpToLLVMPattern<gpu::GPUFuncOp>(converter),
         allocaAddrSpace(allocaAddrSpace),
         workgroupAddrSpace(workgroupAddrSpace),
-        kernelAttributeName(kernelAttributeName),
         kernelBlockSizeAttributeName(kernelBlockSizeAttributeName) {}
 
   LogicalResult
@@ -56,10 +55,6 @@ private:
   unsigned allocaAddrSpace;
   /// The address space to use declaring workgroup memory.
   unsigned workgroupAddrSpace;
-
-  /// The attribute name to use instead of `gpu.kernel`.
-  StringAttr kernelAttributeName;
-
   /// The attribute name to to set block size
   std::optional<StringAttr> kernelBlockSizeAttributeName;
 };

--- a/third_party/intel/lib/GPUToTritonGEN/GPUToTritonGENPass.cpp
+++ b/third_party/intel/lib/GPUToTritonGEN/GPUToTritonGENPass.cpp
@@ -170,9 +170,7 @@ void mlir::triton::populateGPUToTritonGENConversionPatterns(
   patterns.add<GPUFuncOpLowering>(
       converter,
       /*allocaAddrSpace=*/TritonGEN::TritonGENMemorySpace::kFunction,
-      /*workgroupAddrSpace=*/TritonGEN::TritonGENMemorySpace::kWorkgroup,
-      StringAttr::get(&converter.getContext(),
-                      TritonGEN::TritonGENDialect::getKernelFuncAttrName()));
+      /*workgroupAddrSpace=*/TritonGEN::TritonGENMemorySpace::kWorkgroup);
 
   const llvm::StringRef prefix("_Z15__spirv_ocl_");
   populateOpPatterns<math::ExpOp>(converter, patterns, (prefix + "expf").str(),

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -704,13 +704,13 @@ struct AsyncCopyGlobalToLocalOpConversion
   matchAndRewrite(triton::gpu::AsyncCopyGlobalToLocalOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    // This function should not be called on the genx target since all
+    // This function should not be called on the gen target since all
     // AsyncCopyGlobalToLocalOps would be decomposed into InsertSliceOps by the
     // decomposeAsyncCopyGlobalToLocalOp function.
     // FIXME: remove this assertion once a suitable replacement instruction
     // exists for the generated PTX in this function (cp.async.cg.shared.global)
     assert(false &&
-           "AsyncCopyGlobalToLocalOpConversion: genx target not supported yet");
+           "AsyncCopyGlobalToLocalOpConversion: gen target not supported yet");
 
     // insert_slice_async %src, %dst, %index, %mask, %other
     auto loc = op.getLoc();

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -2,7 +2,6 @@
 #include "TritonIntelGPUToLLVM/Passes.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
-#include "mlir/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.h"
 #include "passes.h"
 #include "triton/Dialect/NVGPU/IR/Dialect.h"
@@ -86,7 +85,6 @@ void init_triton_intel(py::module &&m) {
                     mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect,
                     mlir::triton::nvgpu::NVGPUDialect>();
     mlir::registerNVVMDialectTranslation(registry);
-    mlir::registerGENXDialectTranslation(registry);
     context.appendDialectRegistry(registry);
     context.loadAllAvailableDialects();
   });


### PR DESCRIPTION
Mark the kernel with the SPIR_KERNEL calling convention and add custom attributes `intel_reqd_sub_group_size` and `max_work_group_size` as passthrough attributes. 

The custom attributes attached to the kernel are post processed after the LLVM IR is generated and transformed into LLVM metadata.