### PR TITLE
[TT-TO-TTGWARP] Detect and handle flash attention with causal masking

### DIFF
--- a/test/Conversion/intel/triton_to_tritongpu_warp.mlir
+++ b/test/Conversion/intel/triton_to_tritongpu_warp.mlir
@@ -8,7 +8,7 @@
 // CHECK: #triton_gpu.blocked<{sizePerThread = [32, 64], threadsPerWarp = [1, 1], warpsPerCTA = [8, 4], order = [1, 0]}>
 // CHECK: "triton_gpu.num-warps" = 32
 module {
-  tt.func public @matmul_kernel_with_block_pointers(%arg0: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+  tt.func public @matmul_kernel_with_block_pointers(%arg0: !tt.ptr<f16, 1>, %arg1: !tt.ptr<f16, 1>, %arg2: !tt.ptr<f32, 1>, %arg3: i32, %arg4: i32, %arg5: i32) {
     // CHECK: tt.load
     // CHECK-SAME: tensor<256x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}
     // CHECK: tt.load
@@ -57,7 +57,7 @@ module {
 // CHECK1: #triton_gpu.blocked<{sizePerThread = [8, 32], threadsPerWarp = [1, 1], warpsPerCTA = [1, 8], order = [1, 0]}>
 // CHECK1: "triton_gpu.num-warps" = 8
 module {
-  tt.func public @matmul_kernel_with_block_pointers(%arg0: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+  tt.func public @matmul_kernel_with_block_pointers(%arg0: !tt.ptr<f16, 1>, %arg1: !tt.ptr<f16, 1>, %arg2: !tt.ptr<f32, 1>, %arg3: i32, %arg4: i32, %arg5: i32) {
     // CHECK1: tt.load
     // CHECK1-SAME: tensor<8x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}
     // CHECK1: tt.load
@@ -198,7 +198,7 @@ module {
 // CHECK1: #triton_gpu.blocked<{sizePerThread = [16, 64], threadsPerWarp = [1, 1], warpsPerCTA = [8, 1], order = [1, 0]}>
 // CHECK1: "triton_gpu.num-warps" = 8
 module {
-  tt.func public @_attn_fwd(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: f32, %arg4: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg5: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+  tt.func public @_attn_fwd(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>, %arg3: f32, %arg4: !tt.ptr<f32>, %arg5: !tt.ptr<f32>) {
     %cst = arith.constant dense<1.000000e+00> : tensor<128xf32>
     %cst_0 = arith.constant dense<0xFF800000> : tensor<128xf32>
     %c1_i32 = arith.constant 1 : i32
@@ -274,9 +274,9 @@ module {
       %61 = tt.advance %arg11, [%c0_i32, %c64_i32] : <tensor<64x64xf16>>
       scf.yield %53, %59, %43, %60, %61 : tensor<128xf32>, tensor<128x64xf32>, tensor<128xf32>, !tt.ptr<tensor<64x64xf16>>, !tt.ptr<tensor<64x64xf16>>
       // CHECK1: workload = 4
-    } {tt.divisibility_arg1 = dense<64> : tensor<1xi32>}
+    }
     gpu.barrier
-    %26 = arith.muli %0, %c128_i32 {tt.divisibility = dense<128> : tensor<1xi32>} : i32
+    %26 = arith.muli %0, %c128_i32 : i32
     %27 = arith.addi %0, %c1_i32 : i32
     %28 = arith.muli %27, %c128_i32 : i32
     %29 = tt.advance %14, [%c0_i32, %26] : <tensor<64x64xf16>>
@@ -330,7 +330,7 @@ module {
       %66 = tt.advance %arg11, [%c0_i32, %c64_i32] : <tensor<64x64xf16>>
       scf.yield %58, %64, %49, %65, %66 : tensor<128xf32>, tensor<128x64xf32>, tensor<128xf32>, !tt.ptr<tensor<64x64xf16>>, !tt.ptr<tensor<64x64xf16>>
       // CHECK1: workload = 4
-    } {tt.divisibility_arg1 = dense<64> : tensor<1xi32>}
+    }
     %36 = tt.expand_dims %35#0 {axis = 1 : i32} : tensor<128xf32> -> tensor<128x1xf32>
     %37 = tt.broadcast %36 : tensor<128x1xf32> -> tensor<128x64xf32>
     %38 = arith.divf %35#1, %37 : tensor<128x64xf32>

--- a/test/Conversion/intel/triton_to_tritongpu_warp.mlir
+++ b/test/Conversion/intel/triton_to_tritongpu_warp.mlir
@@ -1,5 +1,9 @@
-// RUN: triton-opt %s -split-input-file --convert-triton-to-tritongpu-warp="num-warps=32"  | FileCheck %s --check-prefix=CHECK
-// RUN: triton-opt %s -split-input-file --convert-triton-to-tritongpu-warp="num-warps=8"  | FileCheck %s --check-prefix=CHECK1
+// RUN: triton-opt %s -split-input-file --convert-triton-to-tritongpu-warp="num-warps=32"  | FileCheck %s --check-prefix=CHECK --implicit-check-not="tensor<{{[0-9]+x[0-9]+x[if][0-9]+}}>"
+// RUN: triton-opt %s -split-input-file --convert-triton-to-tritongpu-warp="num-warps=8"  | FileCheck %s --check-prefix=CHECK1 --implicit-check-not="tensor<{{[0-9]+x[0-9]+x[if][0-9]+}}>"
+
+// COM: The implicit-check-not ensures that an encoding attribute is added to all 2D tensors.
+// COM: Ideally, we should also check 1D tensors, but there are some tensor-typed attributes (`tt.divisibility_arg1`) that are not changed by the pass,
+// COM: which are impractical to filter out.
 
 // CHECK: #triton_gpu.blocked<{sizePerThread = [32, 64], threadsPerWarp = [1, 1], warpsPerCTA = [8, 4], order = [1, 0]}>
 // CHECK: "triton_gpu.num-warps" = 32
@@ -181,6 +185,156 @@ module {
     %23 = tt.broadcast %22 : tensor<128x1xf32> -> tensor<128x64xf32>
     %24 = arith.divf %21#1, %23 : tensor<128x64xf32>
     tt.store %16, %24 : !tt.ptr<tensor<128x64xf32>>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: FlashAttention with causal masking
+// COM: - two loops with workload=attention (=4) are detected
+// COM: - encodings are propagated to the operations that correspond to the causal mask computation
+
+// CHECK1: #triton_gpu.blocked<{sizePerThread = [16, 64], threadsPerWarp = [1, 1], warpsPerCTA = [8, 1], order = [1, 0]}>
+// CHECK1: "triton_gpu.num-warps" = 8
+module {
+  tt.func public @_attn_fwd(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: f32, %arg4: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg5: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<1.000000e+00> : tensor<128xf32>
+    %cst_0 = arith.constant dense<0xFF800000> : tensor<128xf32>
+    %c1_i32 = arith.constant 1 : i32
+    %cst_1 = arith.constant dense<-1.000000e+06> : tensor<128x64xf32>
+    %c64_i32 = arith.constant 64 : i32
+    %cst_2 = arith.constant dense<0.000000e+00> : tensor<128x64xf32>
+    %c65536_i64 = arith.constant 65536 : i64
+    %c131072_i64 = arith.constant 131072 : i64
+    %cst_3 = arith.constant 1.44269502 : f32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %0 = tt.get_program_id z : i32
+    %1 = tt.get_program_id x : i32
+    %2 = tt.get_program_id y : i32
+    %3 = arith.extsi %1 : i32 to i64
+    %4 = arith.muli %3, %c131072_i64 : i64
+    %5 = arith.extsi %2 : i32 to i64
+    %6 = arith.muli %5, %c65536_i64 : i64
+    %7 = arith.addi %4, %6 : i64
+    %8 = tt.addptr %arg0, %7 : !tt.ptr<f16>, i64
+    %9 = arith.muli %0, %c128_i32 : i32
+    %10 = tt.make_tensor_ptr %8, [%c1024_i64, %c64_i64], [%c64_i64, %c1_i64], [%9, %c0_i32] {order = array<i32: 1, 0>} : <tensor<128x64xf16>>
+    %11 = tt.addptr %arg2, %7 : !tt.ptr<f16>, i64
+    %12 = tt.make_tensor_ptr %11, [%c1024_i64, %c64_i64], [%c64_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<64x64xf16>>
+    %13 = tt.addptr %arg1, %7 : !tt.ptr<f16>, i64
+    %14 = tt.make_tensor_ptr %13, [%c64_i64, %c1024_i64], [%c1_i64, %c64_i64], [%c0_i32, %c0_i32] {order = array<i32: 0, 1>} : <tensor<64x64xf16>>
+    %15 = tt.addptr %arg5, %7 : !tt.ptr<f32>, i64
+    %16 = tt.make_tensor_ptr %15, [%c1024_i64, %c64_i64], [%c64_i64, %c1_i64], [%9, %c0_i32] {order = array<i32: 1, 0>} : <tensor<128x64xf32>>
+    // CHECK: tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %17 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %18 = tt.splat %9 : i32 -> tensor<128xi32>
+    %19 = arith.addi %18, %17 : tensor<128xi32>
+    // CHECK: tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+    %20 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+    %21 = arith.mulf %arg3, %cst_3 : f32
+    %22 = tt.load %10 : !tt.ptr<tensor<128x64xf16>>
+    %23 = tt.splat %21 : f32 -> tensor<128xf32>
+    %24 = tt.splat %21 : f32 -> tensor<128x64xf32>
+    %25:5 = scf.for %arg6 = %c0_i32 to %9 step %c64_i32 iter_args(%arg7 = %cst, %arg8 = %cst_2, %arg9 = %cst_0, %arg10 = %12, %arg11 = %14) -> (tensor<128xf32>, tensor<128x64xf32>, tensor<128xf32>, !tt.ptr<tensor<64x64xf16>>, !tt.ptr<tensor<64x64xf16>>)  : i32 {
+      %39 = tt.load %arg11 : !tt.ptr<tensor<64x64xf16>>
+      %40 = tt.dot %22, %39, %cst_2, inputPrecision = tf32 : tensor<128x64xf16> * tensor<64x64xf16> -> tensor<128x64xf32>
+      %41 = "tt.reduce"(%40) <{axis = 1 : i32}> ({
+      ^bb0(%arg12: f32, %arg13: f32):
+        %62 = arith.maxnumf %arg12, %arg13 : f32
+        tt.reduce.return %62 : f32
+      }) : (tensor<128x64xf32>) -> tensor<128xf32>
+      %42 = arith.mulf %41, %23 : tensor<128xf32>
+      %43 = arith.maxnumf %arg9, %42 : tensor<128xf32>
+      %44 = arith.mulf %40, %24 : tensor<128x64xf32>
+      %45 = tt.expand_dims %43 {axis = 1 : i32} : tensor<128xf32> -> tensor<128x1xf32>
+      %46 = tt.broadcast %45 : tensor<128x1xf32> -> tensor<128x64xf32>
+      %47 = arith.subf %44, %46 : tensor<128x64xf32>
+      %48 = math.exp2 %47 : tensor<128x64xf32>
+      %49 = "tt.reduce"(%48) <{axis = 1 : i32}> ({
+      ^bb0(%arg12: f32, %arg13: f32):
+        %62 = arith.addf %arg12, %arg13 : f32
+        tt.reduce.return %62 : f32
+      }) : (tensor<128x64xf32>) -> tensor<128xf32>
+      %50 = arith.subf %arg9, %43 : tensor<128xf32>
+      %51 = math.exp2 %50 : tensor<128xf32>
+      %52 = arith.mulf %arg7, %51 : tensor<128xf32>
+      %53 = arith.addf %52, %49 : tensor<128xf32>
+      %54 = tt.expand_dims %51 {axis = 1 : i32} : tensor<128xf32> -> tensor<128x1xf32>
+      %55 = tt.broadcast %54 : tensor<128x1xf32> -> tensor<128x64xf32>
+      %56 = arith.mulf %arg8, %55 : tensor<128x64xf32>
+      %57 = tt.load %arg10 : !tt.ptr<tensor<64x64xf16>>
+      %58 = arith.truncf %48 : tensor<128x64xf32> to tensor<128x64xf16>
+      %59 = tt.dot %58, %57, %56, inputPrecision = tf32 : tensor<128x64xf16> * tensor<64x64xf16> -> tensor<128x64xf32>
+      %60 = tt.advance %arg10, [%c64_i32, %c0_i32] : <tensor<64x64xf16>>
+      %61 = tt.advance %arg11, [%c0_i32, %c64_i32] : <tensor<64x64xf16>>
+      scf.yield %53, %59, %43, %60, %61 : tensor<128xf32>, tensor<128x64xf32>, tensor<128xf32>, !tt.ptr<tensor<64x64xf16>>, !tt.ptr<tensor<64x64xf16>>
+      // CHECK1: workload = 4
+    } {tt.divisibility_arg1 = dense<64> : tensor<1xi32>}
+    gpu.barrier
+    %26 = arith.muli %0, %c128_i32 {tt.divisibility = dense<128> : tensor<1xi32>} : i32
+    %27 = arith.addi %0, %c1_i32 : i32
+    %28 = arith.muli %27, %c128_i32 : i32
+    %29 = tt.advance %14, [%c0_i32, %26] : <tensor<64x64xf16>>
+    %30 = tt.advance %12, [%26, %c0_i32] : <tensor<64x64xf16>>
+    // CHECK1: [[EXP_DIM1:%.*]] = tt.expand_dims {{%.*}} {axis = 1 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xi32, #blocked>
+    // CHECK1: [[EXP_DIM2:%.*]] = tt.expand_dims {{%.*}} {axis = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %31 = tt.expand_dims %19 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
+    %32 = tt.expand_dims %20 {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
+    // CHECK1: [[BC1:%.*]] = tt.broadcast [[EXP_DIM1]] : tensor<128x1xi32, #blocked> -> tensor<128x64xi32, #blocked>
+    %33 = tt.broadcast %31 : tensor<128x1xi32> -> tensor<128x64xi32>
+    %34 = tt.splat %21 : f32 -> tensor<128x64xf32>
+    %35:5 = scf.for %arg6 = %26 to %28 step %c64_i32 iter_args(%arg7 = %25#0, %arg8 = %25#1, %arg9 = %25#2, %arg10 = %30, %arg11 = %29) -> (tensor<128xf32>, tensor<128x64xf32>, tensor<128xf32>, !tt.ptr<tensor<64x64xf16>>, !tt.ptr<tensor<64x64xf16>>)  : i32 {
+      %39 = tt.load %arg11 : !tt.ptr<tensor<64x64xf16>>
+      %40 = tt.dot %22, %39, %cst_2, inputPrecision = tf32 : tensor<128x64xf16> * tensor<64x64xf16> -> tensor<128x64xf32>
+      %41 = tt.splat %arg6 : i32 -> tensor<1x64xi32>
+      // CHECK1: [[OFFSET:%.*]] = arith.addi {{%.*}}, [[EXP_DIM2]] : tensor<1x64xi32, #blocked>
+      %42 = arith.addi %41, %32 : tensor<1x64xi32>
+      // CHECK1: [[BC2:%.*]] = tt.broadcast [[OFFSET]] : tensor<1x64xi32, #blocked> -> tensor<128x64xi32, #blocked>
+      %43 = tt.broadcast %42 : tensor<1x64xi32> -> tensor<128x64xi32>
+      // CHECK1: arith.cmpi sge, [[BC1]], [[BC2]] : tensor<128x64xi32, #blocked>
+      %44 = arith.cmpi sge, %33, %43 : tensor<128x64xi32>
+      %45 = arith.mulf %40, %34 : tensor<128x64xf32>
+      %46 = arith.select %44, %cst_2, %cst_1 : tensor<128x64xi1>, tensor<128x64xf32>
+      %47 = arith.addf %45, %46 : tensor<128x64xf32>
+      %48 = "tt.reduce"(%47) <{axis = 1 : i32}> ({
+      ^bb0(%arg12: f32, %arg13: f32):
+        %67 = arith.maxnumf %arg12, %arg13 : f32
+        tt.reduce.return %67 : f32
+      }) : (tensor<128x64xf32>) -> tensor<128xf32>
+      %49 = arith.maxnumf %arg9, %48 : tensor<128xf32>
+      %50 = tt.expand_dims %49 {axis = 1 : i32} : tensor<128xf32> -> tensor<128x1xf32>
+      %51 = tt.broadcast %50 : tensor<128x1xf32> -> tensor<128x64xf32>
+      %52 = arith.subf %47, %51 : tensor<128x64xf32>
+      %53 = math.exp2 %52 : tensor<128x64xf32>
+      %54 = "tt.reduce"(%53) <{axis = 1 : i32}> ({
+      ^bb0(%arg12: f32, %arg13: f32):
+        %67 = arith.addf %arg12, %arg13 : f32
+        tt.reduce.return %67 : f32
+      }) : (tensor<128x64xf32>) -> tensor<128xf32>
+      %55 = arith.subf %arg9, %49 : tensor<128xf32>
+      %56 = math.exp2 %55 : tensor<128xf32>
+      %57 = arith.mulf %arg7, %56 : tensor<128xf32>
+      %58 = arith.addf %57, %54 : tensor<128xf32>
+      %59 = tt.expand_dims %56 {axis = 1 : i32} : tensor<128xf32> -> tensor<128x1xf32>
+      %60 = tt.broadcast %59 : tensor<128x1xf32> -> tensor<128x64xf32>
+      %61 = arith.mulf %arg8, %60 : tensor<128x64xf32>
+      %62 = tt.load %arg10 : !tt.ptr<tensor<64x64xf16>>
+      %63 = arith.truncf %53 : tensor<128x64xf32> to tensor<128x64xf16>
+      %64 = tt.dot %63, %62, %61, inputPrecision = tf32 : tensor<128x64xf16> * tensor<64x64xf16> -> tensor<128x64xf32>
+      %65 = tt.advance %arg10, [%c64_i32, %c0_i32] : <tensor<64x64xf16>>
+      %66 = tt.advance %arg11, [%c0_i32, %c64_i32] : <tensor<64x64xf16>>
+      scf.yield %58, %64, %49, %65, %66 : tensor<128xf32>, tensor<128x64xf32>, tensor<128xf32>, !tt.ptr<tensor<64x64xf16>>, !tt.ptr<tensor<64x64xf16>>
+      // CHECK1: workload = 4
+    } {tt.divisibility_arg1 = dense<64> : tensor<1xi32>}
+    %36 = tt.expand_dims %35#0 {axis = 1 : i32} : tensor<128xf32> -> tensor<128x1xf32>
+    %37 = tt.broadcast %36 : tensor<128x1xf32> -> tensor<128x64xf32>
+    %38 = arith.divf %35#1, %37 : tensor<128x64xf32>
+    tt.store %16, %38 : !tt.ptr<tensor<128x64xf32>>
     tt.return
   }
 }


### PR DESCRIPTION
Detect and handle flash attention with causal masking in `-convert-triton-to-tritongpu-warp` by supporting `tt.make_range` and *two* dependent attention-`for`-loops.

See #1947 for more context / the complete PoC.