### PR TITLE
[UT] Capture runtime env in reports

### DIFF
--- a/scripts/pytest-utils.sh
+++ b/scripts/pytest-utils.sh
@@ -49,3 +49,51 @@ run_tutorial_test() {
   echo
   python3 -u "$1.py" || $TRITON_TEST_IGNORE_ERRORS
 }
+
+capture_runtime_env() {
+    mkdir -p "$TRITON_TEST_REPORTS_DIR"
+
+    echo "$CMPLR_ROOT" > $TRITON_TEST_REPORTS_DIR/cmplr_version.txt
+    echo "$MKLROOT" > $TRITON_TEST_REPORTS_DIR/mkl_version.txt
+
+    # Exit script execution as long as one of those components is not found.
+    local TRITON_COMMIT=""
+    WHEELS=($SCRIPTS_DIR/../python/dist/*.whl)
+    # This covers cases when multiple whls are found, it will get the commit id only when they have the same commit id
+    # otherwise this script fail to execute
+    if [[ "${#WHEELS[@]}" -gt 1 ]]; then
+        TRITON_COMMIT=$(echo "${WHEELS[0]}" | sed -n 's/.*git\([a-zA-Z0-9]*\)[^a-zA-Z0-9].*/\1/p')
+        for file in "${WHEELS[@]}"; do
+            CUR_TRITON_COMMIT=$(echo "$file" | sed -n 's/.*git\([a-zA-Z0-9]*\)[^a-zA-Z0-9].*/\1/p')
+            if [[ "$TRITON_COMMIT" != "$CUR_TRITON_COMMIT" ]]; then
+                echo "ERROR: Multiple wheels found"
+                exit 1
+            fi
+        done
+    fi
+    # This covers 3 cases: no whl, one whl with commit, one whl without commit
+    if [[ "${#WHEELS[@]}" -eq 1 ]]; then
+        TRITON_COMMIT=$(echo "${WHEELS[0]}" | sed -n 's/.*git\([a-zA-Z0-9]*\)[^a-zA-Z0-9].*/\1/p')
+    fi
+
+    if [[ $TRITON_PROJ && ! $TRITON_COMMIT ]]; then
+        TRITON_COMMIT=$(cd $TRITON_PROJ && git rev-parse --short HEAD)
+    fi
+    if [[ ! $TRITON_COMMIT ]]; then
+        echo "ERROR: Triton wheel package or source code is not found"
+        exit 1
+    fi
+    echo "$TRITON_COMMIT" > $TRITON_TEST_REPORTS_DIR/triton_commit_id.txt
+    cp $TRITON_TEST_REPORTS_DIR/triton_commit_id.txt $TRITON_TEST_REPORTS_DIR/tests_commit_id.txt
+
+    source $SCRIPTS_DIR/capture-hw-details.sh --quiet
+    echo "$LIBIGC1_VERSION" > $TRITON_TEST_REPORTS_DIR/libigc1_version.txt
+    echo "$LEVEL_ZERO_VERSION" > $TRITON_TEST_REPORTS_DIR/level-zero_version.txt
+    echo "$AGAMA_VERSION" > $TRITON_TEST_REPORTS_DIR/agama_driver_version.txt
+    echo "$GPU_DEVICE" > $TRITON_TEST_REPORTS_DIR/gpu.txt
+
+    python -c 'import platform; print(platform.python_version())' > $TRITON_TEST_REPORTS_DIR/triton_version.txt
+    python -c 'import triton; print(triton.__version__)' >  $TRITON_TEST_REPORTS_DIR/triton_version.txt
+    python -c 'import torch; print(torch.__version__)' > $TRITON_TEST_REPORTS_DIR/pytorch_version.txt
+    python -c 'import intel_extension_for_pytorch as ipex; print(ipex.__version__)' > $TRITON_TEST_REPORTS_DIR/IPEX_version.txt
+}

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -86,6 +86,10 @@ if [ "$TRITON_TEST_WARNING_REPORTS" == true ]; then
 fi
 
 source $SCRIPTS_DIR/pytest-utils.sh
+if [ "$TRITON_TEST_REPORTS" == true ]; then
+    capture_runtime_env
+fi
+
 $SKIP_DEPS || $SCRIPTS_DIR/compile-pytorch-ipex.sh --pinned $ARGS
 
 if [ ! -d "$TRITON_PROJ_BUILD" ]


### PR DESCRIPTION
## Functionality

This PR meets request from https://github.com/intel/intel-xpu-backend-for-triton/issues/979

There will be a .txt file in the report folder for each runtime env parameter when users pass `--reports` while executing `test-triton.sh`:
`bash ./scripts/test-triton.sh --reports`.

## Result

Users will find the following files under `$HOME/reports/$TIMESTAMP/`

IPEX_version.txt
agam_driver_version.txt
cmplr_version.txt
gpu.txt
level-zero_version.txt
libigc1_version.txt
mkl_version.txt
python_version.txt
pytorch_version.txt
triton_version.txt

## Note

- Those txt files will be only generated in `test-triton.sh`. Not clear if they are needed in `.yml` files
- Triton commit id is captured from wheel package or from Triton source code when there is no wheel is built.
- The triton build commit id logic covers all cases that I can think of, including:
  1. no whl
  2. whl has commit id: triton-git123asd.whl 
  3. whl has no commit id: triton-x.y.z.whl
  4. multiple whl with different commit ids: triton-git123asd.whl and triton-git456wqe.whl 
  5. multiple whl with the same commit ids: triton-git123asd-py310.whl and triton-git123asd-py312.whl 