### PR TITLE
Benchmark improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,18 @@ build-*/
 python/build/
 python/dist/
 python/triton*.egg-info/
+python/*.whl
 
 python/triton/_C/*.pyd
 python/triton/_C/*.so
 python/triton/_C/*.dylib
+
+benchmarks/dist
+benchmarks/*.egg-info/
+benchmarks/**/*.so
+
+# Logs
+inductor_log/
 
 # Backends copied from submodules
 python/triton/backends/

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -10,9 +10,11 @@ if(NOT WIN32)
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 endif()
 
-find_package(Python3 COMPONENTS Interpreter)
+find_package(Python3 REQUIRED
+  COMPONENTS Development.Module)
 find_package(Torch REQUIRED)
 find_library(TORCH_PYTHON_LIBRARY torch_python PATH "${TORCH_INSTALL_PREFIX}/lib")
+find_package(XeTLALibrary REQUIRED)
 
 if(USE_IPEX)
   string(APPEND CMAKE_CXX_FLAGS " -DUSE_IPEX")

--- a/benchmarks/cmake/FindXeTLALibrary.cmake
+++ b/benchmarks/cmake/FindXeTLALibrary.cmake
@@ -3,13 +3,15 @@
 include(FetchContent)
 
 if (NOT XeTLALibrary_FOUND)
+    # TODO: switch ot FetchContent_MakeAvailable once XeTLA supports it
+    cmake_policy(SET CMP0169 OLD)
 
     set(XeTLALibrary_SOURCE_DIR
             "${CMAKE_CURRENT_BINARY_DIR}/XeTLALibrary")
     message(STATUS "XeTLALibrary is not specified. Will try to download
                   XeTLA library from https://github.com/intel/xetla into
                   ${XeTLALibrary_SOURCE_DIR}")
-    file(READ xetla-library.conf XeTLALibrary_TAG)
+    file(READ xetla_kernel/xetla-library.conf XeTLALibrary_TAG)
     # Strip the potential trailing newline from tag
     string(STRIP "${XeTLALibrary_TAG}" XeTLALibrary_TAG)
     FetchContent_Declare(xetla-library

--- a/benchmarks/setup.py
+++ b/benchmarks/setup.py
@@ -1,5 +1,4 @@
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -25,16 +24,6 @@ class CMakeBuild():
         self.build_type = build_type
 
     def run(self):
-        try:
-            out = subprocess.check_output(["cmake", "--version"])
-        except OSError as error:
-            raise RuntimeError("CMake must be installed") from error
-
-        match = re.search(r"version\s*(?P<major>\d+)\.(?P<minor>\d+)([\d.]+)?", out.decode())
-        cmake_major, cmake_minor = int(match.group("major")), int(match.group("minor"))
-        if (cmake_major, cmake_minor) < (3, 18):
-            raise RuntimeError("CMake >= 3.18.0 is required")
-
         self.build_extension()
 
     def build_extension(self):

--- a/benchmarks/setup.py
+++ b/benchmarks/setup.py
@@ -54,7 +54,7 @@ class CMakeBuild():
         self.cmake_prefix_paths.append(intel_extension_for_pytorch.cmake_prefix_path)
 
     def check_call(self, *popenargs, **kwargs):
-        print(" ".join(popenargs[0]))
+        log.info(" ".join(popenargs[0]))
         if not self.dry_run:
             subprocess.check_call(*popenargs, **kwargs)
 
@@ -69,7 +69,7 @@ class CMakeBuild():
             "-DCMAKE_MAKE_PROGRAM=" +
             ninja_dir,  # Pass explicit path to ninja otherwise cmake may cache a temporary path
             "-DCMAKE_PREFIX_PATH=" + ";".join(self.cmake_prefix_paths),
-            "-DUSE_IPEX=" + ("1" if self.use_ipex else "0"),
+            f"-DUSE_IPEX={int(self.use_ipex)}",
             "-DCMAKE_INSTALL_PREFIX=" + self.extdir,
             "-DPython3_ROOT_DIR:FILEPATH=" + sys.exec_prefix,
             "-DCMAKE_VERBOSE_MAKEFILE=TRUE",

--- a/benchmarks/xetla_kernel/CMakeLists.txt
+++ b/benchmarks/xetla_kernel/CMakeLists.txt
@@ -1,7 +1,3 @@
-# XeTLA library is required.
-find_package(XeTLALibrary REQUIRED)
-set(CMAKE_CXX_STANDARD 20)
-
 set(XETLA_KERNEL_FLAGS ${XETLA_KERNEL_FLAGS}
   -fsycl
   -fsycl-device-code-split=per_kernel
@@ -29,8 +25,7 @@ else()
   set(XETLA_KERNEL_FLAGS ${XETLA_KERNEL_FLAGS} "${XETLA_OFFLINE_OPTIONS}")
 endif()
 
-add_library(xetla_kernel SHARED python_main.cpp)
-set_target_properties(xetla_kernel PROPERTIES PREFIX "")
+Python3_add_library(xetla_kernel MODULE WITH_SOABI python_main.cpp)
 target_compile_options(xetla_kernel PRIVATE "-fPIC")
 if(USE_IPEX)
   target_compile_options(xetla_kernel PRIVATE "-fsycl")
@@ -40,7 +35,6 @@ endif()
 target_compile_options(xetla_kernel PUBLIC "-DXETPP_NEW_XMAIN")
 target_link_options(xetla_kernel PRIVATE ${XETLA_KERNEL_FLAGS})
 target_link_libraries(xetla_kernel PUBLIC ${TORCH_LIBRARIES} ${TORCH_PYTHON_LIBRARY})
-target_include_directories(xetla_kernel PUBLIC "${PYTHON_INCLUDE_DIRS}")
 target_include_directories(xetla_kernel PUBLIC "${XeTLALibrary_INCLUDE_DIR}")
 
 if(USE_IPEX)
@@ -52,3 +46,5 @@ add_subdirectory(softmax)
 add_subdirectory(gemm)
 add_subdirectory(stream_k_gemm)
 add_subdirectory(flash_attention)
+
+install(TARGETS xetla_kernel LIBRARY DESTINATION .)

--- a/benchmarks/xetla_kernel/flash_attention/fmha_forward_v5.h
+++ b/benchmarks/xetla_kernel/flash_attention/fmha_forward_v5.h
@@ -16,6 +16,8 @@
 #ifndef TRITONBENCHMARK_FMHA_FWD_V5_H
 #define TRITONBENCHMARK_FMHA_FWD_V5_H
 
+#include <cmath>
+
 #include "fmha_policy_v2.h"
 #include "fmha_utils.h"
 #include "xetla.hpp"


### PR DESCRIPTION
I've picked up some useful changes from https://github.com/intel/intel-xpu-backend-for-triton/pull/1905 and pushed them here. Also organized python library build.

So basically it is a clean up with some features added and get it ready for the 2025 release

List of changes:

- Add benchmark project artifacts to gitignore
- Compile python library using dedicated cmake api: https://cmake.org/cmake/help/latest/module/FindPython3.html
- Suppress old style warning of xetla library
- Prevent cmake build on clean up commands (before that it was unconditional
- If there is no ipex, library will be compiled in no ipex mode with user warning
- More modular setup.py
- Verbose output of cmake commands being run
- CMakeLists.txt cleanup
- Fix shadow import usage of cmake library

Closes #1905 