### PR TITLE
Use `dest . srcLayout^-1` to preserve surjectivity for transferWithinThread conversion

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -456,19 +456,18 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
   matchAndRewrite(ConvertLayoutOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     MLIRContext *ctx = op.getContext();
+
     const auto &shape = op.getType().getShape();
-    std::optional<LinearLayout> srcLayout;
     auto srcTy = op.getSrc().getType();
-    srcLayout = gpu::toLinearLayout(shape, srcTy.getEncoding());
-
-    std::optional<LinearLayout> dstLayout;
     auto dstTy = op.getType();
-
-    dstLayout = gpu::toLinearLayout(shape, dstTy.getEncoding());
-
+    std::optional<LinearLayout> srcLayout =
+        toLinearLayout(shape, srcTy.getEncoding());
+    std::optional<LinearLayout> dstLayout =
+        toLinearLayout(shape, dstTy.getEncoding());
     if (!srcLayout.has_value() || !dstLayout.has_value()) {
       return failure();
     }
+
     // There are four cases to handle.
     //
     //  1. Transfer between values in the same thread, in which case we simply
@@ -484,65 +483,61 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
     // We can tell which case we're in by examining `conversion`.  If e.g. the
     // block -> block mapping is {1, 2, 4, ...} then there's no movement between
     // data in different CTAs and we know we're not in case 4.
-    LinearLayout conversion = srcLayout->invertAndCompose(*dstLayout);
-
-    int numLanes = conversion.getInDimSize(str_attr("lane"));
-    int numWarps = conversion.getInDimSize(str_attr("warp"));
-    int numBlocks = conversion.getInDimSize(str_attr("block"));
-
-    StringAttr kLane = str_attr("lane");
-    StringAttr kWarp = str_attr("warp");
-    StringAttr kBlock = str_attr("block");
-
-    // TODO(jlebar): These checks are overly-restrictive.  For example, we can
-    // transfer by shuffling registers (case 1) if and only if all of the bases
-    // for `register` have 0s for lane, warp, and block.  But the check below is
-    // stronger than this, checking also that the choice of lane/warp/block does
-    // not affect the permutation of registers.  If we allow different
-    // lane/warp/blocks to have different permutations, we can generalize this.
-    if (std::optional<LinearLayout> c = conversion.divideRight(
-            LinearLayout::identity1D(numLanes, kLane, kLane) *
-            LinearLayout::identity1D(numWarps, kWarp, kWarp) *
-            LinearLayout::identity1D(numBlocks, kBlock, kBlock));
-        c.has_value()) {
-      return transferWithinThread(*c, op, adaptor, rewriter);
+    if (cvtReordersRegisters(srcTy, dstTy)) { // Case 1
+      return transferWithinThread(op, *srcLayout, *dstLayout, adaptor,
+                                  rewriter);
     }
 
-    if (std::optional<LinearLayout> c = conversion.divideRight(
-            LinearLayout::identity1D(numWarps, kWarp, kWarp) *
-            LinearLayout::identity1D(numBlocks, kBlock, kBlock));
-        c.has_value()) {
-      return transferWithinLane(*c, op, adaptor, rewriter);
+    if (cvtNeedsWarpShuffle(srcTy, dstTy)) {
+      return transferWithinLane(op, *srcLayout, *dstLayout, adaptor, rewriter);
     }
 
-    if (std::optional<LinearLayout> c = conversion.divideRight(
-            LinearLayout::identity1D(numBlocks, kBlock, kBlock));
-        c.has_value()) {
-      return transferWithinBlock(*c, op, adaptor, rewriter);
-    }
-
-    return transferWithinBlockGroup(conversion, op, adaptor, rewriter);
+    // TODO: match transferWithinBlockOrGroup from
+    // TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+    return transferWithinBlockGroup(op, *srcLayout, *dstLayout, adaptor,
+                                    rewriter);
   }
 
   LogicalResult
-  transferWithinThread(const LinearLayout &conversion, ConvertLayoutOp op,
-                       OpAdaptor adaptor,
+  transferWithinThread(ConvertLayoutOp op, const LinearLayout &srcLayout,
+                       const LinearLayout &dstLayout, OpAdaptor adaptor,
                        ConversionPatternRewriter &rewriter) const {
     MLIRContext *ctx = op.getContext();
     auto loc = op.getLoc();
     StringAttr kRegister = str_attr("register");
+    StringAttr kLane = str_attr("lane");
+    StringAttr kWarp = str_attr("warp");
+    StringAttr kBlock = str_attr("block");
+
+    // There are three possible cases:
+    //
+    // 1. `srcLayout` has the same number of registers as `dstLayout`.
+    // 2. `srcLayout` has fewer registers than `dstLayout`.
+    // 3. `srcLayout` has more registers than `dstLayout`.
+    //
+    // In the second case `srcLayout . dstLayout^-1` is not surjective
+    // because not all destination registers are covered.
+    // Since the goal is to cover all of the destination
+    // registers, we can instead use `dstLayout . srcLayout^-1`.
+    LinearLayout conversion = dstLayout.invertAndCompose(srcLayout);
+    auto dstToSrc = conversion.divideRight(
+        LinearLayout::identity1D(conversion.getInDimSize(kLane), kLane, kLane) *
+        LinearLayout::identity1D(conversion.getInDimSize(kWarp), kWarp, kWarp) *
+        LinearLayout::identity1D(conversion.getInDimSize(kBlock), kBlock,
+                                 kBlock));
 
     assert(!cvtNeedsSharedMemory(op.getSrc().getType(), op.getType()));
-    assert(ArrayRef(to_vector(conversion.getInDimNames())) ==
+    assert(ArrayRef(to_vector(dstToSrc->getInDimNames())) ==
            ArrayRef{kRegister});
-    assert(ArrayRef(to_vector(conversion.getOutDimNames())) ==
+    assert(ArrayRef(to_vector(dstToSrc->getOutDimNames())) ==
            ArrayRef{kRegister});
 
     auto inVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
-    SmallVector<Value> outVals(conversion.getOutDimSize(kRegister));
-    for (int i = 0; i < conversion.getInDimSize(kRegister); i++) {
-      auto dstIdx = conversion.apply({{kRegister, i}});
-      outVals[dstIdx.begin()->second] = inVals[i];
+    SmallVector<Value> outVals;
+    outVals.resize(dstToSrc->getInDimSize(kRegister));
+    for (int i = 0; i < dstToSrc->getInDimSize(kRegister); i++) {
+      auto srcIdx = dstToSrc->apply({{kRegister, i}});
+      outVals[i] = inVals[srcIdx.begin()->second];
     }
     Value result = packLLElements(loc, getTypeConverter(), outVals, rewriter,
                                   op.getType());
@@ -550,23 +545,18 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
     return success();
   }
 
-  LogicalResult transferWithinLane(const LinearLayout &conversion,
-                                   ConvertLayoutOp op, OpAdaptor adaptor,
+  LogicalResult transferWithinLane(ConvertLayoutOp op,
+                                   const LinearLayout &srcLayout,
+                                   const LinearLayout &dstLayout,
+                                   OpAdaptor adaptor,
                                    ConversionPatternRewriter &rewriter) const {
     // TODO(jlebar): Implement me.
     return failure();
   }
 
-  LogicalResult transferWithinBlock(const LinearLayout &conversion,
-                                    ConvertLayoutOp op, OpAdaptor adaptor,
-                                    ConversionPatternRewriter &rewriter) const {
-    // TODO(jlebar): Implement me.
-    return failure();
-  }
-
   LogicalResult
-  transferWithinBlockGroup(const LinearLayout &conversion, ConvertLayoutOp op,
-                           OpAdaptor adaptor,
+  transferWithinBlockGroup(ConvertLayoutOp op, const LinearLayout &srcLayout,
+                           const LinearLayout &dstLayout, OpAdaptor adaptor,
                            ConversionPatternRewriter &rewriter) const {
     // TODO(jlebar): Implement me.
     return failure();

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -480,15 +480,16 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
     //  4. Transfer between values in different CTAs, in which case we move
     //     values through distributed shared memory.
     //
-    // We can tell which case we're in by examining `conversion`.  If e.g. the
-    // block -> block mapping is {1, 2, 4, ...} then there's no movement between
-    // data in different CTAs and we know we're not in case 4.
-    if (cvtReordersRegisters(srcTy, dstTy)) { // Case 1
+    // We can tell which case we're in by examining `conversion`.
+    // For example, if the block -> block mapping is an identity layout: {1, 2,
+    // 4, ...}, then there's no movement between data in different CTAs, and we
+    // know we're not in case 4.
+    if (cvtReordersRegisters(srcTy, dstTy)) { // Case 1.
       return transferWithinThread(op, *srcLayout, *dstLayout, adaptor,
                                   rewriter);
     }
 
-    if (cvtNeedsWarpShuffle(srcTy, dstTy)) {
+    if (cvtNeedsWarpShuffle(srcTy, dstTy)) { // Case 2.
       return transferWithinLane(op, *srcLayout, *dstLayout, adaptor, rewriter);
     }
 


### PR DESCRIPTION
When lowering from TTGIR to LLVMIR the `convert_layout` op now uses LinearLayout functions to compute the transformation. For a layout conversion between elements of the same thread, i.e. a simple reordering/permutation, we compute a `conversion` LinearLayout (LLL function to determine the ordering, then unpack the inputs and re-pack the outputs. 

Previously, this `conversion` LL was computed using `LL.invertAndCompose` which computes `C = A.invertAndCompose(B)` with the property that `A(x) = B(C(x))`. So, if we compute `conversion = src.invertAndCompose(dst)` then `src(x) = dest(conversion(x))`. But, the `conversion` in this case is not surjective if the `src` has fewer registers than the `dst`. 

In #2004, we convert from 
```
 #blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
```
to
```
#blocked = #triton_gpu.blocked<{sizePerThread = [2, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
```

In this example, `src` has fewer registers than `dst` and so the LLVM output values vector was only partially populated. This resulted in an assertion and eventual segfault when NULL LLVM values were accessed (`1`, `3`, `5`, and `,7` are missing): 

```
Ins:
0 : %643 = "llvm.extractvalue"(%641) <{position = array<i64: 0>}> : (!llvm.struct<(f16, f16, f16, f16)>) -> f16
1 : %644 = "llvm.extractvalue"(%641) <{position = array<i64: 1>}> : (!llvm.struct<(f16, f16, f16, f16)>) -> f16
2 : %645 = "llvm.extractvalue"(%641) <{position = array<i64: 2>}> : (!llvm.struct<(f16, f16, f16, f16)>) -> f16
3 : %646 = "llvm.extractvalue"(%641) <{position = array<i64: 3>}> : (!llvm.struct<(f16, f16, f16, f16)>) -> f16
Outs size: 8
0 : (0, %643 = "llvm.extractvalue"(%641) <{position = array<i64: 0>}> : (!llvm.struct<(f16, f16, f16, f16)>) -> f16)
2 : (1, %644 = "llvm.extractvalue"(%641) <{position = array<i64: 1>}> : (!llvm.struct<(f16, f16, f16, f16)>) -> f16)
4 : (2, %645 = "llvm.extractvalue"(%641) <{position = array<i64: 2>}> : (!llvm.struct<(f16, f16, f16, f16)>) -> f16)
6 : (3, %646 = "llvm.extractvalue"(%641) <{position = array<i64: 3>}> : (!llvm.struct<(f16, f16, f16, f16)>) -> f16)
```

By instead inverting the source layout, we can get `conversion  = dst.invertAndCompose(src)` where `dest(x) = src(conversion(x))`. This conversion is surjective and we can simply populate the destination by iterating its input dimension and applying the layout to each input value. 

I also took the opportunity to make the code in `ConvertLayoutOpToLLVM.cpp` more exactly match upstream where possible.

Resolves #2004 