### PR TITLE
Split reusable part of build&test workflow into a separate file, call it in various modes from other files

### DIFF
--- a/.github/workflows/build-test-a770.yml
+++ b/.github/workflows/build-test-a770.yml
@@ -1,0 +1,58 @@
+name: Build and test on A770
+run-name: ${{ inputs.run_name }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner_label:
+        description: Runner label, keep empty for default
+        type: string
+        default: "a770"
+      install_ipex:
+        # This boolean parameter defines what PyTorch will be used in the workflow:
+        #   true: Stonepia/pytorch (fork) with IPEX
+        #   false: pytorch/pytorch (upstream) without IPX
+        # In both cases, pytorch_ref below allows specifying a branch, tag, or commit id in the
+        # corresponding repository. If not specified, a default (pinned) version will be used.
+        description: Install Intel PyTorch Extension
+        type: boolean
+        default: true
+      pytorch_ref:
+        description: PyTorch ref, keep empty for default
+        type: string
+        default: ""
+      upload_test_reports:
+        description: Upload test reports
+        type: boolean
+        default: false
+      ignore_errors:
+        description: Ignore test errors
+        type: boolean
+        default: false
+      run_name:
+        description: Custom run name
+        type: string
+        default: "Build and test on A770"
+  schedule:
+    # Every midnight PST (UTC-8)
+    - cron: "0 8 * * *"
+
+permissions: read-all
+
+jobs:
+  integration-tests:
+    name: Integration tests matrix
+    strategy:
+      matrix:
+        python: ${{ github.ref_name == 'llvm-target' && fromJson('["3.9", "3.10", "3.11"]') || fromJson('["3.9"]') }}
+        drivers: ["rolling", "lts"]
+    uses: ./.github/workflows/build-test-reusable.yml
+    with:
+      driver_version: ${{ matrix.drivers }}
+      runner_label: ${{ inputs.runner_label || "a770" }}
+      install_ipex: ${{ inputs.install_ipex || github.event_name == 'schedule' }}
+      pytorch_ref: ${{ inputs.pytorch_ref }}
+      python_version: ${{ matrix.python }}
+      upload_test_reports: ${{ inputs.upload_test_reports }}
+      ignore_errors: ${{ inputs.ignore_errors }}
+      run_name: ${{ inputs.run_name }}

--- a/.github/workflows/build-test-no-ipex.yml
+++ b/.github/workflows/build-test-no-ipex.yml
@@ -1,0 +1,49 @@
+name: Build and test upstream pytorch with no IPEX
+run-name: ${{ inputs.run_name }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner_label:
+        description: Runner label, keep empty for default
+        type: string
+        default: ""
+      pytorch_ref:
+        description: PyTorch ref, keep empty for default
+        type: string
+        default: ""
+      upload_test_reports:
+        description: Upload test reports
+        type: boolean
+        default: false
+      ignore_errors:
+        description: Ignore test errors
+        type: boolean
+        default: false
+      run_name:
+        description: Custom run name
+        type: string
+        default: "Build and test upstream pytorch with no IPEX"
+  schedule:
+    # Every midnight PST (UTC-8)
+    - cron: "0 8 * * *"
+
+permissions: read-all
+
+jobs:
+  integration-tests:
+    name: Integration tests matrix
+    strategy:
+      matrix:
+        python: ${{ github.ref_name == 'llvm-target' && fromJson('["3.9", "3.10", "3.11"]') || fromJson('["3.9"]') }}
+        drivers: ["rolling", "lts"]
+    uses: ./.github/workflows/build-test-reusable.yml
+    with:
+      driver_version: ${{ matrix.drivers }}
+      runner_label: ${{ inputs.runner_label }}
+      install_ipex: false
+      pytorch_ref: ${{ inputs.pytorch_ref }}
+      python_version: ${{ matrix.python }}
+      upload_test_reports: ${{ inputs.upload_test_reports }}
+      ignore_errors: ${{ inputs.ignore_errors }}
+      run_name: ${{ inputs.run_name }}

--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -46,6 +46,17 @@ env:
   TORCH_XPU_OPS_COMMIT: 39522db63ce045f52c9d61a286018c266cd00479
 
 jobs:
+  print_inputs:
+    name: Print inputs
+    runs-on: Linux
+    steps:
+      - name: Print inputs
+        run: |
+          cat <<EOF
+          ${{ toJSON(github.event.inputs) }}
+          EOF
+          echo INSTALL_IPEX=${{ env.INSTALL_IPEX }}
+
   integration-tests:
     name: Integration tests
     runs-on:

--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -99,7 +99,7 @@ jobs:
           ref: ${{ inputs.pytorch_ref }}
 
       - name: Setup PyTorch without IPEX
-        if: inputs.install_ipex
+        if: !inputs.install_ipex
         uses: ./.github/actions/setup-pytorch
         with:
           repository: pytorch/pytorch
@@ -111,7 +111,7 @@ jobs:
         uses: ./.github/actions/setup-ipex
 
       - name: Setup fake IPEX
-        if: inputs.install_ipex
+        if: !inputs.install_ipex
         uses: ./.github/actions/setup-fake-ipex
 
       - name: Build Triton

--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -1,0 +1,245 @@
+name: Build and test reusable workflow
+run-name: ${{ inputs.run_name }} - ${{ inputs.python_version }} - ${{ inputs.install_ipex && 'IPEX' || 'no IPEX' }} - ${{ inputs.runner_label || 'default'}}
+
+on:
+  workflow_call:
+    inputs:
+      runner_label:
+        description: Runner label, keep empty for default
+        type: string
+        default: ""
+      install_ipex:
+        # This boolean parameter defines what PyTorch will be used in the workflow:
+        #   true: Stonepia/pytorch (fork) with IPEX
+        #   false: pytorch/pytorch (upstream) without IPX
+        # In both cases, pytorch_ref below allows specifying a branch, tag, or commit id in the
+        # corresponding repository. If not specified, a default (pinned) version will be used.
+        description: Install Intel PyTorch Extension
+        type: boolean
+        default: true
+      pytorch_ref:
+        description: PyTorch ref, keep empty for default
+        type: string
+        default: ""
+      python_version:
+        description: Python version
+        type: string
+        default: "3.9"
+      upload_test_reports:
+        description: Upload test reports
+        type: boolean
+        default: false
+      ignore_errors:
+        description: Ignore test errors
+        type: boolean
+        default: false
+      run_name:
+        description: Custom run name
+        type: string
+        default: "Build and test"
+
+permissions: read-all
+
+env:
+  TRITON_DISABLE_LINE_INFO: 1
+  INSTALL_IPEX: ${{ inputs.install_ipex || 'false' }}
+  TORCH_XPU_OPS_COMMIT: 39522db63ce045f52c9d61a286018c266cd00479
+
+jobs:
+  integration-tests:
+    name: Integration tests
+    runs-on:
+      - ${{ inputs.runner_label || 'runner-0.0.16' }}
+    defaults:
+      run:
+        shell: bash -noprofile --norc -eo pipefail -c "source /home/runner/intel/oneapi/setvars.sh > /dev/null; source {0}"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Load pip cache
+        id: pip-cache
+        uses: ./.github/actions/load
+        env:
+          # Increase this value to reset cache
+          CACHE_NUMBER: 1
+        with:
+          path: $HOME/.cache/pip
+          key: pip-${{ inputs.python_version }}-${{ hashFiles('python/pyproject.toml', 'python/setup.py') }}-${{ env.CACHE_NUMBER }}
+
+      - name: Install Python ${{ inputs.python_version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Get LLVM commit id
+        run: |
+          LLVM_COMMIT_ID=$(<cmake/llvm-hash.txt)
+          echo "LLVM_COMMIT_ID=$LLVM_COMMIT_ID" >> $GITHUB_ENV
+
+      - name: Setup PyTorch with IPEX
+        if: ${{ env.INSTALL_IPEX == 'true' }}
+        uses: ./.github/actions/setup-pytorch
+        with:
+          repository: Stonepia/pytorch
+          ref: ${{ inputs.pytorch_ref }}
+
+      - name: Setup PyTorch without IPEX
+        if: ${{ env.INSTALL_IPEX == 'false' }}
+        uses: ./.github/actions/setup-pytorch
+        with:
+          repository: pytorch/pytorch
+          ref: ${{ inputs.pytorch_ref }}
+          torch_xpu_ops_commit: ${{ env.TORCH_XPU_OPS_COMMIT }}
+
+      - name: Setup IPEX
+        if: ${{ env.INSTALL_IPEX == 'true' }}
+        uses: ./.github/actions/setup-ipex
+
+      - name: Setup fake IPEX
+        if: ${{ env.INSTALL_IPEX == 'false' }}
+        uses: ./.github/actions/setup-fake-ipex
+
+      - name: Build Triton
+        run: |
+          export DEBUG=1
+          cd python
+          pip install wheel pytest pytest-xdist pytest-rerunfailures pytest-select
+          pip install --no-build-isolation '.[build,tests,tutorials]'
+          pip install git+https://github.com/kwasd/pytest-capturewarnings-ng.git@v1.2.0
+
+      - name: Run lit tests
+        run: |
+          cd python
+          lit -v build/*/test
+
+      - name: Create directory for tests reports
+        run: |
+          mkdir reports
+          echo "TRITON_TEST_REPORTS=true" >> $GITHUB_ENV
+          echo "TRITON_TEST_WARNING_REPORTS=true" >> $GITHUB_ENV
+          echo "TRITON_TEST_REPORTS_DIR=$GITHUB_WORKSPACE/reports" >> $GITHUB_ENV
+
+      - name: Enable ignoring test errors
+        if: inputs.ignore_errors
+        run: |
+          echo "TRITON_TEST_IGNORE_ERRORS=true" >> $GITHUB_ENV
+
+      - name: Run core tests
+        run: |
+          source ./scripts/pytest-utils.sh
+          cd python/test/unit
+          TRITON_TEST_SUITE=language \
+            pytest -vvv -n 8 --device xpu language/ --ignore=language/test_line_info.py --ignore=language/test_subprocess.py
+          TRITON_TEST_SUITE=subprocess \
+            pytest -vvv -n 8 language/test_subprocess.py
+          # Run runtime tests serially to avoid race condition with cache handling
+          TRITON_TEST_SUITE=runtime \
+            pytest -vvv --device xpu runtime/
+          # Run test_line_info.py separately with TRITON_DISABLE_LINE_INFO=0
+          TRITON_DISABLE_LINE_INFO=0 TRITON_TEST_SUITE=line_info \
+            pytest -vvv --device xpu language/test_line_info.py
+
+      - name: Clear cache
+        run: |
+          rm -rf ~/.triton
+
+      - name: Run interpreter tests
+        run: |
+          source ./scripts/pytest-utils.sh
+          cd python/test/unit
+          TRITON_INTERPRET=1 TRITON_TEST_SUITE=interpreter \
+            pytest -vvv -n 16 -m interpreter language/test_core.py language/test_standard.py \
+            language/test_random.py operators/test_flash_attention.py::test_op --device cpu
+
+      - name: Run partial operators tests
+        run: |
+          source ./scripts/pytest-utils.sh
+          cd python/test/unit
+          TRITON_TEST_SUITE=operators \
+            pytest -vvv -n 8 --device xpu operators
+
+      - name: Regression tests
+        run: |
+          source ./scripts/pytest-utils.sh
+          cd python/test/regression
+          TRITON_TEST_SUITE=regression \
+            pytest -vvv -s --device xpu . --reruns 10 --ignore=test_performance.py
+
+      - name: Run XPU python tests
+        run: |
+          cd python/test/backend/third_party_backends
+          python3 -m pytest -n auto --verbose test_xpu_backend.py
+
+      - name: Run Tutorials
+        run: |
+          source ./scripts/pytest-utils.sh
+          cd python/tutorials
+          run_tutorial_test "01-vector-add"
+          run_tutorial_test "02-fused-softmax"
+          run_tutorial_test "03-matrix-multiplication"
+          run_tutorial_test "04-low-memory-dropout"
+          run_tutorial_test "05-layer-norm"
+          run_tutorial_test "06-fused-attention"
+          run_tutorial_test "07-extern-functions"
+          run_tutorial_test "08-grouped-gemm"
+          run_tutorial_test "10-experimental-block-pointer"
+          TRITON_INTEL_ENABLE_BLOCK_PTR=1 run_tutorial_test "10-experimental-block-pointer"
+
+      - name: Run CXX unittests
+        run: |
+          cd python/build/*cmake*
+          ctest
+
+      - name: Get transformers version
+        run: |
+          cd pytorch
+          TRANSFORMERS_VERSION="$(<.ci/docker/ci_commit_pins/huggingface.txt)"
+          echo "TRANSFORMERS_VERSION=$TRANSFORMERS_VERSION" | tee -a $GITHUB_ENV
+
+      - name: Install transformers
+        uses: ./.github/actions/install-dependency
+        with:
+          package: transformers
+          repository: huggingface/transformers
+          ref: ${{ env.TRANSFORMERS_VERSION }}
+          try-tag-prefix: v
+
+      - name: Run E2E test
+        run: |
+          # Set WORKSPACE for inductor_xpu_test.sh to make sure it creates "inductor_log" outside of pytorch cloned directory
+          export WORKSPACE=$GITHUB_WORKSPACE
+          cd pytorch
+          pip install pyyaml pandas scipy numpy psutil pyre_extensions torchrec
+          # TODO: Find the fastest Hugging Face model
+          $GITHUB_WORKSPACE/scripts/inductor_xpu_test.sh huggingface float32 inference accuracy xpu 0 static 1 0 AlbertForMaskedLM
+          # The script above always returns 0, so we need an additional check to see if the accuracy test passed
+          cat $WORKSPACE/inductor_log/*/*/*.csv
+          grep AlbertForMaskedLM $WORKSPACE/inductor_log/*/*/*.csv | grep -q ,pass,
+
+      - name: Save pip cache
+        if: ${{ steps.pip-cache.outputs.status == 'miss' }}
+        uses: ./.github/actions/save
+        with:
+          path: ${{ steps.pip-cache.outputs.path }}
+          dest: ${{ steps.pip-cache.outputs.dest }}
+
+      - name: Pass rate
+        run: |
+          python3 scripts/pass_rate.py --reports reports
+          python3 scripts/pass_rate.py --reports reports --json > pass_rate.json
+
+      - name: Upload pass rate report
+        # upload reports only for the default branch
+        if: github.ref_name == 'llvm-target'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pass_rate-${{ inputs.python_version }}
+          path: pass_rate.json
+
+      - name: Upload test reports
+        if: inputs.upload_test_reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-${{ inputs.python_version }}
+          path: reports

--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -92,14 +92,14 @@ jobs:
           echo "LLVM_COMMIT_ID=$LLVM_COMMIT_ID" >> $GITHUB_ENV
 
       - name: Setup PyTorch with IPEX
-        if: inputs.install_ipex
+        if: ${{ inputs.install_ipex }}
         uses: ./.github/actions/setup-pytorch
         with:
           repository: Stonepia/pytorch
           ref: ${{ inputs.pytorch_ref }}
 
       - name: Setup PyTorch without IPEX
-        if: !inputs.install_ipex
+        if: ${{ !inputs.install_ipex }}
         uses: ./.github/actions/setup-pytorch
         with:
           repository: pytorch/pytorch
@@ -107,11 +107,11 @@ jobs:
           torch_xpu_ops_commit: ${{ env.TORCH_XPU_OPS_COMMIT }}
 
       - name: Setup IPEX
-        if: inputs.install_ipex
+        if: ${{ inputs.install_ipex }}
         uses: ./.github/actions/setup-ipex
 
       - name: Setup fake IPEX
-        if: !inputs.install_ipex
+        if: ${{ !inputs.install_ipex }}
         uses: ./.github/actions/setup-fake-ipex
 
       - name: Build Triton

--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -4,6 +4,10 @@ run-name: ${{ inputs.run_name }} - ${{ inputs.python_version }} - ${{ inputs.ins
 on:
   workflow_call:
     inputs:
+      driver_version:
+        description: Driver version
+        type: string
+        default: "rolling"
       runner_label:
         description: Runner label, keep empty for default
         type: string
@@ -24,7 +28,7 @@ on:
       python_version:
         description: Python version
         type: string
-        default: "3.9"
+        required: true
       upload_test_reports:
         description: Upload test reports
         type: boolean
@@ -61,6 +65,7 @@ jobs:
     name: Integration tests
     runs-on:
       - ${{ inputs.runner_label || 'runner-0.0.16' }}
+      - ${{ inputs.driver_version }}
     defaults:
       run:
         shell: bash -noprofile --norc -eo pipefail -c "source /home/runner/intel/oneapi/setvars.sh > /dev/null; source {0}"

--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -46,7 +46,6 @@ permissions: read-all
 
 env:
   TRITON_DISABLE_LINE_INFO: 1
-  INSTALL_IPEX: ${{ inputs.install_ipex || 'false' }}
   TORCH_XPU_OPS_COMMIT: 39522db63ce045f52c9d61a286018c266cd00479
 
 jobs:
@@ -59,15 +58,11 @@ jobs:
           cat <<EOF
           ${{ toJSON(inputs) }}
           EOF
-          echo python = ${{ inputs.python_version }}
-          echo runner = ${{ inputs.runner_label }}
-          echo driver = ${{ inputs.driver_version }}
-          echo INSTALL_IPEX=${{ env.INSTALL_IPEX }}
 
   integration-tests:
     name: Integration tests
     runs-on:
-      - ${{ inputs.runner_label || 'runner-0.0.16' }}
+      - ${{ inputs.runner_label || 'Linux' }}
       - ${{ inputs.driver_version }}
     defaults:
       run:
@@ -97,14 +92,14 @@ jobs:
           echo "LLVM_COMMIT_ID=$LLVM_COMMIT_ID" >> $GITHUB_ENV
 
       - name: Setup PyTorch with IPEX
-        if: ${{ env.INSTALL_IPEX == 'true' }}
+        if: inputs.install_ipex
         uses: ./.github/actions/setup-pytorch
         with:
           repository: Stonepia/pytorch
           ref: ${{ inputs.pytorch_ref }}
 
       - name: Setup PyTorch without IPEX
-        if: ${{ env.INSTALL_IPEX == 'false' }}
+        if: inputs.install_ipex
         uses: ./.github/actions/setup-pytorch
         with:
           repository: pytorch/pytorch
@@ -112,11 +107,11 @@ jobs:
           torch_xpu_ops_commit: ${{ env.TORCH_XPU_OPS_COMMIT }}
 
       - name: Setup IPEX
-        if: ${{ env.INSTALL_IPEX == 'true' }}
+        if: inputs.install_ipex
         uses: ./.github/actions/setup-ipex
 
       - name: Setup fake IPEX
-        if: ${{ env.INSTALL_IPEX == 'false' }}
+        if: inputs.install_ipex
         uses: ./.github/actions/setup-fake-ipex
 
       - name: Build Triton

--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -57,8 +57,11 @@ jobs:
       - name: Print inputs
         run: |
           cat <<EOF
-          ${{ toJSON(github.event.inputs) }}
+          ${{ toJSON(inputs) }}
           EOF
+          echo python = ${{ inputs.python_version }}
+          echo runner = ${{ inputs.runner_label }}
+          echo driver = ${{ inputs.driver_version }}
           echo INSTALL_IPEX=${{ env.INSTALL_IPEX }}
 
   integration-tests:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -103,9 +103,9 @@ jobs:
     with:
       driver_version: ${{ matrix.drivers }}
       runner_label: ${{ inputs.runner_label }}
-      install_ipex: ${{ inputs.install_ipex || github.event_name == 'pull_request' || github.event_name == 'push' }}
+      install_ipex: ${{ inputs.install_ipex == 'true' || github.event_name == 'pull_request' || github.event_name == 'push' || false }}
       pytorch_ref: ${{ inputs.pytorch_ref }}
       python_version: ${{ matrix.python }}
-      upload_test_reports: ${{ inputs.upload_test_reports }}
-      ignore_errors: ${{ inputs.ignore_errors }}
+      upload_test_reports: ${{ inputs.upload_test_reports || false }}
+      ignore_errors: ${{ inputs.ignore_errors || false }}
       run_name: ${{ inputs.run_name }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,10 +17,6 @@ on:
         description: PyTorch ref, keep empty for default
         type: string
         default: ""
-      runner_label:
-        description: Runner label, keep empty for default
-        type: string
-        default: ""
       upload_test_reports:
         description: Upload test reports
         type: boolean
@@ -100,203 +96,17 @@ jobs:
           dest: ${{ steps.pip-cache.outputs.dest }}
 
   integration-tests:
-    name: Integration tests
-    runs-on:
-      - ${{ inputs.runner_label || 'runner-0.0.16' }}
+    name: Integration tests matrix
     strategy:
       matrix:
         python: ${{ github.ref_name == 'llvm-target' && fromJson('["3.9", "3.10", "3.11"]') || fromJson('["3.9"]') }}
-    defaults:
-      run:
-        shell: bash -noprofile --norc -eo pipefail -c "source /home/runner/intel/oneapi/setvars.sh > /dev/null; source {0}"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Load pip cache
-        id: pip-cache
-        uses: ./.github/actions/load
-        env:
-          # Increase this value to reset cache
-          CACHE_NUMBER: 2
-        with:
-          path: $HOME/.cache/pip
-          key: pip-${{ matrix.python }}-${{ hashFiles('python/pyproject.toml', 'python/setup.py') }}-${{ env.CACHE_NUMBER }}
-
-      - name: Install Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
-
-      - name: Get LLVM commit id
-        run: |
-          LLVM_COMMIT_ID=$(<cmake/llvm-hash.txt)
-          echo "LLVM_COMMIT_ID=$LLVM_COMMIT_ID" >> $GITHUB_ENV
-
-      - name: Setup PyTorch with IPEX
-        if: ${{ env.INSTALL_IPEX == 'true' }}
-        uses: ./.github/actions/setup-pytorch
-        with:
-          repository: Stonepia/pytorch
-          ref: ${{ inputs.pytorch_ref }}
-
-      - name: Setup PyTorch without IPEX
-        if: ${{ env.INSTALL_IPEX == 'false' }}
-        uses: ./.github/actions/setup-pytorch
-        with:
-          repository: pytorch/pytorch
-          ref: ${{ inputs.pytorch_ref }}
-          torch_xpu_ops_commit: ${{ env.TORCH_XPU_OPS_COMMIT }}
-
-      - name: Setup IPEX
-        if: ${{ env.INSTALL_IPEX == 'true' }}
-        uses: ./.github/actions/setup-ipex
-
-      - name: Setup fake IPEX
-        if: ${{ env.INSTALL_IPEX == 'false' }}
-        uses: ./.github/actions/setup-fake-ipex
-
-      - name: Build Triton
-        run: |
-          export DEBUG=1
-          cd python
-          pip install wheel pytest pytest-xdist pytest-rerunfailures pytest-select
-          pip install --no-build-isolation '.[build,tests,tutorials]'
-          pip install git+https://github.com/kwasd/pytest-capturewarnings-ng.git@v1.2.0
-
-      - name: Run lit tests
-        run: |
-          cd python
-          lit -v build/*/test
-
-      - name: Create directory for tests reports
-        run: |
-          mkdir reports
-          echo "TRITON_TEST_REPORTS=true" >> $GITHUB_ENV
-          echo "TRITON_TEST_WARNING_REPORTS=true" >> $GITHUB_ENV
-          echo "TRITON_TEST_REPORTS_DIR=$GITHUB_WORKSPACE/reports" >> $GITHUB_ENV
-
-      - name: Enable ignoring test errors
-        if: inputs.ignore_errors
-        run: |
-          echo "TRITON_TEST_IGNORE_ERRORS=true" >> $GITHUB_ENV
-
-      - name: Run core tests
-        run: |
-          source ./scripts/pytest-utils.sh
-          cd python/test/unit
-          TRITON_TEST_SUITE=language \
-            pytest -vvv -n 8 --device xpu language/ --ignore=language/test_line_info.py --ignore=language/test_subprocess.py
-          TRITON_TEST_SUITE=subprocess \
-            pytest -vvv -n 8 language/test_subprocess.py
-          # Run runtime tests serially to avoid race condition with cache handling
-          TRITON_TEST_SUITE=runtime \
-            pytest -vvv --device xpu runtime/
-          # Run test_line_info.py separately with TRITON_DISABLE_LINE_INFO=0
-          TRITON_DISABLE_LINE_INFO=0 TRITON_TEST_SUITE=line_info \
-            pytest -vvv --device xpu language/test_line_info.py
-
-      - name: Clear cache
-        run: |
-          rm -rf ~/.triton
-
-      - name: Run interpreter tests
-        run: |
-          source ./scripts/pytest-utils.sh
-          cd python/test/unit
-          TRITON_INTERPRET=1 TRITON_TEST_SUITE=interpreter \
-            pytest -vvv -n 16 -m interpreter language/test_core.py language/test_standard.py \
-            language/test_random.py operators/test_flash_attention.py::test_op --device cpu
-
-      - name: Run partial operators tests
-        run: |
-          source ./scripts/pytest-utils.sh
-          cd python/test/unit
-          TRITON_TEST_SUITE=operators \
-            pytest -vvv -n 8 --device xpu operators
-
-      - name: Regression tests
-        run: |
-          source ./scripts/pytest-utils.sh
-          cd python/test/regression
-          TRITON_TEST_SUITE=regression \
-            pytest -vvv -s --device xpu . --reruns 10 --ignore=test_performance.py
-
-      - name: Run XPU python tests
-        run: |
-          cd python/test/backend/third_party_backends
-          python3 -m pytest -n auto --verbose test_xpu_backend.py
-
-      - name: Run Tutorials
-        run: |
-          source ./scripts/pytest-utils.sh
-          cd python/tutorials
-          run_tutorial_test "01-vector-add"
-          run_tutorial_test "02-fused-softmax"
-          run_tutorial_test "03-matrix-multiplication"
-          run_tutorial_test "04-low-memory-dropout"
-          run_tutorial_test "05-layer-norm"
-          run_tutorial_test "06-fused-attention"
-          run_tutorial_test "07-extern-functions"
-          run_tutorial_test "08-grouped-gemm"
-          run_tutorial_test "10-experimental-block-pointer"
-          run_tutorial_test "10i-experimental-block-pointer"
-
-      - name: Run CXX unittests
-        run: |
-          cd python/build/*cmake*
-          ctest
-
-      - name: Get transformers version
-        run: |
-          cd pytorch
-          TRANSFORMERS_VERSION="$(<.ci/docker/ci_commit_pins/huggingface.txt)"
-          echo "TRANSFORMERS_VERSION=$TRANSFORMERS_VERSION" | tee -a $GITHUB_ENV
-
-      - name: Install transformers
-        uses: ./.github/actions/install-dependency
-        with:
-          package: transformers
-          repository: huggingface/transformers
-          ref: ${{ env.TRANSFORMERS_VERSION }}
-          try-tag-prefix: v
-
-      - name: Run E2E test
-        run: |
-          # Set WORKSPACE for inductor_xpu_test.sh to make sure it creates "inductor_log" outside of pytorch cloned directory
-          export WORKSPACE=$GITHUB_WORKSPACE
-          cd pytorch
-          pip install pyyaml pandas scipy numpy psutil pyre_extensions torchrec
-          # TODO: Find the fastest Hugging Face model
-          $GITHUB_WORKSPACE/scripts/inductor_xpu_test.sh huggingface float32 inference accuracy xpu 0 static 1 0 AlbertForMaskedLM
-          # The script above always returns 0, so we need an additional check to see if the accuracy test passed
-          cat $WORKSPACE/inductor_log/*/*/*.csv
-          grep AlbertForMaskedLM $WORKSPACE/inductor_log/*/*/*.csv | grep -q ,pass,
-
-      - name: Save pip cache
-        if: ${{ steps.pip-cache.outputs.status == 'miss' }}
-        uses: ./.github/actions/save
-        with:
-          path: ${{ steps.pip-cache.outputs.path }}
-          dest: ${{ steps.pip-cache.outputs.dest }}
-
-      - name: Pass rate
-        run: |
-          source ./scripts/capture-hw-details.sh
-          python3 scripts/pass_rate.py --reports reports
-          python3 scripts/pass_rate.py --reports reports --json > pass_rate.json
-
-      - name: Upload pass rate report
-        # upload reports only for the default branch
-        if: github.ref_name == 'llvm-target'
-        uses: actions/upload-artifact@v4
-        with:
-          name: pass_rate-${{ join(matrix.*, '-') }}
-          path: pass_rate.json
-
-      - name: Upload test reports
-        if: inputs.upload_test_reports
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-reports-${{ join(matrix.*, '-') }}
-          path: reports
+        drivers: ["rolling", "LTS"]
+    uses: ./.github/workflows/build-test-reusable.yml
+    with:
+      runner_label: ${{ matrix.drivers }}
+      install_ipex: ${{ inputs.install_ipex }}
+      pytorch_ref: ${{ inputs.pytorch_ref }}
+      python_version: ${{ matrix.python }}
+      upload_test_reports: ${{ inputs.upload_test_reports }}
+      ignore_errors: ${{ inputs.ignore_errors }}
+      run_name: ${{ inputs.run_name }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -100,7 +100,7 @@ jobs:
     strategy:
       matrix:
         python: ${{ github.ref_name == 'llvm-target' && fromJson('["3.9", "3.10", "3.11"]') || fromJson('["3.9"]') }}
-        drivers: ["rolling", "LTS"]
+        drivers: ["rolling", "lts"]
     uses: ./.github/workflows/build-test-reusable.yml
     with:
       runner_label: ${{ matrix.drivers }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -42,10 +42,6 @@ on:
 
 permissions: read-all
 
-env:
-  TRITON_DISABLE_LINE_INFO: 1
-  TORCH_XPU_OPS_COMMIT: 39522db63ce045f52c9d61a286018c266cd00479
-
 jobs:
   pre-commit:
     name: Pre-commit checks

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -44,7 +44,6 @@ permissions: read-all
 
 env:
   TRITON_DISABLE_LINE_INFO: 1
-  INSTALL_IPEX: ${{ inputs.install_ipex || github.event_name == 'pull_request' || github.event_name == 'push' || 'false' }}
   TORCH_XPU_OPS_COMMIT: 39522db63ce045f52c9d61a286018c266cd00479
 
 jobs:
@@ -60,7 +59,6 @@ jobs:
           cat <<EOF
           ${{ toJSON(github.event.inputs) }}
           EOF
-          echo INSTALL_IPEX=${{ env.INSTALL_IPEX }}
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -109,7 +107,7 @@ jobs:
     with:
       driver_version: ${{ matrix.drivers }}
       runner_label: ${{ inputs.runner_label }}
-      install_ipex: ${{ env.INSTALL_IPEX }}
+      install_ipex: ${{ inputs.install_ipex || github.event_name == 'pull_request' || github.event_name == 'push' }}
       pytorch_ref: ${{ inputs.pytorch_ref }}
       python_version: ${{ matrix.python }}
       upload_test_reports: ${{ inputs.upload_test_reports }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -109,7 +109,7 @@ jobs:
     with:
       driver_version: ${{ matrix.drivers }}
       runner_label: ${{ inputs.runner_label }}
-      install_ipex: ${{ inputs.install_ipex }}
+      install_ipex: ${{ env.INSTALL_IPEX }}
       pytorch_ref: ${{ inputs.pytorch_ref }}
       python_version: ${{ matrix.python }}
       upload_test_reports: ${{ inputs.upload_test_reports }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,6 +4,10 @@ run-name: ${{ inputs.run_name }}
 on:
   workflow_dispatch:
     inputs:
+      runner_label:
+        description: Runner label, keep empty for default
+        type: string
+        default: ""
       install_ipex:
         # This boolean parameter defines what PyTorch will be used in the workflow:
         #   true: Stonepia/pytorch (fork) with IPEX
@@ -103,7 +107,8 @@ jobs:
         drivers: ["rolling", "lts"]
     uses: ./.github/workflows/build-test-reusable.yml
     with:
-      runner_label: ${{ matrix.drivers }}
+      driver_version: ${{ matrix.drivers }}
+      runner_label: ${{ inputs.runner_label }}
       install_ipex: ${{ inputs.install_ipex }}
       pytorch_ref: ${{ inputs.pytorch_ref }}
       python_version: ${{ matrix.python }}


### PR DESCRIPTION
Fixes #1357 

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `this PR doesn't change any triton code`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
