### PR TITLE
Build with gcc9

### DIFF
--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -816,11 +816,11 @@ struct TritonGENThreadIdLowering : public ConvertOpToLLVMPattern<SourceOp>,
                   ConversionPatternRewriter &rewriter) const override {
     Value res;
     if (isa<TritonGEN::ThreadIdXOp>(op))
-      res = rewrite(op, "_Z12get_local_idj", 0, rewriter);
+      res = FuncCallLowering::rewrite(op, "_Z12get_local_idj", 0, rewriter);
     else if (isa<TritonGEN::ThreadIdYOp>(op))
-      res = rewrite(op, "_Z12get_local_idj", 1, rewriter);
+      res = FuncCallLowering::rewrite(op, "_Z12get_local_idj", 1, rewriter);
     else if (isa<TritonGEN::ThreadIdZOp>(op))
-      res = rewrite(op, "_Z12get_local_idj", 2, rewriter);
+      res = FuncCallLowering::rewrite(op, "_Z12get_local_idj", 2, rewriter);
     else
       llvm_unreachable("Unexpected operation");
 
@@ -851,11 +851,11 @@ struct TritonGENBlockIdLowering : public ConvertOpToLLVMPattern<SourceOp>,
                   ConversionPatternRewriter &rewriter) const override {
     Value res;
     if (isa<TritonGEN::BlockIdXOp>(op))
-      res = rewrite(op, "_Z12get_group_idj", 0, rewriter);
+      res = FuncCallLowering::rewrite(op, "_Z12get_group_idj", 0, rewriter);
     else if (isa<TritonGEN::BlockIdYOp>(op))
-      res = rewrite(op, "_Z12get_group_idj", 1, rewriter);
+      res = FuncCallLowering::rewrite(op, "_Z12get_group_idj", 1, rewriter);
     else if (isa<TritonGEN::BlockIdZOp>(op))
-      res = rewrite(op, "_Z12get_group_idj", 2, rewriter);
+      res = FuncCallLowering::rewrite(op, "_Z12get_group_idj", 2, rewriter);
     else
       llvm_unreachable("Unexpected operation");
 
@@ -886,11 +886,11 @@ struct TritonGENBlockDimLowering : public ConvertOpToLLVMPattern<SourceOp>,
                   ConversionPatternRewriter &rewriter) const override {
     Value res;
     if (isa<TritonGEN::BlockDimXOp>(op))
-      res = rewrite(op, "_Z14get_local_sizej", 0, rewriter);
+      res = FuncCallLowering::rewrite(op, "_Z14get_local_sizej", 0, rewriter);
     else if (isa<TritonGEN::BlockDimYOp>(op))
-      res = rewrite(op, "_Z14get_local_sizej", 1, rewriter);
+      res = FuncCallLowering::rewrite(op, "_Z14get_local_sizej", 1, rewriter);
     else if (isa<TritonGEN::BlockDimZOp>(op))
-      res = rewrite(op, "_Z14get_local_sizej", 2, rewriter);
+      res = FuncCallLowering::rewrite(op, "_Z14get_local_sizej", 2, rewriter);
     else
       llvm_unreachable("Unexpected operation");
 
@@ -921,11 +921,11 @@ struct TritonGENGridDimLowering : public ConvertOpToLLVMPattern<SourceOp>,
                   ConversionPatternRewriter &rewriter) const override {
     Value res;
     if (isa<TritonGEN::GridDimXOp>(op))
-      res = rewrite(op, "_Z14get_num_groupsj", 0, rewriter);
+      res = FuncCallLowering::rewrite(op, "_Z14get_num_groupsj", 0, rewriter);
     else if (isa<TritonGEN::GridDimYOp>(op))
-      res = rewrite(op, "_Z14get_num_groupsj", 1, rewriter);
+      res = FuncCallLowering::rewrite(op, "_Z14get_num_groupsj", 1, rewriter);
     else if (isa<TritonGEN::GridDimZOp>(op))
-      res = rewrite(op, "_Z14get_num_groupsj", 2, rewriter);
+      res = FuncCallLowering::rewrite(op, "_Z14get_num_groupsj", 2, rewriter);
     else
       llvm_unreachable("Unexpected operation");
 


### PR DESCRIPTION
These fixes allow the Triton project to build under gcc-9. I had to unset the compiler variables to install test dependencies, though - I think there was conflict with DPCPP/SYCL. I also think we will need to modify the docker image to have gcc-9 available in the CI containers - will talk to @pbchekin next week.

cc #1505