### PR TITLE
[NFC] Refactor to use pass options and generated constructors

### DIFF
--- a/include/triton/Dialect/TritonIntelGPU/Transforms/Passes.h
+++ b/include/triton/Dialect/TritonIntelGPU/Transforms/Passes.h
@@ -22,31 +22,16 @@ enum class DeviceArch {
   PVC,
 };
 
-std::unique_ptr<Pass> createTritonIntelGPUAccelerateMatmulPass(
-    intel::DeviceArch arch = intel::DeviceArch::UNKNOWN);
-
-std::unique_ptr<Pass> createTritonIntelGPUDistributeToWarpsPass();
-
-std::unique_ptr<Pass> createTritonIntelGPUPipelinePass(
-    int numStages = 3, intel::DeviceArch arch = intel::DeviceArch::UNKNOWN);
-
-std::unique_ptr<Pass> createTritonIntelGPURemoveLayoutConversionsPass();
-
-std::unique_ptr<Pass> createTritonIntelGPURewriteTensorPointerPass(
-    intel::DeviceArch arch = intel::DeviceArch::UNKNOWN);
-
-std::unique_ptr<Pass> createPrefetchBlockPass();
-
-std::unique_ptr<Pass> createMatchTargetSizePass();
-
 } // namespace intel
 } // namespace gpu
 } // namespace triton
 
+#define GEN_PASS_DECL
+#include "triton/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "triton/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
-
 } // namespace mlir
 
 #endif // TRITON_DIALECT_TRITON_INTEL_GPU_TRANSFORMS_PASSES_H

--- a/include/triton/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -20,8 +20,6 @@ def TritonIntelGPUAccelerateMatmul
     compatible with the Intel DPAS instruction requirements.
   }];
 
-  let constructor = "mlir::triton::gpu::intel::createTritonIntelGPUAccelerateMatmulPass()";
-
   let dependentDialects = [
     "mlir::triton::TritonDialect",
     "mlir::triton::gpu::intel::TritonIntelGPUDialect",
@@ -93,8 +91,6 @@ def TritonIntelGPUDistributeToWarps
     ```
   }];
 
-  let constructor = "mlir::triton::gpu::intel::createTritonIntelGPUDistributeToWarpsPass()";
-
   let dependentDialects = ["mlir::triton::TritonDialect",
                            "mlir::triton::gpu::intel::TritonIntelGPUDialect",
                            "mlir::arith::ArithDialect",
@@ -109,8 +105,6 @@ def TritonIntelGPUPipeline : Pass<"tritonintelgpu-pipeline", "mlir::ModuleOp"> {
     The pass supports prefetching `tt.dot` operands. The `num-stages` argument controls
     the prefetching and distance (i.e. the number of iterations to prefetch in advance).
   }];
-
-  let constructor = "mlir::triton::gpu::intel::createTritonIntelGPUPipelinePass()";
 
   let dependentDialects = ["mlir::arith::ArithDialect",
                            "mlir::scf::SCFDialect",
@@ -173,8 +167,6 @@ def TritonIntelGPURemoveLayoutConversions : Pass<"tritonintelgpu-remove-layout-c
     accesses in the IO buffer or cache them.
   }];
 
-  let constructor = "mlir::triton::gpu::intel::createTritonIntelGPURemoveLayoutConversionsPass()";
-
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
                            "mlir::triton::TritonDialect"];
 
@@ -189,8 +181,6 @@ def TritonIntelGPURewriteTensorPointer : Pass<"tritonintelgpu-rewrite-tensor-poi
     create and advance the block pointer (that is `tt.make_tensor_tr` and
     `tt.advance`).
   }];
-
-  let constructor = "mlir::triton::gpu::intel::createTritonIntelGPURewriteTensorPointerPass()";
 
   let dependentDialects = ["mlir::triton::TritonDialect"];
 
@@ -217,7 +207,6 @@ def TritonIntelGPUPrefetchBlock : Pass<"tritonintelgpu-prefetch-block", "mlir::M
       - only targets that have a dedicated prefetch instruction are supported
   }];
 
-  let constructor = "mlir::triton::gpu::intel::createPrefetchBlockPass()";
   let dependentDialects = ["mlir::triton::TritonDialect",
                            "mlir::triton::gpu::intel::TritonIntelGPUDialect",
                            "mlir::scf::SCFDialect",
@@ -269,8 +258,6 @@ def TritonIntelGPUMatchTargetSize : Pass<"tritonintelgpu-match-target-size", "ml
       ...
       ```
   }];
-
-  let constructor = "mlir::triton::gpu::intel::createMatchTargetSizePass()";
 
   let dependentDialects = ["mlir::triton::TritonDialect",
                            "mlir::triton::gpu::intel::TritonIntelGPUDialect"];

--- a/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
@@ -235,17 +235,18 @@ static void decomposeMixedModeDotOp(ModuleOp mod) {
   });
 }
 
-#define GEN_PASS_CLASSES
+namespace mlir {
+#define GEN_PASS_DEF_TRITONINTELGPUACCELERATEMATMUL
 #include "triton/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
+} // namespace mlir
 
 class TritonIntelGPUAccelerateMatmulPass
-    : public TritonIntelGPUAccelerateMatmulBase<
+    : public impl::TritonIntelGPUAccelerateMatmulBase<
           TritonIntelGPUAccelerateMatmulPass> {
 public:
-  TritonIntelGPUAccelerateMatmulPass() = default;
-  TritonIntelGPUAccelerateMatmulPass(ttgi::DeviceArch arch) {
-    this->deviceArch = arch;
-  }
+  using impl::TritonIntelGPUAccelerateMatmulBase<
+      TritonIntelGPUAccelerateMatmulPass>::TritonIntelGPUAccelerateMatmulBase;
+
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     ModuleOp m = getOperation();
@@ -260,14 +261,3 @@ public:
     decomposeMixedModeDotOp(m);
   }
 };
-
-std::unique_ptr<Pass> mlir::createTritonIntelGPUAccelerateMatmul() {
-  return createTritonIntelGPUAccelerateMatmul(
-      // Use default specified for the option class.
-      TritonIntelGPUAccelerateMatmulOptions{});
-}
-
-std::unique_ptr<Pass> mlir::createTritonIntelGPUAccelerateMatmul(
-    const TritonIntelGPUAccelerateMatmulOptions &Opt) {
-  return std::make_unique<TritonIntelGPUAccelerateMatmulPass>(Opt.deviceArch);
-}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
@@ -261,8 +261,13 @@ public:
   }
 };
 
-std::unique_ptr<Pass>
-mlir::triton::gpu::intel::createTritonIntelGPUAccelerateMatmulPass(
-    ttgi::DeviceArch arch) {
-  return std::make_unique<TritonIntelGPUAccelerateMatmulPass>(arch);
+std::unique_ptr<Pass> mlir::createTritonIntelGPUAccelerateMatmul() {
+  return createTritonIntelGPUAccelerateMatmul(
+      // Use default specified for the option class.
+      TritonIntelGPUAccelerateMatmulOptions{});
+}
+
+std::unique_ptr<Pass> mlir::createTritonIntelGPUAccelerateMatmul(
+    const TritonIntelGPUAccelerateMatmulOptions &Opt) {
+  return std::make_unique<TritonIntelGPUAccelerateMatmulPass>(Opt.deviceArch);
 }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/DistributeToWarps.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/DistributeToWarps.cpp
@@ -289,11 +289,13 @@ void distributeScfForOp(scf::ForOp op) {
 
 } // namespace
 
-#define GEN_PASS_CLASSES
+namespace mlir {
+#define GEN_PASS_DEF_TRITONINTELGPUDISTRIBUTETOWARPS
 #include "triton/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
+} // namespace mlir
 
 class TritonIntelGPUDistributeToWarpsPass
-    : public TritonIntelGPUDistributeToWarpsBase<
+    : public impl::TritonIntelGPUDistributeToWarpsBase<
           TritonIntelGPUDistributeToWarpsPass> {
 public:
   void runOnOperation() override {
@@ -338,7 +340,3 @@ public:
     }
   }
 };
-
-std::unique_ptr<Pass> mlir::createTritonIntelGPUDistributeToWarps() {
-  return std::make_unique<TritonIntelGPUDistributeToWarpsPass>();
-}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/DistributeToWarps.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/DistributeToWarps.cpp
@@ -339,7 +339,6 @@ public:
   }
 };
 
-std::unique_ptr<Pass>
-mlir::triton::gpu::intel::createTritonIntelGPUDistributeToWarpsPass() {
+std::unique_ptr<Pass> mlir::createTritonIntelGPUDistributeToWarps() {
   return std::make_unique<TritonIntelGPUDistributeToWarpsPass>();
 }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MatchTargetSize.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MatchTargetSize.cpp
@@ -55,7 +55,7 @@
 #include <memory>
 
 namespace mlir {
-#define GEN_PASS_CLASSES
+#define GEN_PASS_DEF_TRITONINTELGPUMATCHTARGETSIZE
 #include "triton/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
 } // namespace mlir
 
@@ -97,7 +97,7 @@ private:
 };
 
 class MatchTargetSizePass
-    : public TritonIntelGPUMatchTargetSizeBase<MatchTargetSizePass> {
+    : public impl::TritonIntelGPUMatchTargetSizeBase<MatchTargetSizePass> {
 public:
   void runOnOperation() override {
     initNativeOperationSizes();
@@ -701,7 +701,3 @@ void MatchTargetSizePass::transformGenericOp(Operation *op) {
 }
 
 } // namespace
-
-std::unique_ptr<mlir::Pass> mlir::createTritonIntelGPUMatchTargetSize() {
-  return std::make_unique<MatchTargetSizePass>();
-}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MatchTargetSize.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MatchTargetSize.cpp
@@ -702,7 +702,6 @@ void MatchTargetSizePass::transformGenericOp(Operation *op) {
 
 } // namespace
 
-std::unique_ptr<mlir::Pass>
-mlir::triton::gpu::intel::createMatchTargetSizePass() {
+std::unique_ptr<mlir::Pass> mlir::createTritonIntelGPUMatchTargetSize() {
   return std::make_unique<MatchTargetSizePass>();
 }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Pipeliner/SoftwarePipeliner.cpp
@@ -7,8 +7,10 @@
 using namespace mlir;
 namespace ttgi = mlir::triton::gpu::intel;
 
-#define GEN_PASS_CLASSES
+namespace mlir {
+#define GEN_PASS_DEF_TRITONINTELGPUPIPELINE
 #include "triton/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
+} // namespace mlir
 
 // Return true if the preconditions for pipelining the loop are met.
 static bool preCondition(scf::ForOp forOp) {
@@ -50,12 +52,10 @@ static void pipelineLoop(scf::ForOp forOp, int numStages) {
 
 namespace {
 struct IntelGPUPipelinePass
-    : public TritonIntelGPUPipelineBase<IntelGPUPipelinePass> {
-  IntelGPUPipelinePass() = default;
-  IntelGPUPipelinePass(int numStages, ttgi::DeviceArch arch) {
-    numStages = numStages;
-    deviceArch = arch;
-  }
+    : public impl::TritonIntelGPUPipelineBase<IntelGPUPipelinePass> {
+
+  using impl::TritonIntelGPUPipelineBase<
+      IntelGPUPipelinePass>::TritonIntelGPUPipelineBase;
 
   void runOnOperation() override {
     if (deviceArch != ttgi::DeviceArch::PVC)
@@ -72,8 +72,3 @@ struct IntelGPUPipelinePass
   }
 };
 } // anonymous namespace
-
-std::unique_ptr<Pass>
-ttgi::createTritonIntelGPUPipelinePass(int numStages, ttgi::DeviceArch arch) {
-  return std::make_unique<IntelGPUPipelinePass>(numStages, arch);
-}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
@@ -54,7 +54,7 @@
 #include <optional>
 
 namespace mlir {
-#define GEN_PASS_CLASSES
+#define GEN_PASS_DEF_TRITONINTELGPUPREFETCHBLOCK
 #include "triton/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
 } // namespace mlir
 
@@ -133,7 +133,7 @@ Type annotatePrefetchType(Type type, unsigned numWarps) {
 }
 
 class PrefetchBlockPass
-    : public TritonIntelGPUPrefetchBlockBase<PrefetchBlockPass> {
+    : public impl::TritonIntelGPUPrefetchBlockBase<PrefetchBlockPass> {
 public:
   /// Groups information for a candidate load.
   struct LoadInfo {
@@ -153,6 +153,9 @@ public:
     SmallVector<Value> offsets;   /// Offsets used by the AdvanceOp
     tt::MakeTensorPtrOp blockPtr; /// Operation defining the blocked pointer
   };
+
+  using impl::TritonIntelGPUPrefetchBlockBase<
+      PrefetchBlockPass>::TritonIntelGPUPrefetchBlockBase;
 
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
@@ -409,7 +412,3 @@ void PrefetchBlockPass::injectPrefetchOpsInBody(
 }
 
 } // namespace
-
-std::unique_ptr<mlir::Pass> mlir::createTritonIntelGPUPrefetchBlock() {
-  return std::make_unique<PrefetchBlockPass>();
-}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
@@ -410,7 +410,6 @@ void PrefetchBlockPass::injectPrefetchOpsInBody(
 
 } // namespace
 
-std::unique_ptr<mlir::Pass>
-mlir::triton::gpu::intel::createPrefetchBlockPass() {
+std::unique_ptr<mlir::Pass> mlir::createTritonIntelGPUPrefetchBlock() {
   return std::make_unique<PrefetchBlockPass>();
 }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -26,9 +26,11 @@
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
+using namespace mlir;
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
 namespace ttgi = mlir::triton::gpu::intel;
 
-namespace mlir::triton::gpu {
 namespace {
 
 // -----------------------------------------------------------------------------
@@ -39,21 +41,21 @@ namespace {
 class ConvertDotConvert : public RewritePattern {
 public:
   ConvertDotConvert(MLIRContext *context)
-      : RewritePattern(ConvertLayoutOp::getOperationName(), 1, context) {}
+      : RewritePattern(ttg::ConvertLayoutOp::getOperationName(), 1, context) {}
 
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
-    auto dstOp = cast<ConvertLayoutOp>(op);
-    auto dotOp = dstOp.getSrc().getDefiningOp<DotOp>();
+    auto dstOp = cast<ttg::ConvertLayoutOp>(op);
+    auto dotOp = dstOp.getSrc().getDefiningOp<tt::DotOp>();
     if (!dotOp)
       return failure();
     if (std::distance(dstOp->user_begin(), dstOp->user_end()) != 1 ||
         std::distance(dotOp->user_begin(), dotOp->user_end()) != 1)
       return failure();
-    auto cvtOp = dotOp.getOperand(2).getDefiningOp<ConvertLayoutOp>();
+    auto cvtOp = dotOp.getOperand(2).getDefiningOp<ttg::ConvertLayoutOp>();
     if (!cvtOp)
       return failure();
-    if (!cvtOp.getSrc().getDefiningOp<LoadOp>())
+    if (!cvtOp.getSrc().getDefiningOp<tt::LoadOp>())
       return failure();
     RankedTensorType dstTy = dstOp.getType();
     RankedTensorType srcTy = cvtOp.getSrc().getType();
@@ -63,12 +65,12 @@ public:
     auto _0f = rewriter.create<arith::ConstantOp>(
         op->getLoc(), dstTy.getElementType(),
         rewriter.getZeroAttr(dstTy.getElementType()));
-    auto _0 = rewriter.create<SplatOp>(op->getLoc(), dotOp.getType(), _0f);
-    auto newDot = rewriter.create<DotOp>(
+    auto _0 = rewriter.create<tt::SplatOp>(op->getLoc(), dotOp.getType(), _0f);
+    auto newDot = rewriter.create<tt::DotOp>(
         op->getLoc(), dotOp.getType(), dotOp.getOperand(0), dotOp.getOperand(1),
         _0, dotOp.getInputPrecision(), dotOp.getMaxNumImpreciseAcc());
-    auto newCvt = rewriter.create<ConvertLayoutOp>(op->getLoc(), dstTy,
-                                                   newDot.getResult());
+    auto newCvt = rewriter.create<ttg::ConvertLayoutOp>(op->getLoc(), dstTy,
+                                                        newDot.getResult());
     rewriter.replaceOpWithNewOp<arith::AddFOp>(op, newCvt, cvtOp.getSrc());
     return success();
   }
@@ -100,7 +102,7 @@ public:
     LayoutInfo() {}
     llvm::SmallSetVector<Attribute, 8> encodings;
   };
-  LayoutPropagation(FuncOp F) : funcOp(F) {}
+  LayoutPropagation(tt::FuncOp F) : funcOp(F) {}
   // Find the anchor ops and set their layout in the data structure.
   void initAnchorLayout();
   // Recursively Propagate the layout to all the users of the anchor ops until
@@ -127,7 +129,7 @@ public:
   void rewriteYieldOp(scf::YieldOp yieldOp);
   void rewriteConditionOp(scf::ConditionOp conditionOp);
   void rewriteReduceToScalar(Operation *reduceOp);
-  void rewriteAssertOp(AssertOp assertOp);
+  void rewriteAssertOp(tt::AssertOp assertOp);
   Operation *cloneElementwise(OpBuilder &rewriter, Operation *op,
                               Attribute encoding);
   // Map the original value to the rewritten one.
@@ -144,12 +146,12 @@ private:
   // map of the values rewrite based on their encoding.
   DenseMap<std::pair<Value, Attribute>, Value> rewriteMapping;
   SetVector<Operation *> opToDelete;
-  FuncOp funcOp;
+  tt::FuncOp funcOp;
 };
 
 class LayoutRematerialization {
 public:
-  LayoutRematerialization(FuncOp F) : funcOp(F) {}
+  LayoutRematerialization(tt::FuncOp F) : funcOp(F) {}
   // Map the original value to the remat'ed one.
   void addRematValue(Value old, Attribute encoding, Value newV);
   bool hasRematValue(Value value, Attribute encoding) {
@@ -163,13 +165,13 @@ public:
   }
   void cleanup();
   void backwardRematerialization();
-  void backwardRematerialization(ConvertLayoutOp convertOp);
+  void backwardRematerialization(ttg::ConvertLayoutOp convertOp);
   void hoistConvertOnTopOfExtOrBroadcast();
-  void hoistConvertOnTopOfExtOrBroadcast(ConvertLayoutOp convertOp);
+  void hoistConvertOnTopOfExtOrBroadcast(ttg::ConvertLayoutOp convertOp);
   void rewriteSlice(SetVector<Value> &slice, DenseMap<Value, Attribute> &layout,
-                    ConvertLayoutOp convertOp, IRMapping &mapping);
+                    ttg::ConvertLayoutOp convertOp, IRMapping &mapping);
   void rewriteSlice(SetVector<Value> &slice, DenseMap<Value, Attribute> &layout,
-                    ConvertLayoutOp convertOp);
+                    ttg::ConvertLayoutOp convertOp);
 
 private:
   void updateRematMapping(SmallVector<std::tuple<Value, Value>> &values);
@@ -181,7 +183,7 @@ private:
   DenseMap<std::pair<Value, Attribute>, Value> rematMapping;
   // DenseMap<std::pair<Operation*, Attribute>, Operation*>
   SetVector<Operation *> opToDelete;
-  FuncOp funcOp;
+  tt::FuncOp funcOp;
 };
 
 void LayoutRematerialization::addRematValue(Value old, Attribute encoding,
@@ -203,21 +205,23 @@ bool hasConvertToMMATransisitiveUse(Operation *op, Attribute encoding) {
   SmallVector<Value> queue = {op->getResult(0)};
   SetVector<Operation *> forwardSlice;
   llvm::SmallDenseSet<Value> seen;
-  bool isMMAV3 = encoding.cast<NvidiaMmaEncodingAttr>().getVersionMajor() == 3;
+  bool isMMAV3 =
+      encoding.cast<ttg::NvidiaMmaEncodingAttr>().getVersionMajor() == 3;
   while (!queue.empty()) {
     Value currentValue = queue.back();
     queue.pop_back();
     getForwardSlice(currentValue, &forwardSlice);
     for (Operation *op : forwardSlice) {
-      if (auto convertOp = dyn_cast<ConvertLayoutOp>(op)) {
+      if (auto convertOp = dyn_cast<ttg::ConvertLayoutOp>(op)) {
         Attribute dstEncoding = convertOp.getType().getEncoding();
-        if (auto mmaLayout = dstEncoding.dyn_cast<NvidiaMmaEncodingAttr>())
+        if (auto mmaLayout = dstEncoding.dyn_cast<ttg::NvidiaMmaEncodingAttr>())
           return (mmaLayout.getVersionMajor() > 1) ? true
                                                    : mmaLayout == encoding;
-        if (dstEncoding.isa<DotOperandEncodingAttr>())
-          return encoding.cast<NvidiaMmaEncodingAttr>().getVersionMajor() > 1;
+        if (dstEncoding.isa<ttg::DotOperandEncodingAttr>())
+          return encoding.cast<ttg::NvidiaMmaEncodingAttr>().getVersionMajor() >
+                 1;
       }
-      if (isMMAV3 && isa<LocalAllocOp>(op))
+      if (isMMAV3 && isa<ttg::LocalAllocOp>(op))
         return true;
       auto yield = dyn_cast<scf::YieldOp>(op);
       if (!yield)
@@ -239,9 +243,9 @@ bool hasConvertToMMATransisitiveUse(Operation *op, Attribute encoding) {
 // Return true if the op is an op with a layout we don't want to change. We will
 // propagate the layout starting from anchor ops.
 bool isLayoutAnchor(Operation *op) {
-  if (isa<LoadOp, StoreOp>(op))
+  if (isa<tt::LoadOp, tt::StoreOp>(op))
     return ttgi::isExpensiveLoadOrStore(op);
-  if (isa<DotOp, AtomicRMWOp, AtomicCASOp>(op))
+  if (isa<tt::DotOp, tt::AtomicRMWOp, tt::AtomicCASOp>(op))
     return true;
 
   // Heuristic: Mark permuting reshape as a layout anchor.  Its dst can be
@@ -249,7 +253,7 @@ bool isLayoutAnchor(Operation *op) {
   // backwards pass to fix it up if necessary.  (If we didn't do this, then
   // anything following the reshape won't be covered by the forward pass at
   // all.)
-  if (auto reshape = dyn_cast<ReshapeOp>(op))
+  if (auto reshape = dyn_cast<tt::ReshapeOp>(op))
     return reshape.getAllowReorder();
 
   return false;
@@ -262,7 +266,7 @@ void LayoutPropagation::initAnchorLayout() {
       // back to mma further down to avoid generating reduction with MMA
       // layout that may have lower performance.
       // This can be improved with more aggressive backward propagation.
-      if (tensorType.getEncoding().isa<NvidiaMmaEncodingAttr>() &&
+      if (tensorType.getEncoding().isa<ttg::NvidiaMmaEncodingAttr>() &&
           v.getDefiningOp() &&
           !hasConvertToMMATransisitiveUse(v.getDefiningOp(),
                                           tensorType.getEncoding())) {
@@ -297,7 +301,7 @@ void LayoutPropagation::setEncoding(ValueRange values, LayoutInfo &info,
     bool hasChanged = false;
     for (auto encoding : info.encodings) {
       std::optional<Attribute> dstEncoding;
-      if (isa<ConvertLayoutOp>(op)) {
+      if (isa<ttg::ConvertLayoutOp>(op)) {
         // Try to remove the convert by making the dst encoding match the source
         // encoding.
         dstEncoding = encoding;
@@ -357,8 +361,8 @@ SmallVector<Value> LayoutPropagation::propagateToUsers(Value value,
     }
     if (user->hasTrait<OpTrait::SameOperandsAndResultEncoding>() ||
         user->hasTrait<OpTrait::Elementwise>() ||
-        isa<ReduceOp, ExpandDimsOp, ReshapeOp, TransOp, JoinOp, SplitOp,
-            ConvertLayoutOp>(user)) {
+        isa<tt::ReduceOp, tt::ExpandDimsOp, tt::ReshapeOp, tt::TransOp,
+            tt::JoinOp, tt::SplitOp, ttg::ConvertLayoutOp>(user)) {
       setEncoding(user->getResults(), info, changed, user);
       continue;
     }
@@ -398,10 +402,11 @@ void LayoutPropagation::resolveConflicts() {
     // TODO: add a proper heuristic.
     Attribute encoding = *info.encodings.begin();
     bool isLoadOrStore =
-        op && isa<LoadOp, StoreOp, AtomicRMWOp, AtomicCASOp>(op);
+        op &&
+        isa<tt::LoadOp, tt::StoreOp, tt::AtomicRMWOp, tt::AtomicCASOp>(op);
     for (Attribute e : info.encodings) {
-      if ((isLoadOrStore && e.isa<BlockedEncodingAttr>()) ||
-          (!isLoadOrStore && e.isa<NvidiaMmaEncodingAttr>())) {
+      if ((isLoadOrStore && e.isa<ttg::BlockedEncodingAttr>()) ||
+          (!isLoadOrStore && e.isa<ttg::NvidiaMmaEncodingAttr>())) {
         encoding = e;
         break;
       }
@@ -431,7 +436,8 @@ void LayoutPropagation::rewrite() { rewriteRegion(funcOp->getRegion(0)); }
 bool reduceToScalar(Operation *op) {
   // For reductions returning a scalar we can change the src encoding without
   // affecting the output.
-  return isa<ReduceOp>(op) && !op->getResultTypes()[0].isa<RankedTensorType>();
+  return isa<tt::ReduceOp>(op) &&
+         !op->getResultTypes()[0].isa<RankedTensorType>();
 }
 
 void LayoutPropagation::rewriteRegion(Region &region) {
@@ -466,7 +472,7 @@ void LayoutPropagation::rewriteRegion(Region &region) {
         rewriteConditionOp(conditionOp);
       } else if (reduceToScalar(&op)) {
         rewriteReduceToScalar(&op);
-      } else if (auto assertOp = dyn_cast<AssertOp>(&op)) {
+      } else if (auto assertOp = dyn_cast<tt::AssertOp>(&op)) {
         rewriteAssertOp(assertOp);
       } else {
         // If we don't need to rewrite the op we still need to remap the
@@ -517,8 +523,8 @@ Value LayoutPropagation::getValueAs(Value value, Attribute encoding) {
     rewriter.setInsertionPointAfterValue(rewrittenValue);
     auto tmpType = RankedTensorType::get(tensorType.getShape(),
                                          tensorType.getElementType(), encoding);
-    Value converted = rewriter.create<ConvertLayoutOp>(value.getLoc(), tmpType,
-                                                       rewrittenValue);
+    Value converted = rewriter.create<ttg::ConvertLayoutOp>(
+        value.getLoc(), tmpType, rewrittenValue);
     // TODO: we could cache the conversion.
     return converted;
   }
@@ -729,7 +735,7 @@ void LayoutPropagation::rewriteReduceToScalar(Operation *reduceOp) {
   }
 }
 
-void LayoutPropagation::rewriteAssertOp(AssertOp assertOp) {
+void LayoutPropagation::rewriteAssertOp(tt::AssertOp assertOp) {
   Attribute srcEncoding;
   // Only need to deal with the first operand which is the condition tensor.
   Value operand = assertOp->getOperand(0);
@@ -751,7 +757,7 @@ Operation *LayoutPropagation::rewriteOp(Operation *op) {
     return rewriteIfOp(ifOp);
   OpBuilder rewriter(op);
   Attribute encoding = *layouts[op->getResult(0)].encodings.begin();
-  if (auto convertOp = dyn_cast<ConvertLayoutOp>(op)) {
+  if (auto convertOp = dyn_cast<ttg::ConvertLayoutOp>(op)) {
     Attribute srcEncoding = convertOp.getSrc().getType().getEncoding();
     auto it = layouts.find(convertOp.getSrc());
     if (it != layouts.end())
@@ -760,7 +766,8 @@ Operation *LayoutPropagation::rewriteOp(Operation *op) {
     auto tensorType = op->getResult(0).getType().cast<RankedTensorType>();
     auto newType = RankedTensorType::get(tensorType.getShape(),
                                          tensorType.getElementType(), encoding);
-    auto cvt = rewriter.create<ConvertLayoutOp>(op->getLoc(), newType, src);
+    auto cvt =
+        rewriter.create<ttg::ConvertLayoutOp>(op->getLoc(), newType, src);
     map(op->getResult(0), cvt.getResult());
     return cvt.getOperation();
   }
@@ -769,15 +776,15 @@ Operation *LayoutPropagation::rewriteOp(Operation *op) {
     auto tensorType = op->getResult(0).getType().cast<RankedTensorType>();
     auto newType = RankedTensorType::get(tensorType.getShape(),
                                          tensorType.getElementType(), encoding);
-    auto cvt = rewriter.create<ConvertLayoutOp>(op->getLoc(), newType,
-                                                newOp->getResult(0));
+    auto cvt = rewriter.create<ttg::ConvertLayoutOp>(op->getLoc(), newType,
+                                                     newOp->getResult(0));
     map(op->getResult(0), cvt.getResult());
     return cvt.getOperation();
   }
   if (op->hasTrait<OpTrait::SameOperandsAndResultEncoding>() ||
       op->hasTrait<OpTrait::Elementwise>() ||
-      isa<ReduceOp, ExpandDimsOp, ReshapeOp, TransOp, JoinOp, SplitOp,
-          ConvertLayoutOp>(op)) {
+      isa<tt::ReduceOp, tt::ExpandDimsOp, tt::ReshapeOp, tt::TransOp,
+          tt::JoinOp, tt::SplitOp, ttg::ConvertLayoutOp>(op)) {
     Operation *newOp = cloneElementwise(rewriter, op, encoding);
     for (auto [oldResult, newResult] :
          llvm::zip(op->getResults(), newOp->getResults())) {
@@ -794,9 +801,9 @@ Operation *LayoutPropagation::rewriteOp(Operation *op) {
 }
 
 bool canBeRemat(Operation *op) {
-  if (isa<LoadOp, StoreOp>(op))
+  if (isa<tt::LoadOp, tt::StoreOp>(op))
     return !ttgi::isExpensiveLoadOrStore(op);
-  if (isa<AtomicRMWOp, AtomicCASOp, DotOp>(op))
+  if (isa<tt::AtomicRMWOp, tt::AtomicCASOp, tt::DotOp>(op))
     return false;
   if (isa<scf::WhileOp, scf::ConditionOp>(op))
     return false;
@@ -831,7 +838,7 @@ void LayoutRematerialization::updateRematMapping(
 
 void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
                                            DenseMap<Value, Attribute> &layout,
-                                           ConvertLayoutOp convertOp,
+                                           ttg::ConvertLayoutOp convertOp,
                                            IRMapping &mapping) {
   SetVector<Operation *> opsToRewrite;
   for (Value v : slice) {
@@ -946,7 +953,7 @@ void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
       auto newType = RankedTensorType::get(tensorType.getShape(),
                                            tensorType.getElementType(),
                                            layout[op->getResult(0)]);
-      auto cvt = builder.create<ConvertLayoutOp>(op->getLoc(), newType,
+      auto cvt = builder.create<ttg::ConvertLayoutOp>(op->getLoc(), newType,
                                                  newOp->getResult(0));
       mapping.map(op->getResult(0), cvt.getResult());
       addRematValue(op->getResult(0), layout[op->getResult(0)],
@@ -960,8 +967,8 @@ void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
         continue;
       Type oldType = old.getType();
       Type newType;
-      if (isTensorPointerType(oldType)) {
-        auto ptrType = oldType.cast<PointerType>();
+      if (tt::isTensorPointerType(oldType)) {
+        auto ptrType = oldType.cast<tt::PointerType>();
         auto tensorType = ptrType.getPointeeType().cast<RankedTensorType>();
         newType = triton::PointerType::get(
             RankedTensorType::get(tensorType.getShape(),
@@ -992,7 +999,7 @@ void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
 
 void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
                                            DenseMap<Value, Attribute> &layout,
-                                           ConvertLayoutOp convertOp) {
+                                           ttg::ConvertLayoutOp convertOp) {
   IRMapping mapping;
   rewriteSlice(slice, layout, convertOp, mapping);
 }
@@ -1018,26 +1025,26 @@ LogicalResult getRematerializableSlice(
 
 void LayoutRematerialization::backwardRematerialization() {
   // Go through each ConvertLayoutOp.
-  SmallVector<ConvertLayoutOp> convertOps;
+  SmallVector<ttg::ConvertLayoutOp> convertOps;
   funcOp.walk(
-      [&](ConvertLayoutOp convertOp) { convertOps.push_back(convertOp); });
-  for (ConvertLayoutOp convertOp : convertOps) {
+      [&](ttg::ConvertLayoutOp convertOp) { convertOps.push_back(convertOp); });
+  for (ttg::ConvertLayoutOp convertOp : convertOps) {
     backwardRematerialization(convertOp);
   }
 }
 
 void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast() {
   // Go through each ConvertLayoutOp.
-  SmallVector<ConvertLayoutOp> convertOps;
+  SmallVector<ttg::ConvertLayoutOp> convertOps;
   funcOp.walk(
-      [&](ConvertLayoutOp convertOp) { convertOps.push_back(convertOp); });
-  for (ConvertLayoutOp convertOp : convertOps) {
+      [&](ttg::ConvertLayoutOp convertOp) { convertOps.push_back(convertOp); });
+  for (ttg::ConvertLayoutOp convertOp : convertOps) {
     hoistConvertOnTopOfExtOrBroadcast(convertOp);
   }
 }
 
 void LayoutRematerialization::backwardRematerialization(
-    ConvertLayoutOp convertOp) {
+    ttg::ConvertLayoutOp convertOp) {
   RankedTensorType targetType = convertOp.getType();
   Value oldV = convertOp->getOperand(0);
   LDBG("check backward remat with source " << oldV << " encoding "
@@ -1076,16 +1083,16 @@ void LayoutRematerialization::backwardRematerialization(
 // For convert left we try to hoist them above type extension to reduce the cost
 // of the convert.
 void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
-    ConvertLayoutOp convertOp) {
+    ttg::ConvertLayoutOp convertOp) {
   // we don't handle conversions to DotOperandEncodingAttr
   // this is a heuristics to accommodate fused attention
   RankedTensorType targetType = convertOp.getType();
-  if (targetType.getEncoding().isa<DotOperandEncodingAttr>())
+  if (targetType.getEncoding().isa<ttg::DotOperandEncodingAttr>())
     return;
 
   auto isExtOrBroadcastOp = [](Operation *op) {
-    return isa<arith::ExtSIOp, arith::ExtUIOp, arith::ExtFOp, BroadcastOp,
-               ExpandDimsOp>(op);
+    return isa<arith::ExtSIOp, arith::ExtUIOp, arith::ExtFOp, tt::BroadcastOp,
+               tt::ExpandDimsOp>(op);
   };
   // 1. Take a backward slice of all the tensor dependencies.
   SetVector<Value> slice;
@@ -1140,7 +1147,7 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
       extOrBroadcatOp->getOperand(0).getType().cast<RankedTensorType>();
   auto newType = RankedTensorType::get(
       tensorType.getShape(), tensorType.getElementType(), *srcEncoding);
-  auto newConvertOp = builder.create<ConvertLayoutOp>(
+  auto newConvertOp = builder.create<ttg::ConvertLayoutOp>(
       convertOp.getLoc(), newType, extOrBroadcatOp->getOperand(0));
   Operation *newExtOrBroadcast = builder.clone(*extOrBroadcatOp);
   newExtOrBroadcast->setOperand(0, newConvertOp.getResult());
@@ -1158,7 +1165,7 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
 }
 
 void backwardRematerialization(ModuleOp module) {
-  module.walk([](FuncOp funcOp) {
+  module.walk([](tt::FuncOp funcOp) {
     LayoutRematerialization layoutRemat(funcOp);
     layoutRemat.backwardRematerialization();
     layoutRemat.cleanup();
@@ -1166,13 +1173,15 @@ void backwardRematerialization(ModuleOp module) {
 }
 
 void hoistConvert(ModuleOp module) {
-  SmallVector<ConvertLayoutOp> convertOps;
-  module.walk([](FuncOp funcOp) {
+  SmallVector<ttg::ConvertLayoutOp> convertOps;
+  module.walk([](tt::FuncOp funcOp) {
     LayoutRematerialization layoutRemat(funcOp);
     layoutRemat.hoistConvertOnTopOfExtOrBroadcast();
     layoutRemat.cleanup();
   });
 }
+
+} // namespace
 
 class TritonIntelGPURemoveLayoutConversionsPass
     : public TritonIntelGPURemoveLayoutConversionsBase<
@@ -1185,7 +1194,7 @@ public:
     ModuleOp m = getOperation();
 
     // 1. Propagate layout forward starting from "anchor" ops.
-    m.walk([](FuncOp funcOp) {
+    m.walk([](tt::FuncOp funcOp) {
       LayoutPropagation layoutPropagation(funcOp);
       layoutPropagation.initAnchorLayout();
       layoutPropagation.propagateLayout();
@@ -1199,7 +1208,7 @@ public:
     });
 
     RewritePatternSet cleanUpPatterns(context);
-    ConvertLayoutOp::getCanonicalizationPatterns(cleanUpPatterns, context);
+    ttg::ConvertLayoutOp::getCanonicalizationPatterns(cleanUpPatterns, context);
     if (applyPatternsAndFoldGreedily(m, std::move(cleanUpPatterns)).failed()) {
       signalPassFailure();
     }
@@ -1242,7 +1251,7 @@ public:
     populateForOpDeadArgumentElimination(cleanUpPatterns2);
     scf::ForOp::getCanonicalizationPatterns(cleanUpPatterns2, context);
     scf::IfOp::getCanonicalizationPatterns(cleanUpPatterns2, context);
-    ConvertLayoutOp::getCanonicalizationPatterns(cleanUpPatterns2, context);
+    ttg::ConvertLayoutOp::getCanonicalizationPatterns(cleanUpPatterns2, context);
     if (applyPatternsAndFoldGreedily(m, std::move(cleanUpPatterns2)).failed()) {
       signalPassFailure();
     }
@@ -1253,10 +1262,7 @@ public:
   }
 };
 
-} // namespace
-
-std::unique_ptr<Pass> intel::createTritonIntelGPURemoveLayoutConversionsPass() {
+std::unique_ptr<mlir::Pass>
+mlir::createTritonIntelGPURemoveLayoutConversions() {
   return std::make_unique<TritonIntelGPURemoveLayoutConversionsPass>();
 }
-
-} // namespace mlir::triton::gpu

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RewriteTensorPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RewriteTensorPointer.cpp
@@ -22,8 +22,10 @@ namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
 namespace ttgi = mlir::triton::gpu::intel;
 
-#define GEN_PASS_CLASSES
+namespace mlir {
+#define GEN_PASS_DEF_TRITONINTELGPUREWRITETENSORPOINTER
 #include "triton/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
+} // namespace mlir
 
 namespace {
 
@@ -318,16 +320,16 @@ private:
 // very fragile and to solve we should expose convert Ptr of tensor to a
 // structure contains all values and not only offsets.
 class TritonIntelGPURewriteTensorPointerPass
-    : public TritonIntelGPURewriteTensorPointerBase<
+    : public impl::TritonIntelGPURewriteTensorPointerBase<
           TritonIntelGPURewriteTensorPointerPass> {
 private:
   DenseMap<Value, RewritedInfo> rewritedInfo;
   DenseSet<Value> valueToRemove;
 
 public:
-  TritonIntelGPURewriteTensorPointerPass(ttgi::DeviceArch arch) {
-    deviceArch = arch;
-  }
+  using impl::TritonIntelGPURewriteTensorPointerBase<
+      TritonIntelGPURewriteTensorPointerPass>::
+      TritonIntelGPURewriteTensorPointerBase;
 
   static bool needRewrite(Operation *op, const DenseSet<Value> &valueToRemove) {
     return std::any_of(op->getOperands().begin(), op->getOperands().end(),
@@ -768,15 +770,3 @@ public:
     }
   }
 };
-
-std::unique_ptr<Pass> mlir::createTritonIntelGPURewriteTensorPointer() {
-  return createTritonIntelGPURewriteTensorPointer(
-      // Use default from option class.
-      TritonIntelGPURewriteTensorPointerOptions{});
-}
-
-std::unique_ptr<Pass> mlir::createTritonIntelGPURewriteTensorPointer(
-    const TritonIntelGPURewriteTensorPointerOptions &Opt) {
-  return std::make_unique<TritonIntelGPURewriteTensorPointerPass>(
-      Opt.deviceArch);
-}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RewriteTensorPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RewriteTensorPointer.cpp
@@ -769,7 +769,14 @@ public:
   }
 };
 
-std::unique_ptr<Pass>
-ttgi::createTritonIntelGPURewriteTensorPointerPass(ttgi::DeviceArch arch) {
-  return std::make_unique<TritonIntelGPURewriteTensorPointerPass>(arch);
+std::unique_ptr<Pass> mlir::createTritonIntelGPURewriteTensorPointer() {
+  return createTritonIntelGPURewriteTensorPointer(
+      // Use default from option class.
+      TritonIntelGPURewriteTensorPointerOptions{});
+}
+
+std::unique_ptr<Pass> mlir::createTritonIntelGPURewriteTensorPointer(
+    const TritonIntelGPURewriteTensorPointerOptions &Opt) {
+  return std::make_unique<TritonIntelGPURewriteTensorPointerPass>(
+      Opt.deviceArch);
 }

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -1,4 +1,4 @@
-﻿#include "TritonIntelGPUToLLVM/Passes.h"
+#include "TritonIntelGPUToLLVM/Passes.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "passes.h"
@@ -30,8 +30,8 @@ void init_triton_intel_passes_ttgpuir(py::module &&m) {
   });
   m.def(
       "add_accelerate_matmul",
-      [](mlir::PassManager &pm, intel::DeviceArch arch) {
-        pm.addPass(intel::createTritonIntelGPUAccelerateMatmulPass(arch));
+      [](mlir::PassManager &pm, mlir::triton::gpu::intel::DeviceArch arch) {
+        pm.addPass(mlir::createTritonIntelGPUAccelerateMatmul({arch}));
       },
       py::arg("pm"), py::arg("arch") = intel::DeviceArch::UNKNOWN);
   m.def("add_decompose_unsupported_conversions", [](mlir::PassManager &pm) {
@@ -43,17 +43,17 @@ void init_triton_intel_passes_ttgpuir(py::module &&m) {
   m.def(
       "add_pipe_line_pass",
       [](mlir::PassManager &pm, int numStages, intel::DeviceArch arch) {
-        pm.addPass(intel::createTritonIntelGPUPipelinePass(numStages, arch));
+        pm.addPass(mlir::createTritonIntelGPUPipeline({numStages, arch}));
       },
       py::arg("pm"), py::arg("numStages"),
       py::arg("arch") = intel::DeviceArch::UNKNOWN);
   m.def("add_remove_layout_conversions", [](mlir::PassManager &pm) {
-    pm.addPass(intel::createTritonIntelGPURemoveLayoutConversionsPass());
+    pm.addPass(mlir::createTritonIntelGPURemoveLayoutConversions());
   });
   m.def(
       "add_rewrite_tensor_pointer",
-      [](mlir::PassManager &pm, intel::DeviceArch arch) {
-        pm.addPass(intel::createTritonIntelGPURewriteTensorPointerPass(arch));
+      [](mlir::PassManager &pm, mlir::triton::gpu::intel::DeviceArch arch) {
+        pm.addPass(mlir::createTritonIntelGPURewriteTensorPointer({arch}));
       },
       py::arg("pm"), py::arg("arch") = intel::DeviceArch::UNKNOWN);
 }


### PR DESCRIPTION
Remove custom pass constructors and use constructors generated by TableGen instead. For passes taking options, this now also uses the generated `struct` for option passing. 

Refactors `RemoveLayoutConversion` to align with the other passes.

This fixes #1002 