### PR TITLE
Use oneAPI version in PyTorch cache key

### DIFF
--- a/.github/actions/setup-pytorch/action.yml
+++ b/.github/actions/setup-pytorch/action.yml
@@ -74,7 +74,8 @@ runs:
     - name: Generate PyTorch cache key
       shell: bash
       run: |
-        PYTORCH_CACHE_KEY=$(echo $PYTHON_VERSION $PYTORCH_COMMIT_ID ${{ hashFiles('scripts/patch-pytorch.sh') }} ${{ inputs.mode }} | sha256sum - | cut -d\  -f1)
+        ONEAPI_KEY=$(sha256sum /opt/intel/installed.txt 2> /dev/null | cut -d\  -f1 || true)
+        PYTORCH_CACHE_KEY=$(echo $PYTHON_VERSION $PYTORCH_COMMIT_ID ${{ hashFiles('scripts/patch-pytorch.sh') }} ${{ inputs.mode }}$ONEAPI_KEY | sha256sum - | cut -d\  -f1)
         echo "PYTORCH_CACHE_KEY=$PYTORCH_CACHE_KEY" | tee -a "$GITHUB_ENV"
 
     - name: Load PyTorch from a cache


### PR DESCRIPTION
In new runners `/opt/intel/installed.txt` will contain a list of installed packages. Use this file, if exists, to calculate a composite cache key for PyTorch. The key should be the same for the existing runners (with PTDB), and a new PyTorch build should be triggered on the new runners (with DLE).

Fixes #2596.
