### PR TITLE
Fix a potential bug in getting the ceil of two integers.

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandDPAS.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandDPAS.cpp
@@ -310,8 +310,8 @@ Value loadOperand(ConversionPatternRewriter &rewriter, Location loc,
   SmallVector<Value> multiDimWarpId =
       mlir::LLVM::delinearize(rewriter, loc, warpId, warpsPerCTA, order);
 
-  double ceilRes =
-      ceil(static_cast<double>(shapePerCTA[opIdx]) / elemsPerInstr[opIdx]);
+  unsigned ceilRes =
+      mlir::ceil<unsigned>(shapePerCTA[opIdx], elemsPerInstr[opIdx]);
   Value outerWarpDim = urem(multiDimWarpId[opIdx], i32_val(ceilRes));
   int warpsPerTile = std::min<int>(warpsPerCTA[opIdx], ceilRes);
 


### PR DESCRIPTION
We should use the `(m + n - 1) / m` to get the ceil of the two integers instead of using the floating value division.