### PR TITLE
[Unit test] Fix the unit test cases issue with the assuming of default num_warps=4 and threads_per_warp=32

### DIFF
--- a/python/test/unit/language/assert_helper.py
+++ b/python/test/unit/language/assert_helper.py
@@ -49,15 +49,15 @@ def test_assert(func: str):
     x = torch.arange(0, shape[0], dtype=torch.int32, device='xpu')
     y = torch.zeros(shape, dtype=x.dtype, device="xpu")
     if func == "device_assert":
-        kernel_device_assert[(1, )](x, y, BLOCK=shape[0], threads_per_warp=32)
+        kernel_device_assert[(1, )](x, y, BLOCK=shape[0], num_warps=4, threads_per_warp=32)
     if func == "device_assert_passes":
         # Assert passes; no error.
         kernel_assert_passes[(1, )](x, y, BLOCK=shape[0])
     elif func == "no_debug":
         # TRITON_DEBUG=1 can override the debug flag
-        kernel_device_assert_no_debug[(1, )](x, y, BLOCK=shape[0], threads_per_warp=32)
+        kernel_device_assert_no_debug[(1, )](x, y, BLOCK=shape[0], num_warps=4, threads_per_warp=32)
     elif func == "assert":
-        kernel_assert[(1, )](x, y, BLOCK=shape[0], threads_per_warp=32)
+        kernel_assert[(1, )](x, y, BLOCK=shape[0], num_warps=4, threads_per_warp=32)
     elif func == "static_assert":
         kernel_static_assert[(1, )](x, y, BLOCK=shape[0])
     elif func == "double_assert":
@@ -71,8 +71,8 @@ def test_assert(func: str):
         #  - Now the GPU is in an error state.  We need to detect this inside
         #    the kernel-launch/loading code and bail out properly.  If we don't,
         #    we segfault.
-        kernel_device_assert[(1, )](x, y, BLOCK=shape[0], threads_per_warp=32)
-        kernel_assert_passes[(1, )](x, y, BLOCK=shape[0], threads_per_warp=32)
+        kernel_device_assert[(1, )](x, y, BLOCK=shape[0], num_warps=4, threads_per_warp=32)
+        kernel_assert_passes[(1, )](x, y, BLOCK=shape[0], num_warps=4, threads_per_warp=32)
     assert_close(y, x)
 
 
@@ -132,11 +132,13 @@ def test_assert_nested(caller: str, callee: str):
     x = torch.arange(0, shape[0], dtype=torch.int32, device='xpu')
     y = torch.zeros(shape, dtype=x.dtype, device="xpu")
     if caller == "none":
-        kernel_device_assert_nested[(1, )](x, y, BLOCK=shape[0], jit_debug=callee, threads_per_warp=32)
+        kernel_device_assert_nested[(1, )](x, y, BLOCK=shape[0], jit_debug=callee, num_warps=4, threads_per_warp=32)
     elif caller == "true":
-        kernel_device_assert_nested_true[(1, )](x, y, BLOCK=shape[0], jit_debug=callee, threads_per_warp=32)
+        kernel_device_assert_nested_true[(1, )](x, y, BLOCK=shape[0], jit_debug=callee, num_warps=4,
+                                                threads_per_warp=32)
     elif caller == "false":
-        kernel_device_assert_nested_false[(1, )](x, y, BLOCK=shape[0], jit_debug=callee, threads_per_warp=32)
+        kernel_device_assert_nested_false[(1, )](x, y, BLOCK=shape[0], jit_debug=callee, num_warps=4,
+                                                 threads_per_warp=32)
     assert_close(y, x)
 
 

--- a/python/test/unit/language/print_helper.py
+++ b/python/test/unit/language/print_helper.py
@@ -80,15 +80,15 @@ def test_print(func: str, data_type: str):
     x = torch.arange(0, shape[0], dtype=torch.int32, device='xpu').to(getattr(torch, data_type))
     y = torch.zeros(shape, dtype=x.dtype, device="xpu")
     if func == "device_print":
-        kernel_device_print[(1, )](x, y, BLOCK=shape[0])
+        kernel_device_print[(1, )](x, y, BLOCK=shape[0], num_warps=4, threads_per_warp=32)
     elif func == "print":
-        kernel_print[(1, )](x, y, BLOCK=shape[0])
+        kernel_print[(1, )](x, y, BLOCK=shape[0], num_warps=4, threads_per_warp=32)
     elif func == "device_print_large":
-        kernel_device_print_large[(1, 2)](BLOCK_M=64, BLOCK_N=128)
+        kernel_device_print_large[(1, 2)](BLOCK_M=64, BLOCK_N=128, num_warps=4, threads_per_warp=32)
     elif func == "print_multiple_args":
-        kernel_print_multiple_args[(1, )](x, y, BLOCK=shape[0])
+        kernel_print_multiple_args[(1, )](x, y, BLOCK=shape[0], num_warps=4, threads_per_warp=32)
     elif func == "device_print_multiple_args":
-        kernel_device_print_multiple_args[(1, )](x, y, BLOCK=shape[0])
+        kernel_device_print_multiple_args[(1, )](x, y, BLOCK=shape[0], num_warps=4, threads_per_warp=32)
     elif func == "static_print":
         kernel_static_print[(1, )](x, y, BLOCK=shape[0], PLACEHOLDER=uuid.uuid4())
     elif func == "no_arg_print":
@@ -96,7 +96,7 @@ def test_print(func: str, data_type: str):
     elif func == "print_no_arg":
         kernel_print_no_arg[(1, )](num_warps=4, threads_per_warp=32)
     elif func == "device_print_hex":
-        kernel_device_print_hex[(1, )](x, y, BLOCK=shape[0], threads_per_warp=32)
+        kernel_device_print_hex[(1, )](x, y, BLOCK=shape[0], num_warps=4, threads_per_warp=32)
     else:
         assert f"Unknown kernel: {func}"
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2379,7 +2379,7 @@ def test_locality(op, BLOCK_N, N, num_pid_n, device):
     BLOCK_M = 32
     x = torch.randn((BLOCK_M, N), dtype=torch.float32, device=device)
     y = torch.randn((BLOCK_M, num_pid_n), dtype=torch.float32, device=device)
-    h = kernel[(1, num_pid_n, 1)](x, y, N, BLOCK_M, BLOCK_N)
+    h = kernel[(1, num_pid_n, 1)](x, y, N, BLOCK_M, BLOCK_N, num_warps=4)
     if not is_interpreter():
         assert h.asm['ttgir'].count(
             '"tt.reduce"') == 2, "tt.reduce should be called twice, otherwise the optimization didn't work"


### PR DESCRIPTION
Enhance the unit test cases in advance for the future that we might change the default num_warps and threads_per_warp to Intel GPU arch for XPU backend.

Explicitly set the num_warps and threads_per_warp number in the unit cases which is designed for such value.