### PR TITLE
Add TritonIntelGPU dependency to TritonGPUIR dialect

### DIFF
--- a/lib/Dialect/TritonGPU/IR/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/IR/CMakeLists.txt
@@ -5,6 +5,7 @@ add_triton_library(TritonGPUIR
   DEPENDS
   TritonGPUTableGen
   TritonGPUAttrDefsIncGen
+  TritonIntelGPUAttrDefsIncGen
 
   LINK_LIBS PUBLIC
   MLIRGPUDialect


### PR DESCRIPTION
Dialect.cpp in TritonGPUIR includes references to TritonGPUIR dialect generated files. This can result in the following error during tablegen:
```
/usr/bin/c++ -DGTEST_HAS_RTTI=0 -I/home/abaden/Projects/intel-xpu-backend-for-triton/python/build/cmake.linux-x86_64-cpython-3.10/lib/Dialect/TritonGPU/IR -I/home/abaden/Projects/intel-xpu-backend-for-triton/lib/Dialect/TritonGPU/IR -I/home/abaden/Projects/intel-xpu-backend-for-triton/include -I/home/abaden/Projects/intel-xpu-backend-for-triton/. -I/home/abaden/.triton/llvm/llvm-ed4e505c-ubuntu-x64/include -I/home/abaden/Projects/intel-xpu-backend-for-triton/python/build/cmake.linux-x86_64-cpython-3.10/include -I/home/abaden/Projects/intel-xpu-backend-for-triton/third_party -I/home/abaden/Projects/intel-xpu-backend-for-triton/python/build/cmake.linux-x86_64-cpython-3.10/third_party -D__STDC_FORMAT_MACROS  -fPIC -std=gnu++17 -Werror -Wno-covered-switch-default -fvisibility=hidden -g -std=gnu++17  -fno-exceptions -funwind-tables -fno-rtti -MD -MT lib/Dialect/TritonGPU/IR/CMakeFiles/TritonGPUIR.dir/Dialect.cpp.o -MF lib/Dialect/TritonGPU/IR/CMakeFiles/TritonGPUIR.dir/Dialect.cpp.o.d -o lib/Dialect/TritonGPU/IR/CMakeFiles/TritonGPUIR.dir/Dialect.cpp.o -c /home/abaden/Projects/intel-xpu-backend-for-triton/lib/Dialect/TritonGPU/IR/Dialect.cpp
      In file included from /home/abaden/Projects/intel-xpu-backend-for-triton/third_party/intel/include/Dialect/TritonIntelGPU/IR/Dialect.h:14,
                       from /home/abaden/Projects/intel-xpu-backend-for-triton/lib/Dialect/TritonGPU/IR/Dialect.cpp:8:
      /home/abaden/Projects/intel-xpu-backend-for-triton/third_party/intel/include/Dialect/TritonIntelGPU/IR/Attributes.h:5:10: fatal error: intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.h.inc: No such file or directory
          5 | #include "intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.h.inc"
            |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      compilation terminated.
```


In a multi-threaded build, you might not see this issue if `TritonIntelGPU` is built by tablegen first. But for me this was reproducible in all envs by using `export MAX_JOBS=1`. 