### PR TITLE
Update CI to use Agama 881.19

### DIFF
--- a/.github/dockerfiles/runner-base/Dockerfile
+++ b/.github/dockerfiles/runner-base/Dockerfile
@@ -12,9 +12,9 @@ RUN set -ex; \
     apt-get install -y --no-install-recommends --fix-missing \
       intel-opencl-icd \
       clinfo \
-      intel-level-zero-gpu \
-      level-zero \
-      level-zero-dev libigc-dev intel-igc-cm libigdfcl-dev libigfxcmrt-dev \
+      intel-opencl-icd intel-level-zero-gpu level-zero \
+      intel-media-va-driver-non-free libmfx1 libmfxgen1 libvpl2 libigdgmm12 \
+      libigc-dev intel-igc-cm libigdfcl-dev libigfxcmrt-dev level-zero-dev \
       \
       build-essential \
       zlib1g-dev \
@@ -24,10 +24,8 @@ RUN set -ex; \
       pkg-config \
       \
       libpng-dev libjpeg-dev libsndfile1-dev libxml2-dev libxslt1-dev \
-      libgl1-mesa-glx  \
       fontconfig libfontconfig1-dev \
       libpango-1.0-0 libpangoft2-1.0-0 \
-      libsdl2-dev libsdl2-2.0-0 \
       \
       gh \
     ; \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -91,7 +91,7 @@ jobs:
   integration-tests:
     name: Integration tests
     runs-on:
-      - ${{ inputs.runner_label || 'runner-0.0.13' }}
+      - ${{ inputs.runner_label || 'runner-0.0.15' }}
     strategy:
       matrix:
         python: ${{ github.ref_name == 'llvm-target' && fromJson('["3.9", "3.10", "3.11"]') || fromJson('["3.9"]') }}

--- a/.github/workflows/conda-basekit-build-test.yml
+++ b/.github/workflows/conda-basekit-build-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on:
       - glados
       - spr
-      - runner-0.0.14
+      - runner-0.0.15
     strategy:
       matrix:
         python: ${{ github.ref_name == 'llvm-target' && fromJson('["3.9", "3.10", "3.11"]') || fromJson('["3.9"]') }}

--- a/.github/workflows/conda-build-test.yml
+++ b/.github/workflows/conda-build-test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on:
       - glados
       - spr
-      - runner-0.0.14
+      - runner-0.0.15
     strategy:
       matrix:
         python: ${{ github.ref_name == 'llvm-target' && fromJson('["3.9", "3.10", "3.11"]') || fromJson('["3.9"]') }}

--- a/.github/workflows/docker-runner.yml
+++ b/.github/workflows/docker-runner.yml
@@ -2,16 +2,12 @@ name: Build self-hosted runner image
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - .github/workflows/docker-runner.yml
-      - .github/dockerfiles/runner-base/Dockerfile
 
 permissions: read-all
 
 env:
   REGISTRY: docker-registry.docker-registry.svc.cluster.local:5000
-  TAG: triton-runner-base:0.0.14
+  TAG: triton-runner-base:0.0.15
 
 jobs:
   build:

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on:
       - glados
       - spr
-      - runner-0.0.13
+      - runner-0.0.15
     strategy:
       matrix:
         python:

--- a/scripts/skiplist/conda/operators.txt
+++ b/scripts/skiplist/conda/operators.txt
@@ -1,0 +1,1 @@
+test/unit/operators/test_matmul.py::test_op[128-256-64-1-8-3-256-512-160-True-True-float32-float32-None-True-None-None]

--- a/scripts/skiplist/default/operators.txt
+++ b/scripts/skiplist/default/operators.txt
@@ -1,0 +1,1 @@
+test/unit/operators/test_matmul.py::test_op[128-256-64-1-8-3-256-512-160-True-True-float32-float32-None-True-None-None]


### PR DESCRIPTION
Build a new Docker image triton-runner-base:0.0.15 with agama 881.19 (the latest rolling release) and use the image in CI workflows.

Closes #1302.