### PR TITLE
[CI] remove ipex for updating translator

### DIFF
--- a/.github/workflows/auto-update-translator-cid.yml
+++ b/.github/workflows/auto-update-translator-cid.yml
@@ -55,11 +55,6 @@ jobs:
         with:
           repository: pytorch/pytorch
 
-      # TODO: remove this step once ipex is deprecated for benchmarks
-      - name: Setup NO-OP-IPEX
-        if: ${{ env.TARGET_PRID == null }}
-        uses: ./.github/actions/setup-no-op-ipex
-
       - name: Install test dependencies
         if: ${{ env.TARGET_PRID == null }}
         run: |

--- a/scripts/check-update-translator-cid.sh
+++ b/scripts/check-update-translator-cid.sh
@@ -31,8 +31,8 @@ for cid in $COMMIT_IDS; do
         continue
     fi
 
-    # execute full tests
-    if ./scripts/test-triton.sh --skip-pytorch; then
+    # execute default tests
+    if ./scripts/test-triton.sh --skip-pytorch-install; then
         echo "Tests passed for translator commit $cid"
         echo "A newer commit found: $cid"
         FOUND=true


### PR DESCRIPTION
Fix: https://github.com/intel/intel-xpu-backend-for-triton/issues/2214

`test-triton.sh` by default dose not execute softmax & gemm & attention benchmarks. I think those should be tested when updating translator. ~~But there is a error in attention benchmark. Created a ticket to track it: https://github.com/intel/intel-xpu-backend-for-triton/issues/2228~~
