### PR TITLE
Print operation of unsupported OpenCL C 2D block read

### DIFF
--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -876,7 +876,8 @@ struct TritonMatrix2DBlockLoadLowering
     }
 
     if (!isOCLBuiltinAvailable(op)) {
-      op.emitWarning("OpenCL API not available for this operation");
+      op.emitWarning() << "OpenCL API not available for this operation. Got "
+                       << *op;
       rewriter.replaceOp(op, createGenISA2DBlockRead(op, rewriter));
       return success();
     }


### PR DESCRIPTION
Verified that warning like below is printed:
```
OpenCL API not available for this operation. Got %827 = "triton_gen.2Dblockload"(%716, %826, %719, %825, %824, %823) <{cache_control = 0 : i32, elem_size_in_bits = 32 : i32, tile_height = 32 : i32, tile_width = 8 : i32, transpose = true, v_blocks = 1 : i32, vnni_transform = false}> : (!llvm.ptr<1>, i32, i32, i32, i32, i32) -> vector<16xi32>
```