### PR TITLE
Fix building torchaudio in E2E workflow

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -81,6 +81,7 @@ jobs:
 
       - name: Install Python build dependencies
         run: |
+          # cmake 3.22.1 does not work with the recent torchaudio: https://github.com/intel/intel-xpu-backend-for-triton/issues/2079
           pip install wheel cmake
 
       - name: Setup PyTorch

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Install Python build dependencies
         run: |
-          pip install wheel
+          pip install wheel cmake
 
       - name: Setup PyTorch
         uses: ./.github/actions/setup-pytorch


### PR DESCRIPTION
Updating `cmake` to the latest version 3.30.2. The runner has 3.22.1 which is apparently too old for the recent torchaudio.

Fixes #2079.