### PR TITLE
Fix PipelinePass usage in pass pipeline

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -166,7 +166,7 @@ class XPUBackend(BaseBackend):
         # FIXME: Use a better way to check if prefetch instructions are supported once available.
         # Prefetch instruction is not available in older drivers.
         if Version(metadata["target"].arch['driver_version']) > Version("1.3.28202"):
-            intel.passes.ttgpuir.add_pipeline(pm, opt.num_stages)
+            intel.passes.ttgpuir.add_pipeline(pm, opt.num_stages, False)
 
         passes.ttgpuir.add_coalesce(pm)
         intel.passes.ttgpuir.add_remove_layout_conversions(pm)


### PR DESCRIPTION
https://github.com/intel/intel-xpu-backend-for-triton/commit/9682dea49add1576b970e2a8fb73ba6a6e5ed4ee added a new pass option to PipelinePass. This PR fixes the usage of `PipelinePass` in pass pipeline with the additional pass option.