### PR TITLE
Fix math::FmaOp lowering for XPU.

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -968,8 +968,6 @@ def test_math_erf_op(dtype, device):
 @pytest.mark.parametrize("dtype", [dtype for dtype in ["float32", "float64"]])
 def test_math_fma_op(dtype, device):
     check_type_supported(dtype, device)
-    if is_xpu():
-        pytest.skip("FIXME: Fails to run on XPU")
     SIZE = 128
 
     @triton.jit

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -2480,6 +2480,9 @@ void populateElementwiseOpToLLVMPatterns(
   POPULATE_UNARY_OP(triton::PtrToIntOp, LLVM::PtrToIntOp)
 #undef POPULATE_UNARY_OP
 
+  patterns.add<ElementwiseOpConversion<math::FmaOp, LLVM::FMAOp>>(
+      typeConverter, axisInfoAnalysis, benefit);
+
   patterns.add<OpToExternCallConversion<triton::PreciseSqrtOp>>(
       typeConverter, axisInfoAnalysis, "__imf_sqrtf", benefit);
   patterns.add<OpToExternCallConversion<triton::PreciseDivFOp>>(


### PR DESCRIPTION
This patch enables Triton lowering for `math::FmaOp` instead of the default one to have proper values packing/unpacking on XPU.

Resolves #755 