### PR TITLE
pre-commit migrate-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: ruff
         files: '^python/.*'
         args: ["--fix", "--line-length", "120"]
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
         exclude: |
           (?x)(
             ^python/triton/runtime/.*|
@@ -35,14 +35,14 @@ repos:
     hooks:
       - id: yapf
         args: ["-p", "-i"]
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
         exclude: "python/test/unit/language/test_line_info.py"
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v16.0.6
     hooks:
       - id: clang-format
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
 
   # Expand YAML anchors in files used by github workflows, because github can't
   # do this itself.  This lets us use anchors, which avoids code duplication.
@@ -69,7 +69,7 @@ repos:
     - id: bandit
       files: '^(benchmarks|scripts|third_party/intel)/.*\.py$'
       args: ["-c", "bandit.yaml", "-s", "B404,B603,B607"]
-      stages: [commit, push, manual]
+      stages: [pre-commit, pre-push, manual]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.3
@@ -77,7 +77,7 @@ repos:
       - id: ruff
         files: '^(benchmarks|third_party/intel|scripts)/.*'
         args: ["--fix", "--line-length", "120"]
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
 
   - repo: https://github.com/pycqa/pylint
     rev: v3.2.6
@@ -105,7 +105,7 @@ repos:
           - --disable=too-many-locals
           - --disable=too-many-statements
           - --disable=too-many-arguments
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
 
       - id: pylint
         name: pylint for benchmarks
@@ -136,7 +136,7 @@ repos:
           - --disable=too-many-statements
           - --disable=too-many-arguments
           - --disable=fixme
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
 
 
 exclude: |


### PR DESCRIPTION
There were warnings:
```bash
[WARNING] hook id `ruff` uses deprecated stage names (commit, push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] hook id `yapf` uses deprecated stage names (commit, push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] hook id `clang-format` uses deprecated stage names (commit, push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] hook id `bandit` uses deprecated stage names (commit, push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] hook id `ruff` uses deprecated stage names (commit, push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] hook id `pylint` uses deprecated stage names (commit, push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] hook id `pylint` uses deprecated stage names (commit, push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
```