### PR TITLE
Install torchdata<0.8.0 when using IPEX

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -195,6 +195,12 @@ jobs:
           ref: ${{ env.TORCHVISION_COMMIT_ID }}
           extra-cache-key: ${{ env.PYTORCH_VERSION }}
 
+      # FIXME: old PyTorch does not work with torchdata=0.8.0
+      - name: Install torchdata package
+        if: ${{ inputs.suite == 'torchbench' && inputs.install_ipex }}
+        run: |
+          pip install 'torchdata<0.8.0'
+
       - name: Install torchtext package
         if: ${{ inputs.suite == 'torchbench' }}
         uses: ./.github/actions/install-dependency

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -24,6 +24,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+      fail-fast: false
     defaults:
       run:
         shell: bash -noprofile --norc -eo pipefail -c "source /home/runner/intel/oneapi/setvars.sh > /dev/null; source {0}"
@@ -131,6 +132,8 @@ jobs:
       - name: Install torchtext
         run: |
           pip install text/dist/*.whl
+          # FIXME: old PyTorch does not work with torchdata=0.8.0
+          pip install 'torchdata<0.8.0'
           python -c "import torchtext; print(torchtext.__version__)"
 
       - name: Save torchtext to a cache


### PR DESCRIPTION
The package torchdata 0.8.0 released recently does not work with PyTorch/IPEX version we use, we have to use torchdata<0.8.0.
Fixes #1755.