### PR TITLE
Remove `test_subprocess.py::test_print` from skiplists

### DIFF
--- a/python/test/unit/language/print_helper.py
+++ b/python/test/unit/language/print_helper.py
@@ -131,11 +131,6 @@ def test_print(func: str, data_type: str, device: str):
     else:
         assert f"Unknown kernel: {func}"
 
-    if device == "xpu":
-        # FIXME: remove trigger to get output from kernel
-        repr(x)
-        repr(y)
-
     if func != "print_no_arg" and func != "no_arg_print" and func != "device_print_large" and \
        func != "print_multiple_args" and func != "device_print_multiple_args" and \
        func != "device_print_pointer" and func != "device_print_scalar":

--- a/scripts/skiplist/a770/subprocess.txt
+++ b/scripts/skiplist/a770/subprocess.txt
@@ -1,2 +1,0 @@
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/1704
-test/unit/language/test_subprocess.py::test_print[device_print_uint-uint32]

--- a/scripts/skiplist/conda/subprocess.txt
+++ b/scripts/skiplist/conda/subprocess.txt
@@ -1,9 +1,0 @@
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/800
-test/unit/language/test_subprocess.py::test_print[device_print-float16]
-test/unit/language/test_subprocess.py::test_print[device_print-float32]
-test/unit/language/test_subprocess.py::test_print[device_print-float64]
-test/unit/language/test_subprocess.py::test_print[device_print_scalar-float16]
-test/unit/language/test_subprocess.py::test_print[device_print_scalar-float64]
-test/unit/language/test_subprocess.py::test_print[device_print_scalar-float32]
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/1704
-test/unit/language/test_subprocess.py::test_print[device_print_uint-uint32]

--- a/scripts/skiplist/default/subprocess.txt
+++ b/scripts/skiplist/default/subprocess.txt
@@ -1,9 +1,0 @@
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/800
-test/unit/language/test_subprocess.py::test_print[device_print-float16]
-test/unit/language/test_subprocess.py::test_print[device_print-float32]
-test/unit/language/test_subprocess.py::test_print[device_print-float64]
-test/unit/language/test_subprocess.py::test_print[device_print_scalar-float16]
-test/unit/language/test_subprocess.py::test_print[device_print_scalar-float64]
-test/unit/language/test_subprocess.py::test_print[device_print_scalar-float32]
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/1704
-test/unit/language/test_subprocess.py::test_print[device_print_uint-uint32]

--- a/scripts/skiplist/lts/subprocess.txt
+++ b/scripts/skiplist/lts/subprocess.txt
@@ -1,9 +1,0 @@
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/800
-test/unit/language/test_subprocess.py::test_print[device_print-float16]
-test/unit/language/test_subprocess.py::test_print[device_print-float32]
-test/unit/language/test_subprocess.py::test_print[device_print-float64]
-test/unit/language/test_subprocess.py::test_print[device_print_scalar-float16]
-test/unit/language/test_subprocess.py::test_print[device_print_scalar-float64]
-test/unit/language/test_subprocess.py::test_print[device_print_scalar-float32]
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/1704
-test/unit/language/test_subprocess.py::test_print[device_print_uint-uint32]

--- a/scripts/skiplist/no-basekit/subprocess.txt
+++ b/scripts/skiplist/no-basekit/subprocess.txt
@@ -1,9 +1,0 @@
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/800
-test/unit/language/test_subprocess.py::test_print[device_print-float16]
-test/unit/language/test_subprocess.py::test_print[device_print-float32]
-test/unit/language/test_subprocess.py::test_print[device_print-float64]
-test/unit/language/test_subprocess.py::test_print[device_print_scalar-float16]
-test/unit/language/test_subprocess.py::test_print[device_print_scalar-float64]
-test/unit/language/test_subprocess.py::test_print[device_print_scalar-float32]
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/1704
-test/unit/language/test_subprocess.py::test_print[device_print_uint-uint32]


### PR DESCRIPTION
The problem is still there, but now the test has been updated (in upstream) with `torch.cuda.synchronize()` construct, which hides the problem (only for A770).

CI A770: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/10707366601

Closes #800