### PR TITLE
Clarified lit test looking for a spirv-env module attribute

### DIFF
--- a/test/Conversion/intel/tritonintelgpu_to_llvm.mlir
+++ b/test/Conversion/intel/tritonintelgpu_to_llvm.mlir
@@ -1,5 +1,5 @@
 // RUN: triton-opt %s --convert-triton-intel-gpu-to-llvm | FileCheck %s
 
 // COM: check that the spirv target env is inserted
-// CHECK: spirv.target_env{{.*}}#spirv.resource_limits<subgroup_size = 16>
+// CHECK: module attributes {{{.*}}spirv.target_env{{.*}}#spirv.resource_limits<subgroup_size = 16>
 module attributes { "triton_gpu.threads-per-warp" = 16 : i32, "triton_gpu.num-warps" = 4 : i32 } { }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PipelineManager.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PipelineManager.h
@@ -146,8 +146,7 @@ struct AddSPIRVEnvPattern : public mlir::OpRewritePattern<ModuleOp> {
       return failure();
     }
 
-    int subgroupSize =
-        ::mlir::triton::gpu::TritonGPUDialect::getThreadsPerWarp(op);
+    int subgroupSize = triton::gpu::TritonGPUDialect::getThreadsPerWarp(op);
 
     auto resourceLimit = spirv::getDefaultResourceLimits(rewriter.getContext());
     auto newResourceLimit = rewriter.getAttr<spirv::ResourceLimitsAttr>(


### PR DESCRIPTION
The lit test in `test/Conversion/intel/tritonintelgpu_to_llvm.mlir` is supposed to check for a module attribute, this PR should make that clearer.

FYI here is the output of `triton-opt`
```
$ triton-opt test/Conversion/intel/tritonintelgpu_to_llvm.mlir --convert-triton-intel-gpu-to-llvm 
module attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.2, [GroupNonUniform, Addresses, Float16Buffer, Int64, Int16, Int8, Kernel, Linkage, Vector16, GenericPointer, Groups, Float64], []>, #spirv.resource_limits<subgroup_size = 16>>, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 16 : i32} {
}
```