### PR TITLE
Fix coverity issues

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/RewriteTensorPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RewriteTensorPointer.cpp
@@ -52,6 +52,7 @@ bool shouldRemove(tt::MakeTensorPtrOp &op, bool isUsedByStoreOp) {
   TypedValue<triton::PointerType> base = op.getBase();
   Operation::operand_range shape = op.getShape();
   unsigned rank = shape.size();
+  assert(rank > 1 && "Expecting tensor with rank > 1");
   Operation::operand_range strides = op.getStrides();
   Operation::operand_range offsets = op.getOffsets();
   ArrayRef<int32_t> order = op.getOrder();


### PR DESCRIPTION
`Coverity` see the INTEGER_OVERFLOW error for the following line when rank == 1:
https://github.com/intel/intel-xpu-backend-for-triton/blob/361dfa7105ecc8ded76803623d4e066fac1297e8/third_party/intel/lib/TritonIntelGPUTransforms/RewriteTensorPointer.cpp#L82

I believe by using an additional assert we can secure the code (at least, we'll show the limitations we rely on in the code more explicitly) and get rid of the error `Coverity` shows.