### PR TITLE
[TritonGEN] Make `Matrix2DBlockLoadOp` function name more generic

### DIFF
--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -1064,7 +1064,7 @@ struct TritonMatrix2DBlockLoadLowering
               std::to_string(op.getVBlocks()) + "c";
     fnName = "_Z" + std::to_string(fnName.size()) + fnName + "PU3AS1viiiDv2_iP";
     fnName +=
-        (resType.getElementType().getIntOrFloatBitWidth() == 32) ? "j" : "t";
+        intel::getTypeMangling(resType.getElementType(), /*isUnsigned=*/true);
     VectorType vecType = vec_ty(i32_ty, 2);
     Value byteCoord = insert_element(
         vecType, insert_element(vecType, undef(vecType), op.getX(), i32_val(0)),


### PR DESCRIPTION
e.g., `intel_sub_group_2d_block_read_8b_8r16x4c` reads `uchar[4][8]`, and should be mangled as `_Z40intel_sub_group_2d_block_read_8b_8r16x4cPU3AS1viiiDv2_iPh`.

`intel_sub_group_2d_block_read_8b_8r16x4c` is not supported in current agama, so cannot yet add a lit test.