### PR TITLE
Don't try to install `intel_extension_for_pytorch-*` from nightly wheels

### DIFF
--- a/.github/workflows/conda-build-test.yml
+++ b/.github/workflows/conda-build-test.yml
@@ -74,6 +74,7 @@ jobs:
           set -x
           export DEBUG=1
           cd python
+          conda run --no-capture-output -n triton pip install pybind11
           conda run --no-capture-output -n triton pip install --no-build-isolation -e '.[build,tests,tutorials]'
 
       - name: Run core tests

--- a/.github/workflows/conda-build-test.yml
+++ b/.github/workflows/conda-build-test.yml
@@ -67,7 +67,7 @@ jobs:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           install_cmd: conda run --no-capture-output -n triton pip install
           python_version: ${{ matrix.python }}
-          wheels_pattern: '{torch-*}'
+          wheels_pattern: 'torch-*'
 
       - name: Build Triton
         run: |

--- a/.github/workflows/conda-build-test.yml
+++ b/.github/workflows/conda-build-test.yml
@@ -67,7 +67,7 @@ jobs:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           install_cmd: conda run --no-capture-output -n triton pip install
           python_version: ${{ matrix.python }}
-          wheels_pattern: '{intel_extension_for_pytorch-*,torch-*}'
+          wheels_pattern: '{torch-*}'
 
       - name: Build Triton
         run: |

--- a/.github/workflows/no-basekit-build-test.yml
+++ b/.github/workflows/no-basekit-build-test.yml
@@ -98,6 +98,7 @@ jobs:
           python -m venv ./.venv; source ./.venv/bin/activate
           export DEBUG=1
           cd python
+          conda run --no-capture-output -n triton pip install pybind11
           conda run --no-capture-output -n triton pip install --no-build-isolation -e '.[build,tests,tutorials]'
 
       - name: Run tests

--- a/.github/workflows/no-basekit-build-test.yml
+++ b/.github/workflows/no-basekit-build-test.yml
@@ -90,7 +90,7 @@ jobs:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           install_cmd: conda run --no-capture-output -n triton pip install
           python_version: ${{ matrix.python }}
-          wheels_pattern: '{intel_extension_for_pytorch-*,torch-*}'
+          wheels_pattern: '{torch-*}'
 
       - name: Build Triton
         run: |

--- a/.github/workflows/no-basekit-build-test.yml
+++ b/.github/workflows/no-basekit-build-test.yml
@@ -90,7 +90,7 @@ jobs:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           install_cmd: conda run --no-capture-output -n triton pip install
           python_version: ${{ matrix.python }}
-          wheels_pattern: '{torch-*}'
+          wheels_pattern: 'torch-*'
 
       - name: Build Triton
         run: |


### PR DESCRIPTION
To fix CI on llvm-target branch: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/10707855695/job/29688800747 and https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/10707855697/job/29688800752.

If I understand correctly, the last wheel will be PyTorch 2.5, for which there is no IPEX wheel.

