### PR TITLE
add a sync after flush cache when doing benchmark

### DIFF
--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -204,6 +204,8 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, return_m
                 x.grad = None
         # we clear the L2 cache before each run
         cache.zero_()
+        if USE_WALL_TIME:
+            di.synchronize()
         # record time of `fn`
         start_event[i].record()
         fn()


### PR DESCRIPTION
I'm doing some benchmarks in pytorch and I find this benchmark always record the time of flush cache kernel. I want to add a sync in each iteration before kernel start. Pytorch calls this function here: https://github.com/pytorch/pytorch/blob/main/torch/_inductor/runtime/benchmarking.py#L176
