### PR TITLE
Move inductor tests up and set Python version

### DIFF
--- a/.github/workflows/try-latest-pytorch.yml
+++ b/.github/workflows/try-latest-pytorch.yml
@@ -84,6 +84,25 @@ jobs:
           }'
           echo e2e_matrix=$e2e_matrix | tee -a $GITHUB_OUTPUT
 
+  inductor-tests:
+    name: Inductor tests
+    needs: prepare
+    strategy:
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+      fail-fast: false
+      max-parallel: 2
+    uses: ./.github/workflows/inductor-tests-reusable.yml
+    with:
+      pytorch_ref: ${{ needs.prepare.outputs.pytorch-commit-id }}
+      suite: >
+        inductor/test_codegen_triton.py
+        inductor/test_triton_extension_backend.py
+        inductor/test_triton_heuristics.py
+        inductor/test_triton_wrapper.py
+        inductor/test_triton_kernels.py
+      runner_label: ${{ inputs.runner_label }}
+      python_version: ${{ matrix.python }}
+
   integration-tests:
     name: Integration tests matrix
     needs: prepare
@@ -104,25 +123,6 @@ jobs:
       skip_list: ${{ inputs.skip_list }}
       run_name: "${{ inputs.run_name }}: ${{ matrix.driver }} ${{ matrix.python }} ${{ needs.prepare.outputs.pytorch-commit-id }}"
       enable_unskip: ${{ inputs.enable_unskip || false }}
-
-  inductor-tests:
-    name: Inductor tests
-    needs: prepare
-    strategy:
-      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
-      fail-fast: false
-      max-parallel: 2
-    uses: ./.github/workflows/inductor-tests-reusable.yml
-    with:
-      pytorch_ref: ${{ needs.prepare.outputs.pytorch-commit-id }}
-      suite: >
-        inductor/test_codegen_triton.py
-        inductor/test_triton_extension_backend.py
-        inductor/test_triton_heuristics.py
-        inductor/test_triton_wrapper.py
-        inductor/test_triton_kernels.py
-      runner_label: ${{ inputs.runner_label }}
-      python_version: ${{ matrix.python }}
 
   e2e-accuracy:
     name: e2e accuracy tests

--- a/.github/workflows/try-latest-pytorch.yml
+++ b/.github/workflows/try-latest-pytorch.yml
@@ -104,7 +104,7 @@ jobs:
       python_version: "3.9"
 
   integration-tests:
-    name: Integration tests matrix
+    name: Integration tests
     needs: [prepare, inductor-tests]
 
     strategy:

--- a/.github/workflows/try-latest-pytorch.yml
+++ b/.github/workflows/try-latest-pytorch.yml
@@ -105,7 +105,7 @@ jobs:
 
   integration-tests:
     name: Integration tests matrix
-    needs: prepare
+    needs: [prepare, inductor-tests]
 
     strategy:
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
@@ -126,7 +126,7 @@ jobs:
 
   e2e-accuracy:
     name: e2e accuracy tests
-    needs: prepare
+    needs: [prepare, inductor-tests]
     strategy:
       matrix: ${{ fromJson(needs.prepare.outputs.e2e_matrix) }}
       fail-fast: false

--- a/.github/workflows/try-latest-pytorch.yml
+++ b/.github/workflows/try-latest-pytorch.yml
@@ -101,7 +101,7 @@ jobs:
         inductor/test_triton_wrapper.py
         inductor/test_triton_kernels.py
       runner_label: ${{ inputs.runner_label }}
-      python_version: ${{ matrix.python }}
+      python_version: "3.9"
 
   integration-tests:
     name: Integration tests matrix


### PR DESCRIPTION
for #1933 

[pbchekin](https://github.com/pbchekin) commented [12 hours ago](https://github.com/intel/intel-xpu-backend-for-triton/issues/1933#issuecomment-2336811395)
> > Inductor for all supported Python versions on Rolling
> 
> Only one Python is fine. Also inductor tests can be a gateway for other tests: execute it first, then if successful execute rest of the tests.

