### PR TITLE
[RAISE-BP] Add `tt.broadcast` support as `tt.addptr` input

### DIFF
--- a/test/Triton/raise-block-pointer.mlir
+++ b/test/Triton/raise-block-pointer.mlir
@@ -155,3 +155,19 @@ tt.func @test_const_splat_addptr_2d(%arg0 : !tt.ptr<f32>) -> tensor<2x128xf32> {
   %2 = tt.load %1 : tensor<2x128x!tt.ptr<f32>>
   tt.return %2 : tensor<2x128xf32>
 }
+
+// CHECK-LABEL:   tt.func @test_addptr_broadcast(
+// CHECK-SAME:                                   %[[VAL_0:.*]]: !tt.ptr<f32>) -> tensor<2x128xf32> {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i32
+// CHECK:           %[[VAL_3:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_1]], %[[VAL_1]]], {{\[}}%[[VAL_1]], %[[VAL_1]]], {{\[}}%[[VAL_2]], %[[VAL_2]]] {order = array<i32>} : <tensor<2x128xf32>>
+// CHECK:           %[[VAL_4:.*]] = tt.load %[[VAL_3]] : !tt.ptr<tensor<2x128xf32>>
+// CHECK:           tt.return %[[VAL_4]] : tensor<2x128xf32>
+tt.func @test_addptr_broadcast(%arg0 : !tt.ptr<f32>) -> tensor<2x128xf32> {
+  %cst = arith.constant dense<1> : tensor<1x128xi32>
+  %0 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<2x128x!tt.ptr<f32>>
+  %1 = tt.broadcast %cst : tensor<1x128xi32> -> tensor<2x128xi32>
+  %2 = tt.addptr %0, %1 : tensor<2x128x!tt.ptr<f32>>, tensor<2x128xi32>
+  %3 = tt.load %2 : tensor<2x128x!tt.ptr<f32>>
+  tt.return %3 : tensor<2x128xf32>
+}

--- a/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
+++ b/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
@@ -487,7 +487,7 @@ LogicalResult
 TritonRaiseBlockPointer::visitAddPointerOperand(triton::BroadcastOp broadcastOp,
                                                 PtrState &state, Location loc,
                                                 OpBuilder &builder) {
-  assert(state.isEmpty());
+  assert(state.isEmpty() && "state is a return argument");
 
   Value src = broadcastOp.getSrc();
   Value dst = broadcastOp.getResult();

--- a/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
+++ b/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
@@ -278,7 +278,7 @@ struct TritonRaiseBlockPointer
 
     return TypeSwitch<Operation *, LogicalResult>(definingOp)
         .Case<arith::AddIOp, arith::ConstantOp, arith::MulIOp,
-              triton::MakeRangeOp, triton::SplatOp>(
+              triton::BroadcastOp, triton::MakeRangeOp, triton::SplatOp>(
             [this, &state, loc, &builder](auto op) {
               return visitAddPointerOperand(op, state, loc, builder);
             })
@@ -478,6 +478,40 @@ LogicalResult TritonRaiseBlockPointer::visitAddPointerOperand(
     state.shape.push_back(
         builder.create<arith::ConstantIntOp>(loc, 0, shapeAndStridesBitwidth));
   }
+
+  return success();
+}
+
+template <>
+LogicalResult
+TritonRaiseBlockPointer::visitAddPointerOperand(triton::BroadcastOp broadcastOp,
+                                                PtrState &state, Location loc,
+                                                OpBuilder &builder) {
+  assert(state.isEmpty());
+
+  Value src = broadcastOp.getSrc();
+  Value dst = broadcastOp.getResult();
+
+  if (!isa<ShapedType>(src.getType())) {
+    broadcastOp->emitRemark(
+        "TritonRaiseBlockPointer: Unsupported broadcast source type");
+    return failure();
+  }
+
+  ArrayRef<int64_t> srcShape = cast<ShapedType>(src.getType()).getShape();
+  ArrayRef<int64_t> dstShape = cast<ShapedType>(dst.getType()).getShape();
+
+  // TODO: Implement srcShape.size() < dstShape.size() case
+  assert(srcShape.size() == dstShape.size() &&
+         "rank of source cannot be different to rank of destination");
+
+  if (failed(visitOperand(src, state, loc, builder))) {
+    return failure();
+  }
+
+  llvm::copy(dstShape, state.sizes.begin());
+
+  LLVM_DEBUG(llvm::dbgs() << "Broadcast state: " << state << "\n";);
 
   return success();
 }


### PR DESCRIPTION
Allow `tt.broadcast` input to `tt.addptr` when the ranks of source and destination types are the same.
