### PR TITLE
[CI] Input parameter to ignore test failures

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,5 @@
 name: Build and test
+run-name: ${{ inputs.run_name }}
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         description: Ignore test errors
         type: boolean
         default: false
+      run_name:
+        description: Custom run name
+        type: string
+        default: "Build and test"
   pull_request:
     branches:
       - llvm-target

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,6 +11,10 @@ on:
         description: Upload test reports
         type: boolean
         default: false
+      ignore_errors:
+        description: Ignore test errors
+        type: boolean
+        default: false
   pull_request:
     branches:
       - llvm-target
@@ -127,6 +131,11 @@ jobs:
           echo "TRITON_TEST_WARNING_REPORTS=true" >> $GITHUB_ENV
           echo "TRITON_TEST_REPORTS_DIR=$GITHUB_WORKSPACE/reports" >> $GITHUB_ENV
 
+      - name: Enable ignoring test errors
+        if: inputs.ignore_errors
+        run: |
+          echo "TRITON_TEST_IGNORE_ERRORS=true" >> $GITHUB_ENV
+
       - name: Run core tests
         run: |
           source ./scripts/pytest-utils.sh
@@ -175,17 +184,18 @@ jobs:
 
       - name: Run Tutorials
         run: |
+          source ./scripts/pytest-utils.sh
           cd python/tutorials
-          python3 01-vector-add.py
-          python3 02-fused-softmax.py
-          python3 03-matrix-multiplication.py
-          python3 04-low-memory-dropout.py
-          python3 05-layer-norm.py
-          python3 06-fused-attention.py
-          python3 07-extern-functions.py
-          python3 08-grouped-gemm.py
-          python3 09-experimental-block-pointer.py
-          TRITON_INTEL_ENABLE_BLOCK_PTR=1 python3 09-experimental-block-pointer.py
+          run_tutorial_test "01-vector-add"
+          run_tutorial_test "02-fused-softmax"
+          run_tutorial_test "03-matrix-multiplication"
+          run_tutorial_test "04-low-memory-dropout"
+          run_tutorial_test "05-layer-norm"
+          run_tutorial_test "06-fused-attention"
+          run_tutorial_test "07-extern-functions"
+          run_tutorial_test "08-grouped-gemm"
+          run_tutorial_test "09-experimental-block-pointer"
+          TRITON_INTEL_ENABLE_BLOCK_PTR=1 run_tutorial_test "09-experimental-block-pointer"
 
       - name: Run CXX unittests
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,6 +35,10 @@ jobs:
       - spr
       - cpu
     steps:
+      - name: Print inputs
+        run: |
+          echo "${{ toJSON(github.event.inputs) }}"
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/scripts/pytest-utils.sh
+++ b/scripts/pytest-utils.sh
@@ -42,3 +42,10 @@ pytest() {
 
     python3 -u -m pytest "${pytest_extra_args[@]}" "$@" || $TRITON_TEST_IGNORE_ERRORS
 }
+
+run_tutorial_test() {
+  echo
+  echo "****** Running $1 test ******"
+  echo
+  python3 -u "$1.py" || $TRITON_TEST_IGNORE_ERRORS
+}

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -161,13 +161,6 @@ run_regression_tests() {
   pytest -vvv -s --device xpu . --reruns 10 --ignore=test_performance.py
 }
 
-run_tutorial_test() {
-  echo
-  echo "****** Running $1 test ******"
-  echo
-  python $1.py || $TRITON_TEST_IGNORE_ERRORS
-}
-
 run_tutorial_tests() {
   echo "***************************************************"
   echo "**** Running Triton Tutorial tests           ******"
@@ -189,9 +182,7 @@ run_tutorial_tests() {
   run_tutorial_test "07-extern-functions"
   run_tutorial_test "08-grouped-gemm"
   run_tutorial_test "09-experimental-block-pointer"
-  export TRITON_INTEL_ENABLE_BLOCK_PTR=1
-  run_tutorial_test "09-experimental-block-pointer"
-  unset TRITON_INTEL_ENABLE_BLOCK_PTR
+  TRITON_INTEL_ENABLE_BLOCK_PTR=1 run_tutorial_test "09-experimental-block-pointer"
 }
 
 test_triton() {


### PR DESCRIPTION
It is possible to run "Build and test" workflow manually and set `ignore_errors` to true to make sure the workflow executes all test suites and report failures. Using a common code to run tutorials in CI and in test-triton.sh.