### PR TITLE
Add a new input 'device' to the the build-test workflow

### DIFF
--- a/.github/workflows/build-test-a770.yml
+++ b/.github/workflows/build-test-a770.yml
@@ -58,7 +58,7 @@ jobs:
     with:
       device: a770
       runner_label: ${{ inputs.runner_label }}
-      install_ipex: ${{ inputs.install_ipex == 'true' || github.event_name == 'schedule' }}
+      install_ipex: ${{ inputs.install_ipex || github.event_name == 'schedule' }}
       pytorch_ref: ${{ inputs.pytorch_ref }}
       python_version: ${{ matrix.python }}
       upload_test_reports: ${{ inputs.upload_test_reports || false }}

--- a/.github/workflows/build-test-a770.yml
+++ b/.github/workflows/build-test-a770.yml
@@ -54,11 +54,10 @@ jobs:
     strategy:
       matrix:
         python: ${{ github.ref_name == 'llvm-target' && fromJson('["3.9", "3.10", "3.11"]') || fromJson('["3.9"]') }}
-        drivers: ["rolling"]
     uses: ./.github/workflows/build-test-reusable.yml
     with:
-      driver_version: ${{ matrix.drivers }}
-      runner_label: ${{ inputs.runner_label || 'a770' }}
+      device: a770
+      runner_label: ${{ inputs.runner_label }}
       install_ipex: ${{ inputs.install_ipex == 'true' || github.event_name == 'schedule' }}
       pytorch_ref: ${{ inputs.pytorch_ref }}
       python_version: ${{ matrix.python }}

--- a/.github/workflows/build-test-no-ipex.yml
+++ b/.github/workflows/build-test-no-ipex.yml
@@ -44,10 +44,10 @@ jobs:
     strategy:
       matrix:
         python: ${{ github.ref_name == 'llvm-target' && fromJson('["3.9", "3.10", "3.11"]') || fromJson('["3.9"]') }}
-        drivers: ["rolling", "lts"]
+        driver: ["rolling", "lts"]
     uses: ./.github/workflows/build-test-reusable.yml
     with:
-      driver_version: ${{ matrix.drivers }}
+      driver_version: ${{ matrix.driver }}
       runner_label: ${{ inputs.runner_label }}
       install_ipex: false
       pytorch_ref: ${{ inputs.pytorch_ref }}

--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -4,10 +4,14 @@ run-name: ${{ inputs.run_name }} - ${{ inputs.python_version }} - ${{ inputs.ins
 on:
   workflow_call:
     inputs:
+      device:
+        description: Device
+        type: string
+        default: max1100
       driver_version:
         description: Driver version
         type: string
-        default: "rolling"
+        default: rolling
       runner_label:
         description: Runner label, keep empty for default
         type: string
@@ -44,7 +48,7 @@ on:
       run_name:
         description: Custom run name
         type: string
-        default: "Build and test"
+        default: Build and test
       build_llvm:
         description: Build LLVM
         type: boolean
@@ -64,9 +68,7 @@ env:
 jobs:
   integration-tests:
     name: Integration tests
-    runs-on:
-      - ${{ inputs.runner_label || 'Linux' }}
-      - ${{ inputs.driver_version }}
+    runs-on: ${{ fromJson(inputs.runner_label && format('["{0}"]', inputs.runner_label) || format('["{0}", "{1}"]', inputs.device, inputs.driver_version)) }}
     defaults:
       run:
         shell: bash -noprofile --norc -eo pipefail -c "source /home/runner/intel/oneapi/setvars.sh > /dev/null; source {0}"
@@ -261,12 +263,12 @@ jobs:
         if: github.ref_name == 'llvm-target'
         uses: actions/upload-artifact@v4
         with:
-          name: pass_rate-${{ inputs.python_version }}-${{ inputs.driver_version }}
+          name: pass_rate-${{ inputs.python_version }}-${{ inputs.runner_label || inputs.driver_version }}
           path: pass_rate.json
 
       - name: Upload test reports
         if: inputs.upload_test_reports
         uses: actions/upload-artifact@v4
         with:
-          name: test-reports-${{ inputs.python_version }}-${{ inputs.driver_version }}
+          name: test-reports-${{ inputs.python_version }}-${{ inputs.runner_label || inputs.driver_version }}
           path: reports

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -96,20 +96,20 @@ jobs:
           path: ${{ steps.pip-cache.outputs.path }}
           dest: ${{ steps.pip-cache.outputs.dest }}
 
-  prepare-matrix:
-    name: Prepare matrix
+  prepare:
+    name: Prepare
     runs-on: Linux
     output:
-      matrix: ${{ steps.prepare-matrix.outputs.matrix }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
-      - name: Print inputs
+      - name: Inputs
         run: |
           cat <<EOF
           ${{ toJSON(inputs) }}
           EOF
 
-      - name: Prepare matrix
-        id: prepare-matrix
+      - name: Matrix
+        id: matrix
         run: |
           if [[ -n "${{ inputs.runner_label }}" ]]; then
             matrix='{"python": ["3.9"]}'
@@ -124,10 +124,10 @@ jobs:
 
   integration-tests:
     name: Matrix
-    needs: prepare-matrix
+    needs: prepare
 
     strategy:
-      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
 
     uses: ./.github/workflows/build-test-reusable.yml
     with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -103,14 +103,25 @@ jobs:
           dest: ${{ steps.pip-cache.outputs.dest }}
 
   integration-tests:
-    name: Integration tests matrix
+    name: Matrix
+
+    env:
+      default_matrix: >
+        {
+          "python": ${{ github.ref_name == 'llvm-target' && '["3.9", "3.10", "3.11"]' || '["3.9"]' }}",
+          "driver": ["rolling", "lts"]
+        }
+      custom_matrix: >
+        {
+          "python": ["3.9"]
+        }
+
     strategy:
-      matrix:
-        python: ${{ github.ref_name == 'llvm-target' && fromJson('["3.9", "3.10", "3.11"]') || fromJson('["3.9"]') }}
-        drivers: ${{ inputs.runner_label && fromJson(format('["{0}"]', inputs.runner_label)) || fromJson('["rolling", "lts"]') }}
+      matrix: ${{ inputs.runner_label && env.custom_matrix || env.default_matrix }}
+
     uses: ./.github/workflows/build-test-reusable.yml
     with:
-      driver_version: ${{ matrix.drivers }}
+      driver_version: ${{ matrix.driver }}
       runner_label: ${{ inputs.runner_label }}
       install_ipex: ${{ inputs.install_ipex || github.event_name == 'pull_request' || github.event_name == 'push' }}
       pytorch_ref: ${{ inputs.pytorch_ref }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -99,7 +99,7 @@ jobs:
   prepare:
     name: Prepare
     runs-on: Linux
-    output:
+    outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - name: Inputs

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -120,7 +120,7 @@ jobs:
               matrix='{"python": ["3.9"], "driver": ["rolling", "lts"]}'
             fi
           fi
-          echo "matrix=$matrix" | tee -a $GITHUB_OUTPUT
+          echo "matrix='$matrix'" | tee -a $GITHUB_OUTPUT
 
   integration-tests:
     name: Matrix

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -59,12 +59,6 @@ jobs:
       - spr
       - cpu
     steps:
-      - name: Print inputs
-        run: |
-          cat <<EOF
-          ${{ toJSON(inputs) }}
-          EOF
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -102,22 +96,38 @@ jobs:
           path: ${{ steps.pip-cache.outputs.path }}
           dest: ${{ steps.pip-cache.outputs.dest }}
 
+  prepare-matrix:
+    name: Prepare matrix
+    runs-on: Linux
+    output:
+      matrix: ${{ steps.prepare-matrix.outputs.matrix }}
+    steps:
+      - name: Print inputs
+        run: |
+          cat <<EOF
+          ${{ toJSON(inputs) }}
+          EOF
+
+      - name: Prepare matrix
+        id: prepare-matrix
+        run: |
+          if [[ -n "${{ inputs.runner_label }}" ]]; then
+            matrix='{"python": ["3.9"]}'
+          else
+            if [[ "${{ github.ref_name }}" = "llvm-target" ]]; then
+              matrix='{"python": ["3.9", "3.10", "3.11"], "driver": ["rolling", "lts"]}'
+            else
+              matrix='{"python": ["3.9"], "driver": ["rolling", "lts"]}'
+            fi
+          fi
+          echo "matrix=$matrix" | tee -a $GITHUB_OUTPUT
+
   integration-tests:
     name: Matrix
-
-    env:
-      default_matrix: >
-        {
-          "python": ${{ github.ref_name == 'llvm-target' && '["3.9", "3.10", "3.11"]' || '["3.9"]' }}",
-          "driver": ["rolling", "lts"]
-        }
-      custom_matrix: >
-        {
-          "python": ["3.9"]
-        }
+    needs: prepare-matrix
 
     strategy:
-      matrix: ${{ inputs.runner_label && env.custom_matrix || env.default_matrix }}
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
 
     uses: ./.github/workflows/build-test-reusable.yml
     with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -99,8 +99,10 @@ jobs:
   prepare:
     name: Prepare
     runs-on: Linux
+
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+
     steps:
       - name: Inputs
         run: |
@@ -120,10 +122,10 @@ jobs:
               matrix='{"python": ["3.9"], "driver": ["rolling", "lts"]}'
             fi
           fi
-          echo "matrix='$matrix'" | tee -a $GITHUB_OUTPUT
+          echo "matrix=$matrix" | tee -a $GITHUB_OUTPUT
 
   integration-tests:
-    name: Matrix
+    name: Integration tests matrix
     needs: prepare
 
     strategy:


### PR DESCRIPTION
By default, `device` is set to `max1100`. Both `device` and `driver_version` are used as labels to select a runner.
If `runner_label` is set, then it will be used to select a runner instead.

Fixes #1542 .