### PR TITLE
[RFC] Add op scheduler for fallback path.

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -224,6 +224,7 @@ class XPUBackend(BaseBackend):
         intel.passes.ttgpuir.add_remove_layout_conversions(pm)
         intel.passes.ttgpuir.add_reduce_data_duplication(pm)
         passes.ttgpuir.add_reorder_instructions(pm)
+        intel.passes.ttgpuir.add_schedule_ops(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
         passes.common.add_canonicalizer(pm)

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -284,4 +284,15 @@ def TritonIntelGPUMaterializeBlockPointer : Pass<"tritonintelgpu-materialize-blo
                            "mlir::arith::ArithDialect"];
 }
 
+def TritonIntelGPUScheduleOps : Pass<"tritonintelgpu-schedule-ops", "mlir::ModuleOp"> {
+  let summary = "";
+
+  let description = [{
+  }];
+
+  let dependentDialects = ["mlir::triton::TritonDialect",
+                           "mlir::triton::gpu::intel::TritonIntelGPUDialect",
+                           "mlir::triton::gpu::TritonGPUDialect"];
+}
+
 #endif // TRITON_INTEL_GPU_PASSES

--- a/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_triton_library(TritonIntelGPUTransforms
   RemoveLayoutConversions.cpp
   RewriteTensorPointer.cpp
   ScheduleLoad.cpp
+  ScheduleOps.cpp
   Utility.cpp
 
   DEPENDS

--- a/third_party/intel/lib/TritonIntelGPUTransforms/ScheduleOps.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/ScheduleOps.cpp
@@ -1,0 +1,50 @@
+#include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LLVM.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+namespace mlir::triton::gpu::intel {
+#define GEN_PASS_DEF_TRITONINTELGPUSCHEDULEOPS
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
+} // namespace mlir::triton::gpu::intel
+
+namespace ttgi = mlir::triton::gpu::intel;
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::gpu;
+
+namespace {
+
+class ScheduleOpsPass
+    : public intel::impl::TritonIntelGPUScheduleOpsBase<ScheduleOpsPass> {
+public:
+  void runOnOperation() override {
+    MLIRContext *ctx = &getContext();
+    ModuleOp mod = getOperation();
+
+    mod.walk([&](scf::ForOp forOp) {
+      llvm::SmallVector<triton::LoadOp> loadOps;
+      for (Operation &opInFor : forOp) {
+        if (LoadOp loadOp = dyn_cast<triton::LoadOp>(opInFor)) {
+          if (loadOp->hasOneUse()) {
+            auto users = loadOp->getUsers();
+            DotOp dotOp = dyn_cast<triton::DotOp>(*(users.begin()));
+            if (dotOp)
+              loadOps.push_back(loadOp);
+          }
+        }
+      }
+
+      for (LoadOp &loadOp : loadOps) {
+        auto users = loadOp->getUsers();
+        loadOp->moveBefore(*users.begin());
+      }
+    });
+  }
+};
+
+} // namespace

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -98,6 +98,8 @@ void init_triton_intel_passes_ttgpuir(py::module &&m) {
                      gpu::intel::createTritonIntelGPUReduceDataDuplication);
   ADD_PASS_WRAPPER_0("add_materialize_block_pointer",
                      gpu::intel::createTritonIntelGPUMaterializeBlockPointer);
+  ADD_PASS_WRAPPER_0("add_schedule_ops",
+                     gpu::intel::createTritonIntelGPUScheduleOps);
 }
 
 void init_triton_intel(py::module &&m) {


### PR DESCRIPTION
## Status
There is common issue on IGC backend in instruction scheduling to reduce the register pressure.
Before the optimization is available on IGC side, we need to add the work around on Triton side to get the performance. 

There are two Intel Triton lowering pipeline "bottom-up" and "top-down" with some differences in implementation.
1. Use two different methodology to chose the optimal layout distribution for the Triton program. 
- The "bottom-up" lowering pipeline mainly depends on `RemoveLayout` pass to propagate the layout based on the costs of the operation on different layout.
- The "top-down" lowering pipeline chose the optimal layout base on the analysis of the operations of whole Triton program.
2. Use different logic to convert the TTGIR to LLVM.
- The "bottom-up" lowering pipeline uses the same lowering as upstream Triton for NV and AMD. `ConvertTritonIntelGPUToLLVM`
- The "top-down" lowering pipeline uses two stage lowering code which is for Intel backend. `TritonIntelGPUDistributeToWarps` -> `TritonIntelGPUMatchTargetSize` -> `ConvertTritonIntelGPUToLLVM with specific type converter`

There are some common optimization pass which should be common for the two pipelines.
1. Loop pipelining with Intel prefetching operation.
2. Spill Tensor to SLM if the register size is too large. 
3. Transpose reduce operation if it is batched reduce horizontally. (Victor is working on this.)
4. Operation folding: Like: `dot(a, load(ptr).T) -> dot(a, load(ptr_trans))`. (Alex is working on this.)
5. TMA, RAISE Blk PTR, and so on. (which should work on TTGIR with layout attribute.)

It is idea that we can reuse those common optimization pass to reuse the effort.

## Problem
Some pass is not general to work with TTGIR. Just as the pass add the in this PR. Because the `ScheduleLoad` only works for "top-down" pipeline.
(And same to the other pass like: https://github.com/intel/intel-xpu-backend-for-triton/pull/2311)

## Question
- Should the new common optimization pass be workable for both pipeline?
- If the pass already exists, should we refactor it for both pipeline or add a new implementation?
