### PR TITLE
[ReduceOp] Fix reduce op correctness issue when threads_per_warp < num_warps.

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1958,7 +1958,8 @@ def get_reduced_dtype(dtype_str, op):
     'sum',
 ] for dtype in dtypes_with_bfloat16 for shape in [32, 64, 128, 512]])
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
-def test_reduce1d(op, dtype_str, shape, num_ctas, device):
+@pytest.mark.parametrize("num_warps, threads_per_warp", [(64, 16), (4, 32)] if is_xpu() else [(4, 32)])
+def test_reduce1d(op, dtype_str, shape, num_ctas, num_warps, threads_per_warp, device):
     check_type_supported(dtype_str, device)  # bfloat16 on cc < 80 will not be tested
 
     # triton kernel
@@ -2007,7 +2008,11 @@ def test_reduce1d(op, dtype_str, shape, num_ctas, device):
         z_ref = numpy_op(x).astype(getattr(np, z_dtype_str))
     # triton result
     z_tri = to_triton(numpy_random((1, ), dtype_str=z_dtype_str, rs=rs), device=device, dst_type=z_tri_dtype_str)
-    kernel[(1, )](x_tri, z_tri, BLOCK=shape, num_ctas=num_ctas)
+    if is_xpu():
+        kernel[(1, )](x_tri, z_tri, BLOCK=shape, num_ctas=num_ctas, num_warps=num_warps,
+                      threads_per_warp=threads_per_warp)
+    else:
+        kernel[(1, )](x_tri, z_tri, BLOCK=shape, num_ctas=num_ctas)
     z_tri = to_numpy(z_tri)
     # compare
     if op == 'sum':
@@ -2061,7 +2066,8 @@ keep_dims_3d_configs = [(op, 'float32', (32, 2, 16), axis, True)
     "op, dtype_str, shape, axis, keep_dims", reduce_configs1 + reduce_configs2 + reduce_configs3 + invalid_config +
     negative_config + keep_dims_2d_configs + keep_dims_3d_configs)
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
-def test_reduce(op, dtype_str, shape, axis, keep_dims, num_ctas, device):
+@pytest.mark.parametrize("num_warps, threads_per_warp", [(64, 16), (4, THREADS_PER_WARP)] if is_xpu() else [(4, 32)])
+def test_reduce(op, dtype_str, shape, axis, keep_dims, num_ctas, num_warps, threads_per_warp, device):
     check_type_supported(dtype_str, device)  # bfloat16 on cc < 80 will not be tested
 
     @triton.jit
@@ -2128,12 +2134,22 @@ def test_reduce(op, dtype_str, shape, axis, keep_dims, num_ctas, device):
     IS_3D = bool(len(shape) == 3)
     if axis is not None and axis >= len(shape):
         with pytest.raises(triton.TritonError):
-            kernel[(1, )](x_tri, z_tri, BLOCK_M=shape[0], BLOCK_N=shape[1], BLOCK_K=BLOCK_K, IS_3D=IS_3D, AXIS=axis,
-                          KEEP_DIMS=keep_dims, num_ctas=num_ctas)
+            if is_xpu():
+                kernel[(1, )](x_tri, z_tri, BLOCK_M=shape[0], BLOCK_N=shape[1], BLOCK_K=BLOCK_K, IS_3D=IS_3D, AXIS=axis,
+                              KEEP_DIMS=keep_dims, num_ctas=num_ctas, num_warps=num_warps,
+                              threads_per_warp=threads_per_warp)
+            else:
+                kernel[(1, )](x_tri, z_tri, BLOCK_M=shape[0], BLOCK_N=shape[1], BLOCK_K=BLOCK_K, IS_3D=IS_3D, AXIS=axis,
+                              KEEP_DIMS=keep_dims, num_ctas=num_ctas)
         return
     else:
-        kernel[(1, )](x_tri, z_tri, BLOCK_M=shape[0], BLOCK_N=shape[1], BLOCK_K=BLOCK_K, IS_3D=IS_3D, AXIS=axis,
-                      KEEP_DIMS=keep_dims, num_ctas=num_ctas)
+        if is_xpu():
+            kernel[(1, )](x_tri, z_tri, BLOCK_M=shape[0], BLOCK_N=shape[1], BLOCK_K=BLOCK_K, IS_3D=IS_3D, AXIS=axis,
+                          KEEP_DIMS=keep_dims, num_ctas=num_ctas, num_warps=num_warps,
+                          threads_per_warp=threads_per_warp)
+        else:
+            kernel[(1, )](x_tri, z_tri, BLOCK_M=shape[0], BLOCK_N=shape[1], BLOCK_K=BLOCK_K, IS_3D=IS_3D, AXIS=axis,
+                          KEEP_DIMS=keep_dims, num_ctas=num_ctas)
 
     z_tri = to_numpy(z_tri)
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1958,7 +1958,8 @@ def get_reduced_dtype(dtype_str, op):
     'sum',
 ] for dtype in dtypes_with_bfloat16 for shape in [32, 64, 128, 512]])
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
-@pytest.mark.parametrize("num_warps, threads_per_warp", [(64, 16), (4, 32)] if is_xpu() else [(4, 32)])
+@pytest.mark.parametrize("num_warps, threads_per_warp",
+                         [(64, 16), (4, THREADS_PER_WARP)] if is_xpu() else [(4, THREADS_PER_WARP)])
 def test_reduce1d(op, dtype_str, shape, num_ctas, num_warps, threads_per_warp, device):
     check_type_supported(dtype_str, device)  # bfloat16 on cc < 80 will not be tested
 
@@ -2066,7 +2067,8 @@ keep_dims_3d_configs = [(op, 'float32', (32, 2, 16), axis, True)
     "op, dtype_str, shape, axis, keep_dims", reduce_configs1 + reduce_configs2 + reduce_configs3 + invalid_config +
     negative_config + keep_dims_2d_configs + keep_dims_3d_configs)
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
-@pytest.mark.parametrize("num_warps, threads_per_warp", [(64, 16), (4, THREADS_PER_WARP)] if is_xpu() else [(4, 32)])
+@pytest.mark.parametrize("num_warps, threads_per_warp",
+                         [(64, 16), (4, THREADS_PER_WARP)] if is_xpu() else [(4, THREADS_PER_WARP)])
 def test_reduce(op, dtype_str, shape, axis, keep_dims, num_ctas, num_warps, threads_per_warp, device):
     check_type_supported(dtype_str, device)  # bfloat16 on cc < 80 will not be tested
 

--- a/test/TritonIntelGPU/tritongpu_reduce_op_lowering.mlir
+++ b/test/TritonIntelGPU/tritongpu_reduce_op_lowering.mlir
@@ -1,0 +1,54 @@
+// RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory  --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [64], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 64 : i32} {
+  // CHECK-LABEL: reduce_problem_size_64_threads_per_warp_32
+  tt.func @reduce_problem_size_64_threads_per_warp_32(%f : tensor<2048xi32, #blocked>) {
+
+  // 1st round intra-warp reduce
+  // CHECK: [[SHUFFLE_0_0:%.*]] = llvm.mlir.constant(16 : i32) : i32
+  // CHECK-NEXT:  %{{.*}} = llvm.call @_Z21sub_group_shuffle_xorij({{.*}}, [[SHUFFLE_0_0]]) {passthrough = ["convergent"]} : (i32, i32) -> i32
+  // CHECK: [[SHUFFLE_0_1:%.*]] = llvm.mlir.constant(8 : i32) : i32
+  // CHECK-NEXT:  %{{.*}} = llvm.call @_Z21sub_group_shuffle_xorij({{.*}}, [[SHUFFLE_0_1]]) {passthrough = ["convergent"]} : (i32, i32) -> i32
+  // CHECK: [[SHUFFLE_0_2:%.*]] = llvm.mlir.constant(4 : i32) : i32
+  // CHECK-NEXT:  %{{.*}} = llvm.call @_Z21sub_group_shuffle_xorij({{.*}}, [[SHUFFLE_0_2]]) {passthrough = ["convergent"]} : (i32, i32) -> i32
+  // CHECK: [[SHUFFLE_0_3:%.*]] = llvm.mlir.constant(2 : i32) : i32
+  // CHECK-NEXT:  %{{.*}} = llvm.call @_Z21sub_group_shuffle_xorij({{.*}}, [[SHUFFLE_0_3]]) {passthrough = ["convergent"]} : (i32, i32) -> i32
+  // CHECK: [[SHUFFLE_0_4:%.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT:  %{{.*}} = llvm.call @_Z21sub_group_shuffle_xorij({{.*}}, [[SHUFFLE_0_4]]) {passthrough = ["convergent"]} : (i32, i32) -> i32
+  // CHECK: llvm.store %{{.*}}, %{{.*}} : i32, !llvm.ptr<3>
+
+  // 2nd round inter-warp reduce with problem size 64 with threads_per_warp 32
+  // CHECK: llvm.call @_Z7barrierj(%{{.*}}) {passthrough = ["convergent"]} : (i32) -> ()
+  // CHECK: [[PARTIAL_REDUCE_0:%.*]] = llvm.load %{{.*}} : !llvm.ptr<3> -> i32
+  // CHECK: [[SHUFFLE_1_0:%.*]] = llvm.mlir.constant(16 : i32) : i32
+  // CHECK-NEXT:  %{{.*}} = llvm.call @_Z21sub_group_shuffle_xorij({{.*}}, [[SHUFFLE_1_0]]) {passthrough = ["convergent"]} : (i32, i32) -> i32
+  // CHECK: [[SHUFFLE_1_1:%.*]] = llvm.mlir.constant(8 : i32) : i32
+  // CHECK-NEXT:  %{{.*}} = llvm.call @_Z21sub_group_shuffle_xorij({{.*}}, [[SHUFFLE_1_1]]) {passthrough = ["convergent"]} : (i32, i32) -> i32
+  // CHECK: [[SHUFFLE_1_2:%.*]] = llvm.mlir.constant(4 : i32) : i32
+  // CHECK-NEXT:  %{{.*}} = llvm.call @_Z21sub_group_shuffle_xorij({{.*}}, [[SHUFFLE_1_2]]) {passthrough = ["convergent"]} : (i32, i32) -> i32
+  // CHECK: [[SHUFFLE_1_3:%.*]] = llvm.mlir.constant(2 : i32) : i32
+  // CHECK-NEXT:  %{{.*}} = llvm.call @_Z21sub_group_shuffle_xorij({{.*}}, [[SHUFFLE_1_3]]) {passthrough = ["convergent"]} : (i32, i32) -> i32
+  // CHECK: [[SHUFFLE_1_4:%.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT:  %{{.*}} = llvm.call @_Z21sub_group_shuffle_xorij({{.*}}, [[SHUFFLE_1_4]]) {passthrough = ["convergent"]} : (i32, i32) -> i32
+  // CHECK: llvm.store %{{.*}}, %{{.*}} : i32, !llvm.ptr<3>
+
+  // 3rd round inter-warp reduce with problem size 2 with threads_per_warp 32
+  // CHECK: llvm.call @_Z7barrierj(%{{.*}}) {passthrough = ["convergent"]} : (i32) -> ()
+  // CHECK: [[PARTIAL_REDUCE_1:%.*]] = llvm.load %{{.*}} : !llvm.ptr<3> -> i32
+  // CHECK: [[SHUFFLE_2_0:%.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT:  %{{.*}} = llvm.call @_Z21sub_group_shuffle_xorij({{.*}}, [[SHUFFLE_2_0]]) {passthrough = ["convergent"]} : (i32, i32) -> i32
+  // CHECK: llvm.store %{{.*}}, %{{.*}} : i32, !llvm.ptr<3>
+
+  // get final result
+  // CHECK: llvm.call @_Z7barrierj(%{{.*}}) {passthrough = ["convergent"]} : (i32) -> ()
+  // CHECK: [[FINAL_RESULT:%.*]] = llvm.load %{{.*}} : !llvm.ptr<3> -> i32
+
+    %g = "tt.reduce" (%f) ({
+    ^bb0(%arg0: i32, %arg1: i32):
+      %add = arith.addi %arg0, %arg1 : i32
+      tt.reduce.return %add : i32
+    }) {axis = 0 : i32} : (tensor<2048xi32, #blocked>) -> i32
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/tritongpu_reduce_op_lowering.mlir
+++ b/test/TritonIntelGPU/tritongpu_reduce_op_lowering.mlir
@@ -1,5 +1,7 @@
 // RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory  --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm
 
+// COM: Tests reduction when threads_per_warp < num_warps.
+
 #blocked = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [64], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 64 : i32} {
   // CHECK-LABEL: reduce_problem_size_64_threads_per_warp_32

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceOpToLLVM.cpp
@@ -1,7 +1,6 @@
 #include "PatternTritonGPUOpToLLVM.h"
 #include "ReduceScanCommon.h"
 #include "Utility.h"
-#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 
 using namespace mlir;
@@ -310,6 +309,8 @@ private:
     auto smemShape = helper.getScratchConfig();
     unsigned elems = product<unsigned>(smemShape);
     unsigned sizeInterWarps = helper.getInterWarpSizeWithUniqueData();
+    assert(((sizeInterWarps - 1) & sizeInterWarps) == 0 &&
+           "sizeInterWarps must be 2^m.");
     Location loc = op.getLoc();
 
     Value threadId = getThreadId(rewriter, loc);
@@ -318,42 +319,76 @@ private:
     Value zero = i32_val(0);
 
     auto mod = op.getOperation()->getParentOfType<ModuleOp>();
+    unsigned threadsPerWarp =
+        triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
+    assert(threadsPerWarp > 1 &&
+           "threadsPerWarp must be larger than 1 to do warp reduce.");
     unsigned numThreads =
         product<unsigned>(triton::gpu::getWarpsPerCTA(srcLayout)) *
-        triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
-    unsigned elemsPerThread = std::max<unsigned>(elems / numThreads, 1);
-    Value threadIsNeeded = icmp_slt(threadId, i32_val(elems));
-    Value readOffset = threadId;
-    for (unsigned round = 0; round < elemsPerThread; ++round) {
-      SmallVector<Value> acc(op.getNumOperands());
-      for (unsigned i = 0; i < op.getNumOperands(); ++i) {
-        auto elemTy = getElementType(op, i);
-        Value readPtr = gep(ptr_ty(rewriter.getContext(), 3), elemTy,
-                            smemBases[i], readOffset);
-        acc[i] = targetInfo.loadShared(rewriter, loc, readPtr, elemTy,
-                                       threadIsNeeded);
-      }
-      warpReduce(rewriter, loc, acc, op, sizeInterWarps, 1 /* interleave */);
-      // only the first thread in each sizeInterWarps is writing
-      Value writeOffset = readOffset;
-      SmallVector<Value> writePtrs(op.getNumOperands());
-      for (unsigned i = 0; i < op.getNumOperands(); ++i) {
-        auto elemTy = getElementType(op, i);
-        writePtrs[i] = gep(ptr_ty(rewriter.getContext(), 3), elemTy,
-                           smemBases[i], writeOffset);
+        threadsPerWarp;
+
+    // It is a batched reduce with the initial problem shape [elems /
+    // sizeInterWarps, sizeInterWarps]. The threadsPerWarp is 2^n. The
+    // sizeInterWarps is 2^m. With the horizontal warp reduction, the problem
+    // size is [elems / sizeInterWarps, N] -> [elems / sizeInterWarps, ceil(N,
+    // threadsPerWarp)] in each reduce iteration.
+    unsigned problemBatchSize = elems / sizeInterWarps;
+    for (unsigned problemSize = sizeInterWarps; problemSize > 0;
+         problemSize = problemSize / threadsPerWarp) {
+      unsigned reduceLaneNumber = std::min(problemSize, threadsPerWarp);
+      unsigned totalProblemSizePerIter = problemSize * problemBatchSize;
+      unsigned elemsPerThread =
+          mlir::ceil<unsigned>(totalProblemSizePerIter, numThreads);
+
+      // The problem stride in each iteration is [sizeInterWarps / problemSize]
+      Value readOffset = mul(threadId, i32_val(sizeInterWarps / problemSize));
+
+      for (unsigned round = 0; round < elemsPerThread; ++round) {
+        Value threadIsNeeded = icmp_slt(readOffset, i32_val(elems));
+
+        SmallVector<Value> acc(op.getNumOperands());
+        for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+          auto elemTy = getElementType(op, i);
+          Value readPtr =
+              gep(ptr_ty(rewriter.getContext(),
+                         triton::TritonGEN::TritonGENMemorySpace::kWorkgroup),
+                  elemTy, smemBases[i], readOffset);
+          acc[i] = targetInfo.loadShared(rewriter, loc, readPtr, elemTy,
+                                         threadIsNeeded);
+        }
+        warpReduce(rewriter, loc, acc, op, reduceLaneNumber,
+                   1 /* interleave */);
+
+        Value writeOffset = readOffset;
+        SmallVector<Value> writePtrs(op.getNumOperands());
+        for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+          auto elemTy = getElementType(op, i);
+          writePtrs[i] =
+              gep(ptr_ty(rewriter.getContext(),
+                         triton::TritonGEN::TritonGENMemorySpace::kWorkgroup),
+                  elemTy, smemBases[i], writeOffset);
+        }
+
+        // only the first thread in each reduceLaneNumber is writing
+        Value threadIdModSizeReduceLanes =
+            urem(threadId, i32_val(reduceLaneNumber));
+        Value threadIdModSizeReduceLanesIsZero =
+            icmp_eq(threadIdModSizeReduceLanes, zero);
+        Value pred = and_(threadIsNeeded, threadIdModSizeReduceLanesIsZero);
+
+        for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+          targetInfo.storeShared(rewriter, loc, writePtrs[i], acc[i], pred);
+        }
+
+        if (round != elemsPerThread - 1) {
+          readOffset = add(
+              readOffset, i32_val(numThreads * (sizeInterWarps / problemSize)));
+        }
       }
 
-      Value laneIdModSizeInterWarps = urem(laneId, i32_val(sizeInterWarps));
-      Value laneIdModSizeInterWarpsIsZero =
-          icmp_eq(laneIdModSizeInterWarps, zero);
-      Value pred = and_(threadIsNeeded, laneIdModSizeInterWarpsIsZero);
-
-      for (unsigned i = 0; i < op.getNumOperands(); ++i) {
-        targetInfo.storeShared(rewriter, loc, writePtrs[i], acc[i], pred);
-      }
-
-      if (round != elemsPerThread - 1) {
-        readOffset = add(readOffset, i32_val(numThreads));
+      if (problemSize > threadsPerWarp) {
+        // More reduce iteration required. Synchronize here.
+        sync(rewriter, loc, op);
       }
     }
   }


### PR DESCRIPTION
Fix the issue in `accumulatePartialReductions` when sizeInterWarps >
threads_per_warp.
Use the warp reduction multiple times to get final result when the
problem size > maximum reduce lane number.