### PR TITLE
[Benchmark] Fix xetla batch gemm cases

### DIFF
--- a/benchmarks/triton_kernels_benchmark/gemm_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_benchmark.py
@@ -401,7 +401,6 @@ def benchmark(B, M, N, K, provider):
         func = getattr(xetla_kernel, name)
         xetla_fn = lambda: func(a, b, c, acc, cnt)
         torch_fn = lambda: torch.matmul(a, b).to(torch.float32)
-        # FIXME: XeTLA batch GEMM implemention
         # benchmark_suit.assert_close(xetla_fn(), torch_fn(), atol=1e-4, rtol=1.0, err_msg="xetla to torch")
         ms, min_ms, max_ms, mean, cv = benchmark_suit.do_bench(xetla_fn, warmup=100, rep=100, quantiles=quantiles,
                                                                fast_flush=False)

--- a/benchmarks/xetla_kernel/gemm/gemm_config.hpp
+++ b/benchmarks/xetla_kernel/gemm/gemm_config.hpp
@@ -533,10 +533,10 @@ public:
   static constexpr size_t mat_k = 128;
   static constexpr size_t mat_n = 16384;
   static constexpr size_t wg_m = 8;
-  static constexpr size_t wg_n = 1024;
+  static constexpr size_t wg_n = 512;
   static constexpr size_t sg_m = 8;
-  static constexpr size_t sg_n = 32;
-  static constexpr size_t sg_k = 32;
+  static constexpr size_t sg_n = 16;
+  static constexpr size_t sg_k = 16;
   static constexpr uint32_t local_kslicing = 1;
   static constexpr uint32_t global_kslicing = 1;
   static constexpr gpu::xetla::mem_layout layout_a =


### PR DESCRIPTION
```c++
  cl::sycl::range<3> group_range{Test::global_kslicing, group_range_m,
                                 group_range_n};
  cl::sycl::range<3> local_range{Test::local_kslicing, subgroup_range_m,
                                 subgroup_range_n};
```
Workgroup size always specified as 1 which will produced incorrect performance number for batch cases (`Test::global_kslicing=1` `Test::local_kslicing=1` ). [link](https://github.com/intel/intel-xpu-backend-for-triton/blob/llvm-target/benchmarks/xetla_kernel/gemm/gemm_config.hpp#L563-L564)

Applied latest changes from [XeTLA](https://github.com/intel/xetla/commit/df8ec78f7e8ed44bc75fde7391785159117dbd3d#diff-55a16a92e5dc8e1df8bebacba042c3d2023e0686fec9de8e13b4aabf9f76061cR209-R216).


[CI run: ](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/10158797437/job/28091611606)

```
Before:
B        M        K        N  Triton-GB/s  XeTLA-GB/s  Triton-GB/s-min  XeTLA-GB/s-min  Triton-GB/s-max  XeTLA-GB/s-max  Triton-TFlops  XeTLA-TFlops  Triton-TFlops-min  XeTLA-TFlops-min  Triton-TFlops-max  XeTLA-TFlops-max  Triton-CV  XeTLA-CV
4096.0      8.0    128.0  16384.0   865.344742  1.921683e+06       863.017794    1.803707e+06       867.366082    2.014140e+06       6.150893  13659.371644           6.134353      12820.797178           6.165261      14316.556973   0.001078  0.018122

After:
4096.0      8.0    128.0  16384.0   871.033047  990.080268       868.831495      988.348955       874.432963      992.537507       6.191326      7.037516           6.175677          7.025210           6.215492          7.054982   0.001016  0.000729

```