### PR TITLE
[GEN] Use OCL builtin for `bf16<->f32` conversions

### DIFF
--- a/test/Conversion/intel/arith_to_llvm.mlir
+++ b/test/Conversion/intel/arith_to_llvm.mlir
@@ -1,6 +1,5 @@
 // RUN: triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm | FileCheck %s
 
-// CHECK-DAG:   llvm.func spir_funccc @_Z27__spirv_ConvertFToBF16INTELf(f32) -> i16
 // CHECK-DAG: #[[$ATTR_0:.+]] = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #blocked = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
 
@@ -13,13 +12,13 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
 // CHECK:           %[[VAL_3:.*]] = llvm.extractvalue %[[VAL_0]][1] : !llvm.struct<(f32, f32, f32, f32)>
 // CHECK:           %[[VAL_4:.*]] = llvm.extractvalue %[[VAL_0]][2] : !llvm.struct<(f32, f32, f32, f32)>
 // CHECK:           %[[VAL_5:.*]] = llvm.extractvalue %[[VAL_0]][3] : !llvm.struct<(f32, f32, f32, f32)>
-// CHECK:           %[[VAL_6:.*]] = llvm.call spir_funccc @_Z27__spirv_ConvertFToBF16INTELf(%[[VAL_2]]) : (f32) -> i16
+// CHECK:           %[[VAL_6:.*]] = llvm.call spir_funccc @_Z32intel_convert_bfloat16_as_ushortf(%[[VAL_2]]) : (f32) -> i16
 // CHECK:           %[[BITCAST_6:.*]] = llvm.bitcast %[[VAL_6]] : i16 to bf16
-// CHECK:           %[[VAL_7:.*]] = llvm.call spir_funccc @_Z27__spirv_ConvertFToBF16INTELf(%[[VAL_3]]) : (f32) -> i16
+// CHECK:           %[[VAL_7:.*]] = llvm.call spir_funccc @_Z32intel_convert_bfloat16_as_ushortf(%[[VAL_3]]) : (f32) -> i16
 // CHECK:           %[[BITCAST_7:.*]] = llvm.bitcast %[[VAL_7]] : i16 to bf16
-// CHECK:           %[[VAL_8:.*]] = llvm.call spir_funccc @_Z27__spirv_ConvertFToBF16INTELf(%[[VAL_4]]) : (f32) -> i16
+// CHECK:           %[[VAL_8:.*]] = llvm.call spir_funccc @_Z32intel_convert_bfloat16_as_ushortf(%[[VAL_4]]) : (f32) -> i16
 // CHECK:           %[[BITCAST_8:.*]] = llvm.bitcast %[[VAL_8]] : i16 to bf16
-// CHECK:           %[[VAL_9:.*]] = llvm.call spir_funccc @_Z27__spirv_ConvertFToBF16INTELf(%[[VAL_5]]) : (f32) -> i16
+// CHECK:           %[[VAL_9:.*]] = llvm.call spir_funccc @_Z32intel_convert_bfloat16_as_ushortf(%[[VAL_5]]) : (f32) -> i16
 // CHECK:           %[[BITCAST_9:.*]] = llvm.bitcast %[[VAL_9]] : i16 to bf16
 // CHECK:           %[[VAL_10:.*]] = llvm.mlir.undef : !llvm.struct<(bf16, bf16, bf16, bf16)>
 // CHECK:           %[[VAL_11:.*]] = llvm.insertvalue %[[BITCAST_6]], %[[VAL_10]][0] : !llvm.struct<(bf16, bf16, bf16, bf16)>
@@ -40,13 +39,13 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
 // CHECK:           %[[VAL_4:.*]] = llvm.extractvalue %[[VAL_0]][2] : !llvm.struct<(bf16, bf16, bf16, bf16)>
 // CHECK:           %[[VAL_5:.*]] = llvm.extractvalue %[[VAL_0]][3] : !llvm.struct<(bf16, bf16, bf16, bf16)>
 // CHECK:           %[[BITCAST_2:.*]] = llvm.bitcast %[[VAL_2]] : bf16 to i16
-// CHECK:           %[[VAL_6:.*]] = llvm.call spir_funccc @_Z27__spirv_ConvertBF16ToFINTELs(%[[BITCAST_2]]) : (i16) -> f32
+// CHECK:           %[[VAL_6:.*]] = llvm.call spir_funccc @_Z31intel_convert_as_bfloat16_floats(%[[BITCAST_2]]) : (i16) -> f32
 // CHECK:           %[[BITCAST_3:.*]] = llvm.bitcast %[[VAL_3]] : bf16 to i16
-// CHECK:           %[[VAL_7:.*]] = llvm.call spir_funccc @_Z27__spirv_ConvertBF16ToFINTELs(%[[BITCAST_3]]) : (i16) -> f32
+// CHECK:           %[[VAL_7:.*]] = llvm.call spir_funccc @_Z31intel_convert_as_bfloat16_floats(%[[BITCAST_3]]) : (i16) -> f32
 // CHECK:           %[[BITCAST_4:.*]] = llvm.bitcast %[[VAL_4]] : bf16 to i16
-// CHECK:           %[[VAL_8:.*]] = llvm.call spir_funccc @_Z27__spirv_ConvertBF16ToFINTELs(%[[BITCAST_4]]) : (i16) -> f32
+// CHECK:           %[[VAL_8:.*]] = llvm.call spir_funccc @_Z31intel_convert_as_bfloat16_floats(%[[BITCAST_4]]) : (i16) -> f32
 // CHECK:           %[[BITCAST_5:.*]] = llvm.bitcast %[[VAL_5]] : bf16 to i16
-// CHECK:           %[[VAL_9:.*]] = llvm.call spir_funccc @_Z27__spirv_ConvertBF16ToFINTELs(%[[BITCAST_5]]) : (i16) -> f32
+// CHECK:           %[[VAL_9:.*]] = llvm.call spir_funccc @_Z31intel_convert_as_bfloat16_floats(%[[BITCAST_5]]) : (i16) -> f32
 // CHECK:           %[[VAL_10:.*]] = llvm.mlir.undef : !llvm.struct<(f32, f32, f32, f32)>
 // CHECK:           %[[VAL_11:.*]] = llvm.insertvalue %[[VAL_6]], %[[VAL_10]][0] : !llvm.struct<(f32, f32, f32, f32)>
 // CHECK:           %[[VAL_12:.*]] = llvm.insertvalue %[[VAL_7]], %[[VAL_11]][1] : !llvm.struct<(f32, f32, f32, f32)>

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1287,7 +1287,7 @@ struct FpToFpOpConversion
                                  const Value &v) {
     auto moduleOp =
         v.getDefiningOp()->getParentWithTrait<OpTrait::SymbolTable>();
-    constexpr StringLiteral name = "_Z27__spirv_ConvertBF16ToFINTELs";
+    constexpr StringLiteral name = "_Z31intel_convert_as_bfloat16_floats";
     auto ext_func = triton::gpu::intel::lookupOrCreateSPIRVFn(moduleOp, name,
                                                               i16_ty, f32_ty);
     auto call = triton::gpu::intel::createSPIRVBuiltinCall(
@@ -1308,7 +1308,7 @@ struct FpToFpOpConversion
       auto moduleOp =
           v.getDefiningOp()->getParentWithTrait<OpTrait::SymbolTable>();
       // Intel SPIR-V extension only supports round-to-nearest-even
-      constexpr StringLiteral name = "_Z27__spirv_ConvertFToBF16INTELf";
+      constexpr StringLiteral name = "_Z32intel_convert_bfloat16_as_ushortf";
       auto trunc_func = triton::gpu::intel::lookupOrCreateSPIRVFn(
           moduleOp, name, f32_ty, i16_ty);
       auto call = triton::gpu::intel::createSPIRVBuiltinCall(loc, rewriter,


### PR DESCRIPTION
Use `intel_convert_bfloat16_as_ushort` OCL builtin instead of the `__spirv_ConvertFToBF16INTEL` SPIR-V builtin to express `bf16<->f32` conversions.
