### PR TITLE
Remove `import intel_extension_for_pytorch` from `fused_softmax.py`

### DIFF
--- a/benchmarks/triton_kernels_benchmark/fused_softmax.py
+++ b/benchmarks/triton_kernels_benchmark/fused_softmax.py
@@ -15,9 +15,6 @@ from triton.runtime import driver
 import triton_kernels_benchmark as benchmark_suit
 import xetla_kernel
 
-if benchmark_suit.USE_IPEX_OPTION:
-    import intel_extension_for_pytorch  # type: ignore # noqa: F401
-
 
 @torch.jit.script
 def naive_softmax(x):


### PR DESCRIPTION
Part of https://github.com/intel/intel-xpu-backend-for-triton/pull/2147

Perf the same: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/10928161213 vs https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/10912513726; geomean diff: 1% for triton, 2% for xetla

One more CI run: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/10928754028 (also looks good)