### PR TITLE
Align prefetch location with PoC branch

### DIFF
--- a/test/TritonIntelGPU/prefetch-block.mlir
+++ b/test/TritonIntelGPU/prefetch-block.mlir
@@ -38,11 +38,11 @@ module attributes {"triton_gpu.num-warps" = 32 : i32, "triton_gpu.threads-per-wa
     // CHECK-SAME:      iter_args([[CST:%.*]] = {{.*}}, [[A6:%.*]] = [[A4]], [[B6:%.*]] = [[B4]], [[A5:%.*]] = [[A3]], [[B5:%.*]] = [[B3]])
     // CHECK-NEXT:   [[LD_A:%.*]] = tt.load [[A6]]
     // CHECK-NEXT:   [[LD_B:%.*]] = tt.load [[B6]]
-    // CHECK-NEXT:   [[DOT:%.*]] = tt.dot [[LD_A]], [[LD_B]], [[CST]]
     // CHECK:        triton_intel_gpu.prefetch [[A5]] {{.*}} : !tt.ptr<tensor<256x32xf16, #blocked1>>
+    // CHECK:        triton_intel_gpu.prefetch [[B5]] {{.*}} : !tt.ptr<tensor<32x256xf16, #blocked2>>    
+    // CHECK-NEXT:   [[DOT:%.*]] = tt.dot [[LD_A]], [[LD_B]], [[CST]]
     // CHECK-NEXT:   tt.advance [[A5]], {{.*}} : <tensor<256x32xf16, #blocked1>>
     // CHECK-DAG:    tt.advance [[A6]], {{.*}} : <tensor<256x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>>
-    // CHECK:        triton_intel_gpu.prefetch [[B5]] {{.*}} : !tt.ptr<tensor<32x256xf16, #blocked2>>
     // CHECK-NEXT:   tt.advance [[B5]], {{.*}} : <tensor<32x256xf16, #blocked2>>
     // CHECK-DAG:    tt.advance [[B6]], {{.*}} : <tensor<32x256xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>>
     // CHECK:        triton_gen.split_barrier_wait {mem_fence = None, mem_scope = WorkGroup}

--- a/test/TritonIntelGPU/prefetch-block.mlir
+++ b/test/TritonIntelGPU/prefetch-block.mlir
@@ -39,7 +39,7 @@ module attributes {"triton_gpu.num-warps" = 32 : i32, "triton_gpu.threads-per-wa
     // CHECK-NEXT:   [[LD_A:%.*]] = tt.load [[A6]]
     // CHECK-NEXT:   [[LD_B:%.*]] = tt.load [[B6]]
     // CHECK:        triton_intel_gpu.prefetch [[A5]] {{.*}} : !tt.ptr<tensor<256x32xf16, #blocked1>>
-    // CHECK:        triton_intel_gpu.prefetch [[B5]] {{.*}} : !tt.ptr<tensor<32x256xf16, #blocked2>>    
+    // CHECK:        triton_intel_gpu.prefetch [[B5]] {{.*}} : !tt.ptr<tensor<32x256xf16, #blocked2>>
     // CHECK-NEXT:   [[DOT:%.*]] = tt.dot [[LD_A]], [[LD_B]], [[CST]]
     // CHECK-NEXT:   tt.advance [[A5]], {{.*}} : <tensor<256x32xf16, #blocked1>>
     // CHECK-DAG:    tt.advance [[A6]], {{.*}} : <tensor<256x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>>

--- a/test/TritonIntelGPU/prefetch-block.mlir
+++ b/test/TritonIntelGPU/prefetch-block.mlir
@@ -38,16 +38,16 @@ module attributes {"triton_gpu.num-warps" = 32 : i32, "triton_gpu.threads-per-wa
     // CHECK-SAME:      iter_args([[CST:%.*]] = {{.*}}, [[A6:%.*]] = [[A4]], [[B6:%.*]] = [[B4]], [[A5:%.*]] = [[A3]], [[B5:%.*]] = [[B3]])
     // CHECK-NEXT:   [[LD_A:%.*]] = tt.load [[A6]]
     // CHECK-NEXT:   [[LD_B:%.*]] = tt.load [[B6]]
-    // CHECK:        triton_intel_gpu.prefetch [[A5]] {{.*}} : !tt.ptr<tensor<256x32xf16, #blocked1>>
-    // CHECK:        triton_intel_gpu.prefetch [[B5]] {{.*}} : !tt.ptr<tensor<32x256xf16, #blocked2>>
     // CHECK-NEXT:   [[DOT:%.*]] = tt.dot [[LD_A]], [[LD_B]], [[CST]]
+    // CHECK:        triton_intel_gpu.prefetch [[A5]] {{.*}} : !tt.ptr<tensor<256x32xf16, #blocked1>>
     // CHECK-NEXT:   tt.advance [[A5]], {{.*}} : <tensor<256x32xf16, #blocked1>>
     // CHECK-DAG:    tt.advance [[A6]], {{.*}} : <tensor<256x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>>
+    // CHECK:        triton_intel_gpu.prefetch [[B5]] {{.*}} : !tt.ptr<tensor<32x256xf16, #blocked2>>
     // CHECK-NEXT:   tt.advance [[B5]], {{.*}} : <tensor<32x256xf16, #blocked2>>
     // CHECK-DAG:    tt.advance [[B6]], {{.*}} : <tensor<32x256xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>>
     // CHECK:        triton_gen.split_barrier_wait {mem_fence = None, mem_scope = WorkGroup}
     // CHECK-NEXT:   triton_gen.split_barrier_signal {mem_fence = None, mem_scope = WorkGroup}
-    // CHECK-NEXT:   scf.yield {{.*}}
+   // CHECK-NEXT:   scf.yield {{.*}}
     // CHECK-NEXT: }
     // CHECK-NEXT: triton_gen.split_barrier_wait {mem_fence = None, mem_scope = WorkGroup}
 

--- a/test/TritonIntelGPU/prefetch-block.mlir
+++ b/test/TritonIntelGPU/prefetch-block.mlir
@@ -47,7 +47,7 @@ module attributes {"triton_gpu.num-warps" = 32 : i32, "triton_gpu.threads-per-wa
     // CHECK-DAG:    tt.advance [[B6]], {{.*}} : <tensor<32x256xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>>
     // CHECK:        triton_gen.split_barrier_wait {mem_fence = None, mem_scope = WorkGroup}
     // CHECK-NEXT:   triton_gen.split_barrier_signal {mem_fence = None, mem_scope = WorkGroup}
-   // CHECK-NEXT:   scf.yield {{.*}}
+    // CHECK-NEXT:   scf.yield {{.*}}
     // CHECK-NEXT: }
     // CHECK-NEXT: triton_gen.split_barrier_wait {mem_fence = None, mem_scope = WorkGroup}
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
@@ -404,9 +404,7 @@ void PrefetchBlockPass::injectPrefetchOpsInBody(
 
   SmallVector<Value> advances;
   unsigned i = 0;
-  Operation *prefetchInsertPoint = loopLoads.at(loop).back();
-
-  prefetchInsertPoint = yield;
+  Operation *prefetchInsertPoint = yield;
   for (tt::LoadOp load : loopLoads.at(loop)) {
     const LoadInfo &loadInfo = loadToLoadInfo.at(load);
     b.setInsertionPoint(loadInfo.getAdvance());

--- a/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
@@ -405,16 +405,16 @@ void PrefetchBlockPass::injectPrefetchOpsInBody(
   SmallVector<Value> advances;
   unsigned i = 0;
   Operation *prefetchInsertPoint = loopLoads.at(loop).back();
+
+  prefetchInsertPoint = yield;
   for (tt::LoadOp load : loopLoads.at(loop)) {
-    b.setInsertionPointAfter(prefetchInsertPoint);
+    const LoadInfo &loadInfo = loadToLoadInfo.at(load);
+    b.setInsertionPoint(loadInfo.getAdvance());
     Location loc = load.getLoc();
     auto prefetch =
         b.create<ttgi::PrefetchOp>(loc, args[num + 1 + i], load.getCache(),
                                    load.getEvict(), load.getIsVolatile());
-    prefetchInsertPoint = prefetch;
 
-    const LoadInfo &loadInfo = loadToLoadInfo.at(load);
-    b.setInsertionPoint(loadInfo.getAdvance());
     loc = loadInfo.getAdvance().getLoc();
     auto advance =
         b.create<tt::AdvanceOp>(loc, args[num + 1 + i].getType(),

--- a/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
@@ -404,7 +404,6 @@ void PrefetchBlockPass::injectPrefetchOpsInBody(
 
   SmallVector<Value> advances;
   unsigned i = 0;
-  Operation *prefetchInsertPoint = yield;
   for (tt::LoadOp load : loopLoads.at(loop)) {
     const LoadInfo &loadInfo = loadToLoadInfo.at(load);
     b.setInsertionPoint(loadInfo.getAdvance());

--- a/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
@@ -37,6 +37,7 @@
 ///     tt.advance %prefetch_ptr
 //===----------------------------------------------------------------------===//
 
+#include "TritonToTritonGPUWarp/TritonToTritonGPUWarpPass.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/PatternMatch.h"
@@ -50,6 +51,8 @@
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <optional>
 
@@ -402,22 +405,55 @@ void PrefetchBlockPass::injectPrefetchOpsInBody(
   auto yield = cast<scf::YieldOp>(newLoop.getBody()->getTerminator());
   loop.erase();
 
+  Attribute attr = loop->getAttr(AttrWorkloadName);
+  assert(attr && "Expecting a workload attribute");
+  Workload workload = static_cast<Workload>(cast<IntegerAttr>(attr).getInt());
+  llvm::errs() << "workload: " << cast<IntegerAttr>(attr).getInt() << "\n";
+
   SmallVector<Value> advances;
   unsigned i = 0;
-  for (tt::LoadOp load : loopLoads.at(loop)) {
-    const LoadInfo &loadInfo = loadToLoadInfo.at(load);
-    b.setInsertionPoint(loadInfo.getAdvance());
-    Location loc = load.getLoc();
-    auto prefetch =
-        b.create<ttgi::PrefetchOp>(loc, args[num + 1 + i], load.getCache(),
-                                   load.getEvict(), load.getIsVolatile());
 
-    loc = loadInfo.getAdvance().getLoc();
-    auto advance =
-        b.create<tt::AdvanceOp>(loc, args[num + 1 + i].getType(),
-                                args[num + 1 + i], loadInfo.getOffsets());
-    advances.push_back(advance);
-    i++;
+  // Inject prefetches in a different fashion depending on workload type.
+  switch (workload) {
+  case Workload::Gemm: {
+    Operation *prefetchInsertPoint = loopLoads.at(loop).back();
+    for (tt::LoadOp load : loopLoads.at(loop)) {
+      b.setInsertionPointAfter(prefetchInsertPoint);
+      Location loc = load.getLoc();
+      auto prefetch =
+          b.create<ttgi::PrefetchOp>(loc, args[num + 1 + i], load.getCache(),
+                                     load.getEvict(), load.getIsVolatile());
+      prefetchInsertPoint = prefetch;
+
+      const LoadInfo &loadInfo = loadToLoadInfo.at(load);
+      b.setInsertionPoint(loadInfo.getAdvance());
+      loc = loadInfo.getAdvance().getLoc();
+      auto advance =
+          b.create<tt::AdvanceOp>(loc, args[num + 1 + i].getType(),
+                                  args[num + 1 + i], loadInfo.getOffsets());
+      advances.push_back(advance);
+      i++;
+    }
+  } break;
+  case mlir::Workload::Attention: {
+    for (tt::LoadOp load : loopLoads.at(loop)) {
+      const LoadInfo &loadInfo = loadToLoadInfo.at(load);
+      b.setInsertionPoint(loadInfo.getAdvance());
+      Location loc = load.getLoc();
+      auto prefetch =
+          b.create<ttgi::PrefetchOp>(loc, args[num + 1 + i], load.getCache(),
+                                     load.getEvict(), load.getIsVolatile());
+
+      loc = loadInfo.getAdvance().getLoc();
+      auto advance =
+          b.create<tt::AdvanceOp>(loc, args[num + 1 + i].getType(),
+                                  args[num + 1 + i], loadInfo.getOffsets());
+      advances.push_back(advance);
+      i++;
+    }
+  } break;
+  default:
+    llvm_unreachable("unexpected workload kind");
   }
 
   // FIXME: try to use a named barrier to increase performance.


### PR DESCRIPTION
The PoC branch puts last two `prefetch` ops with after last `tt.dot` ops. But the `llvm-target` branch does not. 
``` mlir
 _%328 = tt.dot %217, %320, %327, inputPrecision = tf32 {"schedule-group" = 3 : i32} : tensor<8x16xf16> * tensor<16x16xf16> -> tensor<8x16xf32> loc(#loc)_
      **triton_intel_gpu.prefetch %arg42 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<16x32xf16>> loc(#loc)**
      %329 = tt.advance %arg42, [%c64_i32, %c0_i32] : <tensor<16x32xf16>> loc(#loc)
      %330 = tt.advance %arg17, [%c64_i32, %c0_i32] : <tensor<32x16xf16>> loc(#loc)
     ...
      %337 = tt.advance %arg24, [%c64_i32, %c0_i32] : <tensor<32x16xf16>> loc(#loc)
      **triton_intel_gpu.prefetch %arg41 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<16x32xf16>> loc(#loc)**
      %338 = tt.advance %arg41, [%c0_i32, %c64_i32] : <tensor<16x32xf16>> loc(#loc)
      ...
      %354 = tt.advance %arg40, [%c0_i32, %c64_i32] : <tensor<16x16xf16>> loc(#loc)
      scf.yield %260, %282, %286, %296, %300, %310, %314, %324, %328, %181, %330, %331, %332, %333, %334, %335, %336, %337, %339, %340, %341, %342, %343, %344, %345, %346, %347, %348, %349, %350, %351, %352, %353, %354, %338, %329 : tensor<16xf32, #triton_gpu.slice<{dim = 1, parent = #warp}>>, tensor<8x16xf32>, tensor<8x16xf32>, tensor<8x16xf32>, tensor<8x16xf32>, tensor<8x16xf32>, tensor<8x16xf32>, tensor<8x16xf32>, tensor<8x16xf32>, tensor<16xf32, #triton_gpu.slice<{dim = 1, parent = #warp}>>, !tt.ptr<tensor<32x16xf16>>, !tt.ptr<tensor<32x16xf16>>, !tt.ptr<tensor<32x16xf16>>, !tt.ptr<tensor<32x16xf16>>, !tt.ptr<tensor<32x16xf16>>, !tt.ptr<tensor<32x16xf16>>, !tt.ptr<tensor<32x16xf16>>, !tt.ptr<tensor<32x16xf16>>, !tt.ptr<tensor<16x16xf16>>, !tt.ptr<tensor<16x16xf16>>, !tt.ptr<tensor<16x16xf16>>, !tt.ptr<tensor<16x16xf16>>, !tt.ptr<tensor<16x16xf16>>, !tt.ptr<tensor<16x16xf16>>, !tt.ptr<tensor<16x16xf16>>, !tt.ptr<tensor<16x16xf16>>, !tt.ptr<tensor<16x16xf16>>, !tt.ptr<tensor<16x16xf16>>, !tt.ptr<tensor<16x16xf16>>, !tt.ptr<tensor<16x16xf16>>, !tt.ptr<tensor<16x16xf16>>, !tt.ptr<tensor<16x16xf16>>, !tt.ptr<tensor<16x16xf16>>, !tt.ptr<tensor<16x16xf16>>, !tt.ptr<tensor<16x32xf16>>, !tt.ptr<tensor<16x32xf16>> loc(#loc)
```
This change seems to benefit FA performance:
Performance **without** this change:
```
attn-performance:
      Z     H    N_CTX  D_HEAD  Triton-GB/s  XeTLA-GB/s  Triton-GB/s-min  XeTLA-GB/s-min  Triton-GB/s-max  XeTLA-GB/s-max  Triton-TFlops  XeTLA-TFlops  Triton-TFlops-min  XeTLA-TFlops-min  Triton-TFlops-max  XeTLA-TFlops-max  Triton-CV  XeTLA-CV
0   1.0  32.0  16384.0    64.0    11.561404   16.232926        11.561404       16.232926        11.561404       16.232926      94.711020    132.980130          94.711020        132.980130          94.711020        132.980130        NaN       NaN
1   2.0  32.0   8192.0    64.0    22.213829   31.809974        22.213829       31.809974        22.213829       31.809974      90.987842    130.293654          90.987842        130.293654          90.987842        130.293654        NaN       NaN
2   4.0  32.0   4096.0    64.0    46.627988   62.727947        46.627988       62.727947        46.627988       62.727947      95.494119    128.466836          95.494119        128.466836          95.494119        128.466836        NaN       NaN
3   4.0  48.0   1024.0    64.0   190.152540  215.387064       169.125161      215.387064       199.792200      215.387064      97.358100    110.278177          86.592082        110.278177         102.293606        110.278177   0.035186       NaN
4   8.0  32.0   2048.0    64.0    96.287966  121.609276        79.283662      121.609276        99.150262      121.609276      98.598877    124.527899          81.186470        124.527899         101.529868        124.527899        NaN       NaN
5  16.0  32.0   1024.0    64.0   186.337609  227.087402       178.405106      227.087402       196.985040      227.087402      95.404856    116.268750          91.343414        116.268750         100.856340        116.268750   0.005554       NaN
6  32.0  32.0    512.0    64.0   275.956181  407.213973       258.588415      407.213973       284.794020      407.213973      70.644782    104.246777          66.198634        104.246777          72.907269        104.246777   0.010064       NaN
```
Performance **with** this change:
```
attn-performance:
      Z     H    N_CTX  D_HEAD  Triton-GB/s  XeTLA-GB/s  Triton-GB/s-min  XeTLA-GB/s-min  Triton-GB/s-max  XeTLA-GB/s-max  Triton-TFlops  XeTLA-TFlops  Triton-TFlops-min  XeTLA-TFlops-min  Triton-TFlops-max  XeTLA-TFlops-max  Triton-CV  XeTLA-CV
0   1.0  32.0  16384.0    64.0    11.899747   16.320249        11.899747       16.320249        11.899747       16.320249      97.482729    133.695480          97.482729        133.695480          97.482729        133.695480        NaN       NaN
1   2.0  32.0   8192.0    64.0    24.749537   32.125491        24.749537       32.125491        24.749537       32.125491     101.374104    131.586012         101.374104        131.586012         101.374104        131.586012        NaN       NaN
2   4.0  32.0   4096.0    64.0    51.193753   60.219726        51.193753       60.219726        51.193753       60.219726     104.844806    123.329998         104.844806        123.329998         104.844806        123.329998        NaN       NaN
3   4.0  48.0   1024.0    64.0   195.109114  220.057928       184.825380      220.057928       199.475443      220.057928      99.895867    112.669659          94.630595        112.669659         102.131427        112.669659   0.019212       NaN
4   8.0  32.0   2048.0    64.0    91.940030  120.612624        82.817729      120.612624       101.735587      120.612624      94.146591    123.507327          84.805355        123.507327         104.177241        123.507327        NaN       NaN
5  16.0  32.0   1024.0    64.0   191.613706  226.260488       190.541919      226.260488       194.315693      226.260488      98.106217    115.845370          97.557462        115.845370          99.489635        115.845370   0.002101       NaN
6  32.0  32.0    512.0    64.0   273.229723  406.818981       262.266939      406.818981       280.508537      406.818981      69.946809    104.145659          67.140337        104.145659          71.810186        104.145659   0.023795       NaN

```
Performance of **PoC branch** (in the same environment):
```
attn-performance:
      Z     H    N_CTX  D_HEAD  Triton-GB/s  XeTLA-GB/s  Triton-GB/s-min  XeTLA-GB/s-min  Triton-GB/s-max  XeTLA-GB/s-max  Triton-TFlops  XeTLA-TFlops  Triton-TFlops-min  XeTLA-TFlops-min  Triton-TFlops-max  XeTLA-TFlops-max  Triton-CV  XeTLA-CV
0   1.0  32.0  16384.0    64.0    11.832273   16.090474        11.832273       16.090474        11.832273       16.090474      96.929978    131.813164          96.929978        131.813164          96.929978        131.813164        NaN       NaN
1   2.0  32.0   8192.0    64.0    24.439840   31.663491        24.439840       31.663491        24.439840       31.663491     100.105583    129.693659         100.105583        129.693659         100.105583        129.693659        NaN       NaN
2   4.0  32.0   4096.0    64.0    49.430528   62.779587        49.430528       62.779587        49.430528       62.779587     101.233722    128.572594         101.233722        128.572594         101.233722        128.572594        NaN       NaN
3   4.0  48.0   1024.0    64.0   189.688674  215.756376       159.560132      215.756376       201.972904      215.756376      97.120601    110.467264          81.694788        110.467264         103.410127        110.467264   0.051211       NaN
4   8.0  32.0   2048.0    64.0    93.149827  119.768814        75.416775      119.768814       101.661611      119.768814      95.385423    122.643265          77.226778        122.643265         104.101490        122.643265        NaN       NaN
5  16.0  32.0   1024.0    64.0   189.945075  220.289058       167.403868      220.289058       191.761527      220.289058      97.251878    112.787998          85.710780        112.787998          98.181902        112.787998   0.001537       NaN
6  32.0  32.0    512.0    64.0   276.844136  411.710816       264.416323      411.710816       283.830414      411.710816      70.872099    105.397969          67.690579        105.397969          72.660586        105.397969   0.024478       NaN

```
With this change, we can say there is no obvious gap between `llvm-target` and PoC branch.