### PR TITLE
Fixed A770 workflow, it now runs (but tests fail)

### DIFF
--- a/.github/workflows/build-test-a770.yml
+++ b/.github/workflows/build-test-a770.yml
@@ -49,7 +49,7 @@ jobs:
     uses: ./.github/workflows/build-test-reusable.yml
     with:
       driver_version: ${{ matrix.drivers }}
-      runner_label: ${{ inputs.runner_label || "a770" }}
+      runner_label: ${{ inputs.runner_label || 'a770' }}
       install_ipex: ${{ inputs.install_ipex || github.event_name == 'schedule' }}
       pytorch_ref: ${{ inputs.pytorch_ref }}
       python_version: ${{ matrix.python }}


### PR DESCRIPTION

Fixes #1421 

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `does not change any triton code`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
