### PR TITLE
[GEN] Use SPIRV builtin to get subgroup id

### DIFF
--- a/test/TritonGEN/tritongen-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-to-llvm.mlir
@@ -43,7 +43,7 @@ llvm.func @gen_special_regs() -> i32 {
   // CHECK: llvm.call @_Z14get_num_groupsj([[TWO3]]) : (i32) -> i64
   %12 = triton_gen.grid.dim.z : i32
 
-  // CHECK: llvm.call @_Z16get_sub_group_id() : () -> i32
+  // CHECK: llvm.call @_Z16get_sub_group_idv() : () -> i32
   %13 = triton_gen.subgroup.id : i32
 
   llvm.return %1 : i32

--- a/test/TritonGEN/tritongen-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-to-llvm.mlir
@@ -43,7 +43,7 @@ llvm.func @gen_special_regs() -> i32 {
   // CHECK: llvm.call @_Z14get_num_groupsj([[TWO3]]) : (i32) -> i64
   %12 = triton_gen.grid.dim.z : i32
 
-  // CHECK: llvm.call @_Z16get_sub_group_idv() : () -> i32
+  // CHECK: llvm.call @_Z25__spirv_BuiltInSubgroupIdv() : () -> i32
   %13 = triton_gen.subgroup.id : i32
 
   llvm.return %1 : i32

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -500,7 +500,7 @@ struct TritonGENSubgroupIdLowering
                   ConversionPatternRewriter &rewriter) const override {
     auto retType = rewriter.getIntegerType(32);
     LLVM::CallOp callOp = createDeviceFunctionCall(
-        rewriter, "_Z16get_sub_group_id", retType, {}, {});
+        rewriter, "_Z16get_sub_group_idv", retType, {}, {});
     rewriter.replaceOp(op, callOp);
     return success();
   }

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -500,7 +500,7 @@ struct TritonGENSubgroupIdLowering
                   ConversionPatternRewriter &rewriter) const override {
     auto retType = rewriter.getIntegerType(32);
     LLVM::CallOp callOp = createDeviceFunctionCall(
-        rewriter, "_Z16get_sub_group_idv", retType, {}, {});
+        rewriter, "_Z25__spirv_BuiltInSubgroupIdv", retType, {}, {});
     rewriter.replaceOp(op, callOp);
     return success();
   }


### PR DESCRIPTION
The OCL function `_Z16get_sub_group_idv` implementation depends on local id passed in as kernel arguments.
On the other hand, SPIRV builtin function `_Z25__spirv_BuiltInSubgroupIdv` implementation depend on r0.
The OCL version cannot solve the problem described in https://github.com/intel/intel-xpu-backend-for-triton/issues/743.
This PR changes `gen.subgroup.id` to lower to `_Z25__spirv_BuiltInSubgroupIdv` for now to allow better code generation in IGC.