### PR TITLE
Enable ruff for scripts, third_party/intel

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
     rev: v0.1.3
     hooks:
       - id: ruff
-        files: '^benchmarks/.*'
+        files: '^(benchmarks|third_party/intel|scripts)/.*'
         args: ["--fix", "--line-length", "120"]
         stages: [commit, push, manual]
 

--- a/benchmarks/micro_benchmarks/conversion/__init__.py
+++ b/benchmarks/micro_benchmarks/conversion/__init__.py
@@ -1,0 +1,1 @@
+from .float_conversion.float_conversion import benchmark  # type: ignore # noqa: F401

--- a/benchmarks/micro_benchmarks/conversion/__init__.py
+++ b/benchmarks/micro_benchmarks/conversion/__init__.py
@@ -1,1 +1,0 @@
-from .float_conversion.float_conversion import benchmark  # type: ignore # noqa: F401

--- a/scripts/build_report.py
+++ b/scripts/build_report.py
@@ -50,7 +50,7 @@ def transform_df(df, param_cols, tflops_col, hbm_col, benchmark, compiler, tag):
         for n in ["libigc1_version", "level_zero_version", "gpu_device", "agama_version"]
     }
     if not host_info["gpu_device"]:
-        raise RuntimeError(f"Could not find GPU device description, was capture_device.sh called?")
+        raise RuntimeError("Could not find GPU device description, was capture_device.sh called?")
     for name, val in host_info.items():
         df_results[name] = val
 

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -1,4 +1,4 @@
-from triton.backends.compiler import BaseBackend, GPUTarget
+from triton.backends.compiler import BaseBackend
 from triton._C.libtriton import ir, passes, llvm, intel
 
 from dataclasses import dataclass
@@ -11,7 +11,6 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from packaging.version import Version
 
 
 @functools.lru_cache()
@@ -60,7 +59,7 @@ class XPUOptions:
                                                  str(default_libdir / 'libsycl-spir64-unknown-unknown.bc'))
         object.__setattr__(self, 'extern_libs', tuple(extern_libs.items()))
         if self.num_warps <= 0 or (self.num_warps & (self.num_warps - 1)) != 0:
-            raise AssertionError(f"num_warps must be a power of 2")
+            raise AssertionError("num_warps must be a power of 2")
 
     def hash(self):
         key = '_'.join([f'{name}-{val}' for name, val in self.__dict__.items()])
@@ -118,7 +117,7 @@ class XPUBackend(BaseBackend):
     def __init__(self, target: tuple) -> None:
         super().__init__(target)
         if not isinstance(target.arch, dict):
-            raise TypeError(f"target.arch is not a dict")
+            raise TypeError("target.arch is not a dict")
         self.properties = self.parse_target(target.arch)
         self.binary_ext = "spv"
 
@@ -280,7 +279,7 @@ class XPUBackend(BaseBackend):
             metadata["build_flags"] = "-cl-intel-128-GRF-per-thread"
         elif options.grf_mode == 'large':
             if options.num_warps > 32:
-                raise RuntimeError(f"grf_mode = large cannot be used with num_warps > 32")
+                raise RuntimeError("grf_mode = large cannot be used with num_warps > 32")
             metadata["build_flags"] = "-cl-intel-256-GRF-per-thread"
         elif options.grf_mode == 'auto':
             metadata["build_flags"] = "-cl-intel-enable-auto-large-GRF-mode"


### PR DESCRIPTION
Enabling `ruff` for `scripts`, `third_party/intel` also fixing the existing issues found by ruff.

Since upstream uses ruff for python code it is reasonable to enable it for downstream code as well. Related to https://github.com/intel/intel-xpu-backend-for-triton/issues/2001.