### PR TITLE
[intel] Refactor `Utility.h`

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -149,9 +149,9 @@ private:
     auto dstIndices =
         ::intel::emitIndices(loc, rewriter, targetInfo, dstLayout, dstTy, true);
 
-    SmallVector<Value> outVals = ::intel::loadSharedToDistributed(
-        op.getResult(), dstIndices, op.getSrc(), smemObj, elemTy, loc, rewriter,
-        targetInfo);
+    SmallVector<Value> outVals =
+        ::intel::loadSharedToDistributed(op.getResult(), op.getSrc(), smemObj,
+                                         elemTy, loc, rewriter, targetInfo);
 
     Value result = packLLElements(loc, typeConverter, outVals, rewriter, dstTy);
     rewriter.replaceOp(op, result);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/MemoryOpToLLVM.cpp
@@ -36,8 +36,8 @@ void lowerDistributedToShared(LocalAllocOp op, LocalAllocOpAdaptor adaptor,
       loc, rewriter, targetInfo, srcLayout, srcTy, false);
   auto inVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
   mlir::triton::intel::storeDistributedToShared(
-      op.getSrc(), inVals, dstStrides, srcIndices, op.getResult(), smemBase,
-      elemTy, loc, rewriter, targetInfo);
+      op.getSrc(), inVals, dstStrides, op.getResult(), smemBase, elemTy, loc,
+      rewriter, targetInfo);
 }
 
 struct LocalAllocOpConversion


### PR DESCRIPTION
1. Removed specialized version of `emitCTAOffsetForLayout`.
2. Use `emitBaseIndexForLayoutImpl` from common `Utility.h` for some layouts.
3. Other changes are synced from the common `Utility.h`.