### PR TITLE
Fix Triton tests after update pybind11 to 2.13.6 using PyTorch patch

### DIFF
--- a/python/triton/backends/compiler.py
+++ b/python/triton/backends/compiler.py
@@ -16,12 +16,6 @@ class GPUTarget(object):
     arch: Union[int, str, dict]
     warp_size: int
 
-    def __post_init__(self):
-        # Remove `<bound method PyCapsule._pybind11_conduit_v1_ of _XpuDeviceProperties..>`
-        # to fix `json.dumps(metadata, default=vars)` serialization.
-        # This field appears after updating pybind to 2.13.6.
-        self.arch.pop('_pybind11_conduit_v1_', None)
-
 
 class BaseBackend(metaclass=ABCMeta):
 

--- a/python/triton/backends/compiler.py
+++ b/python/triton/backends/compiler.py
@@ -16,6 +16,12 @@ class GPUTarget(object):
     arch: Union[int, str, dict]
     warp_size: int
 
+    def __post_init__(self):
+        # Remove `<bound method PyCapsule._pybind11_conduit_v1_ of _XpuDeviceProperties..>`
+        # to fix `json.dumps(metadata, default=vars)` serialization.
+        # This field appears after updating pybind to 2.13.6.
+        self.arch.pop('_pybind11_conduit_v1_', None)
+
 
 class BaseBackend(metaclass=ABCMeta):
 

--- a/scripts/patch-pytorch.sh
+++ b/scripts/patch-pytorch.sh
@@ -17,3 +17,4 @@ cd "$REPO_ROOT"
 
 curl -sSL https://github.com/pytorch/pytorch/pull/126516.diff | git apply -
 curl -sSL https://github.com/pytorch/pytorch/pull/126456.diff | git apply -
+curl -sSL https://github.com/pytorch/pytorch/pull/136280.diff | git apply -


### PR DESCRIPTION
Closes #2260

CI status:
* ~https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/10922449983~
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/10927513915 (passed with patch from pytorch: https://github.com/pytorch/pytorch/pull/136280)