### PR TITLE
Change target[1] to sycl_device and acquire arch info from Triton side

### DIFF
--- a/.github/pins/ipex.txt
+++ b/.github/pins/ipex.txt
@@ -1,1 +1,1 @@
-ffc62ab3a7ed4cf56dbf1028457b7e4ae34004e4
+47015a84d0ca2f01a661bcd0ac190cbabbaecac3

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -184,7 +184,7 @@ def test_annotation():
 
     x = torch.empty(1, dtype=torch.int32, device='xpu')
 
-    device = torch.xpu.current_device()
+    device = triton.runtime.driver.active.get_current_device()
     kernel[(1, )](x, 1)
     kernel[(1, )](x, 8)
     kernel[(1, )](x, 16)
@@ -226,7 +226,7 @@ def test_jit_warmup_cache() -> None:
         torch.randn(32, dtype=torch.float32, device="xpu"),
         32,
     ]
-    device = torch.xpu.current_device()
+    device = triton.runtime.driver.active.get_current_device()
     assert len(kernel_add.cache[device]) == 0
     kernel_add.warmup(torch.float32, torch.float32, torch.float32, 32, grid=(1, ))
     assert len(kernel_add.cache[device]) == 1
@@ -244,7 +244,7 @@ def test_jit_debug() -> None:
         tl.device_assert(idx < 32, "idx < 32")
         tl.store(o + idx, tl.load(a + idx) + tl.load(b + idx))
 
-    device = torch.xpu.current_device()
+    device = triton.runtime.driver.active.get_current_device()
     assert len(kernel_add.cache[device]) == 0
     kernel_add.warmup(torch.float32, torch.float32, torch.float32, 32, grid=(1, ))
     assert len(kernel_add.cache[device]) == 1
@@ -270,7 +270,7 @@ def test_jit_noinline() -> None:
     def kernel_add_device(a, b, o, N: tl.constexpr):
         add_fn(a, b, o, N)
 
-    device = torch.xpu.current_device()
+    device = triton.runtime.driver.active.get_current_device()
     assert len(kernel_add_device.cache[device]) == 0
     kernel_add_device.warmup(torch.float32, torch.float32, torch.float32, 32, grid=(1, ))
     assert len(kernel_add_device.cache[device]) == 1
@@ -314,7 +314,7 @@ def test_preload() -> None:
         tl.device_assert(idx < 32, "idx < 32")
         tl.store(o + idx, tl.load(a + idx) - tl.load(b + idx))
 
-    device = torch.xpu.current_device()
+    device = triton.runtime.driver.active.get_current_device()
 
     # get the serialized specialization data
     specialization_data = None

--- a/python/test/unit/runtime/test_subproc.py
+++ b/python/test/unit/runtime/test_subproc.py
@@ -40,7 +40,7 @@ def test_compile_in_subproc() -> None:
         major, minor = torch.cuda.get_device_capability(0)
         cc = major * 10 + minor
     elif torch.xpu.is_available():
-        capability = torch.xpu.device(torch.xpu.current_device()).sycl_device
+        cc = torch.xpu.device(torch.xpu.current_device()).sycl_device
 
     config = triton.compiler.AttrsDescriptor(tuple(range(4)), ())
 

--- a/python/test/unit/runtime/test_subproc.py
+++ b/python/test/unit/runtime/test_subproc.py
@@ -40,7 +40,7 @@ def test_compile_in_subproc() -> None:
         major, minor = torch.cuda.get_device_capability(0)
         cc = major * 10 + minor
     elif torch.xpu.is_available():
-        cc = torch.xpu.get_device_capability(0)
+        capability = torch.xpu.device(torch.xpu.current_device()).sycl_device
 
     config = triton.compiler.AttrsDescriptor(tuple(range(4)), ())
 
@@ -71,7 +71,7 @@ def test_compile_in_forked_subproc() -> None:
         major, minor = torch.cuda.get_device_capability(0)
         capability = major * 10 + minor
     elif torch.xpu.is_available():
-        capability = torch.xpu.device(0).sycl_device
+        capability = torch.xpu.device(torch.xpu.current_device()).sycl_device
 
     config = triton.compiler.AttrsDescriptor(tuple(range(1)), ())
 

--- a/python/test/unit/runtime/test_subproc.py
+++ b/python/test/unit/runtime/test_subproc.py
@@ -71,7 +71,7 @@ def test_compile_in_forked_subproc() -> None:
         major, minor = torch.cuda.get_device_capability(0)
         capability = major * 10 + minor
     elif torch.xpu.is_available():
-        capability = torch.xpu.get_device_capability(0)
+        capability = torch.xpu.device(0).sycl_device
 
     config = triton.compiler.AttrsDescriptor(tuple(range(1)), ())
 

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -249,7 +249,7 @@ def compile(src, target=None, options=None):
     # initialize metadata
     metadata = {
         "hash": hash,
-        "target": target,
+        "target": backend.parse_target(target),
         **options.__dict__,
         **get_env_vars(),
     }

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -128,7 +128,7 @@ class XPUBackend(BaseBackend):
         # TTIR -> TTGIR
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
-        passes.ttir.add_convert_to_ttgpuir(pm, opt.num_warps, opt.threads_per_warp, opt.num_ctas, 80)
+        passes.ttir.add_convert_to_ttgpuir(pm, opt.num_warps, opt.threads_per_warp, opt.num_ctas, device_arch)
         # optimize TTGIR
         passes.ttgpuir.add_coalesce(pm)
         # TODO(Qingyi): Move PlanCTAPass to the front of CoalescePass

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -52,7 +52,15 @@ class XPUUtils(object):
         dirname = os.path.dirname(os.path.realpath(__file__))
         mod = compile_module_from_src(Path(os.path.join(dirname, "driver.c")).read_text(), "spirv_utils")
         self.load_binary = mod.load_binary
-        self.get_device_properties = mod.get_device_properties
+        self.get_device_prop = mod.get_device_properties
+        self.is_capsule = mod.is_capsule
+        self.unpack_capsule = mod.unpack_capsule
+
+    def get_device_properties(self, device):
+        if self.is_capsule(device):
+            return self.get_device_prop(self.unpack_capsule(device))
+        else:
+            return self.get_device_prop(device)
 
     def get_current_device(self):
         import torch
@@ -64,7 +72,8 @@ class XPUUtils(object):
 
     def get_sycl_device(self, device_id):
         import torch
-        return torch.xpu.device(device_id).sycl_device
+        # Here must not be PyCapsule for cache key
+        return self.unpack_capsule(torch.xpu.device(device_id).sycl_device)
 
 
 # ------------------------

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -53,15 +53,10 @@ class XPUUtils(object):
         mod = compile_module_from_src(Path(os.path.join(dirname, "driver.c")).read_text(), "spirv_utils")
         self.load_binary = mod.load_binary
         self.get_device_properties = mod.get_device_properties
-        self.context = mod.init_context(self.get_sycl_queue())
-        self.device_count = mod.init_devices(self.get_sycl_queue())
-        self.current_device = 0 if self.device_count[0] > 0 else -1
 
     def get_current_device(self):
-        return self.current_device
-
-    def get_event_pool(self):
-        return self.event_pool
+        import torch
+        return torch.xpu.current_device()
 
     def get_sycl_queue(self):
         import torch

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -396,7 +396,7 @@ class XPUDriver(DriverBase):
             raise AttributeError
 
     def get_current_device(self):
-        return self.utils.get_current_device()
+        return self.utils.get_sycl_device(self.utils.get_current_device())
 
     def get_current_stream(self, device):
         import torch
@@ -404,10 +404,8 @@ class XPUDriver(DriverBase):
 
     def get_current_target(self):
         import torch
-        device = self.get_current_device()
-        dev_property = torch.xpu.get_device_capability(device)
-        warp_size = 32
-        return ("xpu", dev_property, warp_size)
+        device = self.utils.get_sycl_device(self.utils.get_current_device())
+        return ("xpu", device)
 
     @staticmethod
     def is_active():

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -405,7 +405,8 @@ class XPUDriver(DriverBase):
     def get_current_target(self):
         import torch
         device = self.utils.get_sycl_device(self.utils.get_current_device())
-        return ("xpu", device)
+        warp_size = 32
+        return ("xpu", device, warp_size)
 
     @staticmethod
     def is_active():


### PR DESCRIPTION
https://github.com/intel/intel-xpu-backend-for-triton/issues/770
We use target from IPEX previously. The format was `("xpu", properties, num_warps)`, which `properties` is a dict of device properties from IPEX . This PR changes the format to ("xpu", sycl_device_ptr, num_warps), and tries to acquire device properties from Triton side. This can make us decoupling with IPEX.
For the kernel cache, `PyCapsule` variances in each call, so we get the opaque device pointer as the key.
We also cache the device properties for each device to reduce the memory cosuming.