### PR TITLE
get threads_per_warp through kernel attribute

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -201,12 +201,8 @@ class XPUBackend(BaseBackend):
         num_warp_groups = src.get_int_attr("triton_gpu.num-warp-groups-per-cta")
         if num_warp_groups is not None:
             metadata["num_warps"] *= num_warp_groups
-
-        # FIXME: On the experimental path, get_threads_per_warp always return 1.
-        if not XPUOptions.isBlockPtrEnabled:
-            threads_per_warp = ir.ttgpuir.get_threads_per_warp(src)
-            metadata["threads_per_warp"] = threads_per_warp
-
+        threads_per_warp = ir.ttgpuir.get_threads_per_warp(src)
+        metadata["threads_per_warp"] = threads_per_warp
         mod = src
         # TritonGPU -> LLVM-IR (MLIR)
         pm = ir.pass_manager(mod.context)


### PR DESCRIPTION
in blockPtrPath, we already set the threads_per_warp to 16 in the pipeline manager.
so afterwards, we can directly get threads_per_warp through kernel attribute