### PR TITLE
Change default benchmark mode to upstream PyTorch

### DIFF
--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -14,7 +14,7 @@ on:
       install_ipex:
         description: Install Intel PyTorch Extension
         type: boolean
-        default: true
+        default: false
   schedule:
     - cron: "5 23 * * *"
 
@@ -22,7 +22,7 @@ permissions: read-all
 
 env:
   PYTHON_VERSION: "3.10"
-  USE_IPEX: ${{ github.event_name == 'schedule' && '1' || inputs.install_ipex && '1' || '0' }}
+  USE_IPEX: ${{ github.event_name == 'schedule' && '0' || inputs.install_ipex && '1' || '0' }}
 
 jobs:
   build:


### PR DESCRIPTION
Current state (https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/10950264922 vs https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/10949253321):
* **Softmax: triton geomean diff: 13%, xetla geomean diff: 8%, ratio geomean diff: 5%**
  * The performance deteriorates most on small data. For example, for N=256, the average value of milliseconds, from which teraflops are calculated, changes as follows: 0.0055 vs 0.0116. The difference is about 5-6 microseconds. This is approximately the time spent on the host to run the kernel and cannot be avoided. **An option may be** to increase the data volume, which will reduce the impact of associated time losses.
* **FA advanced: triton geomean diff: 2%, xetla geomean diff: 3%, ratio geomean diff: 2%**
  * This change shouldn't be a problem, part of it is definitely fluctuations in measurements.
  * To check the correctness it seems we can use the cpu version: https://github.com/intel/intel-xpu-backend-for-triton/pull/2300
* **GEMM advanced: triton geomean diff: 2%, xetla geomean diff: 2%, ratio geomean diff: 4%**
* **Float conversion microbenchmark: BF16 geomean diff: << 1%, FP16 geomean diff: << 1%**
