### PR TITLE
Set correct attibutes for get_local_id, get_group_id, get_num_groups,…

### DIFF
--- a/test/TritonGEN/tritongen-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-to-llvm.mlir
@@ -1,10 +1,10 @@
 // RUN: triton-opt -convert-tritongen-to-llvm -split-input-file %s | FileCheck %s
 
 // CHECK-DAG: llvm.func spir_funccc @_Z25__spirv_BuiltInSubgroupIdv() -> i32
-// CHECK-DAG: llvm.func spir_funccc @_Z14get_num_groupsj(i32) -> i64
-// CHECK-DAG: llvm.func spir_funccc @_Z14get_local_sizej(i32) -> i64
-// CHECK-DAG: llvm.func spir_funccc @_Z12get_group_idj(i32) -> i64
-// CHECK-DAG: llvm.func spir_funccc @_Z12get_local_idj(i32) -> i64
+// CHECK-DAG: llvm.func spir_funccc @_Z14get_num_groupsj(i32) -> i64 attributes {passthrough = ["nounwind", ["memory", "0"]]}
+// CHECK-DAG: llvm.func spir_funccc @_Z14get_local_sizej(i32) -> i64 attributes {passthrough = ["nounwind", ["memory", "0"]]}
+// CHECK-DAG: llvm.func spir_funccc @_Z12get_group_idj(i32) -> i64 attributes {passthrough = ["nounwind", ["memory", "0"]]}
+// CHECK-DAG: llvm.func spir_funccc @_Z12get_local_idj(i32) -> i64 attributes {passthrough = ["nounwind", ["memory", "0"]]}
 
 llvm.func @gen_special_regs() -> i32 {
   // CHECK-LABEL: gen_special_regs

--- a/test/TritonGEN/tritongen-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-to-llvm.mlir
@@ -1,10 +1,10 @@
 // RUN: triton-opt -convert-tritongen-to-llvm -split-input-file %s | FileCheck %s
 
 // CHECK-DAG: llvm.func spir_funccc @_Z25__spirv_BuiltInSubgroupIdv() -> i32
-// CHECK-DAG: llvm.func spir_funccc @_Z14get_num_groupsj(i32) -> i64 attributes {passthrough = ["nounwind", ["memory", "0"]]}
-// CHECK-DAG: llvm.func spir_funccc @_Z14get_local_sizej(i32) -> i64 attributes {passthrough = ["nounwind", ["memory", "0"]]}
-// CHECK-DAG: llvm.func spir_funccc @_Z12get_group_idj(i32) -> i64 attributes {passthrough = ["nounwind", ["memory", "0"]]}
-// CHECK-DAG: llvm.func spir_funccc @_Z12get_local_idj(i32) -> i64 attributes {passthrough = ["nounwind", ["memory", "0"]]}
+// CHECK-DAG: llvm.func spir_funccc @_Z14get_num_groupsj(i32) -> i64 attributes {passthrough = ["nounwind", "willreturn", ["memory", "0"]]}
+// CHECK-DAG: llvm.func spir_funccc @_Z14get_local_sizej(i32) -> i64 attributes {passthrough = ["nounwind", "willreturn", ["memory", "0"]]}
+// CHECK-DAG: llvm.func spir_funccc @_Z12get_group_idj(i32) -> i64 attributes {passthrough = ["nounwind", "willreturn", ["memory", "0"]]}
+// CHECK-DAG: llvm.func spir_funccc @_Z12get_local_idj(i32) -> i64 attributes {passthrough = ["nounwind", "willreturn", ["memory", "0"]]}
 
 llvm.func @gen_special_regs() -> i32 {
   // CHECK-LABEL: gen_special_regs

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -624,6 +624,7 @@ protected:
 
     intel::AttrBuilder funcAttrBuilder(*ctx);
     funcAttrBuilder.addPassthroughAttribute(llvm::Attribute::NoUnwind)
+        .addPassthroughAttribute(llvm::Attribute::WillReturn)
         .addPassthroughAttribute(llvm::Attribute::Memory,
                                  llvm::MemoryEffects::none().toIntValue());
 


### PR DESCRIPTION
Set LLVM IR attributes for the builtins used to read the thread ID, group ID, group size and number of groups so that these calls can be hoisted outside of loops by LLVM `opt` LICM pass.