### PR TITLE
Use package libze1 to identify level zero version

### DIFF
--- a/scripts/capture-hw-details.sh
+++ b/scripts/capture-hw-details.sh
@@ -24,7 +24,9 @@ else
     export LIBIGC1_VERSION="Not Installed"
 fi
 
-if dpkg-query --show intel-level-zero-gpu &> /dev/null; then
+if dpkg-query --show libze1 &> /dev/null; then
+    export LEVEL_ZERO_VERSION=$(dpkg-query --show --showformat='${version}\n' libze1 | grep -oP '.+(?=~)')
+elif dpkg-query --show intel-level-zero-gpu &> /dev/null; then
     export LEVEL_ZERO_VERSION=$(dpkg-query --show --showformat='${version}\n' intel-level-zero-gpu | grep -oP '.+(?=~)')
 else
     export LEVEL_ZERO_VERSION="Not Installed"


### PR DESCRIPTION
In new versions of the driver, libze1 should be used to identify level zero version. Keep intel-level-zero-gpu as a fallback for the old systems, such as LTS.

Fixes #2262.