### PR TITLE
[CI][Microbench] Renamed FA benchmark for consistency

### DIFF
--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -253,7 +253,7 @@ jobs:
           sed -E 's/, /,/g;s/ /,/g' summary.csv > attention-results.csv
           source ../../scripts/capture-hw-details.sh
           TAG=${{ inputs.tag || 'ci' }}-adv
-          python ./build_report.py attention-results.csv $REPORTS/attention-triton-advanced-report.csv --benchmark flash_attention --compiler triton --tflops_col max_tflops --param_cols "Z,H,N_CTX,D_HEAD" --tag $TAG
+          python ./build_report.py attention-results.csv $REPORTS/attention-triton-advanced-report.csv --benchmark attn --compiler triton --tflops_col max_tflops --param_cols "Z,H,N_CTX,D_HEAD" --tag $TAG
 
       - name: Save pip cache
         if: ${{ steps.pip-cache.outputs.status == 'miss' }}


### PR DESCRIPTION
Right now we have `attn` benchmark that is being run on `llvm-target` branch and old `flash_attention` benchmark from POC branch. Looks like we want to compare these 2 runs, so we need to rename one of them for consistency.

Closes https://github.com/intel/intel-xpu-backend-for-triton/issues/1996