### PR TITLE
[GEN] Use OCL builtin for tf32 dpas

### DIFF
--- a/scripts/skiplist/conda/operators.txt
+++ b/scripts/skiplist/conda/operators.txt
@@ -1,1 +1,3 @@
+test/unit/operators/test_matmul.py::test_op[128-256-64-1-8-3-256-512-160-True-False-float32-float32-None-True-None-None]
+test/unit/operators/test_matmul.py::test_op[128-256-64-1-8-3-256-512-160-False-False-float32-float32-None-True-None-None]
 test/unit/operators/test_matmul.py::test_op[128-256-64-1-8-3-256-512-160-True-True-float32-float32-None-True-None-None]

--- a/scripts/skiplist/default/operators.txt
+++ b/scripts/skiplist/default/operators.txt
@@ -1,1 +1,3 @@
+test/unit/operators/test_matmul.py::test_op[128-256-64-1-8-3-256-512-160-True-False-float32-float32-None-True-None-None]
+test/unit/operators/test_matmul.py::test_op[128-256-64-1-8-3-256-512-160-False-False-float32-float32-None-True-None-None]
 test/unit/operators/test_matmul.py::test_op[128-256-64-1-8-3-256-512-160-True-True-float32-float32-None-True-None-None]

--- a/test/Conversion/intel/tritongpu_to_gen_dot.mlir
+++ b/test/Conversion/intel/tritongpu_to_gen_dot.mlir
@@ -58,7 +58,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
   // CHECK-LABEL: dot_i32_i8_i8_i32_2
   tt.func @dot_i32_i8_i8_i32_2(%a: tensor<8x64xi8, #dot_operand_a>, %b: tensor<64x16xi8, #dot_operand_b>, %c: tensor<8x16xi32, #dpas>) {
     // COM: 2 repetition along axis for K.
-    // CHECK: llvm.call spir_funccc @_Z36intel_sub_group_i8_i8_matrix_mad_k32Dv8_sDv8_iS0_(%{{.*}}, %{{.*}}, %{{.*}}) {{.*}} : (vector<8xi16>, vector<8xi32>, vector<8xi32>) -> vector<8xi32>
+    // CHECK-COUNT2: llvm.call spir_funccc @_Z36intel_sub_group_i8_i8_matrix_mad_k32Dv8_sDv8_iS0_(%{{.*}}, %{{.*}}, %{{.*}}) {{.*}} : (vector<8xi16>, vector<8xi32>, vector<8xi32>) -> vector<8xi32>
     %0 = tt.dot %a, %b, %c, inputPrecision = tf32 : tensor<8x64xi8, #dot_operand_a> * tensor<64x16xi8, #dot_operand_b> -> tensor<8x16xi32, #dpas>
     tt.return
   }
@@ -73,7 +73,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
   // CHECK-LABEL: dot_f32_tf32_tf32_f32_1
   tt.func @dot_f32_tf32_tf32_f32_1(%a: tensor<8x8xf32, #dot_operand_a>, %b: tensor<8x16xf32, #dot_operand_b>, %c: tensor<8x16xf32, #dpas>) {
-    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.sub.group.dpas.v8f32.v8f32.v4i32.v8i32
+    // CHECK: llvm.call spir_funccc @_Z43intel_sub_group_tf32_tf32_matrix_mad_k8_f32Dv4_fDv8_fS0_(%{{.*}}, %{{.*}}, %{{.*}}) {{.*}} : (vector<4xf32>, vector<8xf32>, vector<8xf32>) -> vector<8xf32>
     %0 = tt.dot %a, %b, %c, inputPrecision = tf32 : tensor<8x8xf32, #dot_operand_a> * tensor<8x16xf32, #dot_operand_b> -> tensor<8x16xf32, #dpas>
     tt.return
   }
@@ -89,7 +89,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
   // CHECK-LABEL: dot_f32_tf32_tf32_f32_2
   tt.func @dot_f32_tf32_tf32_f32_2(%a: tensor<8x8xf32, #dot_operand_a>, %b: tensor<8x32xf32, #dot_operand_b>, %c: tensor<8x32xf32, #dpas>) {
     // COM: 2 repetitions along axis for N.
-    // CHECK-COUNT-2: llvm.call spir_funccc @llvm.genx.GenISA.sub.group.dpas.v8f32.v8f32.v4i32.v8i32
+    // CHECK-COUNT-2: llvm.call spir_funccc @_Z43intel_sub_group_tf32_tf32_matrix_mad_k8_f32Dv4_fDv8_fS0_(%{{.*}}, %{{.*}}, %{{.*}}) {{.*}} : (vector<4xf32>, vector<8xf32>, vector<8xf32>) -> vector<8xf32>
     %0 = tt.dot %a, %b, %c, inputPrecision = tf32 : tensor<8x8xf32, #dot_operand_a> * tensor<8x32xf32, #dot_operand_b> -> tensor<8x32xf32, #dpas>
     tt.return
   }

--- a/test/TritonGEN/tritongen-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-to-llvm.mlir
@@ -278,19 +278,12 @@ llvm.func @triton_gen.dpas.f16(%c : vector<8xf32>, %a : vector<8xi16>, %b : vect
 
 // -----
 
-// CHECK: llvm.func spir_funccc @llvm.genx.GenISA.sub.group.dpas.v8f32.v8f32.v4i32.v8i32(vector<8xf32>, vector<4xi32>, vector<8xi32>, i32, i32, i32, i32, i1) -> vector<8xf32>
+// CHECK: llvm.func spir_funccc @_Z43intel_sub_group_tf32_tf32_matrix_mad_k8_f32Dv4_fDv8_fS0_(vector<4xf32>, vector<8xf32>, vector<8xf32>) -> vector<8xf32> attributes {passthrough = ["convergent"]}
 
 llvm.func @triton_gen.dpas.f32(%c : vector<8xf32>, %a : vector<4xf32>, %b : vector<8xf32>) {
   // CHECK:     llvm.func @triton_gen.dpas.f32(%arg0: vector<8xf32>, %arg1: vector<4xf32>, %arg2: vector<8xf32>) {
-  // CHECK-DAG:  [[A:%.*]] = llvm.bitcast %arg1 : vector<4xf32> to vector<4xi32>
-  // CHECK-DAG:  [[B:%.*]] = llvm.bitcast %arg2 : vector<8xf32> to vector<8xi32>
-  // CHECK-DAG:  [[CST_8a:%.*]] = llvm.mlir.constant(8 : i32) : i32
-  // CHECK-DAG:  [[CST_8b:%.*]] = llvm.mlir.constant(8 : i32) : i32
-  // CHECK-DAG:  [[CST_8c:%.*]] = llvm.mlir.constant(8 : i32) : i32
-  // CHECK-DAG:  [[CST_8d:%.*]] = llvm.mlir.constant(8 : i32) : i32
-  // CHECK-DAG:  [[CST_FALSE:%.*]] = llvm.mlir.constant(false) : i1
-  // CHECK-NEXT: llvm.call spir_funccc @llvm.genx.GenISA.sub.group.dpas.v8f32.v8f32.v4i32.v8i32
-  // CHEC-SAME:    (%arg0, [[A]], [[B]], [[CST_8a]], [[CST_8b]], [[CST_8c]], [[CST_8d]], [[CST_FALSE]]) : (vector<8xf32>, vector<4xi32>, vector<8xi32>, i32, i32, i32, i32, i1) -> vector<8xf32>
+  // CHECK-NEXT: llvm.call spir_funccc @_Z43intel_sub_group_tf32_tf32_matrix_mad_k8_f32Dv4_fDv8_fS0_
+  // CHEC-SAME:    (%arg1, %arg2, %arg0)  {passthrough = ["convergent"]} : (vector<4xf32>, vector<8xi32>, vector<8xf32>) -> vector<8xf32>
   %0 = triton_gen.dpas %c, %a, %b {pa = tf32, pb = tf32, rc = 8} : (vector<8xf32>, vector<4xf32>, vector<8xf32>) -> vector<8xf32>
   llvm.return
 }

--- a/test/TritonIntelGPU/load-to-llvm-2dload.mlir
+++ b/test/TritonIntelGPU/load-to-llvm-2dload.mlir
@@ -40,7 +40,7 @@ module attributes {"triton_gpu.num-warps" = 8 : i32, "triton_gpu.threads-per-war
     %ptrB = tt.make_tensor_ptr %arg1, [%arg4, %arg3], [%arg7, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<32x64xf32, #dot1>>
     // CHECK-COUNT-4: llvm.call spir_funccc @llvm.genx.GenISA.LSC2DBlockRead.v8i32{{.*}} -> vector<8xi32>
     // CHECK-COUNT-4: llvm.call spir_funccc @llvm.genx.GenISA.LSC2DBlockRead.v8i32{{.*}} -> vector<8xi32>
-    // CHECK-COUNT-8: llvm.call spir_funccc @llvm.genx.GenISA.sub.group.dpas.v8f32.v8f32.v8i32.v8i32({{.*}}) : (vector<8xf32>, vector<8xi32>, vector<8xi32>, i32, i32, i32, i32, i1) -> vector<8xf32>
+    // CHECK-COUNT-8: llvm.call spir_funccc @_Z43intel_sub_group_tf32_tf32_matrix_mad_k8_f32Dv8_fDv8_fS0_({{.*}}) {{.*}} : (vector<8xf32>, vector<8xf32>, vector<8xf32>) -> vector<8xf32>
     %A = tt.load %ptrA {boundaryCheck = array<i32: 1>, padding = 1 : i32} : !tt.ptr<tensor<64x32xf32, #dot0>>
     %B = tt.load %ptrB {boundaryCheck = array<i32: 0>, padding = 1 : i32} : !tt.ptr<tensor<32x64xf32, #dot1>>
     %D = tt.dot %A, %B, %C, inputPrecision = tf32 : tensor<64x32xf32, #dot0> * tensor<32x64xf32, #dot1> -> tensor<64x64xf32, #dpas>

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -138,19 +138,21 @@ static unsigned getNumOperandsPerDword(TritonGEN::PrecisionType pTy) {
 
 static LLVM::CallOp createGenISADPAS(TritonGEN::MatrixDPASOp op,
                                      ConversionPatternRewriter &rewriter) {
-  auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
-  MLIRContext *context = rewriter.getContext();
   Type resType = op->getResultTypes()[0];
   TypeRange opTypes = op->getOperandTypes();
   Location loc = op->getLoc();
 
-  IntegerType int1Ty = rewriter.getIntegerType(1);
+  FloatType fp32Ty = rewriter.getF32Type();
   IntegerType int16Ty = rewriter.getIntegerType(16);
   IntegerType int32Ty = rewriter.getIntegerType(32);
 
   TritonGEN::PrecisionType precisionA = op.getPa();
-  Type packedAType =
-      (precisionA == TritonGEN::PrecisionType::TF32) ? int32Ty : int16Ty;
+  Type packedAType = (precisionA == TritonGEN::PrecisionType::TF32)
+                         ? cast<Type>(fp32Ty)
+                         : int16Ty;
+  Type packedBType = (precisionA == TritonGEN::PrecisionType::TF32)
+                         ? cast<Type>(fp32Ty)
+                         : int32Ty;
 
   Value a = op.getA();
   VectorType aOrigTy = cast<VectorType>(a.getType());
@@ -165,64 +167,33 @@ static LLVM::CallOp createGenISADPAS(TritonGEN::MatrixDPASOp op,
   VectorType bOrigTy = cast<VectorType>(b.getType());
   bitWidth = bOrigTy.getNumElements() *
              bOrigTy.getElementType().getIntOrFloatBitWidth();
-  VectorType bTy = VectorType::get(bitWidth / 32, int32Ty);
+  VectorType bTy = VectorType::get(
+      bitWidth / packedBType.getIntOrFloatBitWidth(), packedBType);
   if (bOrigTy != bTy)
     b = rewriter.create<LLVM::BitcastOp>(loc, bTy, b);
 
-  // FIXME: Use the OpenCL API also for TF32.
-  if (precisionA != TritonGEN::PrecisionType::TF32) {
-    std::string fnName =
-        "intel_sub_group_" + stringifyPrecisionType(precisionA).str() + "_" +
-        stringifyPrecisionType(op.getPb()).str() + "_matrix_mad_k" +
-        std::to_string(8 /*systolic depth*/ *
-                       getNumOperandsPerDword(precisionA));
-    std::string bMangledTy = intel::getTypeMangling(bTy);
-    std::string cMangledTy = intel::getTypeMangling(opTypes[0]);
-    if (bMangledTy == cMangledTy)
-      cMangledTy = "S0_";
-    fnName = "_Z" + std::to_string(fnName.size()) + fnName +
-             intel::getTypeMangling(aTy) + bMangledTy + cMangledTy;
-    SmallVector<Type> argTypes{aTy, bTy, opTypes[0]};
-    SmallVector<Value> args{a, b, op.getC()};
+  std::string fnName =
+      "intel_sub_group_" + stringifyPrecisionType(precisionA).str() + "_" +
+      stringifyPrecisionType(op.getPb()).str() + "_matrix_mad_k" +
+      std::to_string(8 /*systolic depth*/ * getNumOperandsPerDword(precisionA));
+  if (precisionA == TritonGEN::PrecisionType::TF32)
+    fnName += "_f32";
+  std::string bMangledTy = intel::getTypeMangling(bTy);
+  std::string cMangledTy = intel::getTypeMangling(opTypes[0]);
+  if (bMangledTy == cMangledTy)
+    cMangledTy = "S0_";
+  fnName = "_Z" + std::to_string(fnName.size()) + fnName +
+           intel::getTypeMangling(aTy) + bMangledTy + cMangledTy;
+  SmallVector<Type> argTypes{aTy, bTy, opTypes[0]};
+  SmallVector<Value> args{a, b, op.getC()};
 
-    MLIRContext *ctx = rewriter.getContext();
-    intel::AttrBuilder funcAttrBuilder(*ctx);
-    funcAttrBuilder.addPassthroughAttribute(llvm::Attribute::Convergent);
-    intel::AttributeList attrs = getAttrList(funcAttrBuilder);
+  MLIRContext *ctx = rewriter.getContext();
+  intel::AttrBuilder funcAttrBuilder(*ctx);
+  funcAttrBuilder.addPassthroughAttribute(llvm::Attribute::Convergent);
+  intel::AttributeList attrs = getAttrList(funcAttrBuilder);
 
-    return createDeviceFunctionCall(rewriter, fnName, resType, argTypes, args,
-                                    attrs);
-  }
-
-  llvm::LLVMContext llvmContext;
-  LLVM::TypeToLLVMIRTranslator typeTranslator(llvmContext);
-  auto llvmResTy = typeTranslator.translateType(resType);
-  auto llvmCTy = typeTranslator.translateType(opTypes[0]);
-  auto llvmATy = typeTranslator.translateType(aTy);
-  auto llvmBTy = typeTranslator.translateType(bTy);
-  SmallVector<llvm::Type *> llvmTypes{llvmResTy, llvmCTy, llvmATy, llvmBTy};
-  std::string funcName = llvm::GenISAIntrinsic::getName(
-      llvm::GenISAIntrinsic::GenISA_sub_group_dpas, llvmTypes);
-
-  SmallVector<Type> argTypes{opTypes[0], aTy,     bTy,     int32Ty,
-                             int32Ty,    int32Ty, int32Ty, int1Ty};
-  LLVM::LLVMFuncOp funcOp =
-      LLVM::lookupOrCreateFn(moduleOp, funcName, argTypes, resType);
-  funcOp.setCConv(LLVM::cconv::CConv::SPIR_FUNC);
-
-  auto precA = rewriter.create<LLVM::ConstantOp>(loc, int32Ty,
-                                                 static_cast<int>(op.getPa()));
-  auto precB = rewriter.create<LLVM::ConstantOp>(loc, int32Ty,
-                                                 static_cast<int>(op.getPa()));
-  auto sysDepth =
-      rewriter.create<LLVM::ConstantOp>(loc, int32Ty, 8 /* systolic depth */);
-  auto RC = rewriter.create<LLVM::ConstantOp>(loc, int32Ty, op.getRc());
-  auto False = rewriter.create<LLVM::ConstantOp>(loc, int1Ty, false);
-  SmallVector<Value> args{op.getC(), a, b, precA, precB, sysDepth, RC, False};
-
-  auto callOp = rewriter.create<LLVM::CallOp>(loc, funcOp, args);
-  callOp.setCConv(LLVM::cconv::CConv::SPIR_FUNC);
-  return callOp;
+  return createDeviceFunctionCall(rewriter, fnName, resType, argTypes, args,
+                                  attrs);
 }
 
 static bool isOCLBuiltinAvailable(TritonGEN::Matrix2DBlockLoadOp op) {


### PR DESCRIPTION
Awaiting for a release driver that contains the support of the OCL builtin.

Replace with OCL builtin: `float8 intel_sub_group_tf32_tf32_matrix_mad_k8_f32(float4 a, float8 b, float8 acc);`