### PR TITLE
Fix capture details in "Build and test"

### DIFF
--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -53,16 +53,6 @@ env:
   TORCH_XPU_OPS_COMMIT: 39522db63ce045f52c9d61a286018c266cd00479
 
 jobs:
-  print_inputs:
-    name: Print inputs
-    runs-on: Linux
-    steps:
-      - name: Print inputs
-        run: |
-          cat <<EOF
-          ${{ toJSON(inputs) }}
-          EOF
-
   integration-tests:
     name: Integration tests
     runs-on:
@@ -250,6 +240,7 @@ jobs:
 
       - name: Pass rate
         run: |
+          source ./scripts/capture-hw-details.sh
           python3 scripts/pass_rate.py --reports reports
           python3 scripts/pass_rate.py --reports reports --json > pass_rate.json
 

--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -62,6 +62,12 @@ jobs:
       run:
         shell: bash -noprofile --norc -eo pipefail -c "source /home/runner/intel/oneapi/setvars.sh > /dev/null; source {0}"
     steps:
+      - name: Print inputs
+        run: |
+          cat <<EOF
+          ${{ toJSON(inputs) }}
+          EOF
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/scripts/skiplist/lts/language.txt
+++ b/scripts/skiplist/lts/language.txt
@@ -293,3 +293,5 @@ test/unit/language/test_core.py::test_dot[1-64-128-128-2-False-False-none-tf32-f
 test/unit/language/test_core.py::test_dot[1-64-128-128-2-False-False-none-tf32-float16-float32-1_1]
 test/unit/language/test_core.py::test_dot[1-64-128-128-2-False-False-none-tf32-float32-float32-1_0]
 test/unit/language/test_core.py::test_dot[1-64-128-128-2-False-False-none-tf32-float32-float32-1_1]
+test/unit/language/test_core.py::test_dot[1-128-128-64-4-False-False-chain-dot-ieee-float8e5-float32-1]
+test/unit/language/test_core.py::test_dot[1-128-128-64-4-False-False-chain-dot-ieee-float8e4nv-float32-1]


### PR DESCRIPTION
Return back the call that was lost during the workflow split.

Also remove "Print inputs" jobs to make the list of checks cleaner. The inputs are still available in the "Set up job" step.

Related to #1357.