### PR TITLE
Try PyTorch PR#136514

### DIFF
--- a/scripts/patch-pytorch.sh
+++ b/scripts/patch-pytorch.sh
@@ -18,4 +18,4 @@ cd "$REPO_ROOT"
 curl -sSL https://github.com/pytorch/pytorch/pull/126516.diff | git apply -
 curl -sSL https://github.com/pytorch/pytorch/pull/126456.diff | git apply -
 curl -sSL https://github.com/pytorch/pytorch/pull/136280.diff | git apply -
-curl -sSL https://github.com/pytorch/pytorch/pull/135406.diff | git apply -
+curl -sSL https://github.com/pytorch/pytorch/pull/136514.diff | git apply -

--- a/scripts/patch-pytorch.sh
+++ b/scripts/patch-pytorch.sh
@@ -18,3 +18,4 @@ cd "$REPO_ROOT"
 curl -sSL https://github.com/pytorch/pytorch/pull/126516.diff | git apply -
 curl -sSL https://github.com/pytorch/pytorch/pull/126456.diff | git apply -
 curl -sSL https://github.com/pytorch/pytorch/pull/136280.diff | git apply -
+curl -sSL https://github.com/pytorch/pytorch/pull/135406.diff | git apply -


### PR DESCRIPTION
Just to see if there are any other hidden problems

CI: 
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/11016625956 (works, PR#135406)
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/11017808955 (works, PR#136514)
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/11019490150 (failed, patch didn't apply, not specifying pytorch ref - pinned commit is used, PR#136514)
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/11021171481 (888744bd36d963849a8278b6d5c0c2da91867c7c, failed: new issue) 

```bash
FAILED [3.8904s] inductor/test_triton_kernels.py::KernelTests::test_triton_kernel_dtype_view_cfg_cpp_abi - torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
AttributeError: 'NoneType' object has no attribute 'push_codegened_graph'
```