### PR TITLE
Fix copy of `compile_commands.json` in `compile-triton.sh`

### DIFF
--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -184,7 +184,7 @@ build_triton() {
   pip install -vvv -e '.[build,tests]'
 
   # Copy compile_commands.json in the build directory (so that cland vscode plugin can find it).
-  cp $TRITON_PROJ_BUILD/"$(ls $TRITON_PROJ_BUILD)"/compile_commands.json $TRITON_PROJ/
+  cp $(find $TRITON_PROJ_BUILD -name compile_commands.json) $TRITON_PROJ/
 }
 
 build() {


### PR DESCRIPTION
Closes #2222

Full path looks like: `intel-xpu-backend-for-triton/python/build/cmake.linux-x86_64-cpython-3.10/compile_commands.json`