### PR TITLE
Update version to 3.1.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,7 +145,7 @@ extensions = [
 autosummary_generate = True
 
 # versioning config
-smv_tag_whitelist = r'^(v3.0.0)$'
+smv_tag_whitelist = r'^(v3.1.0)$'
 smv_branch_whitelist = r'^main$'
 smv_remote_whitelist = None
 smv_released_pattern = r'^tags/.*$'

--- a/python/setup.py
+++ b/python/setup.py
@@ -700,7 +700,7 @@ def get_install_requires():
 
 setup(
     name=os.environ.get("TRITON_WHEEL_NAME", "triton"),
-    version="3.0.0" + get_git_commit_hash() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
+    version="3.1.0" + get_git_commit_hash() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
     author="Philippe Tillet",
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -1,5 +1,5 @@
 """isort:skip_file"""
-__version__ = '3.0.0'
+__version__ = '3.1.0'
 
 # ---------------------------------------
 # Note: import order is significant here.


### PR DESCRIPTION
PyTorch is [patching the version number](https://github.com/pytorch/pytorch/blob/main/.github/scripts/build_triton_wheel.py#L44) when building Triton wheels - possibly due to some issue syncing version between Triton and ROCM. Technically version 3.1.0 is the version we just "released" with PyTorch 2.5 so the current working version should be a higher number, but since upstream PyTorch is still using a Triton pin from the release branch, we need to make this change to advance our upstream pin. 

Close #2467 