### PR TITLE
[E2E] Separate dependencies for PyTorch/IPEX

### DIFF
--- a/.github/actions/install-dependency/action.yml
+++ b/.github/actions/install-dependency/action.yml
@@ -35,12 +35,18 @@ runs:
           echo "PYTHON_VERSION=$PYTHON_VERSION" >> "$GITHUB_ENV"
         fi
 
+    - name: Generate cache key
+      shell: bash
+      run: |
+        DEPENDENCY_CACHE_KEY="${{ inputs.package }}-$PYTHON_VERSION-$(echo ${{ steps.commit-id.outputs.commit_id }} ${{ inputs.extra-cache-key }} | sha256sum - | cut -d\  -f1)"
+        echo "DEPENDENCY_CACHE_KEY=$DEPENDENCY_CACHE_KEY" | tee -a "$GITHUB_ENV"
+
     - name: Try to load package from a cache
       id: cache-load
       uses: ./.github/actions/load
       with:
         path: ${{ inputs.package }}-${{ steps.commit-id.outputs.commit_id }}
-        key: ${{ inputs.package }}-$PYTHON_VERSION-${{ steps.commit-id.outputs.commit_id }}${{ inputs.extra-cache-key }}
+        key: ${{ env.DEPENDENCY_CACHE_KEY }}
 
     - name: Clone package repo
       if: ${{ steps.cache-load.outputs.status == 'miss' }}

--- a/.github/actions/install-dependency/action.yml
+++ b/.github/actions/install-dependency/action.yml
@@ -13,6 +13,9 @@ inputs:
   try-tag-prefix:
     description: Try to use a tag with this prefix if commit/branch specified in `ref` doesn't exist
     default: ""
+  extra-cache-key:
+    description: Cache key suffix
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -37,7 +40,7 @@ runs:
       uses: ./.github/actions/load
       with:
         path: ${{ inputs.package }}-${{ steps.commit-id.outputs.commit_id }}
-        key: ${{ inputs.package }}-$PYTHON_VERSION-${{ steps.commit-id.outputs.commit_id }}
+        key: ${{ inputs.package }}-$PYTHON_VERSION-${{ steps.commit-id.outputs.commit_id }}${{ inputs.extra-cache-key }}
 
     - name: Clone package repo
       if: ${{ steps.cache-load.outputs.status == 'miss' }}

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -186,7 +186,7 @@ jobs:
           repository: huggingface/transformers
           ref: ${{ env.TRANSFORMERS_VERSION }}
           try-tag-prefix: v
-          extra-cache-key: -${{ inputs.install_ipex }}
+          extra-cache-key: ${{ env.PYTORCH_VERSION }}
 
       - name: Install torchvision package
         if: ${{ inputs.suite == 'timm_models' || inputs.suite == 'torchbench' }}
@@ -195,7 +195,7 @@ jobs:
           package: torchvision
           repository: pytorch/vision
           ref: ${{ env.TORCHVISION_COMMIT_ID }}
-          extra-cache-key: -${{ inputs.install_ipex }}
+          extra-cache-key: ${{ env.PYTORCH_VERSION }}
 
       - name: Install torchtext package
         if: ${{ inputs.suite == 'torchbench' }}
@@ -204,7 +204,7 @@ jobs:
           package: torchtext
           repository: pytorch/text
           ref: ${{ env.TORCHTEXT_COMMIT_ID }}
-          extra-cache-key: -${{ inputs.install_ipex }}
+          extra-cache-key: ${{ env.PYTORCH_VERSION }}
 
       - name: Install torchaudio package
         if: ${{ inputs.suite == 'torchbench' }}
@@ -213,7 +213,7 @@ jobs:
           package: torchaudio
           repository: pytorch/audio
           ref: ${{ env.TORCHAUDIO_COMMIT_ID }}
-          extra-cache-key: -${{ inputs.install_ipex }}
+          extra-cache-key: ${{ env.PYTORCH_VERSION }}
 
       - name: Clone pytorch benchmark
         if: ${{ inputs.suite == 'torchbench' }}

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -186,6 +186,7 @@ jobs:
           repository: huggingface/transformers
           ref: ${{ env.TRANSFORMERS_VERSION }}
           try-tag-prefix: v
+          extra-cache-key: -${{ inputs.install_ipex }}
 
       - name: Install torchvision package
         if: ${{ inputs.suite == 'timm_models' || inputs.suite == 'torchbench' }}
@@ -194,6 +195,7 @@ jobs:
           package: torchvision
           repository: pytorch/vision
           ref: ${{ env.TORCHVISION_COMMIT_ID }}
+          extra-cache-key: -${{ inputs.install_ipex }}
 
       - name: Install torchtext package
         if: ${{ inputs.suite == 'torchbench' }}
@@ -202,6 +204,7 @@ jobs:
           package: torchtext
           repository: pytorch/text
           ref: ${{ env.TORCHTEXT_COMMIT_ID }}
+          extra-cache-key: -${{ inputs.install_ipex }}
 
       - name: Install torchaudio package
         if: ${{ inputs.suite == 'torchbench' }}
@@ -210,6 +213,7 @@ jobs:
           package: torchaudio
           repository: pytorch/audio
           ref: ${{ env.TORCHAUDIO_COMMIT_ID }}
+          extra-cache-key: -${{ inputs.install_ipex }}
 
       - name: Clone pytorch benchmark
         if: ${{ inputs.suite == 'torchbench' }}


### PR DESCRIPTION
Use PyTorch version as a part of the composite key for each E2E dependency that requires PyTorch.
Fixes #1618.