### PR TITLE
[TritonGEN] Add `subgroup.local.id` operation

### DIFF
--- a/test/TritonGEN/gpu-to-tritongen.mlir
+++ b/test/TritonGEN/gpu-to-tritongen.mlir
@@ -36,5 +36,13 @@ gpu.module @kernels {
     %14 = gpu.subgroup_reduce xor %1 : (i32) -> (i32)
     llvm.return
   }
+
+// CHECK:           tt.func @triton_gen.sub_group_local_id() -> index {
+// CHECK:             %[[VAL_15:.*]] = triton_gen.subgroup.local.id : i32
+// CHECK:             %[[VAL_16:.*]] = llvm.sext %[[VAL_15]] : i32 to i64
+  tt.func @triton_gen.sub_group_local_id() -> index {
+    %0 = gpu.lane_id
+    tt.return %0 : index
+  }
 }
 }

--- a/test/TritonGEN/tritongen-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-to-llvm.mlir
@@ -52,6 +52,9 @@ llvm.func @gen_special_regs() -> i32 {
   // CHECK: llvm.call spir_funccc @_Z16get_sub_group_idv() {{.*}} : () -> i32
   %13 = triton_gen.subgroup.id : i32
 
+  // CHECK: llvm.call spir_funccc @_Z22get_sub_group_local_idv() {{.*}} : () -> i32
+  %14 = triton_gen.subgroup.local.id : i32
+
   llvm.return %1 : i32
 }
 

--- a/test/TritonGEN/tritongen.mlir
+++ b/test/TritonGEN/tritongen.mlir
@@ -28,6 +28,8 @@ llvm.func @triton_gen_special_regs() -> i32 {
   %11 = triton_gen.grid.dim.z : i32
   // CHECK: triton_gen.subgroup.id : i32
   %12 = triton_gen.subgroup.id : i32
+  // CHECK: triton_gen.subgroup.local.id : i32
+  %13 = triton_gen.subgroup.local.id : i32
   llvm.return %0 : i32
 }
 

--- a/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENOps.td
+++ b/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENOps.td
@@ -144,6 +144,22 @@ def TritonGEN_SubgroupIdOp : TritonGEN_Op<"subgroup.id", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
+// Subgroup local index
+//===----------------------------------------------------------------------===//
+
+def TritonGEN_SubgroupLocalIdOp : TritonGEN_Op<"subgroup.local.id", [Pure]> {
+  let summary = "Subgroup Local Invocation Index";
+  string baseDescription = [{
+    The `gen.subgroup.local.id` operation returns the local invocation ID of the
+    work-item within the subgroup, which is a number in the range `[0,
+    subgroup_size)`.
+  }];
+  let arguments = (ins);
+  let results = (outs I32 : $res);
+  let assemblyFormat = "attr-dict `:` type($res)";
+}
+
+//===----------------------------------------------------------------------===//
 // Synchronization
 //===----------------------------------------------------------------------===//
 

--- a/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENOps.td
+++ b/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENOps.td
@@ -150,8 +150,8 @@ def TritonGEN_SubgroupIdOp : TritonGEN_Op<"subgroup.id", [Pure]> {
 def TritonGEN_SubgroupLocalIdOp : TritonGEN_Op<"subgroup.local.id", [Pure]> {
   let summary = "Subgroup Local Invocation Index";
   string baseDescription = [{
-    The `gen.subgroup.local.id` operation returns the local invocation ID of the
-    work-item within the subgroup, which is a number in the range `[0,
+    The `triton_gen.subgroup.local.id` operation returns the local invocation ID
+    of the work-item within the sub-group, which is a number in the range `[0,
     subgroup_size)`.
   }];
   let arguments = (ins);

--- a/third_party/intel/lib/GPUToTritonGEN/GPUToTritonGENPass.cpp
+++ b/third_party/intel/lib/GPUToTritonGEN/GPUToTritonGENPass.cpp
@@ -224,7 +224,9 @@ void mlir::triton::populateGPUToTritonGENConversionPatterns(
       GPUIndexIntrinsicOpLowering<mlir::gpu::GridDimOp, TritonGEN::GridDimXOp,
                                   TritonGEN::GridDimYOp, TritonGEN::GridDimZOp>,
       SingleDimLaunchConfigLowering<mlir::gpu::SubgroupIdOp,
-                                    TritonGEN::SubgroupIdOp>>(converter);
+                                    TritonGEN::SubgroupIdOp>,
+      SingleDimLaunchConfigLowering<mlir::gpu::LaneIdOp,
+                                    TritonGEN::SubgroupLocalIdOp>>(converter);
   patterns.add<GPUFuncOpLowering>(
       converter,
       /*allocaAddrSpace=*/TritonGEN::TritonGENMemorySpace::kFunction,

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -767,6 +767,28 @@ struct TritonGENSubgroupIdLowering
 };
 
 //===----------------------------------------------------------------------===//
+// SubgroupLocalID Op Lowering
+//===----------------------------------------------------------------------===//
+
+struct TritonGENSubgroupLocalIdLowering
+    : ConvertOpToLLVMPattern<TritonGEN::SubgroupLocalIdOp> {
+  using ConvertOpToLLVMPattern<
+      TritonGEN::SubgroupLocalIdOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(TritonGEN::SubgroupLocalIdOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto retType = rewriter.getIntegerType(32);
+
+    intel::AttributeList attrs;
+    LLVM::CallOp callOp = createDeviceFunctionCall(
+        rewriter, "_Z22get_sub_group_local_idv", retType, {}, {}, attrs);
+    rewriter.replaceOp(op, callOp);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // Synchronization Ops Lowerings
 //===----------------------------------------------------------------------===//
 
@@ -1503,14 +1525,14 @@ void mlir::triton::populateTritonGENToLLVMConversionPatterns(
       TritonGENBlockDimXLowering, TritonGENBlockDimYLowering,
       TritonGENBlockDimZLowering, TritonGENGridDimXLowering,
       TritonGENGridDimYLowering, TritonGENGridDimZLowering,
-      TritonGENSubgroupIdLowering, TritonGENBarrierLowering,
-      TritonGENSplitBarrierSignalLowering, TritonGENSplitBarrierWaitLowering,
-      TritonGENNamedBarrierSignalLowering, TritonGENNamedBarrierWaitLowering,
-      TritonSubGroupReduceLowering, TritonSubGroupScanLowering,
-      TritonSubGroupShuffleLowering, TritonMatrixDPASLowering,
-      TritonMatrix2DBlockLoadLowering, TritonMatrix2DBlockStoreLowering,
-      TritonMatrix2DBlockPrefetchLowering, TritonSIMDBlockReadLowering,
-      TritonSIMDBlockWriteLowering>(converter);
+      TritonGENSubgroupIdLowering, TritonGENSubgroupLocalIdLowering,
+      TritonGENBarrierLowering, TritonGENSplitBarrierSignalLowering,
+      TritonGENSplitBarrierWaitLowering, TritonGENNamedBarrierSignalLowering,
+      TritonGENNamedBarrierWaitLowering, TritonSubGroupReduceLowering,
+      TritonSubGroupScanLowering, TritonSubGroupShuffleLowering,
+      TritonMatrixDPASLowering, TritonMatrix2DBlockLoadLowering,
+      TritonMatrix2DBlockStoreLowering, TritonMatrix2DBlockPrefetchLowering,
+      TritonSIMDBlockReadLowering, TritonSIMDBlockWriteLowering>(converter);
 }
 
 void registerConvertTritonTritonGENToLLVMInterface(DialectRegistry &registry) {


### PR DESCRIPTION
Add operation querying the sub-group local invocation id. `gpu.lane_id` converts to this operation.

This is needed to enable some sub-group aware algorithms.
