### PR TITLE
bug fix in match-target-size

### DIFF
--- a/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
@@ -193,7 +193,7 @@ OpFoldResult ExtractOp::fold(FoldAdaptor adaptor) {
   // %0 =  .... : tensor<16x8xf16>
   // extract %0[0] : tensor<16x8xf16> -> %0
   if (getIndex() == 0 && getBase().getType() == getType())
-    return getOperand();
+    return getBase();
 
   return {};
 }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MatchTargetSize.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MatchTargetSize.cpp
@@ -696,8 +696,8 @@ void MatchTargetSizePass::transformGenericOp(Operation *op) {
 
   if (numResults == 1) {
     op->replaceAllUsesWith(b.create<ttgi::GlueOp>(loc, type, subOps));
-    op->erase();
   }
+  op->erase();
 }
 
 } // namespace


### PR DESCRIPTION
typo operand name
misplaced op->erase()