### PR TITLE
[GEN] Use `sub_group_non_uniform_reduce`

### DIFF
--- a/test/Conversion/intel/tritongpu_to_gen.mlir
+++ b/test/Conversion/intel/tritongpu_to_gen.mlir
@@ -1376,63 +1376,63 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
   tt.func public @reduce_all(%arg: tensor<256x1xi32, #blocked>, %arg_0: tensor<256x1xf32, #blocked>) {
 
-    // CHECK: @_Z20sub_group_reduce_addf
+    // CHECK: @_Z32sub_group_non_uniform_reduce_addf
     %0 = "tt.reduce"(%arg_0) <{axis = 0 : i32}> ({
     ^bb0(%arg4: f32, %arg5: f32):
       %48 = arith.addf %arg4, %arg5 : f32
       tt.reduce.return %48 : f32
     }) : (tensor<256x1xf32, #blocked>) -> tensor<1xf32, #slice>
 
-    // CHECK: @_Z20sub_group_reduce_addi
+    // CHECK: @_Z32sub_group_non_uniform_reduce_addi
     %1 = "tt.reduce"(%arg) <{axis = 0 : i32}> ({
     ^bb0(%arg4: i32, %arg5: i32):
       %48 = arith.addi %arg4, %arg5 : i32
       tt.reduce.return %48 : i32
     }) : (tensor<256x1xi32, #blocked>) -> tensor<1xi32, #slice>
 
-    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.f32
+    // CHECK: @_Z32sub_group_non_uniform_reduce_mulf
     %2 = "tt.reduce"(%arg_0) <{axis = 0 : i32}> ({
     ^bb0(%arg4: f32, %arg5: f32):
       %48 = arith.mulf %arg4, %arg5 : f32
       tt.reduce.return %48 : f32
     }) : (tensor<256x1xf32, #blocked>) -> tensor<1xf32, #slice>
 
-    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.i32
+    // CHECK: @_Z32sub_group_non_uniform_reduce_muli
     %3 = "tt.reduce"(%arg) <{axis = 0 : i32}> ({
     ^bb0(%arg4: i32, %arg5: i32):
       %48 = arith.muli %arg4, %arg5 : i32
       tt.reduce.return %48 : i32
     }) : (tensor<256x1xi32, #blocked>) -> tensor<1xi32, #slice>
 
-    // CHECK: @_Z20sub_group_reduce_maxf
+    // CHECK: @_Z32sub_group_non_uniform_reduce_maxf
     %4 = "tt.reduce"(%arg_0) <{axis = 0 : i32}> ({
     ^bb0(%arg4: f32, %arg5: f32):
       %48 = arith.maxnumf %arg4, %arg5 : f32
       tt.reduce.return %48 : f32
     }) : (tensor<256x1xf32, #blocked>) -> tensor<1xf32, #slice>
 
-    // CHECK: @_Z20sub_group_reduce_minf
+    // CHECK: @_Z32sub_group_non_uniform_reduce_minf
     %5 = "tt.reduce"(%arg_0) <{axis = 0 : i32}> ({
     ^bb0(%arg4: f32, %arg5: f32):
       %48 = arith.minnumf %arg4, %arg5 : f32
       tt.reduce.return %48 : f32
     }) : (tensor<256x1xf32, #blocked>) -> tensor<1xf32, #slice>
 
-    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.i32
+    // CHECK: @_Z32sub_group_non_uniform_reduce_andi
     %6 = "tt.reduce"(%arg) <{axis = 0 : i32}> ({
     ^bb0(%arg4: i32, %arg5: i32):
       %48 = arith.andi %arg4, %arg5 : i32
       tt.reduce.return %48 : i32
     }) : (tensor<256x1xi32, #blocked>) -> tensor<1xi32, #slice>
 
-    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.i32
+    // CHECK: @_Z31sub_group_non_uniform_reduce_ori
     %7 = "tt.reduce"(%arg) <{axis = 0 : i32}> ({
     ^bb0(%arg4: i32, %arg5: i32):
       %48 = arith.ori %arg4, %arg5 : i32
       tt.reduce.return %48 : i32
     }) : (tensor<256x1xi32, #blocked>) -> tensor<1xi32, #slice>
 
-    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.i32
+    // CHECK: @_Z32sub_group_non_uniform_reduce_xori
     %8 = "tt.reduce"(%arg) <{axis = 0 : i32}> ({
     ^bb0(%arg4: i32, %arg5: i32):
       %48 = arith.xori %arg4, %arg5 : i32

--- a/test/TritonGEN/tritongen-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-to-llvm.mlir
@@ -142,10 +142,13 @@ module attributes {
 
 // -----
 
-// CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_reduce_addi(i32) -> i32 attributes {passthrough = ["convergent"]}
-// CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_reduce_maxi(i32) -> i32 attributes {passthrough = ["convergent"]}
-// CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_reduce_mini(i32) -> i32 attributes {passthrough = ["convergent"]}
-// CHECK-DAG: llvm.func spir_funccc @llvm.genx.GenISA.WaveAll.i32(i32, i8, i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z32sub_group_non_uniform_reduce_addi(i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z32sub_group_non_uniform_reduce_muli(i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z32sub_group_non_uniform_reduce_mini(i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z32sub_group_non_uniform_reduce_maxi(i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z32sub_group_non_uniform_reduce_andi(i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z31sub_group_non_uniform_reduce_ori(i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z32sub_group_non_uniform_reduce_xori(i32) -> i32 attributes {passthrough = ["convergent"]}
 
 module attributes {
   spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Kernel, Addresses, GroupNonUniformShuffle, Int64], []>, #spirv.resource_limits<subgroup_size = 16>>
@@ -153,27 +156,19 @@ module attributes {
   llvm.func @triton_gen.sub_group_reduce() {
     %0 = llvm.mlir.constant(0 : i32) : i32
     // CHECK: [[VAL:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call spir_funccc @_Z20sub_group_reduce_addi([[VAL]]) {{.*}} : (i32) -> i32
+    // CHECK: llvm.call spir_funccc @_Z32sub_group_non_uniform_reduce_addi([[VAL]]) {{.*}} : (i32) -> i32
     %1 = triton_gen.sub_group_reduce add %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(1 : i8) : i8
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.i32([[VAL]], [[KIND]], [[ZERO]]) {{.*}} : (i32, i8, i32) -> i32
+    // CHECK: llvm.call spir_funccc @_Z32sub_group_non_uniform_reduce_muli([[VAL]]) {{.*}} : (i32) -> i32
     %2 = triton_gen.sub_group_reduce mul %0 {size = 16} : i32
-    // CHECK: llvm.call spir_funccc @_Z20sub_group_reduce_mini([[VAL]]) {{.*}} : (i32) -> i32
+    // CHECK: llvm.call spir_funccc @_Z32sub_group_non_uniform_reduce_mini([[VAL]]) {{.*}} : (i32) -> i32
     %3 = triton_gen.sub_group_reduce min %0 {size = 16} : i32
-    // CHECK: llvm.call spir_funccc @_Z20sub_group_reduce_maxi([[VAL]]) {{.*}} : (i32) -> i32
+    // CHECK: llvm.call spir_funccc @_Z32sub_group_non_uniform_reduce_maxi([[VAL]]) {{.*}} : (i32) -> i32
     %4 = triton_gen.sub_group_reduce max %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(8 : i8) : i8
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.i32([[VAL]], [[KIND]], [[ZERO]]) {{.*}} : (i32, i8, i32) -> i32
+    // CHECK: llvm.call spir_funccc @_Z32sub_group_non_uniform_reduce_andi([[VAL]]) {{.*}} : (i32) -> i32
     %5 = triton_gen.sub_group_reduce and %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(6 : i8) : i8
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.i32([[VAL]], [[KIND]], [[ZERO]]) {{.*}} : (i32, i8, i32) -> i32
+    // CHECK: llvm.call spir_funccc @_Z31sub_group_non_uniform_reduce_ori([[VAL]]) {{.*}} : (i32) -> i32
     %6 = triton_gen.sub_group_reduce or %0 {size = 16} : i32
-    // CHECK: [[KIND:%.*]] = llvm.mlir.constant(7 : i8) : i8
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.call spir_funccc @llvm.genx.GenISA.WaveAll.i32([[VAL]], [[KIND]], [[ZERO]]) {{.*}} : (i32, i8, i32) -> i32
+    // CHECK: llvm.call spir_funccc @_Z32sub_group_non_uniform_reduce_xori([[VAL]]) {{.*}} : (i32) -> i32
     %7 = triton_gen.sub_group_reduce xor %0 {size = 16} : i32
     llvm.return
   }

--- a/test/TritonIntelGPU/tritongpu_reduce_op_lowering.mlir
+++ b/test/TritonIntelGPU/tritongpu_reduce_op_lowering.mlir
@@ -2,7 +2,7 @@
 
 // COM: Tests reduction when threads_per_warp < num_warps.
 
-// CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_reduce_addi(i32) -> i32 attributes {passthrough = ["convergent"]}
+// CHECK-DAG: llvm.func spir_funccc @_Z32sub_group_non_uniform_reduce_addi(i32) -> i32 attributes {passthrough = ["convergent"]}
 // CHECK-DAG: llvm.func spir_funccc @_Z30sub_group_clustered_reduce_addij(i32, i32) -> i32 attributes {passthrough = ["convergent"]}
 
 #blocked = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [64], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
@@ -11,13 +11,13 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 64 
   tt.func @reduce_problem_size_64_threads_per_warp_32(%f : tensor<2048xi32, #blocked>) {
 
   // 1st round intra-warp reduce
-  // CHECK: llvm.call spir_funccc @_Z20sub_group_reduce_addi(%{{.*}})
+  // CHECK: llvm.call spir_funccc @_Z32sub_group_non_uniform_reduce_addi(%{{.*}})
   // CHECK: llvm.store %{{.*}}, %{{.*}} : i32, !llvm.ptr<3>
 
   // 2nd round inter-warp reduce with problem size 64 with threads_per_warp 32
   // CHECK: llvm.call spir_funccc @_Z7barrierj(%{{.*}}) {{.*}} : (i32) -> ()
   // CHECK: [[PARTIAL_REDUCE_0:%.*]] = llvm.load %{{.*}} : !llvm.ptr<3> -> i32
-  // CHECK: llvm.call spir_funccc @_Z20sub_group_reduce_addi(%{{.*}})
+  // CHECK: llvm.call spir_funccc @_Z32sub_group_non_uniform_reduce_addi(%{{.*}})
   // CHECK: llvm.store %{{.*}}, %{{.*}} : i32, !llvm.ptr<3>
 
   // 3rd round inter-warp reduce with problem size 2 with threads_per_warp 32


### PR DESCRIPTION
Verified OpenCL `sub_group_non_uniform_reduce` is lowered to GenISA WaveAll intrinsic.