### PR TITLE
[RAISE-BP] Raise `tt.load` to block pointers

### DIFF
--- a/test/Triton/raise-block-pointer.mlir
+++ b/test/Triton/raise-block-pointer.mlir
@@ -1,79 +1,70 @@
-// RUN: triton-opt %s -triton-raise-block-pointer | FileCheck %s
+// RUN: triton-opt %s -triton-raise-block-pointer -canonicalize | FileCheck %s
 
 // CHECK-LABEL:   tt.func @test_addptr_splat_make_range(
-// CHECK-SAME:                                          %[[VAL_0:.*]]: !tt.ptr<f32>) {
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i32
-// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : i64
-// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 128 : i32
-// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 1 : i64
-// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_8:.*]] = arith.addi %[[VAL_3]], %[[VAL_5]] : i32
-// CHECK:           %[[VAL_9:.*]] = arith.addi %[[VAL_4]], %[[VAL_6]] : i64
-// CHECK:           %[[VAL_10:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_4]]], {{\[}}%[[VAL_9]]], {{\[}}%[[VAL_8]]] {order = array<i32>} : <tensor<128xf32>>
-tt.func @test_addptr_splat_make_range(%arg0 : !tt.ptr<f32>) {
+// CHECK-SAME:                                          %[[VAL_0:.*]]: !tt.ptr<f32>) -> tensor<128xf32> {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 128 : i32
+// CHECK:           %[[VAL_3:.*]] = arith.constant 1 : i64
+// CHECK:           %[[VAL_4:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_1]]], {{\[}}%[[VAL_3]]], {{\[}}%[[VAL_2]]] {order = array<i32>} : <tensor<128xf32>>
+// CHECK:           %[[VAL_5:.*]] = tt.load %[[VAL_4]] : !tt.ptr<tensor<128xf32>>
+// CHECK:           tt.return %[[VAL_5]] : tensor<128xf32>
+tt.func @test_addptr_splat_make_range(%arg0 : !tt.ptr<f32>) -> tensor<128xf32> {
   %0 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
   %1 = tt.make_range {start = 128 : i32, end = 256 : i32} : tensor<128xi32>
   %2 = tt.addptr %0, %1 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
-  tt.return
+  %3 = tt.load %2 : tensor<128x!tt.ptr<f32>>
+  tt.return %3 : tensor<128xf32>
 }
 
 // CHECK-LABEL:   tt.func @test_addptr_splat_splat_i32(
 // CHECK-SAME:                                         %[[VAL_0:.*]]: !tt.ptr<f32>,
-// CHECK-SAME:                                         %[[VAL_1:.*]]: i32) {
-// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : i32
-// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : i64
-// CHECK-DAG:       %[[VAL_6:.*]] = arith.index_cast %[[VAL_1]] : i32 to index
-// CHECK-DAG:       %[[VAL_8:.*]] = arith.constant 0 : i64
-// CHECK-DAG:       %[[VAL_9:.*]] = arith.index_cast %[[VAL_6]] : index to i32
-// CHECK:           %[[VAL_10:.*]] = arith.addi %[[VAL_4]], %[[VAL_9]] : i32
-// CHECK:           %[[VAL_11:.*]] = arith.addi %[[VAL_5]], %[[VAL_8]] : i64
-// CHECK:           %[[VAL_12:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_5]]], {{\[}}%[[VAL_11]]], {{\[}}%[[VAL_10]]] {order = array<i32>} : <tensor<128xf32>>
-tt.func @test_addptr_splat_splat_i32(%arg0 : !tt.ptr<f32>, %arg1: i32) {
+// CHECK-SAME:                                         %[[VAL_1:.*]]: i32,
+// CHECK-SAME:                                         %[[VAL_2:.*]]: tensor<128xi1>) -> tensor<128xf32> {
+// CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_4:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_3]]], {{\[}}%[[VAL_3]]], {{\[}}%[[VAL_1]]] {order = array<i32>} : <tensor<128xf32>>
+// CHECK:           %[[VAL_5:.*]] = tt.load %[[VAL_4]], %[[VAL_2]] cacheModifier = ca evictionPolicy = evict_first {isVolatile = true} : !tt.ptr<tensor<128xf32>>
+// CHECK:           tt.return %[[VAL_5]] : tensor<128xf32>
+tt.func @test_addptr_splat_splat_i32(%arg0 : !tt.ptr<f32>, %arg1: i32, %arg2: tensor<128xi1>) -> tensor<128xf32> {
   %0 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
   %1 = tt.splat %arg1 : i32 -> tensor<128xi32>
   %2 = tt.addptr %0, %1 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
-  tt.return
+  %3 = tt.load %2, %arg2 cacheModifier = ca evictionPolicy = evict_first {isVolatile = true} : tensor<128x!tt.ptr<f32>>
+  tt.return %3 : tensor<128xf32>
 }
 
 // CHECK-LABEL:   tt.func @test_addptr_splat_splat_i64(
 // CHECK-SAME:                                         %[[VAL_0:.*]]: !tt.ptr<f32>,
-// CHECK-SAME:                                         %[[VAL_1:.*]]: i64) {
-// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : i32
-// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : i64
-// CHECK-DAG:       %[[VAL_6:.*]] = arith.index_cast %[[VAL_1]] : i64 to index
-// CHECK-DAG:       %[[VAL_8:.*]] = arith.constant 0 : i64
-// CHECK-DAG:       %[[VAL_9:.*]] = arith.index_cast %[[VAL_6]] : index to i32
-// CHECK:           %[[VAL_10:.*]] = arith.addi %[[VAL_4]], %[[VAL_9]] : i32
-// CHECK:           %[[VAL_11:.*]] = arith.addi %[[VAL_5]], %[[VAL_8]] : i64
-// CHECK:           %[[VAL_12:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_5]]], {{\[}}%[[VAL_11]]], {{\[}}%[[VAL_10]]] {order = array<i32>} : <tensor<128xf32>>
-tt.func @test_addptr_splat_splat_i64(%arg0 : !tt.ptr<f32>, %arg1: i64) {
+// CHECK-SAME:                                         %[[VAL_1:.*]]: i64) -> tensor<128xf32> {
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_3:.*]] = arith.index_cast %[[VAL_1]] : i64 to index
+// CHECK:           %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : index to i32
+// CHECK:           %[[VAL_5:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_2]]], {{\[}}%[[VAL_2]]], {{\[}}%[[VAL_4]]] {order = array<i32>} : <tensor<128xf32>>
+// CHECK:           %[[VAL_6:.*]] = tt.load %[[VAL_5]] : !tt.ptr<tensor<128xf32>>
+// CHECK:           tt.return %[[VAL_6]] : tensor<128xf32>
+tt.func @test_addptr_splat_splat_i64(%arg0 : !tt.ptr<f32>, %arg1: i64) -> tensor<128xf32> {
   %0 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
   %1 = tt.splat %arg1 : i64 -> tensor<128xi64>
   %2 = tt.addptr %0, %1 : tensor<128x!tt.ptr<f32>>, tensor<128xi64>
-  tt.return
+  %3 = tt.load %2 : tensor<128x!tt.ptr<f32>>
+  tt.return %3 : tensor<128xf32>
 }
 
 // CHECK-LABEL:   tt.func @test_addptr_splat_splat_2d(
 // CHECK-SAME:                                        %[[VAL_0:.*]]: !tt.ptr<f32>,
-// CHECK-SAME:                                        %[[VAL_1:.*]]: i64) {
-// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : i32
-// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : i64
-// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 0 : i32
-// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0 : i64
-// CHECK-DAG:       %[[VAL_8:.*]] = arith.index_cast %[[VAL_1]] : i64 to index
-// CHECK-DAG:       %[[VAL_9:.*]] = arith.constant 0 : i32
-// CHECK-DAG:       %[[VAL_10:.*]] = arith.constant 0 : i64
-// CHECK-DAG:       %[[VAL_11:.*]] = arith.constant 0 : i32
-// CHECK-DAG:       %[[VAL_12:.*]] = arith.constant 0 : i64
-// CHECK-DAG:       %[[VAL_13:.*]] = arith.index_cast %[[VAL_8]] : index to i32
-// CHECK:           %[[VAL_14:.*]] = arith.addi %[[VAL_4]], %[[VAL_13]] : i32
-// CHECK:           %[[VAL_15:.*]] = arith.addi %[[VAL_5]], %[[VAL_10]] : i64
-// CHECK:           %[[VAL_16:.*]] = arith.addi %[[VAL_6]], %[[VAL_11]] : i32
-// CHECK:           %[[VAL_17:.*]] = arith.addi %[[VAL_7]], %[[VAL_12]] : i64
-// CHECK:           %[[VAL_18:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_5]], %[[VAL_7]]], {{\[}}%[[VAL_15]], %[[VAL_17]]], {{\[}}%[[VAL_14]], %[[VAL_16]]] {order = array<i32>} : <tensor<2x128xf32>>
-tt.func @test_addptr_splat_splat_2d(%arg0 : !tt.ptr<f32>, %arg1: i64) {
+// CHECK-SAME:                                        %[[VAL_1:.*]]: i64,
+// CHECK-SAME:                                        %[[VAL_2:.*]]: tensor<2x128xi1>,
+// CHECK-SAME:                                        %[[VAL_3:.*]]: tensor<2x128xf32>) -> tensor<2x128xf32> {
+// CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_6:.*]] = arith.index_cast %[[VAL_1]] : i64 to index
+// CHECK:           %[[VAL_7:.*]] = arith.index_cast %[[VAL_6]] : index to i32
+// CHECK:           %[[VAL_8:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_4]], %[[VAL_4]]], {{\[}}%[[VAL_4]], %[[VAL_4]]], {{\[}}%[[VAL_7]], %[[VAL_5]]] {order = array<i32>} : <tensor<2x128xf32>>
+// CHECK:           %[[VAL_9:.*]] = tt.load %[[VAL_8]], %[[VAL_2]], %[[VAL_3]] : !tt.ptr<tensor<2x128xf32>>
+// CHECK:           tt.return %[[VAL_9]] : tensor<2x128xf32>
+tt.func @test_addptr_splat_splat_2d(%arg0 : !tt.ptr<f32>, %arg1: i64, %arg2: tensor<2x128xi1>, %arg3: tensor<2x128xf32>) -> tensor<2x128xf32> {
   %0 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<2x128x!tt.ptr<f32>>
   %1 = tt.splat %arg1 : i64 -> tensor<2x128xi64>
   %2 = tt.addptr %0, %1 : tensor<2x128x!tt.ptr<f32>>, tensor<2x128xi64>
-  tt.return
+  %3 = tt.load %2, %arg2, %arg3 : tensor<2x128x!tt.ptr<f32>>
+  tt.return %3 : tensor<2x128xf32>
 }

--- a/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
+++ b/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
@@ -304,7 +304,7 @@ struct TritonRaiseBlockPointer
   }
 
   LogicalResult rewriteLoadOp(triton::LoadOp op) {
-    auto ptr = ptrMap.lookupOrNull(op.getPtr());
+    Value ptr = ptrMap.lookupOrNull(op.getPtr());
 
     if (!ptr) {
       op->emitRemark("TritonRaiseBlockPointer: pointer is not replace with "

--- a/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
+++ b/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
@@ -307,7 +307,7 @@ struct TritonRaiseBlockPointer
     Value ptr = ptrMap.lookupOrNull(op.getPtr());
 
     if (!ptr) {
-      op->emitRemark("TritonRaiseBlockPointer: pointer is not replace with "
+      op->emitRemark("TritonRaiseBlockPointer: pointer is not replaced with "
                      "tt.make_tensor_ptr so loadOp cannot be rewritten");
       return failure();
     }

--- a/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
+++ b/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
@@ -123,9 +123,17 @@ struct TritonRaiseBlockPointer
   using Base::Base;
 
   void runOnOperation() final {
-    getOperation()->walk([this](triton::AddPtrOp addptr) {
-      if (failed(rewriteAddPtrOp(addptr)))
-        addptr->emitRemark("TritonRaiseToBlockPointer: Failed to rewrite");
+    getOperation()->walk([this](Operation *op) {
+      TypeSwitch<Operation *>(op)
+          .Case([this](triton::AddPtrOp addptr) {
+            if (failed(rewriteAddPtrOp(addptr)))
+              addptr->emitRemark(
+                  "TritonRaiseToBlockPointer: Failed to rewrite");
+          })
+          .Case([this](triton::LoadOp load) {
+            if (failed(rewriteLoadOp(load)))
+              load->emitRemark("TritonRaiseToBlockPointer: Failed to rewrite");
+          });
     });
   }
 
@@ -292,6 +300,34 @@ struct TritonRaiseBlockPointer
 
     LLVM_DEBUG(llvm::dbgs() << "Splat state: " << state << "\n";);
 
+    return success();
+  }
+
+  LogicalResult rewriteLoadOp(triton::LoadOp op) {
+    auto ptr = ptrMap.lookupOrNull(op.getPtr());
+
+    if (!ptr) {
+      op->emitRemark("TritonRaiseBlockPointer: pointer is not replace with "
+                     "tt.make_tensor_ptr so loadOp cannot be rewritten");
+      return failure();
+    }
+
+    auto ptrType = dyn_cast<triton::PointerType>(ptr.getType());
+    if (ptrType && !isa<ShapedType>(ptrType.getPointeeType())) {
+      op->emitRemark(
+          "TritonRaiseBlockPointer: scalar loadOp will not be rewritten");
+      return failure();
+    }
+
+    OpBuilder builder(op);
+    auto loadOp = builder.create<triton::LoadOp>(
+        op.getLoc(), ptr, op.getMask(), op.getOther(), op.getBoundaryCheck(),
+        op.getPadding(), op.getCache(), op.getEvict(), op.getIsVolatile());
+
+    LLVM_DEBUG(llvm::dbgs() << "creating tt.load: " << loadOp << "\n";);
+
+    op.replaceAllUsesWith(loadOp.getResult());
+    op->erase();
     return success();
   }
 


### PR DESCRIPTION
When a pointer is raised to a block pointer, update `tt.load` operations receiving it as an argument. Note the rest of the arguments can remain unchanged.
