### PR TITLE
[GEN] Use `SignlessIntegerOrFloatLike` in `sub_group_reduce` definition

### DIFF
--- a/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENOps.td
+++ b/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENOps.td
@@ -236,12 +236,10 @@ def TritonGEN_NamedBarrierWaitOp : TritonGEN_Op<"named_barrier_wait">,
   }];
 }
 
-def IntegerOrFloatType : AnyTypeOf<[AnyInteger, AnyFloat]>;
-
 def TritonGEN_SubGroupReduceOp : TritonGEN_Op<"sub_group_reduce", [
       AllTypesMatch<["res", "value"]>]>,
-  Results<(outs IntegerOrFloatType:$res)>,
-  Arguments<(ins IntegerOrFloatType:$value,
+  Results<(outs SignlessIntegerOrFloatLike:$res)>,
+  Arguments<(ins SignlessIntegerOrFloatLike:$value,
                  TritonGEN_ReduceKindAttr:$kind,
                  I32Attr:$size)> {
   let summary = "Subgroup reduce";
@@ -263,8 +261,8 @@ def TritonGEN_SubGroupReduceOp : TritonGEN_Op<"sub_group_reduce", [
 
 def TritonGEN_SubGroupShuffleOp : TritonGEN_Op<"sub_group_shuffle", [
       AllTypesMatch<["res", "value"]>]>,
-  Results<(outs IntegerOrFloatType:$res)>,
-  Arguments<(ins IntegerOrFloatType:$value,
+  Results<(outs SignlessIntegerOrFloatLike:$res)>,
+  Arguments<(ins SignlessIntegerOrFloatLike:$value,
                  I32:$mask,
                  TritonGEN_ShflKindAttr:$kind)> {
   let summary = "Subgroup shuffle";


### PR DESCRIPTION
`sub_group_reduce` definition used a custom type accepting any integer or float type. Use standard `SignlessIntegerOrFloatLike` instead, accepting only signless integers.
