### PR TITLE
match attention workload in convert-triton-to-tritongpu-warp

### DIFF
--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUWarpPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUWarpPass.cpp
@@ -208,6 +208,50 @@ public:
           break;
         }
         case Workload::Attention: {
+          LDBG("match workload attention \n");
+          DotInfo &info0 = loopDotInfo.dotInfo0;
+          DotInfo &info1 = loopDotInfo.dotInfo1;
+          auto dot0 = info0.dot;
+          auto aType = dot0.getA().getType().cast<RankedTensorType>();
+          auto bType = dot0.getB().getType().cast<RankedTensorType>();
+          unsigned Br = aType.getShape()[0];
+          unsigned d = bType.getShape()[0];
+          unsigned Bc = bType.getShape()[1];
+          assert(Br % numWarps == 0);
+          assert(Bc % numWarps == 0);
+          SmallVector<unsigned> warpsPerCTA{numWarps, 1};
+          SmallVector<unsigned> sizePerWarpQ{Br / numWarps, d};
+          SmallVector<unsigned> sizePerWarpK{d, Bc};
+          SmallVector<unsigned> sizePerWarpQK{Br / numWarps, Bc};
+          SmallVector<unsigned> sizePerWarpV{Bc, d};
+          SmallVector<unsigned> sizePerWarpO{Br / numWarps, d};
+          auto ctaLayout = ttg::CTALayoutAttr::get(ctx, {1, 1}, {1, 1}, {1, 0});
+          auto qLayout = ttg::BlockedEncodingAttr::get(
+              ctx, sizePerWarpQ, {1, 1}, warpsPerCTA, {1, 0}, ctaLayout);
+          auto kLayout = ttg::BlockedEncodingAttr::get(
+              ctx, sizePerWarpK, {1, 1}, warpsPerCTA, {1, 0}, ctaLayout);
+          auto qkLayout = ttg::BlockedEncodingAttr::get(
+              ctx, sizePerWarpK, {1, 1}, warpsPerCTA, {1, 0}, ctaLayout);
+          auto vLayout = ttg::BlockedEncodingAttr::get(
+              ctx, sizePerWarpV, {1, 1}, warpsPerCTA, {1, 0}, ctaLayout);
+          auto oLayout = ttg::BlockedEncodingAttr::get(
+              ctx, sizePerWarpO, {1, 1}, warpsPerCTA, {1, 0}, ctaLayout);
+
+          // record value's attr
+          // FIXME: the 2nd loop may overwrite, not check it for now
+          for (auto op : info0.chainOpsA)
+            valueAttrMap[op] = qLayout;
+          for (auto op : info0.chainOpsB)
+            valueAttrMap[op] = kLayout;
+          for (auto op : info0.chainOpsC)
+            valueAttrMap[op] = qkLayout;
+          if (info0.advanceA)
+            valueAttrMap[info0.advanceA] = qLayout;
+          if (info0.advanceB)
+            valueAttrMap[info0.advanceB] = kLayout;
+
+          assert(info1.chainOpsA.empty());
+
           break;
         }
         }
@@ -366,11 +410,38 @@ public:
         return Workload::None;
       SmallVector<OpFoldResult> rawOffsetsA = dotInfo.advanceA.getOffsets();
       SmallVector<OpFoldResult> rawOffsetsB = dotInfo.advanceB.getOffsets();
-      auto offsetsA = *getConstantIntValues(rawOffsetsA);
-      auto offsetsB = *getConstantIntValues(rawOffsetsB);
+      SmallVector<int64_t> offsetsA = *getConstantIntValues(rawOffsetsA);
+      SmallVector<int64_t> offsetsB = *getConstantIntValues(rawOffsetsB);
       if (offsetsA.size() == 2 && offsetsB.size() == 2 && offsetsA[0] == 0 &&
           offsetsB[1] == 0)
         return Workload::Gemm;
+    }
+    // match flash-attention pattern
+    // %q
+    //  scf.for idx
+    //    %k = tt.load %ptrK
+    //    %qk = tt.dot %q, %k
+    //    %qk_ = arit/math  %qk
+    //    %v = tt.load %ptrV
+    //    %o = tt.dot %qk_, %v
+    //    tt.advance %ptrK, [stepK, 0]
+    //    tt.advance %ptrV, [0, stepV]
+    else if (loopDotInfo.dotInfo0.dot && loopDotInfo.dotInfo1.dot) {
+      if (!loopDotInfo.connectDotA || loopDotInfo.connectDotB)
+        return Workload::None;
+      DotInfo &info0 = loopDotInfo.dotInfo0;
+      DotInfo &info1 = loopDotInfo.dotInfo1;
+      if (!info0.chainOpsA.empty() && // Q is loop invariant
+          info0.chainOpsA[0].getDefiningOp()->isBeforeInBlock(loop) &&
+          info0.advanceB && info1.advanceB) {
+        SmallVector<OpFoldResult> rawOffsetsK = info0.advanceB.getOffsets();
+        SmallVector<OpFoldResult> rawOffsetsV = info1.advanceB.getOffsets();
+        SmallVector<int64_t> offsetsK = *getConstantIntValues(rawOffsetsK);
+        SmallVector<int64_t> offsetsV = *getConstantIntValues(rawOffsetsV);
+        if (offsetsK.size() == 2 && offsetsV.size() == 2 && offsetsK[0] == 0 &&
+            offsetsV[1] == 0 && offsetsK[1] == offsetsV[0])
+          return Workload::Attention;
+      }
     }
     return Workload::None;
   }
@@ -447,6 +518,29 @@ public:
       else if (op->getDialect() == arithDialect ||
                op->getDialect() == mathDialect)
         ops.push_back(op->getResults()[0]);
+      else if (isa<tt::ReduceOp, tt::ExpandDimsOp, tt::BroadcastOp>(op))
+        ;
+      else if (auto dot1 = dyn_cast<tt::DotOp>(op)) {
+        DotInfo &info1 = loopDotInfo.dotInfo1;
+        info1.dot = dot1;
+        Value dotA = dot1.getA();
+        Value dotB = dot1.getB();
+        Value dotC = dot1.getC();
+        if (std::find(ops.begin(), ops.end(), dotA) == ops.end())
+          expandDefChain(loop, dotA, info1.chainOpsA, info1.loadA,
+                         info1.advanceA);
+        else
+          loopDotInfo.connectDotA = true;
+        if (std::find(ops.begin(), ops.end(), dotB) == ops.end())
+          expandDefChain(loop, dotB, info1.chainOpsB, info1.loadB,
+                         info1.advanceB);
+        else
+          loopDotInfo.connectDotB = true;
+        if (std::find(ops.begin(), ops.end(), dotC) == ops.end())
+          expandDotCChain(loop, dot1, info1.chainOpsC, loopDotInfo);
+        else
+          loopDotInfo.connectDotC = true;
+      }
     }
   }
 };

--- a/test/Conversion/triton_to_tritongpu_warp.mlir
+++ b/test/Conversion/triton_to_tritongpu_warp.mlir
@@ -44,4 +44,81 @@ module {
     tt.store %14, %13#0 : !tt.ptr<tensor<256x256xf32>, 1>
     tt.return
   }
+  tt.func public @attn_fwd(%arg0: !tt.ptr<f16, 1>, %arg1: !tt.ptr<f16, 1>, %arg2: !tt.ptr<f16, 1>, %arg3: f32, %arg4: !tt.ptr<f32, 1>, %arg5: !tt.ptr<f32, 1>) attributes {noinline = false} {
+    %cst = arith.constant dense<1.000000e+00> : tensor<128xf32>
+    %cst_0 = arith.constant dense<0xFF800000> : tensor<128xf32>
+    %c1024_i32 = arith.constant 1024 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %cst_1 = arith.constant dense<0.000000e+00> : tensor<128x64xf32>
+    %c65536_i64 = arith.constant 65536 : i64
+    %c131072_i64 = arith.constant 131072 : i64
+    %cst_2 = arith.constant 1.44269502 : f32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = tt.get_program_id y : i32
+    %2 = arith.divsi %1, %c2_i32 : i32
+    %3 = arith.remsi %1, %c2_i32 : i32
+    %4 = arith.extsi %2 : i32 to i64
+    %5 = arith.muli %4, %c131072_i64 : i64
+    %6 = arith.extsi %3 : i32 to i64
+    %7 = arith.muli %6, %c65536_i64 : i64
+    %8 = arith.addi %5, %7 : i64
+    %9 = tt.addptr %arg0, %8 : !tt.ptr<f16, 1>, i64
+    %10 = arith.muli %0, %c128_i32 : i32
+    %11 = tt.make_tensor_ptr %9, [%c1024_i64, %c64_i64], [%c64_i64, %c1_i64], [%10, %c0_i32] {order = array<i32: 1, 0>} : <tensor<128x64xf16>, 1>
+    %12 = tt.addptr %arg2, %8 : !tt.ptr<f16, 1>, i64
+    %13 = tt.make_tensor_ptr %12, [%c1024_i64, %c64_i64], [%c64_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<64x64xf16>, 1>
+    %14 = tt.addptr %arg1, %8 : !tt.ptr<f16, 1>, i64
+    %15 = tt.make_tensor_ptr %14, [%c64_i64, %c1024_i64], [%c1_i64, %c64_i64], [%c0_i32, %c0_i32] {order = array<i32: 0, 1>} : <tensor<64x64xf16>, 1>
+    %16 = tt.addptr %arg5, %8 : !tt.ptr<f32, 1>, i64
+    %17 = tt.make_tensor_ptr %16, [%c1024_i64, %c64_i64], [%c64_i64, %c1_i64], [%10, %c0_i32] {order = array<i32: 1, 0>} : <tensor<128x64xf32>, 1>
+    %18 = arith.mulf %arg3, %cst_2 : f32
+    %19 = tt.load %11 {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<128x64xf16>, 1>
+    %20 = tt.splat %18 : f32 -> tensor<128xf32>
+    %21 = tt.splat %18 : f32 -> tensor<128x64xf32>
+    %22:5 = scf.for %arg6 = %c0_i32 to %c1024_i32 step %c64_i32 iter_args(%arg7 = %cst, %arg8 = %cst_1, %arg9 = %cst_0, %arg10 = %13, %arg11 = %15) -> (tensor<128xf32>, tensor<128x64xf32>, tensor<128xf32>, !tt.ptr<tensor<64x64xf16>, 1>, !tt.ptr<tensor<64x64xf16>, 1>)  : i32 {
+      %26 = tt.load %arg11 {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<64x64xf16>, 1>
+      %27 = tt.dot %19, %26, %cst_1 {maxNumImpreciseAcc = 0 : i32} : tensor<128x64xf16> * tensor<64x64xf16> -> tensor<128x64xf32>
+      %28 = "tt.reduce"(%27) <{axis = 1 : i32}> ({
+      ^bb0(%arg12: f32, %arg13: f32):
+        %49 = arith.maxnumf %arg12, %arg13 : f32
+        tt.reduce.return %49 : f32
+      }) : (tensor<128x64xf32>) -> tensor<128xf32>
+      %29 = arith.mulf %28, %20 : tensor<128xf32>
+      %30 = arith.maxnumf %arg9, %29 : tensor<128xf32>
+      %31 = arith.mulf %27, %21 : tensor<128x64xf32>
+      %32 = tt.expand_dims %30 {axis = 1 : i32} : tensor<128xf32> -> tensor<128x1xf32>
+      %33 = tt.broadcast %32 : tensor<128x1xf32> -> tensor<128x64xf32>
+      %34 = arith.subf %31, %33 : tensor<128x64xf32>
+      %35 = math.exp2 %34 : tensor<128x64xf32>
+      %36 = "tt.reduce"(%35) <{axis = 1 : i32}> ({
+      ^bb0(%arg12: f32, %arg13: f32):
+        %49 = arith.addf %arg12, %arg13 : f32
+        tt.reduce.return %49 : f32
+      }) : (tensor<128x64xf32>) -> tensor<128xf32>
+      %37 = arith.subf %arg9, %30 : tensor<128xf32>
+      %38 = math.exp2 %37 : tensor<128xf32>
+      %39 = arith.mulf %arg7, %38 : tensor<128xf32>
+      %40 = arith.addf %39, %36 : tensor<128xf32>
+      %41 = tt.expand_dims %38 {axis = 1 : i32} : tensor<128xf32> -> tensor<128x1xf32>
+      %42 = tt.broadcast %41 : tensor<128x1xf32> -> tensor<128x64xf32>
+      %43 = arith.mulf %arg8, %42 : tensor<128x64xf32>
+      %44 = tt.load %arg10 {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<64x64xf16>, 1>
+      %45 = arith.truncf %35 : tensor<128x64xf32> to tensor<128x64xf16>
+      %46 = tt.dot %45, %44, %43 {maxNumImpreciseAcc = 0 : i32} : tensor<128x64xf16> * tensor<64x64xf16> -> tensor<128x64xf32>
+      %47 = tt.advance %arg10, [%c64_i32, %c0_i32] : <tensor<64x64xf16>, 1>
+      %48 = tt.advance %arg11, [%c0_i32, %c64_i32] : <tensor<64x64xf16>, 1>
+      scf.yield %40, %46, %30, %47, %48 : tensor<128xf32>, tensor<128x64xf32>, tensor<128xf32>, !tt.ptr<tensor<64x64xf16>, 1>, !tt.ptr<tensor<64x64xf16>, 1>
+    } {tt.divisibility_arg1 = dense<64> : tensor<1xi32>}
+    %23 = tt.expand_dims %22#0 {axis = 1 : i32} : tensor<128xf32> -> tensor<128x1xf32>
+    %24 = tt.broadcast %23 : tensor<128x1xf32> -> tensor<128x64xf32>
+    %25 = arith.divf %22#1, %24 : tensor<128x64xf32>
+    tt.store %17, %25 {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<128x64xf32>, 1>
+    tt.return
+  }
 }


### PR DESCRIPTION
match flash-attention pattern
```mlir
%q = tt.load %ptrQ
 scf.for idx
   %k = tt.load %ptrK
   %qk = tt.dot %q, %k
   ...
   %qk_ = arit/math  %qk
   ...
   %v = tt.load %ptrV
   %o = tt.dot %qk_, %v
   tt.advance %ptrK, [stepK, 0]
   tt.advance %ptrV, [0, stepV]
```