### PR TITLE
Added new workflow to run pytorch inductor test

### DIFF
--- a/.github/workflows/inductor-tests.yml
+++ b/.github/workflows/inductor-tests.yml
@@ -1,4 +1,4 @@
-name: E2E
+name: Pytorch inductor tests
 
 on:
   workflow_dispatch:

--- a/.github/workflows/inductor-tests.yml
+++ b/.github/workflows/inductor-tests.yml
@@ -1,0 +1,169 @@
+name: E2E
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: Test suite
+        type: string
+        default: "all"
+      runner_label:
+        description: Runner label, keep empty for default
+        type: string
+        default: ""
+
+permissions: read-all
+
+env:
+  PYTHON_VERSION: "3.10"
+  PYTORCH_REPO: "pytorch/pytorch"
+  PYTORCH_COMMIT_ID: "6c503f1dbbf9ef1bf99f19f0048c287f419df600"
+  PYTORCH_XPU_OPS_COMMIT_ID: "39522db63ce045f52c9d61a286018c266cd00479"
+
+jobs:
+  print_inputs:
+    name: Print inputs
+    needs: setup
+    runs-on: Linux
+    steps:
+      - name: Print inputs
+        run: |
+          echo "${{ toJSON(github.event.inputs) }}"
+
+      - name: Print setup outputs
+        run: |
+          echo "${{ toJSON(needs.setup.outputs) }}"
+
+  build:
+    name: Test
+    runs-on:
+      - ${{ inputs.runner_label || 'max1550' }}
+    timeout-minutes: 720
+    defaults:
+      run:
+        shell: bash -noprofile --norc -eo pipefail -c "source /home/runner/intel/oneapi/setvars.sh > /dev/null; source {0}"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Load pip cache
+        id: pip-cache
+        uses: ./.github/actions/load
+        with:
+          path: $HOME/.cache/pip
+          # pip cache per commit id just to minimize network traffic
+          key: pip-$PYTHON_VERSION-$GITHUB_SHA
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Python build dependencies
+        run: |
+          pip install wheel
+
+      - name: Setup PyTorch without IPEX
+        uses: ./.github/actions/setup-pytorch
+        with:
+          repository: ${{ env.PYTORCH_REPO}}
+          commit_id: ${{ env.PYTORCH_COMMIT_ID }}
+          torch_xpu_ops_commit: ${{ env.PYTORCH_XPU_OPS_COMMIT_ID }}
+
+      - name: Generate Triton cache key
+        id: triton-key
+        run: |
+          COMPOSITE_KEY=$(echo $PYTHON_VERSION $LLVM_COMMIT_ID $GITHUB_SHA | sha256sum - | cut -d\  -f1)
+          echo "key=triton-$COMPOSITE_KEY" >> $GITHUB_OUTPUT
+
+      - name: Load Triton wheels from a cache
+        id: triton-cache
+        uses: ./.github/actions/load
+        with:
+          path: python/dist
+          key: ${{ steps.triton-key.outputs.key }}
+
+      - name: Build Triton wheels
+        if: ${{ steps.triton-cache.outputs.status == 'miss' }}
+        run: |
+          export DEBUG=1
+          cd python
+          python setup.py bdist_wheel
+
+      - name: Install Triton
+        run: |
+          pip install python/dist/*.whl
+
+      - name: Save Triton wheels to a cache
+        if: ${{ steps.triton-cache.outputs.status == 'miss' }}
+        uses: ./.github/actions/save
+        with:
+          path: ${{ steps.triton-cache.outputs.path }}
+          dest: ${{ steps.triton-cache.outputs.dest }}
+
+      - name: Install python test dependencies
+        run: |
+          pip install pandas scipy tqdm
+
+      - name: Run inductor tests
+        run: |
+          cd pytorch
+          pip install -r .ci/docker/requirements-ci.txt
+          
+          export PYTORCH_TESTING_DEVICE_ONLY_FOR="xpu"
+          
+          test_cmd="python test/run_test.py --include "
+          if [[ "${{ github.event.inputs.suite }}" == "all" ]]; then
+            for test in $(ls test/inductor | grep test);
+            do 
+              test_cmd="${test_cmd} inductor/$test";
+            done
+          else
+            test_cmd="${test_cmd} '${{ github.event.inputs.suite }}'"
+          fi
+          eval $test_cmd
+        
+      - name: Report environment details
+        run: |
+          mkdir -p inductor_log
+          TIMESTAMP=$(date '+%Y%m%d%H%M%S')
+          echo "TIMESTAMP=$TIMESTAMP" >> "${GITHUB_ENV}"
+
+          source ./scripts/capture-hw-details.sh --quiet
+
+          cat <<EOF | tee inductor_log/.env
+          TIMESTAMP=$TIMESTAMP
+          JOB_NAME=${{ join(matrix.*, '-') }}
+          GITHUB_RUN_ID=$GITHUB_RUN_ID
+          GITHUB_RUN_NUMBER=$GITHUB_RUN_NUMBER
+          GITHUB_RUN_ATTEMPT=$GITHUB_RUN_ATTEMPT
+          PYTHON_VERSION=$PYTHON_VERSION
+          PYTORCH_REPO=$PYTORCH_REPO
+          PYTORCH_COMMIT_ID=$PYTORCH_COMMIT_ID
+          TRITON_REPO=$GITHUB_REPOSITORY
+          TRITON_COMMIT_ID=$GITHUB_SHA
+          TORCHVISION_COMMIT_ID=$TORCHVISION_COMMIT_ID
+          LIBIGC1_VERSION=$LIBIGC1_VERSION
+          LEVEL_ZERO_VERSION=$LEVEL_ZERO_VERSION
+          GPU_DEVICE=$GPU_DEVICE
+          AGAMA_VERSION=$AGAMA_VERSION
+          EOF
+
+      - name: Copy reports
+        run: |
+          if [[ -d torch_compile_debug ]]; then
+            cp -rT torch_compile_debug inductor_log
+          fi
+
+      - name: Upload test logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-${{ join(matrix.*, '-') }}
+          path: inductor_log
+
+      - name: Save pip cache
+        if: ${{ steps.pip-cache.outputs.status == 'miss' }}
+        uses: ./.github/actions/save
+        with:
+          path: ${{ steps.pip-cache.outputs.path }}
+          dest: ${{ steps.pip-cache.outputs.dest }}

--- a/.github/workflows/inductor-tests.yml
+++ b/.github/workflows/inductor-tests.yml
@@ -122,7 +122,7 @@ jobs:
             test_cmd="${test_cmd} '${{ github.event.inputs.suite }}'"
           fi
           eval $test_cmd
-        
+
       - name: Report environment details
         run: |
           mkdir -p inductor_log

--- a/.github/workflows/inductor-tests.yml
+++ b/.github/workflows/inductor-tests.yml
@@ -109,13 +109,13 @@ jobs:
         run: |
           cd pytorch
           pip install -r .ci/docker/requirements-ci.txt
-          
+
           export PYTORCH_TESTING_DEVICE_ONLY_FOR="xpu"
-          
+
           test_cmd="python test/run_test.py --include "
           if [[ "${{ github.event.inputs.suite }}" == "all" ]]; then
             for test in $(ls test/inductor | grep test);
-            do 
+            do
               test_cmd="${test_cmd} inductor/$test";
             done
           else


### PR DESCRIPTION
This PR needs to be merged to add a new workflow in Actions. This workflow doesn't work at this moment because it requires commits from my branch "gregory/no-ipex-ci" to install pytorch without ipex.

Updates issue: https://github.com/intel/intel-xpu-backend-for-triton/issues/1203