### PR TITLE
Fix absense of pytorch_ref when workflow is scheduled

### DIFF
--- a/.github/workflows/try-latest-pytorch.yml
+++ b/.github/workflows/try-latest-pytorch.yml
@@ -63,7 +63,7 @@ jobs:
         uses: ./.github/actions/get-commit-id
         with:
           repository: "pytorch/pytorch"
-          branch: ${{ inputs.pytorch_ref }}
+          branch: ${{ inputs.pytorch_ref || 'main' }}
 
       - name: Matrix
         id: matrix
@@ -126,6 +126,6 @@ jobs:
       mode: ${{ matrix.mode }}
       test_mode: accuracy
       dtype: ${{ matrix.dtype }}
-      models: subset
+      models: "subset"
       only_one_model: ""
       runner_label: "${{ matrix.runner_label }}"

--- a/.github/workflows/try-latest-pytorch.yml
+++ b/.github/workflows/try-latest-pytorch.yml
@@ -126,6 +126,6 @@ jobs:
       mode: ${{ matrix.mode }}
       test_mode: accuracy
       dtype: ${{ matrix.dtype }}
-      models: "subset"
+      models: subset
       only_one_model: ""
       runner_label: "${{ matrix.runner_label }}"


### PR DESCRIPTION
For #2315 