### PR TITLE
Use minimum subgroup size to determine the required DPAS subgroup size

### DIFF
--- a/test/TritonIntelGPU/accelerate-matmul-ats.mlir
+++ b/test/TritonIntelGPU/accelerate-matmul-ats.mlir
@@ -4,7 +4,7 @@
 #blocked = #triton_gpu.blocked<{sizePerThread = [8, 4], threadsPerWarp = [4, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #triton_gpu.blocked<{sizePerThread = [4, 8], threadsPerWarp = [2, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #triton_gpu.blocked<{sizePerThread = [4, 8], threadsPerWarp = [4, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
-module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.ATS", "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 16 : i32, "triton_intel_gpu.support_dpas"} {
+module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.ATS", "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 16 : i32, "triton_intel_gpu.min_sg_size" = 8 : i32, "triton_intel_gpu.support_dpas"} {
   // CHECK: mma_chain_loop
   tt.func public @mma_chain_loop(
    %170: tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,
@@ -43,7 +43,7 @@ module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.ATS", "triton_gpu.num-
 #blocked = #triton_gpu.blocked<{sizePerThread = [4, 8], threadsPerWarp = [2, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked1 = #triton_gpu.blocked<{sizePerThread = [4, 8], threadsPerWarp = [1, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked2 = #triton_gpu.blocked<{sizePerThread = [1, 16], threadsPerWarp = [2, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
-module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.ATS", "triton_gpu.num-warps" = 8 : i32, "triton_gpu.threads-per-warp" = 16 : i32, "triton_intel_gpu.support_dpas"} {
+module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.ATS", "triton_gpu.num-warps" = 8 : i32, "triton_gpu.threads-per-warp" = 16 : i32, "triton_intel_gpu.min_sg_size" = 8 : i32, "triton_intel_gpu.support_dpas"} {
   // CHECK: chained_dot
   tt.func public @chained_dot(
     %arg0: tensor<64x128xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,
@@ -67,7 +67,7 @@ module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.ATS", "triton_gpu.num-
 #blocked = #triton_gpu.blocked<{sizePerThread = [8, 8], threadsPerWarp = [4, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #triton_gpu.blocked<{sizePerThread = [8, 8], threadsPerWarp = [1, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #triton_gpu.blocked<{sizePerThread = [8, 8], threadsPerWarp = [2, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
-module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.ATS", "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 8 : i32, "triton_intel_gpu.support_dpas"} {
+module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.ATS", "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 8 : i32, "triton_intel_gpu.min_sg_size" = 8 : i32, "triton_intel_gpu.support_dpas"} {
   // CHECK: mma_chain_loop_ats
   tt.func public @mma_chain_loop_ats(
    %170: tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,
@@ -112,7 +112,7 @@ module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.ATS", "triton_gpu.num-
 #blocked = #triton_gpu.blocked<{sizePerThread = [4, 16], threadsPerWarp = [2, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked1 = #triton_gpu.blocked<{sizePerThread = [4, 16], threadsPerWarp = [1, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked2 = #triton_gpu.blocked<{sizePerThread = [1, 32], threadsPerWarp = [2, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
-module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.ATS", "triton_gpu.num-warps" = 8 : i32, "triton_gpu.threads-per-warp" = 8 : i32, "triton_intel_gpu.support_dpas"} {
+module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.ATS", "triton_gpu.num-warps" = 8 : i32, "triton_gpu.threads-per-warp" = 8 : i32, "triton_intel_gpu.min_sg_size" = 8 : i32, "triton_intel_gpu.support_dpas"} {
   // CHECK: chained_dot
   tt.func public @chained_dot(
     %arg0: tensor<64x128xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,

--- a/test/TritonIntelGPU/accelerate-matmul-pvc.mlir
+++ b/test/TritonIntelGPU/accelerate-matmul-pvc.mlir
@@ -4,7 +4,7 @@
 #blocked = #triton_gpu.blocked<{sizePerThread = [8, 4], threadsPerWarp = [4, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #triton_gpu.blocked<{sizePerThread = [4, 8], threadsPerWarp = [2, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #triton_gpu.blocked<{sizePerThread = [4, 8], threadsPerWarp = [4, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
-module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.PVC", "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 16 : i32, "triton_intel_gpu.support_dpas"} {
+module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.PVC", "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 16 : i32, "triton_intel_gpu.min_sg_size" = 16 : i32, "triton_intel_gpu.support_dpas"} {
   // CHECK: mma_chain_loop
   tt.func public @mma_chain_loop(
    %170: tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,
@@ -49,7 +49,7 @@ module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.PVC", "triton_gpu.num-
 #blocked = #triton_gpu.blocked<{sizePerThread = [4, 8], threadsPerWarp = [2, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked1 = #triton_gpu.blocked<{sizePerThread = [4, 8], threadsPerWarp = [1, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked2 = #triton_gpu.blocked<{sizePerThread = [1, 16], threadsPerWarp = [2, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
-module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.PVC", "triton_gpu.num-warps" = 8 : i32, "triton_gpu.threads-per-warp" = 16 : i32, "triton_intel_gpu.support_dpas"} {
+module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.PVC", "triton_gpu.num-warps" = 8 : i32, "triton_gpu.threads-per-warp" = 16 : i32, "triton_intel_gpu.min_sg_size" = 16 : i32, "triton_intel_gpu.support_dpas"} {
   // CHECK: chained_dot
   tt.func public @chained_dot(
     %arg0: tensor<64x128xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,
@@ -75,7 +75,7 @@ module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.PVC", "triton_gpu.num-
 #blocked = #triton_gpu.blocked<{sizePerThread = [8, 8], threadsPerWarp = [4, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #triton_gpu.blocked<{sizePerThread = [8, 8], threadsPerWarp = [1, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #triton_gpu.blocked<{sizePerThread = [8, 8], threadsPerWarp = [2, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
-module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.PVC", "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 8 : i32, "triton_intel_gpu.support_dpas"} {
+module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.PVC", "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 8 : i32, "triton_intel_gpu.min_sg_size" = 16 : i32, "triton_intel_gpu.support_dpas"} {
   // CHECK: mma_chain_loop_ats
   tt.func public @mma_chain_loop_ats(
    %170: tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,
@@ -114,7 +114,7 @@ module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.PVC", "triton_gpu.num-
 #blocked = #triton_gpu.blocked<{sizePerThread = [4, 16], threadsPerWarp = [2, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked1 = #triton_gpu.blocked<{sizePerThread = [4, 16], threadsPerWarp = [1, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked2 = #triton_gpu.blocked<{sizePerThread = [1, 32], threadsPerWarp = [2, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
-module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.PVC", "triton_gpu.num-warps" = 8 : i32, "triton_gpu.threads-per-warp" = 8 : i32, "triton_intel_gpu.support_dpas"} {
+module attributes {"triton_gpu.target" = "xpu:DEVICE_ARCH.PVC", "triton_gpu.num-warps" = 8 : i32, "triton_gpu.threads-per-warp" = 8 : i32, "triton_intel_gpu.min_sg_size" = 16 : i32, "triton_intel_gpu.support_dpas"} {
   // CHECK: chained_dot
   tt.func public @chained_dot(
     %arg0: tensor<64x128xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,

--- a/test/TritonIntelGPU/triton_annotate_module.mlir
+++ b/test/TritonIntelGPU/triton_annotate_module.mlir
@@ -1,8 +1,8 @@
-// RUN: triton-opt %s --split-input-file -triton-annotate-module='target=xpu:DEVICE_ARCH.PVC support-sg-2d-block=true support-dpas=true threads-per-warp=32' | FileCheck %s
+// RUN: triton-opt %s --split-input-file -triton-annotate-module='min-sg-size=16 support-sg-2d-block=true support-dpas=true threads-per-warp=32' | FileCheck %s
 
 module {
   // COM: Ensure that the 'threads-per-warp' attribute is set according to the option.
-  // CHECK: module attributes {triton_gpu.target = "xpu:DEVICE_ARCH.PVC", "triton_gpu.threads-per-warp" = 32 : i32, triton_intel_gpu.support_dpas, triton_intel_gpu.support_sg_2d_block}
+  // CHECK: module attributes {"triton_gpu.threads-per-warp" = 32 : i32, triton_intel_gpu.min_sg_size = 16 : i32, triton_intel_gpu.support_dpas, triton_intel_gpu.support_sg_2d_block}
   tt.func @kernel() {
     tt.return
   }
@@ -13,7 +13,7 @@ module {
 module {
   // COM: Ensure that the 'threads-per-warp' attribute is overwritten when the kernel contains a 'tt.dot'
   //      operation that can be lowered to DPAS instructions.
-  // CHECK: module attributes {triton_gpu.target = "xpu:DEVICE_ARCH.PVC", "triton_gpu.threads-per-warp" = 16 : i32, triton_intel_gpu.support_dpas, triton_intel_gpu.support_sg_2d_block}
+  // CHECK: module attributes {"triton_gpu.threads-per-warp" = 16 : i32,  triton_intel_gpu.min_sg_size = 16 : i32, triton_intel_gpu.support_dpas, triton_intel_gpu.support_sg_2d_block}
   tt.func @kernel() {
     %a = arith.constant dense<1.00e+00> : tensor<128x32xf16>
     %b = arith.constant dense<2.00e+00> : tensor<32x128xf16>

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -161,7 +161,7 @@ class XPUBackend(BaseBackend):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         device_arch = properties["device_arch"]
-        intel.passes.ttgpuir.add_triton_annotate_module(pm, f"xpu:{device_arch}",
+        intel.passes.ttgpuir.add_triton_annotate_module(pm, min(properties["sub_group_sizes"]),
                                                         properties["support_cl_sg_2d_block_io"],
                                                         properties["support_cl_sg_matmul_acc"], opt.threads_per_warp)
         pm.run(mod)

--- a/third_party/intel/include/Analysis/DPAS.h
+++ b/third_party/intel/include/Analysis/DPAS.h
@@ -39,10 +39,6 @@ public:
   ///    (aka threads per warp) size.
   Result canUseDPAS(FunctionOpInterface funcOp) const;
 
-  /// Return the threads per warp (aka subgroup size) supported by the DPAS
-  /// instruction on the given device architecture.
-  static unsigned supportedThreadsPerWarp(DeviceArch arch);
-
   /// Given a DotOp operation, return its DPAS engine type.
   static DPASEngineType getDPASType(DotOp op);
 

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
@@ -21,19 +21,19 @@ def TritonIntelGPU_Dialect : Dialect {
   let extraClassDeclaration = [{
     /// Get the name of the attribute used to indicate the minimum subgroup
     /// size supported by the target device.
-    static llvm::StringRef getMinSGSizeAttrName() {
+    static constexpr llvm::StringRef getMinSGSizeAttrName() {
       return "triton_intel_gpu.min_sg_size";
     }
 
     /// Get the name of the attribute used to indicate whether subgroup 2D block
     /// operations (e.g., 2D block read/write) are available.
-    static llvm::StringRef getSupportSG2DBlockAttrName() {
+    static constexpr llvm::StringRef getSupportSG2DBlockAttrName() {
       return "triton_intel_gpu.support_sg_2d_block";
     }
 
     /// Get the name of the attribute used to indicate whether the DPAS
     /// instruction is available.
-    static llvm::StringRef getSupportDPASAttrName() {
+    static constexpr llvm::StringRef getSupportDPASAttrName() {
       return "triton_intel_gpu.support_dpas";
     }
   }];

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
@@ -19,9 +19,10 @@ def TritonIntelGPU_Dialect : Dialect {
   ];
 
   let extraClassDeclaration = [{
-    /// Get the name of the attribute used to indicate the target architecture.
-    static constexpr ::llvm::StringLiteral getTargetAttrName() {
-      return ::llvm::StringLiteral("triton_gpu.target");
+    /// Get the name of the attribute used to indicate the minimum subgroup
+    /// size supported by the target device.
+    static llvm::StringRef getMinSGSizeAttrName() {
+      return "triton_intel_gpu.min_sg_size";
     }
 
     /// Get the name of the attribute used to indicate whether subgroup 2D block

--- a/third_party/intel/include/TritonAnnotateModule/Passes.td
+++ b/third_party/intel/include/TritonAnnotateModule/Passes.td
@@ -25,9 +25,8 @@ def TritonAnnotateModule: Pass<"triton-annotate-module", "mlir::ModuleOp"> {
   let dependentDialects = ["mlir::triton::TritonDialect"];
 
   let options = [
-    Option<"target", "target",
-           "std::string", /*default*/"\"\"",
-           "the GPU target, e.g., PVC">,
+    Option<"minSGSize", "min-sg-size", "unsigned", /*default*/"32",
+           "minimum subgroup size supported by the target device">,
     Option<"supportSG2DBlock", "support-sg-2d-block", "bool", /*default*/"false",
            "whether subgroup 2D block operations (e.g., 2D block read/write) are available">,
     Option<"supportDPAS", "support-dpas", "bool", /*default*/"false",

--- a/third_party/intel/lib/Analysis/DPAS.cpp
+++ b/third_party/intel/lib/Analysis/DPAS.cpp
@@ -22,9 +22,9 @@ DPASAnalysis::DPASAnalysis(Operation *root) {
       else
         funcToDotMap[funcOp] = {dotOp};
 
-      DPASEngineType dpasEngineType = DPASEngineType::NOT_APPLICABLE;
-      if (supportDPAS)
-        dpasEngineType = DPASAnalysis::getDPASType(dotOp);
+      DPASEngineType dpasEngineType = supportDPAS
+                                          ? DPASAnalysis::getDPASType(dotOp)
+                                          : DPASEngineType::NOT_APPLICABLE;
       if (dpasEngineType == DPASEngineType::FP32_FP32_TF32_TF32 &&
           dotOp.getInputPrecision() != InputPrecision::TF32)
         dpasEngineType = DPASEngineType::NOT_APPLICABLE;
@@ -59,10 +59,9 @@ DPASAnalysis::canUseDPAS(FunctionOpInterface funcOp) const {
     return Result::Maybe;
 
   unsigned threadsPerWarp = cast<IntegerAttr>(threadsPerWarpAttr).getInt();
-  unsigned minSGSize =
-      cast<IntegerAttr>(
-          mod->getAttr(TritonIntelGPUDialect::getMinSGSizeAttrName()))
-          .getInt();
+  unsigned minSGSize = mod->getAttrOfType<IntegerAttr>(
+                              TritonIntelGPUDialect::getMinSGSizeAttrName())
+                           .getInt();
   return (threadsPerWarp == minSGSize) ? Result::True : Result::False;
 }
 

--- a/third_party/intel/lib/TritonAnnotateModule/TritonAnnotateModule.cpp
+++ b/third_party/intel/lib/TritonAnnotateModule/TritonAnnotateModule.cpp
@@ -23,9 +23,11 @@ struct TritonAnnotateModule
 
     mod->setAttr(intel::TritonIntelGPUDialect::getMinSGSizeAttrName(),
                  builder.getI32IntegerAttr(minSGSize));
+
     if (supportSG2DBlock)
       mod->setAttr(intel::TritonIntelGPUDialect::getSupportSG2DBlockAttrName(),
                    builder.getUnitAttr());
+
     if (supportDPAS)
       mod->setAttr(intel::TritonIntelGPUDialect::getSupportDPASAttrName(),
                    builder.getUnitAttr());
@@ -42,8 +44,10 @@ private:
         TritonGPUDialect::getThreadsPerWarpAttrName();
 
     mod.walk([&](FunctionOpInterface funcOp) {
-      // TODO: DPAS lowering only implemented for 16 threads per warp.
-      if (minSGSize != 16)
+      // FIXME: DPAS lowering only implemented for 16 threads per warp, i.e.,
+      // DPAS is not used for devices like ATS.
+      constexpr unsigned supportedThreadsPerWarp = 16;
+      if (minSGSize != supportedThreadsPerWarp)
         return WalkResult::interrupt();
 
       if (dpasAnalysis.canUseDPAS(funcOp) == DPASAnalysis::Result::Maybe) {

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -85,8 +85,8 @@ void init_triton_intel_passes_ttgpuir(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_match_target_size",
                      gpu::intel::createTritonIntelGPUMatchTargetSize);
   ADD_PASS_WRAPPER_OPT_4("add_triton_annotate_module",
-                         gpu::intel::createTritonAnnotateModule,
-                         const std::string &, bool, bool, unsigned);
+                         gpu::intel::createTritonAnnotateModule, unsigned, bool,
+                         bool, unsigned);
 }
 
 void init_triton_intel(py::module &&m) {


### PR DESCRIPTION
Target is obtained from an experimental feature, and requires updating switch cases, which is more error prone.
Minimum subgroup size can be used instead to determine the required DPAS subgroup size.
According to https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_subgroup_matrix_multiply_accumulate.html, OpenCL DPAS built-ins work on target minimal subgroup size.
