### PR TITLE
Set a default/custom skip list in CI

### DIFF
--- a/.github/workflows/build-test-a770.yml
+++ b/.github/workflows/build-test-a770.yml
@@ -29,6 +29,10 @@ on:
         description: Ignore test errors
         type: boolean
         default: false
+      skip_list:
+        description: Skip list
+        type: string
+        default: ""
       run_name:
         description: Custom run name
         type: string
@@ -55,4 +59,5 @@ jobs:
       python_version: ${{ matrix.python }}
       upload_test_reports: ${{ inputs.upload_test_reports || false }}
       ignore_errors: ${{ inputs.ignore_errors || false }}
+      skip_list: ${{ inputs.skip_list }}
       run_name: ${{ inputs.run_name }}

--- a/.github/workflows/build-test-no-ipex.yml
+++ b/.github/workflows/build-test-no-ipex.yml
@@ -20,6 +20,10 @@ on:
         description: Ignore test errors
         type: boolean
         default: false
+      skip_list:
+        description: Skip list
+        type: string
+        default: ""
       run_name:
         description: Custom run name
         type: string
@@ -46,4 +50,5 @@ jobs:
       python_version: ${{ matrix.python }}
       upload_test_reports: ${{ inputs.upload_test_reports || false }}
       ignore_errors: ${{ inputs.ignore_errors || false }}
+      skip_list: ${{ inputs.skip_list }}
       run_name: ${{ inputs.run_name }}

--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -37,6 +37,10 @@ on:
         description: Ignore test errors
         type: boolean
         default: false
+      skip_list:
+        description: Skip list
+        type: string
+        default: ""
       run_name:
         description: Custom run name
         type: string
@@ -139,6 +143,19 @@ jobs:
         run: |
           echo "TRITON_TEST_IGNORE_ERRORS=true" >> $GITHUB_ENV
 
+      - name: Set a default skip list
+        if: inputs.skip_list == ''
+        run: |
+          skiplist="$GITHUB_WORKSPACE/scripts/skiplist/${{ inputs.driver_version }}"
+          if [[ -d $skiplist ]]; then
+            echo "TRITON_TEST_SKIPLIST_DIR=$skiplist" | tee -a $GITHUB_ENV
+          fi
+
+      - name: Set a custom skip list
+        if: inputs.skip_list != ''
+        run: |
+          echo "TRITON_TEST_SKIPLIST_DIR=$GITHUB_WORKSPACE/scripts/skiplist/${{ inputs.skip_list }}" | tee -a $GITHUB_ENV
+
       - name: Run core tests
         run: |
           source ./scripts/pytest-utils.sh
@@ -191,7 +208,7 @@ jobs:
           run_tutorial_test "07-extern-functions"
           run_tutorial_test "08-grouped-gemm"
           run_tutorial_test "10-experimental-block-pointer"
-          TRITON_INTEL_ENABLE_BLOCK_PTR=1 run_tutorial_test "10-experimental-block-pointer"
+          run_tutorial_test "10i-experimental-block-pointer"
 
       - name: Run CXX unittests
         run: |

--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -258,12 +258,12 @@ jobs:
         if: github.ref_name == 'llvm-target'
         uses: actions/upload-artifact@v4
         with:
-          name: pass_rate-${{ inputs.python_version }}
+          name: pass_rate-${{ inputs.python_version }}-${{ inputs.driver_version }}
           path: pass_rate.json
 
       - name: Upload test reports
         if: inputs.upload_test_reports
         uses: actions/upload-artifact@v4
         with:
-          name: test-reports-${{ inputs.python_version }}
+          name: test-reports-${{ inputs.python_version }}-${{ inputs.driver_version }}
           path: reports

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,6 +29,10 @@ on:
         description: Ignore test errors
         type: boolean
         default: false
+      skip_list:
+        description: Skip list
+        type: string
+        default: ""
       run_name:
         description: Custom run name
         type: string
@@ -108,4 +112,5 @@ jobs:
       python_version: ${{ matrix.python }}
       upload_test_reports: ${{ inputs.upload_test_reports || false }}
       ignore_errors: ${{ inputs.ignore_errors || false }}
+      skip_list: ${{ inputs.skip_list }}
       run_name: ${{ inputs.run_name }}


### PR DESCRIPTION
Add a new workflow input `skip_list` to specify a skip list when starting a workflow manually. If `skip_list` is not set, then workflow checks if there is a skip list for a given `driver_version` (for example `lts`) and selects it if it exists. Uses a default skip list in other cases. In future, we will potentially need to add a GPU part to the skip list name, for example `a770-lts`.

Required for #986.