### PR TITLE
[RAISE-BP] Allow more `arith` operations as `tt.addptr` operands

### DIFF
--- a/test/Triton/raise-block-pointer.mlir
+++ b/test/Triton/raise-block-pointer.mlir
@@ -87,3 +87,71 @@ tt.func @test_addptr_splat_splat_2d_store(%arg0 : !tt.ptr<f32>, %arg1: i64, %arg
   tt.store %2, %arg3, %arg2 : tensor<2x128x!tt.ptr<f32>>
   tt.return
 }
+
+// CHECK-LABEL:   tt.func @test_addptr_splat_make_range_add(
+// CHECK-SAME:                                              %[[VAL_0:.*]]: !tt.ptr<f32>) -> tensor<128xf32> {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_3:.*]] = arith.constant 2 : i64
+// CHECK:           %[[VAL_4:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_1]]], {{\[}}%[[VAL_3]]], {{\[}}%[[VAL_2]]] {order = array<i32>} : <tensor<128xf32>>
+// CHECK:           %[[VAL_5:.*]] = tt.load %[[VAL_4]] : !tt.ptr<tensor<128xf32>>
+// CHECK:           tt.return %[[VAL_5]] : tensor<128xf32>
+tt.func @test_addptr_splat_make_range_add(%arg0 : !tt.ptr<f32>) -> tensor<128xf32> {
+  %0 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+  %1 = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+  %2 = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+  %3 = arith.addi %1, %2 : tensor<128xi32>
+  %4 = tt.addptr %0, %3 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+  %5 = tt.load %4 : tensor<128x!tt.ptr<f32>>
+  tt.return %5 : tensor<128xf32>
+}
+
+// CHECK-LABEL:   tt.func @test_addptr_splat_make_range_mul(
+// CHECK-SAME:                                              %[[VAL_0:.*]]: !tt.ptr<f32>,
+// CHECK-SAME:                                              %[[VAL_1:.*]]: i32) -> tensor<128xf32> {
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_4:.*]] = arith.index_cast %[[VAL_1]] : i32 to index
+// CHECK:           %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : index to i64
+// CHECK:           %[[VAL_6:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_2]]], {{\[}}%[[VAL_5]]], {{\[}}%[[VAL_3]]] {order = array<i32>} : <tensor<128xf32>>
+// CHECK:           %[[VAL_7:.*]] = tt.load %[[VAL_6]] : !tt.ptr<tensor<128xf32>>
+// CHECK:           tt.return %[[VAL_7]] : tensor<128xf32>
+tt.func @test_addptr_splat_make_range_mul(%arg0 : !tt.ptr<f32>, %arg1: i32) -> tensor<128xf32> {
+  %0 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+  %1 = tt.splat %arg1 : i32 -> tensor<128xi32>
+  %2 = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+  %3 = arith.muli %1, %2 : tensor<128xi32>
+  %4 = tt.addptr %0, %3 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+  %5 = tt.load %4 : tensor<128x!tt.ptr<f32>>
+  tt.return %5 : tensor<128xf32>
+}
+
+// CHECK-LABEL:   tt.func @test_addptr_splat_const(
+// CHECK-SAME:                                     %[[VAL_0:.*]]: !tt.ptr<f32>) -> tensor<128xf32> {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 512 : i32
+// CHECK:           %[[VAL_3:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_1]]], {{\[}}%[[VAL_1]]], {{\[}}%[[VAL_2]]] {order = array<i32>} : <tensor<128xf32>>
+// CHECK:           %[[VAL_4:.*]] = tt.load %[[VAL_3]] : !tt.ptr<tensor<128xf32>>
+// CHECK:           tt.return %[[VAL_4]] : tensor<128xf32>
+tt.func @test_addptr_splat_const(%arg0 : !tt.ptr<f32>) -> tensor<128xf32> {
+  %cst = arith.constant dense<512> : tensor<128xi32>
+  %0 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+  %1 = tt.addptr %0, %cst : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+  %2 = tt.load %1 : tensor<128x!tt.ptr<f32>>
+  tt.return %2 : tensor<128xf32>
+}
+
+// CHECK-LABEL:   tt.func @test_addptr_splat_const_2d(
+// CHECK-SAME:                                        %[[VAL_0:.*]]: !tt.ptr<f32>) -> tensor<2x128xf32> {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 512 : i32
+// CHECK:           %[[VAL_3:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_1]], %[[VAL_1]]], {{\[}}%[[VAL_1]], %[[VAL_1]]], {{\[}}%[[VAL_2]], %[[VAL_2]]] {order = array<i32>} : <tensor<2x128xf32>>
+// CHECK:           %[[VAL_4:.*]] = tt.load %[[VAL_3]] : !tt.ptr<tensor<2x128xf32>>
+// CHECK:           tt.return %[[VAL_4]] : tensor<2x128xf32>
+tt.func @test_addptr_splat_const_2d(%arg0 : !tt.ptr<f32>) -> tensor<2x128xf32> {
+  %cst = arith.constant dense<512> : tensor<2x128xi32>
+  %0 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<2x128x!tt.ptr<f32>>
+  %1 = tt.addptr %0, %cst : tensor<2x128x!tt.ptr<f32>>, tensor<2x128xi32>
+  %2 = tt.load %1 : tensor<2x128x!tt.ptr<f32>>
+  tt.return %2 : tensor<2x128xf32>
+}

--- a/test/Triton/raise-block-pointer.mlir
+++ b/test/Triton/raise-block-pointer.mlir
@@ -126,14 +126,14 @@ tt.func @test_addptr_splat_make_range_mul(%arg0 : !tt.ptr<f32>, %arg1: i32) -> t
   tt.return %5 : tensor<128xf32>
 }
 
-// CHECK-LABEL:   tt.func @test_addptr_splat_const(
+// CHECK-LABEL:   tt.func @test_const_splat_addptr(
 // CHECK-SAME:                                     %[[VAL_0:.*]]: !tt.ptr<f32>) -> tensor<128xf32> {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 512 : i32
 // CHECK:           %[[VAL_3:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_1]]], {{\[}}%[[VAL_1]]], {{\[}}%[[VAL_2]]] {order = array<i32>} : <tensor<128xf32>>
 // CHECK:           %[[VAL_4:.*]] = tt.load %[[VAL_3]] : !tt.ptr<tensor<128xf32>>
 // CHECK:           tt.return %[[VAL_4]] : tensor<128xf32>
-tt.func @test_addptr_splat_const(%arg0 : !tt.ptr<f32>) -> tensor<128xf32> {
+tt.func @test_const_splat_addptr(%arg0 : !tt.ptr<f32>) -> tensor<128xf32> {
   %cst = arith.constant dense<512> : tensor<128xi32>
   %0 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
   %1 = tt.addptr %0, %cst : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
@@ -141,14 +141,14 @@ tt.func @test_addptr_splat_const(%arg0 : !tt.ptr<f32>) -> tensor<128xf32> {
   tt.return %2 : tensor<128xf32>
 }
 
-// CHECK-LABEL:   tt.func @test_addptr_splat_const_2d(
+// CHECK-LABEL:   tt.func @test_const_splat_addptr_2d(
 // CHECK-SAME:                                        %[[VAL_0:.*]]: !tt.ptr<f32>) -> tensor<2x128xf32> {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
 // CHECK:           %[[VAL_2:.*]] = arith.constant 512 : i32
 // CHECK:           %[[VAL_3:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_1]], %[[VAL_1]]], {{\[}}%[[VAL_1]], %[[VAL_1]]], {{\[}}%[[VAL_2]], %[[VAL_2]]] {order = array<i32>} : <tensor<2x128xf32>>
 // CHECK:           %[[VAL_4:.*]] = tt.load %[[VAL_3]] : !tt.ptr<tensor<2x128xf32>>
 // CHECK:           tt.return %[[VAL_4]] : tensor<2x128xf32>
-tt.func @test_addptr_splat_const_2d(%arg0 : !tt.ptr<f32>) -> tensor<2x128xf32> {
+tt.func @test_const_splat_addptr_2d(%arg0 : !tt.ptr<f32>) -> tensor<2x128xf32> {
   %cst = arith.constant dense<512> : tensor<2x128xi32>
   %0 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<2x128x!tt.ptr<f32>>
   %1 = tt.addptr %0, %cst : tensor<2x128x!tt.ptr<f32>>, tensor<2x128xi32>

--- a/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
+++ b/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
@@ -207,7 +207,7 @@ struct TritonRaiseBlockPointer
 
   LogicalResult visitOperandAddptr(triton::AddPtrOp addptrOp, PtrState &state,
                                    Location loc, OpBuilder &builder) {
-    assert(state.isEmpty());
+    assert(state.isEmpty() && "state is a return argument");
 
     PtrState ptrState;
     if (failed(visitOperand(addptrOp.getPtr(), ptrState, addptrOp.getLoc(),
@@ -347,7 +347,7 @@ LogicalResult
 TritonRaiseBlockPointer::visitAddPointerOperand(triton::MakeRangeOp rangeOp,
                                                 PtrState &state, Location loc,
                                                 OpBuilder &builder) {
-  assert(state.isEmpty());
+  assert(state.isEmpty() && "state is a return argument");
 
   ArrayRef<int64_t> shape = cast<ShapedType>(rangeOp.getType()).getShape();
 
@@ -375,7 +375,7 @@ LogicalResult
 TritonRaiseBlockPointer::visitAddPointerOperand(triton::SplatOp splatOp,
                                                 PtrState &state, Location loc,
                                                 OpBuilder &builder) {
-  assert(state.isEmpty());
+  assert(state.isEmpty() && "state is a return argument");
 
   Value src = splatOp.getSrc();
   Value dst = splatOp.getResult();
@@ -414,7 +414,7 @@ TritonRaiseBlockPointer::visitAddPointerOperand(triton::SplatOp splatOp,
 template <>
 LogicalResult TritonRaiseBlockPointer::visitAddPointerOperand(
     arith::AddIOp addOp, PtrState &state, Location loc, OpBuilder &builder) {
-  assert(state.isEmpty());
+  assert(state.isEmpty() && "state is a return argument");
 
   PtrState lhsState;
   if (failed(visitOperand(addOp.getLhs(), lhsState, loc, builder)))
@@ -435,7 +435,7 @@ LogicalResult TritonRaiseBlockPointer::visitAddPointerOperand(
 template <>
 LogicalResult TritonRaiseBlockPointer::visitAddPointerOperand(
     arith::MulIOp mulOp, PtrState &state, Location loc, OpBuilder &builder) {
-  assert(state.isEmpty());
+  assert(state.isEmpty() && "state is a return argument");
 
   PtrState lhsState;
   if (failed(visitOperand(mulOp.getLhs(), lhsState, loc, builder)))
@@ -456,11 +456,12 @@ LogicalResult TritonRaiseBlockPointer::visitAddPointerOperand(
 template <>
 LogicalResult TritonRaiseBlockPointer::visitAddPointerOperand(
     arith::ConstantOp op, PtrState &state, Location loc, OpBuilder &builder) {
-  assert(state.isEmpty());
+  assert(state.isEmpty() && "state is a return argument");
 
   auto attr = cast<DenseElementsAttr>(op.getValue());
   Type elementType = attr.getElementType();
-  assert(attr.isSplat() && isa<IntegerType>(elementType));
+  assert(attr.isSplat() && isa<IntegerType>(elementType) &&
+         "Expecting constant tensor");
 
   state.scalar = builder.create<arith::ConstantIndexOp>(
       loc, attr.getValues<IntegerAttr>()[0].getValue().getSExtValue());

--- a/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
+++ b/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
@@ -91,7 +91,7 @@ struct PtrState {
                          Operation *op, OpBuilder &builder) {
     assert(isEmpty() && lhsState.getRank() == rhsState.getRank());
 
-    auto loc = op->getLoc();
+    Location loc = op->getLoc();
 
     assert(!lhsState.source && !rhsState.source &&
            "Multiplying base pointer does not make sense");
@@ -119,9 +119,9 @@ struct PtrState {
     ArithBuilder abuilder(builder, loc);
     for (const auto &[offset, stride, dim, size] :
          llvm::zip(lhs->offsets, lhs->strides, lhs->shape, lhs->sizes)) {
-      auto newOffset = abuilder.mul(offset, i32Scalar);
-      auto newStride = abuilder.mul(stride, i64Scalar);
-      auto newDim = abuilder.mul(dim, i64Scalar);
+      Value newOffset = abuilder.mul(offset, i32Scalar);
+      Value newStride = abuilder.mul(stride, i64Scalar);
+      Value newDim = abuilder.mul(dim, i64Scalar);
 
       offsets.push_back(newOffset);
       strides.push_back(newStride);
@@ -459,7 +459,7 @@ LogicalResult TritonRaiseBlockPointer::visitAddPointerOperand(
   assert(state.isEmpty());
 
   auto attr = cast<DenseElementsAttr>(op.getValue());
-  auto elementType = attr.getElementType();
+  Type elementType = attr.getElementType();
   assert(attr.isSplat() && isa<IntegerType>(elementType));
 
   state.scalar = builder.create<arith::ConstantIndexOp>(


### PR DESCRIPTION
Allow `arith.[addi|constant|muli]` as `tt.addptr` operands when raising.
