### PR TITLE
Add workaround to avoid the long time in jitting the SYCL kernel on ATSM.

### DIFF
--- a/python/tutorials/01-vector-add.py
+++ b/python/tutorials/01-vector-add.py
@@ -86,10 +86,10 @@ x = torch.rand(size, device='xpu')
 y = torch.rand(size, device='xpu')
 output_torch = x + y
 output_triton = add(x, y)
-print(output_torch)
-print(output_triton)
+print(output_torch.cpu())
+print(output_triton.cpu())
 print(f'The maximum difference between torch and triton is '
-      f'{torch.max(torch.abs(output_torch - output_triton))}')
+      f'{torch.max(torch.abs(output_torch.cpu() - output_triton.cpu()))}')
 
 # %%
 # Seems like we're good to go!


### PR DESCRIPTION
The IPEX includes the AOT SYCL kernel binary for PVC but not for ATSM. This is not an issue on PVC.
The SYCL kernel JIT time is really too long for tutorial.  
Avoid to use the SYCL kernel in triton tutorial to reduce the time to run.