### PR TITLE
Remove unused get_sycl_device method

### DIFF
--- a/benchmarks/triton_kernels_benchmark/benchmark_driver.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_driver.py
@@ -87,10 +87,6 @@ class XPUUtils(object):
         import torch
         return torch.xpu.current_stream().sycl_queue
 
-    def get_sycl_device(self, device_id):
-        import torch
-        return torch.xpu.device(device_id).sycl_device
-
 
 # ------------------------
 # Launcher

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -74,10 +74,6 @@ class XPUUtils(object):
         import torch
         return torch.xpu.current_stream().sycl_queue
 
-    def get_sycl_device(self, device_id):
-        import torch
-        return torch.xpu.device(device_id).sycl_device
-
 
 # ------------------------
 # Launcher


### PR DESCRIPTION
The underlying method/member appears to have been removed from PyTorch.