### PR TITLE
Fix intermittent failure from `PrefetchBlockPass`

### DIFF
--- a/python/tutorials/09-experimental-block-pointer.py
+++ b/python/tutorials/09-experimental-block-pointer.py
@@ -113,8 +113,6 @@ import triton.language as tl
                       num_warps=32),
         triton.Config({'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'GROUP_SIZE_M': 4}, num_stages=4,
                       num_warps=32),
-        triton.Config({'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'GROUP_SIZE_M': 4}, num_stages=4,
-                      num_warps=32),
         triton.Config({'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 512, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 4}, num_stages=4,
                       num_warps=32),
         triton.Config({'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 4}, num_stages=4,

--- a/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
@@ -178,8 +178,8 @@ public:
         continue;
 
       // Prefetch candidate loads collected.
-      for (auto loop : func.getOps<scf::ForOp>())
-        transformLoop(loop);
+      for (auto const &loopLoad : loopLoads)
+        transformLoop(loopLoad.first);
     }
   }
 


### PR DESCRIPTION
`transformLoop` insert new operations to `func`, so we cannot iterate with `func.getOps<scf::ForOp>()`, we should iterate the prepopulated list of loops.