### PR TITLE
Don't deactivate external virtual environment

### DIFF
--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -69,9 +69,6 @@ if [ "$VENV" = true ]; then
   python3 -m venv .venv --prompt triton
   source .venv/bin/activate
   pip install ninja cmake wheel
-elif [ -v VIRTUAL_ENV ]; then
-  echo "**** Cleaning up Python virtualenv ****"
-  deactivate
 fi
 
 if [ ! -d "$PACKAGES_DIR" ]; then


### PR DESCRIPTION
If user has externally configured virtual environment it should not be deactivated. Attempting to do so will just result in error because `deactivate` is a shell function and is not propagated into invoked shell scripts.
```
./scripts/compile-triton.sh: line 74: deactivate: command not found
```
