### PR TITLE
Enable ruff for benchmarks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,14 @@ repos:
       args: ["-c", "bandit.yaml", "-s", "B404,B603,B607"]
       stages: [commit, push, manual]
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.3
+    hooks:
+      - id: ruff
+        files: '^benchmarks/.*'
+        args: ["--fix", "--line-length", "120"]
+        stages: [commit, push, manual]
+
 exclude: |
   (?x)(
     ^include/triton/external/|

--- a/benchmarks/micro_benchmarks/conversion/__init__.py
+++ b/benchmarks/micro_benchmarks/conversion/__init__.py
@@ -1,0 +1,1 @@
+from .float_conversion.float_conversion import benchmark  # type: ignore # noqa: F401

--- a/benchmarks/micro_benchmarks/conversion/__init__.py
+++ b/benchmarks/micro_benchmarks/conversion/__init__.py
@@ -1,1 +1,0 @@
-from .float_conversion.float_conversion import benchmark  # type: ignore # noqa: F401

--- a/benchmarks/micro_benchmarks/conversion/float_conversion/__init__.py
+++ b/benchmarks/micro_benchmarks/conversion/float_conversion/__init__.py
@@ -1,0 +1,1 @@
+from .float_conversion import benchmark  # type: ignore # noqa: F401

--- a/benchmarks/micro_benchmarks/conversion/float_conversion/__init__.py
+++ b/benchmarks/micro_benchmarks/conversion/float_conversion/__init__.py
@@ -1,1 +1,0 @@
-from .float_conversion import benchmark

--- a/benchmarks/micro_benchmarks/conversion/float_conversion/float_conversion.py
+++ b/benchmarks/micro_benchmarks/conversion/float_conversion/float_conversion.py
@@ -1,5 +1,5 @@
 import torch
-import intel_extension_for_pytorch
+import intel_extension_for_pytorch  # type: ignore # noqa: F401
 
 import triton
 import triton.language as tl

--- a/benchmarks/setup.py
+++ b/benchmarks/setup.py
@@ -1,20 +1,11 @@
 from setuptools import setup
-from setuptools.command.build_clib import build_clib
-from setuptools.command.egg_info import egg_info
-from setuptools import setup, distutils
-from pathlib import Path
 
 import sysconfig
-import distutils.ccompiler
-import distutils.command.clean
 import os
-import glob
-import platform
 import shutil
 import subprocess
 import sys
 import re
-import errno
 import torch
 import intel_extension_for_pytorch
 

--- a/benchmarks/triton_kernels_benchmark/__init__.py
+++ b/benchmarks/triton_kernels_benchmark/__init__.py
@@ -1,12 +1,6 @@
-import torch
-import intel_extension_for_pytorch
-from . import xetla_kernel
-from . import benchmark_testing
-from .benchmark_testing import do_bench, assert_close, perf_report, Benchmark
-
-import triton
 import triton.runtime.driver as driver
 from . import benchmark_driver
+from .benchmark_testing import do_bench, assert_close, perf_report, Benchmark  # type: ignore # noqa: F401
 
 # replace the launcher with the profilier hook.
 driver.active.launcher_cls = benchmark_driver.XPULauncher

--- a/benchmarks/triton_kernels_benchmark/benchmark_driver.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_driver.py
@@ -1,8 +1,6 @@
 import os
 import hashlib
 import tempfile
-import sysconfig
-import setuptools
 from pathlib import Path
 from triton.runtime.cache import get_cache_manager
 from triton.backends.compiler import GPUTarget

--- a/benchmarks/triton_kernels_benchmark/benchmark_testing.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_testing.py
@@ -1,11 +1,11 @@
 import argparse
 import functools
+import itertools
 import os
 import subprocess
 import sys
 from contextlib import contextmanager
 from typing import Any, Dict, List
-import itertools
 
 
 def synchronize():
@@ -347,17 +347,6 @@ class Mark:
         return None
 
 
-def perf_report(benchmarks):
-    """
-    Mark a function for benchmarking. The benchmark can then be executed by using the :code:`.run` method on the return value.
-
-    :param benchmarks: Benchmarking configurations.
-    :type benchmarks: List of :class:`Benchmark`
-    """
-    wrapper = lambda fn: Mark(fn, benchmarks)
-    return wrapper
-
-
 def save_path_from_args(save_path: str):
     """Returns a save path that is specified as an argument or via --reports comman line option."""
     if save_path:
@@ -431,3 +420,12 @@ def set_gpu_clock(ref_sm_clock=1350, ref_mem_clock=1215):
         subprocess.check_output(["nvidia-smi", "-i", "0", "-pm", "0"])
         subprocess.check_output(["nvidia-smi", "-i", "0", "-rgc"])
         subprocess.check_output(["nvidia-smi", "-i", "0", "-rmc"])
+
+
+def nvsmi(attrs):
+    attrs = ','.join(attrs)
+    cmd = ['nvidia-smi', '-i', '0', '--query-gpu=' + attrs, '--format=csv,noheader,nounits']
+    out = subprocess.check_output(cmd)
+    ret = out.decode(sys.stdout.encoding).split(',')
+    ret = [int(x) for x in ret]
+    return ret

--- a/benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py
@@ -54,6 +54,7 @@ def _kernel(A, B, C,  #
             b = tl.load(b_block_ptr)
         else:
             # FIXME: Undefined name `rk`
+            # https://github.com/intel/intel-xpu-backend-for-triton/issues/2012
             raise NotImplementedError()
             # k_remaining = K - k * (BLOCK_K * SPLIT_K)
             # _0 = tl.zeros((1, 1), dtype=C.dtype.element_ty)

--- a/benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py
@@ -53,10 +53,12 @@ def _kernel(A, B, C,  #
             a = tl.load(a_block_ptr)
             b = tl.load(b_block_ptr)
         else:
-            k_remaining = K - k * (BLOCK_K * SPLIT_K)
-            _0 = tl.zeros((1, 1), dtype=C.dtype.element_ty)
-            a = tl.load(a_block_ptr, mask=rk[None, :] < k_remaining, other=_0)
-            b = tl.load(b_block_ptr, mask=rk[:, None] < k_remaining, other=_0)
+            # FIXME: Undefined name `rk`
+            raise NotImplementedError()
+            # k_remaining = K - k * (BLOCK_K * SPLIT_K)
+            # _0 = tl.zeros((1, 1), dtype=C.dtype.element_ty)
+            # a = tl.load(a_block_ptr, mask=rk[None, :] < k_remaining, other=_0)
+            # b = tl.load(b_block_ptr, mask=rk[:, None] < k_remaining, other=_0)
         acc += tl.dot(a, b, out_dtype=acc_dtype)
         a_block_ptr = tl.advance(a_block_ptr, (0, BLOCK_K * SPLIT_K))
         b_block_ptr = tl.advance(b_block_ptr, (BLOCK_K * SPLIT_K, 0))


### PR DESCRIPTION
Enabling `ruff` for `benchmarks` also fixing the existing issues found by `ruff`.

Since upstream uses `ruff` for python code it is reasonable to enable it for downstream code as well. Related to #2001.