### PR TITLE
Use stride instead of order to determine block attr

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -65,7 +65,7 @@ public:
           break;
         }
       }
-      
+
       LDBG("Fast change dim: " << fastChangeDim);
       if (fastChangeDim < 0) {
         return;

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -71,9 +71,7 @@ public:
       }
       ArrayRef<int32_t> order = makeTensorPtrOp.getOrder();
 
-      // unsigned fastChangeDim = order[0];
       if (fastChangeDim >= (rank - 2)) {
-
         // HW 2D block read instruction only supports contiguous access.
         Value fastChangeStride = strides[fastChangeDim];
         LLVM_DEBUG({
@@ -89,7 +87,8 @@ public:
         Value pitch =
             strides[(fastChangeDim == rank - 1) ? rank - 2 : rank - 1];
         LDBG("Pitch: " << pitch);
-        if (!ttgi::isDivisible(pitch, 64 / tensorType.getElementTypeBitWidth()))
+        if (!ttgi::isDivisible(pitch,
+                               128 / tensorType.getElementTypeBitWidth()))
           return;
 
         loadOp->setAttr(ttgi::TritonIntelGPUDialect::getBlockIOAttrName(),

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -59,7 +59,7 @@ public:
 
       Operation::operand_range strides = makeTensorPtrOp.getStrides();
       int fastChangeDim = -1;
-      for (size_t i = 0; i < strides.size(); i++) {
+      for (size_t i = 0; i < strides.size(); ++i) {
         if (mlir::triton::gpu::intel::isConstant(strides[i], 1)) {
           fastChangeDim = i;
           break;

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -65,11 +65,11 @@ public:
           break;
         }
       }
+      
       LDBG("Fast change dim: " << fastChangeDim);
       if (fastChangeDim < 0) {
         return;
       }
-      ArrayRef<int32_t> order = makeTensorPtrOp.getOrder();
 
       if (fastChangeDim >= (rank - 2)) {
         // HW 2D block read instruction only supports contiguous access.


### PR DESCRIPTION
Per the Triton slack, `order` is unused on architecture below Hopper. But more importantly, order provides information that stride already has. In fact, order can be completely different from stride (i.e. wrong) and we still generate correct code. I think it is better to use the stride assuming the logic I added here makes sense. 

Note this depends on #2348, I'd like to land the debug logging separately, so we have it even if we decide to modify this approach. It was very useful in debugging this problem. 

cc #2347