### PR TITLE
Fix issue of some GEMM cases with large size 2D load cannot generate correct results.

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -819,10 +819,10 @@ struct StoreOpConversion
     ArrayRef<unsigned> repCluster = dpasLayout.getRepCluster();
     unsigned valOffset = 0;
     for (int m = 0; m < numRepOuter; ++m) {
-      for (int repM = 0; repM < repCluster[0]; ++repM) {
-        Value offsetY = add(warpId0Offset, i32_val(m * replicaStride[0] +
-                                                   repM * elemsPerInstr[0]));
-        for (int n = 0; n < numRepInner; ++n) {
+      for (int n = 0; n < numRepInner; ++n) {
+        for (int repM = 0; repM < repCluster[0]; ++repM) {
+          Value offsetY = add(warpId0Offset, i32_val(m * replicaStride[0] +
+                                                     repM * elemsPerInstr[0]));
           for (int repN = 0; repN < repCluster[1]; ++repN) {
             Value offsetX =
                 add(warpId1Offset,


### PR DESCRIPTION
The loop order is incorrect when compose the matrix data for 2D store from disaggregate scalar.

The order of the repetitions of each warp are strictly ordered.

An example of the DPAS layout with repCluster shape of [2, 2]
![image](https://github.com/user-attachments/assets/6e4643c7-3c8d-4b5e-893e-43018303b5bb)
