### PR TITLE
[UT] Automatically generate skiplist when on a new platform

### DIFF
--- a/scripts/replace_skipcall_to_skiplist.sh
+++ b/scripts/replace_skipcall_to_skiplist.sh
@@ -1,0 +1,40 @@
+# generate skiplist for all test suite on a new platform
+CORE_LOG=${TRITON_PROJ}/${GPU_TYPE}_${AGAMA_TYPE}_core.log
+REGRESSION_LOG=${TRITON_PROJ}/${GPU_TYPE}_${AGAMA_TYPE}_regression.log
+
+echo "Generating core test log ..."
+run_core_tests > "${CORE_LOG}"
+echo "Done generation"
+
+echo "Generating regression test log ..."
+run_regression_tests > "${REGRESSION_LOG}"
+echo "Done generation"
+
+mkdir -p "$TRITON_TEST_SKIPLIST_DIR"
+
+parse_log() {
+    local keyword="$1"
+    local output_file="$2"
+    if grep -q "SKIPPED $keyword" "$CORE_LOG"; then
+        grep "SKIPPED $keyword" "$CORE_LOG" |
+        sed -E "s/^(.*)$keyword(.*)/test\/unit\/$keyword\2/g; s/ //g" > "$output_file"
+    fi
+}
+
+# language.txt & operators.txt
+parse_log "language" "${TRITON_TEST_SKIPLIST_DIR}/language.txt"
+parse_log "operators" "${TRITON_TEST_SKIPLIST_DIR}/operators.txt"
+
+# subprocess.txt
+if grep -q "test_subprocess.py" "${TRITON_TEST_SKIPLIST_DIR}/language.txt"; then
+    grep "test_subprocess.py" "${TRITON_TEST_SKIPLIST_DIR}/language.txt" > ${TRITON_TEST_SKIPLIST_DIR}/subprocess.txt
+    sed -i '/test_subprocess.py/d' ${TRITON_TEST_SKIPLIST_DIR}/language.txt
+fi
+
+# regression.txt
+if grep -q "SKIPPED" ${REGRESSION_LOG}; then
+    grep "SKIPPED" ${REGRESSION_LOG} |
+    sed -E 's/^(.*)SKIPPED(.*)/test\/unit\/language\/\1/g; s/ //g' > ${TRITON_TEST_SKIPLIST_DIR}/regression.txt
+fi
+
+# DOTO: runtime.txt

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -86,6 +86,11 @@ if [ "$TRITON_TEST_WARNING_REPORTS" == true ]; then
 fi
 
 source $SCRIPTS_DIR/pytest-utils.sh
+# got GPU_TYPE & AGAMA_VERSION, example here
+GPU_TYPE="pvc"
+AGAMA_TYPE="TBD" # real value depends on the other PR
+TRITON_TEST_SKIPLIST_DIR=$SCRIPTS_DIR/skiplist/${GPU_TYPE}_${AGAMA_TYPE}
+
 $SKIP_DEPS || $SCRIPTS_DIR/compile-pytorch-ipex.sh --pinned $ARGS
 
 if [ ! -d "$TRITON_PROJ_BUILD" ]
@@ -190,6 +195,12 @@ test_triton() {
     run_unit_tests
   fi
   if [ "$TEST_CORE" = true ]; then
+    # only pre-run tests to replace when no skiplist dir exist.
+    if [ ! -d "${TRITON_TEST_SKIPLIST_DIR}" ]; then
+      # execute run_core_tests & run_regression_tests with NO skiplist
+      source ${SCRIPTS_DIR}/replace_skipcall_to_skiplist.sh
+    fi
+    # execute run_core_tests & run_regression_tests with skiplist
     run_core_tests
     run_regression_tests
   fi


### PR DESCRIPTION
## Functionality
[issue#985](https://github.com/intel/intel-xpu-backend-for-triton/issues/985) & [issue#986](https://github.com/intel/intel-xpu-backend-for-triton/issues/986) are solved by manually add skiplists, this PR automatically generate skiplist whenever on a new platform.

## Result
A set of skiplists is generated and replace all `pytest.skip()` calls:
~~~sh
/skiplist/${GPU}_${AGAMA}/language.txt
                         /operators.txt
                         /subprocess.txt
                         /regression.txt
                         /...
~~~

## Note
New script in this PR will be only executed when on a new platform, a new platform means that there exist no such a directory: /skiplist/${GPU}_${AGAMA}, script generates this directory for this new platform. 

Fixes #1423