### PR TITLE
Replace TritonGEN Shuffle with GPU shuffle

### DIFF
--- a/test/TritonGEN/tritongen-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-to-llvm.mlir
@@ -196,64 +196,6 @@ module attributes {
 
 // -----
 
-// CHECK-DAG: llvm.func spir_funccc @_Z21sub_group_shuffle_xordj(f64, i32) -> f64 attributes {passthrough = ["convergent", "nofree", "nounwind", "willreturn"]}
-// CHECK-DAG: llvm.func spir_funccc @_Z21sub_group_shuffle_xorfj(f32, i32) -> f32 attributes {passthrough = ["convergent", "nofree", "nounwind", "willreturn"]}
-// CHECK-DAG: llvm.func spir_funccc @_Z21sub_group_shuffle_xorDhj(f16, i32) -> f16 attributes {passthrough = ["convergent", "nofree", "nounwind", "willreturn"]}
-// CHECK-DAG: llvm.func spir_funccc @_Z21sub_group_shuffle_xorlj(i64, i32) -> i64 attributes {passthrough = ["convergent", "nofree", "nounwind", "willreturn"]}
-// CHECK-DAG: llvm.func spir_funccc @_Z21sub_group_shuffle_xorsj(i16, i32) -> i16 attributes {passthrough = ["convergent", "nofree", "nounwind", "willreturn"]}
-// CHECK-DAG: llvm.func spir_funccc @_Z21sub_group_shuffle_xorcj(i8, i32) -> i8 attributes {passthrough = ["convergent", "nofree", "nounwind", "willreturn"]}
-// CHECK-DAG: llvm.func spir_funccc @_Z17sub_group_shuffleij(i32, i32) -> i32 attributes {passthrough = ["convergent", "nofree", "nounwind", "willreturn"]}
-// CHECK-DAG: llvm.func spir_funccc @_Z22sub_group_shuffle_downij(i32, i32) -> i32 attributes {passthrough = ["convergent", "nofree", "nounwind", "willreturn"]}
-// CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_shuffle_upij(i32, i32) -> i32 attributes {passthrough = ["convergent", "nofree", "nounwind", "willreturn"]}
-// CHECK-DAG: llvm.func spir_funccc @_Z21sub_group_shuffle_xorij(i32, i32) -> i32 attributes {passthrough = ["convergent", "nofree", "nounwind", "willreturn"]}
-
-llvm.func @triton_gen.sub_group_shuffle() {
-  // CHECK-LABEL: triton_gen.sub_group_shuffle
-  %0 = llvm.mlir.constant(0 : i32) : i32
-  // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-  // CHECK: llvm.call spir_funccc @_Z21sub_group_shuffle_xorij([[ZERO]], [[ZERO]]) {{.*}} : (i32, i32) -> i32
-  // CHECK: llvm.call spir_funccc @_Z20sub_group_shuffle_upij([[ZERO]], [[ZERO]]) {{.*}} : (i32, i32) -> i32
-  // CHECK: llvm.call spir_funccc @_Z22sub_group_shuffle_downij([[ZERO]], [[ZERO]]) {{.*}} : (i32, i32) -> i32
-  // CHECK: llvm.call spir_funccc @_Z17sub_group_shuffleij([[ZERO]], [[ZERO]]) {{.*}} : (i32, i32) -> i32
-  %1 = triton_gen.sub_group_shuffle xor %0, %0 : i32
-  %2 = triton_gen.sub_group_shuffle up %0, %0 : i32
-  %3 = triton_gen.sub_group_shuffle down %0, %0 : i32
-  %4 = triton_gen.sub_group_shuffle idx %0, %0 : i32
-
-  // CHECK: [[ZERO1:%.*]] = llvm.mlir.constant(0 : i8) : i8
-  // CHECK: llvm.call spir_funccc @_Z21sub_group_shuffle_xorcj([[ZERO1]], [[ZERO]]) {{.*}} : (i8, i32) -> i8
-  %5 = llvm.mlir.constant(0 : i8) : i8
-  %6 = triton_gen.sub_group_shuffle xor %5, %0 : i8
-
-  // CHECK: [[ZERO2:%.*]] = llvm.mlir.constant(0 : i16) : i16
-  // CHECK: llvm.call spir_funccc @_Z21sub_group_shuffle_xorsj([[ZERO2]], [[ZERO]]) {{.*}} : (i16, i32) -> i16
-  %7 = llvm.mlir.constant(0 : i16) : i16
-  %8 = triton_gen.sub_group_shuffle xor %7, %0 : i16
-
-  // CHECK: [[ZERO3:%.*]] = llvm.mlir.constant(0 : i64) : i64
-  // CHECK: llvm.call spir_funccc @_Z21sub_group_shuffle_xorlj([[ZERO3]], [[ZERO]]) {{.*}} : (i64, i32) -> i64
-  %9 = llvm.mlir.constant(0 : i64) : i64
-  %10 = triton_gen.sub_group_shuffle xor %9, %0 : i64
-
-  // CHECK: [[ZERO4:%.*]] = llvm.mlir.constant(0.000000e+00 : f16) : f16
-  // CHECK: llvm.call spir_funccc @_Z21sub_group_shuffle_xorDhj([[ZERO4]], [[ZERO]]) {{.*}} : (f16, i32) -> f16
-  %11 = llvm.mlir.constant(0.0 : f16) : f16
-  %12 = triton_gen.sub_group_shuffle xor %11, %0 : f16
-
-  // CHECK: [[ZERO5:%.*]] = llvm.mlir.constant(0.000000e+00 : f32) : f32
-  // CHECK: llvm.call spir_funccc @_Z21sub_group_shuffle_xorfj([[ZERO5]], [[ZERO]]) {{.*}} : (f32, i32) -> f32
-  %13 = llvm.mlir.constant(0.0 : f32) : f32
-  %14 = triton_gen.sub_group_shuffle xor %13, %0 : f32
-
-  // CHECK: [[ZERO6:%.*]] = llvm.mlir.constant(0.000000e+00 : f64) : f64
-  // CHECK: llvm.call spir_funccc @_Z21sub_group_shuffle_xordj([[ZERO6]], [[ZERO]]) {{.*}} : (f64, i32) -> f64
-  %15 = llvm.mlir.constant(0.0 : f64) : f64
-  %16 = triton_gen.sub_group_shuffle xor %15, %0 : f64
-  llvm.return
-}
-
-// -----
-
 // CHECK: llvm.func spir_funccc @_Z36intel_sub_group_i8_i8_matrix_mad_k32Dv8_sDv8_iS0_(vector<8xi16>, vector<8xi32>, vector<8xi32>) -> vector<8xi32> attributes {passthrough = ["convergent", "nofree", "nounwind", "willreturn", ["memory", "0"]]}
 
 llvm.func @triton_gen.dpas.i8(%c : vector<8xi32>, %a : vector<8xi16>, %b : vector<8xi32>) {

--- a/test/TritonGEN/tritongen.mlir
+++ b/test/TritonGEN/tritongen.mlir
@@ -113,38 +113,6 @@ module attributes {
 
 // -----
 
-llvm.func @triton_gen.sub_group_shuffle() {
-  // CHECK-LABEL: triton_gen.sub_group_shuffle
-  %0 = llvm.mlir.constant(0 : i32) : i32
-  // CHECK: %1 = triton_gen.sub_group_shuffle xor %0, %0 : i32
-  %1 = triton_gen.sub_group_shuffle xor %0, %0 : i32
-  // CHECK: %2 = triton_gen.sub_group_shuffle up %0, %0 : i32
-  %2 = triton_gen.sub_group_shuffle up %0, %0 : i32
-  // CHECK: %3 = triton_gen.sub_group_shuffle down %0, %0 : i32
-  %3 = triton_gen.sub_group_shuffle down %0, %0 : i32
-  // CHECK: %4 = triton_gen.sub_group_shuffle idx %0, %0 : i32
-  %4 = triton_gen.sub_group_shuffle idx %0, %0 : i32
-  %5 = llvm.mlir.constant(0 : i8) : i8
-  // CHECK: %6 = triton_gen.sub_group_shuffle xor %5, %0 : i8
-  %6 = triton_gen.sub_group_shuffle xor %5, %0 : i8
-  %7 = llvm.mlir.constant(0 : i16) : i16
-  // CHECK: %8 = triton_gen.sub_group_shuffle xor %7, %0 : i16
-  %8 = triton_gen.sub_group_shuffle xor %7, %0 : i16
-  %9 = llvm.mlir.constant(0 : i64) : i64
-  // CHECK: %10 = triton_gen.sub_group_shuffle xor %9, %0 : i64
-  %10 = triton_gen.sub_group_shuffle xor %9, %0 : i64
-  %11 = llvm.mlir.constant(0.0 : f16) : f16
-  // CHECK: %12 = triton_gen.sub_group_shuffle xor %11, %0 : f16
-  %12 = triton_gen.sub_group_shuffle xor %11, %0 : f16
-  %13 = llvm.mlir.constant(0.0 : f32) : f32
-  // CHECK: %14 = triton_gen.sub_group_shuffle xor %13, %0 : f32
-  %14 = triton_gen.sub_group_shuffle xor %13, %0 : f32
-  %15 = llvm.mlir.constant(0.0 : f64) : f64
-  // CHECK: %16 = triton_gen.sub_group_shuffle xor %15, %0 : f64
-  %16 = triton_gen.sub_group_shuffle xor %15, %0 : f64
-  llvm.return
-}
-
 llvm.func @triton_gen.dpas(%c : vector<8xi32>, %a : vector<8xi16>, %b : vector<8xi32>) {
   // CHECK:      llvm.func @triton_gen.dpas(%arg0: vector<8xi32>, %arg1: vector<8xi16>, %arg2: vector<8xi32>) {
   // CHECK-NEXT:   %0 = triton_gen.dpas %arg0, %arg1, %arg2 {pa = i8, pb = i8, rc = 8} : (vector<8xi32>, vector<8xi16>, vector<8xi32>) -> vector<8xi32>

--- a/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENAttrDefs.td
+++ b/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENAttrDefs.td
@@ -43,17 +43,6 @@ def TritonGEN_ScanKindAttr : I32EnumAttr<"ScanKind", "TritonGEN subgroup scan ki
   let cppNamespace = "::mlir::triton::TritonGEN";
 }
 
-/// Enum attribute of the different subgroup shuffle kinds.
-def TritonGEN_ShflKindAttr : I32EnumAttr<"ShflKind", "TritonGEN subgroup shuffle kind",
-  [
-    I32EnumAttrCase<"XOR",  0, "xor">,
-    I32EnumAttrCase<"UP",   1, "up">,
-    I32EnumAttrCase<"DOWN", 2, "down">,
-    I32EnumAttrCase<"IDX",  3, "idx">
-  ]> {
-  let cppNamespace = "::mlir::triton::TritonGEN";
-}
-
 /// Enum attribute of the different floating-point rounding modes.
 def TritonGEN_RoundingModeAttr : I32EnumAttr<"RoundingMode",
   "TritonGEN floating-point rounding mode",

--- a/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENOps.td
+++ b/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENOps.td
@@ -203,31 +203,6 @@ def TritonGEN_SubGroupScanOp : TritonGEN_Op<"sub_group_scan", [
   }];
 }
 
-def TritonGEN_SubGroupShuffleOp : TritonGEN_Op<"sub_group_shuffle", [
-      AllTypesMatch<["res", "value"]>]>,
-  Results<(outs SignlessIntegerOrFloatLike:$res)>,
-  Arguments<(ins SignlessIntegerOrFloatLike:$value,
-                 I32:$mask,
-                 TritonGEN_ShflKindAttr:$kind)> {
-  let summary = "Subgroup shuffle";
-
-  let description = [{
-    The `triton_gen.sub_group_shuffle` operation is invoked by different work
-    items with different values, given by $value. Different work items have
-    different subgroup local IDs. The shuffle kind, $kind, is given to determine
-    how to calculate the associated subgroup local ID. It returns the associated
-    $value for the work item with subgroup local ID equal to:
-    - $kind == xor, the current invocation’s subgroup local ID xor’ed with $mask.
-    - $kind == up, the current invocation’s subgroup local ID - $mask.
-    - $kind == down, the current invocation’s subgroup local ID + $mask.
-    - $kind == idx, the subgroup local ID $mask.
-  }];
-
-  let assemblyFormat = [{
-    $kind $value `,` $mask attr-dict `:` type($value)
-  }];
-}
-
 //===----------------------------------------------------------------------===//
 // Matrix operations
 //===----------------------------------------------------------------------===//

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
@@ -18,13 +18,12 @@ using namespace mlir::triton;
 namespace mlir::LLVM::intel {
 
 static Type findShuffleType(RewriterBase &rewriter, Type valType) {
-  if (rewriter.getI8Type() == valType || rewriter.getI16Type() == valType ||
-      rewriter.getI32Type() == valType || rewriter.getI64Type() == valType ||
-      rewriter.getF16Type() == valType || rewriter.getF32Type() == valType ||
-      rewriter.getF64Type() == valType) {
+  if (valType.isInteger(8) || valType.isInteger(16) || valType.isInteger(32) ||
+      valType.isInteger(64) || valType.isF16() || valType.isF32() ||
+      valType.isF64()) {
     return valType;
   }
-  if (rewriter.getBF16Type() == valType) {
+  if (valType.isBF16()) {
     return rewriter.getI16Type();
   }
 
@@ -42,7 +41,8 @@ static Value shuffleCommon(Location loc, RewriterBase &rewriter, Value val,
 
   unsigned bitWidth = valType.getIntOrFloatBitWidth();
   if (shuffleType != valType) {
-    assert(shuffleType.isInteger());
+    assert(shuffleType.isInteger() &&
+           "expected to bitcast to an integer for unsupported shuffles");
     if (!valType.isInteger()) {
       val = bitcast(val, int_ty(bitWidth));
     }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
@@ -50,8 +50,7 @@ static Value shuffleCommon(Location loc, RewriterBase &rewriter, Value val,
   }
 
   int width = TritonGEN::getSubgroupSize(i.getDefiningOp());
-  auto widthAttr = rewriter.getI32IntegerAttr(width);
-  Value widthConstant = rewriter.create<LLVM::ConstantOp>(loc, widthAttr);
+  Value widthConstant = i32_val(width);
   Value result =
       rewriter.create<mlir::gpu::ShuffleOp>(loc, val, i, widthConstant, mode)
           .getShuffleResult();


### PR DESCRIPTION
The next step in replacing parts of TritonGEN with the `gpu-to-llvm-spv` pass.
Shuffles are 1-2-1 conversion, but a bit of extra code is needed because of the limit on the number types supported by the `gpu-to-llvm-spv` pass, which follows the types supported by the OpenCL SPIR-V Environment Specification.