### PR TITLE
[GEN] Replace GenISA usages with OCL for `sub_group_reduce` (#1277)

### DIFF
--- a/test/TritonGEN/tritongen-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-to-llvm.mlir
@@ -101,84 +101,54 @@ llvm.func @triton_gen.named_barrier(%barrier_id : i32, %thread_group_count : i32
 
 // -----
 
+// CHECK-DAG: llvm.func spir_funccc @_Z30sub_group_clustered_reduce_addij(i32, i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z30sub_group_clustered_reduce_mulij(i32, i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z30sub_group_clustered_reduce_maxij(i32, i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z30sub_group_clustered_reduce_minij(i32, i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z30sub_group_clustered_reduce_andij(i32, i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z29sub_group_clustered_reduce_orij(i32, i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z30sub_group_clustered_reduce_xorij(i32, i32) -> i32 attributes {passthrough = ["convergent"]}
+
 module attributes {
   spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Kernel, Addresses, GroupNonUniformShuffle, Int64], []>, #spirv.resource_limits<subgroup_size = 32>>
 } {
   llvm.func @triton_gen.sub_group_reduce() {
     %0 = llvm.mlir.constant(0 : i32) : i32
     // CHECK: [[VAL:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(0 : i8) : i8
     // CHECK: [[SIZE:%.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveClustered.i32([[VAL]], [[KIND]], [[SIZE]], [[ZERO]]) : (i32, i8, i32, i32) -> i32
-    %1 = triton_gen.sub_group_reduce sum %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(1 : i8) : i8
+    // CHECK: llvm.call @_Z30sub_group_clustered_reduce_addij([[VAL]], [[SIZE]]) {{.*}} : (i32, i32) -> i32
+    %1 = triton_gen.sub_group_reduce add %0 {size = 16} : i32
     // CHECK: [[SIZE:%.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveClustered.i32([[VAL]], [[KIND]], [[SIZE]], [[ZERO]]) : (i32, i8, i32, i32) -> i32
-    %2 = triton_gen.sub_group_reduce prod %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(2 : i8) : i8
+    // CHECK: llvm.call @_Z30sub_group_clustered_reduce_mulij([[VAL]], [[SIZE]]) {{.*}} : (i32, i32) -> i32
+    %2 = triton_gen.sub_group_reduce mul %0 {size = 16} : i32
     // CHECK: [[SIZE:%.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveClustered.i32([[VAL]], [[KIND]], [[SIZE]], [[ZERO]]) : (i32, i8, i32, i32) -> i32
-    %3 = triton_gen.sub_group_reduce umin %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(3 : i8) : i8
+    // CHECK: llvm.call @_Z30sub_group_clustered_reduce_minij([[VAL]], [[SIZE]]) {{.*}} : (i32, i32) -> i32
+    %3 = triton_gen.sub_group_reduce min %0 {size = 16} : i32
     // CHECK: [[SIZE:%.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveClustered.i32([[VAL]], [[KIND]], [[SIZE]], [[ZERO]]) : (i32, i8, i32, i32) -> i32
-    %4 = triton_gen.sub_group_reduce umax %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(4 : i8) : i8
+    // CHECK: llvm.call @_Z30sub_group_clustered_reduce_maxij([[VAL]], [[SIZE]]) {{.*}} : (i32, i32) -> i32
+    %4 = triton_gen.sub_group_reduce max %0 {size = 16} : i32
     // CHECK: [[SIZE:%.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveClustered.i32([[VAL]], [[KIND]], [[SIZE]], [[ZERO]]) : (i32, i8, i32, i32) -> i32
-    %5 = triton_gen.sub_group_reduce imin %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(5 : i8) : i8
+    // CHECK: llvm.call @_Z30sub_group_clustered_reduce_andij([[VAL]], [[SIZE]]) {{.*}} : (i32, i32) -> i32
+    %5 = triton_gen.sub_group_reduce and %0 {size = 16} : i32
     // CHECK: [[SIZE:%.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveClustered.i32([[VAL]], [[KIND]], [[SIZE]], [[ZERO]]) : (i32, i8, i32, i32) -> i32
-    %6 = triton_gen.sub_group_reduce imax %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(6 : i8) : i8
+    // CHECK: llvm.call @_Z29sub_group_clustered_reduce_orij([[VAL]], [[SIZE]]) {{.*}} : (i32, i32) -> i32
+    %6 = triton_gen.sub_group_reduce or %0 {size = 16} : i32
     // CHECK: [[SIZE:%.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveClustered.i32([[VAL]], [[KIND]], [[SIZE]], [[ZERO]]) : (i32, i8, i32, i32) -> i32
-    %7 = triton_gen.sub_group_reduce or %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(7 : i8) : i8
-    // CHECK: [[SIZE:%.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveClustered.i32([[VAL]], [[KIND]], [[SIZE]], [[ZERO]]) : (i32, i8, i32, i32) -> i32
-    %8 = triton_gen.sub_group_reduce xor %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(8 : i8) : i8
-    // CHECK: [[SIZE:%.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveClustered.i32([[VAL]], [[KIND]], [[SIZE]], [[ZERO]]) : (i32, i8, i32, i32) -> i32
-    %9 = triton_gen.sub_group_reduce and %0 {size = 16} : i32
-    %10 = llvm.mlir.constant(0.0 : f32) : f32
-    // CHECK: [[VAL:%.*]] = llvm.mlir.constant(0.000000e+00 : f32) : f32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(9 : i8) : i8
-    // CHECK: [[SIZE:%.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveClustered.f32([[VAL]], [[KIND]], [[SIZE]], [[ZERO]]) : (f32, i8, i32, i32) -> f32
-    %11 = triton_gen.sub_group_reduce fsum %10 {size = 16} : f32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(10 : i8) : i8
-    // CHECK: [[SIZE:%.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveClustered.f32([[VAL]], [[KIND]], [[SIZE]], [[ZERO]]) : (f32, i8, i32, i32) -> f32
-    %12 = triton_gen.sub_group_reduce fprod %10 {size = 16} : f32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(11 : i8) : i8
-    // CHECK: [[SIZE:%.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveClustered.f32([[VAL]], [[KIND]], [[SIZE]], [[ZERO]]) : (f32, i8, i32, i32) -> f32
-    %13 = triton_gen.sub_group_reduce fmin %10 {size = 16} : f32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(12 : i8) : i8
-    // CHECK: [[SIZE:%.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveClustered.f32([[VAL]], [[KIND]], [[SIZE]], [[ZERO]]) : (f32, i8, i32, i32) -> f32
-    %14 = triton_gen.sub_group_reduce fmax %10 {size = 16} : f32
+    // CHECK: llvm.call @_Z30sub_group_clustered_reduce_xorij([[VAL]], [[SIZE]]) {{.*}} : (i32, i32) -> i32
+    %7 = triton_gen.sub_group_reduce xor %0 {size = 16} : i32
     llvm.return
   }
 }
 
 // -----
+
+// CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_reduce_addi(i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_reduce_muli(i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_reduce_maxi(i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_reduce_mini(i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_reduce_andi(i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z19sub_group_reduce_ori(i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_reduce_xori(i32) -> i32 attributes {passthrough = ["convergent"]}
 
 module attributes {
   spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Kernel, Addresses, GroupNonUniformShuffle, Int64], []>, #spirv.resource_limits<subgroup_size = 16>>
@@ -186,60 +156,20 @@ module attributes {
   llvm.func @triton_gen.sub_group_reduce() {
     %0 = llvm.mlir.constant(0 : i32) : i32
     // CHECK: [[VAL:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(0 : i8) : i8
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveAll.i32([[VAL]], [[KIND]], [[ZERO]]) : (i32, i8, i32) -> i32
-    %1 = triton_gen.sub_group_reduce sum %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(1 : i8) : i8
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveAll.i32([[VAL]], [[KIND]], [[ZERO]]) : (i32, i8, i32) -> i32
-    %2 = triton_gen.sub_group_reduce prod %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(2 : i8) : i8
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveAll.i32([[VAL]], [[KIND]], [[ZERO]]) : (i32, i8, i32) -> i32
-    %3 = triton_gen.sub_group_reduce umin %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(3 : i8) : i8
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveAll.i32([[VAL]], [[KIND]], [[ZERO]]) : (i32, i8, i32) -> i32
-    %4 = triton_gen.sub_group_reduce umax %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(4 : i8) : i8
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveAll.i32([[VAL]], [[KIND]], [[ZERO]]) : (i32, i8, i32) -> i32
-    %5 = triton_gen.sub_group_reduce imin %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(5 : i8) : i8
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveAll.i32([[VAL]], [[KIND]], [[ZERO]]) : (i32, i8, i32) -> i32
-    %6 = triton_gen.sub_group_reduce imax %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(6 : i8) : i8
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveAll.i32([[VAL]], [[KIND]], [[ZERO]]) : (i32, i8, i32) -> i32
-    %7 = triton_gen.sub_group_reduce or %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(7 : i8) : i8
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveAll.i32([[VAL]], [[KIND]], [[ZERO]]) : (i32, i8, i32) -> i32
-    %8 = triton_gen.sub_group_reduce xor %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(8 : i8) : i8
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveAll.i32([[VAL]], [[KIND]], [[ZERO]]) : (i32, i8, i32) -> i32
-    %9 = triton_gen.sub_group_reduce and %0 {size = 16} : i32
-    %10 = llvm.mlir.constant(0.0 : f32) : f32
-    // CHECK: [[VAL:%.*]] = llvm.mlir.constant(0.000000e+00 : f32) : f32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(9 : i8) : i8
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveAll.f32([[VAL]], [[KIND]], [[ZERO]]) : (f32, i8, i32) -> f32
-    %11 = triton_gen.sub_group_reduce fsum %10 {size = 16} : f32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(10 : i8) : i8
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveAll.f32([[VAL]], [[KIND]], [[ZERO]]) : (f32, i8, i32) -> f32
-    %12 = triton_gen.sub_group_reduce fprod %10 {size = 16} : f32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(11 : i8) : i8
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveAll.f32([[VAL]], [[KIND]], [[ZERO]]) : (f32, i8, i32) -> f32
-    %13 = triton_gen.sub_group_reduce fmin %10 {size = 16} : f32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(12 : i8) : i8
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call @llvm.genx.GenISA.WaveAll.f32([[VAL]], [[KIND]], [[ZERO]]) : (f32, i8, i32) -> f32
-    %14 = triton_gen.sub_group_reduce fmax %10 {size = 16} : f32
+    // CHECK: llvm.call @_Z20sub_group_reduce_addi([[VAL]]) {{.*}} : (i32) -> i32
+    %1 = triton_gen.sub_group_reduce add %0 {size = 16} : i32
+    // CHECK: llvm.call @_Z20sub_group_reduce_muli([[VAL]]) {{.*}} : (i32) -> i32
+    %2 = triton_gen.sub_group_reduce mul %0 {size = 16} : i32
+    // CHECK: llvm.call @_Z20sub_group_reduce_mini([[VAL]]) {{.*}} : (i32) -> i32
+    %3 = triton_gen.sub_group_reduce min %0 {size = 16} : i32
+    // CHECK: llvm.call @_Z20sub_group_reduce_maxi([[VAL]]) {{.*}} : (i32) -> i32
+    %4 = triton_gen.sub_group_reduce max %0 {size = 16} : i32
+    // CHECK: llvm.call @_Z20sub_group_reduce_andi([[VAL]]) {{.*}} : (i32) -> i32
+    %5 = triton_gen.sub_group_reduce and %0 {size = 16} : i32
+    // CHECK: llvm.call @_Z19sub_group_reduce_ori([[VAL]]) {{.*}} : (i32) -> i32
+    %6 = triton_gen.sub_group_reduce or %0 {size = 16} : i32
+    // CHECK: llvm.call @_Z20sub_group_reduce_xori([[VAL]]) {{.*}} : (i32) -> i32
+    %7 = triton_gen.sub_group_reduce xor %0 {size = 16} : i32
     llvm.return
   }
 }

--- a/test/TritonGEN/tritongen.mlir
+++ b/test/TritonGEN/tritongen.mlir
@@ -66,38 +66,33 @@ llvm.func @triton_gen.named_barrier_wait(%barrier_id : i32) {
   llvm.return
 }
 
-llvm.func @triton_gen.sub_group_reduce() {
-  // CHECK-LABEL: triton_gen.sub_group_reduce
-  %0 = llvm.mlir.constant(0 : i32) : i32
-  // CHECK: triton_gen.sub_group_reduce sum %0 {size = 16} : i32
-  %1 = triton_gen.sub_group_reduce sum %0 {size = 16} : i32
-  // CHECK: triton_gen.sub_group_reduce prod %0 {size = 16} : i32
-  %2 = triton_gen.sub_group_reduce prod %0 {size = 16} : i32
-  // CHECK: triton_gen.sub_group_reduce umin %0 {size = 16} : i32
-  %3 = triton_gen.sub_group_reduce umin %0 {size = 16} : i32
-  // CHECK: triton_gen.sub_group_reduce umax %0 {size = 16} : i32
-  %4 = triton_gen.sub_group_reduce umax %0 {size = 16} : i32
-  // CHECK: triton_gen.sub_group_reduce imin %0 {size = 16} : i32
-  %5 = triton_gen.sub_group_reduce imin %0 {size = 16} : i32
-  // CHECK: triton_gen.sub_group_reduce imax %0 {size = 16} : i32
-  %6 = triton_gen.sub_group_reduce imax %0 {size = 16} : i32
-  // CHECK: triton_gen.sub_group_reduce or %0 {size = 16} : i32
-  %7 = triton_gen.sub_group_reduce or %0 {size = 16} : i32
-  // CHECK: triton_gen.sub_group_reduce xor %0 {size = 16} : i32
-  %8 = triton_gen.sub_group_reduce xor %0 {size = 16} : i32
-  // CHECK: triton_gen.sub_group_reduce and %0 {size = 16} : i32
-  %9 = triton_gen.sub_group_reduce and %0 {size = 16} : i32
-  %10 = llvm.mlir.constant(0.0 : f32) : f32
-  // CHECK: triton_gen.sub_group_reduce fsum %10 {size = 16} : f32
-  %11 = triton_gen.sub_group_reduce fsum %10 {size = 16} : f32
-  // CHECK: triton_gen.sub_group_reduce fprod %10 {size = 16} : f32
-  %12 = triton_gen.sub_group_reduce fprod %10 {size = 16} : f32
-  // CHECK: triton_gen.sub_group_reduce fmin %10 {size = 16} : f32
-  %13 = triton_gen.sub_group_reduce fmin %10 {size = 16} : f32
-  // CHECK: triton_gen.sub_group_reduce fmax %10 {size = 16} : f32
-  %14 = triton_gen.sub_group_reduce fmax %10 {size = 16} : f32
-  llvm.return
+// -----
+
+module attributes {
+  spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Kernel, Addresses, GroupNonUniformShuffle, Int64], []>, #spirv.resource_limits<subgroup_size = 32>>
+} {
+  llvm.func @triton_gen.sub_group_reduce() {
+    // CHECK-LABEL: triton_gen.sub_group_reduce
+    %0 = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: triton_gen.sub_group_reduce add %0 {size = 16} : i32
+    %1 = triton_gen.sub_group_reduce add %0 {size = 16} : i32
+    // CHECK: triton_gen.sub_group_reduce mul %0 {size = 16} : i32
+    %2 = triton_gen.sub_group_reduce mul %0 {size = 16} : i32
+    // CHECK: triton_gen.sub_group_reduce min %0 {size = 16} : i32
+    %3 = triton_gen.sub_group_reduce min %0 {size = 16} : i32
+    // CHECK: triton_gen.sub_group_reduce max %0 {size = 16} : i32
+    %4 = triton_gen.sub_group_reduce max %0 {size = 16} : i32
+    // CHECK: triton_gen.sub_group_reduce and %0 {size = 16} : i32
+    %5 = triton_gen.sub_group_reduce and %0 {size = 16} : i32
+    // CHECK: triton_gen.sub_group_reduce or %0 {size = 16} : i32
+    %6 = triton_gen.sub_group_reduce or %0 {size = 16} : i32
+    // CHECK: triton_gen.sub_group_reduce xor %0 {size = 16} : i32
+    %7 = triton_gen.sub_group_reduce xor %0 {size = 16} : i32
+    llvm.return
+  }
 }
+
+// -----
 
 llvm.func @triton_gen.sub_group_shuffle() {
   // CHECK-LABEL: triton_gen.sub_group_shuffle

--- a/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENAttrDefs.td
+++ b/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENAttrDefs.td
@@ -23,19 +23,13 @@ class TritonGEN_Attr<string name, string attrMnemonic, list<Trait> traits = []>
 /// Enum attribute of the different reduce kinds.
 def TritonGEN_ReduceKindAttr : I32EnumAttr<"ReduceKind", "TritonGEN reduce kind",
   [
-    I32EnumAttrCase<"SUM",  0, "sum">,
-    I32EnumAttrCase<"PROD",   1, "prod">,
-    I32EnumAttrCase<"UMIN", 2, "umin">,
-    I32EnumAttrCase<"UMAX",  3, "umax">,
-    I32EnumAttrCase<"IMIN",  4, "imin">,
-    I32EnumAttrCase<"IMAX",  5, "imax">,
-    I32EnumAttrCase<"OR",  6, "or">,
-    I32EnumAttrCase<"XOR",  7, "xor">,
-    I32EnumAttrCase<"AND",  8, "and">,
-    I32EnumAttrCase<"FSUM",  9, "fsum">,
-    I32EnumAttrCase<"FPROD",  10, "fprod">,
-    I32EnumAttrCase<"FMIN",  11, "fmin">,
-    I32EnumAttrCase<"FMAX",  12, "fmax">
+    I32EnumAttrCase<"ADD",  0, "add">,
+    I32EnumAttrCase<"MUL",  1, "mul">,
+    I32EnumAttrCase<"MIN",  2, "min">,
+    I32EnumAttrCase<"MAX",  3, "max">,
+    I32EnumAttrCase<"AND",  4, "and">,
+    I32EnumAttrCase<"OR",   5, "or">,
+    I32EnumAttrCase<"XOR",  6, "xor">
   ]> {
   let cppNamespace = "::mlir::triton::TritonGEN";
 }

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -923,36 +923,27 @@ struct TritonSubGroupReduceLowering
     Location loc = op.getLoc();
     Value val = op.getValue();
     Type val_ty = val.getType();
-    llvm::LLVMContext llvmContext;
-    LLVM::TypeToLLVMIRTranslator typeTranslator(llvmContext);
-    auto moduleOp = op->getParentOfType<ModuleOp>();
-    auto kind = rewriter.create<LLVM::ConstantOp>(
-        loc, i8_ty, static_cast<int>(op.getKind()));
 
-    std::string funcName;
-    SmallVector<Type> argTypes;
-    SmallVector<Value> args;
-    if (getSubgroupSize(op) == op.getSize()) {
-      funcName = llvm::GenISAIntrinsic::getName(
-          llvm::GenISAIntrinsic::GenISA_WaveAll,
-          {typeTranslator.translateType(val_ty)});
-      argTypes = {val_ty, i8_ty, i32_ty};
-      args = {val, kind, i32_val(0)};
-    } else {
-      funcName = llvm::GenISAIntrinsic::getName(
-          llvm::GenISAIntrinsic::GenISA_WaveClustered,
-          {typeTranslator.translateType(val_ty)});
-      argTypes = {val_ty, i8_ty, i32_ty, i32_ty};
+    SmallVector<Type> argTypes{val_ty};
+    SmallVector<Value> args{val};
+    bool useCluster = (getSubgroupSize(op) != op.getSize());
+    std::string fnName = "sub_group_";
+    if (useCluster)
+      fnName += "clustered_";
+    fnName += "reduce_" + stringifyReduceKind(op.getKind()).str();
+    fnName =
+        "_Z" + std::to_string(fnName.size()) + fnName + getTypeMangling(val_ty);
+    if (useCluster) {
+      fnName += "j";
+      argTypes.push_back(i32_ty);
       auto size = rewriter.create<LLVM::ConstantOp>(
           loc, i32_ty, static_cast<int>(op.getSize()));
-      args = {val, kind, size, i32_val(0)};
+      args.push_back(size);
     }
 
-    LLVM::LLVMFuncOp funcOp =
-        LLVM::lookupOrCreateFn(moduleOp, funcName, argTypes, val_ty);
-    funcOp.setCConv(LLVM::cconv::CConv::SPIR_FUNC);
-
-    rewriter.replaceOp(op, rewriter.create<LLVM::CallOp>(loc, funcOp, args));
+    LLVM::CallOp callOp = createDeviceFunctionCall(
+        rewriter, fnName, val_ty, argTypes, args, true /*convergent*/);
+    rewriter.replaceOp(op, callOp);
     return success();
   }
 };


### PR DESCRIPTION
It is a prerequisite for removing `libGenISAIntrinsics.a` in the release branch.