### PR TITLE
[fix] fix no pip in a workflow

### DIFF
--- a/.github/workflows/bandit-check.yml
+++ b/.github/workflows/bandit-check.yml
@@ -17,6 +17,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
       - name: Files check
         run: |
           pip install bandit


### PR DESCRIPTION
One dependency of: https://github.com/intel/intel-xpu-backend-for-triton/issues/1476

Missed pip cache and python install in `bandit-check.yml`

Successful run:https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/10483986701/job/29037577073?pr=1963