### PR TITLE
Use the same driver for the upstream profiler as for the legacy profiler with IPEX

### DIFF
--- a/benchmarks/triton_kernels_benchmark/__init__.py
+++ b/benchmarks/triton_kernels_benchmark/__init__.py
@@ -1,6 +1,6 @@
-from .benchmark_testing import do_bench, assert_close, perf_report, Benchmark, USE_IPEX_OPTION  # type: ignore # noqa: F401
+from .benchmark_testing import do_bench, assert_close, perf_report, Benchmark, USE_IPEX_OPTION, BENCHMARKING_METHOD  # type: ignore # noqa: F401
 
-if USE_IPEX_OPTION:
+if USE_IPEX_OPTION or BENCHMARKING_METHOD == "UPSTREAM_PYTORCH_PROFILER":
     from triton.runtime import driver
     from . import benchmark_driver
     # replace the launcher with the profilier hook.


### PR DESCRIPTION
This is another preparatory step to switching to an upstream profiler.

Closes #2512