### PR TITLE
Disable warpReduce under the LTS driver

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.cpp
@@ -87,6 +87,10 @@ bool TargetInfo::warpReduce(ConversionPatternRewriter &rewriter, Location loc,
                             SmallVector<Value> &acc, triton::ReduceOp op,
                             unsigned numLaneToReduce,
                             unsigned interleave) const {
+  const bool isLTS =
+      op->getParentOfType<ModuleOp>()->hasAttr("triton_gpu.is_lts");
+  if (isLTS)
+    return false;
   // No horizontal reduce required.
   if (numLaneToReduce == 1)
     return false;


### PR DESCRIPTION
Allows all HF Float32 Training accuracy models to pass under LTS driver and upstream PyTorch. 

cc #1336 