### PR TITLE
[TEST] Run `test_max_num_imprecise_acc` with subgroup size 16

### DIFF
--- a/scripts/skiplist/lts/language.txt
+++ b/scripts/skiplist/lts/language.txt
@@ -295,3 +295,4 @@ test/unit/language/test_core.py::test_dot[1-64-128-128-2-False-False-none-tf32-f
 test/unit/language/test_core.py::test_dot[1-64-128-128-2-False-False-none-tf32-float32-float32-1_1]
 test/unit/language/test_core.py::test_dot[1-128-128-64-4-False-False-chain-dot-ieee-float8e5-float32-1]
 test/unit/language/test_core.py::test_dot[1-128-128-64-4-False-False-chain-dot-ieee-float8e4nv-float32-1]
+test/unit/language/test_core.py::test_max_num_imprecise_acc


### PR DESCRIPTION
When running with subgroup size 16, we can change the problem size to the original problem size. 