### PR TITLE
Update CI to use PTDB 0.5.1

### DIFF
--- a/.github/dockerfiles/runner-base/Dockerfile
+++ b/.github/dockerfiles/runner-base/Dockerfile
@@ -29,6 +29,9 @@ RUN set -ex; \
       \
       gh \
     ; \
+    apt-get install -y --no-install-recommends --fix-missing \
+      libgl1 \
+    ; \
     rm -rf /var/lib/apt/lists/*
 
 USER runner

--- a/.github/dockerfiles/runner-base/Dockerfile
+++ b/.github/dockerfiles/runner-base/Dockerfile
@@ -22,6 +22,7 @@ RUN set -ex; \
       ninja-build \
       ncurses-term \
       pkg-config \
+      wget \
       \
       libpng-dev libjpeg-dev libsndfile1-dev libxml2-dev libxslt1-dev \
       fontconfig libfontconfig1-dev \

--- a/.github/dockerfiles/runner-base/Dockerfile
+++ b/.github/dockerfiles/runner-base/Dockerfile
@@ -42,7 +42,7 @@ SHELL ["/bin/bash", "-xec"]
 
 # TODO: install only necessary components
 RUN \
-  curl -sSLO https://registrationcenter-download.intel.com/akdlm/IRC_NAS/52723419-d344-42bf-93ca-867606409cf0/l_intel-for-pytorch-gpu-dev_p_0.5.0.49_offline.sh; \
+  curl -sSLO https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6758ce21-bde6-47f8-b4bf-6df4301f187d/l_intel-for-pytorch-gpu-dev_p_0.5.1.40_offline.sh; \
   sh l_intel-for-pytorch-gpu*.sh -a --silent --eula accept; \
   rm l_intel-for-pytorch-gpu*.sh
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -92,7 +92,7 @@ jobs:
   integration-tests:
     name: Integration tests
     runs-on:
-      - ${{ inputs.runner_label || 'runner-0.0.15' }}
+      - ${{ inputs.runner_label || 'runner-0.0.16' }}
     strategy:
       matrix:
         python: ${{ github.ref_name == 'llvm-target' && fromJson('["3.9", "3.10", "3.11"]') || fromJson('["3.9"]') }}

--- a/.github/workflows/conda-basekit-build-test.yml
+++ b/.github/workflows/conda-basekit-build-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on:
       - glados
       - spr
-      - runner-0.0.15
+      - runner-0.0.16
     strategy:
       matrix:
         python: ${{ github.ref_name == 'llvm-target' && fromJson('["3.9", "3.10", "3.11"]') || fromJson('["3.9"]') }}

--- a/.github/workflows/conda-build-test.yml
+++ b/.github/workflows/conda-build-test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on:
       - glados
       - spr
-      - runner-0.0.15
+      - runner-0.0.16
     strategy:
       matrix:
         python: ${{ github.ref_name == 'llvm-target' && fromJson('["3.9", "3.10", "3.11"]') || fromJson('["3.9"]') }}

--- a/.github/workflows/docker-runner.yml
+++ b/.github/workflows/docker-runner.yml
@@ -7,7 +7,7 @@ permissions: read-all
 
 env:
   REGISTRY: docker-registry.docker-registry.svc.cluster.local:5000
-  TAG: triton-runner-base:0.0.15
+  TAG: triton-runner-base:0.0.16
 
 jobs:
   build:

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on:
       - glados
       - spr
-      - runner-0.0.15
+      - runner-0.0.16
     strategy:
       matrix:
         python:


### PR DESCRIPTION
Build a new Docker image triton-runner-base:0.0.16 with PTDB 0.5.1 and use the image in CI workflows.

Closes #1325.