### PR TITLE
Remove cmake>=3.20 from `tests` target in `setup.py`

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -672,7 +672,6 @@ setup(
             "pytest",
             "scipy>=1.7.1",
             "llnl-hatchet",
-            "cmake>=3.20",
         ],
         "tutorials": [
             "matplotlib",

--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -181,7 +181,7 @@ build_triton() {
   pip install -e .
 
   # Install triton tests.
-  pip install -vvv -e '.[tests]'
+  pip install -vvv -e '.[build,tests]'
 
   # Copy compile_commands.json in the build directory (so that cland vscode plugin can find it).
   cp $TRITON_PROJ_BUILD/"$(ls $TRITON_PROJ_BUILD)"/compile_commands.json $TRITON_PROJ/


### PR DESCRIPTION
`Cmake` was added due to https://github.com/intel/intel-xpu-backend-for-triton/issues/1365

Closes #2110