### PR TITLE
[FIX]: fix incorrect transpose flag for 2DBlockLoad

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TritonOpsToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TritonOpsToLLVM.cpp
@@ -220,7 +220,7 @@ public:
       }
       auto load = rewriter.create<TritonGEN::Matrix2DBlockLoadOp>(
           loc, vectorType, base, surfaceW, surfaceH, surfaceP, offsetX, offsetY,
-          dataSize, blockWidth, blockHeight, vBlks, false /*transpose*/, vnni);
+          dataSize, blockWidth, blockHeight, vBlks, transpose, vnni);
       VERIFY_OPERATION(load)
 
       rewriter.replaceOp(op, bitcast(load, resType));


### PR DESCRIPTION
`transpose` is wrongly fixed to `false`.
