### PR TITLE
fix pip installation from source code issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1", "importlib_metadata", "importlib-metadata"]
+requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1", "importlib_metadata"]
 
 [tool.yapf]
 based_on_style = "pep8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1"]
+requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1", "importlib_metadata"]
 
 [tool.yapf]
 based_on_style = "pep8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1", "importlib_metadata"]
+requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1", "importlib_metadata", "importlib-metadata"]
 
 [tool.yapf]
 based_on_style = "pep8"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1"]
+requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1", "importlib_metadata"]
 
 # We're incrementally switching from autopep8 to ruff.
 [tool.autopep8]

--- a/python/setup.py
+++ b/python/setup.py
@@ -492,6 +492,7 @@ setup(
     extras_require={
         "build": [
             "cmake>=3.20",
+            "importlib_metadata",
             "lit",
         ],
         "tests": [


### PR DESCRIPTION
The pip cmake package just release 3.29.0, which broken the pip installation from source code. Refer: https://github.com/intel/intel-xpu-backend-for-triton/issues/679#issuecomment-2020509855. 