### PR TITLE
Fix pylint issues in scripts

### DIFF
--- a/scripts/get_failed_cases.py
+++ b/scripts/get_failed_cases.py
@@ -1,5 +1,6 @@
-from defusedxml.ElementTree import parse
 import argparse
+
+from defusedxml.ElementTree import parse
 
 
 def create_argument_parser() -> argparse.ArgumentParser:
@@ -15,9 +16,10 @@ def extract_failed_from_xml(in_file: str, out_file: str):
     root = parse(in_file).getroot()
     failed = []
 
+    failed_tags = {'error', 'failure'}
     for testcase in root.findall('.//testcase'):
         for child in testcase:
-            if child.tag == 'error' or child.tag == 'failure':
+            if child.tag in failed_tags:
                 classname = testcase.get('classname').replace('.', '/') + '.py'
                 case = testcase.get('name')
                 result = f'{classname}::{case}'
@@ -26,7 +28,7 @@ def extract_failed_from_xml(in_file: str, out_file: str):
     if len(failed) == 0:
         return
 
-    with open(out_file, 'w') as f:
+    with open(out_file, 'w', encoding='utf-8') as f:
         for result in failed:
             f.write(result + '\n')
 

--- a/scripts/pass_rate.py
+++ b/scripts/pass_rate.py
@@ -7,8 +7,9 @@ import json
 import os
 import pathlib
 import platform
-from defusedxml.ElementTree import parse
 from typing import List
+
+from defusedxml.ElementTree import parse
 
 
 @dataclasses.dataclass
@@ -68,10 +69,11 @@ def parse_report(report_path: pathlib.Path) -> ReportStats:
         for _ in testsuite.iter('error'):
             stats.failed += 1
         try:
-            with open(f"{report_path.parent}/{report_path.stem}-warnings.json") as testsuite_warnings_file:
+            warnings_file_name = f'{report_path.parent}/{report_path.stem}-warnings.json'
+            with open(warnings_file_name, encoding='utf-8') as testsuite_warnings_file:
                 testsuite_warnings = json.load(testsuite_warnings_file)
                 for w in testsuite_warnings:
-                    if "FIXME" in list(w.values())[0]:
+                    if 'FIXME' in list(w.values())[0]:
                         testsuite_fixme_tests.add(list(w.keys())[0])
         except FileNotFoundError:
             pass


### PR DESCRIPTION
```
************* Module get_failed_cases
scripts/get_failed_cases.py:20:15: R1714: Consider merging these comparisons with 'in' by using 'child.tag in ('error', 'failure')'. Use a set instead if elements are hashable. (consider-using-in)
scripts/get_failed_cases.py:29:9: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
scripts/get_failed_cases.py:2:0: C0411: standard import "argparse" should be placed before third party import "defusedxml.ElementTree.parse" (wrong-import-order)
************* Module pass_rate
scripts/pass_rate.py:71:17: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
scripts/pass_rate.py:11:0: C0411: standard import "typing.List" should be placed before third party import "defusedxml.ElementTree.parse" (wrong-import-order)
```

Fixes #2016.