### PR TITLE
[BUG Fix]: restrict max 2d block load heigth according to spec

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/MatchTargetSize.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MatchTargetSize.cpp
@@ -475,7 +475,8 @@ MatchTargetSizePass::getSubOpSize(RankedTensorType type) const {
         (isa<ttgi::WarpEncodingAttr, ttg::DotOperandEncodingAttr>(layout)) ? 32
                                                                            : 0;
     subSize[1] = (shape[1] > colLimit) ? colLimit : shape[1];
-    int64_t max = maxLoadStoreSize * 4 / sizeInBytes / subSize[1];
+    // FIXME: From gfxspec, max 2d block load height is 32
+    int64_t max = 32;
     subSize[0] = std::min(max, shape[0]);
   } break;
   default:


### PR DESCRIPTION
![image](https://github.com/intel/intel-xpu-backend-for-triton/assets/68101902/8598d5e4-d70e-491a-a042-91f386b5b3b3)
For 2d load, max height is 32(also for VNNI load). For those loads that have height greater than 32, they will return all zeros. This will lead to incorrect results. 