### PR TITLE
[CI] Refactor `triton-benchmarks.yml`

### DIFF
--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -74,7 +74,7 @@ jobs:
           cd benchmarks
           python setup.py install
 
-      - name: Run triton softmax kernel benchmark
+      - name: Run Triton Softmax kernel benchmark
         run: |
           cd benchmarks/triton_kernels_benchmark
           python fused_softmax.py --reports $REPORTS
@@ -82,6 +82,17 @@ jobs:
           python ../../scripts/build_report.py $REPORTS/softmax-performance.csv $REPORTS/softmax-triton-report.csv --benchmark softmax --compiler triton --param_cols "N" --tflops_col Triton-TFlops-max --hbm_col "Triton-GB/s-max"
           python ../../scripts/build_report.py $REPORTS/softmax-performance.csv $REPORTS/softmax-xetla-report.csv --benchmark softmax --compiler xetla --param_cols "N" --tflops_col XeTLA-TFlops-max --hbm_col "XeTLA-GB/s-max"
 
+      - name: Run Triton GEMM kernel benchmark
+        run: |
+          cd benchmarks/triton_kernels_benchmark
+          TRITON_INTEL_ADVANCED_PATH=1 \
+          TRITON_INTEL_ENABLE_ADDRESS_PAYLOAD_OPT=1 \
+          IGC_VISAOptions=" -TotalGRFNum 256 -enableBCR -nolocalra -printregusage -DPASTokenReduction -enableHalfLSC -abiver 2" \
+          IGC_DisableLoopUnroll=1 \
+          python gemm_benchmark.py --reports $REPORTS
+          source ../../scripts/capture-hw-details.sh
+          python ../../scripts/build_report.py $REPORTS/matmul-performance.csv $REPORTS/gemm-triton-report.csv --benchmark gemm --compiler triton --param_cols "B,M,K,N" --tflops_col Triton-TFlops-max --hbm_col "Triton-GB/s-max"
+          python ../../scripts/build_report.py $REPORTS/matmul-performance.csv $REPORTS/gemm-xetla-report.csv --benchmark gemm --compiler xetla --param_cols "B,M,K,N" --tflops_col XeTLA-TFlops-max --hbm_col "XeTLA-GB/s-max"
 
       - name: Run micro benchmark
         run: |
@@ -193,99 +204,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-attention-reports
-          path: reports
-
-  benchmark-gemm:
-    name: GEMM benchmarks
-    runs-on:
-      - ${{ inputs.runner_label || 'max1550' }}
-    timeout-minutes: 720
-    defaults:
-      run:
-        shell: bash -noprofile --norc -eo pipefail -c "source /home/runner/intel/oneapi/setvars.sh > /dev/null; source {0}"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          path: llvm-target
-
-      - name: Load pip cache
-        id: pip-cache
-        uses: ./.github/actions/load
-        with:
-          path: $HOME/.cache/pip
-          # pip cache per commit id just to minimize network traffic
-          key: pip-$PYTHON_VERSION-$GITHUB_SHA
-
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install Python build dependencies
-        run: |
-          pip install wheel
-
-      - name: Setup PyTorch
-        uses: ./.github/actions/setup-pytorch
-
-      - name: Setup IPEX
-        uses: ./.github/actions/setup-ipex
-
-      - name: Build Triton wheels
-        uses: ./llvm-target/.github/actions/setup-triton
-        with:
-          command: DEBUG=1 python setup.py bdist_wheel
-
-      - name: Install Triton
-        run: |
-          pip install python/dist/*.whl
-
-      - name: Install benchmark dependencies
-        run: |
-          pip install matplotlib pandas tabulate
-
-      - name: Create reports dir
-        run: |
-          mkdir reports
-          echo "REPORTS=$PWD/reports" >> $GITHUB_ENV
-
-      - name: Install benchmarks
-        run: |
-          cd benchmarks
-          python setup.py install
-
-      - name: Run triton gemm kernel benchmark
-        run: |
-          cd benchmarks/triton_kernels_benchmark
-          rm -rf ./tt_cache
-          TRITON_CACHE_DIR=./tt_cache \
-          TRITON_INTEL_ENABLE_ADDRESS_PAYLOAD_OPT=1 \
-          TRITON_INTEL_ADVANCED_PATH=1 \
-          IGC_VISAOptions=" -TotalGRFNum 256 -enableBCR -nolocalra -printregusage -DPASTokenReduction -enableHalfLSC -abiver 2" \
-          IGC_ForcePrefetchToL1Cache=1 \
-          IGC_VATemp=1 \
-          UR_L0_IN_ORDER_BARRIER_BY_SIGNAL=0 \
-          IGC_DisableLoopUnroll=1 \
-          NEO_CACHE_PERSISTENT=0 \
-          SYCL_PROGRAM_COMPILE_OPTIONS=" -vc-codegen -vc-disable-indvars-opt -doubleGRF -Xfinalizer ' -printregusage -enableBCR -DPASTokenReduction ' " \
-          python gemm_benchmark.py --reports $REPORTS
-          source ../../scripts/capture-hw-details.sh
-          python ../../scripts/build_report.py $REPORTS/matmul-performance.csv $REPORTS/gemm-triton-report.csv --benchmark gemm --compiler triton --param_cols "B,M,K,N" --tflops_col Triton-TFlops-max --hbm_col "Triton-GB/s-max"
-          python ../../scripts/build_report.py $REPORTS/matmul-performance.csv $REPORTS/gemm-xetla-report.csv --benchmark gemm --compiler xetla --param_cols "B,M,K,N" --tflops_col XeTLA-TFlops-max --hbm_col "XeTLA-GB/s-max"
-
-      - name: Save pip cache
-        if: ${{ steps.pip-cache.outputs.status == 'miss' }}
-        uses: ./.github/actions/save
-        with:
-          path: ${{ steps.pip-cache.outputs.path }}
-          dest: ${{ steps.pip-cache.outputs.dest }}
-
-      - name: Upload benchmark reports
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-gemm-reports
           path: reports


### PR DESCRIPTION
1. The environment setup for softmax can be reused for GEMM.
2. Remove some unnecessary environment variables from running GEMM. 

https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/10187746673