### PR TITLE
[test-triton.sh] Run micro benchmark tests without IPEX

### DIFF
--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -240,7 +240,7 @@ run_microbench_tests() {
   echo "****************************************************"
   echo "*****   Running Triton Micro Benchmark tests   *****"
   echo "****************************************************"
-  python $TRITON_PROJ/benchmarks/micro_benchmarks/run_benchmarks.py
+  USE_IPEX=0 python $TRITON_PROJ/benchmarks/micro_benchmarks/run_benchmarks.py
 }
 
 run_benchmark_softmax() {


### PR DESCRIPTION
This PR fixes the error below:
```
****************************************************
*****   Running Triton Micro Benchmark tests   *****
****************************************************
Traceback (most recent call last):
  File "/home/jovyan/intel-xpu-backend-for-triton/benchmarks/micro_benchmarks/run_benchmarks.py", line 3, in <module>
    from conversion import float_conversion
  File "/home/jovyan/intel-xpu-backend-for-triton/benchmarks/micro_benchmarks/conversion/float_conversion/__init__.py", line 1, in <module>
    from .float_conversion import benchmark  # type: ignore # noqa: F401
  File "/home/jovyan/intel-xpu-backend-for-triton/benchmarks/micro_benchmarks/conversion/float_conversion/float_conversion.py", line 8, in <module>
    import intel_extension_for_pytorch  # type: ignore # noqa: F401
ModuleNotFoundError: No module named 'intel_extension_for_pytorch'
```