### PR TITLE
Reland `Decode version bytes to str in hash function (#788)`

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -211,6 +211,8 @@ class XPUBackend(BaseBackend):
     @functools.lru_cache()
     def hash(self):
         version = subprocess.check_output([_path_to_binary("spirv-dis")[0], "--version"])
+        if type(version) is bytes:
+            version = version.decode("utf-8")
         return f'{version}-{self.properties}'
 
     def get_codegen_implementation(self):


### PR DESCRIPTION
The change is accidentally removed from https://github.com/intel/intel-xpu-backend-for-triton/commit/82e91f4f0cc895802fa1963b0608ee405a6d5d4a.