### PR TITLE
[GEN] Add subgroup id operator

### DIFF
--- a/include/triton/Dialect/TritonGEN/IR/TritonGENOps.td
+++ b/include/triton/Dialect/TritonGEN/IR/TritonGENOps.td
@@ -128,6 +128,18 @@ def TritonGEN_GridDimZOp : TritonGEN_Op<"grid.dim.z", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
+// Subgroup index
+//===----------------------------------------------------------------------===//
+
+def TritonGEN_SubgroupIdOp : TritonGEN_Op<"subgroup.id", [NoMemoryEffect]> {
+  let arguments = (ins);
+  let results = (outs I32:$res);
+  let assemblyFormat = [{
+    attr-dict `:` type($res)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Synchronization
 //===----------------------------------------------------------------------===//
 

--- a/include/triton/Dialect/TritonGEN/IR/TritonGENOps.td
+++ b/include/triton/Dialect/TritonGEN/IR/TritonGENOps.td
@@ -132,6 +132,11 @@ def TritonGEN_GridDimZOp : TritonGEN_Op<"grid.dim.z", [Pure]> {
 //===----------------------------------------------------------------------===//
 
 def TritonGEN_SubgroupIdOp : TritonGEN_Op<"subgroup.id", [Pure]> {
+  let summary = "Subgroup Index";
+  string baseDescription = [{
+    The `gen.subgroup.id` operation returns the subgroup ID which is a number
+    from 0 to the number of subgroups minus one.
+  }];
   let arguments = (ins);
   let results = (outs I32:$res);
   let assemblyFormat = [{

--- a/include/triton/Dialect/TritonGEN/IR/TritonGENOps.td
+++ b/include/triton/Dialect/TritonGEN/IR/TritonGENOps.td
@@ -131,7 +131,7 @@ def TritonGEN_GridDimZOp : TritonGEN_Op<"grid.dim.z", [Pure]> {
 // Subgroup index
 //===----------------------------------------------------------------------===//
 
-def TritonGEN_SubgroupIdOp : TritonGEN_Op<"subgroup.id", [NoMemoryEffect]> {
+def TritonGEN_SubgroupIdOp : TritonGEN_Op<"subgroup.id", [Pure]> {
   let arguments = (ins);
   let results = (outs I32:$res);
   let assemblyFormat = [{

--- a/test/TritonGEN/tritongen-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-to-llvm.mlir
@@ -42,6 +42,10 @@ llvm.func @gen_special_regs() -> i32 {
   // CHECK: [[TWO3:%.*]] = llvm.mlir.constant(2 : i32) : i32
   // CHECK: llvm.call @_Z14get_num_groupsj([[TWO3]]) : (i32) -> i64
   %12 = triton_gen.grid.dim.z : i32
+
+  // CHECK: llvm.call @_Z16get_sub_group_id() : () -> i32
+  %13 = triton_gen.subgroup.id : i32
+
   llvm.return %1 : i32
 }
 

--- a/test/TritonGEN/tritongen.mlir
+++ b/test/TritonGEN/tritongen.mlir
@@ -26,6 +26,8 @@ llvm.func @triton_gen_special_regs() -> i32 {
   %10 = triton_gen.grid.dim.y : i32
   // CHECK: triton_gen.grid.dim.z : i32
   %11 = triton_gen.grid.dim.z : i32
+  // CHECK: triton_gen.subgroup.id : i32
+  %12 = triton_gen.subgroup.id : i32
   llvm.return %0 : i32
 }
 

--- a/third_party/intel/lib/GPUToTritonGEN/GPUToTritonGENPass.cpp
+++ b/third_party/intel/lib/GPUToTritonGEN/GPUToTritonGENPass.cpp
@@ -165,8 +165,9 @@ void mlir::triton::populateGPUToTritonGENConversionPatterns(
                                   TritonGEN::BlockDimYOp,
                                   TritonGEN::BlockDimZOp>,
       GPUIndexIntrinsicOpLowering<mlir::gpu::GridDimOp, TritonGEN::GridDimXOp,
-                                  TritonGEN::GridDimYOp,
-                                  TritonGEN::GridDimZOp>>(converter);
+                                  TritonGEN::GridDimYOp, TritonGEN::GridDimZOp>,
+      SingleDimLaunchConfigLowering<mlir::gpu::SubgroupIdOp,
+                                    TritonGEN::SubgroupIdOp>>(converter);
   patterns.add<GPUFuncOpLowering>(
       converter,
       /*allocaAddrSpace=*/TritonGEN::TritonGENMemorySpace::kFunction,

--- a/third_party/intel/lib/GPUToTritonGEN/IndexIntrinsicsOpLowering.h
+++ b/third_party/intel/lib/GPUToTritonGEN/IndexIntrinsicsOpLowering.h
@@ -97,15 +97,16 @@ public:
   LogicalResult
   matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto loc = op->getLoc();
+    Location loc = op->getLoc();
     MLIRContext *context = rewriter.getContext();
+    const unsigned resBitWidth = 32;
     Operation *newOp =
-        rewriter.create<TargetOp>(loc, IntegerType::get(context, 32));
+        rewriter.create<TargetOp>(loc, IntegerType::get(context, resBitWidth));
 
-    if (indexBitwidth > 32) {
+    if (indexBitwidth > resBitWidth) {
       newOp = rewriter.create<LLVM::SExtOp>(
           loc, IntegerType::get(context, indexBitwidth), newOp->getResult(0));
-    } else if (indexBitwidth < 32) {
+    } else if (indexBitwidth < resBitWidth) {
       newOp = rewriter.create<LLVM::TruncOp>(
           loc, IntegerType::get(context, indexBitwidth), newOp->getResult(0));
     }

--- a/third_party/intel/lib/GPUToTritonGEN/IndexIntrinsicsOpLowering.h
+++ b/third_party/intel/lib/GPUToTritonGEN/IndexIntrinsicsOpLowering.h
@@ -99,7 +99,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op->getLoc();
     MLIRContext *context = rewriter.getContext();
-    Operation *newOp = newOp =
+    Operation *newOp =
         rewriter.create<TargetOp>(loc, IntegerType::get(context, 32));
 
     if (indexBitwidth > 32) {


### PR DESCRIPTION
In Triton, we currently calculate subgroup id by dividing local id by subgroup size. 
In this PR, we added an operator to get the subgroup id directly. 
One of the benefits is IGC is able to deduce that subgroup id is uniform, 
by it not depending on a calculation that depends on local id.