### PR TITLE
Remove IPEX from workflows

### DIFF
--- a/.github/actions/setup-pytorch/action.yml
+++ b/.github/actions/setup-pytorch/action.yml
@@ -68,6 +68,12 @@ runs:
         sudo mkdir -p /opt/intel
         sudo ln -sfT ${{ inputs.oneapi }} /opt/intel/oneapi
 
+    - name: Generate PyTorch cache key
+      shell: bash
+      run: |
+        PYTORCH_CACHE_KEY=$(echo $PYTHON_VERSION $PYTORCH_COMMIT_ID ${{ hashFiles('scripts/patch-pytorch.sh') }} | sha256sum - | cut -d\  -f1)
+        echo "PYTORCH_CACHE_KEY=$PYTORCH_CACHE_KEY" | tee -a "$GITHUB_ENV"
+
     - name: Load PyTorch from a cache
       id: pytorch-cache
       uses: ./.github/actions/load
@@ -76,7 +82,7 @@ runs:
         CACHE_NUMBER: 11
       with:
         path: pytorch
-        key: pytorch-$PYTHON_VERSION-$PYTORCH_COMMIT_ID-$CACHE_NUMBER
+        key: pytorch-$PYTORCH_CACHE_KEY-$CACHE_NUMBER
 
     - name: Clone PyTorch repository
       if: ${{ steps.pytorch-cache.outputs.status == 'miss' }}

--- a/.github/actions/setup-triton/action.yml
+++ b/.github/actions/setup-triton/action.yml
@@ -1,7 +1,7 @@
 # Builds and installs Triton. Uses git clone in the current directory.
 # Sets the following environment variables:
 # * LLVM_COMMIT_ID
-description: Build and install IPEX wheels
+description: Build and install Triton
 inputs:
   build_llvm:
     description: Build LLVM

--- a/.github/workflows/auto-update-translator-cid.yml
+++ b/.github/workflows/auto-update-translator-cid.yml
@@ -49,16 +49,11 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Setup PyTorch with IPEX
+      - name: Setup PyTorch
         if: ${{ env.TARGET_PRID == null }}
         uses: ./.github/actions/setup-pytorch
         with:
-          repository: Stonepia/pytorch
-          ref: ""
-
-      - name: Setup IPEX
-        if: ${{ env.TARGET_PRID == null }}
-        uses: ./.github/actions/setup-ipex
+          repository: pytorch/pytorch
 
       - name: Install test dependencies
         if: ${{ env.TARGET_PRID == null }}

--- a/.github/workflows/build-test-a770.yml
+++ b/.github/workflows/build-test-a770.yml
@@ -8,15 +8,6 @@ on:
         description: Runner label, keep empty for default
         type: string
         default: ""
-      install_ipex:
-        # This boolean parameter defines what PyTorch will be used in the workflow:
-        #   true: Stonepia/pytorch (fork) with IPEX
-        #   false: pytorch/pytorch (upstream) without IPX
-        # In both cases, pytorch_ref below allows specifying a branch, tag, or commit id in the
-        # corresponding repository. If not specified, a default (pinned) version will be used.
-        description: Install Intel PyTorch Extension
-        type: boolean
-        default: false
       pytorch_ref:
         description: PyTorch ref, keep empty for default
         type: string
@@ -54,7 +45,6 @@ jobs:
     with:
       device: a770
       runner_label: ${{ inputs.runner_label }}
-      install_ipex: ${{ inputs.install_ipex }}
       pytorch_ref: ${{ inputs.pytorch_ref }}
       python_version: ${{ matrix.python }}
       upload_test_reports: ${{ inputs.upload_test_reports }}

--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -8,15 +8,6 @@ on:
         description: Runner label, keep empty for default
         type: string
         default: ""
-      install_ipex:
-        # This boolean parameter defines what PyTorch will be used in the workflow:
-        #   true: Stonepia/pytorch (fork) with IPEX
-        #   false: pytorch/pytorch (upstream) without IPX
-        # In both cases, pytorch_ref below allows specifying a branch, tag, or commit id in the
-        # corresponding repository. If not specified, a default (pinned) version will be used.
-        description: Install Intel PyTorch Extension
-        type: boolean
-        default: false
       pytorch_ref:
         description: PyTorch ref, keep empty for default
         type: string
@@ -81,7 +72,6 @@ jobs:
     with:
       driver_version: ${{ matrix.driver }}
       runner_label: ${{ inputs.runner_label }}
-      install_ipex: ${{ inputs.install_ipex }}
       pytorch_ref: ${{ inputs.pytorch_ref }}
       python_version: ${{ matrix.python }}
       upload_test_reports: ${{ inputs.upload_test_reports }}

--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -1,5 +1,5 @@
 name: Build and test reusable workflow
-run-name: ${{ inputs.run_name }} - ${{ inputs.python_version }} - ${{ inputs.install_ipex && 'IPEX' || 'no IPEX' }} - ${{ inputs.runner_label || 'default'}}
+run-name: ${{ inputs.run_name }} - ${{ inputs.python_version }} - ${{ inputs.runner_label || 'default'}}
 
 on:
   workflow_call:
@@ -16,15 +16,6 @@ on:
         description: Runner label, keep empty for default
         type: string
         default: ""
-      install_ipex:
-        # This boolean parameter defines what PyTorch will be used in the workflow:
-        #   true: Stonepia/pytorch (fork) with IPEX
-        #   false: pytorch/pytorch (upstream) without IPX
-        # In both cases, pytorch_ref below allows specifying a branch, tag, or commit id in the
-        # corresponding repository. If not specified, a default (pinned) version will be used.
-        description: Install Intel PyTorch Extension
-        type: boolean
-        default: true
       pytorch_ref:
         description: PyTorch ref, keep empty for default
         type: string
@@ -100,27 +91,11 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
-      - name: Setup PyTorch with IPEX
-        if: ${{ inputs.install_ipex }}
-        uses: ./.github/actions/setup-pytorch
-        with:
-          repository: Stonepia/pytorch
-          ref: ${{ inputs.pytorch_ref }}
-
-      - name: Setup PyTorch without IPEX
-        if: ${{ !inputs.install_ipex }}
+      - name: Setup PyTorch
         uses: ./.github/actions/setup-pytorch
         with:
           repository: pytorch/pytorch
           ref: ${{ inputs.pytorch_ref }}
-
-      - name: Setup IPEX
-        if: ${{ inputs.install_ipex }}
-        uses: ./.github/actions/setup-ipex
-
-      - name: Setup no-op IPEX
-        if: ${{ !inputs.install_ipex }}
-        uses: ./.github/actions/setup-no-op-ipex
 
       - name: Install test dependencies
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,15 +8,6 @@ on:
         description: Runner label, keep empty for default
         type: string
         default: ""
-      install_ipex:
-        # This boolean parameter defines what PyTorch will be used in the workflow:
-        #   true: Stonepia/pytorch (fork) with IPEX
-        #   false: pytorch/pytorch (upstream) without IPX
-        # In both cases, pytorch_ref below allows specifying a branch, tag, or commit id in the
-        # corresponding repository. If not specified, a default (pinned) version will be used.
-        description: Install Intel PyTorch Extension
-        type: boolean
-        default: false
       pytorch_ref:
         description: PyTorch ref, keep empty for default
         type: string
@@ -67,7 +58,7 @@ jobs:
           CACHE_NUMBER: 2
         with:
           path: $HOME/.cache/pip
-          key: pip-3.10-${{ hashFiles('.pre-commit-config.yaml') }}-${{ env.INSTALL_IPEX }}-${{ env.CACHE_NUMBER }}
+          key: pip-3.10-${{ hashFiles('.pre-commit-config.yaml') }}-${{ env.CACHE_NUMBER }}
 
       - name: Install Python 3.10
         uses: actions/setup-python@v5
@@ -128,7 +119,6 @@ jobs:
     with:
       driver_version: ${{ matrix.driver }}
       runner_label: ${{ inputs.runner_label }}
-      install_ipex: ${{ inputs.install_ipex || false }}
       pytorch_ref: ${{ inputs.pytorch_ref }}
       python_version: ${{ matrix.python }}
       upload_test_reports: ${{ inputs.upload_test_reports || false }}

--- a/.github/workflows/e2e-accuracy.yml
+++ b/.github/workflows/e2e-accuracy.yml
@@ -4,10 +4,6 @@ run-name: ${{ inputs.run_name }}
 on:
   workflow_dispatch:
     inputs:
-      install_ipex:
-        description: Install Intel PyTorch Extension
-        type: boolean
-        default: false
       pytorch_ref:
         description: PyTorch ref, keep empty for default
         type: string
@@ -123,7 +119,6 @@ jobs:
       fail-fast: false
     uses: ./.github/workflows/e2e-reusable.yml
     with:
-      install_ipex: ${{ inputs.install_ipex }}
       pytorch_ref: ${{ inputs.pytorch_ref }}
       suite: ${{ matrix.suite }}
       mode: ${{ matrix.mode }}

--- a/.github/workflows/e2e-performance.yml
+++ b/.github/workflows/e2e-performance.yml
@@ -4,10 +4,6 @@ run-name: ${{ inputs.run_name }}
 on:
   workflow_dispatch:
     inputs:
-      install_ipex:
-        description: Install Intel PyTorch Extension
-        type: boolean
-        default: false
       pytorch_ref:
         description: PyTorch ref, keep empty for default
         type: string
@@ -133,7 +129,6 @@ jobs:
       fail-fast: false
     uses: ./.github/workflows/e2e-reusable.yml
     with:
-      install_ipex: ${{ inputs.install_ipex }}
       pytorch_ref: ${{ inputs.pytorch_ref }}
       suite: ${{ matrix.suite }}
       mode: ${{ matrix.mode }}

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -3,10 +3,6 @@ name: E2E reusable workflow
 on:
   workflow_call:
     inputs:
-      install_ipex:
-        description: Install Intel PyTorch Extension
-        type: boolean
-        default: false
       pytorch_ref:
         description: PyTorch ref, keep empty for default
         type: string
@@ -87,40 +83,17 @@ jobs:
         run: |
           pip install wheel
 
-      - name: Setup PyTorch with IPEX
-        if: ${{ inputs.install_ipex }}
-        uses: ./.github/actions/setup-pytorch
-        with:
-          repository: Stonepia/pytorch
-          ref: ${{ inputs.pytorch_ref }}
-
-      - name: Setup PyTorch without IPEX
-        if: ${{ !inputs.install_ipex }}
+      - name: Setup PyTorch
         uses: ./.github/actions/setup-pytorch
         with:
           repository: pytorch/pytorch
           ref: ${{ inputs.pytorch_ref }}
 
-      - name: Set benchmark repository (IPEX)
-        if: ${{ inputs.install_ipex }}
-        run: |
-          echo "BENCHMARK_REPO=weishi-deng/benchmark" | tee -a "$GITHUB_ENV"
-
-      - name: Set benchmark repository (PyTorch)
-        if: ${{ !inputs.install_ipex }}
+      - name: Set benchmark repository
         run: |
           echo "BENCHMARK_REPO=pytorch/benchmark" | tee -a "$GITHUB_ENV"
 
-      - name: Get benchmark commit id (IPEX)
-        if: ${{ inputs.install_ipex }}
-        uses: ./.github/actions/get-commit-id
-        with:
-          repository: ${{ env.BENCHMARK_REPO }}
-          branch: main
-          variable: BENCHMARK_COMMIT_ID
-
-      - name: Get benchmark commit id (PyTorch)
-        if: ${{ !inputs.install_ipex }}
+      - name: Get benchmark commit id
         run: |
           cd pytorch
           echo "BENCHMARK_COMMIT_ID=$(<.github/ci_commit_pins/torchbench.txt)" | tee -a "$GITHUB_ENV"
@@ -133,14 +106,6 @@ jobs:
           echo "TORCHAUDIO_COMMIT_ID=$(<.github/ci_commit_pins/audio.txt)" >> "${GITHUB_ENV}"
           echo "TRANSFORMERS_VERSION=$(<.ci/docker/ci_commit_pins/huggingface.txt)" >> "${GITHUB_ENV}"
           echo "TIMM_COMMIT_ID=$(<.ci/docker/ci_commit_pins/timm.txt)" >> "${GITHUB_ENV}"
-
-      - name: Setup IPEX
-        if: ${{ inputs.install_ipex }}
-        uses: ./.github/actions/setup-ipex
-
-      - name: Setup no-op IPEX
-        if: ${{ !inputs.install_ipex }}
-        uses: ./.github/actions/setup-no-op-ipex
 
       - name: Generate Triton cache key
         id: triton-key
@@ -194,12 +159,6 @@ jobs:
           repository: pytorch/vision
           ref: ${{ env.TORCHVISION_COMMIT_ID }}
           extra-cache-key: ${{ env.PYTORCH_VERSION }}
-
-      # FIXME: old PyTorch does not work with torchdata=0.8.0
-      - name: Install torchdata package
-        if: ${{ inputs.suite == 'torchbench' && inputs.install_ipex }}
-        run: |
-          pip install 'torchdata<0.8.0'
 
       - name: Install torchtext package
         if: ${{ inputs.suite == 'torchbench' }}
@@ -290,9 +249,6 @@ jobs:
           PYTORCH_REPO=$PYTORCH_REPO
           PYTORCH_COMMIT_ID=$PYTORCH_COMMIT_ID
           PYTORCH_VERSION=$PYTORCH_VERSION
-          IPEX_REPO=$IPEX_REPO
-          IPEX_COMMIT_ID=$IPEX_COMMIT_ID
-          IPEX_VERSION=$IPEX_VERSION
           LLVM_REPO=llvm/llvm-project
           LLVM_COMMIT_ID=$LLVM_COMMIT_ID
           BENCHMARK_REPO=$BENCHMARK_REPO

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -24,8 +24,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-        mode:
-          - pytorch
       fail-fast: false
       max-parallel: 2
     defaults:
@@ -44,14 +42,7 @@ jobs:
         run: |
           pip install wheel
 
-      - name: Setup PyTorch with IPEX
-        if: ${{ matrix.mode == 'ipex' }}
-        uses: ./.github/actions/setup-pytorch
-        with:
-          repository: Stonepia/pytorch
-
-      - name: Setup PyTorch without IPEX
-        if: ${{ matrix.mode == 'pytorch' }}
+      - name: Setup PyTorch
         uses: ./.github/actions/setup-pytorch
         with:
           repository: pytorch/pytorch
@@ -62,10 +53,6 @@ jobs:
           echo "TORCHVISION_COMMIT_ID=$(<.github/ci_commit_pins/vision.txt)" >> $GITHUB_ENV
           echo "TORCHTEXT_COMMIT_ID=$(<.github/ci_commit_pins/text.txt)" >> $GITHUB_ENV
           echo "TORCHAUDIO_COMMIT_ID=$(<.github/ci_commit_pins/audio.txt)" >> $GITHUB_ENV
-
-      - name: Setup IPEX
-        if: ${{ matrix.mode == 'ipex' }}
-        uses: ./.github/actions/setup-ipex
 
       - name: Identify Triton commit id
         run: |
@@ -108,12 +95,6 @@ jobs:
           ref: ${{ env.TORCHVISION_COMMIT_ID }}
           extra-cache-key: ${{ env.PYTORCH_VERSION }}
 
-      # FIXME: old PyTorch does not work with torchdata=0.8.0
-      - name: Install torchdata package
-        if: ${{ matrix.mode == 'ipex' }}
-        run: |
-          pip install 'torchdata<0.8.0'
-
       - name: Install torchtext package
         uses: ./.github/actions/install-dependency
         with:
@@ -139,12 +120,6 @@ jobs:
           cp -L torchtext*/dist/*.whl wheels/
           cp -L torchaudio*/dist/*.whl wheels/
 
-      - name: Prepare IPEX wheels for upload
-        if: ${{ matrix.mode == 'ipex' }}
-        run: |
-          mkdir -p wheels
-          cp -L intel-extension-for-pytorch/dist/*.whl wheels/
-
       - name: Report environment details
         run: |
           TIMESTAMP=$(date '+%Y%m%d')
@@ -158,8 +133,6 @@ jobs:
           PYTHON_VERSION=$PYTHON_VERSION
           PYTORCH_REPO=$PYTORCH_REPO
           PYTORCH_COMMIT_ID=$PYTORCH_COMMIT_ID
-          IPEX_REPO=$IPEX_REPO
-          IPEX_COMMIT_ID=$IPEX_COMMIT_ID
           LLVM_REPO=llvm/llvm-project
           LLVM_COMMIT_ID=$LLVM_COMMIT_ID
           TRITON_REPO=intel/intel-xpu-backend-for-triton
@@ -169,15 +142,7 @@ jobs:
           TORCHAUDIO_COMMIT_ID=$TORCHAUDIO_COMMIT_ID
           EOF
 
-      - name: Upload IPEX wheels to artifacts
-        if: ${{ matrix.mode == 'ipex' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-py${{ matrix.python }}-${{ env.TIMESTAMP }}
-          path: wheels
-
       - name: Upload PyTorch wheels to artifacts
-        if: ${{ matrix.mode == 'pytorch' }}
         uses: actions/upload-artifact@v4
         with:
           name: wheels-pytorch-py${{ matrix.python }}-${{ env.TIMESTAMP }}

--- a/.github/workflows/try-latest-pytorch.yml
+++ b/.github/workflows/try-latest-pytorch.yml
@@ -85,7 +85,6 @@ jobs:
     with:
       driver_version: ${{ matrix.driver }}
       runner_label: ${{ inputs.runner_label }}
-      install_ipex: false
       pytorch_ref: ${{ needs.prepare.outputs.pytorch-commit-id }}
       python_version: ${{ matrix.python }}
       upload_test_reports: ${{ inputs.upload_test_reports || false }}

--- a/scripts/pass_rate.py
+++ b/scripts/pass_rate.py
@@ -162,7 +162,6 @@ def print_json_stats(stats: List[ReportStats]):
         'gpu_device': os.getenv('GPU_DEVICE', ''),
         'python_version': platform.python_version(),
         'pytorch_version': os.getenv('PYTORCH_VERSION', ''),
-        'ipex_version': os.getenv('IPEX_VERSION', ''),
         'testsuite': overall.name,
         'passed': overall.passed,
         'failed': overall.failed,


### PR DESCRIPTION
Some workflows, such as triton-benchmarks, conda-build-test, no-basekit-build-test still use IPEX. They will be addressed later.

Fixes #925.