### PR TITLE
Revert "Enable FP64 emulation for E2E AlbertForMaskedLM test on A770 (#1879)"

### DIFF
--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -169,15 +169,6 @@ jobs:
           export WORKSPACE=$GITHUB_WORKSPACE
           cd pytorch
           pip install pyyaml pandas scipy numpy psutil pyre_extensions torchrec
-
-          source $GITHUB_WORKSPACE/scripts/capture-hw-details.sh
-          if [[ $GPU_DEVICE = *A770* ]]; then
-            # To enable FP64 type emulation.
-            # For details see: https://github.com/intel/intel-xpu-backend-for-triton/pull/1879
-            export OverrideDefaultFP64Settings=1
-            export IGC_EnableDPEmulation=1
-          fi
-
           # TODO: Find the fastest Hugging Face model
           $GITHUB_WORKSPACE/scripts/inductor_xpu_test.sh huggingface float32 inference accuracy xpu 0 static 1 0 AlbertForMaskedLM
           # The script above always returns 0, so we need an additional check to see if the accuracy test passed


### PR DESCRIPTION
This reverts commit 87e5c063b4a2a8b53fc27162d5fd5b8a43bc524e.

Closes #2005

CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/10997430471 (passed)