### PR TITLE
Introduce `BENCHMARKING_METHOD` for `Triton benchmarks`

### DIFF
--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -11,10 +11,13 @@ on:
         description: Tag for benchmark results
         type: string
         default: "test"
-      install_ipex:
-        description: Install Intel PyTorch Extension
-        type: boolean
-        default: true
+      benchmarking_method:
+        description: The method used to obtain performance numbers
+        type: choice
+        options:
+          - PYTORCH_LEGACY_PROFILER_USING_IPEX
+          - ELAPSED_TIME
+        default: PYTORCH_LEGACY_PROFILER_USING_IPEX
   schedule:
     - cron: "5 23 * * *"
 
@@ -22,7 +25,8 @@ permissions: read-all
 
 env:
   PYTHON_VERSION: "3.10"
-  USE_IPEX: ${{ github.event_name == 'schedule' && '1' || inputs.install_ipex && '1' || '0' }}
+  BENCHMARKING_METHOD: ${{ github.event_name == 'schedule' && 'PYTORCH_LEGACY_PROFILER_USING_IPEX' || inputs.benchmarking_method }}
+  USE_IPEX: ${{ $BENCHMARKING_METHOD == 'PYTORCH_LEGACY_PROFILER_USING_IPEX' }}
 
 jobs:
   build:

--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -26,7 +26,6 @@ permissions: read-all
 env:
   PYTHON_VERSION: "3.10"
   BENCHMARKING_METHOD: ${{ github.event_name == 'schedule' && 'PYTORCH_LEGACY_PROFILER_USING_IPEX' || inputs.benchmarking_method }}
-  USE_IPEX: ${{ $BENCHMARKING_METHOD == 'PYTORCH_LEGACY_PROFILER_USING_IPEX' }}
 
 jobs:
   build:
@@ -57,6 +56,9 @@ jobs:
       - name: Install Python build dependencies
         run: |
           pip install wheel cmake
+
+      - name: Set USE_IPEX environment variable
+        run: echo "USE_IPEX=$($BENCHMARKING_METHOD == 'PYTORCH_LEGACY_PROFILER_USING_IPEX')" >> $GITHUB_ENV
 
       - name: Setup PyTorch with IPEX
         if: ${{ env.USE_IPEX == '1' }}

--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -26,6 +26,7 @@ permissions: read-all
 env:
   PYTHON_VERSION: "3.10"
   BENCHMARKING_METHOD: ${{ github.event_name == 'schedule' && 'PYTORCH_LEGACY_PROFILER_USING_IPEX' || inputs.benchmarking_method }}
+  USE_IPEX: ${{ github.event_name == 'schedule' && '1' || inputs.benchmarking_method  == 'PYTORCH_LEGACY_PROFILER_USING_IPEX' && '1' || '0' }}
 
 jobs:
   build:
@@ -56,9 +57,6 @@ jobs:
       - name: Install Python build dependencies
         run: |
           pip install wheel cmake
-
-      - name: Set USE_IPEX environment variable
-        run: echo "USE_IPEX=$($BENCHMARKING_METHOD == 'PYTORCH_LEGACY_PROFILER_USING_IPEX')" >> $GITHUB_ENV
 
       - name: Setup PyTorch with IPEX
         if: ${{ env.USE_IPEX == '1' }}

--- a/benchmarks/triton_kernels_benchmark/benchmark_testing.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_testing.py
@@ -126,8 +126,8 @@ def do_bench_ipex(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fas
     return _summarize_statistics(times, quantiles, return_mode)
 
 
-def do_bench_elapsed_time(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fast_flush=True, return_mode="mean",
-                          device="xpu"):
+def do_bench_elapsed_time(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fast_flush=True,
+                          return_mode="mean", device="xpu"):
     """
     Benchmark the runtime of the provided function. By default, return the median runtime of :code:`fn` along with
     the 20-th and 80-th performance percentile.
@@ -155,7 +155,6 @@ def do_bench_elapsed_time(fn, warmup=25, rep=100, grad_to_none=None, quantiles=N
     return _summarize_statistics(times, quantiles, return_mode)
 
 
-do_bench = do_bench_no_ipex
 if USE_IPEX_OPTION:
     do_bench = do_bench_ipex
 elif BENCHMARKING_METHOD == "ELAPSED_TIME":

--- a/benchmarks/triton_kernels_benchmark/benchmark_testing.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_testing.py
@@ -4,6 +4,10 @@ import os
 from typing import Any, Dict, List
 
 USE_IPEX_OPTION = os.getenv("USE_IPEX", "1") == "1"
+if USE_IPEX_OPTION:
+    BENCHMARKING_METHOD = "PYTORCH_LEGACY_PROFILER_USING_IPEX"
+else:
+    BENCHMARKING_METHOD = os.getenv("BENCHMARKING_METHOD", "ELAPSED_TIME")
 
 
 def synchronize():
@@ -122,8 +126,8 @@ def do_bench_ipex(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fas
     return _summarize_statistics(times, quantiles, return_mode)
 
 
-def do_bench_no_ipex(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fast_flush=True, return_mode="mean",
-                     device="xpu"):
+def do_bench_elapsed_time(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fast_flush=True, return_mode="mean",
+                          device="xpu"):
     """
     Benchmark the runtime of the provided function. By default, return the median runtime of :code:`fn` along with
     the 20-th and 80-th performance percentile.
@@ -154,6 +158,10 @@ def do_bench_no_ipex(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, 
 do_bench = do_bench_no_ipex
 if USE_IPEX_OPTION:
     do_bench = do_bench_ipex
+elif BENCHMARKING_METHOD == "ELAPSED_TIME":
+    do_bench = do_bench_elapsed_time
+else:
+    raise NotImplementedError(f"BENCHMARKING_METHOD: {BENCHMARKING_METHOD} isn't implemented")
 
 
 def assert_close(x, y, atol=None, rtol=None, err_msg=""):

--- a/benchmarks/triton_kernels_benchmark/benchmark_testing.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_testing.py
@@ -155,7 +155,7 @@ def do_bench_elapsed_time(fn, warmup=25, rep=100, grad_to_none=None, quantiles=N
     return _summarize_statistics(times, quantiles, return_mode)
 
 
-if USE_IPEX_OPTION:
+if BENCHMARKING_METHOD == "PYTORCH_LEGACY_PROFILER_USING_IPEX":
     do_bench = do_bench_ipex
 elif BENCHMARKING_METHOD == "ELAPSED_TIME":
     do_bench = do_bench_elapsed_time

--- a/scripts/capture-hw-details.sh
+++ b/scripts/capture-hw-details.sh
@@ -61,7 +61,7 @@ fi
 if [[ "${USE_IPEX:-}" == "1" ]]; then
     export BENCHMARKING_METHOD="PYTORCH_LEGACY_PROFILER_USING_IPEX"
 elif [[ "${USE_IPEX:-}" == "0" ]]; then
-    export BENCHMARKING_METHOD="ELAPSED_TIME"
+    export BENCHMARKING_METHOD="${BENCHMARKING_METHOD:ELAPSED_TIME}"
 fi
 
 if [ "$QUIET" = false ]; then

--- a/scripts/capture-hw-details.sh
+++ b/scripts/capture-hw-details.sh
@@ -61,7 +61,7 @@ fi
 if [[ "${USE_IPEX:-}" == "1" ]]; then
     export BENCHMARKING_METHOD="PYTORCH_LEGACY_PROFILER_USING_IPEX"
 elif [[ "${USE_IPEX:-}" == "0" ]]; then
-    export BENCHMARKING_METHOD="${BENCHMARKING_METHOD:ELAPSED_TIME}"
+    export BENCHMARKING_METHOD="${BENCHMARKING_METHOD:-ELAPSED_TIME}"
 fi
 
 if [ "$QUIET" = false ]; then


### PR DESCRIPTION
Required for https://github.com/intel/intel-xpu-backend-for-triton/pull/2343 because it will add a new benchmarking method: `UPSTREAM_PYTORCH_PROFILER`

The option is added more with an eye on CI, so for now I left `USE_IPEX` option so as not to change the interaction interface (default behavior is also not changed).