### PR TITLE
Use `gpu::SubgroupIdOp` directly

### DIFF
--- a/test/TritonIntelGPU/store-to-llvm-2dstore.mlir
+++ b/test/TritonIntelGPU/store-to-llvm-2dstore.mlir
@@ -23,7 +23,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 8 :
     %12 = arith.truncf %11#0 : tensor<64x64xf32, #dpas> to tensor<64x64xf16, #dpas>
     %13 = tt.make_tensor_ptr %arg2, [%arg3, %arg5], [%arg6, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<64x64xf16, #dpas>>
     // The next two lines is used to start checking constant related to the BlockStore.
-    // CHECK-COUNT-6: llvm.call spir_funccc @_Z12get_local_idj
+    // CHECK-COUNT-3: llvm.call spir_funccc @_Z25__spirv_BuiltInSubgroupIdv
     // CHECK-COUNT-39: llvm.extractvalue
     // Next constant must be equal to warpsPerCTA[0]
     // CHECK: %[[CST_4:.*]] = llvm.mlir.constant(4 : i32) : i32

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -264,9 +264,8 @@ struct PrefetchOpConversion
         mlir::ceil<unsigned>(bytesPerCol * 8, elemSizeInBits);
     unsigned tileHeightInElem = shapePerWarp[0];
 
-    Value warpSize = LLVM::intel::getModuleWarpSize(rewriter, loc);
-    Value warpId = udiv(getThreadId(rewriter, loc), warpSize);
-    Value laneId = urem(getThreadId(rewriter, loc), warpSize);
+    Value warpId = rewriter.create<arith::IndexCastOp>(
+        loc, i32_ty, rewriter.create<mlir::gpu::SubgroupIdOp>(loc));
     SmallVector<Value> multiDimWarpId =
         mlir::LLVM::delinearize(rewriter, loc, warpId, warpsPerCTA, {1, 0});
 
@@ -372,9 +371,8 @@ struct LoadOpConversion
     SmallVector<unsigned> order = triton::gpu::getOrder(dpasLayout);
     int threadsPerWarp = triton::gpu::getWarpSize(dpasLayout);
 
-    Value warpSize = i32_val(threadsPerWarp);
-    Value warpId = udiv(getThreadId(rewriter, loc), warpSize);
-    Value laneId = urem(getThreadId(rewriter, loc), warpSize);
+    Value warpId = rewriter.create<arith::IndexCastOp>(
+        loc, i32_ty, rewriter.create<mlir::gpu::SubgroupIdOp>(loc));
     SmallVector<Value> multiDimWarpId =
         delinearize(rewriter, loc, warpId, warpsPerCTA, order);
 
@@ -673,9 +671,8 @@ struct StoreOpConversion
     SmallVector<unsigned> order = triton::gpu::getOrder(dpasLayout);
     int threadsPerWarp = triton::gpu::getWarpSize(dpasLayout);
 
-    Value warpSize = i32_val(threadsPerWarp);
-    Value warpId = udiv(getThreadId(rewriter, loc), warpSize);
-    Value laneId = urem(getThreadId(rewriter, loc), warpSize);
+    Value warpId = rewriter.create<arith::IndexCastOp>(
+        loc, i32_ty, rewriter.create<mlir::gpu::SubgroupIdOp>(loc));
     SmallVector<Value> multiDimWarpId =
         mlir::LLVM::delinearize(rewriter, loc, warpId, warpsPerCTA, order);
 


### PR DESCRIPTION
Obtain `warpId` using `gpu::SubgroupIdOp` instead of calculating from thread id for better performance.