### PR TITLE
Additional patches for PyTorch upstream

### DIFF
--- a/.github/actions/setup-pytorch/action.yml
+++ b/.github/actions/setup-pytorch/action.yml
@@ -73,7 +73,7 @@ runs:
       uses: ./.github/actions/load
       env:
         # Increase this value to reset cache
-        CACHE_NUMBER: 8
+        CACHE_NUMBER: 9
       with:
         path: pytorch
         key: pytorch-$PYTHON_VERSION-$PYTORCH_COMMIT_ID-$CACHE_NUMBER

--- a/.github/actions/setup-pytorch/action.yml
+++ b/.github/actions/setup-pytorch/action.yml
@@ -92,7 +92,8 @@ runs:
       shell: bash
       run: |
         cd pytorch
-        curl -Ls https://github.com/pytorch/pytorch/pull/126516.diff | git apply -
+        curl -sSL https://github.com/pytorch/pytorch/pull/126516.diff | git apply -
+        curl -sSL https://github.com/pytorch/pytorch/compare/main...ZzEeKkAa:pytorch:triton-zeka.diff | git apply -
 
     # FIXME: Old PyTorch does not work with numpy==2.0.0
     - name: Install numpy < 2.0.0

--- a/.github/workflows/build-test-no-ipex.yml
+++ b/.github/workflows/build-test-no-ipex.yml
@@ -42,6 +42,7 @@ jobs:
       matrix:
         python: ["3.9"]
         driver: ["rolling", "lts"]
+      fail-fast: false
     uses: ./.github/workflows/build-test-reusable.yml
     with:
       driver_version: ${{ matrix.driver }}


### PR DESCRIPTION
Fixes #1748.

Note that PRs in #1748 cannot be applied directly without conflicts, temporary apply commits from https://github.com/pytorch/pytorch/compare/main...ZzEeKkAa:pytorch:triton-zeka.