### PR TITLE
[GEN] Change `SubgroupIdOp` return type to be `IndexType`

### DIFF
--- a/test/TritonGEN/tritongen-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-to-llvm.mlir
@@ -1,6 +1,6 @@
 // RUN: triton-opt -convert-tritongen-to-llvm -split-input-file %s | FileCheck %s
 
-// CHECK-DAG: llvm.func spir_funccc @_Z25__spirv_BuiltInSubgroupIdv() -> i32
+// CHECK-DAG: llvm.func spir_funccc @_Z25__spirv_BuiltInSubgroupIdv() -> i64
 // CHECK-DAG: llvm.func spir_funccc @_Z14get_num_groupsj(i32) -> i64 attributes {passthrough = ["nounwind", "willreturn", ["memory", "0"]]}
 // CHECK-DAG: llvm.func spir_funccc @_Z14get_local_sizej(i32) -> i64 attributes {passthrough = ["nounwind", "willreturn", ["memory", "0"]]}
 // CHECK-DAG: llvm.func spir_funccc @_Z12get_group_idj(i32) -> i64 attributes {passthrough = ["nounwind", "willreturn", ["memory", "0"]]}
@@ -49,8 +49,8 @@ llvm.func @gen_special_regs() -> i32 {
   // CHECK: llvm.call spir_funccc @_Z14get_num_groupsj([[TWO3]]) {{.*}} : (i32) -> i64
   %12 = triton_gen.grid.dim.z : i32
 
-  // CHECK: llvm.call spir_funccc @_Z25__spirv_BuiltInSubgroupIdv() {{.*}} : () -> i32
-  %13 = triton_gen.subgroup.id : i32
+  // CHECK: llvm.call spir_funccc @_Z25__spirv_BuiltInSubgroupIdv() {{.*}} : () -> i64
+  %13 = triton_gen.subgroup.id : i64
 
   llvm.return %1 : i32
 }

--- a/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENOps.td
+++ b/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENOps.td
@@ -137,7 +137,7 @@ def TritonGEN_SubgroupIdOp : TritonGEN_Op<"subgroup.id", [Pure]> {
     number from 0 to the number of subgroups minus one.
   }];
   let arguments = (ins);
-  let results = (outs I32:$res);
+  let results = (outs IndexType:$res);
   let assemblyFormat = [{
     attr-dict `:` type($res)
   }];

--- a/third_party/intel/lib/GPUToTritonGEN/IndexIntrinsicsOpLowering.h
+++ b/third_party/intel/lib/GPUToTritonGEN/IndexIntrinsicsOpLowering.h
@@ -99,17 +99,8 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
     MLIRContext *context = rewriter.getContext();
-    const unsigned resBitWidth = 32;
-    Operation *newOp =
-        rewriter.create<TargetOp>(loc, IntegerType::get(context, resBitWidth));
-
-    if (indexBitwidth > resBitWidth) {
-      newOp = rewriter.create<LLVM::SExtOp>(
-          loc, IntegerType::get(context, indexBitwidth), newOp->getResult(0));
-    } else if (indexBitwidth < resBitWidth) {
-      newOp = rewriter.create<LLVM::TruncOp>(
-          loc, IntegerType::get(context, indexBitwidth), newOp->getResult(0));
-    }
+    Operation *newOp = rewriter.create<TargetOp>(
+        loc, IntegerType::get(context, indexBitwidth));
 
     rewriter.replaceOp(op, newOp->getResults());
     return success();

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -734,7 +734,7 @@ struct TritonGENSubgroupIdLowering
   LogicalResult
   matchAndRewrite(TritonGEN::SubgroupIdOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto retType = rewriter.getIntegerType(32);
+    auto retType = getTypeConverter()->getIndexType();
 
     intel::AttributeList attrs;
     LLVM::CallOp callOp = createDeviceFunctionCall(


### PR DESCRIPTION
The return type of `gpu.subgroup_id` is also `IndexType`: https://mlir.llvm.org/docs/Dialects/GPU/#gpusubgroup_id-gpusubgroupidop.