### PR TITLE
Introduce optional profiling option for SPIRVRunner

### DIFF
--- a/utils/SPIRVRunner/SPIRVRunner.cpp
+++ b/utils/SPIRVRunner/SPIRVRunner.cpp
@@ -365,7 +365,7 @@ at::Tensor launchKernel(sycl::queue stream, sycl::kernel kernel,
   }
 
   if (!triton_args.host_outbuffer.defined()) {
-    std::string message = "Output tensor isn't configurated; \
+    std::string message = "Output tensor isn't configured; \
         the second positional parameter is ";
     throw std::runtime_error(message + triton_args.out_tensor_name);
   }

--- a/utils/SPIRVRunner/SPIRVRunner.cpp
+++ b/utils/SPIRVRunner/SPIRVRunner.cpp
@@ -406,16 +406,11 @@ bool check_option_amoung_argv(int argc, char **argv, std::string option) {
 
 int main(int argc, char **argv) {
   try {
-    std::string print_output_kernel_tensor = "--print-output-kernel-tensor";
     std::string enable_profiling = "--enable-profiling";
     if (argc < 2) {
       std::cout << "Help: " << std::endl;
       std::cout << "<Executable> <Output Tensor Name>" << std::endl;
       std::cout << "./build/SPIRVRunner tensor_2" << std::endl;
-      std::cout << "To print the output kernel tensor to stdout, use:"
-                << std::endl;
-      std::cout << "./build/SPIRVRunner tensor_2 " << print_output_kernel_tensor
-                << std::endl;
       std::cout << "To get kernel time, use:" << std::endl;
       std::cout << "./build/SPIRVRunner tensor_2 " << enable_profiling
                 << std::endl;
@@ -454,10 +449,6 @@ int main(int argc, char **argv) {
               << n_spills << " register spills." << std::endl;
 
     auto output = launchKernel(q, kernel, tritonArgDict, get_kernel_time);
-
-    if (check_option_amoung_argv(argc, argv, print_output_kernel_tensor)) {
-      std::cout << "Kernel return output: " << output[0] << std::endl;
-    }
 
     auto output_tensor = tritonArgDict.spirv_dump_dir + "/cpp_outs.pt";
     write_tensor(output_tensor, output);


### PR DESCRIPTION
Closes #2565 

Usage: `./build/SPIRVRunner tensor_2 --enable-profiling`

Output example:
```bash
...
Tensor output: [8192, 8192], Float (268435456 bytes)
Kernel execution time: 4.81872 ms
...
```

Profiling ref: https://github.com/intel/pti-gpu/blob/master/chapters/device_activity_tracing/DPCXX.md#how-to-use
Profiling ref with Kineto: https://github.com/pytorch/pytorch/issues/52936#issuecomment-2047893643

<details>

<summary>Example with Kineto</summary>

```c++
  #include <torch/csrc/autograd/profiler_kineto.h>
  using namespace torch::autograd::profiler;
  ProfilerConfig cfg{
    ProfilerState::KINETO,
      false,
      false,
      false,
      false,
      false
  };
  std::set<torch::autograd::profiler::ActivityType> activities{torch::autograd::profiler::ActivityType::CPU, torch::autograd::profiler::ActivityType::XPU};
  prepareProfiler(cfg, activities);
  enableProfiler(cfg, activities);

  sycl_kernel_launch(stream, kernel, triton_args);

  auto result = disableProfiler();
  result->save("./some_local_file2.json");
```

</details>