### PR TITLE
Do not set suffix for Triton wheels

### DIFF
--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -80,7 +80,6 @@ jobs:
         with:
           command: >
             DEBUG=1
-            TRITON_WHEEL_VERSION_SUFFIX="+git$(git rev-parse --short HEAD)"
             python setup.py bdist_wheel && pip install dist/*.whl
 
       - name: Save Triton wheels to a cache


### PR DESCRIPTION
Fixes #2397.

The commit 6c3e9535c44774dfd56357acba9c2183b247f58e adds local suffix, additional suffix is not required.