### PR TITLE
[RAISE-BP] Add support for tt.broadcast increasing tensor rank

### DIFF
--- a/test/Triton/raise-block-pointer.mlir
+++ b/test/Triton/raise-block-pointer.mlir
@@ -220,3 +220,20 @@ tt.func @test_addptr_broadcast_rank_2(%arg0 : !tt.ptr<f32>) -> tensor<128x2x128x
   %3 = tt.load %2 : tensor<128x2x128x!tt.ptr<f32>>
   tt.return %3 : tensor<128x2x128xf32>
 }
+
+// CHECK-LABEL:   tt.func @test_addptr_broadcast_rank_3(
+// CHECK-SAME:                                   %[[VAL_0:.*]]: !tt.ptr<f32>) -> tensor<128x2x128xf32> {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i32
+// CHECK:           %[[VAL_3:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_1]], %[[VAL_1]], %[[VAL_1]]], {{\[}}%[[VAL_1]], %[[VAL_1]], %[[VAL_1]]], {{\[}}%[[VAL_2]], %[[VAL_2]], %[[VAL_2]]] {order = array<i32>} : <tensor<128x2x128xf32>>
+// CHECK:           %[[VAL_4:.*]] = tt.load %[[VAL_3]] : !tt.ptr<tensor<128x2x128xf32>>
+// CHECK:           tt.return %[[VAL_4]] : tensor<128x2x128xf32>
+tt.func @test_addptr_broadcast_rank_3(%arg0 : !tt.ptr<f32>) -> tensor<128x2x128xf32> {
+  %cst = arith.constant dense<1> : tensor<128xi32>
+  %0 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x2x128x!tt.ptr<f32>>
+  %1 = tt.broadcast %cst : tensor<128xi32> -> tensor<128x2x128xi32>
+  %2 = tt.addptr %0, %1 : tensor<128x2x128x!tt.ptr<f32>>, tensor<128x2x128xi32>
+  %3 = tt.load %2 : tensor<128x2x128x!tt.ptr<f32>>
+  tt.return %3 : tensor<128x2x128xf32>
+}
+

--- a/test/Triton/raise-block-pointer.mlir
+++ b/test/Triton/raise-block-pointer.mlir
@@ -236,4 +236,3 @@ tt.func @test_addptr_broadcast_rank_3(%arg0 : !tt.ptr<f32>) -> tensor<128x2x128x
   %3 = tt.load %2 : tensor<128x2x128x!tt.ptr<f32>>
   tt.return %3 : tensor<128x2x128xf32>
 }
-

--- a/test/Triton/raise-block-pointer.mlir
+++ b/test/Triton/raise-block-pointer.mlir
@@ -188,3 +188,35 @@ tt.func @test_addptr_broadcast(%arg0 : !tt.ptr<f32>) -> tensor<2x128xf32> {
   %3 = tt.load %2 : tensor<2x128x!tt.ptr<f32>>
   tt.return %3 : tensor<2x128xf32>
 }
+
+// CHECK-LABEL:   tt.func @test_addptr_broadcast_rank(
+// CHECK-SAME:                                   %[[VAL_0:.*]]: !tt.ptr<f32>) -> tensor<2x128xf32> {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i32
+// CHECK:           %[[VAL_3:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_1]], %[[VAL_1]]], {{\[}}%[[VAL_1]], %[[VAL_1]]], {{\[}}%[[VAL_2]], %[[VAL_2]]] {order = array<i32>} : <tensor<2x128xf32>>
+// CHECK:           %[[VAL_4:.*]] = tt.load %[[VAL_3]] : !tt.ptr<tensor<2x128xf32>>
+// CHECK:           tt.return %[[VAL_4]] : tensor<2x128xf32>
+tt.func @test_addptr_broadcast_rank(%arg0 : !tt.ptr<f32>) -> tensor<2x128xf32> {
+  %cst = arith.constant dense<1> : tensor<128xi32>
+  %0 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<2x128x!tt.ptr<f32>>
+  %1 = tt.broadcast %cst : tensor<128xi32> -> tensor<2x128xi32>
+  %2 = tt.addptr %0, %1 : tensor<2x128x!tt.ptr<f32>>, tensor<2x128xi32>
+  %3 = tt.load %2 : tensor<2x128x!tt.ptr<f32>>
+  tt.return %3 : tensor<2x128xf32>
+}
+
+// CHECK-LABEL:   tt.func @test_addptr_broadcast_rank_2(
+// CHECK-SAME:                                   %[[VAL_0:.*]]: !tt.ptr<f32>) -> tensor<128x2x128xf32> {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i32
+// CHECK:           %[[VAL_3:.*]] = tt.make_tensor_ptr %[[VAL_0]], {{\[}}%[[VAL_1]], %[[VAL_1]], %[[VAL_1]]], {{\[}}%[[VAL_1]], %[[VAL_1]], %[[VAL_1]]], {{\[}}%[[VAL_2]], %[[VAL_2]], %[[VAL_2]]] {order = array<i32>} : <tensor<128x2x128xf32>>
+// CHECK:           %[[VAL_4:.*]] = tt.load %[[VAL_3]] : !tt.ptr<tensor<128x2x128xf32>>
+// CHECK:           tt.return %[[VAL_4]] : tensor<128x2x128xf32>
+tt.func @test_addptr_broadcast_rank_2(%arg0 : !tt.ptr<f32>) -> tensor<128x2x128xf32> {
+  %cst = arith.constant dense<1> : tensor<128x128xi32>
+  %0 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x2x128x!tt.ptr<f32>>
+  %1 = tt.broadcast %cst : tensor<128x128xi32> -> tensor<128x2x128xi32>
+  %2 = tt.addptr %0, %1 : tensor<128x2x128x!tt.ptr<f32>>, tensor<128x2x128xi32>
+  %3 = tt.load %2 : tensor<128x2x128x!tt.ptr<f32>>
+  tt.return %3 : tensor<128x2x128xf32>
+}

--- a/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
+++ b/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
@@ -574,15 +574,62 @@ TritonRaiseBlockPointer::visitAddPointerOperand(triton::BroadcastOp broadcastOp,
   ArrayRef<int64_t> srcShape = cast<ShapedType>(src.getType()).getShape();
   ArrayRef<int64_t> dstShape = cast<ShapedType>(dst.getType()).getShape();
 
-  // TODO: Implement srcShape.size() < dstShape.size() case
-  assert(srcShape.size() == dstShape.size() &&
-         "rank of source cannot be different to rank of destination");
+  assert(srcShape.size() <= dstShape.size() &&
+         "rank of source cannot be greater than the rank of destination");
 
   if (failed(visitOperand(src, state, loc, builder))) {
     return failure();
   }
 
-  llvm::copy(dstShape, state.sizes.begin());
+  if (srcShape.size() == dstShape.size()) {
+    llvm::copy(dstShape, state.sizes.begin());
+  } else {
+    // Offset must be equal, otherwise we don.t know which offset should be
+    // propagate to the new axis.
+    for (int i = 1; i < state.offsets.size(); i++) {
+      if (state.offsets[0] != state.offsets[i]) {
+        broadcastOp->emitRemark(
+            "TritonRaiseBlockPointer: Unsupported broadcast with different "
+            "offsets while source rank and destination rank differ.");
+        return failure();
+      }
+    }
+
+    // Create the new axis.
+    // The positions of the new axis are determined based and the shape values.
+    // If shape are the same, the new axis are added at the end.
+    size_t srcAxis = 0;
+    for (size_t axis = 0; axis < dstShape.size(); axis++) {
+      if ((srcAxis < srcShape.size()) &&
+          (srcShape[srcAxis] == dstShape[axis])) {
+        srcAxis++;
+      } else {
+        Value c0i32 =
+            builder.create<arith::ConstantIntOp>(loc, 0, offsetBitwidth);
+        Value c0i64 = builder.create<arith::ConstantIntOp>(
+            loc, 0, shapeAndStridesBitwidth);
+        state.offsets.insert(state.offsets.begin() + axis,
+                             getValueOrCreateCastToIndexLike(
+                                 builder, loc,
+                                 builder.getIntegerType(offsetBitwidth),
+                                 state.offsets[0]));
+        state.sizes.insert(state.sizes.begin() + axis, dstShape[axis]);
+        state.strides.insert(state.strides.begin() + axis, c0i64);
+        state.shape.insert(state.shape.begin() + axis, c0i64);
+      }
+    }
+
+    // The following condition has been duplicated from the expand_dim support
+    // TODO : Verify if we need still need it given that triton `make_block_ptr`
+    // op differs from triton-shared `make_block_ptr` op regarding how address
+    // wrap around are handled.
+    if (state.hasModulo() && state.getRank() > 2) {
+      broadcastOp->emitRemark("TritonRaiseBlockPointer: unsupported scenario "
+                              "where broadcast result "
+                              "has modulo and rank > 2");
+      return failure();
+    }
+  }
 
   LLVM_DEBUG(llvm::dbgs() << "Broadcast state: " << state << "\n";);
 

--- a/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
+++ b/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
@@ -585,8 +585,8 @@ TritonRaiseBlockPointer::visitAddPointerOperand(triton::BroadcastOp broadcastOp,
     llvm::copy(dstShape, state.sizes.begin());
   } else {
     // Offset must be equal, otherwise we don.t know which offset should be
-    // propagate to the new axis.
-    for (int i = 1; i < state.offsets.size(); i++) {
+    // propagated to the new axis.
+    for (int i = 1; i < state.offsets.size(); ++i) {
       if (state.offsets[0] != state.offsets[i]) {
         broadcastOp->emitRemark(
             "TritonRaiseBlockPointer: Unsupported broadcast with different "
@@ -599,24 +599,24 @@ TritonRaiseBlockPointer::visitAddPointerOperand(triton::BroadcastOp broadcastOp,
     // The positions of the new axis are determined based and the shape values.
     // If shape are the same, the new axis are added at the end.
     size_t srcAxis = 0;
-    for (size_t axis = 0; axis < dstShape.size(); axis++) {
+    for (size_t axis = 0; axis < dstShape.size(); ++axis) {
       if ((srcAxis < srcShape.size()) &&
           (srcShape[srcAxis] == dstShape[axis])) {
-        srcAxis++;
-      } else {
-        Value c0i32 =
-            builder.create<arith::ConstantIntOp>(loc, 0, offsetBitwidth);
-        Value c0i64 = builder.create<arith::ConstantIntOp>(
-            loc, 0, shapeAndStridesBitwidth);
-        state.offsets.insert(state.offsets.begin() + axis,
-                             getValueOrCreateCastToIndexLike(
-                                 builder, loc,
-                                 builder.getIntegerType(offsetBitwidth),
-                                 state.offsets[0]));
-        state.sizes.insert(state.sizes.begin() + axis, dstShape[axis]);
-        state.strides.insert(state.strides.begin() + axis, c0i64);
-        state.shape.insert(state.shape.begin() + axis, c0i64);
+        ++srcAxis;
+        continue;
       }
+      Value c0i32 =
+          builder.create<arith::ConstantIntOp>(loc, 0, offsetBitwidth);
+      Value c0i64 =
+          builder.create<arith::ConstantIntOp>(loc, 0, shapeAndStridesBitwidth);
+      state.offsets.insert(state.offsets.begin() + axis,
+                           getValueOrCreateCastToIndexLike(
+                               builder, loc,
+                               builder.getIntegerType(offsetBitwidth),
+                               state.offsets[0]));
+      state.sizes.insert(state.sizes.begin() + axis, dstShape[axis]);
+      state.strides.insert(state.strides.begin() + axis, c0i64);
+      state.shape.insert(state.shape.begin() + axis, c0i64);
     }
 
     // The following condition has been duplicated from the expand_dim support


### PR DESCRIPTION
Extend the broadcast support to handle `tt.broadcast` operations when the rank of the destination tensor is greater than the rank of the source tensor.

Closes Issue: #1429