### PR TITLE
Maintain fractional millisecond precision when recording wall time events

### DIFF
--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -22,7 +22,7 @@ else:
             self.record()
 
         def record(self):
-            self.timestamp = time.time_ns() // 1_000_000
+            self.timestamp = time.time_ns() / 1_000_000
 
         def elapsed_time(self, end):
             return end.timestamp - self.timestamp


### PR DESCRIPTION
Use fp division instead of integer division to maintain sub-ms precision. Without this patch, the tutorials fail w/ upstream pytorch on small shapes because the runtime is less than 1ms and we get a divide by zero error in processing the timing. 

cc #1563 