### PR TITLE
[CI] Remove `test_xpu_backend.py`

### DIFF
--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -204,11 +204,6 @@ jobs:
           TRITON_TEST_SUITE=regression \
             pytest -vvv -s --device xpu . --reruns 10 --ignore=test_performance.py
 
-      - name: Run XPU python tests
-        run: |
-          cd python/test/backend/third_party_backends
-          python3 -m pytest -n auto --verbose test_xpu_backend.py
-
       - name: Run Tutorials
         run: |
           source ./scripts/pytest-utils.sh


### PR DESCRIPTION
Decided to remove the test, as it adds no extra test coverage than existing tests.
And `test_xpu_backend.py` is never run correctly, as backend is not passed.