### PR TITLE
Enable pytest-capturewarnings-ng plugin

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -106,6 +106,7 @@ jobs:
           cd python
           pip install wheel pytest pytest-xdist pytest-rerunfailures pytest-select
           pip install --no-build-isolation '.[build,tests,tutorials]'
+          pip install git+https://github.com/kwasd/pytest-capturewarnings-ng.git@v1.1
 
       - name: Run lit tests
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -116,6 +116,7 @@ jobs:
         run: |
           mkdir ~/reports
           echo "TRITON_TEST_REPORTS=true" >> $GITHUB_ENV
+          echo "TRITON_TEST_WARNING_REPORTS=true" >> $GITHUB_ENV
           echo "TRITON_TEST_REPORTS_DIR=$HOME/reports" >> $GITHUB_ENV
 
       - name: Run core tests

--- a/python/setup.py
+++ b/python/setup.py
@@ -602,7 +602,7 @@ setup(
             "numpy",
             "pytest",
             "scipy>=1.7.1",
-            "pytest-capturewarnings-ng @ git+https://github.com/kwasd/pytest-capturewarnings-ng.git@v1.0"
+            "pytest-capturewarnings-ng @ git+https://github.com/kwasd/pytest-capturewarnings-ng.git@v1.1"
         ],
         "tutorials": [
             "matplotlib",

--- a/python/setup.py
+++ b/python/setup.py
@@ -602,7 +602,7 @@ setup(
             "numpy",
             "pytest",
             "scipy>=1.7.1",
-            "pytest-capturewarnings-ng @ git+https://github.com/kwasd/pytest-capturewarnings-ng.git@v1.1"
+            "pytest-capturewarnings-ng @ git+https://github.com/kwasd/pytest-capturewarnings-ng.git@v1.1#egg=src/pytest_capturewarnings_ng"
         ],
         "tutorials": [
             "matplotlib",

--- a/python/setup.py
+++ b/python/setup.py
@@ -602,6 +602,7 @@ setup(
             "numpy",
             "pytest",
             "scipy>=1.7.1",
+            "pytest-capturewarnings-ng @ git+https://github.com/kwasd/pytest-capturewarnings-ng.git@v1.0"
         ],
         "tutorials": [
             "matplotlib",

--- a/python/setup.py
+++ b/python/setup.py
@@ -602,7 +602,6 @@ setup(
             "numpy",
             "pytest",
             "scipy>=1.7.1",
-            "pytest-capturewarnings-ng @ git+https://github.com/kwasd/pytest-capturewarnings-ng.git@v1.1#egg=src/pytest_capturewarnings_ng"
         ],
         "tutorials": [
             "matplotlib",

--- a/scripts/pytest-utils.sh
+++ b/scripts/pytest-utils.sh
@@ -4,6 +4,7 @@ SCRIPTS_DIR="${SCRIPTS_DIR:-$PWD/scripts}"
 TRITON_TEST_REPORTS="${TRITON_TEST_REPORTS:-false}"
 TRITON_TEST_REPORTS_DIR="${TRITON_TEST_REPORTS_DIR:-$HOME/reports/$TIMESTAMP}"
 TRITON_TEST_SKIPLIST_DIR="${TRITON_TEST_SKIPLIST_DIR:-$SCRIPTS_DIR/skiplist/default}"
+TRITON_TEST_WARNING_REPORTS="${TRITON_TEST_WARNING_REPORTS:-false}"
 
 # absolute path for the selected skip list
 TRITON_TEST_SKIPLIST_DIR="$(cd "$TRITON_TEST_SKIPLIST_DIR" && pwd)"
@@ -17,6 +18,13 @@ pytest() {
         mkdir -p "$TRITON_TEST_REPORTS_DIR"
         pytest_extra_args+=(
             "--junitxml=$TRITON_TEST_REPORTS_DIR/$TRITON_TEST_SUITE.xml"
+        )
+    fi
+
+    if [[ -v TRITON_TEST_SUITE && $TRITON_TEST_WARNING_REPORTS = true ]]; then
+        mkdir -p "$TRITON_TEST_REPORTS_DIR"
+        pytest_extra_args+=(
+            "--warnings-output-file=$TRITON_TEST_REPORTS_DIR/${TRITON_TEST_SUITE}-warnings.txt"
         )
     fi
 

--- a/scripts/pytest-utils.sh
+++ b/scripts/pytest-utils.sh
@@ -24,7 +24,8 @@ pytest() {
     if [[ -v TRITON_TEST_SUITE && $TRITON_TEST_WARNING_REPORTS = true ]]; then
         mkdir -p "$TRITON_TEST_REPORTS_DIR"
         pytest_extra_args+=(
-            "--warnings-output-file=$TRITON_TEST_REPORTS_DIR/${TRITON_TEST_SUITE}-warnings.txt"
+            "--warnings-output-file"
+            "$TRITON_TEST_REPORTS_DIR/${TRITON_TEST_SUITE}-warnings.txt"
         )
     fi
 

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -42,7 +42,7 @@ for arg in "$@"; do
       shift
       ;;
     --help)
-      echo "Example usage: ./test-triton.sh [--core | --tutorial | --unit | --venv | --reports]"
+      echo "Example usage: ./test-triton.sh [--core | --tutorial | --unit | --venv | --reports | --warning-reports]"
       exit 1
       ;;
     *)

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -75,7 +75,7 @@ export SCRIPTS_DIR=$(cd $(dirname "$0") && pwd)
 python3 -m pip install lit pytest pytest-xdist pytest-rerunfailures pytest-select
 
 if [ "$TRITON_TEST_WARNING_REPORTS" == true ]; then
-    python3 -m pip install git+https://github.com/kwasd/pytest-capturewarnings-ng@feature/main
+    python3 -m pip install git+https://github.com/kwasd/pytest-capturewarnings-ng@v1.0
 fi
 
 source $SCRIPTS_DIR/pytest-utils.sh

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -8,6 +8,7 @@ TEST_TUTORIAL=false
 TEST_UNIT=false
 VENV=false
 TRITON_TEST_REPORTS=false
+TRITON_TEST_WARNING_REPORTS=false
 SKIP_DEPS=false
 ARGS=
 for arg in "$@"; do
@@ -34,6 +35,10 @@ for arg in "$@"; do
       ;;
     --reports)
       TRITON_TEST_REPORTS=true
+      shift
+      ;;
+    --warning-reports)
+      TRITON_TEST_WARNING_REPORTS=true
       shift
       ;;
     --help)
@@ -68,6 +73,10 @@ export TRITON_PROJ_BUILD=$TRITON_PROJ/python/build
 export SCRIPTS_DIR=$(cd $(dirname "$0") && pwd)
 
 python3 -m pip install lit pytest pytest-xdist pytest-rerunfailures pytest-select
+
+if [ "$TRITON_TEST_WARNING_REPORTS" == true ]; then
+    python3 -m pip install git+https://github.com/kwasd/pytest-capturewarnings-ng@feature/main
+fi
 
 source $SCRIPTS_DIR/pytest-utils.sh
 $SKIP_DEPS || $SCRIPTS_DIR/compile-pytorch-ipex.sh --pinned $ARGS


### PR DESCRIPTION
This PR introduces feature to capture test warnings to txt files (per suite). 