### PR TITLE
Add support for Intel fast math functions

### DIFF
--- a/python/triton/language/extra/intel/libdevice.py
+++ b/python/triton/language/extra/intel/libdevice.py
@@ -677,6 +677,48 @@ def double_as_longlong(arg0, _builder=None):
 
 
 @core.extern
+def fast_log2f(arg0, _builder=None):
+    return core.extern_elementwise("", "", [arg0], {
+        (core.dtype("fp32"), ): ("__imf_fast_log2f", core.dtype("fp32")),
+    }, is_pure=True, _builder=_builder)
+
+
+@core.extern
+def fast_logf(arg0, _builder=None):
+    return core.extern_elementwise("", "", [arg0], {
+        (core.dtype("fp32"), ): ("__imf_fast_logf", core.dtype("fp32")),
+    }, is_pure=True, _builder=_builder)
+
+
+@core.extern
+def fast_expf(arg0, _builder=None):
+    return core.extern_elementwise("", "", [arg0], {
+        (core.dtype("fp32"), ): ("__imf_fast_expf", core.dtype("fp32")),
+    }, is_pure=True, _builder=_builder)
+
+
+@core.extern
+def fast_exp10f(arg0, _builder=None):
+    return core.extern_elementwise("", "", [arg0], {
+        (core.dtype("fp32"), ): ("__imf_fast_exp10f", core.dtype("fp32")),
+    }, is_pure=True, _builder=_builder)
+
+
+@core.extern
+def fast_log10f(arg0, _builder=None):
+    return core.extern_elementwise("", "", [arg0], {
+        (core.dtype("fp32"), ): ("__imf_fast_log10f", core.dtype("fp32")),
+    }, is_pure=True, _builder=_builder)
+
+
+@core.extern
+def fast_powf(arg0, arg1, _builder=None):
+    return core.extern_elementwise("", "", [arg0, arg1], {
+        (core.dtype("fp32"), core.dtype("fp32")): ("__imf_fast_powf", core.dtype("fp32")),
+    }, is_pure=True, _builder=_builder)
+
+
+@core.extern
 def hadd(arg0, arg1, _builder=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {


### PR DESCRIPTION
The Intel LLVM bitcode library we include in Triton contains several math functions with a "fast" device implementation. This PR adds support for the following fast math functions in our Triton port:

-   __imf_fast_log2f
-   __imf_fast_logf
-   __imf_fast_expf
-   __imf_fast_exp10f
-  __imf_fast_log10f
-   __imf_fast_powf

Note: The difference in performance between the full precision and the "fast" implementation can be substantial. For example I wrote a Triton test program using  `__imf_fast_expf` and it was more than 4x faster than `__imf_expf`.