### PR TITLE
Runner 0.0.13 with PyTorch dependencies bundle (PTDB) 0.5

### DIFF
--- a/.github/actions/setup-ipex/action.yml
+++ b/.github/actions/setup-ipex/action.yml
@@ -35,7 +35,7 @@ runs:
       uses: ./.github/actions/load
       env:
         # Increase this value to reset cache
-        CACHE_NUMBER: "1"
+        CACHE_NUMBER: "1-ptdb"
       with:
         path: intel-extension-for-pytorch/dist
         key: ipex-$PYTHON_VERSION-$IPEX_COMMIT_ID-$CACHE_NUMBER

--- a/.github/actions/setup-pytorch/action.yml
+++ b/.github/actions/setup-pytorch/action.yml
@@ -49,7 +49,7 @@ runs:
       uses: ./.github/actions/load
       env:
         # Increase this value to reset cache
-        CACHE_NUMBER: "4"
+        CACHE_NUMBER: "4-ptdb"
       with:
         path: pytorch
         key: pytorch-$PYTHON_VERSION-$PYTORCH_COMMIT_ID-$CACHE_NUMBER

--- a/.github/dockerfiles/runner-base/Dockerfile
+++ b/.github/dockerfiles/runner-base/Dockerfile
@@ -40,9 +40,9 @@ SHELL ["/bin/bash", "-xec"]
 
 # TODO: install only necessary components
 RUN \
-  curl -sSLO https://registrationcenter-download.intel.com/akdlm/IRC_NAS/fdc7a2bc-b7a8-47eb-8876-de6201297144/l_BaseKit_p_2024.1.0.596_offline.sh; \
-  sh l_BaseKit*.sh -a --silent --eula accept; \
-  rm l_BaseKit*.sh
+  curl -sSLO https://registrationcenter-download.intel.com/akdlm/IRC_NAS/52723419-d344-42bf-93ca-867606409cf0/l_intel-for-pytorch-gpu-dev_p_0.5.0.49_offline.sh; \
+  sh l_intel-for-pytorch-gpu*.sh -a --silent --eula accept; \
+  rm l_intel-for-pytorch-gpu*.sh
 
 RUN \
   curl -sSLO https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh; \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on:
       - glados
       - spr
-      - runner-0.0.12
+      - runner-0.0.13
     strategy:
       matrix:
         python:

--- a/.github/workflows/conda-build-test.yml
+++ b/.github/workflows/conda-build-test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on:
       - glados
       - spr
-      - runner-0.0.12
+      - runner-0.0.13
     strategy:
       matrix:
         python:

--- a/.github/workflows/docker-runner.yml
+++ b/.github/workflows/docker-runner.yml
@@ -7,7 +7,7 @@ permissions: read-all
 
 env:
   REGISTRY: docker-registry.docker-registry.svc.cluster.local:5000
-  TAG: triton-runner-base:0.0.12
+  TAG: triton-runner-base:0.0.13
 
 jobs:
   build:

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on:
       - glados
       - spr
-      - runner-0.0.12
+      - runner-0.0.13
     strategy:
       matrix:
         python:


### PR DESCRIPTION
Replacing oneAPI 2024.1.0 with PTDB 0.5 (https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpus.html).