### PR TITLE
[CI] Python 3.9 for PR commits, Python 3.9 - 3.11 for merge commits

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -66,9 +66,7 @@ jobs:
       - runner-0.0.13
     strategy:
       matrix:
-        python:
-          - "3.9"
-          - "3.10"
+        python: ${{ github.ref_name == 'llvm-target' && fromJson('["3.9", "3.10", "3.11"]') || fromJson('["3.9"]') }}
     defaults:
       run:
         shell: bash -noprofile --norc -eo pipefail -c "source /home/runner/intel/oneapi/setvars.sh > /dev/null; source {0}"


### PR DESCRIPTION
Run tests only for one Python version 3.9 for PR commits, run tests for Python 3.9, 3.10, 3.11 for merge commits to the default branch. Since many developers use 3.9 for their environment it is reasonable to use 3.9 as a "default" Python version for all commits. Later, after upgrading development environments to Python 3.9 or 3.11, we can change the "default" Python version for CI.