### PR TITLE
Increase cache size

### DIFF
--- a/benchmarks/triton_kernels_benchmark/benchmark_testing.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_testing.py
@@ -61,10 +61,10 @@ def do_bench_ipex(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fas
     fn()
     synchronize()
 
-    # We maintain a buffer of 256 MB that we clear
+    # We maintain a buffer of 512 MB that we clear
     # before each kernel call to make sure that the L2
     # doesn't contain any input data before the run
-    cache_size = 256 * 1024 * 1024
+    cache_size = 512 * 1024 * 1024
     if fast_flush:
         cache = torch.empty(int(cache_size // 4), dtype=torch.int, device=device)
     else:

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -166,10 +166,10 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fast_flu
     fn()
     di.synchronize()
 
-    # We maintain a buffer of 256 MB that we clear
+    # We maintain a buffer of 512 MB that we clear
     # before each kernel call to make sure that the L2 cache
     # doesn't contain any input data before the run
-    cache_size = 256 * 1024 * 1024
+    cache_size = 512 * 1024 * 1024
     if fast_flush:
         cache = torch.empty(int(cache_size // 4), dtype=torch.int, device=device_type)
     else:


### PR DESCRIPTION
Checking the impact

CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/10890455942
CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/10891992012 (without IPEX)


AFAIK clearing 256MB L2 cache isn't enough for our main benchmarking system. The performance numbers get a little worse when increasing this way, however it seems we should do it (not necessary, since we only use one tile).