### PR TITLE
Enable `test_subprocess.py::test_print` for A770

### DIFF
--- a/scripts/skiplist/a770/subprocess.txt
+++ b/scripts/skiplist/a770/subprocess.txt
@@ -1,9 +1,2 @@
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/800
-test/unit/language/test_subprocess.py::test_print[device_print-float16]
-test/unit/language/test_subprocess.py::test_print[device_print-float32]
-test/unit/language/test_subprocess.py::test_print[device_print-float64]
-test/unit/language/test_subprocess.py::test_print[device_print_scalar-float16]
-test/unit/language/test_subprocess.py::test_print[device_print_scalar-float64]
-test/unit/language/test_subprocess.py::test_print[device_print_scalar-float32]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/1704
 test/unit/language/test_subprocess.py::test_print[device_print_uint-uint32]


### PR DESCRIPTION
Closes https://github.com/intel/intel-xpu-backend-for-triton/issues/1833.

Let's wait for result in https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/10326529474 (the tests are working).