### PR TITLE
Remove capability from Intel lowering passes

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -72,9 +72,6 @@ class XPUBackend(BaseBackend):
         dirname = os.path.dirname(os.path.realpath(__file__))
         mod = compile_module_from_src(Path(os.path.join(dirname, "arch_parser.c")).read_text(), "arch_utils")
         self.parse_device_arch = mod.parse_device_arch
-        # TODO: Deprecate capability in XPU compilation
-        # capability should be < 80, because some features in passes with capability >= 80 are not supported on PVC
-        self.capability = intel.passes.ttgpuir.DEVICE_ARCH.PVC
         self.properties = self._parse_target(target[1])
         self.device_arch = self.properties["device_arch"]
         self.binary_ext = "spv"
@@ -157,7 +154,7 @@ class XPUBackend(BaseBackend):
         return mod
 
     @staticmethod
-    def make_llir(src, metadata, options, capability):
+    def make_llir(src, metadata, options, device_arch):
         # warp-specialization mutates num_warps
         num_warp_groups = src.get_int_attr("triton_gpu.num-warp-groups-per-cta")
         if num_warp_groups is not None:
@@ -172,7 +169,7 @@ class XPUBackend(BaseBackend):
         passes.convert.add_scf_to_cf(pm)
         passes.convert.add_index_to_llvmir(pm)
         intel.passes.ttgpuir.add_allocate_shared_memory(pm)
-        intel.passes.ttgpuir.add_to_llvmir(pm, capability)
+        intel.passes.ttgpuir.add_to_llvmir(pm)
         passes.convert.add_arith_to_llvmir(pm)
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)

--- a/third_party/intel/include/TritonIntelGPUToLLVM/Passes.h
+++ b/third_party/intel/include/TritonIntelGPUToLLVM/Passes.h
@@ -27,8 +27,6 @@ std::unique_ptr<OperationPass<ModuleOp>> createIntelAllocateSharedMemoryPass();
 
 std::unique_ptr<OperationPass<ModuleOp>>
 createConvertTritonIntelGPUToLLVMPass();
-std::unique_ptr<OperationPass<ModuleOp>>
-createConvertTritonIntelGPUToLLVMPass(int32_t computeCapability);
 
 #define GEN_PASS_REGISTRATION
 #include "intel/include/TritonIntelGPUToLLVM/Passes.h.inc"

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1508,8 +1508,7 @@ struct FpToFpOpConversion
       return outVals;
     }
 
-    bool useFP16IntermediateSrc =
-        srcElementType.isF32() && roundingMode.value() == RoundingMode::RTZ;
+    bool useFP16IntermediateSrc = srcElementType.isF32();
     bool isDstFP32 = dstElementType.isF32();
     Type srcType = useFP16IntermediateSrc ? f16_ty : srcElementType;
     Type dstType = isDstFP32 ? f16_ty : dstElementType;

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -32,8 +32,8 @@ void populateDotOpToLLVMPatterns(TritonGPUToLLVMTypeConverter &typeConverter,
 
 void populateElementwiseOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
-    ModuleAxisInfoAnalysis &axisInfoAnalysis, int computeCapability,
-    const TargetInfoBase &targetInfo, PatternBenefit benefit);
+    ModuleAxisInfoAnalysis &axisInfoAnalysis, const TargetInfoBase &targetInfo,
+    PatternBenefit benefit);
 
 void populateHistogramOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                        RewritePatternSet &patterns,

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.h
@@ -14,7 +14,7 @@
 namespace mlir::triton::intel {
 class TargetInfo : public mlir::triton::TargetInfoBase {
 public:
-  TargetInfo(int computeCapability) : computeCapability(computeCapability) {}
+  TargetInfo() = default;
 
   bool supportMaximumMinimum() const override;
 
@@ -57,8 +57,6 @@ public:
                   int line) const override;
 
 private:
-  // TODO: revisit the computeCapability field, as it should not be used on XPU.
-  int computeCapability;
 };
 } // namespace mlir::triton::intel
 #endif // TRITON_CONVERSION_TRITONGPU_TO_LLVM_TARGETINFOINTEL_H

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVM.cpp
@@ -195,9 +195,6 @@ struct ConvertTritonGPUToLLVM
                     NVVM::NVVMDialect, TritonGEN::TritonGENDialect>();
   }
 
-  ConvertTritonGPUToLLVM(int32_t computeCapability)
-      : ConvertTritonIntelGPUToLLVMBase({computeCapability}) {}
-
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     ModuleOp mod = getOperation();
@@ -234,14 +231,13 @@ struct ConvertTritonGPUToLLVM
     OpBuilder::InsertPoint indexInsertPoint;
 
     RewritePatternSet patterns(context);
-    mlir::triton::intel::TargetInfo targetInfo(computeCapability);
+    mlir::triton::intel::TargetInfo targetInfo;
     int benefit = 10;
     using namespace mlir::triton::intel;
     populateConvertLayoutOpToLLVMPatterns(typeConverter, patterns, benefit);
     populateDotOpToLLVMPatterns(typeConverter, patterns, benefit);
     mlir::triton::intel::populateElementwiseOpToLLVMPatterns(
-        typeConverter, patterns, axisInfoAnalysis, computeCapability,
-        targetInfo, benefit);
+        typeConverter, patterns, axisInfoAnalysis, targetInfo, benefit);
     populateLoadStoreOpToLLVMPatterns(typeConverter, patterns, axisInfoAnalysis,
                                       benefit);
     mlir::triton::intel::populateReduceOpToLLVMPatterns(typeConverter, patterns,
@@ -310,10 +306,6 @@ namespace triton {
 std::unique_ptr<OperationPass<ModuleOp>>
 createConvertTritonIntelGPUToLLVMPass() {
   return std::make_unique<ConvertTritonGPUToLLVM>();
-}
-std::unique_ptr<OperationPass<ModuleOp>>
-createConvertTritonIntelGPUToLLVMPass(int32_t computeCapability) {
-  return std::make_unique<ConvertTritonGPUToLLVM>(computeCapability);
 }
 
 } // namespace triton

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -26,8 +26,8 @@ void init_triton_intel_passes_ttgpuir(py::module &&m) {
       .value("PVC", mlir::triton::gpu::intel::DeviceArch::PVC)
       .export_values();
 
-  m.def("add_to_llvmir", [](mlir::PassManager &pm, int32_t capability) {
-    pm.addPass(mlir::triton::createConvertTritonIntelGPUToLLVMPass(capability));
+  m.def("add_to_llvmir", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::createConvertTritonIntelGPUToLLVMPass());
   });
   m.def(
       "add_accelerate_matmul",


### PR DESCRIPTION
This PR is for https://github.com/intel/intel-xpu-backend-for-triton/issues/764
These features controlled by `capability` are copied from NV passes and are not applicable for Intel GPUs, so simply remove them for now.