### PR TITLE
Run unit tests first

### DIFF
--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -106,11 +106,6 @@ jobs:
         with:
           build_llvm: ${{ inputs.build_llvm }}
 
-      - name: Run lit tests
-        run: |
-          cd python
-          lit -v build/*/test
-
       - name: Create test-triton command line
         run: |
           if [[ -n "${{ inputs.skip_list }}" ]]; then
@@ -131,9 +126,13 @@ jobs:
             echo TRITON_TEST_CMD="bash -v -x scripts/test-triton.sh --warning-reports --skip-pytorch-install --reports-dir $GITHUB_WORKSPACE/reports --ignore-errors $skiplist"
           } | tee -a $GITHUB_ENV
 
+      - name: Run unit tests
+        run: |
+          ${{ env.TRITON_TEST_CMD }} --unit
+
       - name: Run core tests
         run: |
-          ${{ env.TRITON_TEST_CMD }} --core
+          ${{ env.TRITON_TEST_CMD }} --core --skip-pip-install
 
       - name: Run interpreter tests
         run: |
@@ -143,17 +142,9 @@ jobs:
         run: |
           ${{ env.TRITON_TEST_CMD }} --tutorial --skip-pip-install
 
-      - name: Run CXX unittests
-        run: |
-          ${{ env.TRITON_TEST_CMD }} --unit --skip-pip-install
-
       - name: Run instrumentation tests
         run: |
           ${{ env.TRITON_TEST_CMD }} --instrumentation --skip-pip-install
-
-      - name: Clear cache
-        run: |
-          rm -rf ~/.triton
 
       - name: Get transformers version
         run: |


### PR DESCRIPTION
`test-triton.sh --unit` includes lit tests, so there is no need to run them separately.

Fixes #2240.