### PR TITLE
[scripts] Disable pip version check

### DIFF
--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+export PIP_DISABLE_PIP_VERSION_CHECK=1
+
 # Select what to build.
 BUILD_LLVM=false
 BUILD_TRITON=false

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+export PIP_DISABLE_PIP_VERSION_CHECK=1
+
 # Select which tests to run.
 TEST_CORE=false
 TEST_TUTORIAL=false


### PR DESCRIPTION
Disabling pip version check since we don't need notifications about new pip releases, and the version check mechanism is broken sometimes, causing fails.

```
Successfully installed triton-3.0.0
WARNING: There was an error checking the latest version of pip.
See below for error
Traceback (most recent call last):
  File "/home/jovyan/.conda/envs/python-3.9/lib/python3.9/site-packages/pip/_internal/self_outdated_check.py", line 230, in pip_self_version_check
    upgrade_prompt = _self_version_check_logic(
  File "/home/jovyan/.conda/envs/python-3.9/lib/python3.9/site-packages/pip/_internal/self_outdated_check.py", line 191, in _self_version_check_logic
    remote_version_str = state.get(current_time)
  File "/home/jovyan/.conda/envs/python-3.9/lib/python3.9/site-packages/pip/_internal/self_outdated_check.py", line 79, in get
    last_check = datetime.datetime.strptime(self._state["last_check"], _DATE_FMT)
  File "/home/jovyan/.conda/envs/python-3.9/lib/python3.9/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/home/jovyan/.conda/envs/python-3.9/lib/python3.9/_strptime.py", line 349, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data '2024-05-01T15:42:44.407514+00:00' does not match format '%Y-%m-%dT%H:%M:%SZ'
Removed build tracker: '/tmp/pip-build-tracker-0v2_x_vx'
```