### PR TITLE
Remove duplicate shuffle utilities

### DIFF
--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -117,7 +117,7 @@ run_core_tests() {
   fi
   cd ${CORE_TEST_DIR}
 
-  TRITON_DISABLE_LINE_INFO=1 python3 -m pytest -vvv -n 16 --device xpu language/ --deselect-from-file ../../../scripts/core.exclude-list --ignore=language/test_line_info.py --ignore=language/test_subprocess.py $(pytest_extra_args language)
+  TRITON_DISABLE_LINE_INFO=1 python3 -m pytest -vvv -n 8 --device xpu language/ --deselect-from-file ../../../scripts/core.exclude-list --ignore=language/test_line_info.py --ignore=language/test_subprocess.py $(pytest_extra_args language)
 
   TRITON_DISABLE_LINE_INFO=1 python3 -m pytest -vvv -n 8 language/test_subprocess.py $(pytest_extra_args subprocess)
 
@@ -130,7 +130,7 @@ run_core_tests() {
   TRITON_INTERPRET=1 TRITON_DISABLE_LINE_INFO=1 python3 -m pytest -vvv -n 16 -m interpreter --deselect-from-file ../../../scripts/interpreter.exclude-list language/test_core.py language/test_standard.py \
   language/test_random.py operators/test_flash_attention.py::test_op --device cpu $(pytest_extra_args interpreter)
 
-  TRITON_DISABLE_LINE_INFO=1 python3 -m pytest -n 16 --verbose --device xpu operators/ $(pytest_extra_args operators)
+  TRITON_DISABLE_LINE_INFO=1 python3 -m pytest -n 8 --verbose --device xpu operators/ $(pytest_extra_args operators)
 }
 
 run_regression_tests() {

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -117,7 +117,7 @@ run_core_tests() {
   fi
   cd ${CORE_TEST_DIR}
 
-  TRITON_DISABLE_LINE_INFO=1 python3 -m pytest -vvv -n 8 --device xpu language/ --deselect-from-file ../../../scripts/core.exclude-list --ignore=language/test_line_info.py --ignore=language/test_subprocess.py $(pytest_extra_args language)
+  TRITON_DISABLE_LINE_INFO=1 python3 -m pytest -vvv -n 16 --device xpu language/ --deselect-from-file ../../../scripts/core.exclude-list --ignore=language/test_line_info.py --ignore=language/test_subprocess.py $(pytest_extra_args language)
 
   TRITON_DISABLE_LINE_INFO=1 python3 -m pytest -vvv -n 8 language/test_subprocess.py $(pytest_extra_args subprocess)
 
@@ -130,7 +130,7 @@ run_core_tests() {
   TRITON_INTERPRET=1 TRITON_DISABLE_LINE_INFO=1 python3 -m pytest -vvv -n 16 -m interpreter --deselect-from-file ../../../scripts/interpreter.exclude-list language/test_core.py language/test_standard.py \
   language/test_random.py operators/test_flash_attention.py::test_op --device cpu $(pytest_extra_args interpreter)
 
-  TRITON_DISABLE_LINE_INFO=1 python3 -m pytest -n 8 --verbose --device xpu operators/ $(pytest_extra_args operators)
+  TRITON_DISABLE_LINE_INFO=1 python3 -m pytest -n 16 --verbose --device xpu operators/ $(pytest_extra_args operators)
 }
 
 run_regression_tests() {

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ControlFlowOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ControlFlowOpToLLVM.cpp
@@ -83,12 +83,12 @@ private:
         callOp.getLoc(), /*opOperands=*/callOp->getOperands(),
         adaptor.getOperands(), rewriter);
     if (!caller->hasAttr("allocation.offset")) {
-      auto base = LLVM::Intel::getStackPointer(rewriter, caller);
+      auto base = LLVM::intel::getStackPointer(rewriter, caller);
       promotedOperands.push_back(base);
       return promotedOperands;
     }
     promotedOperands.push_back(
-        LLVM::Intel::getSharedMemoryBase(callOp->getLoc(), rewriter, callOp));
+        LLVM::intel::getSharedMemoryBase(callOp->getLoc(), rewriter, callOp));
     return promotedOperands;
   }
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -388,7 +388,7 @@ private:
     auto elemPtrTy = ptr_ty(rewriter.getContext(), 3);
 
     Value smemBase =
-        LLVM::Intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
+        LLVM::intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
     smemBase = bitcast(smemBase, elemPtrTy);
     auto smemShape = convertType<unsigned, int64_t>(srcShapePerCTA);
 
@@ -468,7 +468,7 @@ private:
     if (shouldUseDistSmem(srcLayout, dstLayout))
       return lowerDistToDistWithDistSmem(op, adaptor, rewriter);
     Value smemBase =
-        LLVM::Intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
+        LLVM::intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
     auto elemPtrTy = ptr_ty(rewriter.getContext(), 3);
     smemBase = bitcast(smemBase, elemPtrTy);
     auto shape = dstTy.getShape();

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/HistogramOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/HistogramOpToLLVM.cpp
@@ -1,7 +1,5 @@
 #include "PatternTritonGPUOpToLLVM.h"
 #include "Utility.h"
-// #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
-// #include "triton/Analysis/Utility.h"
 
 using namespace mlir;
 using namespace mlir::triton;

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/HistogramOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/HistogramOpToLLVM.cpp
@@ -1,7 +1,7 @@
 #include "PatternTritonGPUOpToLLVM.h"
 #include "Utility.h"
-#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
-#include "triton/Analysis/Utility.h"
+// #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
+// #include "triton/Analysis/Utility.h"
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -19,7 +19,7 @@ static Value generateVoteBallot(Location loc, Value bit, int threadMask,
   Value laneId = and_(threadId, i32_val(numThreadPerWarp - 1));
   Value reduced_val = shl(select(bit, i32_val(1), i32_val(0)), laneId);
   for (int offs = 1; offs < numThreadPerWarp; offs = offs << 1) {
-    Value other_val = LLVM::Intel::shflSync(loc, rewriter, reduced_val, offs);
+    Value other_val = LLVM::intel::shuffleXor(loc, rewriter, reduced_val, offs);
     reduced_val = or_(reduced_val, other_val);
   }
   return reduced_val;
@@ -186,7 +186,7 @@ public:
     // generate the right layout. Currently the warp level histogram generates
     // data in the default blocked layout.
     Value baseSharedMemPtr =
-        LLVM::Intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
+        LLVM::intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
     auto dstType = op.getType();
     auto mod = op->getParentOfType<ModuleOp>();
     int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(mod);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/MemoryOpToLLVM.cpp
@@ -23,7 +23,7 @@ void lowerDistributedToShared(LocalAllocOp op, LocalAllocOpAdaptor adaptor,
          (srcTy.getShape().size() <= 3 && outOrd[2] == 0) &&
              "Unexpected rank of ConvertLayout(blocked->shared)");
   Value smemBase =
-      LLVM::Intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
+      LLVM::intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
   auto elemTy = typeConverter->convertType(srcTy.getElementType());
 
   int32_t elemSize = elemTy.getIntOrFloatBitWidth();
@@ -49,7 +49,7 @@ struct LocalAllocOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
     Value smemBase =
-        LLVM::Intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
+        LLVM::intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
     auto resultTy = op.getType().cast<MemDescType>();
     auto typeConverter = getTypeConverter();
     auto sharedLayout =

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PrintOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PrintOpToLLVM.cpp
@@ -29,7 +29,7 @@ struct PrintOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     auto typeConverter = getTypeConverter();
     auto loc = op->getLoc();
-    Value prefixStr = LLVM::Intel::addStringToModule(
+    Value prefixStr = LLVM::intel::addStringToModule(
         loc, rewriter, "printfPrefix_", op.getPrefix(),
         TritonGEN::TritonGENMemorySpace::kUniformConstant);
 
@@ -45,7 +45,7 @@ struct PrintOpConversion
       llvm::raw_string_ostream os(formatStr);
       os << "pid (" << getFormatSubstr(pid[0]) << ", "
          << getFormatSubstr(pid[1]) << ", " << getFormatSubstr(pid[2]) << ")%s";
-      LLVM::Intel::llPrintf(rewriter, formatStr,
+      LLVM::intel::llPrintf(rewriter, formatStr,
                             {pid[0], pid[1], pid[2], prefixStr});
     } else {
       for (size_t i = 0; i < op.getNumOperands(); i++) {
@@ -168,7 +168,7 @@ struct PrintOpConversion
       // strings, so we cache the Value.
       if (i == 0) {
         formatStrValue =
-            LLVM::Intel::llPrintf(rewriter, formatStr, printfOperands);
+            LLVM::intel::llPrintf(rewriter, formatStr, printfOperands);
       } else {
         targetInfo.printf(rewriter, formatStrValue, formatStrByteCount,
                           printfOperands);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceOpToLLVM.cpp
@@ -262,7 +262,7 @@ private:
     Location loc = op.getLoc();
     Value threadId = getThreadId(rewriter, loc);
     auto srcLayout = helper.getSrcLayout();
-    Value warpSize = LLVM::Intel::getModuleWarpSize(rewriter, loc);
+    Value warpSize = LLVM::intel::getModuleWarpSize(rewriter, loc);
     Value warpId = udiv(threadId, warpSize);
     Value laneId = urem(threadId, warpSize);
     auto srcShape = helper.getSrcShape();
@@ -313,7 +313,7 @@ private:
     Location loc = op.getLoc();
 
     Value threadId = getThreadId(rewriter, loc);
-    Value warpSize = LLVM::Intel::getModuleWarpSize(rewriter, loc);
+    Value warpSize = LLVM::intel::getModuleWarpSize(rewriter, loc);
     Value laneId = urem(threadId, warpSize);
     Value zero = i32_val(0);
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceScanCommon.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceScanCommon.h
@@ -70,7 +70,7 @@ public:
     // Assign base index to each operand in their order in indices
     std::map<unsigned, Value> indexToBase;
     indexToBase[indices[0]] =
-        LLVM::Intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
+        LLVM::intel::getSharedMemoryBase(loc, rewriter, op.getOperation());
     for (unsigned i = 1; i < op.getNumOperands(); ++i) {
       indexToBase[indices[i]] = gep(
           ptr_ty(rewriter.getContext(), 3), getElementType(op, indices[i - 1]),

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/SPMDOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/SPMDOpToLLVM.cpp
@@ -64,7 +64,7 @@ struct GetClusterCTAIdOpConversion
   matchAndRewrite(triton::nvidia_gpu::GetClusterCTAIdOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOp(op,
-                       LLVM::Intel::getClusterCTAId(rewriter, op->getLoc()));
+                       LLVM::intel::getClusterCTAId(rewriter, op->getLoc()));
     return success();
   }
 };

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
@@ -1,4 +1,3 @@
-
 //===- Utility.cpp - Code generation utilities ----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
@@ -15,6 +15,12 @@ namespace mlir {
 namespace LLVM {
 namespace intel {
 
+static Value shuffleCommon(Location loc, ConversionPatternRewriter &rewriter,
+                           Value val, Value i, TritonGEN::ShflKind mode) {
+  Type type = val.getType();
+  return rewriter.create<TritonGEN::SubGroupShuffleOp>(loc, type, val, i, mode);
+}
+
 Value storeShared(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
                   Value val, Value pred) {
   createPredicatedBlock(rewriter, loc, pred, [&] {
@@ -37,23 +43,15 @@ Value loadShared(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
   return *endBlock.args_begin();
 }
 
-static Value shuffleCommon(Location loc, ConversionPatternRewriter &rewriter,
-                           Value val, Value i, TritonGEN::ShflKind mode,
-                           Value clamp) {
-  Type type = val.getType();
-  return rewriter.create<TritonGEN::SubGroupShuffleOp>(loc, type, val, i, mode);
-}
-
 Value shuffleXor(Location loc, ConversionPatternRewriter &rewriter, Value val,
                  int i) {
-  return shuffleCommon(loc, rewriter, val, i32_val(i), TritonGEN::ShflKind::XOR,
-                       i32_val(0x1f));
+  return shuffleCommon(loc, rewriter, val, i32_val(i),
+                       TritonGEN::ShflKind::XOR);
 }
 
 Value shuffleUp(Location loc, ConversionPatternRewriter &rewriter, Value val,
                 int i) {
-  return shuffleCommon(loc, rewriter, val, i32_val(i), TritonGEN::ShflKind::UP,
-                       i32_val(0x0));
+  return shuffleCommon(loc, rewriter, val, i32_val(i), TritonGEN::ShflKind::UP);
 }
 
 Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
@@ -63,8 +61,7 @@ Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
 
 Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
                  Value i) {
-  return shuffleCommon(loc, rewriter, val, i, TritonGEN::ShflKind::IDX,
-                       i32_val(0x1f));
+  return shuffleCommon(loc, rewriter, val, i, TritonGEN::ShflKind::IDX);
 }
 
 Value addStringToModule(Location loc, ConversionPatternRewriter &rewriter,

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
@@ -1,11 +1,20 @@
-#include "Utility.h"
-#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
-#include "triton/Dialect/NVGPU/IR/Dialect.h"
 
+//===- Utility.cpp - Code generation utilities ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Utility.h"
+
+using namespace mlir;
 using namespace mlir::triton;
+
 namespace mlir {
 namespace LLVM {
-namespace Intel {
+namespace intel {
 
 Value storeShared(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
                   Value val, Value pred) {
@@ -29,63 +38,34 @@ Value loadShared(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
   return *endBlock.args_begin();
 }
 
-static TritonGEN::ShflKind toGenShuffleMode(NVVM::ShflKind mode) {
-  switch (mode) {
-  case NVVM::ShflKind::bfly:
-    return TritonGEN::ShflKind::XOR;
-  case NVVM::ShflKind::up:
-    return TritonGEN::ShflKind::UP;
-  case NVVM::ShflKind::down:
-    return TritonGEN::ShflKind::DOWN;
-  case NVVM::ShflKind::idx:
-    return TritonGEN::ShflKind::IDX;
-  }
-  llvm_unreachable("unsupported NVVM::ShflKind");
-}
-
-static Value commonShflSync(Location loc, ConversionPatternRewriter &rewriter,
-                            Value val, Value i, NVVM::ShflKind mode,
-                            Value clamp) {
-  unsigned bits = val.getType().getIntOrFloatBitWidth();
-
-  if (bits == 64) {
-    Type vecTy = vec_ty(f32_ty, 2);
-    Value vec = bitcast(val, vecTy);
-    Value val0 = extract_element(f32_ty, vec, i32_val(0));
-    Value val1 = extract_element(f32_ty, vec, i32_val(1));
-    val0 = commonShflSync(loc, rewriter, val0, i, mode, clamp);
-    val1 = commonShflSync(loc, rewriter, val1, i, mode, clamp);
-    vec = undef(vecTy);
-    vec = insert_element(vecTy, vec, val0, i32_val(0));
-    vec = insert_element(vecTy, vec, val1, i32_val(1));
-    return bitcast(vec, val.getType());
-  }
+static Value shuffleCommon(Location loc, ConversionPatternRewriter &rewriter,
+                           Value val, Value i, TritonGEN::ShflKind mode,
+                           Value clamp) {
   Type type = val.getType();
-  return rewriter.create<TritonGEN::SubGroupShuffleOp>(loc, type, val, i,
-                                                       toGenShuffleMode(mode));
+  return rewriter.create<TritonGEN::SubGroupShuffleOp>(loc, type, val, i, mode);
 }
 
-Value shflSync(Location loc, ConversionPatternRewriter &rewriter, Value val,
-               int i) {
-  return commonShflSync(loc, rewriter, val, i32_val(i), NVVM::ShflKind::bfly,
-                        i32_val(0x1f));
-}
-
-Value shflUpSync(Location loc, ConversionPatternRewriter &rewriter, Value val,
+Value shuffleXor(Location loc, ConversionPatternRewriter &rewriter, Value val,
                  int i) {
-  return commonShflSync(loc, rewriter, val, i32_val(i), NVVM::ShflKind::up,
-                        i32_val(0x0));
+  return shuffleCommon(loc, rewriter, val, i32_val(i), TritonGEN::ShflKind::XOR,
+                       i32_val(0x1f));
 }
 
-Value shflIdxSync(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                  int i) {
-  return shflIdxSync(loc, rewriter, val, i32_val(i));
+Value shuffleUp(Location loc, ConversionPatternRewriter &rewriter, Value val,
+                int i) {
+  return shuffleCommon(loc, rewriter, val, i32_val(i), TritonGEN::ShflKind::UP,
+                       i32_val(0x0));
 }
 
-Value shflIdxSync(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                  Value i) {
-  return commonShflSync(loc, rewriter, val, i, NVVM::ShflKind::idx,
-                        i32_val(0x1f));
+Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
+                 int i) {
+  return shuffleIdx(loc, rewriter, val, i32_val(i));
+}
+
+Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
+                 Value i) {
+  return shuffleCommon(loc, rewriter, val, i, TritonGEN::ShflKind::IDX,
+                       i32_val(0x1f));
 }
 
 Value addStringToModule(Location loc, ConversionPatternRewriter &rewriter,
@@ -180,6 +160,6 @@ Value llPrintf(ConversionPatternRewriter &rewriter, StringRef msg,
   return msgValue;
 }
 
-} // namespace Intel
+} // namespace intel
 } // namespace LLVM
 } // namespace mlir

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
@@ -1,4 +1,3 @@
-
 //===- Utility.h - Code generation utilities ------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
@@ -1,3 +1,12 @@
+
+//===- Utility.h - Code generation utilities ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #ifndef TRITON_CONVERSION_TRITONINTELGPU_TO_LLVM_UTILITY_H
 #define TRITON_CONVERSION_TRITONINTELGPU_TO_LLVM_UTILITY_H
 
@@ -15,7 +24,7 @@ using namespace mlir::triton;
 namespace mlir {
 namespace LLVM {
 
-namespace Intel {
+namespace intel {
 
 /// Create a predicated block, using \p cond as the condition and \p ops for the
 /// values supplied by the conditional branch to the exit block. The \p
@@ -78,14 +87,15 @@ Value storeShared(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
 Value loadShared(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
                  Type elemTy, Value pred);
 
-Value shflSync(Location loc, ConversionPatternRewriter &rewriter, Value val,
-               int i);
-Value shflUpSync(Location loc, ConversionPatternRewriter &rewriter, Value val,
+Value shuffleXor(Location loc, ConversionPatternRewriter &rewriter, Value val,
                  int i);
-Value shflIdxSync(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                  int i);
-Value shflIdxSync(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                  Value i);
+Value shuffleUp(Location loc, ConversionPatternRewriter &rewriter, Value val,
+                int i);
+Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
+                 int i);
+Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
+                 Value i);
+
 Value addStringToModule(Location loc, ConversionPatternRewriter &rewriter,
                         StringRef key, StringRef content,
                         unsigned addressSpace);
@@ -115,7 +125,7 @@ static Value getSharedMemoryBase(Location loc,
                       .getZExtValue();
   Value offVal = i32_val(offset);
   Value base =
-      gep(ptrTy, i8_ty, LLVM::Intel::getStackPointer(rewriter, func), offVal);
+      gep(ptrTy, i8_ty, LLVM::intel::getStackPointer(rewriter, func), offVal);
   return base;
 }
 
@@ -134,7 +144,7 @@ static Value getClusterCTAId(RewriterBase &rewriter, Location loc) {
   // Clusters of thread blocks aren't supported.
   return rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
 }
-} // namespace Intel
+} // namespace intel
 } // namespace LLVM
 
 // -----------------------------------------------------------------------
@@ -275,7 +285,7 @@ static SmallVector<Value> emitCTAOffsetForLayout(Location loc,
       triton::gpu::getShapePerCTA(CTASplitNum, shape);
 
   // Delinearize clusterCTAId
-  Value clusterCTAId = LLVM::Intel::getClusterCTAId(rewriter, loc);
+  Value clusterCTAId = LLVM::intel::getClusterCTAId(rewriter, loc);
   SmallVector<Value> multiDimClusterCTAId =
       delinearize(rewriter, loc, clusterCTAId, CTAsPerCGA, CTAOrder);
 


### PR DESCRIPTION
This PR contains the following changes:
  - remove duplicate shuffle functions and match NVidia implementation more closely
  - restructure Intel's `Targetinfo.cpp` and `Utility.cpp` to match NVidia implementation more closely
  - remove `toGenShuffleMode`
  - change Intel namespace to intel (lowercase)
  - add some copyright headers