### PR TITLE
Retain ownership of kernel and kernel bundle plus code cleanups

### DIFF
--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -63,6 +63,7 @@ def _build(name, src, srcdir, library_dirs, include_dirs, libraries):
         cc_cmd = [cxx]
         if icpx is not None:
             cc_cmd += ["-fsycl"]
+        cc_cmd += ["-O3"]
     else:
         cc_cmd = [cc, "-O3"]
 

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -21,7 +21,6 @@
 #include <numpy/arrayobject.h>
 
 static SyclQueueMap g_sycl_queue_map;
-static ze_context_handle_t g_context = {nullptr};
 
 static std::vector<ze_device_handle_t> g_devices;
 static std::vector<std::pair<sycl::device, ze_device_handle_t>>
@@ -238,8 +237,8 @@ static PyObject *initContext(PyObject *self, PyObject *args) {
       }
     }
   }
-  g_context = g_sycl_queue_map[*sycl_queue].context;
-  return Py_BuildValue("(K)", (uint64_t)g_context);
+  auto context = g_sycl_queue_map[*sycl_queue].context;
+  return Py_BuildValue("(K)", (uint64_t)context);
 }
 
 static PyObject *initDevices(PyObject *self, PyObject *args) {

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -129,7 +129,7 @@ def make_launcher(constants, signature, ids):
         }[ty]
 
     args_format = ''.join([format_of(_extracted_type(ty)) for ty in signature.values()])
-    format = "iiiOKOOOO" + args_format
+    format = "iiiOOOOOO" + args_format
     args_list = ', ' + ', '.join(f"&_arg{i}" for i, ty in signature.items()) if len(signature) > 0 else ''
 
     # generate glue code
@@ -289,10 +289,10 @@ def make_launcher(constants, signature, ids):
       PyObject *kernel_metadata = NULL;
       PyObject *launch_metadata = NULL;
       PyObject *py_obj_stream;
-      void* pKrnl;
+      PyObject* py_kernel;
 
       {' '.join([f"{_extracted_type(ty)} _arg{i}; " for i, ty in signature.items()])}
-      if(!PyArg_ParseTuple(args, \"{format}\", &gridX, &gridY, &gridZ, &py_obj_stream, &pKrnl,
+      if(!PyArg_ParseTuple(args, \"{format}\", &gridX, &gridY, &gridZ, &py_obj_stream, &py_kernel,
                                            &kernel_metadata, &launch_metadata,
                                            &launch_enter_hook, &launch_exit_hook {args_list})) {{
         return NULL;
@@ -324,10 +324,12 @@ def make_launcher(constants, signature, ids):
 
       void * pStream = PyLong_AsVoidPtr(py_obj_stream);
       //error check
-      if(pStream == nullptr || pKrnl == nullptr) return NULL;
+      if(pStream == nullptr || py_kernel == nullptr) return NULL;
 
       sycl::queue stream = *(static_cast<sycl::queue*>(pStream));
-      sycl::kernel kernel = *(static_cast<sycl::kernel*>(pKrnl));
+      sycl::kernel* kernel_ptr = reinterpret_cast<sycl::kernel*>(PyCapsule_GetPointer(py_kernel, "kernel"));
+      if(kernel_ptr == nullptr) return NULL;
+      sycl::kernel kernel = *kernel_ptr;
 
       {"; ".join([f"DevicePtrInfo ptr_info{i} = getPointer(_arg{i}, {i}, stream); if (!ptr_info{i}.valid) return NULL;" if ty[0] == "*" else "" for i, ty in signature.items()])};
       sycl_kernel_launch(gridX, gridY, gridZ, num_warps, threads_per_warp, shared_memory, stream, kernel {',' + ', '.join(f"ptr_info{i}.dev_ptr" if ty[0]=="*" else f"_arg{i}" for i, ty in signature.items()) if len(signature) > 0 else ''});

--- a/third_party/intel/backend/include/sycl_functions.h
+++ b/third_party/intel/backend/include/sycl_functions.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <variant>
 
@@ -61,8 +62,6 @@ create_module(ze_context_handle_t context, ze_device_handle_t device,
   module_description.pBuildFlags = build_flags;
   ze_module_build_log_handle_t buildlog;
   ze_module_handle_t module;
-  auto context_initial = context;
-  auto device_initial = device;
   auto error_no =
       zeModuleCreate(context, device, &module_description, &module, &buildlog);
   if (error_no != ZE_RESULT_SUCCESS) {
@@ -80,13 +79,13 @@ create_module(ze_context_handle_t context, ze_device_handle_t device,
 
 std::tuple<ze_kernel_handle_t, ze_result_t>
 create_function(ze_module_handle_t module, ze_kernel_flags_t flag,
-                std::string func_name) {
+                std::string_view func_name) {
   ze_kernel_handle_t kernel;
   ze_kernel_desc_t kernel_description = {};
   kernel_description.stype = ZE_STRUCTURE_TYPE_KERNEL_DESC;
   kernel_description.pNext = nullptr;
   kernel_description.flags = flag;
-  kernel_description.pKernelName = func_name.c_str();
+  kernel_description.pKernelName = func_name.data();
   assert(module);
   auto module_initial = module;
   if (getBoolEnv("MLIR_ENABLE_DUMP")) {
@@ -97,7 +96,7 @@ create_function(ze_module_handle_t module, ze_kernel_flags_t flag,
 }
 
 std::tuple<ze_kernel_handle_t, ze_result_t>
-create_function(ze_module_handle_t module, std::string func_name) {
+create_function(ze_module_handle_t module, std::string_view func_name) {
   return create_function(module, ZE_KERNEL_FLAG_FORCE_RESIDENCY, func_name);
 }
 
@@ -122,9 +121,11 @@ std::vector<sycl::device> update(sycl::queue sycl_queue,
   ze_context_handle_t hCtxt =
       sycl::get_native<sycl::backend::ext_oneapi_level_zero>(sycl_context);
   // Get l0-device
-  std::vector<sycl::device> sycl_devices = sycl_context.get_devices();
+  const std::vector<sycl::device> &sycl_devices = sycl_context.get_devices();
+  assert(sycl_devices.size() > 0);
   ze_device_handle_t hDev =
-      sycl::get_native<sycl::backend::ext_oneapi_level_zero>(sycl_devices[0]);
+      sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
+          sycl_devices.front());
   // Get l0-queue
   bool immediate_cmd_list = false;
   std::variant<ze_command_queue_handle_t, ze_command_list_handle_t> queue_var =

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -130,7 +130,7 @@ void init_triton_intel(py::module &&m) {
 
   m.def(
       "translate_to_spirv",
-      [](const std::string llvmIR) -> std::tuple<py::object, std::string> {
+      [](const std::string &llvmIR) -> std::tuple<py::object, std::string> {
         std::string name;
         std::string spirvBitcode;
         {
@@ -149,7 +149,7 @@ void init_triton_intel(py::module &&m) {
           }
           // Get name of kernel in the module
           std::set<llvm::Function *> kernels;
-          uint32_t numKernels = findKernels(*module, kernels);
+          const uint32_t numKernels = findKernels(*module, kernels);
           assert(numKernels == 1 && "Expecting a single SPIR kernel");
           name = (*kernels.begin())->getName().str();
           spirvBitcode = triton::translateLLVMIRToSPIRV(*module);


### PR DESCRIPTION
While working on the cached native code feature, I discovered some areas for improvement in our c++ code supporting spirv and sycl compilation. The major change here is to use a `PyCapsule` object to maintain ownership of the `sycl::kernel` and `sycl::kernel_bundle` generated code owners after code compilation in `loadBinary`. This means we no longer need to store compiled kernels in a global variable inside the compiled `driver.c` library, and the Triton Python code will properly cleanup kernel artifacts when the owning python object is garbage collected. Additional cleanups are to improve legibility or are small optimizations. I did some local testing to ensure PyCapsule did not negatively impact performance and I did not notice performance impacts, so I think for now this is mostly a correctness change (the performance improvements of the C++ code I changed are likely small, but we should still follow core guidelines where possible).

Close #1883 

~I have one or two small changes to push if this passes benchmarks and CI, so I am leaving it as a draft for now. The bulk of the changes are ready for review.~
The branch was out of date with llvm-target so I rebased and pushed my additional two commits. 