### PR TITLE
Minor fix to GEMM benchmark kernel performance regression

### DIFF
--- a/benchmarks/xetla_benchmark/gemm_benchmark.py
+++ b/benchmarks/xetla_benchmark/gemm_benchmark.py
@@ -365,8 +365,8 @@ def benchmark(B, M, N, K, provider):
         ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b), warmup=100, rep=100, quantiles=quantiles,
                                                      fast_flush=False)
     if provider == 'xetla':
-        c = torch.empty((M, N), device='xpu', dtype=torch.float16)
-        d = torch.empty((M, N), device='xpu', dtype=torch.float16)
+        c = torch.empty((M, N), device='xpu', dtype=torch.bfloat16)
+        d = torch.empty((M, N), device='xpu', dtype=torch.bfloat16)
         cnt = torch.empty((M, N), device='xpu', dtype=torch.int32)
         name = "bgemm_shape_{}_{}_{}".format(M, N, K)
         func = getattr(xetla_kernel, name)

--- a/benchmarks/xetla_benchmark/gemm_benchmark.py
+++ b/benchmarks/xetla_benchmark/gemm_benchmark.py
@@ -345,11 +345,11 @@ def matmul(a, b):
     ))
 def benchmark(B, M, N, K, provider):
     if B == 1:
-        a = torch.randn((M, K), device='xpu', dtype=torch.float16)
-        b = torch.randn((K, N), device='xpu', dtype=torch.float16)
+        a = torch.rand((M, K), device='xpu', dtype=torch.bfloat16)
+        b = torch.rand((K, N), device='xpu', dtype=torch.bfloat16)
     else:
-        a = torch.randn((B, M, K), device='xpu', dtype=torch.float16)
-        b = torch.randn((B, K, N), device='xpu', dtype=torch.float16)
+        a = torch.rand((B, M, K), device='xpu', dtype=torch.bfloat16)
+        b = torch.rand((B, K, N), device='xpu', dtype=torch.bfloat16)
 
     quantiles = [0.5, 0.2, 0.8]
 
@@ -358,11 +358,11 @@ def benchmark(B, M, N, K, provider):
         return 2 * M * N * K * 1e-12 / (ms * 1e-3)
 
     if provider == 'onednn':
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), warmup=10, rep=10, quantiles=quantiles,
-                                                     fast_flush=False)
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), warmup=100, rep=100,
+                                                     quantiles=quantiles, fast_flush=False)
         # print(f"oneDNN Peak TFlops {calculate_tflops(min_ms)}")
     if provider == 'triton':
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b), warmup=10, rep=10, quantiles=quantiles,
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b), warmup=100, rep=100, quantiles=quantiles,
                                                      fast_flush=False)
     if provider == 'xetla':
         c = torch.empty((M, N), device='xpu', dtype=torch.float16)
@@ -370,7 +370,7 @@ def benchmark(B, M, N, K, provider):
         cnt = torch.empty((M, N), device='xpu', dtype=torch.int32)
         name = "bgemm_shape_{}_{}_{}".format(M, N, K)
         func = getattr(xetla_kernel, name)
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: func(a, b, c, d, cnt), warmup=10, rep=10,
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: func(a, b, c, d, cnt), warmup=100, rep=100,
                                                      quantiles=quantiles, fast_flush=False)
 
     return calculate_tflops(ms), calculate_tflops(min_ms), calculate_tflops(max_ms)

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -99,7 +99,7 @@ def TTIG_ExtractOp : TTIG_Op<"extract", [Pure]> {
   let hasFolder = 1;
 }
 
-def TTIG_PrefetchOp : TTIG_Op<"prefetch"> {
+def TTIG_PrefetchOp : TTIG_Op<"prefetch", [MemoryEffects<[MemWrite, MemRead]>]> {
   let summary = "Tensor prefetch operation";
   let description = [{
     The `prefetch` operation prefetches an input tensor.

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -99,7 +99,7 @@ def TTIG_ExtractOp : TTIG_Op<"extract", [Pure]> {
   let hasFolder = 1;
 }
 
-def TTIG_PrefetchOp : TTIG_Op<"prefetch", [MemoryEffects<[MemWrite, MemRead]>]> {
+def TTIG_PrefetchOp : TTIG_Op<"prefetch"> {
   let summary = "Tensor prefetch operation";
   let description = [{
     The `prefetch` operation prefetches an input tensor.


### PR DESCRIPTION
After comparing the source code and code generation between POC branch and default branch.
There is no big gap in assemble code generation. The main diff is the input data type and data distribution.

On POC branch, to align with XeTLA, we used `bfloat16` as input dtype and "uniform real distribution" on the interval [0,1) to generate random data (`torch.rand`). 
Current test file uses `float16` and `torch.randn`, which are copied from tutorial file.
This pull request changes those as POC branch.

With this change, the average TFlops for 4k Gemm increase from 234 to 279, tested on IDC Max 1550.