### PR TITLE
Fix calling convention.

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -945,8 +945,6 @@ def test_math_op(dtype_x, expr, x, device):
 @pytest.mark.parametrize("dtype", [dtype for dtype in ["float32", "float64"]])
 def test_math_erf_op(dtype, device):
     check_type_supported(dtype, device)
-    if is_xpu():
-        pytest.skip("FIXME: Fails to run on XPU")
     SIZE = 128
 
     @triton.jit

--- a/third_party/intel/lib/GPUToTritonGEN/OpToFuncCallLowering.h
+++ b/third_party/intel/lib/GPUToTritonGEN/OpToFuncCallLowering.h
@@ -63,6 +63,7 @@ public:
     LLVMFuncOp funcOp = appendOrGetFuncOp(funcName, funcType, op);
     auto callOp =
         rewriter.create<LLVM::CallOp>(op->getLoc(), funcOp, castedOperands);
+    callOp.setCConv(LLVM::cconv::CConv::SPIR_FUNC);
 
     if (resultType == adaptor.getOperands().front().getType()) {
       rewriter.replaceOp(op, {callOp.getResult()});


### PR DESCRIPTION
Proper calling convention fixes `test_core.py::test_math_erf_op` which is a part of #755