### PR TITLE
Disable fail-fast for Python matrix workflow

### DIFF
--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -75,6 +75,7 @@ jobs:
 
     strategy:
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+      fail-fast: false
 
     uses: ./.github/workflows/build-test-reusable.yml
     with:


### PR DESCRIPTION
We need to test all supported versions of Python, even if one job of the matrix fails we want to continue testing other versions.