### PR TITLE
[Draft] Spill tensor values to SLM to reduce the register requirements.

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2741,6 +2741,11 @@ struct CanonicalizeConvertFromAlloc
     auto convert = op.getSrc().getDefiningOp<ConvertLayoutOp>();
     if (!convert)
       return failure();
+    // We don't fold alloc(cvt) with DotOperandEncodingAttr.
+    // Because the dot layout doesn't support LL yet.
+    if (auto dotEncoding = dyn_cast<DotOperandEncodingAttr>(
+            convert.getSrc().getType().getEncoding()))
+      return failure();
     rewriter.replaceOpWithNewOp<triton::gpu::LocalAllocOp>(
         op, op->getResult(0).getType(), convert.getSrc());
     return mlir::success();

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -223,6 +223,8 @@ class XPUBackend(BaseBackend):
         passes.ttgpuir.add_optimize_dot_operands(pm, True)
         intel.passes.ttgpuir.add_remove_layout_conversions(pm)
         intel.passes.ttgpuir.add_reduce_data_duplication(pm)
+        intel.passes.ttgpuir.add_spill_tensor_to_slm(pm)
+        intel.passes.ttgpuir.add_remove_layout_conversions(pm)
         passes.ttgpuir.add_reorder_instructions(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -284,4 +284,16 @@ def TritonIntelGPUMaterializeBlockPointer : Pass<"tritonintelgpu-materialize-blo
                            "mlir::arith::ArithDialect"];
 }
 
+def TritonIntelSpillTensorToSLM: Pass<"tritonintelgpu-spill-tensor-slm", "mlir::ModuleOp"> {
+  let summary = "";
+
+  let description = [{
+    Spill the tensor of the dot layout to SLM to reduce the register pressure.
+  }];
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::gpu::intel::TritonIntelGPUDialect",
+                           "mlir::triton::TritonDialect"];
+}
+
 #endif // TRITON_INTEL_GPU_PASSES

--- a/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_triton_library(TritonIntelGPUTransforms
   RemoveLayoutConversions.cpp
   RewriteTensorPointer.cpp
   ScheduleLoad.cpp
+  SpillTensorToSLM.cpp
   Utility.cpp
 
   DEPENDS

--- a/third_party/intel/lib/TritonIntelGPUTransforms/SpillTensorToSLM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/SpillTensorToSLM.cpp
@@ -1,0 +1,95 @@
+#include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LLVM.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+namespace mlir::triton::gpu::intel {
+#define GEN_PASS_DEF_TRITONINTELSPILLTENSORTOSLM
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
+} // namespace mlir::triton::gpu::intel
+
+namespace ttgi = mlir::triton::gpu::intel;
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::gpu;
+
+namespace {
+
+class TritonIntelSpillTensorPass
+    : public intel::impl::TritonIntelSpillTensorToSLMBase<
+          TritonIntelSpillTensorPass> {
+public:
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    mod.walk([&](mlir::scf::ForOp forOp) -> void {
+      // We cannot use forOp.walk(...) here because we only want to visit the
+      // dot op in the loop body block. Nested blocks are handled separately.
+      llvm::SmallVector<triton::DotOp> dotOps;
+      for (Operation &opInFor : forOp) {
+        if (auto dotOp = dyn_cast<triton::DotOp>(opInFor)) {
+          auto A = dotOp.getA();
+          if (auto *definingOp = A.getDefiningOp()) {
+            auto parentOp = definingOp->getParentOp();
+            if (parentOp != forOp) {
+              dotOps.push_back(dotOp);
+            }
+          }
+        }
+      }
+
+      for (auto dotOp : dotOps) {
+        auto A = dotOp.getA();
+        OpBuilder builder(A.getContext());
+        builder.setInsertionPointAfter(A.getDefiningOp());
+        auto srcType = cast<RankedTensorType>(A.getType());
+        auto dstDotOp = dyn_cast<triton::gpu::DotOperandEncodingAttr>(
+            srcType.getEncoding());
+
+        auto srcOrder = triton::gpu::getOrder(dstDotOp);
+        auto rank = srcOrder.size();
+        SmallVector<unsigned> sharedOrder;
+        if (rank == 3) {
+          // add all elements except the element that is zero
+          for (unsigned i = 0; i < rank; ++i)
+            if (srcOrder[i] != 0)
+              sharedOrder.emplace_back(srcOrder[i]);
+          sharedOrder.emplace_back(0);
+        } else {
+          sharedOrder = std::move(srcOrder);
+        }
+
+        ArrayRef<int64_t> shape = srcType.getShape();
+        triton::gpu::BlockedEncodingAttr blockEncoding =
+            getDefaultBlockedEncoding(
+                srcType.getContext(), shape,
+                triton::gpu::TritonGPUDialect::getNumWarps(mod),
+                triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod),
+                triton::gpu::TritonGPUDialect::getNumCTAs(mod));
+        auto cvtType = RankedTensorType::get(
+            srcType.getShape(), srcType.getElementType(), blockEncoding);
+        auto cvtOp = builder.create<triton::gpu::ConvertLayoutOp>(
+            A.getDefiningOp()->getLoc(), cvtType, A);
+
+        auto sharedMemorySpace =
+            triton::gpu::SharedMemorySpaceAttr::get(srcType.getContext());
+        auto tmpType = triton::MemDescType::get(
+            srcType.getShape(), srcType.getElementType(),
+            triton::gpu::SharedEncodingAttr::get(
+                mod.getContext(), dstDotOp, srcType.getShape(), sharedOrder,
+                triton::gpu::getCTALayout(dstDotOp), srcType.getElementType()),
+            sharedMemorySpace);
+        auto tmp = builder.create<triton::gpu::LocalAllocOp>(
+            A.getDefiningOp()->getLoc(), tmpType, cvtOp);
+        auto newConvert = builder.create<triton::gpu::LocalLoadOp>(
+            A.getDefiningOp()->getLoc(), srcType, tmp);
+        dotOp.setOperand(0, newConvert);
+      }
+    });
+  }
+};
+
+} // namespace

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -98,6 +98,8 @@ void init_triton_intel_passes_ttgpuir(py::module &&m) {
                      gpu::intel::createTritonIntelGPUReduceDataDuplication);
   ADD_PASS_WRAPPER_0("add_materialize_block_pointer",
                      gpu::intel::createTritonIntelGPUMaterializeBlockPointer);
+  ADD_PASS_WRAPPER_0("add_spill_tensor_to_slm",
+                     gpu::intel::createTritonIntelSpillTensorToSLM);
 }
 
 void init_triton_intel(py::module &&m) {


### PR DESCRIPTION
This is a PoC for spilling the tensor in register to SLM to reduce the register size.

It is not general pass to optimize the kernel for the register size aspect. It only works for the case of 06 tutorial for now.

There are more things need to be finished for performance:
1. We uses the blocked layout to load the block pointer to reduce the duplication of memory accessing caused by the dot layout. But that is fallback to the gather memory accessing semantic not best performance.  
```
%20 = tt.load %10 {triton_intel_gpu.block_io = "row_major"} : !tt.ptr<tensor<64x64xf16, #blocked>> loc(#loc20)
%21 = triton_gpu.local_alloc %20 {allocation.offset = 0 : i32} : (tensor<64x64xf16, #blocked>) -> !tt.memdesc<64x64xf16, #shared, #triton_gpu.shared_memory> loc(#loc20)
...
%51 = triton_gpu.local_load %21 : !tt.memdesc<64x64xf16, #shared, #triton_gpu.shared_memory> -> tensor<64x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> loc(#loc20)
%52 = tt.dot %51, %49, %cst_2, inputPrecision = tf32 : tensor<64x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<64x32xf32, #mma> loc(#loc59)
```
2. There are changes in the RemoveLayout pass. Need to backward propagate the layout before the canonicalizing. Gonna to remove that for decoupling.
3. The register size is not reduced as expected. Need to check the IGC backend in the register allocation.

To run the CI. 