### PR TITLE
Use custom URL to download pre-built LLVM

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -207,7 +207,7 @@ def get_llvm_package_info():
     with open(llvm_hash_path, "r") as llvm_hash_file:
         rev = llvm_hash_file.read(8)
     name = f"llvm-{rev}-{system_suffix}"
-    url = f"https://oaitriton.blob.core.windows.net/public/llvm-builds/{name}.tar.gz"
+    url = f"https://github.com/intel/intel-xpu-backend-for-triton/releases/download/llvm-{rev}/{name}.tar.gz"
     return Package("llvm", name, url, "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR", "LLVM_SYSPATH")
 
 


### PR DESCRIPTION
CentOS versions of pre-built LLVM are no longer published in upstream.

Fixes #2488.

