### PR TITLE
Fix unit test test_reduce_layout issue.

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2474,8 +2474,6 @@ def test_reduce_layouts(M, N, src_layout, axis, epilogue_kind, dtype_str, reduce
     if epilogue_kind == 'expand_reduce2d' and isinstance(src_layout, MmaLayout):
         pytest.skip(
             "Currently MmaLayout combined with slice encoding and reduce op trigger device illegal memory access")
-    if type(src_layout) is DpasLayout:
-        pytest.skip("FIXME: support DPAS layout")
 
     ty = {"int32": "i32", "float32": "f32", "float16": "f16"}[dtype_str]
     arith_op = {

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
@@ -3,6 +3,7 @@
 
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGEN/IR/TritonGENDialect.h"
 #include "triton/Dialect/TritonIntelGPU/IR/Dialect.h"
 
@@ -227,10 +228,10 @@ emitBaseIndexForDpasLayout(Location loc, RewriterBase &rewriter,
   // Compute the 2-dim coordinates of the warp containing the tensor element
   // operated on by this thread.
   SmallVector<unsigned> warpShape = dpasLayout.getShapeC();
-  Value rowWarpId =
-      urem(multiDimWarpId[0], i32_val(std::ceil(shape[0] / warpShape[0])));
-  Value colWarpId =
-      urem(multiDimWarpId[1], i32_val(std::ceil(shape[1] / warpShape[1])));
+  Value rowWarpId = urem(multiDimWarpId[0],
+                         i32_val(mlir::ceil<unsigned>(shape[0], warpShape[0])));
+  Value colWarpId = urem(multiDimWarpId[1],
+                         i32_val(mlir::ceil<unsigned>(shape[1], warpShape[1])));
   Value rowWarpOffset = mul(rowWarpId, i32_val(warpShape[0]));
   Value colWarpOffset = mul(colWarpId, i32_val(warpShape[1]));
 


### PR DESCRIPTION
The DPAS offset layout utils used `std::ceil` incorrectly.
Need to use the `mlir::ceil` for the integer coordinate computation. The logic is `(N + M - 1) / M` for rounding and padding.