### PR TITLE
[GEN] Do not allow unknown operations when initializing `triton_gen`

### DIFF
--- a/third_party/intel/lib/Dialect/TritonGEN/IR/TritonGENDialect.cpp
+++ b/third_party/intel/lib/Dialect/TritonGEN/IR/TritonGENDialect.cpp
@@ -34,9 +34,6 @@ void TritonGENDialect::initialize() {
 #define GET_ATTRDEF_LIST
 #include "intel/include/Dialect/TritonGEN/IR/TritonGENOpsAttrDefs.cpp.inc"
       >();
-
-  // Support unknown operations because not all GEN operations are registered.
-  allowUnknownOperations();
 }
 
 int triton::TritonGEN::getSubgroupSize(Operation *op) {


### PR DESCRIPTION
Allowing unknown operations is not the way to go. We should register required dialects instead.
