### PR TITLE
Cancel outdated benchmark runs

### DIFF
--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -43,8 +43,9 @@ on:
       - .github/workflows/triton-benchmarks.yml
       - benchmarks/**
 
+# Cancels in-progress PR runs when the PR is updated.  Manual runs are never cancelled.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions: read-all


### PR DESCRIPTION
Currently each update to a PR runs benchmarks, which can take ~30mins to run. They can overload the runners and relevant runs will be delayed. At the same time there's rarely any point in outdated results.

Explanation about changes: https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre