### PR TITLE
[CI][FA] Enable `TRITON_INTEL_ENABLE_INSTR_SCHED`

### DIFF
--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -200,6 +200,7 @@ jobs:
         run: |
           cd benchmarks/triton_kernels_benchmark
           TRITON_INTEL_ADVANCED_PATH=1 \
+          TRITON_INTEL_ENABLE_INSTR_SCHED=1 \
           TRITON_INTEL_ENABLE_ADDRESS_PAYLOAD_OPT=1 \
           IGC_VISAOptions=" -enableBCR -nolocalra -printregusage -DPASTokenReduction -enableHalfLSC -abiver 2" \
           IGC_DisableLoopUnroll=1 \

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -306,6 +306,7 @@ run_benchmark_attention() {
   echo "Advanced path:"
   TRITON_INTEL_ADVANCED_PATH=1 \
   TRITON_INTEL_ENABLE_ADDRESS_PAYLOAD_OPT=1 \
+  TRITON_INTEL_ENABLE_INSTR_SCHED=1 \
   IGC_VISAOptions=" -enableBCR -nolocalra -printregusage -DPASTokenReduction -enableHalfLSC" \
   IGC_DisableLoopUnroll=1 \
   python ${BENCHMARK_TEST_DIR}/flash_attention_fwd_benchmark.py


### PR DESCRIPTION
`TRITON_INTEL_ENABLE_INSTR_SCHED` is required to get good performance for flash attention on the advanced path.

Z | H | N_CTX | D_HEAD | % of reported
-- | -- | -- | -- | --
1 | 32 | 16384 | 64 | 90.11%
2 | 32 | 8192 | 64 | 87.43%
4 | 32 | 4096 | 64 | 85.17%
4 | 48 | 1024 | 64 | 84.94%
8 | 32 | 2048 | 64 | 87.19%
16 | 32 | 1024 | 64 | 93.03%
32 | 32 | 512 | 64 | 95.75%