### PR TITLE
Enhance the ReduceDataDuplication pass for Intel DPAS layout.

### DIFF
--- a/test/TritonIntelGPU/tritonintlgpu-reduce-data-duplication.mlir
+++ b/test/TritonIntelGPU/tritonintlgpu-reduce-data-duplication.mlir
@@ -1,34 +1,34 @@
 // RUN: triton-opt %s -split-input-file --tritonintelgpu-reduce-data-duplication | FileCheck %s
 
-#mma1 = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [32, 1], repCluster = [1, 2], A = [8, 16], B = [16, 32], C = [8, 32]}>
-#mma2 = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 32], repCluster = [1, 2], A = [8, 16], B = [16, 32], C = [8, 32]}>
-module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 32 : i32, triton_gpu.target = "xpu:DEVICE_ARCH.PVC", "triton_gpu.threads-per-warp" = 16 : i32, triton_intel_gpu.min_sg_size = 16 : i32, triton_intel_gpu.support_dpas, triton_intel_gpu.support_sg_2d_block} {
+#dpas1 = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [32, 1], repCluster = [1, 2], A = [8, 16], B = [16, 32], C = [8, 32]}>
+#dpas2 = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 32], repCluster = [1, 2], A = [8, 16], B = [16, 32], C = [8, 32]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 32 : i32, "triton_gpu.threads-per-warp" = 16 : i32, triton_intel_gpu.min_sg_size = 16 : i32, triton_intel_gpu.support_dpas, triton_intel_gpu.support_sg_2d_block} {
   // CHECK-LABEL: no_duplication
-  tt.func public @no_duplication() attributes {noinline = false} {
-    %cst1 = arith.constant dense<0.000000e+00> : tensor<64x32xf16, #mma1>
-    %cst2 = arith.constant dense<0.000000e+00> : tensor<64x32xf16, #mma2>
+  tt.func public @no_duplication() {
+    %cst1 = arith.constant dense<0.000000e+00> : tensor<64x32xf16, #dpas1>
+    %cst2 = arith.constant dense<0.000000e+00> : tensor<64x32xf16, #dpas2>
     // CHECK-NOT: triton_gpu.local_alloc
     // CHECK-NOT: triton_gpu.local_load
-    %108 = triton_gpu.convert_layout %cst1 : tensor<64x32xf16, #mma1> -> tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma1, kWidth = 2}>>
-    %109 = triton_gpu.convert_layout %cst2 : tensor<64x32xf16, #mma2> -> tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma2, kWidth = 2}>>
+    %108 = triton_gpu.convert_layout %cst1 : tensor<64x32xf16, #dpas1> -> tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #dpas1, kWidth = 2}>>
+    %109 = triton_gpu.convert_layout %cst2 : tensor<64x32xf16, #dpas2> -> tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #dpas2, kWidth = 2}>>
     tt.return
   }
 }
 
 // -----
 
-#mma1 = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [32, 1], repCluster = [1, 2], A = [8, 16], B = [16, 32], C = [8, 32]}>
-#mma2 = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 32], repCluster = [1, 2], A = [8, 16], B = [16, 32], C = [8, 32]}>
-module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 32 : i32, triton_gpu.target = "xpu:DEVICE_ARCH.PVC", "triton_gpu.threads-per-warp" = 16 : i32, triton_intel_gpu.min_sg_size = 16 : i32, triton_intel_gpu.support_dpas, triton_intel_gpu.support_sg_2d_block} {
+#dpas1 = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [32, 1], repCluster = [1, 2], A = [8, 16], B = [16, 32], C = [8, 32]}>
+#dpas2 = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 32], repCluster = [1, 2], A = [8, 16], B = [16, 32], C = [8, 32]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 32 : i32, "triton_gpu.threads-per-warp" = 16 : i32, triton_intel_gpu.min_sg_size = 16 : i32, triton_intel_gpu.support_dpas, triton_intel_gpu.support_sg_2d_block} {
   // CHECK-LABEL: reduce_duplication
-  tt.func public @reduce_duplication() attributes {noinline = false} {
-    %cst1 = arith.constant dense<0.000000e+00> : tensor<64x32xf16, #mma1>
-    %cst2 = arith.constant dense<0.000000e+00> : tensor<64x32xf16, #mma2>
+  tt.func public @reduce_duplication() {
+    %cst1 = arith.constant dense<0.000000e+00> : tensor<64x32xf16, #dpas1>
+    %cst2 = arith.constant dense<0.000000e+00> : tensor<64x32xf16, #dpas2>
     // CHECK: triton_gpu.local_alloc
     // CHECK: triton_gpu.local_load
     // CHECK-NOT: triton_gpu.convert_layout
-    %108 = triton_gpu.convert_layout %cst1 : tensor<64x32xf16, #mma1> -> tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma1, kWidth = 2}>>
-    %109 = triton_gpu.convert_layout %cst2 : tensor<64x32xf16, #mma2> -> tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma2, kWidth = 2}>>
+    %108 = triton_gpu.convert_layout %cst1 : tensor<64x32xf16, #dpas1> -> tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #dpas1, kWidth = 2}>>
+    %109 = triton_gpu.convert_layout %cst2 : tensor<64x32xf16, #dpas2> -> tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #dpas2, kWidth = 2}>>
     tt.return
   }
 }

--- a/test/TritonIntelGPU/tritonintlgpu-reduce-data-duplication.mlir
+++ b/test/TritonIntelGPU/tritonintlgpu-reduce-data-duplication.mlir
@@ -1,0 +1,34 @@
+// RUN: triton-opt %s -split-input-file --tritonintelgpu-reduce-data-duplication | FileCheck %s
+
+#mma1 = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [32, 1], repCluster = [1, 2], A = [8, 16], B = [16, 32], C = [8, 32]}>
+#mma2 = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 32], repCluster = [1, 2], A = [8, 16], B = [16, 32], C = [8, 32]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 32 : i32, triton_gpu.target = "xpu:DEVICE_ARCH.PVC", "triton_gpu.threads-per-warp" = 16 : i32, triton_intel_gpu.min_sg_size = 16 : i32, triton_intel_gpu.support_dpas, triton_intel_gpu.support_sg_2d_block} {
+  // CHECK-LABEL: no_duplication
+  tt.func public @no_duplication() attributes {noinline = false} {
+    %cst1 = arith.constant dense<0.000000e+00> : tensor<64x32xf16, #mma1>
+    %cst2 = arith.constant dense<0.000000e+00> : tensor<64x32xf16, #mma2>
+    // CHECK-NOT: triton_gpu.local_alloc
+    // CHECK-NOT: triton_gpu.local_load
+    %108 = triton_gpu.convert_layout %cst1 : tensor<64x32xf16, #mma1> -> tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma1, kWidth = 2}>>
+    %109 = triton_gpu.convert_layout %cst2 : tensor<64x32xf16, #mma2> -> tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma2, kWidth = 2}>>
+    tt.return
+  }
+}
+
+// -----
+
+#mma1 = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [32, 1], repCluster = [1, 2], A = [8, 16], B = [16, 32], C = [8, 32]}>
+#mma2 = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 32], repCluster = [1, 2], A = [8, 16], B = [16, 32], C = [8, 32]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 32 : i32, triton_gpu.target = "xpu:DEVICE_ARCH.PVC", "triton_gpu.threads-per-warp" = 16 : i32, triton_intel_gpu.min_sg_size = 16 : i32, triton_intel_gpu.support_dpas, triton_intel_gpu.support_sg_2d_block} {
+  // CHECK-LABEL: reduce_duplication
+  tt.func public @reduce_duplication() attributes {noinline = false} {
+    %cst1 = arith.constant dense<0.000000e+00> : tensor<64x32xf16, #mma1>
+    %cst2 = arith.constant dense<0.000000e+00> : tensor<64x32xf16, #mma2>
+    // CHECK: triton_gpu.local_alloc
+    // CHECK: triton_gpu.local_load
+    // CHECK-NOT: triton_gpu.convert_layout
+    %108 = triton_gpu.convert_layout %cst1 : tensor<64x32xf16, #mma1> -> tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma1, kWidth = 2}>>
+    %109 = triton_gpu.convert_layout %cst2 : tensor<64x32xf16, #mma2> -> tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma2, kWidth = 2}>>
+    tt.return
+  }
+}

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -247,9 +247,10 @@ def TritonIntelGPUReduceDataDuplication: Pass<"tritonintelgpu-reduce-data-duplic
   let summary = "Reduce data duplication in register by decomposing convert[distributed -> dotOperand] "
                 "into convert[distributed -> shared -> dotOperand]";
 
-  let description = [{Decomposing conversions this way makes it possible to use CSE and reuse #shared tensors.
-                      This Intel pass supports the Intel DPAS layout which is not supported by upstream Triton pass.
-                    }];
+  let description = [{
+    Decomposing conversions this way makes it possible to use CSE and reuse #shared tensors.
+    This Intel pass supports the Intel DPAS layout in additional to the upstream Triton pass.
+  }];
 
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
                            "mlir::triton::gpu::intel::TritonIntelGPUDialect",

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -243,4 +243,17 @@ def TritonIntelGPUMatchTargetSize : Pass<"tritonintelgpu-match-target-size", "ml
                            "mlir::triton::gpu::intel::TritonIntelGPUDialect"];
 }
 
+def TritonIntelGPUReduceDataDuplication: Pass<"tritonintelgpu-reduce-data-duplication", "mlir::ModuleOp"> {
+  let summary = "Reduce data duplication in register by decomposing convert[distributed -> dotOperand] "
+                "into convert[distributed -> shared -> dotOperand]";
+
+  let description = [{Decomposing conversions this way makes it possible to use CSE and reuse #shared tensors.
+                      This Intel pass supports the Intel DPAS layout which is not supported by upstream Triton pass.
+                    }];
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::gpu::intel::TritonIntelGPUDialect",
+                           "mlir::triton::TritonDialect"];
+}
+
 #endif // TRITON_INTEL_GPU_PASSES

--- a/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_triton_library(TritonIntelGPUTransforms
   PrefetchBlock.cpp
   RemoveLayoutConversions.cpp
   RewriteTensorPointer.cpp
+  ReduceDataDuplication.cpp
   Utility.cpp
 
   DEPENDS

--- a/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
@@ -5,9 +5,9 @@ add_triton_library(TritonIntelGPUTransforms
   Pipeliner/MatmulLoopPipeline.cpp
   Pipeliner/SoftwarePipeliner.cpp
   PrefetchBlock.cpp
+  ReduceDataDuplication.cpp
   RemoveLayoutConversions.cpp
   RewriteTensorPointer.cpp
-  ReduceDataDuplication.cpp
   Utility.cpp
 
   DEPENDS

--- a/third_party/intel/lib/TritonIntelGPUTransforms/ReduceDataDuplication.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/ReduceDataDuplication.cpp
@@ -1,0 +1,111 @@
+#include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/TritonGPUConversion.h"
+
+namespace mlir::triton::gpu::intel {
+#define GEN_PASS_DEF_TRITONINTELGPUREDUCEDATADUPLICATION
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
+} // namespace mlir::triton::gpu::intel
+
+namespace ttgi = mlir::triton::gpu::intel;
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::gpu;
+
+namespace {
+
+class TritonIntelGPUReduceDataDuplicationPass
+    : public intel::impl::TritonIntelGPUReduceDataDuplicationBase<
+          TritonIntelGPUReduceDataDuplicationPass> {
+public:
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    mod.walk([&](triton::gpu::ConvertLayoutOp cvtOp) -> void {
+      OpBuilder builder(cvtOp);
+      auto srcType = cast<RankedTensorType>(cvtOp.getSrc().getType());
+      auto dstType = cast<RankedTensorType>(cvtOp.getType());
+      auto srcEncoding = srcType.getEncoding();
+      if (isa<triton::gpu::SharedEncodingAttr>(srcEncoding))
+        return;
+      auto dstDotOp =
+          dyn_cast<triton::gpu::DotOperandEncodingAttr>(dstType.getEncoding());
+      if (!dstDotOp)
+        return;
+      if (auto srcMmaEncoding =
+              dyn_cast<triton::gpu::NvidiaMmaEncodingAttr>(srcEncoding)) {
+
+        if (srcMmaEncoding.getVersionMajor() != 2 ||
+            (srcMmaEncoding.getWarpsPerCTA()[1] == 1 &&
+             dstDotOp.getParent() == srcMmaEncoding))
+          return;
+      }
+      if (auto srcMfmaEncoding =
+              dyn_cast<triton::gpu::AMDMfmaEncodingAttr>(srcEncoding)) {
+
+        if (srcMfmaEncoding.getWarpsPerCTA()[1] == 1 &&
+            srcMfmaEncoding.getIsTransposed() &&
+            dstDotOp.getParent() == srcMfmaEncoding)
+          return;
+      }
+      if (auto srcDpasEncoding =
+              dyn_cast<triton::gpu::intel::DpasEncodingAttr>(srcEncoding)) {
+        unsigned opIdx = dstDotOp.getOpIdx();
+        if ((opIdx == 0 /* Operand A */ &&
+             dstDotOp.getParent() == srcDpasEncoding &&
+             srcDpasEncoding.getWarpsPerCTA()[1] ==
+                 1 /* No parallel on N dim */) ||
+            (opIdx == 1 /* Operand B */ &&
+             dstDotOp.getParent() == srcDpasEncoding &&
+             srcDpasEncoding.getWarpsPerCTA()[0] ==
+                 1 /* No parallel on M dim */))
+          /* The destination dot layout has no duplication. */
+          return;
+      }
+      auto srcOrder = triton::gpu::getOrder(srcEncoding);
+      auto rank = srcOrder.size();
+      SmallVector<unsigned> sharedOrder;
+      if (rank == 3) {
+        // add all elements except the element that is zero
+        for (unsigned i = 0; i < rank; ++i)
+          if (srcOrder[i] != 0)
+            sharedOrder.emplace_back(srcOrder[i]);
+        sharedOrder.emplace_back(0);
+      } else {
+        sharedOrder = srcOrder;
+      }
+      auto sharedMemorySpace =
+          triton::gpu::SharedMemorySpaceAttr::get(srcType.getContext());
+      auto tmpType = triton::MemDescType::get(
+          dstType.getShape(), dstType.getElementType(),
+          triton::gpu::SharedEncodingAttr::get(
+              mod.getContext(), dstDotOp, srcType.getShape(), sharedOrder,
+              triton::gpu::getCTALayout(srcEncoding), srcType.getElementType()),
+          sharedMemorySpace);
+      auto tmp = builder.create<triton::gpu::LocalAllocOp>(
+          cvtOp.getLoc(), tmpType, cvtOp.getSrc());
+      auto newConvert = builder.create<triton::gpu::LocalLoadOp>(cvtOp.getLoc(),
+                                                                 dstType, tmp);
+      cvtOp.replaceAllUsesWith(newConvert.getResult());
+      cvtOp.erase();
+    });
+  }
+};
+
+} // namespace

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -87,6 +87,8 @@ void init_triton_intel_passes_ttgpuir(py::module &&m) {
   ADD_PASS_WRAPPER_OPT_4("add_triton_annotate_module",
                          gpu::intel::createTritonAnnotateModule, unsigned, bool,
                          bool, unsigned);
+  ADD_PASS_WRAPPER_0("add_reduce_data_duplication",
+                     gpu::intel::createTritonIntelGPUReduceDataDuplication);
 }
 
 void init_triton_intel(py::module &&m) {


### PR DESCRIPTION
Skip the optimization to convert the dot layout when there is no data duplication in it.

We should keep the `triton_gpu.convert_layout` ops to the further optimization for some DPAS layout..