### PR TITLE
Support small BLOCK_SIZE_M while fixing some bugs.

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1367,9 +1367,6 @@ def dot(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, input_precision: Optiona
     assert lhs_rank == rhs_rank == 2 or lhs_rank == rhs_rank == 3, f"Both inputs must be either 2D or 3D; (lhs: {lhs.shape} vs rhs: {rhs.shape})"
     assert lhs.shape[-1].value == rhs.shape[
         -2].value, f"First input shape ({lhs.shape}) and second input shape {rhs.shape} are not compatible for matmul (second index of first shape ({lhs.shape[-1].value}) must be equal to first index of second shape ({rhs.shape[-2].value})"
-    assert lhs.shape[-2].value >= 16 and lhs.shape[-1].value >= 16 \
-        and rhs.shape[-1].value >= 16, \
-        f"All non-batch values in both first input shape ({lhs.shape}) and second input shape ({rhs.shape}) must be >= 16!"
     if lhs.type.scalar.is_int():
         assert lhs.type.scalar == tl.int8, "only int8 supported!"
         # TODO: This is CUDA specific, check if ROCm has the same limitation

--- a/python/tutorials/09-experimental-block-pointer.py
+++ b/python/tutorials/09-experimental-block-pointer.py
@@ -119,6 +119,9 @@ import triton.language as tl
                       num_warps=32),
         triton.Config({'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 4}, num_stages=4,
                       num_warps=32),
+       # For mxnxk=4x4096x512
+        triton.Config({'BLOCK_SIZE_M': 8, 'BLOCK_SIZE_N':64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 1}, num_stages=4,
+                      num_warps=4),
     ],
     key=['M', 'N', 'K'],
 )

--- a/python/tutorials/09-experimental-block-pointer.py
+++ b/python/tutorials/09-experimental-block-pointer.py
@@ -119,8 +119,8 @@ import triton.language as tl
                       num_warps=32),
         triton.Config({'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 4}, num_stages=4,
                       num_warps=32),
-       # For mxnxk=4x4096x512
-        triton.Config({'BLOCK_SIZE_M': 8, 'BLOCK_SIZE_N':64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 1}, num_stages=4,
+        # For mxnxk=4x4096x512
+        triton.Config({'BLOCK_SIZE_M': 8, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 1}, num_stages=4,
                       num_warps=4),
     ],
     key=['M', 'N', 'K'],

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -254,8 +254,12 @@ createGenISA2DBlockRead(TritonGEN::Matrix2DBlockLoadOp op,
         op.getY(), i32_val(1));
     SmallVector<Type> argTypes{ptr_ty(context, 1), i32_ty, i32_ty, i32_ty,
                                vecType};
-    SmallVector<Value> args{op.getPtr(), op.getBaseWidth(), op.getBaseHeight(),
-                            op.getBasePitch(), byteCoord};
+    Value one = i32_val(1);
+    // We use minus 1 encoding in Gen lower pass,
+    // need to add it back for OpenCL call
+    SmallVector<Value> args{op.getPtr(), add(op.getBaseWidth(), one),
+                            add(op.getBaseHeight(), one),
+                            add(op.getBasePitch(), one), byteCoord};
     return createDeviceFunctionCall(rewriter, fnName, resType, argTypes, args,
                                     true /*convergent*/);
   }


### PR DESCRIPTION
For 16 bits datatype with VNNI. This restriction is
![image](https://github.com/intel/intel-xpu-backend-for-triton/assets/68101902/bfc9bfd7-f8e5-4109-aaf7-e0ffd3776a80)
So for 16x64, we split it to 2x16x32.