### PR TITLE
[UT] Enabling float8e4b15 for test_fp8_dot_acc

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5241,8 +5241,6 @@ def test_fp8_dot_acc(in_type_str, low_precision_acc, device):
         if cc[0] >= 9 and in_type_str == "float8e4b15":
             pytest.skip("Dot op does not support fp8e4b15 on CUDA arch >= 90")
     check_type_supported(in_type_str, device)
-    if is_xpu() and in_type_str == "float8e4b15":
-        pytest.skip("FIXME: Fails to compile on XPU")
 
     if is_interpreter():
         pytest.skip("FIXME: RuntimeError: \"addmm_impl_cpu_\" not implemented for 'Half'")

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -43,7 +43,7 @@ class XPUOptions:
     default_dot_input_precision: str = "tf32"
     allowed_dot_input_precisions: Tuple[str] = ("tf32", "tf32x3", "ieee")
     allow_fp8e4nv: bool = False
-    allow_fp8e4b15: bool = False
+    allow_fp8e4b15: bool = True
     max_num_imprecise_acc_default: int = 0  # `max_num_imprecise_acc` only applies to fp8 -> fp32 dot on sm_90 for cuda
     extern_libs: dict = None
     debug: bool = False


### PR DESCRIPTION
Addressing the compilation failure issue of `test_core.py::test_fp8_dot_acc` (#1351).
Enabling `allow_fp8e4b15` in `compiler.py` solves the problem.