### PR TITLE
[CI] show less verbose log and give failed summary for each commit id

### DIFF
--- a/.github/workflows/auto-update-translator-cid.yml
+++ b/.github/workflows/auto-update-translator-cid.yml
@@ -86,12 +86,17 @@ jobs:
       - name: Search the latest valid Translator cid
         if: ${{ env.TARGET_PRID == null }}
         run: |
-          env
-          ./scripts/check-update-translator-cid.sh $CID_LATEST $CID_CURRENT
+          touch test_failed_summary.log
+          ./scripts/check-update-translator-cid.sh $CID_LATEST $CID_CURRENT test_failed_summary.log
           if git status --porcelain ./lib/Target/SPIRV/spirv-llvm-translator.conf | grep '^ M'; then
             echo "MODIFIED=true" >> $GITHUB_ENV
             echo "spirv-llvm-translator.conf has been modified"
           fi
+
+      - name: Show summary of failed commit id
+        if: ${{ env.TARGET_PRID == null }}
+        run: |
+          cat test_failed_summary.log
 
       # raise PR by bot
       - name: Create PR if config is updated

--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -179,7 +179,7 @@ build_triton() {
 
   cd python
   # Install triton and its dependencies.
-  pip install -vvv -e '.[build,tests]'
+  pip install -v -e '.[build,tests]'
 
   # Copy compile_commands.json in the build directory (so that cland vscode plugin can find it).
   cp $(find $TRITON_PROJ_BUILD -name compile_commands.json) $TRITON_PROJ/


### PR DESCRIPTION
Fix: https://github.com/intel/intel-xpu-backend-for-triton/issues/2302

Now we have a failed cases summary:
![image](https://github.com/user-attachments/assets/8b2e5393-6954-4fa7-833b-36f8ae0b391e)
https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/11009534190/job/30569394563

Note that there are no more detailed log for FAILED cases. so could not get exact error message for each cases.