### PR TITLE
[UT] Precision bug fix in test_core.py::test_dot

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3269,6 +3269,13 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
         z_ref = num / denom
     if epilogue == 'chain-dot':
         if 'float8' in in_dtype:
+            if in_dtype == 'float8e4nv':
+                z_fp8 = torch.tensor(z_ref, dtype=torch.float8_e4m3fn)
+            elif in_dtype == 'float8e5':
+                z_fp8 = torch.tensor(z_ref, dtype=torch.float8_e5m2)
+            else:
+                assert "Unsupported float8 dtype"
+            z_ref = to_numpy(z_fp8.to(torch.float32))
             w = to_numpy(convert_fp8_to_fp32(w, device, in_dtype))
         z_ref = np.matmul(z_ref, w)
     # compare


### PR DESCRIPTION
There is a precision bug in test_core.py::test_dot for chain-dot cases.
Inside the kernel, it does fp8xfp8->fp32 dot-product (`z=xy`), cast the output to fp8 (fp32->fp8) and do the fp8xfp8->fp32 dot-product again (`z=zw`).
However, the reference code does not cast the intermediate output to fp8 so that the second dot-product becomes fp32xfp8->fp32.
This precision problem causes the output mismatch in float8e4nv setup, so I fixed the precision issue.