### PR TITLE
Add elapsed_time check

### DIFF
--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -173,8 +173,8 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fast_flu
         cache = torch.empty(int(cache_size), dtype=torch.int8, device=device_type)
 
     # Estimate the runtime of the function
-    start_event = di.Event(enable_timing=True)
-    end_event = di.Event(enable_timing=True)
+    start_event = Event(enable_timing=True)
+    end_event = Event(enable_timing=True)
     start_event.record()
     for _ in range(5):
         cache.zero_()
@@ -189,8 +189,8 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fast_flu
     # compute number of warmup and repeat
     n_warmup = max(1, int(warmup / estimate_ms))
     n_repeat = max(1, int(rep / estimate_ms))
-    start_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
-    end_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
+    start_event = [Event(enable_timing=True) for i in range(n_repeat)]
+    end_event = [Event(enable_timing=True) for i in range(n_repeat)]
     # Warm-up
     for _ in range(n_warmup):
         fn()

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -5,7 +5,7 @@ import sys
 from contextlib import contextmanager
 from typing import Any, Dict, List
 from . import language as tl
-import torch.xpu
+import torch
 import logging
 
 


### PR DESCRIPTION
Fixes: #1855 

Tested manually. Warning would look like:

```shell
$ python tutorials/01-vector-add.py
WARNING:root:Wall time is used instead of elapsed_time (not supported). The timing measurements could be innacurate.
tensor([1.3713, 1.3076, 0.4940,  ..., 0.6724, 1.2141, 0.9733])
tensor([1.3713, 1.3076, 0.4940,  ..., 0.6724, 1.2141, 0.9733])
The maximum difference between torch and triton is 0.0
vector-add-performance:
           size      Triton       Torch
0        4096.0    2.075676    2.021053
1        8192.0    3.510857    3.828037
2       16384.0    7.728302    7.402410
3       32768.0   13.884746   15.360000
4       65536.0   21.463756   32.230820
5      131072.0   59.941462   59.578182
6      262144.0  106.274595  104.025399
7      524288.0  168.762228  171.710046
8     1048576.0  241.236816  251.256223
9     2097152.0  310.229589  321.649081
10    4194304.0  370.521558  383.158116
11    8388608.0  413.911572  418.036955
12   16777216.0  516.116154  523.089245
13   33554432.0  612.456163  622.146464
14   67108864.0  673.558335  684.877495
15  134217728.0  706.954825  723.779795
```
