### PR TITLE
Fix labels for runners

### DIFF
--- a/.github/workflows/auto-update-translator-cid.yml
+++ b/.github/workflows/auto-update-translator-cid.yml
@@ -11,8 +11,8 @@ env:
 jobs:
   update-config:
     runs-on:
-      - glados
-      - spr
+      - max1100
+      - rolling
       - runner-0.0.18
     defaults:
       run:

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -14,8 +14,8 @@ jobs:
   build:
     name: Build
     runs-on:
-      - glados
-      - spr
+      - max1100
+      - rolling
       - runner-0.0.18
     strategy:
       matrix:


### PR DESCRIPTION
After reducing the number of runners some workflows are no longer working.
Using new labels to select the remaining runners. Relates to #1793.