### PR TITLE
[GEN] Fix incorrect `sub_group_reduce` lowering

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2180,8 +2180,6 @@ reduce_bool = [(op, 'bool', shape, axis, False) for op in ['xor_sum'] for shape 
                          [(64, 16), (4, THREADS_PER_WARP)] if is_xpu() else [(4, THREADS_PER_WARP)])
 def test_reduce(op, dtype_str, shape, axis, keep_dims, num_ctas, num_warps, threads_per_warp, device):
     check_type_supported(dtype_str, device)  # bfloat16 on cc < 80 will not be tested
-    if is_xpu() and op == 'xor_sum':
-        pytest.skip("FIXME: Incorrect result on XPU")
 
     @triton.jit
     def kernel(X, Z, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr, IS_3D: tl.constexpr,

--- a/test/Conversion/intel/tritongpu_to_gen.mlir
+++ b/test/Conversion/intel/tritongpu_to_gen.mlir
@@ -1390,14 +1390,14 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
       tt.reduce.return %48 : i32
     }) : (tensor<256x1xi32, #blocked>) -> tensor<1xi32, #slice>
 
-    // CHECK: @_Z20sub_group_reduce_mulf
+    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.f32
     %2 = "tt.reduce"(%arg_0) <{axis = 0 : i32}> ({
     ^bb0(%arg4: f32, %arg5: f32):
       %48 = arith.mulf %arg4, %arg5 : f32
       tt.reduce.return %48 : f32
     }) : (tensor<256x1xf32, #blocked>) -> tensor<1xf32, #slice>
 
-    // CHECK: @_Z20sub_group_reduce_muli
+    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.i32
     %3 = "tt.reduce"(%arg) <{axis = 0 : i32}> ({
     ^bb0(%arg4: i32, %arg5: i32):
       %48 = arith.muli %arg4, %arg5 : i32
@@ -1418,21 +1418,21 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
       tt.reduce.return %48 : f32
     }) : (tensor<256x1xf32, #blocked>) -> tensor<1xf32, #slice>
 
-    // CHECK: @_Z20sub_group_reduce_andi
+    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.i32
     %6 = "tt.reduce"(%arg) <{axis = 0 : i32}> ({
     ^bb0(%arg4: i32, %arg5: i32):
       %48 = arith.andi %arg4, %arg5 : i32
       tt.reduce.return %48 : i32
     }) : (tensor<256x1xi32, #blocked>) -> tensor<1xi32, #slice>
 
-    // CHECK: @_Z19sub_group_reduce_ori
+    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.i32
     %7 = "tt.reduce"(%arg) <{axis = 0 : i32}> ({
     ^bb0(%arg4: i32, %arg5: i32):
       %48 = arith.ori %arg4, %arg5 : i32
       tt.reduce.return %48 : i32
     }) : (tensor<256x1xi32, #blocked>) -> tensor<1xi32, #slice>
 
-    // CHECK: @_Z20sub_group_reduce_xori
+    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.i32
     %8 = "tt.reduce"(%arg) <{axis = 0 : i32}> ({
     ^bb0(%arg4: i32, %arg5: i32):
       %48 = arith.xori %arg4, %arg5 : i32

--- a/test/TritonGEN/tritongen-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-to-llvm.mlir
@@ -143,12 +143,9 @@ module attributes {
 // -----
 
 // CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_reduce_addi(i32) -> i32 attributes {passthrough = ["convergent"]}
-// CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_reduce_muli(i32) -> i32 attributes {passthrough = ["convergent"]}
 // CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_reduce_maxi(i32) -> i32 attributes {passthrough = ["convergent"]}
 // CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_reduce_mini(i32) -> i32 attributes {passthrough = ["convergent"]}
-// CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_reduce_andi(i32) -> i32 attributes {passthrough = ["convergent"]}
-// CHECK-DAG: llvm.func spir_funccc @_Z19sub_group_reduce_ori(i32) -> i32 attributes {passthrough = ["convergent"]}
-// CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_reduce_xori(i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @llvm.genx.GenISA.WaveAll.i32(i32, i8, i32) -> i32 attributes {passthrough = ["convergent"]}
 
 module attributes {
   spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Kernel, Addresses, GroupNonUniformShuffle, Int64], []>, #spirv.resource_limits<subgroup_size = 16>>
@@ -158,17 +155,25 @@ module attributes {
     // CHECK: [[VAL:%.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK: llvm.call spir_funccc @_Z20sub_group_reduce_addi([[VAL]]) {{.*}} : (i32) -> i32
     %1 = triton_gen.sub_group_reduce add %0 {size = 16} : i32
-    // CHECK: llvm.call spir_funccc @_Z20sub_group_reduce_muli([[VAL]]) {{.*}} : (i32) -> i32
+    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(1 : i8) : i8
+    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.i32([[VAL]], [[KIND]], [[ZERO]]) {{.*}} : (i32, i8, i32) -> i32
     %2 = triton_gen.sub_group_reduce mul %0 {size = 16} : i32
     // CHECK: llvm.call spir_funccc @_Z20sub_group_reduce_mini([[VAL]]) {{.*}} : (i32) -> i32
     %3 = triton_gen.sub_group_reduce min %0 {size = 16} : i32
     // CHECK: llvm.call spir_funccc @_Z20sub_group_reduce_maxi([[VAL]]) {{.*}} : (i32) -> i32
     %4 = triton_gen.sub_group_reduce max %0 {size = 16} : i32
-    // CHECK: llvm.call spir_funccc @_Z20sub_group_reduce_andi([[VAL]]) {{.*}} : (i32) -> i32
+    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(8 : i8) : i8
+    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.i32([[VAL]], [[KIND]], [[ZERO]]) {{.*}} : (i32, i8, i32) -> i32
     %5 = triton_gen.sub_group_reduce and %0 {size = 16} : i32
-    // CHECK: llvm.call spir_funccc @_Z19sub_group_reduce_ori([[VAL]]) {{.*}} : (i32) -> i32
+    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(6 : i8) : i8
+    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.i32([[VAL]], [[KIND]], [[ZERO]]) {{.*}} : (i32, i8, i32) -> i32
     %6 = triton_gen.sub_group_reduce or %0 {size = 16} : i32
-    // CHECK: llvm.call spir_funccc @_Z20sub_group_reduce_xori([[VAL]]) {{.*}} : (i32) -> i32
+    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(7 : i8) : i8
+    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.i32([[VAL]], [[KIND]], [[ZERO]]) {{.*}} : (i32, i8, i32) -> i32
     %7 = triton_gen.sub_group_reduce xor %0 {size = 16} : i32
     llvm.return
   }


### PR DESCRIPTION
Some OpenCL `sub_group_reduce` built-ins don't exist for some reduce kinds.

pass rate: 97.63%->97.7%