### PR TITLE
Enable fp8 2d block read with fp16 DPAS format

### DIFF
--- a/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
@@ -195,6 +195,14 @@ llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_
 
 // -----
 
+llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.LSC2DBlockRead.v4i16
+  %0 = triton_gen.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=8, tile_width=16, tile_height=8, v_blocks=1, transpose=false, vnni_transform=false, cache_control=Default} : (!llvm.ptr, i32, i32, i32, i32, i32) -> vector<4xi16>
+  llvm.return
+}
+
+// -----
+
 llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
   // CHECK:      llvm.call spir_funccc @_Z51intel_sub_group_2d_block_read_transform_8b_32r16x1cPU3AS1viiiDv2_iPj(%arg0, %arg1, %arg2, %arg3, {{.*}}, [[DEST:%.*]]) {{.*}} : (!llvm.ptr<1>, i32, i32, i32, vector<2xi32>, !llvm.ptr) -> ()
   // CHECK-NEXT: llvm.load [[DEST]] : !llvm.ptr -> vector<8xi32>

--- a/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
@@ -203,6 +203,14 @@ llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr, %base_width : i32, %base_hei
 
 // -----
 
+llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.LSC2DBlockRead.v8i16
+  %0 = triton_gen.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=8, tile_width=16, tile_height=16, v_blocks=1, transpose=false, vnni_transform=false, cache_control=Default} : (!llvm.ptr, i32, i32, i32, i32, i32) -> vector<8xi16>
+  llvm.return
+}
+
+// -----
+
 llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
   // CHECK:      llvm.call spir_funccc @_Z51intel_sub_group_2d_block_read_transform_8b_32r16x1cPU3AS1viiiDv2_iPj(%arg0, %arg1, %arg2, %arg3, {{.*}}, [[DEST:%.*]]) {{.*}} : (!llvm.ptr<1>, i32, i32, i32, vector<2xi32>, !llvm.ptr) -> ()
   // CHECK-NEXT: llvm.load [[DEST]] : !llvm.ptr -> vector<8xi32>

--- a/test/TritonGEN/tritongen-invalid.mlir
+++ b/test/TritonGEN/tritongen-invalid.mlir
@@ -260,8 +260,8 @@ llvm.func @matrix_2Dblockload(%ptr : !llvm.ptr, %base_width : i32, %base_height 
 // -----
 
 llvm.func @matrix_2Dblockload(%ptr : !llvm.ptr, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
-  // expected-error @+1 {{'triton_gen.2Dblockload' op tile_width for 8 bit elements when vnni_transform is false should be equal to 32}}
-  %0 = triton_gen.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=8, tile_width=16, tile_height=8, v_blocks=1, transpose=false, vnni_transform=false, cache_control=Default} : (!llvm.ptr, i32, i32, i32, i32, i32) -> vector<4xi16>
+  // expected-error @+1 {{'triton_gen.2Dblockload' op tile_width for 8 bit elements when vnni_transform is false should be equal to 16 or 32}}
+  %0 = triton_gen.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=8, tile_width=8, tile_height=8, v_blocks=1, transpose=false, vnni_transform=false, cache_control=Default} : (!llvm.ptr, i32, i32, i32, i32, i32) -> vector<2xi16>
   llvm.return
 }
 

--- a/test/TritonIntelGPU/load-to-llvm-2dload.mlir
+++ b/test/TritonIntelGPU/load-to-llvm-2dload.mlir
@@ -50,7 +50,7 @@ module attributes {"triton_gpu.num-warps" = 8 : i32, "triton_gpu.threads-per-war
 // -----
 
 #blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 4], order = [1, 0]}>
-#mma = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [32, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#mma = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [32, 1], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot0 = #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>
 #blocked1 = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 2], warpsPerCTA = [1, 32], order = [0, 1]}>
 #dot1 = #triton_gpu.dot_op<{opIdx = 1, parent = #mma, kWidth=2}>

--- a/third_party/intel/lib/Dialect/TritonGEN/IR/TritonGENOps.cpp
+++ b/third_party/intel/lib/Dialect/TritonGEN/IR/TritonGENOps.cpp
@@ -207,10 +207,16 @@ LogicalResult TritonGEN::Matrix2DBlockLoadOp::verify() {
     return success();
   }
 
+  bool isFP8 = (resTy.getElementType().isFloat8E5M2() ||
+                resTy.getElementType().isFloat8E4M3FNUZ());
   assert(!getVnniTransform() && "Expecting vnni_transform should be false");
   switch (getElemSizeInBits()) {
   case 8:
-    if (tileWidth != 32)
+    // Because FP8 is promoted to fp16, it should follow tile_width=16
+    if (isFP8 && tileWidth != 16)
+      return emitOpError("tile_width for 16 bit elements when vnni_transform "
+                         "is false should be equal to 16");
+    else if (tileWidth != 32)
       return emitOpError("tile_width for 8 bit elements when vnni_transform is "
                          "false should be equal to 32");
     break;

--- a/third_party/intel/lib/Dialect/TritonGEN/IR/TritonGENOps.cpp
+++ b/third_party/intel/lib/Dialect/TritonGEN/IR/TritonGENOps.cpp
@@ -207,18 +207,13 @@ LogicalResult TritonGEN::Matrix2DBlockLoadOp::verify() {
     return success();
   }
 
-  bool isFP8 = (resTy.getElementType().isFloat8E5M2() ||
-                resTy.getElementType().isFloat8E4M3FNUZ());
   assert(!getVnniTransform() && "Expecting vnni_transform should be false");
   switch (getElemSizeInBits()) {
   case 8:
-    // Because FP8 is promoted to fp16, it should follow tile_width=16
-    if (isFP8 && tileWidth != 16)
-      return emitOpError("tile_width for fp8 element type when vnni_transform "
-                         "is false should be equal to 16");
-    else if (tileWidth != 32)
+    // FP8 is promoted to fp16, so should also support tile width = 16
+    if (tileWidth != 32 && tileWidth != 16)
       return emitOpError("tile_width for 8 bit elements when vnni_transform is "
-                         "false should be equal to 32");
+                         "false should be equal to 16 or 32");
     break;
   case 16:
     if (tileWidth != 16)

--- a/third_party/intel/lib/Dialect/TritonGEN/IR/TritonGENOps.cpp
+++ b/third_party/intel/lib/Dialect/TritonGEN/IR/TritonGENOps.cpp
@@ -214,7 +214,7 @@ LogicalResult TritonGEN::Matrix2DBlockLoadOp::verify() {
   case 8:
     // Because FP8 is promoted to fp16, it should follow tile_width=16
     if (isFP8 && tileWidth != 16)
-      return emitOpError("tile_width for 16 bit elements when vnni_transform "
+      return emitOpError("tile_width for fp8 element type when vnni_transform "
                          "is false should be equal to 16");
     else if (tileWidth != 32)
       return emitOpError("tile_width for 8 bit elements when vnni_transform is "

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -231,8 +231,8 @@ static bool isOCLBuiltinAvailable(TritonGEN::Matrix2DBlockLoadOp op) {
       op.getTileWidth() == 32 && op.getVBlocks() == 1)
     return false;
 
-  // Missing intel_sub_group_2d_block_read_8b_8r16x and
-  // intel_sub_group_2d_block_read_8b_16r16x
+  // Missing intel_sub_group_2d_block_read_8b_8r16x1c and
+  // intel_sub_group_2d_block_read_8b_16r16x1c
   // when vnni_transform is false.
   if (op.getElemSizeInBits() == 8 && op.getTileWidth() == 16 &&
       !op.getVnniTransform())

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -231,6 +231,12 @@ static bool isOCLBuiltinAvailable(TritonGEN::Matrix2DBlockLoadOp op) {
       op.getTileWidth() == 32 && op.getVBlocks() == 1)
     return false;
 
+  // Missing intel_sub_group_2d_block_read_8b_8r16x1c and
+  // intel_sub_group_2d_block_read_8b_16r16x1c.
+  Type eltTy = op.getRes().getType().getElementType();
+  bool isFP8 = (eltTy.isFloat8E5M2() || eltTy.isFloat8E4M3FNUZ());
+  if (isFP8 && op.getTileWidth() == 16 && op.getVBlocks() == 1)
+    return false;
   return true;
 }
 

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -231,11 +231,11 @@ static bool isOCLBuiltinAvailable(TritonGEN::Matrix2DBlockLoadOp op) {
       op.getTileWidth() == 32 && op.getVBlocks() == 1)
     return false;
 
-  // Missing intel_sub_group_2d_block_read_8b_8r16x1c and
-  // intel_sub_group_2d_block_read_8b_16r16x1c.
-  Type eltTy = op.getRes().getType().getElementType();
-  bool isFP8 = (eltTy.isFloat8E5M2() || eltTy.isFloat8E4M3FNUZ());
-  if (isFP8 && op.getTileWidth() == 16 && op.getVBlocks() == 1)
+  // Missing intel_sub_group_2d_block_read_8b_8r16x and
+  // intel_sub_group_2d_block_read_8b_16r16x
+  // when vnni_transform is false.
+  if (op.getElemSizeInBits() == 8 && op.getTileWidth() == 16 &&
+      !op.getVnniTransform())
     return false;
   return true;
 }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -391,6 +391,11 @@ struct LoadOpConversion
     unsigned opsPerChannel = dpasLayout.getOpsPerChannel();
     elemsPerLane = isOperandA ? elemsPerLane / (opsPerChannel == 4 ? 2 : 1)
                               : elemsPerLane / opsPerChannel;
+
+    // FP8 tensors will be promoted to FP16 to use DPAS
+    // Hence, there are 2 elements per lane instead of four
+    if (isOperandA && (eltTy.isFloat8E5M2() || eltTy.isFloat8E4M3FNUZ()))
+      elemsPerLane = elemsPerLane / 2;
     Type load2DGenXType = LLVM::getFixedVectorType(elemType, elemsPerLane);
 
     // Outer dim for A is the M, for B is the N. Inner dim for both is the K.

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RewriteTensorPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RewriteTensorPointer.cpp
@@ -73,11 +73,6 @@ bool shouldRemove(tt::MakeTensorPtrOp &op, ttgi::DeviceArch deviceArch,
       !(isUsedByStoreOp && ttgi::hasDpasEncoding(tensorType)))
     return true;
 
-  // FIXME: Temporary workaround to avoid
-  // compile error on fp8 2d block read
-  Type eltType = tensorType.getElementType();
-  if (eltType.isFloat8E5M2() || eltType.isFloat8E4M3FNUZ())
-    return true;
   TypedValue<triton::PointerType> base = op.getBase();
   Operation::operand_range shape = op.getShape();
   Operation::operand_range strides = op.getStrides();


### PR DESCRIPTION
This PR fixes #1442 
Because fp8 tensors are promoted to fp16 for enabling DPAS, there was a format mismatch.
It is fixed by 1) matching the format when lowering 2d block load to LLVM and 2) enabling 8-bit 2d block primitive that supports different shape format.