### PR TITLE
Fix pylint issues in third_party/intel

### DIFF
--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -86,7 +86,7 @@ def compile_module_from_src(src, name):
             with open(src_path, "w", encoding="utf-8") as f:
                 f.write(src)
             so = _build(name, src_path, tmpdir, library_dir, include_dir, libraries)
-            with open(so, "rb", encoding="utf-8") as f:
+            with open(so, "rb") as f:
                 cache_path = cache.put(f.read(), f"{name}.so", binary=True)
     spec = importlib.util.spec_from_file_location(name, cache_path)
     mod = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
```
************* Module backend.compiler
third_party/intel/backend/compiler.py:25:8: W0622: Redefining built-in 'bin' (redefined-builtin)
third_party/intel/backend/compiler.py:36:0: R0902: Too many instance attributes (16/7) (too-many-instance-attributes)
third_party/intel/backend/compiler.py:95:28: W0613: Unused argument 'metadata' (unused-argument)
third_party/intel/backend/compiler.py:92:4: R0903: Too few public methods (1/2) (too-few-public-methods)
third_party/intel/backend/compiler.py:145:36: E1101: Class 'XPUOptions' has no '__dataclass_fields__' member (no-member)
third_party/intel/backend/compiler.py:153:8: C0415: Import outside toplevel (triton.language.extra.intel.convert_custom_float8) (import-outside-toplevel)
third_party/intel/backend/compiler.py:160:8: C0415: Import outside toplevel (triton.language.extra.intel.libdevice) (import-outside-toplevel)
third_party/intel/backend/compiler.py:167:23: W0613: Unused argument 'metadata' (unused-argument)
third_party/intel/backend/compiler.py:167:33: W0613: Unused argument 'opt' (unused-argument)
third_party/intel/backend/compiler.py:4:0: C0411: standard import "dataclasses.dataclass" should be placed before third party imports "triton.backends.compiler.BaseBackend", "triton._C.libtriton.ir" (wrong-import-order)
third_party/intel/backend/compiler.py:5:0: C0411: standard import "functools" should be placed before third party imports "triton.backends.compiler.BaseBackend", "triton._C.libtriton.ir" (wrong-import-order)
third_party/intel/backend/compiler.py:6:0: C0411: standard import "typing.Any" should be placed before third party imports "triton.backends.compiler.BaseBackend", "triton._C.libtriton.ir" (wrong-import-order)
third_party/intel/backend/compiler.py:7:0: C0411: standard import "types.ModuleType" should be placed before third party imports "triton.backends.compiler.BaseBackend", "triton._C.libtriton.ir" (wrong-import-order)
third_party/intel/backend/compiler.py:8:0: C0411: standard import "hashlib" should be placed before third party imports "triton.backends.compiler.BaseBackend", "triton._C.libtriton.ir" (wrong-import-order)
third_party/intel/backend/compiler.py:9:0: C0411: standard import "re" should be placed before third party imports "triton.backends.compiler.BaseBackend", "triton._C.libtriton.ir" (wrong-import-order)
third_party/intel/backend/compiler.py:10:0: C0411: standard import "os" should be placed before third party imports "triton.backends.compiler.BaseBackend", "triton._C.libtriton.ir" (wrong-import-order)
third_party/intel/backend/compiler.py:11:0: C0411: standard import "shutil" should be placed before third party imports "triton.backends.compiler.BaseBackend", "triton._C.libtriton.ir" (wrong-import-order)
third_party/intel/backend/compiler.py:12:0: C0411: standard import "subprocess" should be placed before third party imports "triton.backends.compiler.BaseBackend", "triton._C.libtriton.ir" (wrong-import-order)
third_party/intel/backend/compiler.py:13:0: C0411: standard import "pathlib.Path" should be placed before third party imports "triton.backends.compiler.BaseBackend", "triton._C.libtriton.ir" (wrong-import-order)
************* Module backend.driver
third_party/intel/backend/driver.py:18:14: W0621: Redefining name 'include_dir' from outer scope (line 15) (redefined-outer-name)
third_party/intel/backend/driver.py:31:4: W0621: Redefining name 'library_dir' from outer scope (line 68) (redefined-outer-name)
third_party/intel/backend/driver.py:52:8: W0707: Consider explicitly re-raising using 'except Exception as exc' and 'raise AssertionError(assertion_message) from exc' (raise-missing-from)
third_party/intel/backend/driver.py:89:4: W0621: Redefining name 'importlib' from outer scope (line 1) (redefined-outer-name)
third_party/intel/backend/driver.py:84:17: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
third_party/intel/backend/driver.py:89:4: C0415: Import outside toplevel (importlib.util) (import-outside-toplevel)
third_party/intel/backend/driver.py:101:0: R0205: Class 'XPUUtils' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
third_party/intel/backend/driver.py:109:8: W0621: Redefining name 'dirname' from outer scope (line 70) (redefined-outer-name)
third_party/intel/backend/driver.py:110:38: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
third_party/intel/backend/driver.py:121:15: E1101: Instance of 'XPUUtils' has no 'event_pool' member (no-member)
third_party/intel/backend/driver.py:124:8: C0415: Import outside toplevel (torch) (import-outside-toplevel)
third_party/intel/backend/driver.py:182:4: W0622: Redefining built-in 'format' (redefined-builtin)
third_party/intel/backend/driver.py:155:40: W0613: Unused argument 'ids' (unused-argument)
third_party/intel/backend/driver.py:428:0: R0205: Class 'XPULauncher' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
third_party/intel/backend/driver.py:432:68: R1735: Consider using '{}' instead of a call to 'dict'. (use-dict-literal)
third_party/intel/backend/driver.py:433:18: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
third_party/intel/backend/driver.py:430:28: W0613: Unused argument 'metadata' (unused-argument)
third_party/intel/backend/driver.py:428:0: R0903: Too few public methods (1/2) (too-few-public-methods)
third_party/intel/backend/driver.py:452:8: R1705: Unnecessary "else" after "return", remove the "else" and de-indent the code inside it (no-else-return)
third_party/intel/backend/driver.py:462:8: C0415: Import outside toplevel (torch) (import-outside-toplevel)
third_party/intel/backend/driver.py:461:33: W0613: Unused argument 'device' (unused-argument)
third_party/intel/backend/driver.py:466:8: C0415: Import outside toplevel (torch) (import-outside-toplevel)
third_party/intel/backend/driver.py:474:8: C0415: Import outside toplevel (torch) (import-outside-toplevel)
third_party/intel/backend/driver.py:453:12: W0201: Attribute 'utils' defined outside __init__ (attribute-defined-outside-init)
```

Fixes #2016.