### PR TITLE
Fetch specific ipex commit when building pinned ipex version

### DIFF
--- a/scripts/compile-pytorch-ipex.sh
+++ b/scripts/compile-pytorch-ipex.sh
@@ -183,7 +183,6 @@ build_ipex() {
   cd $IPEX_PROJ
   if [ ! -d "$IPEX_PROJ/dist" ]; then
     if [ "$BUILD_PINNED" = true ]; then
-      git fetch --all
       IPEX_COMMIT_ID="$(<$BASE/intel-xpu-backend-for-triton/.github/pins/ipex.txt)"
       git fetch origin $IPEX_COMMIT_ID
       git checkout $IPEX_COMMIT_ID

--- a/scripts/compile-pytorch-ipex.sh
+++ b/scripts/compile-pytorch-ipex.sh
@@ -185,8 +185,10 @@ build_ipex() {
     if [ "$BUILD_PINNED" = true ]; then
       git fetch --all
       IPEX_COMMIT_ID="$(<$BASE/intel-xpu-backend-for-triton/.github/pins/ipex.txt)"
+      git fetch origin $IPEX_COMMIT_ID
       git checkout $IPEX_COMMIT_ID
-      git submodule update --recursive
+      git submodule sync
+      git submodule update --init --recursive
     fi
     pip install -r requirements.txt
     python setup.py bdist_wheel


### PR DESCRIPTION
I was attempting to run this script using an existing ipex folder and was getting an error message:
"reference is not a tree"
I did a little research and it looks like `fetch --all` won't update local branches. So, my theory is that you need to explicitly update the local branch. But, we're in detached head state because we previously checked out a specific commit. It looks like in that case, you can use fetch to get the commit you are interested in, and change the HEAD to that fetched commit. I think the `fetch --all` in line 186 may not be required anymore, but I left it for now (can easily remove it).

I also modified the submodule update command to mirror that from pytorch, though I don't think that is related to this issue. But, it is nice to not have to worry about re-initializing submodules if IPEX were to add any. 