### PR TITLE
[TMP]: Disable layout rematerialization cache

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -161,7 +161,7 @@ class XPUBackend(BaseBackend):
         passes.ttir.add_convert_to_ttgpuir(pm, f"xpu:{device_arch}", opt.num_warps, opt.threads_per_warp, opt.num_ctas)
 
         is_lts_driver = Version(metadata["target"].arch['driver_version']) == Version("1.3.27642")
-        enable_remat_cache = False # not is_lts_driver
+        enable_remat_cache = not is_lts_driver
 
         # optimize TTGIR
         intel.passes.ttgpuir.add_accelerate_matmul(pm)

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -156,6 +156,10 @@ def TritonIntelGPURemoveLayoutConversions : Pass<"tritonintelgpu-remove-layout-c
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
                            "mlir::triton::TritonDialect"];
 
+  let options = [
+    Option<"enableRematCache", "enable-remat-cache", "bool", /*default*/"true", "Whether to enable the rematerialization cache (currently causing problems with the LTS driver).">,
+  ];
+
 }
 
 def TritonIntelGPURewriteTensorPointer : Pass<"tritonintelgpu-rewrite-tensor-pointer", "mlir::ModuleOp"> {

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -1290,7 +1290,7 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
   mapping.map(extOrBroadcatOp->getResult(0), newExtOrBroadcast->getResult(0));
   slice.remove(extOrBroadcatOp->getResult(0));
   // 3. Rewrite the slice.
-  rewriteSlice(slice, layout, convertOp, mapping, /*enableRematCache=*/false);
+  rewriteSlice(slice, layout, convertOp, mapping, /*enableRematCache=*/true);
 }
 
 void backwardRematerialization(ModuleOp module, bool enableRematCache) {

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -166,11 +166,13 @@ public:
   }
   void cleanup();
   void backwardRematerialization(bool enableRematCache);
-  void backwardRematerialization(ConvertLayoutOp convertOp, bool enableRematCache);
+  void backwardRematerialization(ConvertLayoutOp convertOp,
+                                 bool enableRematCache);
   void hoistConvertOnTopOfExtOrBroadcast();
   void hoistConvertOnTopOfExtOrBroadcast(ConvertLayoutOp convertOp);
   void rewriteSlice(SetVector<Value> &slice, DenseMap<Value, Attribute> &layout,
-                    ConvertLayoutOp convertOp, IRMapping &mapping, bool enableRematCache);
+                    ConvertLayoutOp convertOp, IRMapping &mapping,
+                    bool enableRematCache);
   void rewriteSlice(SetVector<Value> &slice, DenseMap<Value, Attribute> &layout,
                     ConvertLayoutOp convertOp, bool enableRematCache);
 
@@ -944,7 +946,8 @@ void LayoutRematerialization::updateRematMapping(
 void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
                                            DenseMap<Value, Attribute> &layout,
                                            ConvertLayoutOp convertOp,
-                                           IRMapping &mapping, bool enableRematCache) {
+                                           IRMapping &mapping,
+                                           bool enableRematCache) {
   SetVector<Operation *> opsToRewrite;
   // Keep track of yield operands that need to be duplicated.
   DenseMap<Operation *, SmallVector<int>> yieldOperandsMap;
@@ -952,12 +955,10 @@ void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
     auto layoutIt = layout.find(v);
     assert(layoutIt != layout.end());
     // If we already have a remat value for this value, use it.
-#if 0
-    if (false && hasRematValue(v, layoutIt->second)) {
+    if (enableRematCache && hasRematValue(v, layoutIt->second)) {
       mapping.map(v, getRematValue(v, layoutIt->second));
       continue;
     }
-#endif 
     if (v.getDefiningOp()) {
       opsToRewrite.insert(v.getDefiningOp());
       if (auto ifOp = v.getDefiningOp<scf::IfOp>()) {
@@ -1120,7 +1121,8 @@ void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
 
 void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
                                            DenseMap<Value, Attribute> &layout,
-                                           ConvertLayoutOp convertOp, bool enableRematCache) {
+                                           ConvertLayoutOp convertOp,
+                                           bool enableRematCache) {
   IRMapping mapping;
   rewriteSlice(slice, layout, convertOp, mapping, enableRematCache);
 }
@@ -1312,7 +1314,8 @@ class TritonIntelGPURemoveLayoutConversionsPass
     : public intel::impl::TritonIntelGPURemoveLayoutConversionsBase<
           TritonIntelGPURemoveLayoutConversionsPass> {
 public:
-  using TritonIntelGPURemoveLayoutConversionsBase::TritonIntelGPURemoveLayoutConversionsBase;
+  using TritonIntelGPURemoveLayoutConversionsBase::
+      TritonIntelGPURemoveLayoutConversionsBase;
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -952,10 +952,12 @@ void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
     auto layoutIt = layout.find(v);
     assert(layoutIt != layout.end());
     // If we already have a remat value for this value, use it.
+  #if 0 // FIXME: Fails on LTS driver 
     if (hasRematValue(v, layoutIt->second)) {
       mapping.map(v, getRematValue(v, layoutIt->second));
       continue;
     }
+  #endif 
     if (v.getDefiningOp()) {
       opsToRewrite.insert(v.getDefiningOp());
       if (auto ifOp = v.getDefiningOp<scf::IfOp>()) {

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -952,12 +952,12 @@ void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
     auto layoutIt = layout.find(v);
     assert(layoutIt != layout.end());
     // If we already have a remat value for this value, use it.
-  #if 0 // FIXME: Fails on LTS driver 
+#if 0 // FIXME: Fails on LTS driver
     if (hasRematValue(v, layoutIt->second)) {
       mapping.map(v, getRematValue(v, layoutIt->second));
       continue;
     }
-  #endif 
+#endif
     if (v.getDefiningOp()) {
       opsToRewrite.insert(v.getDefiningOp());
       if (auto ifOp = v.getDefiningOp<scf::IfOp>()) {

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -65,8 +65,9 @@ void init_triton_intel_passes_ttgpuir(py::module &&m) {
                      gpu::intel::createIntelAllocateSharedMemory);
   ADD_PASS_WRAPPER_OPT_2("add_pipeline",
                          gpu::intel::createTritonIntelGPUPipeline, int, bool);
-  ADD_PASS_WRAPPER_OPT_1("add_remove_layout_conversions",
-                     gpu::intel::createTritonIntelGPURemoveLayoutConversions, bool);
+  ADD_PASS_WRAPPER_OPT_1(
+      "add_remove_layout_conversions",
+      gpu::intel::createTritonIntelGPURemoveLayoutConversions, bool);
   ADD_PASS_WRAPPER_0("add_rewrite_tensor_pointer",
                      gpu::intel::createTritonIntelGPURewriteTensorPointer);
   ADD_PASS_WRAPPER_OPT_2("add_prefetch_block",

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -1,4 +1,4 @@
-#include "mlir/Pass/PassManager.h"
+﻿#include "mlir/Pass/PassManager.h"
 #include "passes.h"
 
 #include "llvm/IRReader/IRReader.h"
@@ -65,8 +65,8 @@ void init_triton_intel_passes_ttgpuir(py::module &&m) {
                      gpu::intel::createIntelAllocateSharedMemory);
   ADD_PASS_WRAPPER_OPT_2("add_pipeline",
                          gpu::intel::createTritonIntelGPUPipeline, int, bool);
-  ADD_PASS_WRAPPER_0("add_remove_layout_conversions",
-                     gpu::intel::createTritonIntelGPURemoveLayoutConversions);
+  ADD_PASS_WRAPPER_OPT_1("add_remove_layout_conversions",
+                     gpu::intel::createTritonIntelGPURemoveLayoutConversions, bool);
   ADD_PASS_WRAPPER_0("add_rewrite_tensor_pointer",
                      gpu::intel::createTritonIntelGPURewriteTensorPointer);
   ADD_PASS_WRAPPER_OPT_2("add_prefetch_block",


### PR DESCRIPTION
Temporarily disables the layout rematerialization cache for backward slice rematerialization. The remat cache is exposing a bug on systems with the LTS driver which results in an accuracy error with two HuggingFace models under the PyTorch Inductor benchmarks. Tracking down the driver issue and providing a reproducer to the driver team will take some time, so this is a stopgap solution. I ran the same Float32 / training HF benchmarks compared with llvm-target and there is a small regression on the `T5Small` model, but all other models are relatively similar to `llvm-target`. I am running the accuracy tests locally for Float32 / Training HF and so far results are promising so I am marking this ready for review.

Issue #1255 

![image](https://github.com/intel/intel-xpu-backend-for-triton/assets/5845842/fb68e0ea-fec3-4351-9b16-0e2ed94cd222)
