### PR TITLE
Enhance the utils of finding the executable SPIRV tools

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -26,7 +26,7 @@ def _path_to_binary(binary: str):
         if os.path.exists(bin) and os.path.isfile(bin):
             try:
                 result = subprocess.check_output([bin, "--version"], stderr=subprocess.STDOUT)
-            except BaseException:
+            except subprocess.CalledProcessError:
                 pass
             if result is not None:
                 version = re.search(r".*SPIRV-Tools v(\d+\.\d+).*", result.decode("utf-8"), flags=re.MULTILINE)

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -24,7 +24,10 @@ def _path_to_binary(binary: str):
     for p in paths:
         bin = p.split(" ")[0]
         if os.path.exists(bin) and os.path.isfile(bin):
-            result = subprocess.check_output([bin, "--version"], stderr=subprocess.STDOUT)
+            try:
+                result = subprocess.check_output([bin, "--version"], stderr=subprocess.STDOUT)
+            except BaseException:
+                pass
             if result is not None:
                 version = re.search(r".*SPIRV-Tools v(\d+\.\d+).*", result.decode("utf-8"), flags=re.MULTILINE)
                 if version is not None:


### PR DESCRIPTION
The `subprocess.check_output` may throw exceptions and interrupt the searching by accident. To ignore the exceptions and continue to search the first usable binary under all the candidate directors.
