### PR TITLE
Inject a SPIR-V env when going from TritonIntelGPU to LLVM

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -26,6 +26,7 @@ constexpr int patternBenefitDefault = 1;
 constexpr int patternBenefitPrioritizeOverLLVMConversions = 10;
 constexpr int patternBenefitClampOptimizedPattern = 20;
 constexpr int patternBenefitConvertLayoutOptimizedPattern = 20;
+constexpr int patternBenefitAddSPIRVEnv = 30;
 
 void populateElementwiseOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,

--- a/test/Conversion/intel/tritonintelgpu_to_llvm.mlir
+++ b/test/Conversion/intel/tritonintelgpu_to_llvm.mlir
@@ -1,0 +1,5 @@
+// RUN: triton-opt %s --convert-triton-intel-gpu-to-llvm | FileCheck %s
+
+// COM: check that the spirv target env is inserted
+// CHECK: spirv.target_env{{.*}}#spirv.resource_limits<subgroup_size = 16>
+module attributes { "triton_gpu.threads-per-warp" = 16 : i32, "triton_gpu.num-warps" = 4 : i32 } { }

--- a/third_party/intel/include/TritonIntelGPUToLLVM/Passes.td
+++ b/third_party/intel/include/TritonIntelGPUToLLVM/Passes.td
@@ -20,6 +20,7 @@ def ConvertTritonIntelGPUToLLVM
                            "mlir::math::MathDialect",
                            "mlir::gpu::GPUDialect",
                            "mlir::scf::SCFDialect",
+                           "mlir::spirv::SPIRVDialect",
                            "mlir::LLVM::LLVMDialect",
                            "mlir::tensor::TensorDialect",
                            "mlir::triton::TritonDialect",

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PipelineManager.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PipelineManager.h
@@ -17,6 +17,7 @@
 #include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
 #include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
+#include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
 #include "mlir/IR/PatternMatch.h"
 
 #include "intel/include/GPUToTritonGEN/GPUToTritonGENPass.h"
@@ -135,6 +136,44 @@ private:
   int numWarps{0};
 };
 
+struct AddSPIRVEnvPattern : public mlir::OpRewritePattern<ModuleOp> {
+
+  using mlir::OpRewritePattern<ModuleOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ModuleOp op,
+                                PatternRewriter &rewriter) const override {
+    if (spirv::lookupTargetEnv(op)) {
+      return failure();
+    }
+
+    int subgroupSize =
+        ::mlir::triton::gpu::TritonGPUDialect::getThreadsPerWarp(op);
+
+    auto resourceLimit = spirv::getDefaultResourceLimits(rewriter.getContext());
+    auto newResourceLimit = rewriter.getAttr<spirv::ResourceLimitsAttr>(
+        resourceLimit.getMaxComputeSharedMemorySize(),
+        resourceLimit.getMaxComputeWorkgroupInvocations(),
+        resourceLimit.getMaxComputeWorkgroupSize(), subgroupSize,
+        resourceLimit.getMinSubgroupSize(), resourceLimit.getMaxSubgroupSize(),
+        resourceLimit.getCooperativeMatrixPropertiesKhr(),
+        resourceLimit.getCooperativeMatrixPropertiesNv());
+    auto triple = spirv::VerCapExtAttr::get(
+        spirv::Version::V_1_2,
+        {spirv::Capability::GroupNonUniform, spirv::Capability::Addresses,
+         spirv::Capability::Float16Buffer, spirv::Capability::Int64,
+         spirv::Capability::Int16, spirv::Capability::Int8,
+         spirv::Capability::Kernel, spirv::Capability::Linkage,
+         spirv::Capability::Vector16, spirv::Capability::GenericPointer,
+         spirv::Capability::Groups, spirv::Capability::Float64},
+        {}, rewriter.getContext());
+    auto newTargetEnv = spirv::TargetEnvAttr::get(triple, newResourceLimit);
+    rewriter.modifyOpInPlace(op, [op, newTargetEnv] {
+      op->setAttr(spirv::getTargetEnvAttrName(), newTargetEnv);
+    });
+    return success();
+  }
+};
+
 /// Manages TritonIntelGPU --> LLVM the conversion pipeline.
 /// Currently the conversion pipeline depends on whether the kernel contains
 /// block pointers or not.
@@ -168,6 +207,9 @@ public:
                              TargetInfo &targetInfo, int benefit) const {
     using namespace mlir;
     using namespace mlir::triton;
+
+    // should run before other patterns need the SPIRV-ENV attr
+    patterns.add<AddSPIRVEnvPattern>(&typeConverter.getContext(), benefit);
 
     if (blockPtrPathIsEnabled) {
       intel::populateTritonOpsToLLVMPatterns(typeConverter, patterns, benefit);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PipelineManager.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PipelineManager.h
@@ -208,8 +208,10 @@ public:
     using namespace mlir;
     using namespace mlir::triton;
 
-    // should run before other patterns need the SPIRV-ENV attr
-    patterns.add<AddSPIRVEnvPattern>(&typeConverter.getContext(), benefit);
+    // should run before other patterns that need the SPIRV-ENV attr
+    // (e.g. patterns that output triton_gen.sub_group_reduce)
+    patterns.add<AddSPIRVEnvPattern>(&typeConverter.getContext(),
+                                     patternBenefitAddSPIRVEnv);
 
     if (blockPtrPathIsEnabled) {
       intel::populateTritonOpsToLLVMPatterns(typeConverter, patterns, benefit);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVM.cpp
@@ -5,6 +5,7 @@
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
 
 #include "intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h"
 #include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
@@ -56,6 +57,8 @@ public:
     addIllegalDialect<triton::gpu::intel::TritonIntelGPUDialect>();
     addIllegalDialect<mlir::gpu::GPUDialect>();
     addLegalOp<mlir::UnrealizedConversionCastOp>();
+    addDynamicallyLegalOp<ModuleOp>(
+        [](ModuleOp op) { return spirv::lookupTargetEnv(op) != nullptr; });
   }
 };
 
@@ -65,7 +68,8 @@ struct ConvertTritonGPUToLLVM
   using ConvertTritonIntelGPUToLLVMBase::ConvertTritonIntelGPUToLLVMBase;
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<LLVM::LLVMDialect, TritonGEN::TritonGENDialect>();
+    registry.insert<LLVM::LLVMDialect, TritonGEN::TritonGENDialect,
+                    spirv::SPIRVDialect>();
   }
 
   void runOnOperation() override {


### PR DESCRIPTION
The purpose of this is to allow the use of `triton_gen.sub_group_reduce`, since the verification for was added in #1223.