### PR TITLE
[FIX]: fix FlashAttention E2E performance

### DIFF
--- a/test/Conversion/intel/triton_to_tritongpu_warp.mlir
+++ b/test/Conversion/intel/triton_to_tritongpu_warp.mlir
@@ -41,6 +41,7 @@ module {
       %18 = tt.advance %arg8, [%c0_i32, %c32_i32] : <tensor<256x32xf16>, 1>
       %19 = tt.advance %arg9, [%c32_i32, %c0_i32] : <tensor<32x256xf16>, 1>
       scf.yield %17, %18, %19 : tensor<256x256xf32>, !tt.ptr<tensor<256x32xf16>, 1>, !tt.ptr<tensor<32x256xf16>, 1>
+    // CHECK: {triton_gpu.workload = 3 : i32}
     }
     %14 = tt.make_tensor_ptr %arg2, [%c4096_i64, %c4096_i64], [%c4096_i64, %c1_i64], [%9, %11] {order = array<i32: 1, 0>} : <tensor<256x256xf32>, 1>
     tt.store %14, %13#0 : !tt.ptr<tensor<256x256xf32>, 1>
@@ -90,6 +91,7 @@ module {
       %18 = tt.advance %arg8, [%c0_i32, %c32_i32] : <tensor<8x32xf16>, 1>
       %19 = tt.advance %arg9, [%c32_i32, %c0_i32] : <tensor<32x256xf16>, 1>
       scf.yield %17, %18, %19 : tensor<8x256xf32>, !tt.ptr<tensor<8x32xf16>, 1>, !tt.ptr<tensor<32x256xf16>, 1>
+    // CHECK: {triton_gpu.workload = 3 : i32}
     }
     %14 = tt.make_tensor_ptr %arg2, [%c4096_i64, %c4096_i64], [%c4096_i64, %c1_i64], [%9, %11] {order = array<i32: 1, 0>} : <tensor<8x256xf32>, 1>
     tt.store %14, %13#0 : !tt.ptr<tensor<8x256xf32>, 1>
@@ -176,6 +178,7 @@ module {
       %46 = tt.advance %arg10, [%c64_i32, %c0_i32] : <tensor<64x64xf16>>
       %47 = tt.advance %arg11, [%c0_i32, %c64_i32] : <tensor<64x64xf16>>
       scf.yield %39, %45, %29, %46, %47 : tensor<128xf32>, tensor<128x64xf32>, tensor<128xf32>, !tt.ptr<tensor<64x64xf16>>, !tt.ptr<tensor<64x64xf16>>
+    // CHECK: {triton_gpu.workload = 4 : i32}
     }
     %22 = tt.expand_dims %21#0 {axis = 1 : i32} : tensor<128xf32> -> tensor<128x1xf32>
     %23 = tt.broadcast %22 : tensor<128x1xf32> -> tensor<128x64xf32>

--- a/test/TritonIntelGPU/match-target-size.mlir
+++ b/test/TritonIntelGPU/match-target-size.mlir
@@ -59,13 +59,15 @@ module {
       %39 = tt.dot %37, %38, %arg10 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<32x32xf16, #dot0_> * tensor<32x64xf16, #dot1_> -> tensor<32x64xf32, #warp>
       // CHECK: scf.for
       // CHECK: [[A:%.*]] = tt.load {{.*}} : !tt.ptr<tensor<32x32xf16>>
-      // CHECK: [[B0:%.*]] = tt.load {{.*}} : !tt.ptr<tensor<32x32xf16>>
-      // CHECK: [[B1:%.*]] = tt.load {{.*}} : !tt.ptr<tensor<32x32xf16>>
+      // CHECK: [[B0:%.*]] = tt.load {{.*}} : !tt.ptr<tensor<32x16xf16>>
+      // CHECK: [[B1:%.*]] = tt.load {{.*}} : !tt.ptr<tensor<32x16xf16>>
+      // CHECK: [[B2:%.*]] = tt.load {{.*}} : !tt.ptr<tensor<32x16xf16>>
+      // CHECK: [[B3:%.*]] = tt.load {{.*}} : !tt.ptr<tensor<32x16xf16>>
       // CHECK: [[subA0:%.*]] = triton_intel_gpu.extract [[A]][0] : tensor<32x32xf16> -> tensor<8x16xf16>
-      // CHECK: [[subB0:%.*]] = triton_intel_gpu.extract [[B0]][0] : tensor<32x32xf16> -> tensor<16x16xf16>
+      // CHECK: [[subB0:%.*]] = triton_intel_gpu.extract [[B0]][0] : tensor<32x16xf16> -> tensor<16x16xf16>
       // CHECK: [[subC0:%.*]] = tt.dot [[subA0]], [[subB0]], {{.*}} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
       // CHECK: [[subA1:%.*]] = triton_intel_gpu.extract [[A]][4] : tensor<32x32xf16> -> tensor<8x16xf16>
-      // CHECK: [[subB1:%.*]] = triton_intel_gpu.extract [[B0]][1] : tensor<32x32xf16> -> tensor<16x16xf16>
+      // CHECK: [[subB1:%.*]] = triton_intel_gpu.extract [[B0]][1] : tensor<32x16xf16> -> tensor<16x16xf16>
       // CHECK: [[subC1:%.*]] = tt.dot [[subA1]], [[subB1]], [[subC0]], {{.*}} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
       %40 = tt.advance %arg11, [%c0_i32, %c32_i32] : <tensor<32x32xf16, #dot0_>>
       %41 = tt.advance %arg12, [%c32_i32, %c0_i32] : <tensor<32x64xf16, #dot1_>>
@@ -344,7 +346,7 @@ tt.func public @attn_fwd(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.pt
     %49 = triton_gpu.convert_layout %48 : tensor<16x64xf16, #warp> -> tensor<16x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #warp}>>
 
     // CHECK-COUNT-32: tt.dot {{.*}} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
-    // CHECK-COUNT-4: tt.advance {{.*}} : <tensor<32x32xf16>>
+    // CHECK-COUNT-4: tt.advance {{.*}} : <tensor<32x16xf16>>
     // CHECK-COUNT-16: tt.advance {{.*}} : <tensor<16x16xf16>>
     // CHECK: scf.yield
     %50 = tt.dot %49, %47, %46, inputPrecision = tf32 : tensor<16x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #warp}>> * tensor<64x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #warp}>> -> tensor<16x64xf32, #warp>

--- a/test/TritonIntelGPU/match-target-size.mlir
+++ b/test/TritonIntelGPU/match-target-size.mlir
@@ -83,6 +83,87 @@ module {
 
 // -----
 
+#warp = #triton_intel_gpu.warp<{sizePerThread = [32, 64], threadsPerWarp = [1, 1], order = [1, 0]}>
+#dot0_ = #triton_gpu.dot_op<{opIdx = 0, parent = #warp}>
+#dot1_ = #triton_gpu.dot_op<{opIdx = 1, parent = #warp}>
+
+// COM: Test code generation for the 'tritonintelgpu-match-target-size' transformation.
+module {
+  tt.func public @matmul_kernel_with_block_pointers_without_convertlayout(
+    %arg0: !tt.ptr<f16, 1>, %arg1: !tt.ptr<f16, 1>, %arg2: !tt.ptr<f16, 1>, %arg3: i32, %arg4: i32,
+    %arg5: i32, %arg6: i32, %arg7: i32, %arg8: i32) {
+    // CHECK-LABEL: @matmul_kernel_with_block_pointers_without_convertlayout
+    %c64_i32 = arith.constant 64 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c127_i32 = arith.constant 127 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x64xf32, #warp>
+    %0 = gpu.subgroup_id : index
+    %1 = arith.index_cast %0 : index to i32
+    %2 = tt.get_program_id x : i32
+    %3 = arith.addi %arg3, %c127_i32 : i32
+    %4 = arith.divsi %3, %c128_i32 : i32
+    %5 = arith.addi %arg4, %c127_i32 : i32
+    %6 = arith.divsi %5, %c128_i32 : i32
+    %7 = arith.muli %6, %c8_i32 : i32
+    %8 = arith.divsi %2, %7 : i32
+    %9 = arith.muli %8, %c8_i32 : i32
+    %10 = arith.subi %4, %9 : i32
+    %11 = arith.minsi %10, %c8_i32 : i32
+    %12 = arith.remsi %2, %11 : i32
+    %13 = arith.addi %9, %12 : i32
+    %14 = arith.remsi %2, %7 : i32
+    %15 = arith.divsi %14, %11 : i32
+    %16 = arith.muli %13, %c128_i32 : i32
+    %17 = arith.extsi %arg3 : i32 to i64
+    %18 = arith.extsi %arg5 : i32 to i64
+    %19 = arith.extsi %arg6 : i32 to i64
+    %20 = arith.divsi %1, %c4_i32 : i32
+    %21 = arith.remsi %20, %c8_i32 : i32
+    %22 = arith.muli %21, %c32_i32 : i32
+    %23 = arith.addi %22, %16 : i32
+    %24 = tt.make_tensor_ptr %arg0, [%17, %18], [%19, %c1_i64], [%23, %c0_i32] {order = array<i32: 1, 0>} : <tensor<32x32xf16, #dot0_>>
+    %25 = arith.muli %15, %c128_i32 : i32
+    %26 = arith.extsi %arg4 : i32 to i64
+    %27 = arith.extsi %arg7 : i32 to i64
+    %28 = arith.remsi %1, %c4_i32 : i32
+    %29 = arith.remsi %28, %c4_i32 : i32
+    %30 = arith.muli %29, %c64_i32 : i32
+    %31 = arith.addi %30, %25 : i32
+    %32 = tt.make_tensor_ptr %arg1, [%18, %26], [%27, %c1_i64], [%c0_i32, %31] {order = array<i32: 1, 0>} : <tensor<32x64xf16, #dot1_>>
+    %33:3 = scf.for %arg9 = %c0_i32 to %arg5 step %c32_i32 iter_args(%arg10=%cst, %arg11=%24, %arg12=%32)
+          -> (tensor<32x64xf32, #warp>, !tt.ptr<tensor<32x32xf16, #dot0_>>, !tt.ptr<tensor<32x64xf16, #dot1_>>) : i32 {
+      %37 = tt.load %arg11 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<32x32xf16, #dot0_>>
+      %38 = tt.load %arg12 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<32x64xf16, #dot1_>>
+      %39 = tt.dot %37, %38, %arg10 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<32x32xf16, #dot0_> * tensor<32x64xf16, #dot1_> -> tensor<32x64xf32, #warp>
+      // CHECK: scf.for
+      // CHECK: [[A:%.*]] = tt.load {{.*}} : !tt.ptr<tensor<32x32xf16>>
+      // CHECK: [[B0:%.*]] = tt.load {{.*}} : !tt.ptr<tensor<32x32xf16>>
+      // CHECK: [[B1:%.*]] = tt.load {{.*}} : !tt.ptr<tensor<32x32xf16>>
+      // CHECK: [[subA0:%.*]] = triton_intel_gpu.extract [[A]][0] : tensor<32x32xf16> -> tensor<8x16xf16>
+      // CHECK: [[subB0:%.*]] = triton_intel_gpu.extract [[B0]][0] : tensor<32x32xf16> -> tensor<16x16xf16>
+      // CHECK: [[subC0:%.*]] = tt.dot [[subA0]], [[subB0]], {{.*}} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      // CHECK: [[subA1:%.*]] = triton_intel_gpu.extract [[A]][4] : tensor<32x32xf16> -> tensor<8x16xf16>
+      // CHECK: [[subB1:%.*]] = triton_intel_gpu.extract [[B0]][1] : tensor<32x32xf16> -> tensor<16x16xf16>
+      // CHECK: [[subC1:%.*]] = tt.dot [[subA1]], [[subB1]], [[subC0]], {{.*}} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32>
+      %40 = tt.advance %arg11, [%c0_i32, %c32_i32] : <tensor<32x32xf16, #dot0_>>
+      %41 = tt.advance %arg12, [%c32_i32, %c0_i32] : <tensor<32x64xf16, #dot1_>>
+      scf.yield %39, %40, %41 : tensor<32x64xf32, #warp>, !tt.ptr<tensor<32x32xf16, #dot0_>>, !tt.ptr<tensor<32x64xf16, #dot1_>>
+    } {triton_gpu.workload = 3 : i32}
+    %34 = arith.truncf %33#0 : tensor<32x64xf32, #warp> to tensor<32x64xf16, #warp>
+    %35 = arith.extsi %arg8 : i32 to i64
+    %36 = tt.make_tensor_ptr %arg2, [%17, %26], [%35, %c1_i64], [%23, %31] {order = array<i32: 1, 0>} : <tensor<32x64xf16, #warp>>
+    tt.store %36, %34 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<32x64xf16, #warp>>
+    tt.return
+  }
+}
+
+// -----
+
 // COM: Test SCF canonicalization: ensure result of loop (containing simplification opportunities) can be
 //      consumed by a extract operations.
 tt.func public @simplify_scf_for(%arg0: tensor<16x8xf16>, %arg1: tensor<16x8xf16>, %arg2: !tt.ptr<f16, 1>,

--- a/test/TritonIntelGPU/match-target-size.mlir
+++ b/test/TritonIntelGPU/match-target-size.mlir
@@ -70,7 +70,7 @@ module {
       %40 = tt.advance %arg11, [%c0_i32, %c32_i32] : <tensor<32x32xf16, #dot0_>>
       %41 = tt.advance %arg12, [%c32_i32, %c0_i32] : <tensor<32x64xf16, #dot1_>>
       scf.yield %39, %40, %41 : tensor<32x64xf32, #warp>, !tt.ptr<tensor<32x32xf16, #dot0_>>, !tt.ptr<tensor<32x64xf16, #dot1_>>
-    }
+    } {triton_gpu.workload = 4 : i32}
     %34 = arith.truncf %33#0 : tensor<32x64xf32, #warp> to tensor<32x64xf16, #warp>
     %35 = arith.extsi %arg8 : i32 to i64
     %36 = tt.make_tensor_ptr %arg2, [%17, %26], [%35, %c1_i64], [%23, %31] {order = array<i32: 1, 0>} : <tensor<32x64xf16, #warp>>

--- a/third_party/intel/include/TritonToTritonGPUWarp/TritonToTritonGPUWarpPass.h
+++ b/third_party/intel/include/TritonToTritonGPUWarp/TritonToTritonGPUWarpPass.h
@@ -5,6 +5,16 @@
 
 namespace mlir {
 
+constexpr static char AttrWorkloadName[] = "triton_gpu.workload";
+enum class Workload {
+  // TODO: add more
+  None = 0, // pattern not match any of below
+  ElementWise = 1,
+  Reduction = 2,
+  Gemm = 3,
+  Attention = 4
+};
+
 class ModuleOp;
 template <typename T> class OperationPass;
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MatchTargetSize.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MatchTargetSize.cpp
@@ -51,7 +51,6 @@
 #include "intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h"
 #include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h"
-// For Workload
 #include "intel/include/TritonToTritonGPUWarp/TritonToTritonGPUWarpPass.h"
 
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MatchTargetSize.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MatchTargetSize.cpp
@@ -51,6 +51,8 @@
 #include "intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h"
 #include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h"
+// For Workload
+#include "intel/include/TritonToTritonGPUWarp/TritonToTritonGPUWarpPass.h"
 
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -270,10 +272,17 @@ class MatchTargetSizePass
           MatchTargetSizePass> {
 public:
   void runOnOperation() override {
-    initNativeOperationSizes();
-
     MLIRContext *ctx = &getContext();
     ModuleOp m = getOperation();
+
+    Workload workload = Workload::None;
+    m.walk([&](scf::ForOp forOp) {
+      if (Attribute attr = forOp->getAttr(AttrWorkloadName))
+        workload = static_cast<Workload>(cast<IntegerAttr>(attr).getInt());
+    });
+
+    initNativeOperationSizes(workload);
+
     // this is ad-hoc for flash attention load/store Q on SLM
     if (tools::getBoolEnv("TRITON_INTEL_ENABLE_FIRST_LOAD_TO_SLM"))
       rewriteLoadWithSLM(m, dotWithSLMOperands, ctx);
@@ -349,7 +358,7 @@ public:
 private:
   /// Initialize the native operation sizes supported by the target
   /// architecture.
-  void initNativeOperationSizes();
+  void initNativeOperationSizes(Workload workload = Workload::None);
 
   /// Determine whether the given type is a tensor (or a pointer to a tensor)
   /// that has a warp layout or a dot layout with a parent warp layout.
@@ -578,7 +587,7 @@ public:
   }
 };
 
-void MatchTargetSizePass::initNativeOperationSizes() {
+void MatchTargetSizePass::initNativeOperationSizes(Workload workload) {
   // FIXME: sets the target dot shape natively supported by the target
   // architecture using the target architecture information when available.
   // These values works for PVC.
@@ -588,7 +597,11 @@ void MatchTargetSizePass::initNativeOperationSizes() {
   nativeSizes.setDotShape(32, {8, 16, 8});
 
   nativeSizes.setBlockMemShape(8, {16, 64, 32, 32});
-  nativeSizes.setBlockMemShape(16, {32, 32, 32, 32});
+  if (workload == Workload::Attention)
+    nativeSizes.setBlockMemShape(16, {32, 32, 32, 16});
+  else
+    nativeSizes.setBlockMemShape(16, {32, 32, 32, 32});
+
   nativeSizes.setBlockMemShape(32, {8, 8, 8, 16});
 
   nativeSizes.setLoadStoreSize(512); // max 512DW;

--- a/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
@@ -390,6 +390,7 @@ void PrefetchBlockPass::injectPrefetchOpsInBody(
   auto newLoop =
       b.create<scf::ForOp>(loop.getLoc(), loop.getLowerBound(),
                            loop.getUpperBound(), loop.getStep(), iterArgs);
+  newLoop->setAttrs(loop->getAttrs());
   auto args = newLoop.getBody()->getArguments();
 
   for (auto [lhs, rhs] :

--- a/third_party/intel/lib/TritonToTritonGPUWarp/TritonToTritonGPUWarpPass.cpp
+++ b/third_party/intel/lib/TritonToTritonGPUWarp/TritonToTritonGPUWarpPass.cpp
@@ -50,7 +50,6 @@ namespace mlir::triton::intel {
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace {
-constexpr static char AttrWorkloadName[] = "triton_gpu.workload";
 
 // pass named attrs (e.g., tt.contiguity) from Triton to TritonGPU
 static void addNamedAttrs(Operation *op, DictionaryAttr dictAttrs) {
@@ -58,15 +57,6 @@ static void addNamedAttrs(Operation *op, DictionaryAttr dictAttrs) {
     if (!op->hasAttr(attr.getName()))
       op->setAttr(attr.getName(), attr.getValue());
 }
-
-enum class Workload {
-  // TODO: add more
-  None = 0, // pattern not match any of below
-  ElementWise = 1,
-  Reduction = 2,
-  Gemm = 3,
-  Attention = 4
-};
 
 struct DotInfo {
   tt::DotOp dot;


### PR DESCRIPTION
FlashAttention E2E needs BlockMemShape{32, 32, 32, 16}, but it causes a specific shape's performance degragation. (For detail: please refer [link](https://github.com/intel/intel-xpu-backend-for-triton/pull/2061#discussion_r1741724264))
This PR tries to distinguish gemm/flashattention by Workload type of `scf::ForOp`.