### PR TITLE
Revert "Change default benchmark mode to upstream PyTorch (#2298)"

### DIFF
--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -14,7 +14,7 @@ on:
       install_ipex:
         description: Install Intel PyTorch Extension
         type: boolean
-        default: false
+        default: true
   schedule:
     - cron: "5 23 * * *"
 
@@ -22,7 +22,7 @@ permissions: read-all
 
 env:
   PYTHON_VERSION: "3.10"
-  USE_IPEX: ${{ github.event_name == 'schedule' && '0' || inputs.install_ipex && '1' || '0' }}
+  USE_IPEX: ${{ github.event_name == 'schedule' && '1' || inputs.install_ipex && '1' || '0' }}
 
 jobs:
   build:


### PR DESCRIPTION
Address https://github.com/intel/intel-xpu-backend-for-triton/pull/2298#issuecomment-2374166710.

This reverts commit 782aecfa3302afa4aebf3842a2eafec337982b8d.

CI status: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/11034669496