### PR TITLE
Use PyLong_AsVoidPtr to cast dev_ptr

### DIFF
--- a/benchmarks/triton_kernels_benchmark/benchmark_driver.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_driver.py
@@ -204,7 +204,7 @@ def make_launcher(constants, signature, ids):  # pylint: disable=unused-argument
       ptr_info.dev_ptr = 0;
       ptr_info.valid = true;
       if (PyLong_Check(obj)) {{
-        ptr_info.dev_ptr = (void*) PyLong_AsLongLong(obj);
+        ptr_info.dev_ptr = PyLong_AsVoidPtr(obj)
         checkDevicePointer(&ptr_info, idx, queue);
         return ptr_info;
       }}
@@ -223,7 +223,7 @@ def make_launcher(constants, signature, ids):  # pylint: disable=unused-argument
           ptr_info.valid = false;
           return ptr_info;
         }}
-        ptr_info.dev_ptr = (void*) PyLong_AsLongLong(ret);
+        ptr_info.dev_ptr = PyLong_AsVoidPtr(ret);
         if(!ptr_info.dev_ptr) {{
           return ptr_info;
         }}

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -271,7 +271,7 @@ def make_launcher(constants, signature, ids):
       ptr_info.dev_ptr = 0;
       ptr_info.valid = true;
       if (PyLong_Check(obj)) {{
-        ptr_info.dev_ptr = (void*) PyLong_AsLongLong(obj);
+        ptr_info.dev_ptr = PyLong_AsVoidPtr(obj);
         checkDevicePointer(&ptr_info, idx, queue);
         return ptr_info;
       }}
@@ -290,7 +290,7 @@ def make_launcher(constants, signature, ids):
           ptr_info.valid = false;
           return ptr_info;
         }}
-        ptr_info.dev_ptr = (void*) PyLong_AsLongLong(ret);
+        ptr_info.dev_ptr = PyLong_AsVoidPtr(ret);
         if(!ptr_info.dev_ptr) {{
           return ptr_info;
         }}


### PR DESCRIPTION
Fixes: #2188

Calling PyLong_AsLongLong causes overflow and return of a wrong pointer.