### PR TITLE
Move output tensor allocation out of benchmark function for GEMM

### DIFF
--- a/benchmarks/triton_kernels_benchmark/gemm_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_benchmark.py
@@ -252,12 +252,12 @@ def benchmark(B, M, N, K, provider):
         _, min_ms, max_ms, mean_ms, cv = benchmark_suit.do_bench(lambda: torch.matmul(a, b), warmup=10, rep=10,
                                                                  quantiles=quantiles, fast_flush=False)
     elif provider == 'triton':
-        if len(a.shape) == 3 and len(b.shape) == 3:
+        assert len(a.shape) == len(b.shape), 'Incompatible sizes'
+        if len(a.shape) == 3:
             c = torch.empty((B, M, N), device='xpu', dtype=torch.float32)
-        elif len(a.shape) == 2 and len(b.shape) == 2:
-            c = torch.empty((M, N), device='xpu', dtype=torch.float32)
         else:
-            c = None
+            assert len(a.shape) == 2, 'Expecting shape of length 2'
+            c = torch.empty((M, N), device='xpu', dtype=torch.float32)
         triton_fn = lambda: matmul(a, b, c)
         torch_fn = lambda: torch.matmul(a, b).to(torch.float32)
         rtol = 1e-2 if a.dtype == torch.bfloat16 else 1e-3

--- a/benchmarks/triton_kernels_benchmark/gemm_postop_addmatrix_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_postop_addmatrix_benchmark.py
@@ -263,12 +263,12 @@ def benchmark(B, M, N, K, provider):
     quantiles = [0.5, 0.0, 1.0]
 
     if provider == 'triton':
-        if len(a.shape) == 3 and len(b.shape) == 3:
+        assert len(a.shape) == len(b.shape), 'Incompatible sizes'
+        if len(a.shape) == 3:
             c = torch.empty((B, M, N), device='xpu', dtype=torch.float32)
-        elif len(a.shape) == 2 and len(b.shape) == 2:
-            c = torch.empty((M, N), device='xpu', dtype=torch.float32)
         else:
-            c = None
+            assert len(a.shape) == 2, 'Expecting shape of length 2'
+            c = torch.empty((M, N), device='xpu', dtype=torch.float32)
         triton_fn = lambda: matmul(a, b, d, c)
         torch_fn = lambda: torch.matmul(a, b).to(torch.float32) + d
         rtol = 1e-2 if a.dtype == torch.bfloat16 else 1e-3

--- a/benchmarks/triton_kernels_benchmark/gemm_postop_addmatrix_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_postop_addmatrix_benchmark.py
@@ -167,8 +167,8 @@ def matmul_kernel_with_block_pointers_batched(
 
 
 # We can now create a convenience wrapper function that only takes two input tensors,
-# and (1) checks any shape constraint; (2) allocates the output; (3) launches the above kernel.
-def matmul(a, b, d):
+# and (1) checks any shape constraint; (2) launches the above kernel.
+def matmul(a, b, d, c):
     # Check constraints.
     if len(a.shape) == 3 and len(b.shape) == 3:
         assert a.shape[0] == b.shape[0], 'Incompatible Batch dimension'
@@ -177,8 +177,6 @@ def matmul(a, b, d):
         assert b.is_contiguous(), 'Matrix B must be contiguous'
         B, M, K = a.shape
         B, K, N = b.shape
-        # Allocates output.
-        c = torch.empty((B, M, N), device=a.device, dtype=torch.float32)
         # 1D launch kernel where each block gets its own program.
         grid = lambda META: (
             B,
@@ -197,8 +195,6 @@ def matmul(a, b, d):
         assert b.is_contiguous(), 'Matrix B must be contiguous'
         M, K = a.shape
         K, N = b.shape
-        # Allocates output.
-        c = torch.empty((M, N), device=a.device, dtype=torch.float32)
         grid = lambda META: (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']), )
         matmul_kernel_with_block_pointers[grid](
             a, b, c, d,  #
@@ -267,7 +263,13 @@ def benchmark(B, M, N, K, provider):
     quantiles = [0.5, 0.0, 1.0]
 
     if provider == 'triton':
-        triton_fn = lambda: matmul(a, b, d)
+        if len(a.shape) == 3 and len(b.shape) == 3:
+            c = torch.empty((B, M, N), device='xpu', dtype=torch.float32)
+        elif len(a.shape) == 2 and len(b.shape) == 2:
+            c = torch.empty((M, N), device='xpu', dtype=torch.float32)
+        else:
+            c = None
+        triton_fn = lambda: matmul(a, b, d, c)
         torch_fn = lambda: torch.matmul(a, b).to(torch.float32) + d
         rtol = 1e-2 if a.dtype == torch.bfloat16 else 1e-3
         benchmark_suit.assert_close(triton_fn(), torch_fn(), atol=1e-4, rtol=rtol, err_msg='triton to torch')

--- a/benchmarks/triton_kernels_benchmark/gemm_postop_gelu_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_postop_gelu_benchmark.py
@@ -173,8 +173,8 @@ def matmul_kernel_with_block_pointers_batched(
 
 
 # We can now create a convenience wrapper function that only takes two input tensors,
-# and (1) checks any shape constraint; (2) allocates the output; (3) launches the above kernel.
-def matmul(a, b):
+# and (1) checks any shape constraint; (2) launches the above kernel.
+def matmul(a, b, c):
     # Check constraints.
     if len(a.shape) == 3 and len(b.shape) == 3:
         assert a.shape[0] == b.shape[0], 'Incompatible Batch dimension'
@@ -183,8 +183,6 @@ def matmul(a, b):
         assert b.is_contiguous(), 'Matrix B must be contiguous'
         B, M, K = a.shape
         B, K, N = b.shape
-        # Allocates output.
-        c = torch.empty((B, M, N), device=a.device, dtype=torch.float32)
         # 1D launch kernel where each block gets its own program.
         grid = lambda META: (
             B,
@@ -202,8 +200,6 @@ def matmul(a, b):
         assert b.is_contiguous(), 'Matrix B must be contiguous'
         M, K = a.shape
         K, N = b.shape
-        # Allocates output.
-        c = torch.empty((M, N), device=a.device, dtype=torch.float32)
         grid = lambda META: (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']), )
         matmul_kernel_with_block_pointers[grid](
             a, b, c,  #
@@ -269,7 +265,13 @@ def benchmark(B, M, N, K, provider):
     quantiles = [0.5, 0.0, 1.0]
 
     if provider == 'triton':
-        triton_fn = lambda: matmul(a, b)
+        if len(a.shape) == 3 and len(b.shape) == 3:
+            c = torch.empty((B, M, N), device='xpu', dtype=torch.float32)
+        elif len(a.shape) == 2 and len(b.shape) == 2:
+            c = torch.empty((M, N), device='xpu', dtype=torch.float32)
+        else:
+            c = None
+        triton_fn = lambda: matmul(a, b, c)
         torch_fn = lambda: torch.nn.functional.gelu(torch.matmul(a, b).to(torch.float32))
         rtol = 1e-2 if a.dtype == torch.bfloat16 else 1e-3
         benchmark_suit.assert_close(triton_fn(), torch_fn(), atol=1e-4, rtol=rtol, err_msg='triton to torch')

--- a/benchmarks/triton_kernels_benchmark/gemm_postop_gelu_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_postop_gelu_benchmark.py
@@ -265,12 +265,12 @@ def benchmark(B, M, N, K, provider):
     quantiles = [0.5, 0.0, 1.0]
 
     if provider == 'triton':
-        if len(a.shape) == 3 and len(b.shape) == 3:
+        assert len(a.shape) == len(b.shape), 'Incompatible sizes'
+        if len(a.shape) == 3:
             c = torch.empty((B, M, N), device='xpu', dtype=torch.float32)
-        elif len(a.shape) == 2 and len(b.shape) == 2:
-            c = torch.empty((M, N), device='xpu', dtype=torch.float32)
         else:
-            c = None
+            assert len(a.shape) == 2, 'Expecting shape of length 2'
+            c = torch.empty((M, N), device='xpu', dtype=torch.float32)
         triton_fn = lambda: matmul(a, b, c)
         torch_fn = lambda: torch.nn.functional.gelu(torch.matmul(a, b).to(torch.float32))
         rtol = 1e-2 if a.dtype == torch.bfloat16 else 1e-3

--- a/benchmarks/triton_kernels_benchmark/gemm_preop_exp_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_preop_exp_benchmark.py
@@ -253,12 +253,12 @@ def benchmark(B, M, N, K, provider):
     quantiles = [0.5, 0.0, 1.0]
 
     if provider == 'triton':
-        if len(a.shape) == 3 and len(b.shape) == 3:
+        assert len(a.shape) == len(b.shape), 'Incompatible sizes'
+        if len(a.shape) == 3:
             c = torch.empty((B, M, N), device='xpu', dtype=torch.float32)
-        elif len(a.shape) == 2 and len(b.shape) == 2:
-            c = torch.empty((M, N), device='xpu', dtype=torch.float32)
         else:
-            c = None
+            assert len(a.shape) == 2, 'Expecting shape of length 2'
+            c = torch.empty((M, N), device='xpu', dtype=torch.float32)
         triton_fn = lambda: matmul(a, b, c)
         torch_fn = lambda: torch.matmul(torch.exp(a), b).to(torch.float32)
         rtol = 1e-2 if a.dtype == torch.bfloat16 else 1e-3

--- a/benchmarks/triton_kernels_benchmark/gemm_preop_exp_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_preop_exp_benchmark.py
@@ -161,8 +161,8 @@ def matmul_kernel_with_block_pointers_batched(
 
 
 # We can now create a convenience wrapper function that only takes two input tensors,
-# and (1) checks any shape constraint; (2) allocates the output; (3) launches the above kernel.
-def matmul(a, b):
+# and (1) checks any shape constraint; (2) launches the above kernel.
+def matmul(a, b, c):
     # Check constraints.
     if len(a.shape) == 3 and len(b.shape) == 3:
         assert a.shape[0] == b.shape[0], 'Incompatible Batch dimension'
@@ -171,8 +171,6 @@ def matmul(a, b):
         assert b.is_contiguous(), 'Matrix B must be contiguous'
         B, M, K = a.shape
         B, K, N = b.shape
-        # Allocates output.
-        c = torch.empty((B, M, N), device=a.device, dtype=torch.float32)
         # 1D launch kernel where each block gets its own program.
         grid = lambda META: (
             B,
@@ -190,8 +188,6 @@ def matmul(a, b):
         assert b.is_contiguous(), 'Matrix B must be contiguous'
         M, K = a.shape
         K, N = b.shape
-        # Allocates output.
-        c = torch.empty((M, N), device=a.device, dtype=torch.float32)
         grid = lambda META: (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']), )
         matmul_kernel_with_block_pointers[grid](
             a, b, c,  #
@@ -257,7 +253,13 @@ def benchmark(B, M, N, K, provider):
     quantiles = [0.5, 0.0, 1.0]
 
     if provider == 'triton':
-        triton_fn = lambda: matmul(a, b)
+        if len(a.shape) == 3 and len(b.shape) == 3:
+            c = torch.empty((B, M, N), device='xpu', dtype=torch.float32)
+        elif len(a.shape) == 2 and len(b.shape) == 2:
+            c = torch.empty((M, N), device='xpu', dtype=torch.float32)
+        else:
+            c = None
+        triton_fn = lambda: matmul(a, b, c)
         torch_fn = lambda: torch.matmul(torch.exp(a), b).to(torch.float32)
         rtol = 1e-2 if a.dtype == torch.bfloat16 else 1e-3
         benchmark_suit.assert_close(triton_fn(), torch_fn(), atol=1e-4, rtol=rtol, err_msg='triton to torch')

--- a/benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py
@@ -194,7 +194,7 @@ def full_tiles(
 # ---------------------------------------------------------------------------
 
 
-def matmul(a: torch.Tensor, b: torch.Tensor):
+def matmul(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor):
     num_xe_core = torch.xpu.get_device_capability(0)['gpu_subslice_count']
     streamk_programs = num_xe_core
 
@@ -226,8 +226,6 @@ def matmul(a: torch.Tensor, b: torch.Tensor):
     streamk_full_tiles = streamk_iters // streamk_programs
     streamk_partial_tiles = streamk_iters % streamk_programs
 
-    # Allocates output.
-    c = torch.empty((M, N), device=a.device, dtype=torch.float32)
     first_wave[(streamk_programs, )](
         a, b, c,  #
         M, N, K,  #
@@ -276,7 +274,8 @@ def benchmark(M, N, K, provider):
         _, min_ms, max_ms, mean, cv = benchmark_suit.do_bench(lambda: torch.matmul(a, b), warmup=10, rep=10,
                                                               quantiles=quantiles, fast_flush=False)
     elif provider == 'triton':
-        triton_fn = lambda: matmul(a, b)
+        c = torch.empty((M, N), device=a.device, dtype=torch.float32)
+        triton_fn = lambda: matmul(a, b, c)
         torch_fn = lambda: torch.matmul(a, b).to(torch.float32)
         benchmark_suit.assert_close(triton_fn(), torch_fn(), atol=1e-4, rtol=1e-2, err_msg='triton to torch')
         _, min_ms, max_ms, mean, cv = benchmark_suit.do_bench(triton_fn, warmup=10, rep=10, quantiles=quantiles,


### PR DESCRIPTION
Geomean was incorrectly calculated for GEMM (in https://github.com/intel/intel-xpu-backend-for-triton/pull/2298), after recalculating I saw a deterioration in the ratio, which may be due to allocations.

Let's see: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/11019414473

The Triton GEMM adv geomean increased by ~1TFlops.