### PR TITLE
Revert changes in `python/triton/tools/compile.py`

### DIFF
--- a/python/triton/tools/compile.py
+++ b/python/triton/tools/compile.py
@@ -8,7 +8,7 @@ from typing import List
 
 import triton
 from triton.compiler.code_generator import kernel_suffix
-from triton.backends.intel.driver import ty_to_cpp
+from triton.backends.nvidia.driver import ty_to_cpp
 
 desc = """
 Triton ahead-of-time compiler:


### PR DESCRIPTION
This change was first introduced in https://github.com/intel/intel-xpu-backend-for-triton/commit/7b680e6e3cdeadd72d67ab73d9535015eba7b559#diff-293af646f671d3a895c453a8b175754e9d4ec4fc855bb939ffa4d6e9e91b07c6 and after that in https://github.com/intel/intel-xpu-backend-for-triton/commit/b93e92e0510b2cd5ad62b80ba723d378767e4d30. 

Since the code shows the use of cubin https://github.com/intel/intel-xpu-backend-for-triton/blob/34824dca8c97292e7dd8e657845daecd3b70cfbe/python/triton/tools/compile.py#L123, it is likely that the code is currently not working for the intel backend and we can safely remove this change.


Closes #2030