### PR TITLE
Disable LLVM post processing

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -298,7 +298,7 @@ class XPUBackend(BaseBackend):
             paths = [path for (name, path) in options.extern_libs]
             llvm.link_extern_libs(llvm_mod, paths)
         intel.optimize_module(llvm_mod, llvm.OPTIMIZE_O3)
-        if os.getenv("TRITON_INTEL_ENABLE_POST_PROCESS_LLIR", "1") == "1":
+        if os.getenv("TRITON_INTEL_ENABLE_POST_PROCESS_LLIR", "0") == "1":
             intel.post_process_llir(llvm_mod)
 
         # Get some metadata


### PR DESCRIPTION
`IGCVectorizer` of driver agama 1032 has improved. This PR attends to disable the LLVM post processing Triton performed by default, which includes `SLPVectorizer`.

By disabling LLVM post processing, the performance impact to the 3 key workloads (FA, GEMM, Softmax) are all positive.
For example, GEMM out of box has improved by 16%.
 ![Screenshot 2024-11-04 184048](https://github.com/user-attachments/assets/84b97f67-3ac4-4f61-975a-eb44ccfe3936)

CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/11664443045, https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/11674882693