### PR TITLE
[GEN] Add memory ref attribute to 2Dblockload

### DIFF
--- a/test/TritonGEN/tritongen-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-to-llvm.mlir
@@ -297,7 +297,7 @@ llvm.func @triton_gen.dpas.f32(%c : vector<8xf32>, %a : vector<4xf32>, %b : vect
 
 // -----
 
-// CHECK: llvm.func spir_funccc @intel_subgroup_block_read_u8_m8k32v2(!llvm.ptr<1> {llvm.nonnull}, i32, i32, i32, vector<2xi32>) -> vector<16xi16> attributes {passthrough = ["nounwind"]}
+// CHECK: llvm.func spir_funccc @intel_subgroup_block_read_u8_m8k32v2(!llvm.ptr<1> {llvm.nonnull}, i32, i32, i32, vector<2xi32>) -> vector<16xi16> attributes {passthrough = ["nounwind", ["memory", "1"]]}
 
 llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
   // CHECK:     llvm.func @triton_gen.2Dblockload(%arg0: !llvm.ptr<1>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -295,7 +295,11 @@ createGenISA2DBlockRead(TritonGEN::Matrix2DBlockLoadOp op,
     MLIRContext *ctx = rewriter.getContext();
     intel::AttrBuilder funcAttrBuilder(*ctx);
     intel::AttrBuilder paramAttrBuilder(*ctx);
-    funcAttrBuilder.addPassthroughAttribute(llvm::Attribute::NoUnwind);
+    funcAttrBuilder.addPassthroughAttribute(llvm::Attribute::NoUnwind)
+        .addPassthroughAttribute(
+            llvm::Attribute::Memory,
+            llvm::MemoryEffects::argMemOnly(llvm::ModRefInfo::Ref)
+                .toIntValue());
     paramAttrBuilder.addAttribute(llvm::Attribute::NonNull);
     std::vector<NamedAttrList> paramAttrs(argTypes.size());
     paramAttrs[0] = paramAttrBuilder.getAttributes();


### PR DESCRIPTION
Address code review comment: https://github.com/intel/intel-xpu-backend-for-triton/pull/1278/files#r1631274117
Note that this memory attribute needs to be removed when changing to the new OCL interface, as it writes the return value in the last operand.   