### PR TITLE
Setup microbenchmark structure + bfloat conversion bench

### DIFF
--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build:
-    name: xetla benchmark
+    name: Triton benchmarks
     runs-on:
       - ${{ inputs.runner_label || 'max1550' }}
     timeout-minutes: 720
@@ -101,14 +101,19 @@ jobs:
         run: |
           source /home/runner/intel/oneapi/mkl/2024.1/env/vars.sh
           cd benchmarks
-          python setup.py bdist_wheel
-          pip install dist/*.whl
+          python setup.py install
 
       - name: Run xetla benchmark
         run: |
           source /home/runner/intel/oneapi/mkl/2024.1/env/vars.sh
           cd benchmarks/xetla_benchmark
           python fused_softmax.py
+
+      - name: Run micro benchmark
+        run: |
+          source /home/runner/intel/oneapi/mkl/2024.1/env/vars.sh
+          cd benchmarks/micro_benchmarks
+          python run_benchmarks.py
 
       - name: Save pip cache
         if: ${{ steps.pip-cache.outputs.status == 'miss' }}

--- a/benchmarks/micro_benchmarks/conversion/float_conversion/__init__.py
+++ b/benchmarks/micro_benchmarks/conversion/float_conversion/__init__.py
@@ -1,0 +1,1 @@
+from .float_conversion import benchmark

--- a/benchmarks/micro_benchmarks/conversion/float_conversion/float_conversion.py
+++ b/benchmarks/micro_benchmarks/conversion/float_conversion/float_conversion.py
@@ -22,7 +22,7 @@ def float_trunc_kernel(
     as_target = x.to(target_type)
     as_f32 = as_target.to(tl.float32)
     for _ in range(100):
-        as_f32 += 1  # plus one ensures that there are no redunant conversions that can be removed
+        as_f32 += 1  # plus one ensures that there are no redundant conversions that can be removed
         as_target = as_f32.to(target_type)
         as_f32 = as_target.to(tl.float32)
 

--- a/benchmarks/micro_benchmarks/conversion/float_conversion/float_conversion.py
+++ b/benchmarks/micro_benchmarks/conversion/float_conversion/float_conversion.py
@@ -1,0 +1,68 @@
+import torch
+import intel_extension_for_pytorch
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def float_trunc_kernel(
+    x_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+    target_type: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    as_target = x.to(target_type)
+    as_f32 = as_target.to(tl.float32)
+    for _ in range(100):
+        as_f32 += 1  # plus one ensures that there are no redunant conversions that can be removed
+        as_target = as_f32.to(target_type)
+        as_f32 = as_target.to(tl.float32)
+
+    tl.store(x_ptr + offsets, as_f32, mask=mask)
+
+
+def launch_conversion(x: torch.Tensor, target_type: type):
+    assert x.is_xpu
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']), )
+    float_trunc_kernel[grid](x, n_elements, BLOCK_SIZE=1024, target_type=target_type)
+    return x
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=['N'],
+        x_vals=[2**i for i in range(12, 28, 2)],
+        line_arg='target_type',
+        line_vals=['bfloat16', 'float16'],
+        line_names=['BF16', 'FP16'],
+        styles=[('blue', '-'), ('green', '-'), ('orange', '-')],
+        ylabel='GB/s',
+        plot_name='type-conversion in GB/s',
+        args={},
+    ))
+def benchmark(N, target_type):
+    quantiles = [0.5, 0.2, 0.8]
+    inputs = torch.rand(N, dtype=torch.float32, device='xpu', requires_grad=True)
+
+    if target_type == "bfloat16":
+        fwd = lambda: launch_conversion(inputs, tl.bfloat16)
+    elif target_type == "float16":
+        fwd = lambda: launch_conversion(inputs, tl.float16)
+
+    ms, min_ms, max_ms = triton.testing.do_bench(fwd, quantiles=quantiles)
+    gbps = lambda ms: (inputs.numel() * inputs.element_size() * 1e-9) / (ms * 1e-3)
+
+    return gbps(ms), gbps(max_ms), gbps(min_ms)
+
+
+if __name__ == "__main__":
+    benchmark.run(print_data=True)

--- a/benchmarks/micro_benchmarks/run_benchmarks.py
+++ b/benchmarks/micro_benchmarks/run_benchmarks.py
@@ -1,0 +1,4 @@
+from conversion import float_conversion
+
+if __name__ == "__main__":
+    float_conversion.benchmark.run(print_data=True)

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -54,7 +54,7 @@ for arg in "$@"; do
       shift
       ;;
     --help)
-      echo "Example usage: ./test-triton.sh [--core | --tutorial | --unit | --venv | --reports | --warning-reports | --ignore-errors | --microbench]"
+      echo "Example usage: ./test-triton.sh [--core | --tutorial | --unit | --microbench | --venv | --reports | --warning-reports | --ignore-errors]"
       exit 1
       ;;
     *)
@@ -203,9 +203,6 @@ run_tutorial_tests() {
 }
 
 test_triton() {
-  if [ "$TEST_MICRO_BENCHMARKS" = true ]; then
-    run_benchmark_tests
-  fi
   if [ "$TEST_UNIT" = true ]; then
     run_unit_tests
   fi
@@ -215,6 +212,9 @@ test_triton() {
   fi
   if [ "$TEST_TUTORIAL" = true ]; then
     run_tutorial_tests
+  fi
+  if [ "$TEST_MICRO_BENCHMARKS" = true ]; then
+    run_benchmark_tests
   fi
 }
 


### PR DESCRIPTION
Introduce microbenchmarks to help avoid performance regression for cases that aren't full models.
Structure taken from #1076, but I didn't want to wait for the rest of the code to be approved.