### PR TITLE
Fix upstream pytorch installation from nightly builds in the `compile-pytorch-ipex` script

### DIFF
--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -122,7 +122,7 @@ if [ "$TRITON_TEST_REPORTS" == true ]; then
     capture_runtime_env
 fi
 
-$SKIP_DEPS || $SCRIPTS_DIR/compile-pytorch-ipex.sh --pinned $ARGS
+$SKIP_DEPS || $SCRIPTS_DIR/compile-pytorch-ipex.sh --upstream-pytorch --pinned $([ $VENV = true ] && echo "--venv")
 
 if [ ! -d "$TRITON_PROJ_BUILD" ]
 then


### PR DESCRIPTION
Closes #1949

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
