### PR TITLE
[TritonIntelGPU] Add `sub_group_transpose` operation

### DIFF
--- a/test/Conversion/intel/tritongpu_to_llvm_intel_advanced_path.mlir
+++ b/test/Conversion/intel/tritongpu_to_llvm_intel_advanced_path.mlir
@@ -266,3 +266,27 @@ module attributes {"triton_gpu.num-warps" = 8 : i32, "triton_gpu.threads-per-war
     tt.return
   }
 }
+
+// -----
+
+module attributes {"triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 16 : i32, triton_intel_gpu.support_dpas, triton_intel_gpu.support_sg_2d_block} {
+// CHECK-LABEL:   llvm.func spir_kernelcc @test(
+// CHECK-SAME:                                  %[[VAL_0:.*]]: !llvm.ptr<3>,
+// CHECK-SAME:                                  %[[VAL_1:.*]]: vector<16xf32>) -> vector<16xf32>
+// CHECK:           %[[VAL_4:.*]] = llvm.call spir_funccc @_Z16get_sub_group_idv() {{{.*}}} : () -> i32
+// CHECK:           %[[VAL_5:.*]] = llvm.call spir_funccc @_Z22get_sub_group_local_idv() {{{.*}}} : () -> i32
+// CHECK:           %[[VAL_6:.*]] = llvm.mlir.constant(16 : i32) : i32
+// CHECK:           %[[VAL_7:.*]] = llvm.mlir.constant(256 : i32) : i32
+// CHECK:           %[[VAL_8:.*]] = llvm.mul %[[VAL_7]], %[[VAL_4]]  : i32
+// CHECK:           %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<3>, i32) -> !llvm.ptr<3>, f32
+// CHECK:           llvm.call spir_funccc @llvm.genx.GenISA.simdBlockWrite(%[[VAL_9]], %[[VAL_1]]) {{{.*}}} : (!llvm.ptr<3>, vector<16xf32>) -> ()
+// CHECK:           %[[VAL_10:.*]] = llvm.mul %[[VAL_6]], %[[VAL_5]]  : i32
+// CHECK:           %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_9]]{{\[}}%[[VAL_10]]] : (!llvm.ptr<3>, i32) -> !llvm.ptr<3>, f32
+// CHECK:           %[[VAL_12:.*]] = llvm.load %[[VAL_11]] : !llvm.ptr<3> -> vector<16xf32>
+// CHECK:           llvm.return %[[VAL_12]] : vector<16xf32>
+// CHECK:         }
+  tt.func @test(%arg0: !tt.ptr<f32, 3>, %arg1: tensor<16x16xf32>) -> tensor<16x16xf32> {
+    %0 = triton_intel_gpu.sub_group_transpose %arg0, %arg1 : tensor<16x16xf32>
+    tt.return %0 : tensor<16x16xf32>
+  }
+}

--- a/test/TritonIntelGPU/tritonintelgpu.mlir
+++ b/test/TritonIntelGPU/tritonintelgpu.mlir
@@ -47,3 +47,12 @@ tt.func @simplify_scf_for(%arg0: tensor<16x8xf16>, %arg1: tensor<16x8xf16>, %arg
   tt.store %ptr, %res {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<16x16xf16>>
   tt.return
 }
+
+// -----
+
+tt.func @triton_intel_gpu.sub_group_transpose(%local_buffer : !tt.ptr<f16, 3>, %src : tensor<16x16xf16>) -> tensor<16x16xf16> {
+  // CHECK-LABEL: @triton_intel_gpu.sub_group_transpose
+  // CHECK:         triton_intel_gpu.sub_group_transpose %arg0, %arg1 : tensor<16x16xf16>
+  %res = triton_intel_gpu.sub_group_transpose %local_buffer, %src : tensor<16x16xf16>
+  tt.return %res : tensor<16x16xf16>
+}

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/Dialect.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/Dialect.h
@@ -11,8 +11,13 @@
 
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
+#include "intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h"
 #include "intel/include/Dialect/TritonIntelGPU/IR/Attributes.h"
 #include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h.inc"
+
+namespace mlir::triton::gpu::intel {
+inline constexpr int64_t transposableSize = 16;
+} // namespace mlir::triton::gpu::intel
 
 #define GET_OP_CLASSES
 #include "intel/include/Dialect/TritonIntelGPU/IR/Ops.h.inc"

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/Dialect.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/Dialect.h
@@ -15,10 +15,6 @@
 #include "intel/include/Dialect/TritonIntelGPU/IR/Attributes.h"
 #include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h.inc"
 
-namespace mlir::triton::gpu::intel {
-inline constexpr int64_t transposableSize = 16;
-} // namespace mlir::triton::gpu::intel
-
 #define GET_OP_CLASSES
 #include "intel/include/Dialect/TritonIntelGPU/IR/Ops.h.inc"
 

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -141,4 +141,61 @@ def TTIG_BroadcastOp : TTIG_Op<"broadcast", [Pure, SameOperandsAndResultElementT
   }];
 }
 
+class IsLocalPointerToElementType<string pointer, string value, string summary> :
+    TypesMatchWith<summary, value, pointer, [{
+      ::mlir::triton::PointerType::get( }] # ElementType<"_self">.result # [{,
+          static_cast<unsigned>(::mlir::triton::TritonGEN::kWorkgroup))
+    }]>;
+
+// NOTE: This operation shouldn't be needed, as simply modifying the encoding
+// would be equivalent. As we are not handling encodings much, I created this for
+// prototyping.
+def TTIG_SubGroupTransposeOp
+    : TTIG_Op<"sub_group_transpose",
+        [AllTypesMatch<["src", "res"]>,
+         IsLocalPointerToElementType<"local_buffer", "src",
+             "local_buffer can be used to store src in local memory">]> {
+  let summary = "Sub-group elements transpose operation";
+     let description = [{
+     For a distribution of tensor elements across a sub-group forming a squared
+     matrix like:
+
+    ```
+| Sub-group local id |                       Elements                        |
+|--------------------|-------------------------------------------------------|
+| 0                  | [0,sub_group_size)                                    |
+| 1                  | [sub_group_size,2*sub_group_size)                     |
+| ...                | ...                                                   |
+| sub_group_size-1   | [(sub_group_size-1)*sub_group_size,sub_group_size**2) |
+    ```
+
+    Redistribute elements such as the following mapping applies:
+
+    ```
+| Sub-group local id |                           Elements                           |
+|--------------------|--------------------------------------------------------------|
+| 0                  | 0, sub_group_size, 2*sub_group_size, ...                     |
+| 1                  | 1, sub_group_size+1, 2*sub_group_size+1, ...                 |
+| ...                | ...                                                          |
+| sub_group_size-1   | [sub_group_size-1+i*sub_group_size|i in [0, sub_group_size)] |
+    ```
+
+    In order to do this traspose, each sub-group stores its contents to local
+    memory via `$local_buffer`, each of them forming a matrix there, and loads
+    them back transposed. Note no barriers will be needed as no memory is shared
+    across sub-groups.
+
+    Also note the tensor shape does not change, as only the encoding of the tensor
+    is modified.
+
+    Example:
+      ```
+%matrix_t = triton_intel_gpu.sub_group_transpose %local_buffer, %src : tensor<256x32xf16>
+      ```
+   }];
+  let arguments = (ins TT_Ptr: $local_buffer, TT_Tensor:$src);
+  let results = (outs TT_Tensor:$res);
+  let assemblyFormat = "operands attr-dict `:` type($src)";
+}
+
 #endif

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -180,7 +180,7 @@ def TTIG_SubGroupTransposeOp
 | sub_group_size-1   | [sub_group_size-1+i*sub_group_size|i in [0, sub_group_size)] |
     ```
 
-    In order to do this traspose, each sub-group stores its contents to local
+    In order to do this transpose, each sub-group stores its contents to local
     memory via `$local_buffer`, each of them forming a matrix there, and loads
     them back transposed. Note no barriers will be needed as no memory is shared
     across sub-groups.


### PR DESCRIPTION
Add operation simulating a layout conversion such as:

For a distribution of tensor elements across a sub-group forming a squared matrix like:

| Sub-group local id |                       Elements                        |
|--------------------|-------------------------------------------------------|
| 0                  | [0,sub_group_size)                                    |
| 1                  | [sub_group_size,2*sub_group_size)                     |
| ...                | ...                                                   |
| sub_group_size-1   | [(sub_group_size-1)*sub_group_size,sub_group_size**2) |

Redistribute elements such as the following mapping applies:

| Sub-group local id |                           Elements                           |
|--------------------|--------------------------------------------------------------|
| 0                  | 0, sub_group_size, 2*sub_group_size, ...                     |
| 1                  | 1, sub_group_size+1, 2*sub_group_size+1, ...                 |
| ...                | ...                                                          |
| sub_group_size-1   | [sub_group_size-1+i*sub_group_size|i in [0, sub_group_size)] |

In order to do this transpose, each sub-group stores its contents to local memory via `$local_buffer`, each of them forming a matrix there, and loads them back transposed. Note no barriers will be needed as no memory is shared across sub-groups.

Also note the tensor shape does not change, as only the encoding of the tensor is modified.

**NOTE:** This operation shouldn't be needed, as simply modifying the encoding would be equivalent. As we are not handling encodings much, we need this in the advanced path.
