### PR TITLE
Fix test_dot failures for float8 data types

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3130,9 +3130,6 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
         if not is_hip() and kpack == 2:
             pytest.xfail("Skip duplicated tests on nv path")
 
-    if is_xpu() and (in_dtype == 'float8e4nv' or in_dtype == 'float8e5'):
-        pytest.skip("FIXME: float8e4nv and float8e5 fails to run on XPU")
-
     if is_cuda():
         torch.backends.cuda.matmul.allow_tf32 = input_precision == "tf32"
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
@@ -213,16 +213,11 @@ static void decomposeMixedModeDotOp(ModuleOp mod) {
     DpasEncodingAttr dpasLayout =
         dyn_cast<DpasEncodingAttr>(D.getType().getEncoding());
     if (dpasLayout) {
-      // For fp8, DPAS is not supported yet.
-      // Hence, fp8 is promoted to fp16 to use DPAS dot operation.
       bool isNativeFP8 = AElType.isFloat8E5M2() || AElType.isFloat8E4M3FNUZ();
-
-      // No operands promotion because of DPAS using different layout
-      // to pack the dot operands for different scalar type.
+      // promote operands for fp8 since fp8 DPAS is not natively supported
+      // fp8 is promoted to fp16 to use DPAS implementation
       if (!isNativeFP8)
         return;
-
-      // promote operands from fp8 to fp16 to use DPAS
       promoteType = builder.getF16Type();
     } else {
       // FMA case.

--- a/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
@@ -213,7 +213,8 @@ static void decomposeMixedModeDotOp(ModuleOp mod) {
     DpasEncodingAttr dpasLayout =
         dyn_cast<DpasEncodingAttr>(D.getType().getEncoding());
     if (dpasLayout) {
-
+      // For fp8, DPAS is not supported yet.
+      // Hence, fp8 is promoted to fp16 to use DPAS dot operation.
       bool isNativeFP8 = AElType.isFloat8E5M2() || AElType.isFloat8E4M3FNUZ();
 
       // No operands promotion because of DPAS using different layout

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RewriteTensorPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RewriteTensorPointer.cpp
@@ -75,7 +75,8 @@ bool shouldRemove(tt::MakeTensorPtrOp &op, ttgi::DeviceArch deviceArch,
 
   // FIXME: Temporary workaround to avoid
   // compile error on fp8 2d block read
-  if (tensorType.getElementTypeBitWidth() == 8)
+  Type eltType = tensorType.getElementType();
+  if (eltType.isFloat8E5M2() || eltType.isFloat8E4M3FNUZ())
     return true;
   TypedValue<triton::PointerType> base = op.getBase();
   Operation::operand_range shape = op.getShape();

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RewriteTensorPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RewriteTensorPointer.cpp
@@ -73,6 +73,10 @@ bool shouldRemove(tt::MakeTensorPtrOp &op, ttgi::DeviceArch deviceArch,
       !(isUsedByStoreOp && ttgi::hasDpasEncoding(tensorType)))
     return true;
 
+  // FIXME: Temporary workaround to avoid
+  // compile error on fp8 2d block read
+  if (tensorType.getElementTypeBitWidth() == 8)
+    return true;
   TypedValue<triton::PointerType> base = op.getBase();
   Operation::operand_range shape = op.getShape();
   Operation::operand_range strides = op.getStrides();

--- a/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
@@ -86,6 +86,13 @@ DPASEngineType getDPASType(DotOp op) {
       if (aTy.getElementType().isF32() && bTy.getElementType().isF32() &&
           op.getInputPrecision() == InputPrecision::TF32)
         return DPASEngineType::FP32_FP32_TF32_TF32;
+      // For FP8XFP8->FP32, upcast to FP16
+      if (aTy.getElementType().isFloat8E5M2() &&
+          bTy.getElementType().isFloat8E5M2())
+        return DPASEngineType::FP32_FP32_FP16_FP16;
+      if (aTy.getElementType().isFloat8E4M3FNUZ() &&
+          bTy.getElementType().isFloat8E4M3FNUZ())
+        return DPASEngineType::FP32_FP32_FP16_FP16;
     } else if (dTy.getElementType().isF16()) {
       if (aTy.getElementType().isF16() && bTy.getElementType().isF16())
         return DPASEngineType::FP16_FP16_FP16_FP16;


### PR DESCRIPTION
This is a fix to test_dot failures for float8 data types (#1326)
Originally, float8 tensors are converted to fp32 and we performed FMA dot product.
This created kernels with massive instruction count (~70K lines) which cause module build failure errors.
Following NVIDIA's approach, fp8xfp8->fp32 dot is now converted to fp16xfp16->fp32 dot to use DPAS implementation.
This fixes test_dot failures in float8 dtypes.

However, it creates a new compile error on `python/tutorial/06-fused-attention.py` because 2d block read generates an invalid bitcast operation.
As a workaround, 2d tensor pointer of fp8 tensor is disabled.
Refer to the new issue (#1442 ) for the status of debugging this error.