### PR TITLE
[SCRIPT] Remove explicit exit when encounter error

### DIFF
--- a/scripts/compile-pytorch-ipex.sh
+++ b/scripts/compile-pytorch-ipex.sh
@@ -139,13 +139,6 @@ if [ "$BUILD_PYTORCH" = false ] && [ "$BUILD_IPEX" = false ]; then
   fi
 fi
 
-check_rc() {
-  if [ $? != 0 ]; then
-    echo "Command failed with rc: $rc"
-    exit 1
-  fi
-}
-
 ############################################################################
 # Configure and build the pytorch project.
 
@@ -172,7 +165,6 @@ build_pytorch() {
   pip install dist/*.whl
   cd $BASE
   python -c "import torch;print(torch.__version__)"
-  check_rc
 }
 
 ############################################################################
@@ -199,7 +191,6 @@ build_ipex() {
   pip install dist/*.whl
   cd $BASE
   python -c "import torch;import intel_extension_for_pytorch as ipex;print(ipex.__version__)"
-  check_rc
 }
 
 build() {

--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -73,13 +73,6 @@ elif [ -v VIRTUAL_ENV ]; then
   deactivate
 fi
 
-check_rc() {
-  if [ $? != 0 ]; then
-    echo "Command failed with rc: $rc"
-    exit 1
-  fi
-}
-
 if [ ! -d "$PACKAGES_DIR" ]; then
   mkdir $PACKAGES_DIR
 fi
@@ -161,11 +154,8 @@ build_llvm() {
 
   echo "****** Building $LLVM_PROJ ******"
   ninja
-  check_rc
   ninja install
-  check_rc
   ninja check-mlir
-  check_rc
 }
 
 ############################################################################
@@ -201,11 +191,9 @@ build_triton() {
 
   cd python
   pip install -e .
-  check_rc
 
   # Install triton tests.
   pip install -vvv -e '.[tests]'
-  check_rc
 
   # Copy compile_commands.json in the build directory (so that cland vscode plugin can find it).
   cp $TRITON_PROJ_BUILD/"$(ls $TRITON_PROJ_BUILD)"/compile_commands.json $TRITON_PROJ/

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -151,7 +151,7 @@ run_tutorial_tests() {
   run_tutorial_test "03-matrix-multiplication"
   run_tutorial_test "04-low-memory-dropout"
   run_tutorial_test "05-layer-norm"
-  run_tutorial_test "06-fused-attention.py"
+  run_tutorial_test "06-fused-attention"
   run_tutorial_test "07-extern-functions"
   run_tutorial_test "08-grouped-gemm"
   run_tutorial_test "09-experimental-block-pointer"


### PR DESCRIPTION
No need to explicitly exit the script when encountering an error, as `set -euo pipefail` should do the same.