### PR TITLE
Add packaging to triton-xpu dependencies

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -578,7 +578,10 @@ def get_entry_points():
 
 
 def get_install_requires():
-    install_requires = ["filelock"]
+    install_requires = [
+        "filelock",
+        "packaging",  # used by third_party/intel/backend/compiler.py
+    ]  # yapf: disable
     return install_requires
 
 


### PR DESCRIPTION
This package is used in third_party/intel/backend/compiler.py.

Fixes #1367.