### PR TITLE
[RAISE-BP] Conditionaly enable -triton-raise-block-pointer pass

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -143,6 +143,8 @@ class XPUBackend(BaseBackend):
         passes.common.add_cse(pm)
         passes.common.add_licm(pm)
         passes.common.add_symbol_dce(pm)
+        if (os.getenv("TRITON_RAISE_BLOCK_POINTER", "0") == "1"):
+            intel.passes.ttir.add_raise_block_pointer(pm)
         pm.run(mod)
         return mod
 

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -10,6 +10,7 @@
 #include "intel/include/Target/LLVMIR/Dialect/TritonGEN/TritonGENToLLVMIRTranslation.h"
 #include "intel/include/Target/LLVMIR/LICM.h"
 #include "intel/include/TritonIntelGPUToLLVM/Passes.h"
+#include "intel/include/TritonRaiseBlockPointer/Passes.h"
 #include "intel/include/TritonToTritonGPUWarp/Passes.h"
 
 #include "triton/Target/SPIRV/SPIRVTranslation.h"
@@ -47,6 +48,8 @@ static uint32_t findKernels(llvm::Module &M,
 void init_triton_intel_passes_ttir(py::module &&m) {
   ADD_PASS_WRAPPER_OPT_1("add_convert_to_ttgpuir_warp",
                          intel::createConvertTritonToTritonGPUWarp, unsigned);
+  ADD_PASS_WRAPPER_0("add_raise_block_pointer",
+                     intel::createTritonRaiseBlockPointer);
 }
 
 void init_triton_intel_passes_ttgpuir(py::module &&m) {


### PR DESCRIPTION
Enable the `-triton-raise-block-pointer` pass when the pipeline is called with `TRITON_RAISE_BLOCK_POINTER` environment variable is set to 1.

If the pass fails to raise memory access, a warning message is displayed.

Closes Issue: #1430
