### PR TITLE
Do not build LLVM in CI by default

### DIFF
--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -48,7 +48,7 @@ on:
       build_llvm:
         description: Build LLVM
         type: boolean
-        default: true
+        default: false
 
 permissions: read-all
 
@@ -96,6 +96,7 @@ jobs:
           echo "LLVM_COMMIT_ID=$LLVM_COMMIT_ID" | tee -a $GITHUB_ENV
 
       - name: Load LLVM cache
+        if: inputs.build_llvm
         id: llvm-cache
         uses: ./.github/actions/load
         env:
@@ -127,7 +128,7 @@ jobs:
           echo "LLVM_SYSPATH=$HOME/packages/llvm" | tee -a $GITHUB_ENV
 
       - name: Save LLVM cache
-        if: steps.llvm-cache.outputs.status == 'miss'
+        if: inputs.build_llvm && steps.llvm-cache.outputs.status == 'miss'
         uses: ./.github/actions/save
         with:
           path: ${{ steps.llvm-cache.outputs.path }}


### PR DESCRIPTION
The access to llvm tarball is now restored, no need to build LLVM in the workflow.

Note that this is not a complete undo of #1489, because we need to keep an option to build LLVM if something happens to the tarball again. Relates to #1490.