### PR TITLE
[GEN] Use OCL builtin for some variants of 2D block read 

### DIFF
--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -218,7 +218,7 @@ static LLVM::CallOp createGenISADPAS(TritonGEN::MatrixDPASOp op,
   return rewriter.create<LLVM::CallOp>(loc, funcOp, args);
 }
 
-static bool isOCLAvailable(TritonGEN::Matrix2DBlockLoadOp op) {
+static bool isOCLBuiltinAvailable(TritonGEN::Matrix2DBlockLoadOp op) {
   if (op.getVnniTransform() || op.getTranspose())
     return false;
 
@@ -242,7 +242,7 @@ createGenISA2DBlockRead(TritonGEN::Matrix2DBlockLoadOp op,
   Location loc = op->getLoc();
 
   // FIXME: Use the OpenCL API also for all other variants.
-  if (isOCLAvailable(op)) {
+  if (isOCLBuiltinAvailable(op)) {
     std::string fnName = "intel_subgroup_block_read_u" +
                          std::to_string(op.getElemSizeInBits()) + "_m" +
                          std::to_string(op.getTileHeight()) + "k" +


### PR DESCRIPTION
```
// 2x ATile (MxK) block read:
ushort2 intel_subgroup_block_read_u8_m1k32v2(
    __global void* base_address,
    int width, int height, int pitch, int2 byte_coord);
ushort4 intel_subgroup_block_read_u8_m2k32v2(
    __global void* base_address,
    int width, int height, int pitch, int2 byte_coord);
ushort8 intel_subgroup_block_read_u8_m4k32v2(
    __global void* base_address,
    int width, int height, int pitch, int2 byte_coord);
ushort16 intel_subgroup_block_read_u8_m8k32v2(
    __global void* base_address,
    int width, int height, int pitch, int2 byte_coord);
ushort2 intel_subgroup_block_read_u16_m1k16v2(
    __global void* base_address,
    int width, int height, int pitch, int2 byte_coord);
ushort4 intel_subgroup_block_read_u16_m2k16v2(
    __global void* base_address,
    int width, int height, int pitch, int2 byte_coord);
ushort8 intel_subgroup_block_read_u16_m4k16v2(
    __global void* base_address,
    int width, int height, int pitch, int2 byte_coord);
ushort16 intel_subgroup_block_read_u16_m8k16v2(
    __global void* base_address,
    int width, int height, int pitch, int2 byte_coord);
```