### PR TITLE
Fix pylint issues in benchmarks

### DIFF
--- a/benchmarks/micro_benchmarks/conversion/float_conversion/float_conversion.py
+++ b/benchmarks/micro_benchmarks/conversion/float_conversion/float_conversion.py
@@ -57,6 +57,8 @@ def benchmark(N, target_type):
         fwd = lambda: launch_conversion(inputs, tl.bfloat16)
     elif target_type == "float16":
         fwd = lambda: launch_conversion(inputs, tl.float16)
+    else:
+        raise NotImplementedError(f'Type {target_type} is not supported')
 
     ms, min_ms, max_ms = triton.testing.do_bench(fwd, quantiles=quantiles)
     gbps = lambda ms: (inputs.numel() * inputs.element_size() * 1e-9) / (ms * 1e-3)

--- a/benchmarks/setup.py
+++ b/benchmarks/setup.py
@@ -1,11 +1,12 @@
-from setuptools import setup
-
-import sysconfig
 import os
+import re
 import shutil
 import subprocess
+import sysconfig
 import sys
-import re
+
+from setuptools import setup
+
 import torch
 import intel_extension_for_pytorch
 
@@ -20,8 +21,8 @@ class CMakeBuild():
     def run(self):
         try:
             out = subprocess.check_output(["cmake", "--version"])
-        except OSError:
-            raise RuntimeError("CMake must be installed to build the following extensions: ")
+        except OSError as error:
+            raise RuntimeError("CMake must be installed") from error
 
         match = re.search(r"version\s*(?P<major>\d+)\.(?P<minor>\d+)([\d.]+)?", out.decode())
         cmake_major, cmake_minor = int(match.group("major")), int(match.group("minor"))

--- a/benchmarks/triton_kernels_benchmark/__init__.py
+++ b/benchmarks/triton_kernels_benchmark/__init__.py
@@ -1,4 +1,4 @@
-import triton.runtime.driver as driver
+from triton.runtime import driver
 from . import benchmark_driver
 from .benchmark_testing import do_bench, assert_close, perf_report, Benchmark  # type: ignore # noqa: F401
 

--- a/benchmarks/triton_kernels_benchmark/benchmark_driver.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_driver.py
@@ -1,19 +1,21 @@
 import os
 import hashlib
+import importlib.util
 import tempfile
 from pathlib import Path
-from triton.runtime.cache import get_cache_manager
+
 from triton.backends.compiler import GPUTarget
 from triton.backends.driver import DriverBase
+from triton.runtime.cache import get_cache_manager
 from triton.runtime.build import _build, quiet
 
 import torch
 import intel_extension_for_pytorch
 
-dirname = os.getenv("ZE_PATH", default="/usr/local")
+_dirname = os.getenv("ZE_PATH", default="/usr/local")
 
 include_dir = [
-    os.path.join(dirname, "include"),
+    os.path.join(_dirname, "include"),
     os.path.join(torch.utils.cmake_prefix_path, "../../include"),
     os.path.join(torch.utils.cmake_prefix_path, "../../include/torch/csrc/api/include"),
     os.path.join(intel_extension_for_pytorch.cmake_prefix_path, "../../include")
@@ -27,7 +29,7 @@ if oneapi_root:
     ]
 
 library_dir = [
-    os.path.join(dirname, "lib"),
+    os.path.join(_dirname, "lib"),
     os.path.join(torch.utils.cmake_prefix_path, "../../lib"),
     os.path.join(intel_extension_for_pytorch.cmake_prefix_path, "../../lib")
 ]
@@ -41,13 +43,12 @@ def compile_module_from_src(src, name):
     if cache_path is None:
         with tempfile.TemporaryDirectory() as tmpdir:
             src_path = os.path.join(tmpdir, "main.cpp")
-            with open(src_path, "w") as f:
+            with open(src_path, "w", encoding="utf-8") as f:
                 f.write(src)
             with quiet():
                 so = _build(name, src_path, tmpdir, library_dir, include_dir, libraries)
             with open(so, "rb") as f:
                 cache_path = cache.put(f.read(), f"{name}.so", binary=True)
-    import importlib.util
     spec = importlib.util.spec_from_file_location(name, cache_path)
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
@@ -59,7 +60,7 @@ def compile_module_from_src(src, name):
 # ------------------------
 
 
-class XPUUtils(object):
+class XPUUtils:
 
     def __new__(cls):
         if not hasattr(cls, "instance"):
@@ -68,7 +69,8 @@ class XPUUtils(object):
 
     def __init__(self):
         dirname = os.path.dirname(os.path.realpath(__file__))
-        mod = compile_module_from_src(Path(os.path.join(dirname, "driver.c")).read_text(), "spirv_utils")
+        mod = compile_module_from_src(
+            Path(os.path.join(dirname, "driver.c")).read_text(encoding="utf-8"), "spirv_utils")
         self.load_binary = mod.load_binary
         self.get_device_properties = mod.get_device_properties
         self.context = mod.init_context(self.get_sycl_queue())
@@ -78,11 +80,7 @@ class XPUUtils(object):
     def get_current_device(self):
         return self.current_device
 
-    def get_event_pool(self):
-        return self.event_pool
-
     def get_sycl_queue(self):
-        import torch
         return torch.xpu.current_stream().sycl_queue
 
 
@@ -113,7 +111,7 @@ def ty_to_cpp(ty):
     }[ty]
 
 
-def make_launcher(constants, signature, ids):
+def make_launcher(constants, signature, ids):  # pylint: disable=unused-argument
     # Record the end of regular arguments;
     # subsequent arguments are architecture-specific descriptors.
     arg_decls = ', '.join(f"{ty_to_cpp(ty)} arg{i}" for i, ty in signature.items())
@@ -140,7 +138,7 @@ def make_launcher(constants, signature, ids):
         }[ty]
 
     args_format = ''.join([format_of(_extracted_type(ty)) for ty in signature.values()])
-    format = "iiiOOOOOO" + args_format
+    fmt = "iiiOOOOOO" + args_format
     args_list = ', ' + ', '.join(f"&_arg{i}" for i, ty in signature.items()) if len(signature) > 0 else ''
 
     # generate glue code
@@ -307,7 +305,7 @@ def make_launcher(constants, signature, ids):
       PyObject *py_kernel;
 
       {' '.join([f"{_extracted_type(ty)} _arg{i}; " for i, ty in signature.items()])}
-      if(!PyArg_ParseTuple(args, \"{format}\", &gridX, &gridY, &gridZ, &py_obj_stream, &py_kernel,
+      if(!PyArg_ParseTuple(args, \"{fmt}\", &gridX, &gridY, &gridZ, &py_obj_stream, &py_kernel,
                                            &kernel_metadata, &launch_metadata,
                                            &launch_enter_hook, &launch_exit_hook {args_list})) {{
         return NULL;
@@ -390,11 +388,11 @@ def make_launcher(constants, signature, ids):
     return src
 
 
-class XPULauncher(object):
+class XPULauncher:
 
-    def __init__(self, src, metadata):
+    def __init__(self, src, metadata):  # pylint: disable=unused-argument
         ids = {"ids_of_const_exprs": src.fn.constexprs if hasattr(src, "fn") else tuple()}
-        constants = src.constants if hasattr(src, "constants") else dict()
+        constants = src.constants if hasattr(src, "constants") else {}
         cst_key = lambda i: src.fn.arg_names.index(i) if isinstance(i, str) else i
         constants = {cst_key(key): value for key, value in constants.items()}
         signature = {cst_key(key): value for key, value in src.signature.items()}
@@ -415,20 +413,17 @@ class XPUDriver(DriverBase):
         # Lazily initialize utils to avoid unnecessary XPU runtime invocations.
         # See https://github.com/intel/intel-xpu-backend-for-triton/issues/624
         if name == "utils":
-            self.utils = XPUUtils()
+            self.utils = XPUUtils()  # pylint: disable=attribute-defined-outside-init
             return self.utils
-        else:
-            raise AttributeError
+        raise AttributeError
 
     def get_current_device(self):
         return self.utils.get_current_device()
 
-    def get_current_stream(self, device):
-        import torch
+    def get_current_stream(self, device):  # pylint: disable=unused-argument
         return torch.xpu.current_stream().sycl_queue
 
     def get_current_target(self):
-        import torch
         device = self.get_current_device()
         dev_property = torch.xpu.get_device_capability(device)
         warp_size = 32
@@ -436,5 +431,4 @@ class XPUDriver(DriverBase):
 
     @staticmethod
     def is_active():
-        import torch
         return torch.xpu.is_available()

--- a/benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py
@@ -48,7 +48,7 @@ def _kernel(A, B, C,  #
                                     order=(1, 0))
 
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=acc_dtype)
-    for k in range(0, K, BLOCK_K * SPLIT_K):
+    for _ in range(0, K, BLOCK_K * SPLIT_K):
         if EVEN_K:
             a = tl.load(a_block_ptr)
             b = tl.load(b_block_ptr)
@@ -96,7 +96,7 @@ class _matmul(torch.autograd.Function):
         _, N = b.shape
 
         # allocates output
-        if (output_dtype is None):
+        if output_dtype is None:
             output_dtype = torch.float32
 
         c = torch.empty((M, N), device=device, dtype=output_dtype)
@@ -115,7 +115,7 @@ class _matmul(torch.autograd.Function):
             assert acc_dtype in supported_acc_dtypes[b.dtype], "acc_dtype not compatible with the type of b"
 
         def to_tl_type(ty):
-            return getattr(tl, str(ty).split(".")[-1])
+            return getattr(tl, str(ty).rsplit(".", maxsplit=1)[-1])
 
         acc_dtype = to_tl_type(acc_dtype)
         output_dtype = to_tl_type(output_dtype)
@@ -130,6 +130,7 @@ class _matmul(torch.autograd.Function):
             acc_dtype=acc_dtype)
         return c
 
+    # pylint: disable=unused-argument
     @staticmethod
     def forward(ctx, a, b, acc_dtype=None, output_dtype=None):
         return _matmul._call(a, b, acc_dtype=acc_dtype, output_dtype=output_dtype)
@@ -169,15 +170,17 @@ def benchmark(M, N, K, provider):
     quantiles = [0.5, 0.0, 1.0]
 
     if provider == 'onednn':
-        ms, min_ms, max_ms, mean, cv = benchmark_suit.do_bench(lambda: torch.matmul(a, b), warmup=10, rep=10,
-                                                               quantiles=quantiles, fast_flush=False)
-    if provider == 'triton':
+        _, min_ms, max_ms, mean, cv = benchmark_suit.do_bench(lambda: torch.matmul(a, b), warmup=10, rep=10,
+                                                              quantiles=quantiles, fast_flush=False)
+    elif provider == 'triton':
         triton_fn = lambda: matmul(a, b)
         torch_fn = lambda: torch.matmul(a, b).to(torch.float32)
         rtol = 1e-2 if a.dtype == torch.bfloat16 else 1e-3
         benchmark_suit.assert_close(triton_fn(), torch_fn(), atol=1e-4, rtol=rtol, err_msg="triton to torch")
-        ms, min_ms, max_ms, mean, cv = benchmark_suit.do_bench(triton_fn, warmup=10, rep=10, quantiles=quantiles,
-                                                               fast_flush=False)
+        _, min_ms, max_ms, mean, cv = benchmark_suit.do_bench(triton_fn, warmup=10, rep=10, quantiles=quantiles,
+                                                              fast_flush=False)
+    else:
+        raise NotImplementedError(f"Unsupported provider {provider}")
 
     tflops = lambda mean: 2 * M * N * K * (1e-12) / (mean * 1e-3)
     gbps = lambda mean: 2 * (M * K + K * N) + 4.0 * (M * N) * (1e-9) / (mean * 1e-3)

--- a/benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py
@@ -16,6 +16,7 @@ import triton_kernels_benchmark
 benchmark_suit = triton_kernels_benchmark  # triton.testing
 
 
+# pylint: disable=unused-argument
 @triton.jit
 def swizzle_tile(tile_id,
                  # Matrix dimensions
@@ -33,6 +34,7 @@ def swizzle_tile(tile_id,
     return pid_m, pid_n
 
 
+# pylint: disable=unused-argument
 @triton.jit
 def linear_tile(tile_id,
                 # Matrix dimensions
@@ -116,7 +118,8 @@ def first_wave(
         stride_bk: tl.constexpr, stride_bn: tl.constexpr,  #
         stride_cm: tl.constexpr, stride_cn: tl.constexpr,
         # Stream-K parameters
-        full_tiles, partial_tiles, iters_per_tile,
+        full_tiles,  # pylint: disable=redefined-outer-name
+        partial_tiles, iters_per_tile,
         # Meta-parameters
         BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr, GROUP_SIZE_M: tl.constexpr):
 
@@ -271,14 +274,16 @@ def benchmark(M, N, K, provider):
     quantiles = [0.5, 0.0, 1.0]
 
     if provider == 'onednn':
-        ms, min_ms, max_ms, mean, cv = benchmark_suit.do_bench(lambda: torch.matmul(a, b), warmup=10, rep=10,
-                                                               quantiles=quantiles, fast_flush=False)
-    if provider == 'triton':
+        _, min_ms, max_ms, mean, cv = benchmark_suit.do_bench(lambda: torch.matmul(a, b), warmup=10, rep=10,
+                                                              quantiles=quantiles, fast_flush=False)
+    elif provider == 'triton':
         triton_fn = lambda: matmul(a, b)
         torch_fn = lambda: torch.matmul(a, b).to(torch.float32)
         benchmark_suit.assert_close(triton_fn(), torch_fn(), atol=1e-4, rtol=1e-2, err_msg="triton to torch")
-        ms, min_ms, max_ms, mean, cv = benchmark_suit.do_bench(triton_fn, warmup=10, rep=10, quantiles=quantiles,
-                                                               fast_flush=False)
+        _, min_ms, max_ms, mean, cv = benchmark_suit.do_bench(triton_fn, warmup=10, rep=10, quantiles=quantiles,
+                                                              fast_flush=False)
+    else:
+        raise NotImplementedError(f"Unsupported provider {provider}")
 
     tflops = lambda mean: 2 * M * N * K * (1e-12) / (mean * 1e-3)
     gbps = lambda mean: 2 * (M * K + K * N) + 4.0 * (M * N) * (1e-9) / (mean * 1e-3)


### PR DESCRIPTION
```
************* Module conversion.float_conversion.float_conversion
benchmarks/micro_benchmarks/conversion/float_conversion/float_conversion.py:61:49: E0606: Possibly using variable 'fwd' before assignment (possibly-used-before-assignment)
************* Module setup
benchmarks/setup.py:24:12: W0707: Consider explicitly re-raising using 'except OSError as exc' and 'raise RuntimeError('CMake must be installed to build the following extensions: ') from exc' (raise-missing-from)
benchmarks/setup.py:3:0: C0411: standard import "sysconfig" should be placed before third party import "setuptools.setup" (wrong-import-order)
benchmarks/setup.py:4:0: C0411: standard import "os" should be placed before third party import "setuptools.setup" (wrong-import-order)
benchmarks/setup.py:5:0: C0411: standard import "shutil" should be placed before third party import "setuptools.setup" (wrong-import-order)
benchmarks/setup.py:6:0: C0411: standard import "subprocess" should be placed before third party import "setuptools.setup" (wrong-import-order)
benchmarks/setup.py:7:0: C0411: standard import "sys" should be placed before third party import "setuptools.setup" (wrong-import-order)
benchmarks/setup.py:8:0: C0411: standard import "re" should be placed before third party import "setuptools.setup" (wrong-import-order)
************* Module triton_kernels_benchmark
benchmarks/triton_kernels_benchmark/__init__.py:1:0: R0402: Use 'from triton.runtime import driver' instead (consider-using-from-import)
************* Module triton_kernels_benchmark.benchmark_driver
benchmarks/triton_kernels_benchmark/benchmark_driver.py:44:17: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:50:4: C0415: Import outside toplevel (importlib.util) (import-outside-toplevel)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:62:0: R0205: Class 'XPUUtils' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:70:8: W0621: Redefining name 'dirname' from outer scope (line 13) (redefined-outer-name)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:71:38: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:82:15: E1101: Instance of 'XPUUtils' has no 'event_pool' member (no-member)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:85:8: W0621: Redefining name 'torch' from outer scope (line 10) (redefined-outer-name)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:85:8: W0404: Reimport 'torch' (imported line 10) (reimported)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:85:8: C0415: Import outside toplevel (torch) (import-outside-toplevel)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:143:4: W0622: Redefining built-in 'format' (redefined-builtin)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:116:40: W0613: Unused argument 'ids' (unused-argument)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:393:0: R0205: Class 'XPULauncher' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:397:68: R1735: Consider using '{}' instead of a call to 'dict'. (use-dict-literal)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:395:28: W0613: Unused argument 'metadata' (unused-argument)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:393:0: R0903: Too few public methods (1/2) (too-few-public-methods)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:417:8: R1705: Unnecessary "else" after "return", remove the "else" and de-indent the code inside it (no-else-return)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:427:8: W0621: Redefining name 'torch' from outer scope (line 10) (redefined-outer-name)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:427:8: W0404: Reimport 'torch' (imported line 10) (reimported)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:427:8: C0415: Import outside toplevel (torch) (import-outside-toplevel)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:426:33: W0613: Unused argument 'device' (unused-argument)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:431:8: W0621: Redefining name 'torch' from outer scope (line 10) (redefined-outer-name)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:431:8: W0404: Reimport 'torch' (imported line 10) (reimported)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:431:8: C0415: Import outside toplevel (torch) (import-outside-toplevel)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:439:8: W0621: Redefining name 'torch' from outer scope (line 10) (redefined-outer-name)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:439:8: W0404: Reimport 'torch' (imported line 10) (reimported)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:439:8: C0415: Import outside toplevel (torch) (import-outside-toplevel)
benchmarks/triton_kernels_benchmark/benchmark_driver.py:418:12: W0201: Attribute 'utils' defined outside __init__ (attribute-defined-outside-init)
************* Module triton_kernels_benchmark.benchmark_testing
benchmarks/triton_kernels_benchmark/benchmark_testing.py:104:0: C0325: Unnecessary parens after 'if' keyword (superfluous-parens)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:157:0: C0301: Line too long (126/120) (line-too-long)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:12:4: C0415: Import outside toplevel (torch) (import-outside-toplevel)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:39:4: C0415: Import outside toplevel (torch) (import-outside-toplevel)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:40:4: C0415: Import outside toplevel (torch.autograd.profiler.record_function) (import-outside-toplevel)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:90:16: R1721: Unnecessary use of a comprehension, use list(profiling_func_filter) instead. (unnecessary-comprehension)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:101:26: R1728: Consider using a generator instead 'sum(k.duration for k in ks)' (consider-using-generator)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:72:12: W0612: Unused variable 'i' (unused-variable)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:119:4: C0415: Import outside toplevel (numpy) (import-outside-toplevel)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:120:4: C0415: Import outside toplevel (torch) (import-outside-toplevel)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:166:0: R0902: Too many instance attributes (12/7) (too-many-instance-attributes)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:184:8: W0613: Unused argument 'color' (unused-argument)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:166:0: R0903: Too few public methods (0/2) (too-few-public-methods)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:240:8: W0621: Redefining name 'os' from outer scope (line 4) (redefined-outer-name)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:267:20: W0622: Redefining built-in 'id' (redefined-builtin)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:240:8: W0404: Reimport 'os' (imported line 4) (reimported)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:240:8: C0415: Import outside toplevel (os) (import-outside-toplevel)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:242:8: C0415: Import outside toplevel (matplotlib.pyplot) (import-outside-toplevel)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:243:8: C0415: Import outside toplevel (pandas) (import-outside-toplevel)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:238:4: R0912: Too many branches (21/12) (too-many-branches)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:333:19: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:343:12: R1705: Unnecessary "else" after "return", remove the "else" and de-indent the code inside it (no-else-return)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:333:19: R1732: Consider using 'with' for resource-allocating operations (consider-using-with)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:232:0: R0903: Too few public methods (1/2) (too-few-public-methods)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:375:12: C0415: Import outside toplevel (psutil) (import-outside-toplevel)
benchmarks/triton_kernels_benchmark/benchmark_testing.py:385:22: W1510: 'subprocess.run' used without explicitly defining the value for 'check'. (subprocess-run-check)
************* Module triton_kernels_benchmark.flash_attention_fwd_benchmark
benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py:8:0: R0402: Use 'from triton_kernels_benchmark import xetla_kernel' instead (consider-using-from-import)
benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py:8:0: E0611: No name 'xetla_kernel' in module 'triton_kernels_benchmark' (no-name-in-module)
benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py:17:43: W0613: Unused argument 'BLOCK_DMODEL' (unused-argument)
benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py:64:33: W0613: Unused argument 'M' (unused-argument)
benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py:66:14: W0613: Unused argument 'stride_kz' (unused-argument)
benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py:66:39: W0613: Unused argument 'stride_kh' (unused-argument)
benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py:67:14: W0613: Unused argument 'stride_vz' (unused-argument)
benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py:67:39: W0613: Unused argument 'stride_vh' (unused-argument)
benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py:68:14: W0613: Unused argument 'stride_oz' (unused-argument)
benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py:68:39: W0613: Unused argument 'stride_oh' (unused-argument)
benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py:69:14: W0613: Unused argument 'Z' (unused-argument)
benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py:69:31: W0613: Unused argument 'H' (unused-argument)
benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py:244:17: E0606: Possibly using variable 'mean' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py:244:29: E0606: Possibly using variable 'max_ms' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py:244:43: E0606: Possibly using variable 'min_ms' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py:244:101: E0606: Possibly using variable 'cv' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py:221:8: W0612: Unused variable 'ms' (unused-variable)
************* Module triton_kernels_benchmark.fused_softmax
benchmarks/triton_kernels_benchmark/fused_softmax.py:18:0: R0402: Use 'from triton_kernels_benchmark import xetla_kernel' instead (consider-using-from-import)
benchmarks/triton_kernels_benchmark/fused_softmax.py:18:0: E0611: No name 'xetla_kernel' in module 'triton_kernels_benchmark' (no-name-in-module)
benchmarks/triton_kernels_benchmark/fused_softmax.py:146:15: C0209: Formatting a regular string which could be an f-string (consider-using-f-string)
benchmarks/triton_kernels_benchmark/fused_softmax.py:156:17: E0606: Possibly using variable 'mean' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/fused_softmax.py:156:29: E0606: Possibly using variable 'max_ms' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/fused_softmax.py:156:43: E0606: Possibly using variable 'min_ms' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/fused_softmax.py:156:101: E0606: Possibly using variable 'cv' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/fused_softmax.py:133:8: W0612: Unused variable 'ms' (unused-variable)
************* Module triton_kernels_benchmark.gemm_benchmark
benchmarks/triton_kernels_benchmark/gemm_benchmark.py:214:34: W0511: FIXME: Remove this case when gemm_streamk_benchmark works (fixme)
benchmarks/triton_kernels_benchmark/gemm_benchmark.py:17:0: R0402: Use 'from triton_kernels_benchmark import xetla_kernel' instead (consider-using-from-import)
benchmarks/triton_kernels_benchmark/gemm_benchmark.py:17:0: E0611: No name 'xetla_kernel' in module 'triton_kernels_benchmark' (no-name-in-module)
benchmarks/triton_kernels_benchmark/gemm_benchmark.py:70:8: W0612: Unused variable 'k' (unused-variable)
benchmarks/triton_kernels_benchmark/gemm_benchmark.py:112:8: W0613: Unused argument 'B' (unused-argument)
benchmarks/triton_kernels_benchmark/gemm_benchmark.py:141:8: W0612: Unused variable 'k' (unused-variable)
benchmarks/triton_kernels_benchmark/gemm_benchmark.py:269:15: C0209: Formatting a regular string which could be an f-string (consider-using-f-string)
benchmarks/triton_kernels_benchmark/gemm_benchmark.py:280:17: E0606: Possibly using variable 'mean_ms' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/gemm_benchmark.py:280:32: E0606: Possibly using variable 'max_ms' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/gemm_benchmark.py:280:46: E0606: Possibly using variable 'min_ms' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/gemm_benchmark.py:280:107: E0606: Possibly using variable 'cv' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/gemm_benchmark.py:251:8: W0612: Unused variable 'median_ms' (unused-variable)
************* Module triton_kernels_benchmark.gemm_splitk_benchmark
benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py:99:0: C0325: Unnecessary parens after 'if' keyword (superfluous-parens)
benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py:56:13: W0511: FIXME: Undefined name `rk` (fixme)
benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py:51:8: W0612: Unused variable 'k' (unused-variable)
benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py:118:31: C0207: Use str(ty).rsplit('.', maxsplit=1)[-1] instead (use-maxsplit-arg)
benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py:134:16: W0613: Unused argument 'ctx' (unused-argument)
benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py:82:0: R0903: Too few public methods (1/2) (too-few-public-methods)
benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py:185:17: E0606: Possibly using variable 'mean' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py:185:29: E0606: Possibly using variable 'max_ms' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py:185:43: E0606: Possibly using variable 'min_ms' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py:185:101: E0606: Possibly using variable 'cv' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py:172:8: W0612: Unused variable 'ms' (unused-variable)
************* Module triton_kernels_benchmark.gemm_streamk_benchmark
benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py:199:5: W0511: TODO: use autotune config instread of hardcoding (fixme)
benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py:22:51: W0613: Unused argument 'K' (unused-argument)
benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py:24:73: W0613: Unused argument 'BLOCK_SIZE_K' (unused-argument)
benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py:39:16: W0613: Unused argument 'M' (unused-argument)
benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py:39:50: W0613: Unused argument 'K' (unused-argument)
benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py:41:16: W0613: Unused argument 'BLOCK_SIZE_M' (unused-argument)
benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py:41:72: W0613: Unused argument 'BLOCK_SIZE_K' (unused-argument)
benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py:42:16: W0613: Unused argument 'GROUP_SIZE_M' (unused-argument)
benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py:119:8: W0621: Redefining name 'full_tiles' from outer scope (line 145) (redefined-outer-name)
benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py:286:17: E0606: Possibly using variable 'mean' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py:286:29: E0606: Possibly using variable 'max_ms' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py:286:43: E0606: Possibly using variable 'min_ms' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py:286:101: E0606: Possibly using variable 'cv' before assignment (possibly-used-before-assignment)
benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py:274:8: W0612: Unused variable 'ms' (unused-variable)
```