### PR TITLE
[08-grouped-gemm] Run with `threads_per_warp=16`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -165,8 +165,7 @@ jobs:
           python3 05-layer-norm.py
           python3 06-fused-attention.py
           python3 07-extern-functions.py
-          # FIXME: next tutorial is failing with the current rolling stable release, see issue #797
-          python3 08-grouped-gemm.py || true
+          python3 08-grouped-gemm.py
           python3 09-experimental-block-pointer.py
 
       - name: Run CXX unittests

--- a/.github/workflows/conda-build-test.yml
+++ b/.github/workflows/conda-build-test.yml
@@ -81,8 +81,6 @@ jobs:
           mv scripts/core-conda.exclude-list scripts/core.exclude-list
           mv scripts/interpreter-conda.exclude-list scripts/interpreter.exclude-list
 
-          # FIXME https://github.com/intel/intel-xpu-backend-for-triton/issues/797
-          sed -ie 's/\(.*08-grouped-gemm\)/#\1/' scripts/test-triton.sh
           conda run --no-capture-output -n triton bash -v -x scripts/test-triton.sh
 
       - name: Run E2E test

--- a/python/tutorials/08-grouped-gemm.py
+++ b/python/tutorials/08-grouped-gemm.py
@@ -181,6 +181,7 @@ def group_gemm_fn(group_A, group_B):
         d_g_sizes,
         d_g_lds,
         group_size,
+        threads_per_warp=16,
     )
 
     return group_C
@@ -221,6 +222,7 @@ def triton_perf_fn(a_ptrs, b_ptrs, c_ptrs, sizes, lds, group_size):
         sizes,
         lds,
         group_size,
+        threads_per_warp=16,
     )
 
 


### PR DESCRIPTION
DPAS is only enabled when threads_per_warp=16 on PVC.