### PR TITLE
Update E2E workloads to use runner max1550 by default

### DIFF
--- a/.github/workflows/e2e-performance.yml
+++ b/.github/workflows/e2e-performance.yml
@@ -50,8 +50,6 @@ on:
         description: TORCH_COMPILE_DEBUG
         type: string
         default: ""
-#  schedule:
-#    - cron: "5 1 * * *"
 
 permissions: read-all
 

--- a/.github/workflows/e2e-performance.yml
+++ b/.github/workflows/e2e-performance.yml
@@ -74,7 +74,7 @@ jobs:
       mode: ${{ steps.set-matrix.outputs.mode }}
       dtype: ${{ steps.set-matrix.outputs.dtype }}
       models: ${{ steps.set-matrix.outputs.models }}
-      ref: ${{ env.GITHUB_SHA }}
+      triton_commit_id: ${{ steps.setup.outputs.github_sha }}
     timeout-minutes: 30
     defaults:
       run:
@@ -111,7 +111,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up parameters
+        id: setup
+        run :
+          echo "github_sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
+
   print_inputs:
+    name: Print inputs
     needs: setup
     runs-on: Linux
     steps:

--- a/.github/workflows/e2e-performance.yml
+++ b/.github/workflows/e2e-performance.yml
@@ -147,6 +147,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.setup.outputs.dtype.triton_commit_id }}
 
       - name: Get LLVM commit id
         run: |

--- a/.github/workflows/e2e-performance.yml
+++ b/.github/workflows/e2e-performance.yml
@@ -308,10 +308,6 @@ jobs:
           if [[ -d torch_compile_debug ]]; then
             cp -rT torch_compile_debug inductor_log
           fi
-          mkdir -p /cache/reports/e2e-performance
-          TMPDIR=$(mktemp -d -p /cache/reports/e2e-performance XXXXXXXXX.tmp)
-          cp -rT $GITHUB_WORKSPACE/inductor_log $TMPDIR
-          mv -T $TMPDIR /cache/reports/e2e-performance/$TIMESTAMP-${{ join(matrix.*, '-') }} || rm -rf $TMPDIR
 
       - name: Upload test logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-performance.yml
+++ b/.github/workflows/e2e-performance.yml
@@ -63,14 +63,8 @@ env:
   BENCHMARK_BRANCH: main
 
 jobs:
-  print_inputs:
-    runs-on: Linux
-    steps:
-        - name: Print Inputs
-          run: echo "${{ toJSON(github.event.inputs) }}"
-
-  matrix:
-    name: Matrix
+  setup:
+    name: Setup
     runs-on:
       - glados
       - spr
@@ -80,7 +74,11 @@ jobs:
       mode: ${{ steps.set-matrix.outputs.mode }}
       dtype: ${{ steps.set-matrix.outputs.dtype }}
       models: ${{ steps.set-matrix.outputs.models }}
-    timeout-minutes: 10
+      ref: ${{ env.GITHUB_SHA }}
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash -noprofile --norc -eo pipefail {0}
     steps:
       - name: Set matrix
         id: set-matrix
@@ -110,17 +108,31 @@ jobs:
           echo "dtype=$dtype" >> $GITHUB_OUTPUT
           echo "models=$models" >> $GITHUB_OUTPUT
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+  print_inputs:
+    needs: setup
+    runs-on: Linux
+    steps:
+      - name: Print inputs
+        run: |
+          echo "${{ toJSON(github.event.inputs) }}"
+
+      - name: Print setup outputs
+        run: |
+          echo "${{ toJSON(needs.setup.outputs) }}"
+
   build:
     name: Test
-    needs: matrix
+    needs: setup
     runs-on:
-      - ${{ inputs.runner_label || 'runner-0.0.12' }}
+      - ${{ inputs.runner_label || 'max1550' }}
     strategy:
       matrix:
-        suite: ${{ fromJson(needs.matrix.outputs.suite) }}
-        mode: ${{ fromJson(needs.matrix.outputs.mode) }}
-        dtype: ${{ fromJson(needs.matrix.outputs.dtype) }}
-      max-parallel: 2
+        suite: ${{ fromJson(needs.setup.outputs.suite) }}
+        mode: ${{ fromJson(needs.setup.outputs.mode) }}
+        dtype: ${{ fromJson(needs.setup.outputs.dtype) }}
       fail-fast: false
     timeout-minutes: 720
     defaults:
@@ -256,7 +268,7 @@ jobs:
 
           if [[ "${{ inputs.only_one_model }}" ]]; then
             $GITHUB_WORKSPACE/scripts/inductor_xpu_test.sh ${{ matrix.suite }} ${{ matrix.dtype }} ${{ matrix.mode }} performance xpu 0 static 1 0 ${{ inputs.only_one_model }}
-          elif [[ "${{ needs.matrix.outputs.models }}" == "subset" ]]; then
+          elif [[ "${{ needs.setup.outputs.models }}" == "subset" ]]; then
             while read model; do
               $GITHUB_WORKSPACE/scripts/inductor_xpu_test.sh ${{ matrix.suite }} ${{ matrix.dtype }} ${{ matrix.mode }} performance xpu 0 static 1 0 $model
             done < $GITHUB_WORKSPACE/.github/models/performance/${{ matrix.suite }}.txt

--- a/.github/workflows/e2e-performance.yml
+++ b/.github/workflows/e2e-performance.yml
@@ -74,7 +74,6 @@ jobs:
       mode: ${{ steps.set-matrix.outputs.mode }}
       dtype: ${{ steps.set-matrix.outputs.dtype }}
       models: ${{ steps.set-matrix.outputs.models }}
-      triton_commit_id: ${{ steps.setup.outputs.github_sha }}
     timeout-minutes: 30
     defaults:
       run:
@@ -108,14 +107,6 @@ jobs:
           echo "dtype=$dtype" >> $GITHUB_OUTPUT
           echo "models=$models" >> $GITHUB_OUTPUT
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up parameters
-        id: setup
-        run :
-          echo "github_sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
-
   print_inputs:
     name: Print inputs
     needs: setup
@@ -147,8 +138,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.setup.outputs.dtype.triton_commit_id }}
 
       - name: Get LLVM commit id
         run: |

--- a/.github/workflows/e2e-performance.yml
+++ b/.github/workflows/e2e-performance.yml
@@ -72,10 +72,7 @@ jobs:
       mode: ${{ steps.set-matrix.outputs.mode }}
       dtype: ${{ steps.set-matrix.outputs.dtype }}
       models: ${{ steps.set-matrix.outputs.models }}
-    timeout-minutes: 30
-    defaults:
-      run:
-        shell: bash -noprofile --norc -eo pipefail {0}
+    timeout-minutes: 10
     steps:
       - name: Set matrix
         id: set-matrix

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,8 +50,8 @@ env:
   BENCHMARK_BRANCH: main
 
 jobs:
-  matrix:
-    name: Matrix
+  setup:
+    name: Setup
     runs-on:
       - glados
       - spr
@@ -84,16 +84,29 @@ jobs:
           echo "mode=$mode" >> $GITHUB_OUTPUT
           echo "dtype=$dtype" >> $GITHUB_OUTPUT
 
+  print_inputs:
+    name: Print inputs
+    needs: setup
+    runs-on: Linux
+    steps:
+      - name: Print inputs
+        run: |
+          echo "${{ toJSON(github.event.inputs) }}"
+
+      - name: Print setup outputs
+        run: |
+          echo "${{ toJSON(needs.setup.outputs) }}"
+
   build:
     name: Test
-    needs: matrix
+    needs: setup
     runs-on:
       - ${{ inputs.runner_label || 'max1550' }}
     strategy:
       matrix:
-        suite: ${{ fromJson(needs.matrix.outputs.suite) }}
-        mode: ${{ fromJson(needs.matrix.outputs.mode) }}
-        dtype: ${{ fromJson(needs.matrix.outputs.dtype) }}
+        suite: ${{ fromJson(needs.setup.outputs.suite) }}
+        mode: ${{ fromJson(needs.setup.outputs.mode) }}
+        dtype: ${{ fromJson(needs.setup.outputs.dtype) }}
       fail-fast: false
     timeout-minutes: 720
     defaults:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,12 +31,14 @@ on:
           - float16
           - float32
         default: all
+      runner_label:
+        description: Runner label, keep empty for default
+        type: string
+        default: ""
       TORCH_COMPILE_DEBUG:
         description: TORCH_COMPILE_DEBUG
         type: string
         default: ""
-  schedule:
-    - cron: "5 1 * * *"
 
 permissions: read-all
 
@@ -86,15 +88,12 @@ jobs:
     name: Test
     needs: matrix
     runs-on:
-      - glados
-      - spr
-      - runner-0.0.12
+      - ${{ inputs.runner_label || 'max1550' }}
     strategy:
       matrix:
         suite: ${{ fromJson(needs.matrix.outputs.suite) }}
         mode: ${{ fromJson(needs.matrix.outputs.mode) }}
         dtype: ${{ fromJson(needs.matrix.outputs.dtype) }}
-      max-parallel: 2
       fail-fast: false
     timeout-minutes: 720
     defaults:
@@ -344,10 +343,6 @@ jobs:
           if [[ -d torch_compile_debug ]]; then
             cp -rT torch_compile_debug inductor_log
           fi
-          mkdir -p /cache/reports/e2e
-          TMPDIR=$(mktemp -d -p /cache/reports/e2e XXXXXXXXX.tmp)
-          cp -rT $GITHUB_WORKSPACE/inductor_log $TMPDIR
-          mv -T $TMPDIR /cache/reports/e2e/$TIMESTAMP-${{ join(matrix.*, '-') }} || rm -rf $TMPDIR
 
       - name: Upload test logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Both workflows have an input to select a runner via a single label. By default max1550 is used.

Other changes:
* Removed cron: will run them manually for some time.
* Removed copying reports to /cache: use published artifacts to collect reports.