### PR TITLE
Zero-initialize masked loads if "other" argument is not present

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -401,7 +401,7 @@ struct LoadOpConversion
                        ? vec_ty(IntegerType::get(ctx, width), nWords)
                        : retTys[0];
 
-      Value other_;
+      Value other_ = undef(retTy);
       if (other) {
         for (size_t ii = 0; ii < nWords; ++ii) {
           size_t size = width / valueElemNBits;
@@ -431,7 +431,8 @@ struct LoadOpConversion
           }
         }
       } else {
-        other_ = rewriter.create<LLVM::ConstantOp>(loc, retTy, rewriter.getZeroAttr(retTy));
+        other_ = rewriter.create<LLVM::ConstantOp>(loc, retTy,
+                                                   rewriter.getZeroAttr(retTy));
       }
 
       // Create a predicated load operation.

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -401,7 +401,7 @@ struct LoadOpConversion
                        ? vec_ty(IntegerType::get(ctx, width), nWords)
                        : retTys[0];
 
-      Value other_ = undef(retTy);
+      Value other_;
       if (other) {
         for (size_t ii = 0; ii < nWords; ++ii) {
           size_t size = width / valueElemNBits;
@@ -430,6 +430,8 @@ struct LoadOpConversion
             other_ = v;
           }
         }
+      } else {
+        other_ = rewriter.create<LLVM::ConstantOp>(loc, retTy, rewriter.getZeroAttr(retTy));
       }
 
       // Create a predicated load operation.


### PR DESCRIPTION
Given the following kernel (generated by inductor):
```
@triton.jit
def triton_(in_ptr0, out_ptr0, xnumel, XBLOCK : tl.constexpr):
    xnumel = 5
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.arange(0, XBLOCK)[:]
    xmask = xindex < xnumel
    x0 = xindex
    tmp0 = tl.load(in_ptr0 + (x0), xmask)
    tmp1 = tl.full([1], -100, tl.int64)
    tmp2 = tmp0 != tmp1
    tmp3 = tl.full([1], 0, tl.int64)
    tmp4 = tl.where(tmp2, tmp0, tmp3)
    tmp5 = tmp4 + 5
    tmp6 = tmp4 < 0
    tmp7 = tl.where(tmp6, tmp5, tmp4)
    tl.device_assert((0 <= tmp7) & (tmp7 < 5), "index out of bounds: 0 <= tmp7 < 5")
    tmp8 = -1.0
    tl.store(out_ptr0 + (tmp7 + (5*x0)), tmp8, xmask)
```

`tmp0` is a masked load using `tl.load` which accepts a mask and other parameter (https://triton-lang.org/main/python-api/generated/triton.language.load.html#triton.language.load). In this instance, the mask parameter is used but the other parameter is unspecified, meaning the value loaded for a false value in the mask is undefined. Cuda semantics 0-initialize this mask as part of the masked load instruction:

```
	setp.lt.s32 	%p1, %r2, 5; // this is the predicate which determines the true/false value for the mask
	.loc	1 24 30
	mul.wide.s32 	%rd6, %r2, 8;
	add.s64 	%rd4, %rd5, %rd6;
	.loc	1 24 35
	// begin inline asm
	mov.u64 %rd3, 0x0; // the value to use if the mask is false
	@%p1 ld.global.b64 { %rd3 }, [ %rd4 + 0 ]; // the predicated masked load
	// end inline asm
```

but we do not have a masked load instruction, and in our XPU implementation we translate the load to llvm IR conditional branches:
```
%11 = icmp slt i32 %10, 5, !dbg !22
  br i1 %11, label %12, label %16, !dbg !23

12:                                               ; preds = %3
  %13 = sext i32 %10 to i64, !dbg !24
  %14 = getelementptr i64, ptr addrspace(1) %0, i64 %13, !dbg !24
  %15 = load i64, ptr addrspace(1) %14, align 8, !dbg !23
  br label %16, !dbg !23

16:                                               ; preds = %12, %3
  %17 = phi i64 [ %15, %12 ], [ undef, %3 ]
```
where the load is simply skipped and the value "loaded" is undefined if the mask is false and the "other" value to use when the mask is false is not specified.

This PR changes that behavior to match CUDA by adding an explicit "other" value to load when other is not specified. The value chosen is a zero value for the specified return type of the load, effectively resulting in a 0-initialized vector that is filled based on the mask, even if the vector is constructed one load at a time. 

```
%11 = icmp slt i32 %10, 5, !dbg !22
  br i1 %11, label %12, label %.thread5, !dbg !23

12:                                               ; preds = %3
  %13 = sext i32 %10 to i64, !dbg !24
  %14 = getelementptr i64, ptr addrspace(1) %0, i64 %13, !dbg !24
  %15 = load i64, ptr addrspace(1) %14, align 8, !dbg !23
  %.fr = freeze i64 %15, !dbg !25
  %.not = icmp eq i64 %.fr, -100, !dbg !25
  br i1 %.not, label %.thread5, label %16, !dbg !26

16:                                               ; preds = %12
  %17 = add nsw i64 %.fr, 5, !dbg !27
  %18 = icmp slt i64 %.fr, 0, !dbg !28
  %spec.select = select i1 %18, i64 %17, i64 %.fr, !dbg !29
  br label %.thread5, !dbg !29

.thread5:                                         ; preds = %16, %12, %3
  %19 = phi i64 [ 0, %3 ], [ 0, %12 ], [ %spec.select, %16 ]
```
where `%11` is the computation of the mask, `%12` is entered if the mask is true, and `%16` is the result of LLVM optimizations merging the true branch for the mask and the true branch for the comparison with `-100` (`tmp2`).

The previous code had the result of running a comparison with an `undef` value. I wondered why this was not caught in the unit tests and it turns out we don't test masked loads if with no `other` parameter - so I modified the unit tests to add this to the parameters list. 

There does not appear to be documentation in Triton to define the behavior when `other` is not present, but for purposes of working well with inductor and matching the reference implementation zero-initialization seems to be the right answer. 

Close #1125 