### PR TITLE
Fix build-test on workflow_dispatch

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Print inputs
         run: |
           cat <<EOF
-          ${{ toJSON(github.event.inputs) }}
+          ${{ toJSON(inputs) }}
           EOF
 
       - name: Checkout repository
@@ -98,12 +98,12 @@ jobs:
     strategy:
       matrix:
         python: ${{ github.ref_name == 'llvm-target' && fromJson('["3.9", "3.10", "3.11"]') || fromJson('["3.9"]') }}
-        drivers: ["rolling", "lts"]
+        drivers: ${{ inputs.runner_label || fromJson('["rolling", "lts"]') }}
     uses: ./.github/workflows/build-test-reusable.yml
     with:
       driver_version: ${{ matrix.drivers }}
       runner_label: ${{ inputs.runner_label }}
-      install_ipex: ${{ inputs.install_ipex == 'true' || github.event_name == 'pull_request' || github.event_name == 'push' || false }}
+      install_ipex: ${{ inputs.install_ipex || github.event_name == 'pull_request' || github.event_name == 'push' }}
       pytorch_ref: ${{ inputs.pytorch_ref }}
       python_version: ${{ matrix.python }}
       upload_test_reports: ${{ inputs.upload_test_reports || false }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       matrix:
         python: ${{ github.ref_name == 'llvm-target' && fromJson('["3.9", "3.10", "3.11"]') || fromJson('["3.9"]') }}
-        drivers: ${{ inputs.runner_label || fromJson('["rolling", "lts"]') }}
+        drivers: ${{ inputs.runner_label && fromJson(format('["{0}"]', inputs.runner_label)) || fromJson('["rolling", "lts"]') }}
     uses: ./.github/workflows/build-test-reusable.yml
     with:
       driver_version: ${{ matrix.drivers }}


### PR DESCRIPTION
If runner_label is set, then use it instead of ["rolling", "lts"].
`install_ipex` was false even if checkbox is checked.

Fixes #1447.