### PR TITLE
Return n_regs for binaries compiled explicitly with a register size mode option 

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -318,7 +318,7 @@ class XPUBackend(BaseBackend):
                     if os.path.exists(flog.name):
                         with open(flog.name) as log_file:
                             log = log_file.read().strip()
-                            if 'spilled' in log:
+                            if 'spilled' in log and metadata["build_flags"].find("-cl-intel-256-GRF-per-thread") is -1:
                                 """
                                 The exact message is something like:
                                     warning: kernel matmul_kernel  compiled SIMD16 allocated 128 regs and spilled around 217

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -108,8 +108,8 @@ template <typename L0_DEVICE, typename L0_CONTEXT>
 std::tuple<ze_module_handle_t, ze_kernel_handle_t, Spills>
 compileLevelZeroObjects(uint8_t *binary_ptr, const size_t binary_size,
                         const std::string &kernel_name, L0_DEVICE l0_device,
-                        L0_CONTEXT l0_context,
-                        const std::string& build_flags, const bool is_spv) {
+                        L0_CONTEXT l0_context, const std::string &build_flags,
+                        const bool is_spv) {
   auto l0_module =
       checkSyclErrors(create_module(l0_context, l0_device, binary_ptr,
                                     binary_size, build_flags.data(), is_spv));
@@ -137,9 +137,7 @@ struct BuildFlags {
 
   BuildFlags(const char *build_flags) : build_flags_str(build_flags) {}
 
-  const std::string& operator()() const {
-    return build_flags_str;
-  }
+  const std::string &operator()() const { return build_flags_str; }
 
   int32_t n_regs() {
     if (build_flags_str.find(LARGE_GRF_FLAG) != std::string::npos) {
@@ -164,7 +162,9 @@ struct BuildFlags {
     }
   }
 
-  void addLargeGRFSizeFlag() { build_flags_str = build_flags_str.append(" " + LARGE_GRF_FLAG); }
+  void addLargeGRFSizeFlag() {
+    build_flags_str = build_flags_str.append(" " + LARGE_GRF_FLAG);
+  }
 };
 
 static PyObject *loadBinary(PyObject *self, PyObject *args) {
@@ -218,7 +218,7 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
       // than the threshold, recompile the kernel using large GRF mode.
       if (!is_GRF_mode_specified && n_spills > max_reg_spill) {
         const std::optional<bool> debugEnabled =
-          isEnvValueBool(getStrEnv("TRITON_DEBUG"));
+            isEnvValueBool(getStrEnv("TRITON_DEBUG"));
         if (debugEnabled)
           std::cout << "(I): Detected " << n_spills
                     << " spills, recompiling the kernel using large GRF mode"
@@ -230,12 +230,12 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
             binary_ptr, binary_size, kernel_name, l0_device, l0_context,
             build_flags(), is_spv);
 
-      if (debugEnabled)
-        std::cout << "(I): Kernel has now " << n_spills << " spills"
-                  << std::endl;
+        if (debugEnabled)
+          std::cout << "(I): Kernel has now " << n_spills << " spills"
+                    << std::endl;
       }
     }
-    
+
     auto n_regs = build_flags.n_regs();
 
     auto mod = new sycl::kernel_bundle<sycl::bundle_state::executable>(

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -102,15 +102,17 @@ void freeKernelBundle(PyObject *p) {
       PyCapsule_GetPointer(p, "kernel_bundle"));
 }
 
+using Spills = int32_t;
+
 template <typename L0_DEVICE, typename L0_CONTEXT>
-std::tuple<ze_module_handle_t, ze_kernel_handle_t, int32_t, int32_t>
+std::tuple<ze_module_handle_t, ze_kernel_handle_t, Spills>
 compileLevelZeroObjects(uint8_t *binary_ptr, const size_t binary_size,
                         const std::string &kernel_name, L0_DEVICE l0_device,
-                        L0_CONTEXT l0_context, const std::string &build_flags,
-                        const bool is_spv) {
+                        L0_CONTEXT l0_context,
+                        const std::string& build_flags, const bool is_spv) {
   auto l0_module =
       checkSyclErrors(create_module(l0_context, l0_device, binary_ptr,
-                                    binary_size, build_flags.c_str(), is_spv));
+                                    binary_size, build_flags.data(), is_spv));
 
   // Retrieve the kernel properties (e.g. register spills).
   auto l0_kernel = checkSyclErrors(create_function(l0_module, kernel_name));
@@ -121,20 +123,58 @@ compileLevelZeroObjects(uint8_t *binary_ptr, const size_t binary_size,
   checkSyclErrors(
       std::make_tuple(NULL, zeKernelGetProperties(l0_kernel, &props)));
 
-  int32_t n_spills = props.spillMemSize;
-  const int32_t n_regs = 0;
+  const int32_t n_spills = props.spillMemSize;
 
-  return std::make_tuple(l0_module, l0_kernel, n_regs, n_spills);
+  return std::make_tuple(l0_module, l0_kernel, n_spills);
 }
 
+struct BuildFlags {
+  std::string build_flags_str;
+
+  const std::string LARGE_GRF_FLAG{"-cl-intel-256-GRF-per-thread"};
+  const std::string SMALL_GRF_FLAG{"-cl-intel-128-GRF-per-thread"};
+  const std::string AUTO_GRF_FLAG{"-cl-intel-enable-auto-large-GRF-mode"};
+
+  BuildFlags(const char *build_flags) : build_flags_str(build_flags) {}
+
+  const std::string& operator()() const {
+    return build_flags_str;
+  }
+
+  int32_t n_regs() {
+    if (build_flags_str.find(LARGE_GRF_FLAG) != std::string::npos) {
+      return 256;
+    }
+    if (build_flags_str.find(SMALL_GRF_FLAG) != std::string::npos) {
+      return 128;
+    }
+    // TODO: arguably we could return 128 if we find no flag instead of 0. For
+    // now, stick with the conservative choice and alert the user only if a
+    // specific GRF mode is specified.
+    return 0;
+  }
+
+  const bool hasGRFSizeFlag() {
+    if (build_flags_str.find(LARGE_GRF_FLAG) != std::string::npos ||
+        build_flags_str.find(SMALL_GRF_FLAG) != std::string::npos ||
+        build_flags_str.find(AUTO_GRF_FLAG) != std::string::npos) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  void addLargeGRFSizeFlag() { build_flags_str = build_flags_str.append(" " + LARGE_GRF_FLAG); }
+};
+
 static PyObject *loadBinary(PyObject *self, PyObject *args) {
-  const char *name, *build_flags;
+  const char *name, *build_flags_ptr;
   int shared;
   PyObject *py_bytes;
   int devId;
 
-  if (!PyArg_ParseTuple(args, "sSisi", &name, &py_bytes, &shared, &build_flags,
-                        &devId)) {
+  if (!PyArg_ParseTuple(args, "sSisi", &name, &py_bytes, &shared,
+                        &build_flags_ptr, &devId)) {
     std::cerr << "loadBinary arg parse failed" << std::endl;
     return NULL;
   }
@@ -143,6 +183,8 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
     std::cerr << "Device is not found " << std::endl;
     return NULL;
   }
+
+  BuildFlags build_flags(build_flags_ptr);
 
   try {
 
@@ -164,24 +206,13 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
         isEnvValueBool(getStrEnv("TRITON_XPU_GEN_NATIVE_CODE"));
     const bool is_spv = use_native_code ? !(*use_native_code) : true;
 
-    auto [l0_module, l0_kernel, n_regs, n_spills] =
+    auto [l0_module, l0_kernel, n_spills] =
         compileLevelZeroObjects(binary_ptr, binary_size, kernel_name, l0_device,
-                                l0_context, build_flags, is_spv);
+                                l0_context, build_flags(), is_spv);
 
     if (is_spv) {
       constexpr int32_t max_reg_spill = 1000;
-      std::string build_flags_str(build_flags);
-      bool is_GRF_mode_specified = false;
-
-      // Check whether the GRF mode is specified by the build flags.
-      if (build_flags_str.find("-cl-intel-256-GRF-per-thread") !=
-              std::string::npos ||
-          build_flags_str.find("-cl-intel-128-GRF-per-thread") !=
-              std::string::npos ||
-          build_flags_str.find("-cl-intel-enable-auto-large-GRF-mode") !=
-              std::string::npos) {
-        is_GRF_mode_specified = true;
-      }
+      const bool is_GRF_mode_specified = build_flags.hasGRFSizeFlag();
 
       // If the register mode isn't set, and the number of spills is greater
       // than the threshold, recompile the kernel using large GRF mode.
@@ -193,18 +224,19 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
                     << " spills, recompiling the kernel using large GRF mode"
                     << std::endl;
 
-        const std::string new_build_flags =
-            build_flags_str.append(" -cl-intel-256-GRF-per-thread");
+        build_flags.addLargeGRFSizeFlag();
 
-        auto [l0_module, l0_kernel, n_regs, n_spills] = compileLevelZeroObjects(
+        auto [l0_module, l0_kernel, n_spills] = compileLevelZeroObjects(
             binary_ptr, binary_size, kernel_name, l0_device, l0_context,
-            new_build_flags, is_spv);
-      
+            build_flags(), is_spv);
+
       if (debugEnabled)
         std::cout << "(I): Kernel has now " << n_spills << " spills"
                   << std::endl;
       }
     }
+    
+    auto n_regs = build_flags.n_regs();
 
     auto mod = new sycl::kernel_bundle<sycl::bundle_state::executable>(
         sycl::make_kernel_bundle<sycl::backend::ext_oneapi_level_zero,


### PR DESCRIPTION
Intel Data Center Max GPUs will dynamically scale the number of hardware threads available per XVE depending on the specified GRF mode. With small GRF mode (default), a single hardware thread can access 128 GRF registers and each XVE engine has 8 hardware threads. In large GRF mode, a single hardware thread can access 256 GRF registers but each XVE engine only has 4 hardware threads. There is also an auto mode.

([see the docs for more info](https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2024-2/small-register-mode-vs-large-register-mode.html))

This PR adds support for populating the `n_regs` parameter returned from loading a binary with information about the selected GRF mode. Because L0 does not return the number of registers and our register size info does not work like NVIDIA, the semantics are a bit different from upstream Triton. We _only_ return a value if the user has specified a small or large GRF mode build flag. The purpose of returning `n_regs` in upstream Triton/Torch Inductor is b/c NVIDIA can dynamically adjust occupancy of a SM based on the register pressure per warp. This means high register pressure can result in fewer running warps which reduces parallelism and performance. Theoretically, you can have many different "GRF modes" on a NVIDIA GPU as you adjust SM occupancy. For Intel GPUs, the choice is binary - large or small - and the performance penalty for register spills in small always outweighs any parallelism gains (at least, in our testing so far). It is not clear that returning 128 is actionable as further reductions in register usage will not effect occupancy - only the large GRF mode effects occupancy. So, I focused on making sure large GRF mode was properly handled and other cases were handled as we were able, with any ambiguous case returning 0 (which will cause torch inductor to skip any register-specific optimization). 

The approach to returning GRF size is dependent on parsing the build flags passed to the binary loader. Because the build flags are modified in the `make_spv` step during generation of native code instead of a SPIRV file, this approach should work for the native code POC recently merged in #2148. 

Note that I had to introduce exceptions into our `driver.c` code to make the error handling acceptable. This cleaned up a lot of the code, and I believe should be acceptable both because we already depend on c++ in `driver.c` (just not in the external signatures) and because exceptions are used in other parts of the Triton codebase. 

I marked this as a draft PR because I would like to do a bit more testing, but it is ready for review. 