### PR TITLE
[INTEL] Refactor utility file in third_party/intel

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/AssertOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/AssertOpToLLVM.cpp
@@ -61,11 +61,11 @@ struct AssertOpConversion
     auto moduleOp =
         rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
     unsigned addrSpace = TritonGEN::TritonGENMemorySpace::kCrossWorkgroup;
-    Value messageString = LLVM::utils::addStringToModule(
+    Value messageString = LLVM::Intel::addStringToModule(
         loc, rewriter, "assertMessage_", message, addrSpace);
-    Value fileString = LLVM::utils::addStringToModule(
+    Value fileString = LLVM::Intel::addStringToModule(
         loc, rewriter, "assertFile_", file, addrSpace);
-    Value funcString = LLVM::utils::addStringToModule(
+    Value funcString = LLVM::Intel::addStringToModule(
         loc, rewriter, "assertFunc_", func, addrSpace);
     Value lineNumber = i32_val(line);
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ControlFlowOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ControlFlowOpToLLVM.cpp
@@ -83,12 +83,12 @@ private:
         callOp.getLoc(), /*opOperands=*/callOp->getOperands(),
         adaptor.getOperands(), rewriter);
     if (!caller->hasAttr("allocation.offset")) {
-      auto base = LLVM::utils::getStackPointer(rewriter, caller);
+      auto base = LLVM::Intel::getStackPointer(rewriter, caller);
       promotedOperands.push_back(base);
       return promotedOperands;
     }
     promotedOperands.push_back(
-        LLVM::utils::getSharedMemoryBase(callOp->getLoc(), rewriter, callOp));
+        LLVM::Intel::getSharedMemoryBase(callOp->getLoc(), rewriter, callOp));
     return promotedOperands;
   }
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -388,7 +388,7 @@ private:
     auto elemPtrTy = ptr_ty(rewriter.getContext(), 3);
 
     Value smemBase =
-        LLVM::utils::getSharedMemoryBase(loc, rewriter, op.getOperation());
+        LLVM::Intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
     smemBase = bitcast(smemBase, elemPtrTy);
     auto smemShape = convertType<unsigned, int64_t>(srcShapePerCTA);
 
@@ -468,7 +468,7 @@ private:
     if (shouldUseDistSmem(srcLayout, dstLayout))
       return lowerDistToDistWithDistSmem(op, adaptor, rewriter);
     Value smemBase =
-        LLVM::utils::getSharedMemoryBase(loc, rewriter, op.getOperation());
+        LLVM::Intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
     auto elemPtrTy = ptr_ty(rewriter.getContext(), 3);
     smemBase = bitcast(smemBase, elemPtrTy);
     auto shape = dstTy.getShape();

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandDPAS.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandDPAS.cpp
@@ -309,7 +309,7 @@ Value loadOperand(ConversionPatternRewriter &rewriter, Location loc,
   Value laneId = urem(threadId, warpSize);
 
   SmallVector<Value> multiDimWarpId =
-      mlir::LLVM::utils::delinearize(rewriter, loc, warpId, warpsPerCTA, order);
+      mlir::LLVM::delinearize(rewriter, loc, warpId, warpsPerCTA, order);
 
   double ceilRes =
       ceil(static_cast<double>(shapePerCTA[opIdx]) / elemsPerInstr[opIdx]);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM.cpp
@@ -5,7 +5,7 @@
 using namespace mlir;
 using namespace mlir::triton;
 
-using ::mlir::LLVM::utils::getSharedMemoryObjectFromStruct;
+using ::mlir::LLVM::getSharedMemoryObjectFromStruct;
 using ::mlir::triton::gpu::DotOperandEncodingAttr;
 using ::mlir::triton::gpu::getShapePerCTA;
 using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -2160,7 +2160,7 @@ struct MinMaxFOpConversion
     auto isNan = rewriter.create<LLVM::OrOp>(loc, lhsIsNan, rhsIsNan);
     auto nonNanRes = rewriter.create<DestOpNoNanProp>(loc, elemTy, lhs, rhs);
 
-    auto nan = LLVM::utils::createNaNConstant(loc, rewriter, elemTy);
+    auto nan = LLVM::createNaNConstant(loc, rewriter, elemTy);
 
     // Select the result based on the isNan flag.
     return {rewriter.create<LLVM::SelectOp>(loc, isNan, nan, nonNanRes)};
@@ -2252,7 +2252,7 @@ struct ClampFOpConversion
       auto v = rewriter.create<LLVM::MaxNumOp>(loc, elemTy, operands[0][0],
                                                operands[0][1]);
       auto nonNanRes = rewriter.create<LLVM::MinNumOp>(loc, v, operands[0][2]);
-      auto nan = LLVM::utils::createNaNConstant(loc, rewriter, elemTy);
+      auto nan = LLVM::createNaNConstant(loc, rewriter, elemTy);
       // Select the result based on the isNan flag.
       return {rewriter.create<LLVM::SelectOp>(loc, isNan, nan, nonNanRes)};
     }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/HistogramOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/HistogramOpToLLVM.cpp
@@ -192,7 +192,7 @@ public:
     int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(mod);
     Attribute dstEncoding = dstType.getEncoding();
     auto indices =
-        emitIndices(op.getLoc(), rewriter, dstEncoding, dstType, true);
+        ::intel::emitIndices(op.getLoc(), rewriter, dstEncoding, dstType, true);
     SmallVector<Value> innerDimIndices;
     for (int i = 0; i < indices.size(); ++i)
       innerDimIndices.push_back(indices[i][0]);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/HistogramOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/HistogramOpToLLVM.cpp
@@ -19,7 +19,7 @@ static Value generateVoteBallot(Location loc, Value bit, int threadMask,
   Value laneId = and_(threadId, i32_val(numThreadPerWarp - 1));
   Value reduced_val = shl(select(bit, i32_val(1), i32_val(0)), laneId);
   for (int offs = 1; offs < numThreadPerWarp; offs = offs << 1) {
-    Value other_val = LLVM::utils::shflSync(loc, rewriter, reduced_val, offs);
+    Value other_val = LLVM::Intel::shflSync(loc, rewriter, reduced_val, offs);
     reduced_val = or_(reduced_val, other_val);
   }
   return reduced_val;
@@ -186,7 +186,7 @@ public:
     // generate the right layout. Currently the warp level histogram generates
     // data in the default blocked layout.
     Value baseSharedMemPtr =
-        LLVM::utils::getSharedMemoryBase(loc, rewriter, op.getOperation());
+        LLVM::Intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
     auto dstType = op.getType();
     auto mod = op->getParentOfType<ModuleOp>();
     int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(mod);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -15,9 +15,9 @@
 using namespace mlir;
 using namespace mlir::triton;
 
-using ::mlir::LLVM::utils::delinearize;
-using ::mlir::LLVM::utils::getSharedMemoryObjectFromStruct;
-using ::mlir::LLVM::utils::linearize;
+using ::mlir::LLVM::delinearize;
+using ::mlir::LLVM::getSharedMemoryObjectFromStruct;
+using ::mlir::LLVM::linearize;
 using ::mlir::triton::gpu::getCTALayout;
 using ::mlir::triton::gpu::getShapePerCTA;
 using ::mlir::triton::gpu::getTotalElemsPerThread;
@@ -32,7 +32,7 @@ Value redundantDataMask(Type valueTy, ConversionPatternRewriter &rewriter,
   auto tensorTy = valueTy.dyn_cast<RankedTensorType>();
   Value mask = int_val(1, 1);
   auto tid = tid_val();
-  auto clusterCTAId = getClusterCTAId(rewriter, loc);
+  auto clusterCTAId = getClusterCTAIdIntel(rewriter, loc);
   if (tensorTy) {
     auto layout = tensorTy.getEncoding();
     auto shape = tensorTy.getShape();

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -32,7 +32,7 @@ Value redundantDataMask(Type valueTy, ConversionPatternRewriter &rewriter,
   auto tensorTy = valueTy.dyn_cast<RankedTensorType>();
   Value mask = int_val(1, 1);
   auto tid = tid_val();
-  auto clusterCTAId = getClusterCTAIdIntel(rewriter, loc);
+  auto clusterCTAId = LLVM::Intel::getClusterCTAId(rewriter, loc);
   if (tensorTy) {
     auto layout = tensorTy.getEncoding();
     auto shape = tensorTy.getShape();
@@ -42,7 +42,7 @@ Value redundantDataMask(Type valueTy, ConversionPatternRewriter &rewriter,
     auto warpsPerCTA = triton::gpu::getWarpsPerCTA(layout);
     auto order = triton::gpu::getOrder(layout);
     auto shapePerCTATile = triton::gpu::getShapePerCTATile(layout, shape);
-    Value warpSize = getModuleWarpSize(rewriter, loc);
+    Value warpSize = LLVM::Intel::getModuleWarpSize(rewriter, loc);
     Value laneId = urem(tid, warpSize);
     Value warpId = udiv(tid, warpSize);
     SmallVector<Value> multiDimWarpId =
@@ -254,7 +254,7 @@ struct LoadOpConversion
       }
 
       // Create a predicated load operation.
-      Block &endBlock = LLVM::utils::createPredicatedBlock(
+      Block &endBlock = LLVM::Intel::createPredicatedBlock(
           rewriter, loc, pred, SmallVector<Value, 1>{other_}, [&]() {
             Value addrElem =
                 bitcast(ptrElems[vecStart], ptr_ty(ctx, 1 /*global*/));
@@ -395,7 +395,7 @@ struct StoreOpConversion
       }
 
       // Create a predicated store operation.
-      mlir::LLVM::utils::createPredicatedBlock(rewriter, loc, maskVal, [&] {
+      LLVM::Intel::createPredicatedBlock(rewriter, loc, maskVal, [&] {
         Value addrElem = bitcast(ptrElems[vecStart], ptr_ty(ctx, 1 /*global*/));
         uint32_t alignment = nWords * width / 8;
         store(vecWord, addrElem, alignment);
@@ -482,8 +482,8 @@ struct AtomicCASOpConversion
              "Unexpected width");
 
       Value zero = (valueElemNBits == 32) ? i32_val(0) : i64_val(0);
-      Block &endBlock = mlir::LLVM::utils::createPredicatedBlock(
-          rewriter, loc, mask, {zero}, [&] {
+      Block &endBlock =
+          LLVM::Intel::createPredicatedBlock(rewriter, loc, mask, {zero}, [&] {
             // casPtr = bitcast(casPtr, ptr_ty(ctx, 1));
             casCmp = bitcast(casCmp, zero.getType());
             casVal = bitcast(casVal, zero.getType());
@@ -508,9 +508,9 @@ struct AtomicCASOpConversion
       } else {
         createBarrier(rewriter, loc, numCTAs);
         Value atomPtr =
-            LLVM::utils::getSharedMemoryBase(loc, rewriter, op.getOperation());
+            LLVM::Intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
         atomPtr = bitcast(atomPtr, ptr_ty(ctx, 3));
-        mlir::LLVM::utils::storeShared(rewriter, loc, atomPtr, ret, mask);
+        LLVM::Intel::storeShared(rewriter, loc, atomPtr, ret, mask);
         createBarrier(rewriter, loc, numCTAs);
         Value ret = load(valueElemTy, atomPtr);
         createBarrier(rewriter, loc, numCTAs);
@@ -620,7 +620,7 @@ struct AtomicRMWOpConversion
             emulateFp16AtomicRmw(rewriter, loc, atomicRmwAttr, valueElemTy,
                                  rmwPtr, rmwVal, rmwMask, {zero});
       } else {
-        endBlock = &mlir::LLVM::utils::createPredicatedBlock(
+        endBlock = &LLVM::Intel::createPredicatedBlock(
             rewriter, loc, rmwMask, {zero}, [&] {
               mlir::LLVM::AtomicBinOp rmwKind;
               switch (atomicRmwAttr) {
@@ -674,10 +674,10 @@ struct AtomicRMWOpConversion
         }
       } else {
         Value atomPtr =
-            LLVM::utils::getSharedMemoryBase(loc, rewriter, op.getOperation());
+            LLVM::Intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
         atomPtr = bitcast(atomPtr, ptr_ty(ctx, 3));
         // Only threads with rmwMask = True store the result
-        mlir::LLVM::utils::storeShared(rewriter, loc, atomPtr, ret, rmwMask);
+        LLVM::Intel::storeShared(rewriter, loc, atomPtr, ret, rmwMask);
         createBarrier(rewriter, loc, numCTAs);
         Value loadVal = load(valueElemTy, atomPtr);
         createBarrier(rewriter, loc, numCTAs);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/MakeRangeOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/MakeRangeOpToLLVM.cpp
@@ -25,7 +25,7 @@ struct MakeRangeOpConversion
     auto elemTy = ty.getElementType();
     assert(elemTy.isInteger(32));
     Value start = createIndexAttrConstant(rewriter, loc, elemTy, op.getStart());
-    auto idxs = emitIndices(loc, rewriter, layout, ty, true);
+    auto idxs = ::intel::emitIndices(loc, rewriter, layout, ty, true);
     unsigned elems = idxs.size();
     SmallVector<Value> retVals(elems);
     // TODO: slice layout has more elements than expected.

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/MemoryOpToLLVM.cpp
@@ -23,7 +23,7 @@ void lowerDistributedToShared(LocalAllocOp op, LocalAllocOpAdaptor adaptor,
          (srcTy.getShape().size() <= 3 && outOrd[2] == 0) &&
              "Unexpected rank of ConvertLayout(blocked->shared)");
   Value smemBase =
-      LLVM::utils::getSharedMemoryBase(loc, rewriter, op.getOperation());
+      LLVM::Intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
   auto elemTy = typeConverter->convertType(srcTy.getElementType());
 
   int32_t elemSize = elemTy.getIntOrFloatBitWidth();
@@ -48,7 +48,7 @@ struct LocalAllocOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
     Value smemBase =
-        LLVM::utils::getSharedMemoryBase(loc, rewriter, op.getOperation());
+        LLVM::Intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
     auto resultTy = op.getType().cast<MemDescType>();
     auto typeConverter = getTypeConverter();
     auto sharedLayout =

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/MemoryOpToLLVM.cpp
@@ -29,9 +29,10 @@ void lowerDistributedToShared(LocalAllocOp op, LocalAllocOpAdaptor adaptor,
   int32_t elemSize = elemTy.getIntOrFloatBitWidth();
   auto mmaLayout = srcLayout.dyn_cast<DpasEncodingAttr>();
   unsigned numElems = triton::gpu::getTotalElemsPerThread(srcTy);
-  auto dstStrides = LLVM::utils::getStridesFromShapeAndOrder(
-      dstShapePerCTA, outOrd, loc, rewriter);
-  auto srcIndices = emitIndices(loc, rewriter, srcLayout, srcTy, false);
+  auto dstStrides =
+      LLVM::getStridesFromShapeAndOrder(dstShapePerCTA, outOrd, loc, rewriter);
+  auto srcIndices = ::mlir::triton::intel::emitIndices(loc, rewriter, srcLayout,
+                                                       srcTy, false);
   auto inVals = unpackLLElements(loc, adaptor.getInit(), rewriter);
   storeDistributedToShared(op.getInit(), inVals, dstStrides, srcIndices,
                            op.getResult(), smemBase, elemTy, loc, rewriter);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PrintOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PrintOpToLLVM.cpp
@@ -23,13 +23,13 @@ struct PrintOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     auto typeConverter = getTypeConverter();
     auto loc = op->getLoc();
-    Value prefixStr = LLVM::utils::addStringToModule(
+    Value prefixStr = LLVM::Intel::addStringToModule(
         loc, rewriter, "printfPrefix_", op.getPrefix(),
         TritonGEN::TritonGENMemorySpace::kUniformConstant);
 
     auto getPid = [&](int axis) {
-      return mlir::LLVM::utils::llGetPid(loc, rewriter,
-                                         op->getParentOfType<ModuleOp>(), axis);
+      return LLVM::Intel::llGetPid(loc, rewriter,
+                                   op->getParentOfType<ModuleOp>(), axis);
     };
     std::array<Value, 3> pid = {getPid(0), getPid(1), getPid(2)};
 
@@ -39,8 +39,8 @@ struct PrintOpConversion
       llvm::raw_string_ostream os(formatStr);
       os << "pid (" << getFormatSubstr(pid[0]) << ", "
          << getFormatSubstr(pid[1]) << ", " << getFormatSubstr(pid[2]) << ")%s";
-      mlir::LLVM::utils::llPrintf(rewriter, formatStr,
-                                  {pid[0], pid[1], pid[2], prefixStr});
+      LLVM::Intel::llPrintf(rewriter, formatStr,
+                            {pid[0], pid[1], pid[2], prefixStr});
     } else {
       for (size_t i = 0; i < op.getNumOperands(); i++) {
         // Elements of the tensor that are resident in this GPU thread.
@@ -161,9 +161,9 @@ struct PrintOpConversion
       // strings, so we cache the Value.
       if (i == 0) {
         formatStrValue =
-            mlir::LLVM::utils::llPrintf(rewriter, formatStr, printfOperands);
+            LLVM::Intel::llPrintf(rewriter, formatStr, printfOperands);
       } else {
-        mlir::LLVM::utils::llPrintf(rewriter, formatStrValue, printfOperands);
+        LLVM::Intel::llPrintf(rewriter, formatStrValue, printfOperands);
       }
     }
   }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PrintOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PrintOpToLLVM.cpp
@@ -56,8 +56,8 @@ struct PrintOpConversion
         SmallVector<SmallVector<Value>> indices;
         if (auto rankedTy =
                 op.getOperand(i).getType().dyn_cast<RankedTensorType>()) {
-          indices = emitIndices(loc, rewriter, rankedTy.getEncoding(), rankedTy,
-                                true);
+          indices = ::intel::emitIndices(loc, rewriter, rankedTy.getEncoding(),
+                                         rankedTy, true);
           for (int64_t dim : rankedTy.getShape()) {
             if (dim > 0) {
               dimWidths.push_back(static_cast<int>(std::ceil(std::log10(dim))));

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceOpToLLVM.cpp
@@ -9,9 +9,6 @@ using namespace mlir::triton;
 
 using ::mlir::LLVM::delinearize;
 using ::mlir::LLVM::linearize;
-using ::mlir::LLVM::utils::loadShared;
-using ::mlir::LLVM::utils::shflSync;
-using ::mlir::LLVM::utils::storeShared;
 using ::mlir::triton::gpu::getOrder;
 using ::mlir::triton::gpu::getTotalElemsPerThread;
 
@@ -258,7 +255,7 @@ private:
     triton::ReduceOp op = helper.getOperation();
     Location loc = op.getLoc();
     Value threadId = getThreadId(rewriter, loc);
-    Value warpSize = getModuleWarpSize(rewriter, loc);
+    Value warpSize = LLVM::Intel::getModuleWarpSize(rewriter, loc);
     Value warpId = udiv(threadId, warpSize);
     Value laneId = urem(threadId, warpSize);
     auto srcLayout = helper.getSrcLayout();

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceOpToLLVM.cpp
@@ -7,8 +7,8 @@
 using namespace mlir;
 using namespace mlir::triton;
 
-using ::mlir::LLVM::utils::delinearize;
-using ::mlir::LLVM::utils::linearize;
+using ::mlir::LLVM::delinearize;
+using ::mlir::LLVM::linearize;
 using ::mlir::LLVM::utils::loadShared;
 using ::mlir::LLVM::utils::shflSync;
 using ::mlir::LLVM::utils::storeShared;
@@ -147,11 +147,11 @@ private:
     RankedTensorType operandType = op.getInputTypes()[0];
     // Assumes offsets don't actually depend on type
     SmallVector<SmallVector<unsigned>> offset =
-        emitOffsetForLayout(helper.getSrcLayout(), operandType);
+        ::intel::emitOffsetForLayout(helper.getSrcLayout(), operandType);
     unsigned srcElems = getTotalElemsPerThread(operandType);
     auto *combineOp = &op.getCombineOp();
-    auto srcIndices = emitIndices(op.getLoc(), rewriter, helper.getSrcLayout(),
-                                  operandType, true);
+    auto srcIndices = ::intel::emitIndices(
+        op.getLoc(), rewriter, helper.getSrcLayout(), operandType, true);
     // reduce within threads
     for (unsigned i = 0; i < srcElems; ++i) {
       SmallVector<unsigned> key = offset[i];
@@ -208,7 +208,7 @@ private:
         auto resultLayout = resultTy.getEncoding().cast<SliceEncodingAttr>();
         unsigned resultElems = getTotalElemsPerThread(resultTy);
         SmallVector<SmallVector<unsigned>> resultOffset =
-            emitOffsetForLayout(resultLayout, resultTy);
+            ::intel::emitOffsetForLayout(resultLayout, resultTy);
         SmallVector<Value> resultVals;
         for (int j = 0; j < resultElems; j++) {
           auto key = resultOffset[j];
@@ -405,7 +405,7 @@ private:
         auto resultLayout = resultTy.getEncoding().cast<SliceEncodingAttr>();
         unsigned resultElems = getTotalElemsPerThread(resultTy);
         auto resultIndices =
-            emitIndices(loc, rewriter, resultLayout, resultTy, true);
+            ::intel::emitIndices(loc, rewriter, resultLayout, resultTy, true);
         auto resultShape = resultTy.getShape();
         auto resultCTATile = getShapePerCTATile(resultLayout, resultShape);
         assert(resultIndices.size() == resultElems);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceScanCommon.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceScanCommon.h
@@ -22,8 +22,8 @@
 using namespace mlir;
 using namespace mlir::triton;
 
-using ::mlir::LLVM::utils::delinearize;
-using ::mlir::LLVM::utils::SharedMemoryObject;
+using ::mlir::LLVM::delinearize;
+using ::mlir::LLVM::SharedMemoryObject;
 using ::mlir::triton::gpu::BlockedEncodingAttr;
 using ::mlir::triton::gpu::CTALayoutAttr;
 using ::mlir::triton::gpu::DotOperandEncodingAttr;

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceScanCommon.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceScanCommon.h
@@ -70,7 +70,7 @@ public:
     // Assign base index to each operand in their order in indices
     std::map<unsigned, Value> indexToBase;
     indexToBase[indices[0]] =
-        LLVM::utils::getSharedMemoryBase(loc, rewriter, op.getOperation());
+        LLVM::Intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
     for (unsigned i = 1; i < op.getNumOperands(); ++i) {
       indexToBase[indices[i]] = gep(
           ptr_ty(rewriter.getContext(), 3), getElementType(op, indices[i - 1]),

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/SPMDOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/SPMDOpToLLVM.cpp
@@ -14,9 +14,9 @@ struct GetProgramIdOpConversion
   LogicalResult
   matchAndRewrite(triton::GetProgramIdOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value programId = mlir::LLVM::utils::llGetPid(
-        op->getLoc(), rewriter, op->getParentOfType<ModuleOp>(),
-        op.getAxisAsInt());
+    Value programId = LLVM::Intel::llGetPid(op->getLoc(), rewriter,
+                                            op->getParentOfType<ModuleOp>(),
+                                            op.getAxisAsInt());
     rewriter.replaceOp(op, programId);
     return success();
   }
@@ -54,7 +54,8 @@ struct GetClusterCTAIdOpConversion
   LogicalResult
   matchAndRewrite(triton::nvidia_gpu::GetClusterCTAIdOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOp(op, getClusterCTAIdIntel(rewriter, op->getLoc()));
+    rewriter.replaceOp(op,
+                       LLVM::Intel::getClusterCTAId(rewriter, op->getLoc()));
     return success();
   }
 };

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/SPMDOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/SPMDOpToLLVM.cpp
@@ -54,7 +54,7 @@ struct GetClusterCTAIdOpConversion
   LogicalResult
   matchAndRewrite(triton::nvidia_gpu::GetClusterCTAIdOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOp(op, getClusterCTAId(rewriter, op->getLoc()));
+    rewriter.replaceOp(op, getClusterCTAIdIntel(rewriter, op->getLoc()));
     return success();
   }
 };

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ScanOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ScanOpToLLVM.cpp
@@ -6,12 +6,12 @@
 using namespace mlir;
 using namespace mlir::triton;
 
+using ::LLVM::Intel::shflIdxSync;
+using ::LLVM::Intel::shflSync;
+using ::LLVM::Intel::shflUpSync;
+using ::LLVM::Intel::storeShared;
 using ::mlir::LLVM::delinearize;
 using ::mlir::LLVM::linearize;
-using ::mlir::LLVM::utils::shflIdxSync;
-using ::mlir::LLVM::utils::shflSync;
-using ::mlir::LLVM::utils::shflUpSync;
-using ::mlir::LLVM::utils::storeShared;
 using ::mlir::triton::gpu::getTotalElemsPerThread;
 
 namespace {

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ScanOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ScanOpToLLVM.cpp
@@ -6,8 +6,8 @@
 using namespace mlir;
 using namespace mlir::triton;
 
-using ::mlir::LLVM::utils::delinearize;
-using ::mlir::LLVM::utils::linearize;
+using ::mlir::LLVM::delinearize;
+using ::mlir::LLVM::linearize;
 using ::mlir::LLVM::utils::shflIdxSync;
 using ::mlir::LLVM::utils::shflSync;
 using ::mlir::LLVM::utils::shflUpSync;

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.cpp
@@ -23,7 +23,7 @@ Value TargetInfo::ballot(ConversionPatternRewriter &rewriter, Location loc,
 }
 Value TargetInfo::storeShared(ConversionPatternRewriter &rewriter, Location loc,
                               Value ptr, Value val, Value pred) const {
-  mlir::LLVM::utils::createPredicatedBlock(rewriter, loc, pred, [&] {
+  LLVM::Intel::createPredicatedBlock(rewriter, loc, pred, [&] {
     store(val, ptr);
     return ArrayRef<Value>();
   });
@@ -36,7 +36,7 @@ Value TargetInfo::loadShared(ConversionPatternRewriter &rewriter, Location loc,
              3 &&
          "Invalid addr space for loadShared");
   Value undef = undef(elemTy);
-  Block &endBlock = mlir::LLVM::utils::createPredicatedBlock(
+  Block &endBlock = LLVM::Intel::createPredicatedBlock(
       rewriter, loc, pred, SmallVector<Value, 1>{undef}, [&] {
         Value ret = load(elemTy, ptr);
         return SmallVector<Value, 1>{ret};
@@ -95,7 +95,7 @@ Value TargetInfo::shuffleUp(Location loc, ConversionPatternRewriter &rewriter,
 
 Value TargetInfo::shuffleIdx(Location loc, ConversionPatternRewriter &rewriter,
                              Value val, int i) const {
-  return mlir::LLVM::utils::shflIdxSync(loc, rewriter, val, i32_val(i));
+  return LLVM::Intel::shflIdxSync(loc, rewriter, val, i32_val(i));
 }
 
 Value TargetInfo::shuffleIdx(Location loc, ConversionPatternRewriter &rewriter,
@@ -106,7 +106,7 @@ Value TargetInfo::shuffleIdx(Location loc, ConversionPatternRewriter &rewriter,
 
 Value TargetInfo::programId(Location loc, ConversionPatternRewriter &rewriter,
                             ModuleOp moduleOp, int axis) const {
-  return LLVM::utils::llGetPid(loc, rewriter, moduleOp, axis);
+  return LLVM::Intel::llGetPid(loc, rewriter, moduleOp, axis);
 }
 
 bool TargetInfo::warpReduce(ConversionPatternRewriter &rewriter, Location loc,

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVM.cpp
@@ -130,7 +130,7 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
                   ConversionPatternRewriter &rewriter) const override {
     // Prevent LLVM's inliner to inline this function
     auto amendedFuncOp = funcOp;
-    if (!LLVM::utils::isKernel(funcOp))
+    if (!LLVM::isKernel(funcOp))
       amendedFuncOp = amendFuncOp(funcOp, rewriter);
 
     LLVM::LLVMFuncOp newFuncOp = *mlir::convertFuncOpToLLVMFuncOp(
@@ -141,7 +141,7 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     MLIRContext *ctx = funcOp->getContext();
     auto mod = funcOp->getParentOfType<ModuleOp>();
     int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
-    if (LLVM::utils::isKernel(funcOp))
+    if (LLVM::isKernel(funcOp))
       newFuncOp.setCConv(LLVM::CConv::SPIR_KERNEL);
 
     auto maxWorkGroupSizeAttr = rewriter.getArrayAttr(
@@ -156,7 +156,7 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     newFuncOp.setPassthroughAttr(
         ArrayAttr::get(ctx, {reqSubGroupSizeAttr, maxWorkGroupSizeAttr}));
 
-    if (!LLVM::utils::isKernel(funcOp)) {
+    if (!LLVM::isKernel(funcOp)) {
       newFuncOp.setPassthroughAttr(
           ArrayAttr::get(ctx, rewriter.getStringAttr("noinline")));
       rewriter.eraseOp(amendedFuncOp);
@@ -276,7 +276,7 @@ struct ConvertTritonGPUToLLVM
     if (numCTAs == 1) {
       mod.walk([](triton::nvgpu::ClusterCTAIdOp id) {
         OpBuilder b(id);
-        Value zero = LLVM::utils::createConstantI32(id->getLoc(), b, 0);
+        Value zero = LLVM::createConstantI32(id->getLoc(), b, 0);
         id.replaceAllUsesWith(zero);
       });
     }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVMBase.h
@@ -24,8 +24,8 @@
 using namespace mlir;
 using namespace mlir::triton;
 
-using ::mlir::LLVM::utils::delinearize;
-using ::mlir::LLVM::utils::SharedMemoryObject;
+using ::mlir::LLVM::delinearize;
+using ::mlir::LLVM::SharedMemoryObject;
 using ::mlir::triton::gpu::BlockedEncodingAttr;
 using ::mlir::triton::gpu::CTALayoutAttr;
 using ::mlir::triton::gpu::DotOperandEncodingAttr;

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
@@ -7,12 +7,6 @@ namespace mlir {
 namespace LLVM {
 namespace utils {
 
-Value createConstantI32(Location loc, OpBuilder &rewriter, int32_t v) {
-  auto i32ty = rewriter.getIntegerType(32);
-  return rewriter.create<LLVM::ConstantOp>(loc, i32ty,
-                                           IntegerAttr::get(i32ty, v));
-}
-
 Value createConstantI64(Location loc, OpBuilder &rewriter, int64_t v) {
   auto i64ty = rewriter.getIntegerType(64);
   return rewriter.create<LLVM::ConstantOp>(loc, i64ty,
@@ -23,132 +17,6 @@ Value createConstantF16(Location loc, OpBuilder &rewriter, float v) {
   auto type = type::f16Ty(rewriter.getContext());
   return rewriter.create<LLVM::ConstantOp>(loc, type,
                                            rewriter.getF16FloatAttr(v));
-}
-
-Value createConstantF32(Location loc, OpBuilder &rewriter, float v) {
-  auto type = type::f32Ty(rewriter.getContext());
-  return rewriter.create<LLVM::ConstantOp>(loc, type,
-                                           rewriter.getF32FloatAttr(v));
-}
-
-Value createConstantF64(Location loc, OpBuilder &rewriter, double v) {
-  auto type = type::f64Ty(rewriter.getContext());
-  return rewriter.create<LLVM::ConstantOp>(loc, type,
-                                           rewriter.getF64FloatAttr(v));
-}
-
-Value createNaNConstant(Location loc, OpBuilder &rewriter, Type type) {
-  if (!type.isa<FloatType>()) {
-    llvm::report_fatal_error("Creating NaN constant for non-float type!");
-  }
-  return rewriter.create<LLVM::ConstantOp>(
-      loc, type, APFloat::getNaN(type.cast<FloatType>().getFloatSemantics()));
-}
-
-// Create an index type constant.
-Value createIndexConstant(OpBuilder &builder, Location loc,
-                          TypeConverter *converter, int64_t value) {
-  Type ty = converter->convertType(builder.getIndexType());
-  return builder.create<LLVM::ConstantOp>(loc, ty,
-                                          builder.getIntegerAttr(ty, value));
-}
-
-// Create an integer constant of \param width bits.
-Value createLLVMIntegerConstant(OpBuilder &builder, Location loc, short width,
-                                int64_t value) {
-  Type ty = builder.getIntegerType(width);
-  return builder.create<LLVM::ConstantOp>(loc, ty,
-                                          builder.getIntegerAttr(ty, value));
-}
-
-// A wrapper of LoadDSmemOp when vec = 1
-// (1) Get bitwidth from elemTy
-// (2) Create LoadDSmemOp
-// (3) Bitcast result from dataTy (u16/u32/u64) back to elemTy
-Value createLoadDSmem(Location loc, PatternRewriter &rewriter, Value addr,
-                      Value ctaId, Type elemTy) {
-  assert(addr.getType().isa<LLVMPointerType>() &&
-         "addr must be a pointer type");
-  auto ptrTy = addr.getType().cast<LLVMPointerType>();
-  assert(ptrTy.getAddressSpace() == 3 && "Invalid addr space for load_dsmem");
-  unsigned bitwidth = elemTy.getIntOrFloatBitWidth();
-  Value ret =
-      rewriter.create<triton::nvgpu::LoadDSmemOp>(loc, addr, ctaId, bitwidth);
-  return bitcast(ret, elemTy);
-}
-
-// A wrapper of LoadDSmemOp when vec > 1
-// (1) Get bitwidth from elemTy
-// (2) Create LoadDSmemOp and extract results from retStruct
-// (3) Bitcast results from dataTy (u16/u32/u64) back to elemTy
-SmallVector<Value> createLoadDSmem(Location loc, PatternRewriter &rewriter,
-                                   Value addr, Value ctaId, unsigned vec,
-                                   Type elemTy) {
-  assert(addr.getType().isa<LLVMPointerType>() &&
-         "addr must be a pointer type");
-  auto ptrTy = addr.getType().cast<LLVMPointerType>();
-  assert(ptrTy.getAddressSpace() == 3 && "Invalid addr space for load_dsmem");
-  unsigned bitwidth = elemTy.getIntOrFloatBitWidth();
-  Value retStruct = rewriter.create<triton::nvgpu::LoadDSmemOp>(
-      loc, addr, ctaId, bitwidth, vec);
-  SmallVector<Value> retVals;
-  for (unsigned i = 0; i < vec; ++i) {
-    auto dataTy = rewriter.getIntegerType(bitwidth);
-    Value data = extract_val(dataTy, retStruct, i);
-    retVals.push_back(bitcast(data, elemTy));
-  }
-  return retVals;
-}
-
-// A wrapper of StoreDSmemOp when vec = 1
-// (1) Get bitwidth from elemTy
-// (2) Bitcast value from elemTy to dataTy (u16/u32/u64)
-// (3) Create StoreDSmemOp
-void createStoreDSmem(Location loc, PatternRewriter &rewriter, Value addr,
-                      Value ctaId, Value value, Value pred) {
-  assert(addr.getType().isa<LLVMPointerType>() &&
-         "addr must be a pointer type");
-  auto ptrTy = addr.getType().cast<LLVMPointerType>();
-  assert(ptrTy.getAddressSpace() == 3 && "Invalid addr space for load_dsmem");
-  unsigned bitwidth = value.getType().getIntOrFloatBitWidth();
-  auto dataTy = rewriter.getIntegerType(bitwidth);
-  Value data = bitcast(value, dataTy);
-  rewriter.create<triton::nvgpu::StoreDSmemOp>(loc, addr, ctaId, data, pred);
-}
-
-// A wrapper of StoreDSmemOp when vec = 1 and pred = 1
-void createStoreDSmem(Location loc, PatternRewriter &rewriter, Value addr,
-                      Value ctaId, Value value) {
-  Value pred = int_val(/*width=*/1, 1);
-  createStoreDSmem(loc, rewriter, addr, ctaId, value, pred);
-}
-
-// A wrapper of StoreDSmemOp when vec > 1
-// (1) Get bitwidth from elemTy
-// (2) Bitcast values from elemTy to dataTy (u16/u32/u64)
-// (3) Create StoreDSmemOp
-void createStoreDSmem(Location loc, PatternRewriter &rewriter, Value addr,
-                      Value ctaId, ArrayRef<Value> values, Value pred) {
-  assert(addr.getType().isa<LLVMPointerType>() &&
-         "addr must be a pointer type");
-  auto ptrTy = addr.getType().cast<LLVMPointerType>();
-  assert(ptrTy.getAddressSpace() == 3 && "Invalid addr space for load_dsmem");
-  unsigned bitwidth = 0;
-  if (!values.empty()) {
-    bitwidth = values.back().getType().getIntOrFloatBitWidth();
-  }
-  auto dataTy = rewriter.getIntegerType(bitwidth);
-  SmallVector<Value> data;
-  for (unsigned i = 0; i < values.size(); ++i)
-    data.push_back(bitcast(values[i], dataTy));
-  rewriter.create<triton::nvgpu::StoreDSmemOp>(loc, addr, ctaId, data, pred);
-}
-
-// A wrapper of StoreDSmemOp when vec > 1 and pred = 1
-void createStoreDSmem(Location loc, PatternRewriter &rewriter, Value addr,
-                      Value ctaId, ArrayRef<Value> values) {
-  Value pred = int_val(/*width=*/1, 1);
-  createStoreDSmem(loc, rewriter, addr, ctaId, values, pred);
 }
 
 SharedMemoryObject
@@ -167,20 +35,6 @@ getSharedMemoryObjectFromStruct(Location loc, Value llvmStruct, Type elemTy,
           /*baseElemType=*/elemTy,
           /*strides=*/{elems.begin() + 1, elems.begin() + 1 + rank},
           /*offsets=*/{elems.begin() + 1 + rank, elems.end()}};
-}
-
-SmallVector<Value> getStridesFromShapeAndOrder(ArrayRef<int64_t> shape,
-                                               ArrayRef<unsigned> order,
-                                               Location loc,
-                                               RewriterBase &rewriter) {
-  auto rank = shape.size();
-  SmallVector<Value> strides(rank);
-  int64_t stride = 1;
-  for (auto idx : order) {
-    strides[idx] = i32_val(stride);
-    stride *= shape[idx];
-  }
-  return strides;
 }
 
 // Convert an \param linear to a multi-dim coordinate given \param shape and
@@ -232,28 +86,6 @@ SmallVector<Value> delinearize(RewriterBase &rewriter, Location loc,
     remained = udiv(remained, dimSize);
   }
   return multiDim;
-}
-
-Value linearize(ConversionPatternRewriter &rewriter, Location loc,
-                ArrayRef<Value> multiDim, ArrayRef<unsigned> shape,
-                ArrayRef<unsigned> order) {
-  return linearize(rewriter, loc, applyPermutation(multiDim, order),
-                   applyPermutation(shape, order));
-}
-
-Value linearize(ConversionPatternRewriter &rewriter, Location loc,
-                ArrayRef<Value> multiDim, ArrayRef<unsigned> shape) {
-  auto rank = multiDim.size();
-  Value linear = i32_val(0);
-  if (rank > 0) {
-    linear = multiDim.back();
-    for (auto [dim, dimShape] :
-         llvm::reverse(llvm::zip(multiDim.drop_back(), shape.drop_back()))) {
-      Value dimSize = i32_val(dimShape);
-      linear = add(mul(linear, dimSize), dim);
-    }
-  }
-  return linear;
 }
 
 Value storeShared(ConversionPatternRewriter &rewriter, Location loc, Value ptr,

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
@@ -1,200 +1,22 @@
 #ifndef TRITON_CONVERSION_TRITONINTELGPU_TO_LLVM_UTILITY_H
 #define TRITON_CONVERSION_TRITONINTELGPU_TO_LLVM_UTILITY_H
 
-#include "intel/include/TritonIntelGPUToLLVM/Passes.h"
-#include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "triton/Conversion/MLIRTypes.h"
-#include "triton/Dialect/NVGPU/IR/Dialect.h"
-#include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/TritonGEN/IR/TritonGENDialect.h"
 #include "triton/Dialect/TritonIntelGPU/IR/Dialect.h"
-#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
-#include <set>
 
-using namespace mlir;
-using namespace mlir::triton;
-
-// Shortcuts for some commonly used LLVM ops to keep code simple and intuitive
-// Operators
-#define inttoptr(...) rewriter.create<LLVM::IntToPtrOp>(loc, __VA_ARGS__)
-#define ptrtoint(...) rewriter.create<LLVM::PtrToIntOp>(loc, __VA_ARGS__)
-#define zext(...) rewriter.create<LLVM::ZExtOp>(loc, __VA_ARGS__)
-#define trunc(...) rewriter.create<LLVM::TruncOp>(loc, __VA_ARGS__)
-#define sext(...) rewriter.create<LLVM::SExtOp>(loc, __VA_ARGS__)
-#define fpext(...) rewriter.create<LLVM::FPExtOp>(loc, __VA_ARGS__)
-#define trunc(...) rewriter.create<LLVM::TruncOp>(loc, __VA_ARGS__)
-#define udiv(...) rewriter.create<LLVM::UDivOp>(loc, __VA_ARGS__)
-#define urem(...) rewriter.create<LLVM::URemOp>(loc, __VA_ARGS__)
-#define add(...) rewriter.create<LLVM::AddOp>(loc, __VA_ARGS__)
-#define sub(...) rewriter.create<LLVM::SubOp>(loc, __VA_ARGS__)
-#define fadd(...) rewriter.create<LLVM::FAddOp>(loc, __VA_ARGS__)
-#define mul(...) rewriter.create<LLVM::MulOp>(loc, __VA_ARGS__)
-#define fmul(...) rewriter.create<LLVM::FMulOp>(loc, __VA_ARGS__)
-#define lshr(...) rewriter.create<LLVM::LShrOp>(loc, __VA_ARGS__)
-#define smax(...) rewriter.create<LLVM::SMaxOp>(loc, __VA_ARGS__)
-#define umax(...) rewriter.create<LLVM::UMaxOp>(loc, __VA_ARGS__)
-#define fmax(...) rewriter.create<LLVM::MaxNumOp>(loc, __VA_ARGS__)
-#define smin(...) rewriter.create<LLVM::SMinOp>(loc, __VA_ARGS__)
-#define umin(...) rewriter.create<LLVM::UMinOp>(loc, __VA_ARGS__)
-#define fmin(...) rewriter.create<LLVM::MinNumOp>(loc, __VA_ARGS__)
-#define shl(...) rewriter.create<LLVM::ShlOp>(loc, __VA_ARGS__)
-#define lshr(...) rewriter.create<LLVM::LShrOp>(loc, __VA_ARGS__)
-#define and_(...) rewriter.create<LLVM::AndOp>(loc, __VA_ARGS__)
-#define xor_(...) rewriter.create<LLVM::XOrOp>(loc, __VA_ARGS__)
-#define or_(...) rewriter.create<LLVM::OrOp>(loc, __VA_ARGS__)
-#define bitcast(val__, type__)                                                 \
-  rewriter.create<LLVM::BitcastOp>(loc, type__, val__)
-#define gep(...) rewriter.create<LLVM::GEPOp>(loc, __VA_ARGS__)
-#define ptr_ty(...) LLVM::LLVMPointerType::get(__VA_ARGS__)
-#define insert_val(...) rewriter.create<LLVM::InsertValueOp>(loc, __VA_ARGS__)
-#define extract_val(...) rewriter.create<LLVM::ExtractValueOp>(loc, __VA_ARGS__)
-#define insert_element(...)                                                    \
-  rewriter.create<LLVM::InsertElementOp>(loc, __VA_ARGS__)
-#define extract_element(...)                                                   \
-  rewriter.create<LLVM::ExtractElementOp>(loc, __VA_ARGS__)
-#define load(...) rewriter.create<LLVM::LoadOp>(loc, __VA_ARGS__)
+#undef store
 #define store(...) rewriter.create<LLVM::StoreOp>(loc, __VA_ARGS__)
-#define load_dsmem(...) LLVM::utils::createLoadDSmem(loc, rewriter, __VA_ARGS__)
-#define store_dsmem(...)                                                       \
-  LLVM::utils::createStoreDSmem(loc, rewriter, __VA_ARGS__)
-#define fcmp_ogt(lhs, rhs)                                                     \
-  rewriter.create<LLVM::FCmpOp>(loc, rewriter.getI1Type(),                     \
-                                LLVM::FCmpPredicate::ogt, lhs, rhs)
-#define fcmp_olt(lhs, rhs)                                                     \
-  rewriter.create<LLVM::FCmpOp>(loc, rewriter.getI1Type(),                     \
-                                LLVM::FCmpPredicate::olt, lhs, rhs)
-#define fcmp_eq(lhs, rhs)                                                      \
-  rewriter.create<LLVM::FCmpOp>(loc, rewriter.getI1Type(),                     \
-                                LLVM::FCmpPredicate::oeq, lhs, rhs)
-#define icmp_eq(...)                                                           \
-  rewriter.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::eq, __VA_ARGS__)
-#define icmp_ne(...)                                                           \
-  rewriter.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::ne, __VA_ARGS__)
-#define icmp_slt(...)                                                          \
-  rewriter.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::slt, __VA_ARGS__)
-#define icmp_sle(...)                                                          \
-  rewriter.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::sle, __VA_ARGS__)
-#define icmp_sgt(...)                                                          \
-  rewriter.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::sgt, __VA_ARGS__)
-#define icmp_sge(...)                                                          \
-  rewriter.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::sge, __VA_ARGS__)
-#define icmp_ult(...)                                                          \
-  rewriter.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::ult, __VA_ARGS__)
-#define icmp_ule(...)                                                          \
-  rewriter.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::ule, __VA_ARGS__)
-#define icmp_ugt(...)                                                          \
-  rewriter.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::ugt, __VA_ARGS__)
-#define icmp_uge(...)                                                          \
-  rewriter.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::uge, __VA_ARGS__)
-#define select(...) rewriter.create<LLVM::SelectOp>(loc, __VA_ARGS__)
-#define address_of(...) rewriter.create<LLVM::AddressOfOp>(loc, __VA_ARGS__)
-#define barrier() rewriter.create<mlir::gpu::BarrierOp>(loc)
-#define undef(...) rewriter.create<LLVM::UndefOp>(loc, __VA_ARGS__)
-#define null(...) rewriter.create<LLVM::ZeroOp>(loc, __VA_ARGS__)
-#define call(...) rewriter.create<LLVM::CallOp>(loc, __VA_ARGS__)
+#undef addrspacecast
 #define addrspacecast(...)                                                     \
   rewriter.create<LLVM::AddrSpaceCastOp>(loc, __VA_ARGS__)
 
-// Types
-#define int_ty(width) rewriter.getIntegerType(width)
-#define i64_ty rewriter.getIntegerType(64)
-#define i32_ty rewriter.getIntegerType(32)
-#define i16_ty rewriter.getIntegerType(16)
-#define i32_ty rewriter.getIntegerType(32)
-#define i64_ty rewriter.getIntegerType(64)
-#define ui32_ty rewriter.getIntegerType(32, false)
-#define f16_ty rewriter.getF16Type()
-#define bf16_ty rewriter.getBF16Type()
-#define i8_ty rewriter.getIntegerType(8)
-#define i1_ty rewriter.getI1Type()
-#define f32_ty rewriter.getF32Type()
-#define f64_ty rewriter.getF64Type()
-#define vec_ty(type, num) VectorType::get(num, type)
-#define void_ty(ctx) LLVM::LLVMVoidType::get(ctx)
-#define struct_ty(...) LLVM::LLVMStructType::getLiteral(ctx, __VA_ARGS__)
-#define array_ty(elemTy, count) LLVM::LLVMArrayType::get(elemTy, count)
-
 // Constants
 #define f16_val(...) LLVM::utils::createConstantF16(loc, rewriter, __VA_ARGS__)
-#define f32_val(...) LLVM::utils::createConstantF32(loc, rewriter, __VA_ARGS__)
-#define f64_val(...) LLVM::utils::createConstantF64(loc, rewriter, __VA_ARGS__)
-#define i32_val(...) LLVM::utils::createConstantI32(loc, rewriter, __VA_ARGS__)
 #define i64_val(...) LLVM::utils::createConstantI64(loc, rewriter, __VA_ARGS__)
-#define int_val(width, val)                                                    \
-  LLVM::utils::createLLVMIntegerConstant(rewriter, loc, width, val)
-#define tid_val() getThreadId(rewriter, loc)
-
-// Attributes
-#define i32_arr_attr(...) rewriter.getI32ArrayAttr({__VA_ARGS__})
-#define i64_arr_attr(...) rewriter.getI64ArrayAttr({__VA_ARGS__})
 
 namespace mlir {
-namespace triton {
-// namespace intel {
-
-// Delinearize supposing order is [0, 1, .. , n]
-template <typename T>
-llvm::SmallVector<T> getMultiDimIndexImpl(T linearIndex,
-                                          llvm::ArrayRef<T> shape) {
-  // shape: {a, b, c, d}  ->  accMul: {1, a, a*b, a*b*c}
-  size_t rank = shape.size();
-  T accMul = product(shape.drop_back());
-  T linearRemain = linearIndex;
-  llvm::SmallVector<T> multiDimIndex(rank);
-  for (int i = rank - 1; i >= 0; --i) {
-    multiDimIndex[i] = linearRemain / accMul;
-    linearRemain = linearRemain % accMul;
-    if (i != 0) {
-      accMul = accMul / shape[i - 1];
-    }
-  }
-  return multiDimIndex;
-}
-
-template <typename T>
-llvm::SmallVector<T> getMultiDimIndex(T linearIndex, llvm::ArrayRef<T> shape,
-                                      llvm::ArrayRef<unsigned> order) {
-  size_t rank = shape.size();
-  assert(rank == order.size());
-  auto reordered = applyPermutation(shape, order);
-  auto reorderedMultiDim = getMultiDimIndexImpl<T>(linearIndex, reordered);
-  llvm::SmallVector<T> multiDim(rank);
-  for (unsigned i = 0; i < rank; ++i) {
-    multiDim[order[i]] = reorderedMultiDim[i];
-  }
-  return multiDim;
-}
-
-// Linearize supposing order is [0, 1, .. , n]
-template <typename T>
-T getLinearIndexImpl(llvm::ArrayRef<T> multiDimIndex, llvm::ArrayRef<T> shape) {
-  assert(multiDimIndex.size() == shape.size());
-  // shape: {a, b, c, d}  ->  accMul: {1, a, a*b, a*b*c}
-  size_t rank = shape.size();
-  T accMul = product(shape.drop_back());
-  T linearIndex = 0;
-  for (int i = rank - 1; i >= 0; --i) {
-    linearIndex += multiDimIndex[i] * accMul;
-    if (i != 0) {
-      accMul = accMul / shape[i - 1];
-    }
-  }
-  return linearIndex;
-}
-
-template <typename T>
-T getLinearIndex(llvm::ArrayRef<T> multiDimIndex, llvm::ArrayRef<T> shape,
-                 llvm::ArrayRef<unsigned> order) {
-  assert(shape.size() == order.size());
-  return getLinearIndexImpl<T>(applyPermutation(multiDimIndex, order),
-                               applyPermutation(shape, order));
-}
-
-// } // namespace intel
-} // namespace triton
-
 namespace LLVM {
 namespace utils {
 using namespace mlir::triton;
@@ -254,152 +76,11 @@ Block &createPredicatedBlock(ConversionPatternRewriter &rewriter, Location loc,
   return createPredicatedBlock(rewriter, loc, cond, {}, thenOpsFn);
 }
 
-/// Create a 32-bit integer constant.
-Value createConstantI32(Location loc, OpBuilder &rewriter, int32_t v);
-
 /// Create a 64-bit integer constant.
 Value createConstantI64(Location loc, OpBuilder &rewriter, int64_t v);
 
 /// Create a 16-bit float constant.
 Value createConstantF16(Location loc, OpBuilder &rewriter, float v);
-
-/// Create a 32-bit float constant.
-Value createConstantF32(Location loc, OpBuilder &rewriter, float v);
-
-/// Create a 64-bit float constant.
-Value createConstantF64(Location loc, OpBuilder &rewriter, double v);
-
-/// Create NaN constant of specified type.
-Value createNaNConstant(Location loc, OpBuilder &rewriter, Type type);
-
-/// Create an index type constant.
-Value createIndexConstant(OpBuilder &builder, Location loc,
-                          TypeConverter *converter, int64_t value);
-
-/// Create an integer constant of \param width bits.
-Value createLLVMIntegerConstant(OpBuilder &builder, Location loc, short width,
-                                int64_t value);
-
-/// Usage of macro load_dsmem
-/// (1) load_dsmem(addr, ctaId)
-/// (2) load_dsmem(addr, ctaId, vec)
-Value createLoadDSmem(Location loc, PatternRewriter &rewriter, Value addr,
-                      Value ctaId, Type elemTy);
-SmallVector<Value> createLoadDSmem(Location loc, PatternRewriter &rewriter,
-                                   Value addr, Value ctaId, unsigned vec,
-                                   Type elemTy);
-
-/// Usage of macro store_dsmem
-/// (1) store_dsmem(addr, ctaId, value, pred)
-/// (2) store_dsmem(addr, ctaId, value)
-/// (3) store_dsmem(addr, ctaId, values, pred)
-/// (4) store_dsmem(addr, ctaId, values)
-void createStoreDSmem(Location loc, PatternRewriter &rewriter, Value addr,
-                      Value ctaId, Value value, Value pred);
-void createStoreDSmem(Location loc, PatternRewriter &rewriter, Value addr,
-                      Value ctaId, Value value);
-void createStoreDSmem(Location loc, PatternRewriter &rewriter, Value addr,
-                      Value ctaId, ArrayRef<Value> values, Value pred);
-void createStoreDSmem(Location loc, PatternRewriter &rewriter, Value addr,
-                      Value ctaId, ArrayRef<Value> values);
-
-/// Helper function to get strides from a given shape and its order
-SmallVector<Value> getStridesFromShapeAndOrder(ArrayRef<int64_t> shape,
-                                               ArrayRef<unsigned> order,
-                                               Location loc,
-                                               RewriterBase &rewriter);
-struct SharedMemoryObject {
-  Value base; // i32 ptr. The start address of the shared memory object after
-              // the initial allocation or the last slicing operation.
-  Type baseElemType;
-  // We need to store strides as Values, not integers, because the
-  // extract_slice instruction can take a slice at arbitrary offsets.
-  // Take $a[16:32, 16:32] as an example; though we know the stride of $a[0] is
-  // 32, we need to let the instruction that uses $a be aware of that.
-  // Otherwise, when we use $a, we only know that the shape of $a is 16x16. If
-  // we store strides into an attribute array of integers, the information
-  // cannot pass through block argument assignment because attributes are
-  // associated with operations, not Values.
-  // TODO(Keren): We may need to figure out a way to store strides as integers
-  // if we want to support more optimizations.
-  SmallVector<Value>
-      strides; // i32 int. The strides of the shared memory object.
-  SmallVector<Value> offsets; // i32 int.
-  // Offsets are applied at the last slicing operation.
-  // We can use offsets to recover the previous base.
-  // The offsets are zero at the initial allocation.
-
-  SharedMemoryObject(Value base, Type baseElemType, ArrayRef<Value> strides,
-                     ArrayRef<Value> offsets)
-      : base(base), baseElemType(baseElemType),
-        strides(strides.begin(), strides.end()),
-        offsets(offsets.begin(), offsets.end()) {}
-
-  SharedMemoryObject(Value base, Type baseElemType, ArrayRef<int64_t> shape,
-                     ArrayRef<unsigned> order, Location loc,
-                     RewriterBase &rewriter)
-      : base(base), baseElemType(baseElemType) {
-    strides = getStridesFromShapeAndOrder(shape, order, loc, rewriter);
-    offsets.append(order.size(), i32_val(0));
-  }
-
-  SmallVector<Value> getStrides() const { return strides; }
-  SmallVector<Value> getOffsets() const { return offsets; }
-  Value getBase() const { return base; }
-  Type getBaseElemType() const { return baseElemType; }
-
-  SmallVector<Value> getElems() const {
-    SmallVector<Value> elems;
-    elems.push_back(base);
-    elems.append(strides.begin(), strides.end());
-    elems.append(offsets.begin(), offsets.end());
-    return elems;
-  }
-
-  SmallVector<Type> getTypes() const {
-    SmallVector<Type> types;
-    types.push_back(base.getType());
-    types.append(strides.size(), IntegerType::get(base.getContext(), 32));
-    types.append(offsets.size(), IntegerType::get(base.getContext(), 32));
-    return types;
-  }
-
-  Value getCSwizzleOffset(int order) const {
-    assert(order >= 0 && order < strides.size());
-    return offsets[order];
-  }
-
-  Value getBaseBeforeSlice(int order, Location loc,
-                           ConversionPatternRewriter &rewriter) const {
-    Value cSwizzleOffset = getCSwizzleOffset(order);
-    Value offset = sub(i32_val(0), cSwizzleOffset);
-    Type type = base.getType();
-    return gep(type, baseElemType, base, offset);
-  }
-};
-
-SharedMemoryObject
-getSharedMemoryObjectFromStruct(Location loc, Value llvmStruct, Type elemTy,
-                                ConversionPatternRewriter &rewriter);
-
-// Convert an \param linear to a multi-dim coordinate given \param shape and
-// \param order.
-SmallVector<Value> delinearize(RewriterBase &rewriter, Location loc,
-                               Value linear, ArrayRef<unsigned> shape,
-                               ArrayRef<unsigned> order);
-
-SmallVector<Value> delinearize(RewriterBase &rewriter, Location loc,
-                               unsigned linear, ArrayRef<unsigned> shape);
-
-SmallVector<Value> delinearize(RewriterBase &rewriter, Location loc,
-                               Value linear, ArrayRef<unsigned> shape);
-
-Value linearize(ConversionPatternRewriter &rewriter, Location loc,
-                ArrayRef<Value> multiDim, ArrayRef<unsigned> shape,
-                ArrayRef<unsigned> order);
-
-Value linearize(ConversionPatternRewriter &rewriter, Location loc,
-                ArrayRef<Value> multiDim, ArrayRef<unsigned> shape);
 
 Value storeShared(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
                   Value val, Value pred);
@@ -422,10 +103,6 @@ Value llGetPid(Location loc, ConversionPatternRewriter &rewriter,
 Value addStringToModule(Location loc, ConversionPatternRewriter &rewriter,
                         StringRef key, StringRef content,
                         unsigned addressSpace);
-
-static bool isKernel(FunctionOpInterface funcOp) {
-  return funcOp.getVisibility() == SymbolTable::Visibility::Public;
-}
 
 static Value getStackPointer(PatternRewriter &rewriter,
                              FunctionOpInterface funcOp) {
@@ -463,36 +140,18 @@ void llPrintf(ConversionPatternRewriter &rewriter, Value msg, ValueRange args);
 } // namespace utils
 } // namespace LLVM
 
-/* ------------------------------------ */
-// Returns CTA level thread idx
-static Value getThreadIdInCTA(RewriterBase &rewriter, Location loc) {
-  Value tid =
-      rewriter.create<::mlir::gpu::ThreadIdOp>(loc, ::mlir::gpu::Dimension::x);
-  return rewriter.create<arith::IndexCastOp>(loc, i32_ty, tid);
-}
-
-// Returns CTA level thread idx.
-static Value getThreadId(RewriterBase &rewriter, Location loc) {
-  Value tid = getThreadIdInCTA(rewriter, loc);
-  auto mod = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
-  return tid;
-}
-
 static Value getModuleWarpSize(RewriterBase &rewriter, Location loc) {
   auto mod = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
   return i32_val(triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod));
 }
 
-static Value getClusterCTAId(RewriterBase &rewriter, Location loc) {
+static Value getClusterCTAIdIntel(RewriterBase &rewriter, Location loc) {
   // Clusters of thread blocks aren't supported.
   return rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
 }
-
 // -----------------------------------------------------------------------
 // Shared memory utilities
 // -----------------------------------------------------------------------
-using ::mlir::LLVM::utils::delinearize;
-using ::mlir::LLVM::utils::SharedMemoryObject;
 using ::mlir::triton::getMultiDimIndex;
 using ::mlir::triton::gpu::BlockedEncodingAttr;
 using ::mlir::triton::gpu::CTALayoutAttr;
@@ -501,369 +160,10 @@ using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
 using ::mlir::triton::gpu::SliceEncodingAttr;
 using ::mlir::triton::gpu::intel::DpasEncodingAttr;
 
-static Value dot(RewriterBase &rewriter, Location loc, ArrayRef<Value> offsets,
-                 ArrayRef<Value> strides) {
-  assert(offsets.size() == strides.size());
-  Value ret = i32_val(0);
-  for (auto [offset, stride] : llvm::zip(offsets, strides)) {
-    ret = add(ret, mul(offset, stride));
-  }
-  return ret;
-}
-
-// -----------------------------------------------------------------------
-// Blocked layout indices
-// -----------------------------------------------------------------------
-
-// Get an index-base for each dimension for a \param blockedLayout.
-static SmallVector<Value>
-emitBaseIndexWithinCTAForBlockedLayout(Location loc, RewriterBase &rewriter,
-                                       const BlockedEncodingAttr &blockedLayout,
-                                       RankedTensorType type) {
-  auto shape = type.getShape();
-  Value threadId = getThreadId(rewriter, loc);
-  Value warpSize = getModuleWarpSize(rewriter, loc);
-  Value laneId = urem(threadId, warpSize);
-  Value warpId = udiv(threadId, warpSize);
-  auto sizePerThread = blockedLayout.getSizePerThread();
-  auto threadsPerWarp = blockedLayout.getThreadsPerWarp();
-  auto warpsPerCTA = blockedLayout.getWarpsPerCTA();
-  auto order = blockedLayout.getOrder();
-  auto shapePerCTA = triton::gpu::getShapePerCTA(blockedLayout, shape);
-  unsigned rank = shape.size();
-
-  // delinearize threadId to get the base index
-  SmallVector<Value> multiDimWarpId =
-      delinearize(rewriter, loc, warpId, warpsPerCTA, order);
-  SmallVector<Value> multiDimThreadId =
-      delinearize(rewriter, loc, laneId, threadsPerWarp, order);
-
-  SmallVector<Value> multiDimBase(rank);
-  for (unsigned k = 0; k < rank; ++k) {
-    // Wrap around multiDimWarpId/multiDimThreadId in case
-    // shapePerCTATile[k] > shapePerCTA[k]
-    auto maxWarps =
-        ceil<unsigned>(shapePerCTA[k], sizePerThread[k] * threadsPerWarp[k]);
-    auto maxThreads = ceil<unsigned>(shapePerCTA[k], sizePerThread[k]);
-    multiDimWarpId[k] = urem(multiDimWarpId[k], i32_val(maxWarps));
-    multiDimThreadId[k] = urem(multiDimThreadId[k], i32_val(maxThreads));
-    // multiDimBase[k] = (multiDimThreadId[k] +
-    //                    multiDimWarpId[k] * threadsPerWarp[k]) *
-    //                   sizePerThread[k];
-    Value threadsPerWarpK = i32_val(threadsPerWarp[k]);
-    Value sizePerThreadK = i32_val(sizePerThread[k]);
-    multiDimBase[k] =
-        mul(sizePerThreadK,
-            add(multiDimThreadId[k], mul(multiDimWarpId[k], threadsPerWarpK)));
-  }
-  return multiDimBase;
-}
-
-static SmallVector<SmallVector<unsigned>>
-emitOffsetForBlockedLayout(const BlockedEncodingAttr &blockedLayout,
-                           RankedTensorType type) {
-  auto shape = type.getShape();
-  auto sizePerThread = blockedLayout.getSizePerThread();
-  auto threadsPerWarp = blockedLayout.getThreadsPerWarp();
-  auto warpsPerCTA = blockedLayout.getWarpsPerCTA();
-  auto order = blockedLayout.getOrder();
-  auto shapePerCTATile = getShapePerCTATile(blockedLayout);
-  auto shapePerCTA = triton::gpu::getShapePerCTA(blockedLayout, shape);
-
-  unsigned rank = shape.size();
-  SmallVector<unsigned> tilesPerDim(rank);
-  for (unsigned k = 0; k < rank; ++k)
-    tilesPerDim[k] = ceil<unsigned>(shapePerCTA[k], shapePerCTATile[k]);
-
-  unsigned elemsPerThread = triton::gpu::getTotalElemsPerThread(type);
-  unsigned totalSizePerThread = product<unsigned>(sizePerThread);
-  SmallVector<SmallVector<unsigned>> reorderedOffset(elemsPerThread);
-  for (unsigned n = 0; n < elemsPerThread; ++n) {
-    unsigned linearNanoTileId = n / totalSizePerThread;
-    unsigned linearNanoTileElemId = n % totalSizePerThread;
-    SmallVector<unsigned> multiDimNanoTileId =
-        getMultiDimIndex<unsigned>(linearNanoTileId, tilesPerDim, order);
-    SmallVector<unsigned> multiDimNanoTileElemId =
-        getMultiDimIndex<unsigned>(linearNanoTileElemId, sizePerThread, order);
-    for (unsigned k = 0; k < rank; ++k) {
-      unsigned reorderedMultiDimId =
-          multiDimNanoTileId[k] *
-              (sizePerThread[k] * threadsPerWarp[k] * warpsPerCTA[k]) +
-          multiDimNanoTileElemId[k];
-      reorderedOffset[n].push_back(reorderedMultiDimId);
-    }
-  }
-  return reorderedOffset;
-}
-
-// -----------------------------------------------------------------------
-// Mma layout indices
-// -----------------------------------------------------------------------
-
-static SmallVector<Value>
-emitBaseIndexWithinCTAForMmaLayoutV1(Location loc, RewriterBase &rewriter,
-                                     const NvidiaMmaEncodingAttr &mmaLayout,
-                                     RankedTensorType type) {
-  auto shape = type.getShape();
-  auto wpt = mmaLayout.getWarpsPerCTA();
-  static constexpr std::array<int, 3> fpw{{2, 2, 1}};
-  auto [isARow, isBRow, isAVec4, isBVec4, _] =
-      mmaLayout.decodeVoltaLayoutStates();
-
-  Value thread = getThreadId(rewriter, loc);
-  auto *ctx = thread.getContext();
-  Value _1 = i32_val(1);
-  Value _2 = i32_val(2);
-  Value _4 = i32_val(4);
-  Value _16 = i32_val(16);
-  Value _32 = i32_val(32);
-  Value _fpw0 = i32_val(fpw[0]);
-  Value _fpw1 = i32_val(fpw[1]);
-
-  // A info
-  auto aRep = mmaLayout.getMMAv1Rep(0);
-  auto aSpw = mmaLayout.getMMAv1ShapePerWarp(0);
-  // B info
-  auto bSpw = mmaLayout.getMMAv1ShapePerWarp(1);
-  auto bRep = mmaLayout.getMMAv1Rep(1);
-
-  SmallVector<int, 2> rep({aRep[0], bRep[1]});
-  SmallVector<int, 2> spw({aSpw[0], bSpw[1]});
-  SmallVector<unsigned, 2> shapePerCTA({spw[0] * wpt[0], spw[1] * wpt[1]});
-
-  Value lane = urem(thread, _32);
-  Value warp = udiv(thread, _32);
-
-  Value warp0 = urem(warp, i32_val(wpt[0]));
-  Value warp12 = udiv(warp, i32_val(wpt[0]));
-  Value warp1 = urem(warp12, i32_val(wpt[1]));
-
-  // warp offset
-  Value offWarpM = mul(warp0, i32_val(spw[0]));
-  Value offWarpN = mul(warp1, i32_val(spw[1]));
-  // quad offset
-  Value offQuadM = mul(udiv(and_(lane, _16), _4), _fpw0);
-  Value offQuadN = mul(udiv(and_(lane, _16), _4), _fpw1);
-  // pair offset
-  Value offPairM = udiv(urem(lane, _16), _4);
-  offPairM = urem(offPairM, _fpw0);
-  offPairM = mul(offPairM, _4);
-  Value offPairN = udiv(urem(lane, _16), _4);
-  offPairN = udiv(offPairN, _fpw0);
-  offPairN = urem(offPairN, _fpw1);
-  offPairN = mul(offPairN, _4);
-  offPairM = mul(offPairM, i32_val(rep[0] / 2));
-  offQuadM = mul(offQuadM, i32_val(rep[0] / 2));
-  offPairN = mul(offPairN, i32_val(rep[1] / 2));
-  offQuadN = mul(offQuadN, i32_val(rep[1] / 2));
-  // quad pair offset
-  Value offLaneM = add(offPairM, offQuadM);
-  Value offLaneN = add(offPairN, offQuadN);
-  // a, b offset
-  Value offsetAM = add(offWarpM, offLaneM);
-  Value offsetBN = add(offWarpN, offLaneN);
-  // m indices
-  Value offsetCM = add(and_(lane, _1), offsetAM);
-  // n indices
-  Value offsetCN = add((and_(lane, _2)), (add(offWarpN, offPairN)));
-  return {offsetCM, offsetCN};
-}
-
-static SmallVector<SmallVector<unsigned>>
-emitOffsetForMmaLayoutV1(const NvidiaMmaEncodingAttr &mmaLayout,
-                         RankedTensorType type) {
-  auto shape = type.getShape();
-
-  auto [isARow, isBRow, isAVec4, isBVec4, _] =
-      mmaLayout.decodeVoltaLayoutStates();
-
-  // TODO: seems like the apttern below to get `rep`/`spw` appears quite often
-  // A info
-  auto aRep = mmaLayout.getMMAv1Rep(0);
-  auto aSpw = mmaLayout.getMMAv1ShapePerWarp(0);
-  // B info
-  auto bSpw = mmaLayout.getMMAv1ShapePerWarp(1);
-  auto bRep = mmaLayout.getMMAv1Rep(1);
-
-  auto wpt = mmaLayout.getWarpsPerCTA();
-  static constexpr std::array<int, 3> fpw{{2, 2, 1}};
-  SmallVector<int, 2> rep({aRep[0], bRep[1]});
-  SmallVector<int, 2> spw({aSpw[0], bSpw[1]});
-  SmallVector<unsigned, 2> shapePerCTA({spw[0] * wpt[0], spw[1] * wpt[1]});
-
-  SmallVector<unsigned> idxM;
-  for (unsigned m = 0; m < shape[0]; m += shapePerCTA[0])
-    for (unsigned mm = 0; mm < rep[0]; ++mm)
-      idxM.push_back(m + mm * 2);
-
-  SmallVector<unsigned> idxN;
-  for (int n = 0; n < shape[1]; n += shapePerCTA[1]) {
-    for (int nn = 0; nn < rep[1]; ++nn) {
-      idxN.push_back(n + nn / 2 * 4 + (nn % 2) * 2 * fpw[1] * rep[1]);
-      idxN.push_back(n + nn / 2 * 4 + (nn % 2) * 2 * fpw[1] * rep[1] + 1);
-    }
-  }
-
-  SmallVector<SmallVector<unsigned>> ret;
-  for (unsigned x1 : idxN) {   // N
-    for (unsigned x0 : idxM) { // M
-      SmallVector<unsigned> idx(2);
-      idx[0] = x0; // M
-      idx[1] = x1; // N
-      ret.push_back(std::move(idx));
-    }
-  }
-  return ret;
-}
-
-static SmallVector<SmallVector<unsigned>>
-emitOffsetForMmaLayoutV2(const NvidiaMmaEncodingAttr &mmaLayout,
-                         RankedTensorType type) {
-  auto shape = type.getShape();
-  auto shapePerCTA = getShapePerCTA(mmaLayout, shape);
-  SmallVector<SmallVector<unsigned>> ret;
-
-  auto rank = shape.size();
-  for (unsigned i = 0; i < shapePerCTA[rank - 2];
-       i += getShapePerCTATile(mmaLayout)[rank - 2]) {
-    for (unsigned j = 0; j < shapePerCTA[rank - 1];
-         j += getShapePerCTATile(mmaLayout)[rank - 1]) {
-      if (rank == 3) {
-        ret.push_back({0, i, j});
-        ret.push_back({0, i, j + 1});
-        ret.push_back({0, i + 8, j});
-        ret.push_back({0, i + 8, j + 1});
-      } else {
-        ret.push_back({i, j});
-        ret.push_back({i, j + 1});
-        ret.push_back({i + 8, j});
-        ret.push_back({i + 8, j + 1});
-      }
-    }
-  }
-  return ret;
-}
-
-static SmallVector<Value>
-emitBaseIndexWithinCTAForMmaLayoutV2V3(Location loc, RewriterBase &rewriter,
-                                       const NvidiaMmaEncodingAttr &mmaLayout,
-                                       RankedTensorType type) {
-  auto shape = type.getShape();
-  auto _warpsPerCTA = mmaLayout.getWarpsPerCTA();
-  auto rank = shape.size();
-  assert(rank == 2 || rank == 3);
-  auto order = triton::gpu::getOrder(mmaLayout);
-  ArrayRef<unsigned int> instrShape = mmaLayout.getInstrShape();
-  SmallVector<Value> warpsPerCTA;
-  for (unsigned i = 0; i < rank; ++i)
-    warpsPerCTA.push_back(i32_val(_warpsPerCTA[i]));
-  auto shapePerCTA = getShapePerCTA(mmaLayout, shape);
-
-  Value threadId = getThreadId(rewriter, loc);
-  Value warpSize = i32_val(32);
-  Value laneId = urem(threadId, warpSize);
-  Value warpId = udiv(threadId, warpSize);
-
-  uint32_t repM =
-      (_warpsPerCTA[rank - 2] * instrShape[rank - 2]) / shapePerCTA[rank - 2];
-  uint32_t repN =
-      (_warpsPerCTA[rank - 1] * instrShape[rank - 1]) / shapePerCTA[rank - 1];
-
-  uint32_t warpsM;
-  if (repM > 1)
-    warpsM = _warpsPerCTA[rank - 2] / repM;
-  else
-    warpsM = shape[rank - 2] / instrShape[rank - 2];
-
-  uint32_t warpsN;
-  if (repN > 1)
-    warpsN = _warpsPerCTA[rank - 1] / repN;
-  else
-    warpsN = shape[rank - 1] / instrShape[rank - 1];
-
-  SmallVector<Value> multiDimWarpId(rank);
-  if (mmaLayout.isHopper()) {
-    // TODO[goostavz]: the tiling order from CTA->warp level is different for
-    // MMAv2/3. This is a workaround since we don't explicitly have warpGrp
-    // level in the layout definition, and the tiling order of warpGrp->warp
-    // must be fixed to meet the HW's needs. We may need to consider to
-    // explicitly define warpGrpPerCTA for MMAv3 layout.
-    assert(rank == 2 && "MMAv3 layout is does not support 3D tensor yet");
-    multiDimWarpId[rank - 2] = urem(warpId, warpsPerCTA[rank - 2]);
-    multiDimWarpId[rank - 1] =
-        urem(udiv(warpId, warpsPerCTA[rank - 2]), warpsPerCTA[rank - 1]);
-  } else {
-    multiDimWarpId = delinearize(rewriter, loc, warpId, _warpsPerCTA, order);
-  }
-  Value warpIdM = urem(multiDimWarpId[rank - 2], i32_val(warpsM));
-  Value warpIdN = urem(multiDimWarpId[rank - 1], i32_val(warpsN));
-
-  Value offWarpM = mul(warpIdM, i32_val(instrShape[rank - 2]));
-  Value offWarpN = mul(warpIdN, i32_val(instrShape[rank - 1]));
-
-  SmallVector<Value> multiDimBase(rank);
-  if (rank == 3)
-    multiDimBase[0] = multiDimWarpId[0];
-  multiDimBase[rank - 2] = add(udiv(laneId, i32_val(4)), offWarpM);
-  multiDimBase[rank - 1] =
-      add(mul(i32_val(2), urem(laneId, i32_val(4))), offWarpN);
-  return multiDimBase;
-}
-
-static SmallVector<SmallVector<unsigned>>
-emitOffsetForMmaLayoutV3(const NvidiaMmaEncodingAttr &mmaLayout,
-                         RankedTensorType type) {
-  auto shape = type.getShape();
-  auto shapePerCTA = getShapePerCTA(mmaLayout, shape);
-  SmallVector<SmallVector<unsigned>> ret;
-  ArrayRef<unsigned int> instrShape = mmaLayout.getInstrShape();
-
-  for (unsigned i = 0; i < shapePerCTA[0];
-       i += getShapePerCTATile(mmaLayout)[0]) {
-    for (unsigned j = 0; j < shapePerCTA[1];
-         j += getShapePerCTATile(mmaLayout)[1]) {
-      for (unsigned k = 0; k < instrShape[1]; k += 8) {
-        ret.push_back({i, j + k});
-        ret.push_back({i, j + k + 1});
-        ret.push_back({i + 8, j + k});
-        ret.push_back({i + 8, j + k + 1});
-      }
-    }
-  }
-  return ret;
-}
-
-static SmallVector<SmallVector<unsigned>>
-emitOffsetForLayout(Attribute layout, RankedTensorType type);
 static SmallVector<Value>
 emitBaseIndexForDpasLayout(Location loc, RewriterBase &rewriter,
                            const DpasEncodingAttr &dpasLayout,
                            RankedTensorType type);
-
-static SmallVector<SmallVector<unsigned>>
-emitOffsetForSliceLayout(const SliceEncodingAttr &sliceLayout,
-                         RankedTensorType type) {
-  auto parentEncoding = sliceLayout.getParent();
-  unsigned dim = sliceLayout.getDim();
-  auto parentShape = sliceLayout.paddedShape(type.getShape());
-  RankedTensorType parentTy =
-      RankedTensorType::get(parentShape, type.getElementType(), parentEncoding);
-  auto parentOffsets = emitOffsetForLayout(parentEncoding, parentTy);
-
-  unsigned numOffsets = parentOffsets.size();
-  SmallVector<SmallVector<unsigned>> resultOffsets;
-  std::set<SmallVector<unsigned>> uniqueOffsets;
-
-  for (unsigned i = 0; i < numOffsets; ++i) {
-    SmallVector<unsigned> offsets = parentOffsets[i];
-    offsets.erase(offsets.begin() + dim);
-    if (uniqueOffsets.find(offsets) == uniqueOffsets.end()) {
-      resultOffsets.push_back(offsets);
-      uniqueOffsets.insert(offsets);
-    }
-  }
-  return resultOffsets;
-}
 
 static void
 emitOffsetForDpasLayoutPerCTA(const DpasEncodingAttr &dpasLayout,
@@ -883,11 +183,82 @@ emitOffsetForDpasLayoutPerCTA(const DpasEncodingAttr &dpasLayout,
   }
 }
 
-//
+static SmallVector<SmallVector<unsigned>>
+emitOffsetForDpasLayout(const DpasEncodingAttr &dpasLayout,
+                        RankedTensorType type) {
+  ArrayRef<int64_t> shape = type.getShape();
+  SmallVector<SmallVector<unsigned>> offsets;
+  SmallVector<unsigned> shapePerCTA = getShapePerCTATile(dpasLayout);
+
+  for (unsigned i = 0; i < shape[0]; i += shapePerCTA[0]) {
+    for (unsigned j = 0; j < shape[1]; j += shapePerCTA[1]) {
+      emitOffsetForDpasLayoutPerCTA(dpasLayout, offsets, i, j);
+    }
+  }
+
+  return offsets;
+}
 
 // -----------------------------------------------------------------------
-// Get offsets / indices for any layout
+// Dpas layout indices
 // -----------------------------------------------------------------------
+
+static SmallVector<Value>
+emitBaseIndexForDpasLayout(Location loc, RewriterBase &rewriter,
+                           const DpasEncodingAttr &dpasLayout,
+                           RankedTensorType type) {
+  Value threadId = getThreadId(rewriter, loc);
+  Value warpSize = i32_val(triton::gpu::getWarpSize(dpasLayout));
+  Value warpId = udiv(threadId, warpSize);
+  Value laneId = urem(threadId, warpSize);
+
+  auto warpsPerCTA = dpasLayout.getWarpsPerCTA();
+  ArrayRef<int64_t> shape = type.getShape();
+
+  auto order = triton::gpu::getOrder(dpasLayout);
+  SmallVector<Value> multiDimWarpId =
+      delinearize(rewriter, loc, warpId, warpsPerCTA, order);
+
+  // Compute the 2-dim coordinates of the warp containing the tensor element
+  // operated on by this thread.
+  SmallVector<unsigned> warpShape = dpasLayout.getShapeC();
+  Value rowWarpId =
+      urem(multiDimWarpId[0], i32_val(std::ceil(shape[0] / warpShape[0])));
+  Value colWarpId =
+      urem(multiDimWarpId[1], i32_val(std::ceil(shape[1] / warpShape[1])));
+  Value rowWarpOffset = mul(rowWarpId, i32_val(warpShape[0]));
+  Value colWarpOffset = mul(colWarpId, i32_val(warpShape[1]));
+
+  // Compute the 2-dim coordinates of the first element in the warp operated
+  // on by this thread.
+  SmallVector<unsigned> threadsPerWarp = getThreadsPerWarp(dpasLayout);
+  SmallVector<Value> multiDimBase = {
+      add(udiv(laneId, i32_val(threadsPerWarp[1])), rowWarpOffset),
+      add(urem(laneId, i32_val(threadsPerWarp[1])), colWarpOffset)};
+  return multiDimBase;
+}
+
+namespace triton {
+namespace intel {
+static SmallVector<SmallVector<unsigned>>
+emitOffsetForLayout(Attribute layout, RankedTensorType type) {
+  if (auto blockedLayout = layout.dyn_cast<BlockedEncodingAttr>())
+    return emitOffsetForBlockedLayout(blockedLayout, type);
+  if (auto mmaLayout = layout.dyn_cast<NvidiaMmaEncodingAttr>()) {
+    if (mmaLayout.isVolta())
+      return emitOffsetForMmaLayoutV1(mmaLayout, type);
+    if (mmaLayout.isAmpere())
+      return emitOffsetForMmaLayoutV2(mmaLayout, type);
+    if (mmaLayout.isHopper())
+      return emitOffsetForMmaLayoutV3(mmaLayout, type);
+  }
+  if (auto dpasLayout = layout.dyn_cast<DpasEncodingAttr>()) {
+    return emitOffsetForDpasLayout(dpasLayout, type);
+  }
+  if (auto sliceLayout = layout.dyn_cast<SliceEncodingAttr>())
+    return emitOffsetForSliceLayout(sliceLayout, type);
+  llvm_unreachable("unsupported emitOffsetForLayout");
+}
 
 static SmallVector<Value> emitCTAOffsetForLayout(Location loc,
                                                  RewriterBase &rewriter,
@@ -901,7 +272,7 @@ static SmallVector<Value> emitCTAOffsetForLayout(Location loc,
       triton::gpu::getShapePerCTA(CTASplitNum, shape);
 
   // Delinearize clusterCTAId
-  Value clusterCTAId = getClusterCTAId(rewriter, loc);
+  Value clusterCTAId = getClusterCTAIdIntel(rewriter, loc);
   SmallVector<Value> multiDimClusterCTAId =
       delinearize(rewriter, loc, clusterCTAId, CTAsPerCGA, CTAOrder);
 
@@ -944,8 +315,8 @@ emitBaseIndexForLayout(Location loc, RewriterBase &rewriter, Attribute layout,
     auto parentShape = sliceLayout.paddedShape(type.getShape());
     RankedTensorType parentTy =
         RankedTensorType::get(parentShape, type.getElementType(), parentLayout);
-    result = emitBaseIndexForLayout(loc, rewriter, parentLayout, parentTy,
-                                    withCTAOffset);
+    result = ::intel::emitBaseIndexForLayout(loc, rewriter, parentLayout,
+                                             parentTy, withCTAOffset);
     result.erase(result.begin() + sliceLayout.getDim());
     // CTAOffset has been added in emitBaseIndexForLayout of parentLayout
     return result;
@@ -953,87 +324,13 @@ emitBaseIndexForLayout(Location loc, RewriterBase &rewriter, Attribute layout,
     llvm_unreachable("unsupported emitBaseIndexForLayout");
   }
   if (withCTAOffset) {
-    auto CTAOffset = emitCTAOffsetForLayout(loc, rewriter, layout, shape);
+    auto CTAOffset =
+        ::intel::emitCTAOffsetForLayout(loc, rewriter, layout, shape);
     assert(CTAOffset.size() == result.size() && "Rank mismatch");
     for (unsigned k = 0; k < result.size(); ++k)
       result[k] = add(result[k], CTAOffset[k]);
   }
   return result;
-}
-
-static SmallVector<SmallVector<unsigned>>
-emitOffsetForDpasLayout(const DpasEncodingAttr &dpasLayout,
-                        RankedTensorType type) {
-  ArrayRef<int64_t> shape = type.getShape();
-  SmallVector<SmallVector<unsigned>> offsets;
-  SmallVector<unsigned> shapePerCTA = getShapePerCTATile(dpasLayout);
-
-  for (unsigned i = 0; i < shape[0]; i += shapePerCTA[0]) {
-    for (unsigned j = 0; j < shape[1]; j += shapePerCTA[1]) {
-      emitOffsetForDpasLayoutPerCTA(dpasLayout, offsets, i, j);
-    }
-  }
-
-  return offsets;
-}
-
-static SmallVector<SmallVector<unsigned>>
-emitOffsetForLayout(Attribute layout, RankedTensorType type) {
-  if (auto blockedLayout = layout.dyn_cast<BlockedEncodingAttr>())
-    return emitOffsetForBlockedLayout(blockedLayout, type);
-  if (auto mmaLayout = layout.dyn_cast<NvidiaMmaEncodingAttr>()) {
-    if (mmaLayout.isVolta())
-      return emitOffsetForMmaLayoutV1(mmaLayout, type);
-    if (mmaLayout.isAmpere())
-      return emitOffsetForMmaLayoutV2(mmaLayout, type);
-    if (mmaLayout.isHopper())
-      return emitOffsetForMmaLayoutV3(mmaLayout, type);
-  }
-  if (auto dpasLayout = layout.dyn_cast<DpasEncodingAttr>()) {
-    return emitOffsetForDpasLayout(dpasLayout, type);
-  }
-  if (auto sliceLayout = layout.dyn_cast<SliceEncodingAttr>())
-    return emitOffsetForSliceLayout(sliceLayout, type);
-  llvm_unreachable("unsupported emitOffsetForLayout");
-}
-
-// -----------------------------------------------------------------------
-// Dpas layout indices
-// -----------------------------------------------------------------------
-
-static SmallVector<Value>
-emitBaseIndexForDpasLayout(Location loc, RewriterBase &rewriter,
-                           const DpasEncodingAttr &dpasLayout,
-                           RankedTensorType type) {
-  Value threadId = getThreadId(rewriter, loc);
-  Value warpSize = i32_val(triton::gpu::getWarpSize(dpasLayout));
-  Value warpId = udiv(threadId, warpSize);
-  Value laneId = urem(threadId, warpSize);
-
-  auto warpsPerCTA = dpasLayout.getWarpsPerCTA();
-  ArrayRef<int64_t> shape = type.getShape();
-
-  auto order = triton::gpu::getOrder(dpasLayout);
-  SmallVector<Value> multiDimWarpId =
-      delinearize(rewriter, loc, warpId, warpsPerCTA, order);
-
-  // Compute the 2-dim coordinates of the warp containing the tensor element
-  // operated on by this thread.
-  SmallVector<unsigned> warpShape = dpasLayout.getShapeC();
-  Value rowWarpId =
-      urem(multiDimWarpId[0], i32_val(std::ceil(shape[0] / warpShape[0])));
-  Value colWarpId =
-      urem(multiDimWarpId[1], i32_val(std::ceil(shape[1] / warpShape[1])));
-  Value rowWarpOffset = mul(rowWarpId, i32_val(warpShape[0]));
-  Value colWarpOffset = mul(colWarpId, i32_val(warpShape[1]));
-
-  // Compute the 2-dim coordinates of the first element in the warp operated
-  // on by this thread.
-  SmallVector<unsigned> threadsPerWarp = getThreadsPerWarp(dpasLayout);
-  SmallVector<Value> multiDimBase = {
-      add(udiv(laneId, i32_val(threadsPerWarp[1])), rowWarpOffset),
-      add(urem(laneId, i32_val(threadsPerWarp[1])), colWarpOffset)};
-  return multiDimBase;
 }
 
 // Emit indices calculation within each ConversionPattern, and returns a
@@ -1042,10 +339,10 @@ static SmallVector<SmallVector<Value>>
 emitIndices(Location loc, RewriterBase &rewriter, Attribute layout,
             RankedTensorType type, bool withCTAOffset) {
   // step 1, delinearize threadId to get the base index
-  auto multiDimBase =
-      emitBaseIndexForLayout(loc, rewriter, layout, type, withCTAOffset);
+  auto multiDimBase = ::intel::emitBaseIndexForLayout(loc, rewriter, layout,
+                                                      type, withCTAOffset);
   // step 2, get offset of each element
-  auto offset = emitOffsetForLayout(layout, type);
+  auto offset = intel::emitOffsetForLayout(layout, type);
   // step 3, add offset to base, and reorder the sequence
   // of indices to guarantee that elems in the same
   // sizePerThread are adjacent in order
@@ -1112,7 +409,8 @@ DenseMap<unsigned, Value> static getSwizzledSharedPtrs(
          outVec * maxPhase <= srcShape[outOrder[0]] &&
              "Swizzling would generate out of bounds memory accesses");
   // Tensor indices held by the current thread, as LLVM values
-  auto srcIndices = emitIndices(loc, rewriter, srcEncoding, srcTy, false);
+  auto srcIndices =
+      ::intel::emitIndices(loc, rewriter, srcEncoding, srcTy, false);
   // Swizzling with leading offsets (e.g. Hopper GMMA)
   unsigned swizzlingByteWidth = 0;
   if (resSharedLayout.getHasLeadingOffset()) {
@@ -1221,13 +519,15 @@ DenseMap<unsigned, Value> static getSwizzledSharedPtrs(
   return ret;
 }
 
+// good
 static SmallVector<Value>
 loadSharedToDistributed(Value dst, ArrayRef<SmallVector<Value>> dstIndices,
                         Value src, SharedMemoryObject smemObj, Type elemTy,
                         Location loc, ConversionPatternRewriter &rewriter) {
   auto dstTy = dst.getType().cast<RankedTensorType>();
   auto dstShape = dstTy.getShape();
-  assert(dstShape.size() <= 2 && "Unexpected rank of loadSharedToDistributed");
+  assert(dstShape.size() <= 2 &&
+         "Unexpected rank of loadSharedToDistributedIntel");
   auto srcTy = src.getType().cast<MemDescType>();
   auto dstDistributedLayout = dstTy.getEncoding();
   if (auto mmaLayout = dstDistributedLayout.dyn_cast<NvidiaMmaEncodingAttr>()) {
@@ -1250,13 +550,15 @@ loadSharedToDistributed(Value dst, ArrayRef<SmallVector<Value>> dstIndices,
   SmallVector<Value> offsetVals = {smemObj.strides.size(), i32_val(0)};
   assert(outElems == dstIndices.size());
 
-  DenseMap<unsigned, Value> sharedPtrs =
-      getSwizzledSharedPtrs(loc, outVec, dstTy, srcSharedLayout, elemTy,
-                            smemObj, rewriter, offsetVals, smemObj.strides);
+  DenseMap<unsigned, Value> sharedPtrs = ::intel::getSwizzledSharedPtrs(
+      loc, outVec, dstTy, srcSharedLayout, elemTy, smemObj, rewriter,
+      offsetVals, smemObj.strides);
   assert(outElems % minVec == 0 && "Unexpected number of elements");
   unsigned numVecs = outElems / minVec;
   auto wordTy = vec_ty(elemTy, minVec);
   SmallVector<Value> outVals(outElems);
+  LDBG("loadSharedToDistributedIntel: numVecs = " << numVecs << " minVec = "
+                                                  << minVec << " " << wordTy);
   for (unsigned i = 0; i < numVecs; ++i) {
     Value smemAddr = sharedPtrs[i * minVec];
     smemAddr = bitcast(smemAddr, ptr_ty(rewriter.getContext(), 3));
@@ -1269,127 +571,8 @@ loadSharedToDistributed(Value dst, ArrayRef<SmallVector<Value>> dstIndices,
   return outVals;
 }
 
-static void storeDistributedToShared(Value src, ArrayRef<Value> inVals,
-                                     ArrayRef<Value> dstStrides,
-                                     ArrayRef<SmallVector<Value>> srcIndices,
-                                     Value dst, Value smemBase, Type elemTy,
-                                     Location loc,
-                                     ConversionPatternRewriter &rewriter) {
-  auto srcTy = src.getType().cast<RankedTensorType>();
-  auto srcShape = srcTy.getShape();
-  auto rank = srcShape.size();
-  assert(rank == 2 ||
-         rank == 3 && "Unexpected rank of storeDistributedToShared");
-  auto dstTy = dst.getType().cast<MemDescType>();
-  auto srcDistributedLayout = srcTy.getEncoding();
-  if (auto mmaLayout = srcDistributedLayout.dyn_cast<NvidiaMmaEncodingAttr>()) {
-    assert((!mmaLayout.isVolta()) &&
-           "ConvertLayout MMAv1->Shared is not supported yet");
-  }
-  auto dstSharedLayout =
-      dstTy.getEncoding().cast<triton::gpu::SharedEncodingAttr>();
-  auto dstElemTy = dstTy.getElementType();
-  auto inOrd = triton::gpu::getOrder(srcDistributedLayout);
-  auto outOrd = dstSharedLayout.getOrder();
-  unsigned inVec = inOrd == outOrd
-                       ? triton::gpu::getUniqueContigPerThread(
-                             srcDistributedLayout, srcShape)[inOrd[0]]
-                       : 1;
-  unsigned outVec = dstSharedLayout.getVec();
-  unsigned minVec = std::min(outVec, inVec);
-  unsigned numElems = triton::gpu::getTotalElemsPerThread(srcTy);
-  assert(numElems == srcIndices.size());
-  auto wordTy = vec_ty(elemTy, minVec);
-  Value word;
-
-  SmallVector<Value, 3> srcStrides(dstStrides);
-  SmallVector<Value, 3> offsetVals(rank, i32_val(0));
-  SharedMemoryObject smemObj(smemBase, elemTy, srcStrides, offsetVals);
-
-  DenseMap<unsigned, Value> sharedPtrs =
-      getSwizzledSharedPtrs(loc, inVec, srcTy, dstSharedLayout, elemTy, smemObj,
-                            rewriter, offsetVals, srcStrides);
-
-  for (unsigned i = 0; i < numElems; ++i) {
-    if (i % minVec == 0)
-      word = undef(wordTy);
-    word = insert_element(wordTy, word, inVals[i], i32_val(i % minVec));
-    if (i % minVec == minVec - 1) {
-      Value smemAddr = sharedPtrs[i / minVec * minVec];
-      smemAddr = bitcast(smemAddr, ptr_ty(rewriter.getContext(), 3));
-      store(word, smemAddr);
-    }
-  }
-}
-
-static Value
-getStructFromSharedMemoryObject(Location loc, const SharedMemoryObject &smemObj,
-                                ConversionPatternRewriter &rewriter) {
-  auto elems = smemObj.getElems();
-  auto types = smemObj.getTypes();
-  auto structTy =
-      LLVM::LLVMStructType::getLiteral(rewriter.getContext(), types);
-  // pack into struct
-  Value llvmStruct = rewriter.create<LLVM::UndefOp>(loc, structTy);
-  for (const auto &v : llvm::enumerate(elems)) {
-    assert(v.value() && "can not insert null values");
-    llvmStruct = insert_val(structTy, llvmStruct, v.value(), v.index());
-  }
-  return llvmStruct;
-}
-
-static SmallVector<Value>
-unpackLLElements(Location loc, Value llvmStruct,
-                 ConversionPatternRewriter &rewriter) {
-  assert(bool(llvmStruct) && "can not unpack null values");
-  if (llvmStruct.getType().isIntOrIndexOrFloat() ||
-      llvmStruct.getType().isa<triton::PointerType>() ||
-      llvmStruct.getType().isa<LLVM::LLVMPointerType>())
-    return {llvmStruct};
-  ArrayRef<Type> types =
-      llvmStruct.getType().cast<LLVM::LLVMStructType>().getBody();
-  SmallVector<Value> results(types.size());
-  for (unsigned i = 0; i < types.size(); ++i) {
-    Type type = types[i];
-    results[i] = extract_val(type, llvmStruct, i);
-  }
-  return results;
-}
-
-static Value packLLElements(Location loc,
-                            const LLVMTypeConverter *typeConverter,
-                            ValueRange resultVals,
-                            ConversionPatternRewriter &rewriter, Type type) {
-  auto structType =
-      typeConverter->convertType(type).dyn_cast<LLVM::LLVMStructType>();
-  if (!structType) {
-    assert(resultVals.size() == 1);
-    return *resultVals.begin();
-  }
-
-  auto elementTypes = structType.getBody();
-  if (elementTypes.size() != resultVals.size()) {
-    emitError(loc) << " size mismatch when packing elements for LLVM struct"
-                   << " expected " << elementTypes.size() << " but got "
-                   << resultVals.size();
-  }
-  Value llvmStruct = rewriter.create<LLVM::UndefOp>(loc, structType);
-  for (const auto &v : llvm::enumerate(resultVals)) {
-    if (!v.value()) {
-      emitError(loc)
-          << "cannot insert null values into struct, but tried to insert"
-          << v.value();
-    }
-    if (v.value().getType() != elementTypes[v.index()]) {
-      emitError(loc) << "invalid element type in packLLEElements. Expected "
-                     << elementTypes[v.index()] << " but got "
-                     << v.value().getType();
-    }
-    llvmStruct = insert_val(structType, llvmStruct, v.value(), v.index());
-  }
-  return llvmStruct;
-}
-
+} // namespace intel
+} // namespace triton
 } // namespace mlir
 
 #endif


### PR DESCRIPTION
Refactor third_party/intel Utility.h and Utility.cpp to remove code that is common to lib/Conversion/TritonGPUToLLVM/Utility.h/.cpp