### PR TITLE
[TritonIntelGPU] Add `llvm` to allocate shared memory pass dependencies

### DIFF
--- a/third_party/intel/include/TritonIntelGPUToLLVM/Passes.td
+++ b/third_party/intel/include/TritonIntelGPUToLLVM/Passes.td
@@ -11,6 +11,7 @@ def IntelDecomposeUnsupportedConversions
 def IntelAllocateSharedMemory
     : Pass<"intel-allocate-shared-memory", "mlir::ModuleOp"> {
   let summary = "Add metadata for shared memory allocation";
+  let dependentDialects = ["mlir::LLVM::LLVMDialect"];
 }
 
 def ConvertTritonIntelGPUToLLVM


### PR DESCRIPTION
Add `llvm` to dependent dialects of Intel allocate shared memory pass. This is needed for correctness as this pass creates `llvm.ptr` type instances.
