### PR TITLE
[Draft] Add matmul pipelining with L3 prefetching.

### DIFF
--- a/include/triton/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/include/triton/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -14,4 +14,38 @@ include "mlir/Interfaces/InferTypeOpInterface.td" // SameOperandsAndResultType
 class TTIG_Op<string mnemonic, list<Trait> traits = []> :
     Op<TritonIntelGPU_Dialect, mnemonic, traits>;
 
+def TTIG_PrefetchCacheOp : TTIG_Op<"prefetch_cache",
+                                  [
+                                  //AttrSizedOperandSegments,
+                                   DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+                                  // MemoryEffects<[MemRead, MemWrite]>,
+                                   //TypesMatchWith<"infer mask type from src type",
+                                   //                "src", "mask", "getI1SameShape($_self)",
+                                   //                "($_op.getOperands().size() <= 3) || std::equal_to<>()">,
+                                   //TypesMatchWith<"infer other type from src type",
+                                   //                "src", "other", "getPointeeType($_self)",
+                                   //                "($_op.getOperands().size() <= 4) || std::equal_to<>()">
+                                                   ]> {
+  let summary = "prefetch data to L3 cache";
+
+  let description = [{
+    This is operation to prefetch cache
+  }];
+
+  let arguments = (ins AnyTypeOf<[TT_PtrLike, TT_TensorPtr]>:$ptr);
+
+  let builders = [
+      // A tensor of pointers
+      // OpBuilder<(ins "Value":$ptr_johnlu)>,
+  ];
+
+    // Format: `tt.load operands attrs : optional(type(ptr)) -> type(result)`
+  let assemblyFormat = "$ptr attr-dict `:` type($ptr)";
+
+  let extraClassDeclaration = [{
+  }];
+
+  //let hasCustomAssemblyFormat = 1;
+}
+
 #endif

--- a/include/triton/Dialect/TritonIntelGPU/Transforms/Passes.h
+++ b/include/triton/Dialect/TritonIntelGPU/Transforms/Passes.h
@@ -30,6 +30,11 @@ std::unique_ptr<Pass> createTritonIntelGPUAccelerateMatmulPass(
     triton::gpu::intel::DeviceArch arch =
         triton::gpu::intel::DeviceArch::UNKNOWN);
 
+std::unique_ptr<Pass>
+createTritonIntelGPUPipelinePass(int numStages = 2,
+                                 triton::gpu::intel::DeviceArch arch =
+                                     triton::gpu::intel::DeviceArch::UNKNOWN);
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "triton/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"

--- a/include/triton/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -39,4 +39,32 @@ def TritonIntelGPUAccelerateMatmul
   ];
 }
 
+def TritonIntelGPUPipeline : Pass<"tritonintelgpu-pipeline", "mlir::ModuleOp"> {
+  let summary = "Intel GPU pipeline";
+
+  let description = [{
+    Use the cache prefetch to buffer the `LoadOp` in loops that needed at next iteration.
+  }];
+
+  let constructor = "mlir::createTritonIntelGPUPipelinePass()";
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::gpu::intel::TritonIntelGPUDialect",
+                           "mlir::scf::SCFDialect",
+                           "mlir::arith::ArithDialect"];
+
+  let options = [
+    Option<"numStages", "num-stages",
+           "int32_t", /*default*/"2",
+           "number of pipeline stages">,
+    Option<"deviceArch", "device-architecture",
+            "mlir::triton::gpu::intel::DeviceArch", /*default*/" mlir::triton::gpu::intel::DeviceArch::PVC",
+            "device architecture",
+            "llvm::cl::values("
+            "clEnumValN(mlir::triton::gpu::intel::DeviceArch::UNKNOWN, \"UNKNOWN\", \"Unknown arch\"), "
+            "clEnumValN(mlir::triton::gpu::intel::DeviceArch::ATS, \"ATS\", \"ATS arch\"), "
+            "clEnumValN(mlir::triton::gpu::intel::DeviceArch::PVC, \"PVC\", \"PVC arch\"))">
+  ];
+}
+
 #endif // TRITON_INTEL_GPU_PASSES

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/Schedule.h
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/Schedule.h
@@ -16,6 +16,9 @@ namespace triton {
 bool preProcessLoopAndGetSchedule(scf::ForOp &forOp, int numStages,
                                   mlir::triton::PipeliningOption &options);
 
+bool preProcessLoopAndGetScheduleIntel(scf::ForOp &forOp, int numStages,
+                                       mlir::triton::PipeliningOption &options);
+
 /// Fills out pipelining options for an outer loop pipelining case. This
 /// schedules async copies to overlap with the epilogue of a loop.
 bool getOuterLoopSchedule(scf::ForOp &forOp, int numStages,

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -906,6 +906,8 @@ void backwardRematerialization(ConvertLayoutOp convertOp) {
   RankedTensorType targetType = convertOp.getType();
   if (targetType.getEncoding().isa<DotOperandEncodingAttr>())
     return;
+  //  if (targetType.getEncoding().isa<DotOperandEncodingAttr>())
+  //    return;
 
   // 1. Take a backward slice of all the tensor dependencies that can be
   // rematerialized.

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -500,6 +500,8 @@ bool isExpensiveLoadOrStore(Operation *op) {
   auto operandType = op->getOperand(0).getType();
   if (triton::isTensorPointerType(operandType))
     return true;
+  //  if (triton::isTensorPointerType(operandType))
+  //    return true;
   // Case 2a: A size 1 tensor is not expensive since all threads will load the
   // same
   if (isSingleValue(op->getOperand(0)))

--- a/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
@@ -7,7 +7,17 @@
 namespace mlir {
 namespace triton {
 namespace gpu {
-namespace intel {} // namespace intel
+namespace intel {
+
+void PrefetchCacheOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  // The write effect to protect optimization to move the ops away.
+  effects.emplace_back(MemoryEffects::Write::get(),
+                       SideEffects::DefaultResource::get());
+}
+
+} // namespace intel
 } // namespace gpu
 } // namespace triton
 } // namespace mlir

--- a/lib/Dialect/TritonIntelGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonIntelGPU/Transforms/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_triton_library(TritonIntelGPUTransforms
   AccelerateMatmul.cpp
+  Pipeliner/MatmulLoopPipeline.cpp
+  Pipeliner/SoftwarePipeliner.cpp
   Utility.cpp
 
   DEPENDS
@@ -8,6 +10,7 @@ add_triton_library(TritonIntelGPUTransforms
   LINK_LIBS PUBLIC
   MLIRTransforms
   MLIRTransformUtils
+  MLIRSCFTransforms
   TritonAnalysis
   TritonIR
   TritonGPUIR

--- a/lib/Dialect/TritonIntelGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonIntelGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -1,0 +1,468 @@
+#include "Schedule.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "triton/Analysis/AxisInfo.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonIntelGPU/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+
+using namespace mlir;
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+
+// TODO: We can extra some helpers into common utilities once we add more
+// schedules.
+
+/// Replace the yield with a new one with the given operands appended.
+static void appendToYield(scf::ForOp forOp, ArrayRef<Value> newOperands) {
+  // Fix up the yield op.
+  Operation *yieldOp = forOp.getBody()->getTerminator();
+  SmallVector<Value> operands(yieldOp->getOperands().begin(),
+                              yieldOp->getOperands().end());
+  operands.append(newOperands.begin(), newOperands.end());
+  OpBuilder builder(yieldOp);
+  builder.create<scf::YieldOp>(yieldOp->getLoc(), operands);
+  yieldOp->erase();
+}
+
+namespace {
+struct LoadDotOperand {
+  LoadDotOperand(tt::LoadOp load,
+                 ttg::DotOperandEncodingAttr dotOperandEncoding,
+                 bool needTrans = false)
+      : load(load), dotOperandEncoding(dotOperandEncoding),
+        needTrans(needTrans) {}
+  tt::LoadOp load;
+  ttg::DotOperandEncodingAttr dotOperandEncoding;
+  bool needTrans;
+};
+} // namespace
+
+// If all the transitive uses of the given value have are used by a convert to
+// the same dot operand encoding, return the encoding. Otherwise return nullptr.
+// Negate `needTrans` when a TransOp is seen on the transitive use chain.
+static ttg::DotOperandEncodingAttr
+allTransitiveUsesHaveDotEncoding(Value val, bool &needTrans) {
+  ttg::DotOperandEncodingAttr attr{nullptr};
+  for (Operation *user : val.getUsers()) {
+    if (user->getNumResults() != 1)
+      return nullptr;
+    auto tensorType = user->getResult(0).getType().dyn_cast<RankedTensorType>();
+    if (!tensorType)
+      return nullptr;
+    if (isa<triton::TransOp>(user))
+      needTrans = !needTrans;
+    ttg::DotOperandEncodingAttr tempAttr;
+    if (tensorType.getEncoding().isa<ttg::SharedEncodingAttr>()) {
+      tempAttr =
+          allTransitiveUsesHaveDotEncoding(user->getResult(0), needTrans);
+    } else if (auto convertLayout =
+                   llvm::dyn_cast<ttg::ConvertLayoutOp>(user)) {
+      auto tensorType =
+          convertLayout.getResult().getType().dyn_cast<RankedTensorType>();
+      if (!tensorType)
+        return nullptr;
+      tempAttr =
+          tensorType.getEncoding().dyn_cast<ttg::DotOperandEncodingAttr>();
+    } else if (auto dotOp = llvm::dyn_cast<tt::DotOp>(user)) {
+      auto tensorType = val.getType().dyn_cast<RankedTensorType>();
+      if (!tensorType)
+        return nullptr;
+      tempAttr =
+          tensorType.getEncoding().dyn_cast<ttg::DotOperandEncodingAttr>();
+    } else {
+      return nullptr;
+    }
+    if (!tempAttr || (attr != nullptr && attr != tempAttr))
+      return nullptr;
+    attr = tempAttr;
+  }
+  return attr;
+}
+
+static void createPrefetchOp(scf::ForOp &forOp, tt::LoadOp loadOp, Value ptr) {
+  OpBuilder builder(forOp);
+  // Replace the load with load/prefetch in different stage.
+  builder.setInsertionPoint(loadOp);
+  Location loc = loadOp->getLoc();
+  auto prefetchOp =
+      builder.create<triton::gpu::intel::PrefetchCacheOp>(loc, ptr);
+}
+
+/// Create an async load equivalent to the given load.
+static void createPrefetchLoad(scf::ForOp &forOp, tt::LoadOp loadOp,
+                               Value ptr) {
+  createPrefetchOp(forOp, loadOp, ptr);
+}
+
+// Return the transitive use of the load which is a dot operand.
+static std::optional<LoadDotOperand> loadDotOperand(tt::LoadOp loadOp) {
+  bool isCandidate = false;
+  if (loadOp.getResult().hasOneUse()) {
+    Operation *use = *loadOp.getResult().getUsers().begin();
+    if (auto convertLayout = llvm::dyn_cast<ttg::ConvertLayoutOp>(use)) {
+      auto tensorType =
+          convertLayout.getResult().getType().cast<RankedTensorType>();
+      if (auto sharedEnc =
+              tensorType.getEncoding().dyn_cast<ttg::SharedEncodingAttr>()) {
+        if (sharedEnc.getHasLeadingOffset()) {
+          // MMA V3 case.
+          auto newOrder = sharedEnc.getOrder();
+          auto ty = loadOp.getType().cast<RankedTensorType>();
+          auto oldOrder = ttg::getOrder(ty.getEncoding());
+          if (newOrder[0] == oldOrder[0] || newOrder[1] == oldOrder[1]) {
+            // The operand of MMAv3 is in SharedEncoding and it's order should
+            // not be changed after FuseTranspositions Pass. So we only pipeline
+            // the load if the order of the loaded BlockedEncoding is the same
+            // as the order of the SharedEncoding it is converted to.
+            // TODO: remove this constraint once the LoadOp supports transpose
+            // fusion
+            //            hasMMAV3 = true;
+            return LoadDotOperand(loadOp, nullptr);
+          }
+        }
+      }
+    } else if (auto dotOp = llvm::dyn_cast<tt::DotOp>(use)) {
+    }
+  }
+  bool needTrans = false;
+  ttg::DotOperandEncodingAttr attr =
+      allTransitiveUsesHaveDotEncoding(loadOp.getResult(), needTrans);
+  if (!attr)
+    return std::nullopt;
+  return LoadDotOperand(loadOp, attr, needTrans);
+}
+
+/// Collect loads to pipeline. Return success if we can pipeline this loop
+static void collectOpsToPipeline(scf::ForOp forOp,
+                                 SmallVectorImpl<LoadDotOperand> &ops) {
+  ModuleOp moduleOp = forOp->getParentOfType<ModuleOp>();
+  tt::ModuleAxisInfoAnalysis axisInfoAnalysis(moduleOp);
+
+  // We cannot use forOp.walk(...) here because we only want to visit the
+  // operations in the loop body block. Nested blocks are handled separately.
+  for (Operation &op : forOp) {
+    if (auto loadOp = dyn_cast<tt::LoadOp>(&op)) {
+      bool candidate = false;
+      if (isLoadFromTensorPtr(loadOp)) {
+        // 2D load/store.
+        candidate = true;
+      } else {
+        auto ptr = loadOp.getPtr();
+        unsigned vec = axisInfoAnalysis.getPtrContiguity(ptr);
+        if (auto mask = loadOp.getMask())
+          vec =
+              std::min<unsigned>(vec, axisInfoAnalysis.getMaskAlignment(mask));
+
+        auto tensorTy = ptr.getType().dyn_cast<RankedTensorType>();
+        if (!tensorTy || tensorTy.getRank() < 2)
+          continue;
+        auto ty =
+            tensorTy.getElementType().cast<tt::PointerType>().getPointeeType();
+        unsigned width = vec * ty.getIntOrFloatBitWidth();
+        // We do not pipeline all loads for the following reasons:
+        // 1. On nvidia GPUs, cp.async's cp-size can only be 4, 8 and 16.
+        // 2. It's likely that pipling small loads won't offer much performance
+        //    improvement and may even hurt performance by increasing register
+        //    pressure.
+        if (width >= 32)
+          candidate = true;
+      }
+      if (!candidate)
+        continue;
+      std::optional<LoadDotOperand> loadWithDotOperand = loadDotOperand(loadOp);
+      if (!loadWithDotOperand.has_value())
+        continue;
+      ops.push_back(loadWithDotOperand.value());
+    }
+  }
+}
+
+static Value createPrefetch(scf::ForOp &forOp, tt::LoadOp loadOp) {
+  OpBuilder builder(forOp);
+  auto ty = loadOp.getType().cast<RankedTensorType>();
+  if (!loadOp.getResult().hasOneUse())
+    return Value();
+
+  //  auto args = forOp.getRegion().getArguments();
+  BlockArgument loadPtr = loadOp.getPtr().cast<BlockArgument>();
+  //  int argNum = loadPtr.getArgNumber();
+  //  Value ptr = forOp.getOpOperandForRegionIterArg(loadPtr).get();
+  Value ptr = loadPtr;
+
+  return ptr;
+}
+
+static void createPrefetchOps(scf::ForOp &forOp, ArrayRef<LoadDotOperand> loads,
+                              int numStages) {
+  struct prefetchLoad {
+    prefetchLoad(tt::LoadOp load, Value ptr) : load(load), ptr(ptr) {}
+    tt::LoadOp load;
+    Value ptr;
+  };
+  int numBuffers = numStages - 1;
+  SmallVector<prefetchLoad> prefetchLoads;
+
+  for (const LoadDotOperand &loadOperand : loads) {
+    tt::LoadOp loadOp = loadOperand.load;
+
+    //    auto args = forOp.getRegion().getArguments();
+    //    BlockArgument loadPtr = loadOp.getPtr().cast<BlockArgument>();
+    //    int argNum = loadPtr.getArgNumber();
+    //    auto yield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+    //
+    //    auto ops = yield->getOpOperands();
+    //    prefetchLoads.emplace_back(loadOp, ops[argNum-
+    //    forOp.getNumInductionVars()].get());
+    prefetchLoads.emplace_back(loadOp, loadOp.getPtr());
+  }
+
+  for (prefetchLoad &prefetchLoad : prefetchLoads) {
+    createPrefetchLoad(forOp, prefetchLoad.load, prefetchLoad.ptr);
+  }
+}
+
+// Combine the current mask with the given predicate.
+static Value getPredMask(RewriterBase &rewriter, Type typeLike,
+                         Value currentMask, Value pred) {
+  Type maskType = tt::getI1SameShape(typeLike);
+  Location loc = pred.getLoc();
+  Value mask = pred;
+  if (maskType.isa<RankedTensorType>()) {
+    mask = rewriter.create<tt::SplatOp>(loc, maskType, pred);
+  }
+  if (currentMask) {
+    mask = rewriter.create<arith::AndIOp>(loc, mask, currentMask);
+  }
+  return mask;
+}
+
+// Function to mask operations during scheduling.
+static Operation *predicateOp(RewriterBase &rewriter, Operation *op,
+                              Value pred) {
+  OpBuilder::InsertionGuard guard(rewriter);
+  if (mlir::isMemoryEffectFree(op))
+    return op;
+  if (isa<ttg::AsyncCommitGroupOp>(op))
+    return op;
+  if (isa<ttg::AsyncWaitOp>(op))
+    return op;
+  if (isa<triton::gpu::intel::PrefetchCacheOp>(op))
+    return op;
+  if (auto insertOp = dyn_cast<ttg::AsyncCopyGlobalToLocalOp>(op)) {
+    rewriter.setInsertionPoint(insertOp);
+    Value mask = getPredMask(rewriter, insertOp.getSrc().getType(),
+                             insertOp.getMask(), pred);
+    insertOp.getMaskMutable().assign(mask);
+    return op;
+  }
+  if (auto loadOp = dyn_cast<tt::LoadOp>(op)) {
+    rewriter.setInsertionPoint(loadOp);
+    Value mask = getPredMask(rewriter, loadOp.getPtr().getType(),
+                             loadOp.getMask(), pred);
+    loadOp.getMaskMutable().assign(mask);
+    return op;
+  }
+
+  assert("don't know how to predicate this op" && false);
+  return op;
+}
+
+static void setWaitNum(Operation *op,
+                       mlir::scf::PipeliningOption::PipelinerPart part,
+                       unsigned iteration, unsigned numLoadsInStage) {
+  if (auto waitOp = dyn_cast<ttg::AsyncWaitOp>(op)) {
+    waitOp.setNum(numLoadsInStage);
+  }
+}
+
+/// Helper to recursively add dependencies to the same stage.
+static void addDep(Operation *op, DenseSet<Operation *> &deps,
+                   bool includeArg = true,
+                   DenseSet<Operation *> *filter = nullptr) {
+  if (filter && filter->count(op))
+    return;
+  if (!deps.insert(op).second)
+    return;
+  for (Value operand : op->getOperands()) {
+    Value v = operand;
+    llvm::SmallDenseSet<Value> seen;
+    while (auto arg = v.dyn_cast<BlockArgument>()) {
+      if (!includeArg)
+        break;
+      if (!seen.insert(v).second)
+        break;
+      if (arg.getArgNumber() > 0 && arg.getOwner() == op->getBlock()) {
+        auto yieldOp = op->getBlock()->getTerminator();
+        v = yieldOp->getOperand(arg.getArgNumber() - 1);
+        continue;
+      }
+      break;
+    }
+    Operation *defOp = v.getDefiningOp();
+    if (defOp && defOp->getBlock() == op->getBlock()) {
+      addDep(defOp, deps, includeArg, filter);
+    }
+  }
+}
+
+// Add operations to the shedule with the given stage based on the filter
+// function.
+static void addOps(scf::ForOp forOp, int stage,
+                   std::vector<std::pair<Operation *, unsigned>> &schedule,
+                   std::function<bool(Operation *)> filter) {
+  for (Operation &op : forOp.getBody()->without_terminator()) {
+    if (!filter(&op))
+      continue;
+    schedule.emplace_back(&op, stage);
+  }
+}
+
+// create the schedule for a matmul loop. This is ad hoc based on how we know
+// matmul loops should be pipelined and is not a generic scheduler.
+static std::vector<std::pair<Operation *, unsigned>>
+createSchedule(scf::ForOp forOp, int numStages) {
+  SmallVector<Operation *> prefetchOps;
+  SmallVector<Operation *> loadOps;
+  //  SmallVector<Operation *> dotOps;
+  // Find the prefetch/load ops that will go respectively in stage 0 and stage
+  // `numStages - 1`. All the other operations will go in stage `numStages - 1`.
+  for (Operation &op : forOp.getBody()->without_terminator()) {
+    if (isa<triton::gpu::intel::PrefetchCacheOp>(op))
+      prefetchOps.emplace_back(&op);
+    if (isa<tt::LoadOp>(op))
+      loadOps.emplace_back(&op);
+    //    if (isa<tt::DotOp>(op))
+    //      dotOps.emplace_back(&op);
+  }
+  DenseSet<Operation *> prefetchAndDeps;
+  for (Operation *op : prefetchOps) {
+    addDep(op, prefetchAndDeps, false);
+  }
+
+  // Find depenencies with distance of 1.
+  SmallVector<Operation *> distanceOneUsers;
+  for (Operation *op : prefetchAndDeps) {
+    for (Value operand : op->getOperands()) {
+      if (auto arg = operand.dyn_cast<BlockArgument>()) {
+        if (arg.getArgNumber() > 0 && arg.getOwner() == op->getBlock()) {
+          auto yieldOp = op->getBlock()->getTerminator();
+          Value v = yieldOp->getOperand(arg.getArgNumber() - 1);
+          Operation *defOp = v.getDefiningOp();
+          if (defOp) {
+            distanceOneUsers.push_back(defOp);
+          }
+        }
+      }
+    }
+  }
+  //  // Schedule loads with a distance of 1 in stage 0
+  //  for (Operation *op : distanceOneUsers) {
+  //    if (isa<tt::LoadOp>(op)) {
+  //      addDep(op, prefetchAndDeps, true);
+  //    }
+  //  }
+  // For the rest of the ops we can move then into stage 1 so that they can be
+  // closer to their uses.
+  DenseSet<Operation *> stage1deps;
+  for (Operation *op : distanceOneUsers) {
+    //    if (!isa<tt::LoadOp>(op)) {
+    addDep(op, stage1deps, true, &prefetchAndDeps);
+    //    }
+  }
+
+  for (auto &opPair : stage1deps) {
+    llvm::outs() << "johnlu stage1deps:" << *opPair << "\n";
+    llvm::outs().flush();
+  }
+
+  DenseSet<Operation *> loadAndDeps;
+  for (Operation *op : loadOps) {
+    addDep(op, loadAndDeps, false, &prefetchAndDeps);
+  }
+  for (auto &opPair : loadAndDeps) {
+    llvm::outs() << "johnlu loadAndDeps:" << *opPair << "\n";
+    llvm::outs().flush();
+  }
+  std::vector<std::pair<Operation *, unsigned>> schedule;
+
+  // Schedule some dependencies with distance of 1 into stage 1 to reduce
+  // pressure.
+  addOps(forOp, 1, schedule,
+         [&](Operation *op) { return stage1deps.count(op); });
+
+  // Then Schedule stage 0.
+  addOps(forOp, 0, schedule,
+         [&](Operation *op) { return prefetchAndDeps.count(op); });
+
+  // Schedule stage `numStage - 1` first.
+  // Finally schedule the dot ops in stage `numStage - 1` so that they get
+  // pre-fetched and play well with pretech pass.
+  addOps(forOp, numStages - 1, schedule,
+         [&](Operation *op) { return loadAndDeps.count(op); });
+
+  addOps(forOp, numStages - 1, schedule, [&](Operation *op) {
+    return prefetchAndDeps.count(op) == 0 && stage1deps.count(op) == 0 &&
+           loadAndDeps.count(op) == 0;
+  });
+
+  for (auto &opPair : schedule) {
+    llvm::outs() << "johnlu stage:" << opPair.second << " def:" << *opPair.first
+                 << "\n";
+    llvm::outs().flush();
+  }
+
+  return schedule;
+}
+
+bool mlir::triton::gpu::intel::preProcessLoopAndGetSchedule(
+    scf::ForOp &forOp, int numStages, mlir::scf::PipeliningOption &options) {
+  // 1. First collect "interesting" operations with a stage where to schedule
+  // them. This gives a coarse scheduling for the loop.
+  SmallVector<LoadDotOperand> loads;
+  collectOpsToPipeline(forOp, loads);
+  if (loads.empty())
+    return false;
+  // 2. Convert the loads into async loads and create the allocs.
+  llvm::outs() << "johnlu here I want to change it to prefetch"
+               << "\n";
+  llvm::outs().flush();
+  createPrefetchOps(forOp, loads, numStages);
+
+  llvm::outs() << "johnlu loop with prefetch:\n" << forOp << "\n";
+  llvm::outs().flush();
+  llvm::outs() << "johnlu here to create the schedule for loop"
+               << "\n";
+  llvm::outs().flush();
+  // 3. Create the final schedule for the kernel loop. This will dictate the
+  // stages and order of operations to the pipeline expander.
+  std::vector<std::pair<Operation *, unsigned>> schedule =
+      createSchedule(forOp, numStages);
+
+  llvm::outs() << "johnlu here schedule:" << schedule.size() << "\n";
+  llvm::outs().flush();
+  // 4. Fill out the pipeline options.
+  options.getScheduleFn =
+      [schedule](scf::ForOp forOp,
+                 std::vector<std::pair<Operation *, unsigned>> &s) {
+        s = std::move(schedule);
+      };
+  options.peelEpilogue = false;
+  options.predicateFn = predicateOp;
+  options.supportDynamicLoops = true;
+  unsigned numLoadsInStage = (numStages - 2) * loads.size();
+  options.annotateFn =
+      [numLoadsInStage](Operation *op,
+                        mlir::scf::PipeliningOption::PipelinerPart part,
+                        unsigned iteration) {
+        return setWaitNum(op, part, iteration, numLoadsInStage);
+      };
+
+  return true;
+}

--- a/lib/Dialect/TritonIntelGPU/Transforms/Pipeliner/Schedule.h
+++ b/lib/Dialect/TritonIntelGPU/Transforms/Pipeliner/Schedule.h
@@ -1,0 +1,21 @@
+#ifndef TRITON_TRITONINTELGPU_TRANSFORM_PIPELINE_SCHEDULE_H_
+#define TRITON_TRITONINTELGPU_TRANSFORM_PIPELINE_SCHEDULE_H_
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Transforms/Transforms.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/ArrayRef.h"
+#include <vector>
+
+namespace mlir {
+namespace triton {
+namespace gpu {
+namespace intel {
+
+bool preProcessLoopAndGetSchedule(scf::ForOp &forOp, int numStages, mlir::scf::PipeliningOption &options);
+
+} // namespace intel
+} // namespace gpu
+} // namespace triton
+} // namespace mlir
+#endif // TRITON_TRITONINTELGPU_TRANSFORM_PIPELINE_SCHEDULE_H_

--- a/lib/Dialect/TritonIntelGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonIntelGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -1,0 +1,81 @@
+#include "Schedule.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "triton/Analysis/AxisInfo.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonIntelGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonIntelGPU/Transforms/Passes.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
+#include "llvm/Support/Debug.h"
+
+//===----------------------------------------------------------------------===//
+// This file will create a schedule that will be handed over to the pipeline
+// expander.
+// Software pipeliners are usually separated into two pieces, one that create a
+// modulo schedule and an expander that rewrites the loop and emits a prologue
+// and epilogue. This pass first calls a helper that will pre-process the IR
+// to create async operations and create a modulo schedule. Then we call the
+// expander to generate the prologue and new loop.
+//===----------------------------------------------------------------------===//
+
+using namespace mlir;
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+namespace ttgi = mlir::triton::gpu::intel;
+
+#define GEN_PASS_CLASSES
+#include "triton/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
+
+static void pipelineLoop(scf::ForOp forOp, int numStages) {
+  mlir::scf::PipeliningOption options;
+  // Skip loop with distance > 1 for now.
+  // TODO: relax the constraint in the expander.
+  if (llvm::any_of(forOp.getBody()->getTerminator()->getOperands(),
+                   [](Value operand) {
+                     Operation *def = operand.getDefiningOp();
+                     return !def;
+                   }))
+    return;
+
+  bool foundSchedule = false;
+  foundSchedule = mlir::triton::gpu::intel::preProcessLoopAndGetSchedule(
+      forOp, numStages, options);
+
+  // TODO: add more pipelines strategy.
+  if (!foundSchedule)
+    return;
+
+  IRRewriter rewriter(forOp->getContext());
+  rewriter.setInsertionPoint(forOp);
+  FailureOr<scf::ForOp> newForOp =
+      mlir::scf::pipelineForLoop(rewriter, forOp, options);
+}
+
+namespace {
+struct IntelGPUPipelinePass
+    : public TritonIntelGPUPipelineBase<IntelGPUPipelinePass> {
+  IntelGPUPipelinePass() = default;
+  IntelGPUPipelinePass(int numStages) { this->numStages = numStages; }
+
+  void runOnOperation() override {
+    if (this->numStages <= 1)
+      return;
+    SmallVector<scf::ForOp> loops;
+    getOperation()->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
+    for (scf::ForOp forOp : loops) {
+      pipelineLoop(forOp, numStages);
+    }
+  }
+};
+} // anonymous namespace
+
+std::unique_ptr<Pass>
+mlir::createTritonIntelGPUPipelinePass(int numStages,
+                                       triton::gpu::intel::DeviceArch arch) {
+  return std::make_unique<IntelGPUPipelinePass>(numStages);
+}

--- a/lib/Dialect/TritonIntelGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonIntelGPU/Transforms/Utility.cpp
@@ -26,17 +26,17 @@ bool supportDPAS(DotOp op, DeviceArch arch) {
     return false;
   }
 
-  if (arch == DeviceArch::ATS && threadsPerWarp != 8) {
-    // Only support threadsPerWarp 8 for ATS now.
-    return false;
-  }
+  //  if (arch == DeviceArch::ATS && threadsPerWarp != 8) {
+  //    // Only support threadsPerWarp 8 for ATS now.
+  //    return false;
+  //  }
 
   DPASEngineType dpasType = getDPASType(op);
 
-  if (dpasType == DPASEngineType::FP32_FP32_TF32_TF32) {
-    // Only PVC support TF32.
-    return op.getAllowTF32() && arch == DeviceArch::PVC;
-  }
+  //  if (dpasType == DPASEngineType::FP32_FP32_TF32_TF32) {
+  //    // Only PVC support TF32.
+  //    return op.getAllowTF32() && arch == DeviceArch::PVC;
+  //  }
 
   return dpasType != DPASEngineType::NOT_APPLICABLE;
 }

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -207,7 +207,7 @@ class Config:
                     function are args.
     """
 
-    def __init__(self, kwargs, num_warps=4, num_stages=2, num_ctas=1, pre_hook=None):
+    def __init__(self, kwargs, num_warps=None, num_stages=2, num_ctas=1, pre_hook=None):
         self.kwargs = kwargs
         self.num_warps = num_warps
         self.num_ctas = num_ctas

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -135,7 +135,7 @@ class XPUBackend(BaseBackend):
             passes.ttgpuir.add_optimize_epilogue(pm)
         passes.ttgpuir.add_optimize_dot_operands(pm)
         passes.common.add_cse(pm)
-        passes.ttgpuir.add_prefetch(pm)
+        intel.passes.ttgpuir.add_tritonintelgpu_pipe_line_pass(pm, opt.num_stages, intel.passes.ttgpuir.DEVICE_ARCH.PVC)
         passes.ttgpuir.add_optimize_dot_operands(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm)
         passes.ttgpuir.add_reduce_data_duplication(pm)

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -36,6 +36,10 @@ void init_triton_intel_passes_ttgpuir(py::module &&m) {
       },
       py::arg("pm"),
       py::arg("arch") = mlir::triton::gpu::intel::DeviceArch::UNKNOWN);
+  m.def("add_tritonintelgpu_pipe_line_pass",
+        [](mlir::PassManager &self, int numStages) {
+          self.addPass(mlir::createTritonIntelGPUPipelinePass(numStages));
+        });
   m.def("add_decompose_unsupported_conversions", [](mlir::PassManager &pm) {
     pm.addPass(createIntelDecomposeUnsupportedConversionsPass());
   });


### PR DESCRIPTION
This is a draft for review and feed back. Do not merge.

@Dewei-Wang-sh 
This s a draft which is picked up from my PoC. 

It is for the same purpose of your PR https://github.com/intel/intel-xpu-backend-for-triton/pull/678.

I think the logic is exactly the same but with different implementation.

Here is some points I focused on the implementation:
1. The better we can reuse the existing component/infrastructure as the one in upstream Triton/MLIR. It can save us a lot effort and more robust. (The MLIR has the SCF pipelining infrastructure which is originally in Triton. We can reuse that.)
2. I think all the analysis and optimization on the TTGIR could be unified. We can make the divergent to the later stage. (As in this example, the pipelining pass can finish its job based on just the TTIR ops and TTGIR attribution.)

Is there any gap or the disadvantage I was not aware in this way? Please help to feedback directly and we can discus how to solve it or some issue cannot be solved in the common Triton way. 