### PR TITLE
Update triton version to 3.1.0 for release 2.5.0

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -620,7 +620,7 @@ def get_install_requires():
 
 setup(
     name=os.environ.get("TRITON_WHEEL_NAME", "triton"),
-    version="3.0.0" + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
+    version="3.1.0" + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
     author="Philippe Tillet",
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -1,5 +1,5 @@
 """isort:skip_file"""
-__version__ = '3.0.0'
+__version__ = '3.1.0'
 
 # ---------------------------------------
 # Note: import order is significant here.


### PR DESCRIPTION
Similar to: https://github.com/triton-lang/triton/pull/4696
Since triton is building from this branch: https://github.com/triton-lang/triton/tree/release/3.1.x
We need to bump this version as well.
This should fix failures on this PR: https://github.com/pytorch/pytorch/pull/135627

cc @EikanWang @chuanqi129 

