### PR TITLE
Uses the `triton_gpu.threads-per-warp` attribute instead of spirv target env.

### DIFF
--- a/test/TritonGEN/tritongen-invalid.mlir
+++ b/test/TritonGEN/tritongen-invalid.mlir
@@ -16,15 +16,6 @@ llvm.func @triton_gen.illegal_cache_controls_attr(%arg0: !llvm.ptr) {
 
 // -----
 
-llvm.func @triton_gen.sub_group_reduce() {
-  // expected-error @+2 {{'triton_gen.sub_group_reduce' op expecting valid target env attribute}}
-  %0 = llvm.mlir.constant(0 : i32) : i32
-  %1 = triton_gen.sub_group_reduce fsum %0 {size = 16} : i32
-  llvm.return
-}
-
-// -----
-
 module attributes {
   spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Kernel, Addresses, GroupNonUniformShuffle, Int64], []>, #spirv.resource_limits<subgroup_size = 32>>
 } {

--- a/third_party/intel/lib/Dialect/TritonGEN/IR/TritonGENOps.cpp
+++ b/third_party/intel/lib/Dialect/TritonGEN/IR/TritonGENOps.cpp
@@ -76,9 +76,10 @@ template <typename Op> static LogicalResult verifyInput(Op op) {
 //===----------------------------------------------------------------------===//
 
 LogicalResult TritonGEN::SubGroupReduceOp::verify() {
-  spirv::TargetEnvAttr attr = spirv::lookupTargetEnv(*this);
-  if (!attr)
-    return this->emitOpError("expecting valid target env attribute");
+  // FIXME: Add back when `spirv.target_env` is added in Triton pipeline.
+  // spirv::TargetEnvAttr attr = spirv::lookupTargetEnv(*this);
+  // if (!attr)
+  //  return this->emitOpError("expecting valid target env attribute");
 
   Type ty = getValue().getType();
   switch (getKind()) {


### PR DESCRIPTION
There is no stage to add the spirv target env for now in the lowering pipeline for now.
Use the `triton_gpu.threads-per-warp` at first. This attribute would be converted to the Intel SPV extension for IGC to vectorize.

Remove the changes after the LLVM is updated to the https://github.com/llvm/llvm-project/pull/90972
