### PR TITLE
[Performance] Use the Intel reduce data duplication pass to replace the upstream one

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -221,7 +221,7 @@ class XPUBackend(BaseBackend):
         passes.ttgpuir.add_prefetch(pm)
         passes.ttgpuir.add_optimize_dot_operands(pm, True)
         intel.passes.ttgpuir.add_remove_layout_conversions(pm)
-        passes.ttgpuir.add_reduce_data_duplication(pm)
+        intel.passes.ttgpuir.add_reduce_data_duplication(pm)
         passes.ttgpuir.add_reorder_instructions(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)


### PR DESCRIPTION
As all the pre-request PRs have been merged, to use the Intel pass for omitting the conversion of DPAS layout to DotOp layout with shortcut.

