### PR TITLE
[UT] Automatically generate skiplist when on a new platform

### DIFF
--- a/scripts/automate_skiplist.sh
+++ b/scripts/automate_skiplist.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The target platform
+PLATFORM=$1
+
+if [ "$#" -ne 1 ]; then
+   echo "Please provide the platform name. Usage: $0 arg"
+   exit 1
+fi
+
+BASE=$(cd $(dirname "$0")/../.. && pwd)
+TRITON_PROJ=${BASE}/intel-xpu-backend-for-triton
+
+# Run core test, regression test and interpreter test in mode unskip
+. ${TRITON_PROJ}/scripts/test-triton.sh --core --interpreter --unskip --reports
+
+# Parse logs and get all failed cases for all categories
+TXT_DIR=${TRITON_PROJ}/scripts/skiplist/${PLATFORM}
+mkdir -p "${TXT_DIR}"
+
+for xml_file in ${TRITON_TEST_REPORTS_DIR}/*.xml; do
+    file_name=$(basename ${xml_file} .xml)
+    OUT_FILE=${TXT_DIR}/$file_name.txt
+
+    python ${TRITON_PROJ}/scripts/get_failed_cases.py ${xml_file} ${OUT_FILE}
+done

--- a/scripts/get_failed_cases.py
+++ b/scripts/get_failed_cases.py
@@ -1,0 +1,41 @@
+import xml.etree.ElementTree as ET
+import argparse
+
+
+def create_argument_parser() -> argparse.ArgumentParser:
+    """Create argument parser."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input_file', type=str, help='input XML file')
+    parser.add_argument('output_file', type=str, help='output TXT file')
+    return parser
+
+
+def extract_failed_from_xml(in_file: str, out_file: str):
+    """Process XML log file and output failed cases."""
+    root = ET.parse(in_file).getroot()
+    failed = []
+
+    for testcase in root.findall('.//testcase'):
+        for child in testcase:
+            if child.tag == 'error' or child.tag == 'failure':
+                classname = testcase.get('classname').replace('.', '/') + '.py'
+                case = testcase.get('name')
+                result = f'{classname}::{case}'
+                failed.append(result)
+
+    if len(failed) == 0:
+        return
+
+    with open(out_file, 'w') as f:
+        for result in failed:
+            f.write(result + '\n')
+
+
+def main():
+    """Main."""
+    args = create_argument_parser().parse_args()
+    extract_failed_from_xml(args.input_file, args.output_file)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/pytest-utils.sh
+++ b/scripts/pytest-utils.sh
@@ -7,6 +7,9 @@ TRITON_TEST_SKIPLIST_DIR="${TRITON_TEST_SKIPLIST_DIR:-$SCRIPTS_DIR/skiplist/defa
 TRITON_TEST_WARNING_REPORTS="${TRITON_TEST_WARNING_REPORTS:-false}"
 TRITON_TEST_IGNORE_ERRORS="${TRITON_TEST_IGNORE_ERRORS:-false}"
 
+if [[ $TEST_UNSKIP = true ]]; then
+    TRITON_TEST_IGNORE_ERRORS=true
+fi
 # absolute path for the selected skip list
 TRITON_TEST_SKIPLIST_DIR="$(cd "$TRITON_TEST_SKIPLIST_DIR" && pwd)"
 # absolute path for the current skip list


### PR DESCRIPTION
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `This is for skiplists generation`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

# Functionality

This PR fix https://github.com/intel/intel-xpu-backend-for-triton/issues/1423

# Use

`./scripts/automate_skiplist.sh  ${NEW_PLATFORM}`  gives you 
`./scripts/skiplist/${NEW_PLATFORM}/....txt`
