### PR TITLE
Use the GenISA for the 2D matrix load of the varianet 32b 8x8x2c.

### DIFF
--- a/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
@@ -174,8 +174,14 @@ llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_
 // -----
 
 llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
-  // CHECK:      llvm.call spir_funccc @_Z40intel_sub_group_2d_block_read_32b_8r8x2cPU3AS1viiiDv2_iPj(%arg0, %arg1, %arg2, %arg3, {{.*}}, [[DEST:%.*]]) {{.*}} : (!llvm.ptr<1>, i32, i32, i32, vector<2xi32>, !llvm.ptr) -> ()
-  // CHECK-NEXT: llvm.load [[DEST]] : !llvm.ptr -> vector<8xi32>
+  // CHECK: %[[ELEM_SIZE:.*]] = llvm.mlir.constant(32 : i32) : i32
+  // CHECK: %[[TILE_WIDTH:.*]] = llvm.mlir.constant(8 : i32) : i32
+  // CHECK: %[[TILE_HEIGHT:.*]] = llvm.mlir.constant(8 : i32) : i32
+  // CHECK: %[[VBLOCKS:.*]] = llvm.mlir.constant(2 : i32) : i32
+  // CHECK: %[[VNNI:.*]] = llvm.mlir.constant(false) : i1
+  // CHECK: %[[TRANSFORM:.*]] = llvm.mlir.constant(false) : i1
+  // CHECK: %[[CACHE_CTRL:.*]] = llvm.mlir.constant(0 : i32) : i32
+  // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.LSC2DBlockRead.v8i32({{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[ELEM_SIZE]], %[[TILE_WIDTH]], %[[TILE_HEIGHT]], %[[VBLOCKS]], %[[VNNI]], %[[TRANSFORM]], %[[CACHE_CTRL]]) : (i64, i32, i32, i32, i32, i32, i32, i32, i32, i32, i1, i1, i32) -> vector<8xi32>
   %0 = triton_gen.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=32, tile_width=8, tile_height=8, v_blocks=2, transpose=false, vnni_transform=false, cache_control=Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32) -> vector<8xi32>
   llvm.return
 }

--- a/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
@@ -174,14 +174,7 @@ llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_
 // -----
 
 llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
-  // CHECK: %[[ELEM_SIZE:.*]] = llvm.mlir.constant(32 : i32) : i32
-  // CHECK: %[[TILE_WIDTH:.*]] = llvm.mlir.constant(8 : i32) : i32
-  // CHECK: %[[TILE_HEIGHT:.*]] = llvm.mlir.constant(8 : i32) : i32
-  // CHECK: %[[VBLOCKS:.*]] = llvm.mlir.constant(2 : i32) : i32
-  // CHECK: %[[VNNI:.*]] = llvm.mlir.constant(false) : i1
-  // CHECK: %[[TRANSFORM:.*]] = llvm.mlir.constant(false) : i1
-  // CHECK: %[[CACHE_CTRL:.*]] = llvm.mlir.constant(0 : i32) : i32
-  // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.LSC2DBlockRead.v8i32({{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[ELEM_SIZE]], %[[TILE_WIDTH]], %[[TILE_HEIGHT]], %[[VBLOCKS]], %[[VNNI]], %[[TRANSFORM]], %[[CACHE_CTRL]]) : (i64, i32, i32, i32, i32, i32, i32, i32, i32, i32, i1, i1, i32) -> vector<8xi32>
+  // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.LSC2DBlockRead.v8i32
   %0 = triton_gen.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=32, tile_width=8, tile_height=8, v_blocks=2, transpose=false, vnni_transform=false, cache_control=Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32) -> vector<8xi32>
   llvm.return
 }

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -216,15 +216,11 @@ static bool isOCLBuiltinAvailable(TritonGEN::Matrix2DBlockLoadOp op) {
   // intel_sub_group_2d_block_read_32b_8r8x1c is expected to be lowered to
   // llvm.genx.GenISA.LSC2DBlockRead.v4i32, but it is incorrectly lowered to
   // llvm.genx.GenISA.LSC2DBlockRead.v8i32.
-  if (op.getElemSizeInBits() == 32 && op.getTileHeight() == 8 &&
-      op.getTileWidth() == 8 && op.getVBlocks() == 1)
-    return false;
-
   // intel_sub_group_2d_block_read_32b_8r8x2c is expected to be lowered to
   // llvm.genx.GenISA.LSC2DBlockRead.v8i32, but it is incorrectly lowered to
   // llvm.genx.GenISA.LSC2DBlockRead.v16i32.
   if (op.getElemSizeInBits() == 32 && op.getTileHeight() == 8 &&
-      op.getTileWidth() == 8 && op.getVBlocks() == 2)
+      op.getTileWidth() == 8)
     return false;
 
   // Missing intel_sub_group_2d_block_read_32b_8r16x1c and

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -220,6 +220,13 @@ static bool isOCLBuiltinAvailable(TritonGEN::Matrix2DBlockLoadOp op) {
       op.getTileWidth() == 8 && op.getVBlocks() == 1)
     return false;
 
+  // intel_sub_group_2d_block_read_32b_8r8x2c is expected to be lowered to
+  // llvm.genx.GenISA.LSC2DBlockRead.v8i32, but it is incorrectly lowered to
+  // llvm.genx.GenISA.LSC2DBlockRead.v16i32.
+  if (op.getElemSizeInBits() == 32 && op.getTileHeight() == 8 &&
+      op.getTileWidth() == 8 && op.getVBlocks() == 2)
+    return false;
+
   // Missing intel_sub_group_2d_block_read_32b_8r16x1c and
   // intel_sub_group_2d_block_read_32b_16r16x1c.
   if (op.getElemSizeInBits() == 32 && op.getTileWidth() == 16 &&


### PR DESCRIPTION
The OCL interface is in-correctly lowered to GenISA.

Use the GenISA directly to work around the issue.

https://github.com/intel/intel-xpu-backend-for-triton/issues/1426