### PR TITLE
[tests] Skip float64 tests if unsupported by XPU hardware

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -35,6 +35,7 @@ def is_hip():
 def is_xpu():
     return not is_interpreter() and triton.runtime.driver.active.get_current_target()[0] == "xpu"
 
+
 def xpu_has_fp64():
     assert is_xpu()
     return triton.runtime.driver.active.get_current_target()[1]['has_fp64']

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1378,6 +1378,7 @@ def test_noinline(mode, device):
                                    for mode in ['all_neg', 'all_pos', 'min_neg', 'max_pos']
                                    for sem in [None, 'acquire', 'release', 'acq_rel', 'relaxed']]))
 def test_atomic_rmw(op, dtype_x_str, mode, sem, device):
+    check_type_supported(dtype_x_str, device)
     if is_interpreter():
         if dtype_x_str == 'float16':
             pytest.skip("Only test atomic float16 ops on GPU")

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -385,7 +385,7 @@ def _test_binary(dtype_x, dtype_y, expr, numpy_expr=None, mode_x='real', mode_y=
             # Downcast the output type. Assumes similar overflow behavior to reference eval on the device.
             z_ref = z_ref.astype("float32")
         z_tri = to_triton(np.empty(SIZE, dtype=z_ref.dtype), device=device)
-        
+
         kernel_fn[(1, )](z_tri, x_tri, y_tri, SIZE=SIZE, num_warps=4, num_ctas=num_ctas)
         err_msg = f"{expr}, {kernel_fn.__name__}"
         np.testing.assert_allclose(z_ref, to_numpy(z_tri), err_msg=err_msg, atol=1e-3, rtol=0.01)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1045,7 +1045,7 @@ def test_precise_math(expr_prec, expr_ref, num_ctas, device):
 
     if is_xpu():
         # use cpu result as reference, see https://github.com/llvm/llvm-project/issues/88222
-        out_ref = torch.div(x.to(torch.float64).cpu(), y.to(torch.float64).cpu()).to(torch.float32).to(device=device)
+        out_ref = torch.div(x.cpu().to(torch.float64), y.cpu().to(torch.float64)).to(torch.float32).to(device=device)
     assert torch.all(out == out_ref)  # bitwise exact
 
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -35,6 +35,10 @@ def is_hip():
 def is_xpu():
     return not is_interpreter() and triton.runtime.driver.active.get_current_target()[0] == "xpu"
 
+def xpu_has_fp64():
+    assert is_xpu()
+    return triton.runtime.driver.active.get_current_target()[1]['has_fp64']
+
 
 int_dtypes = ['int8', 'int16', 'int32', 'int64']
 uint_dtypes = ['uint8', 'uint16', 'uint32', 'uint64']
@@ -166,6 +170,9 @@ def check_type_supported(dtype, device):
     if is_interpreter():
         if dtype in [tl.bfloat16, "bfloat16", torch.bfloat16]:
             pytest.xfail("bfloat16 is not supported in the interpreter")
+    elif device in ['xpu']:
+        if dtype in [torch.float64, "float64"] and not xpu_has_fp64():
+            pytest.xfail("float64 not supported on current xpu hardware")
 
 
 class MfmaLayout:

--- a/python/test/unit/language/test_libdevice.py
+++ b/python/test/unit/language/test_libdevice.py
@@ -20,6 +20,9 @@ from triton.language.extra.intel import libdevice
     ],
 )
 def test_bessel(dtype_str, libdevice_fn, torch_special_fn, device):
+    if device in ['xpu']:
+        if dtype_str in ["float64"] and not triton.runtime.driver.active.get_current_target()[1]['has_fp64']:
+            pytest.xfail("float64 not supported on current xpu hardware")
     SIZE = 128
     dtype = getattr(torch, dtype_str)
 


### PR DESCRIPTION
* Adds float64 type checking to the `check_type_supported` function in `test_core`
* Extends the use of `check_type_supported` in `test_core` to a few tests where we have float64 inputs/outputs
* Adds float64 type checking to `test_libdevice` 

Close #888 

I would suggest keeping commits separate so we can more easily revert if problems pop up later.