### PR TITLE
[RAISE-BP] Raise `tt.store` to block pointer

### DIFF
--- a/test/Triton/raise-block-pointer.mlir
+++ b/test/Triton/raise-block-pointer.mlir
@@ -68,3 +68,22 @@ tt.func @test_addptr_splat_splat_2d(%arg0 : !tt.ptr<f32>, %arg1: i64, %arg2: ten
   %3 = tt.load %2, %arg2, %arg3 : tensor<2x128x!tt.ptr<f32>>
   tt.return %3 : tensor<2x128xf32>
 }
+
+// CHECK-LABEL:   tt.func @test_addptr_splat_splat_2d_store(
+// CHECK-SAME:                                              %[[VAL_0:.*]]: !tt.ptr<f32>,
+// CHECK-SAME:                                              %[[VAL_1:.*]]: i64,
+// CHECK-SAME:                                              %[[VAL_2:.*]]: tensor<2x128xi1>,
+// CHECK-SAME:                                              %[[VAL_3:.*]]: tensor<2x128xf32>) {
+// CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_5:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_6:.*]] = arith.index_cast %[[VAL_1]] : i64 to index
+// CHECK:           %[[VAL_7:.*]] = arith.index_cast %[[VAL_6]] : index to i32
+// CHECK:           %[[VAL_8:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_4]], %[[VAL_4]]], {{\[}}%[[VAL_4]], %[[VAL_4]]], {{\[}}%[[VAL_7]], %[[VAL_5]]] {order = array<i32>} : <tensor<2x128xf32>>
+// CHECK:           tt.store %[[VAL_8]], %[[VAL_3]], %[[VAL_2]] : !tt.ptr<tensor<2x128xf32>>
+tt.func @test_addptr_splat_splat_2d_store(%arg0 : !tt.ptr<f32>, %arg1: i64, %arg2: tensor<2x128xi1>, %arg3: tensor<2x128xf32>) {
+  %0 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<2x128x!tt.ptr<f32>>
+  %1 = tt.splat %arg1 : i64 -> tensor<2x128xi64>
+  %2 = tt.addptr %0, %1 : tensor<2x128x!tt.ptr<f32>>, tensor<2x128xi64>
+  tt.store %2, %arg3, %arg2 : tensor<2x128x!tt.ptr<f32>>
+  tt.return
+}

--- a/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
+++ b/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
@@ -316,14 +316,14 @@ struct TritonRaiseBlockPointer
     if (!ptr) {
       op->emitRemark("TritonRaiseBlockPointer: pointer is not replaced with "
                      "tt.make_tensor_ptr so ")
-          << opName << "cannot be rewritten";
+          << opName << " cannot be rewritten";
       return failure();
     }
 
     auto ptrType = dyn_cast<triton::PointerType>(ptr.getType());
     if (ptrType && !isa<ShapedType>(ptrType.getPointeeType())) {
       op->emitRemark("TritonRaiseBlockPointer: scalar ")
-          << opName << "will not be rewritten";
+          << opName << " will not be rewritten";
       return failure();
     }
 

--- a/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
+++ b/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
@@ -337,7 +337,7 @@ struct TritonRaiseBlockPointer
 
       op.replaceAllUsesWith(loadOp.getResult());
     } else {
-      auto storeOp = builder.create<triton::StoreOp>(
+      [[maybe_unused]] auto storeOp = builder.create<triton::StoreOp>(
           op.getLoc(), ptr, op.getValue(), op.getMask(), op.getBoundaryCheck(),
           op.getCache(), op.getEvict());
 

--- a/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
+++ b/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
@@ -130,9 +130,10 @@ struct TritonRaiseBlockPointer
               addptr->emitRemark(
                   "TritonRaiseToBlockPointer: Failed to rewrite");
           })
-          .Case([this](triton::LoadOp load) {
-            if (failed(rewriteLoadOp(load)))
-              load->emitRemark("TritonRaiseToBlockPointer: Failed to rewrite");
+          .Case<triton::LoadOp, triton::StoreOp>([this](auto loadstore) {
+            if (failed(rewriteLoadStoreOp(loadstore)))
+              loadstore->emitRemark(
+                  "TritonRaiseToBlockPointer: Failed to rewrite");
           });
     });
   }
@@ -303,30 +304,46 @@ struct TritonRaiseBlockPointer
     return success();
   }
 
-  LogicalResult rewriteLoadOp(triton::LoadOp op) {
+  template <typename OpTy, typename = std::enable_if_t<llvm::is_one_of<
+                               OpTy, triton::LoadOp, triton::StoreOp>::value>>
+  LogicalResult rewriteLoadStoreOp(OpTy op) {
+    constexpr bool isLoad = std::is_same_v<OpTy, triton::LoadOp>;
+    constexpr StringLiteral opName =
+        isLoad ? StringLiteral("loadOp") : StringLiteral("storeOp");
+
     Value ptr = ptrMap.lookupOrNull(op.getPtr());
 
     if (!ptr) {
       op->emitRemark("TritonRaiseBlockPointer: pointer is not replaced with "
-                     "tt.make_tensor_ptr so loadOp cannot be rewritten");
+                     "tt.make_tensor_ptr so ")
+          << opName << "cannot be rewritten";
       return failure();
     }
 
     auto ptrType = dyn_cast<triton::PointerType>(ptr.getType());
     if (ptrType && !isa<ShapedType>(ptrType.getPointeeType())) {
-      op->emitRemark(
-          "TritonRaiseBlockPointer: scalar loadOp will not be rewritten");
+      op->emitRemark("TritonRaiseBlockPointer: scalar ")
+          << opName << "will not be rewritten";
       return failure();
     }
 
     OpBuilder builder(op);
-    auto loadOp = builder.create<triton::LoadOp>(
-        op.getLoc(), ptr, op.getMask(), op.getOther(), op.getBoundaryCheck(),
-        op.getPadding(), op.getCache(), op.getEvict(), op.getIsVolatile());
+    if constexpr (isLoad) {
+      auto loadOp = builder.create<triton::LoadOp>(
+          op.getLoc(), ptr, op.getMask(), op.getOther(), op.getBoundaryCheck(),
+          op.getPadding(), op.getCache(), op.getEvict(), op.getIsVolatile());
 
-    LLVM_DEBUG(llvm::dbgs() << "creating tt.load: " << loadOp << "\n";);
+      LLVM_DEBUG(llvm::dbgs() << "creating tt.load: " << loadOp << "\n";);
 
-    op.replaceAllUsesWith(loadOp.getResult());
+      op.replaceAllUsesWith(loadOp.getResult());
+    } else {
+      auto storeOp = builder.create<triton::StoreOp>(
+          op.getLoc(), ptr, op.getValue(), op.getMask(), op.getBoundaryCheck(),
+          op.getCache(), op.getEvict());
+
+      LLVM_DEBUG(llvm::dbgs() << "creating tt.store: " << storeOp << "\n";);
+    }
+
     op->erase();
     return success();
   }


### PR DESCRIPTION
When the pointer argument to `tt.store` can be raised to a block pointer, do so, creating a new `tt.store` operation with the same arguments but with a changed pointer, taking the new block pointer.