### PR TITLE
Add prefetch ops lowering pattern.

### DIFF
--- a/include/triton/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/include/triton/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -36,7 +36,7 @@ def TTIG_AllocOp : TTIG_Op<"alloc", [MemoryEffects<[MemAlloc]>]> {
 def TTIG_PrefetchOp : TTIG_Op<"prefetch", []> {
   let summary = "Prefetch from a tensor pointer";
 
-  let arguments = (ins AnyTypeOf<[TT_TensorPtr]>:$ptr, TT_CacheModifierAttr:$cache,
+  let arguments = (ins AnyTypeOf<[TT_PtrLike, TT_TensorPtr]>:$ptr, TT_CacheModifierAttr:$cache,
                        TT_EvictionPolicyAttr:$evict, BoolAttr:$isVolatile);
 
   let results = (outs);


### PR DESCRIPTION
Add the prefetching ops lowering pattern in advance for Intel GPU matmul pipelining.
1. A placeholder pattern to omit the prefetching ops which allow the functionality test cases.
2. Support both the tensor of pointers and block pointer in prefetching op.