### PR TITLE
Use `pytorch-stonepia` folder as a root folder for building proxy pytorch

### DIFF
--- a/scripts/compile-pytorch-ipex.sh
+++ b/scripts/compile-pytorch-ipex.sh
@@ -100,7 +100,7 @@ fi
 # Configure, build and install PyTorch from source.
 
 if [[ $BUILD_PYTORCH = true ]]; then
-  PYTORCH_PROJ=$BASE/pytorch
+  PYTORCH_PROJ=$BASE/pytorch-stonepia
 
   echo "**** Cleaning $PYTORCH_PROJ before build ****"
   rm -rf $PYTORCH_PROJ


### PR DESCRIPTION
Closes #2651 

Having multiple versions of PyTorch should not be a problem. One of the possible scenarios is when the build occurs in different environments and they should not conflict.