### PR TITLE
Prepare XeTLA benchmarks for 2025 compiler

### DIFF
--- a/benchmarks/xetla_kernel/flash_attention/fmha_backward.h
+++ b/benchmarks/xetla_kernel/flash_attention/fmha_backward.h
@@ -4,6 +4,7 @@
 #include "fmha_backward_policy.h"
 #include "fmha_utils.h"
 #include "xetla.hpp"
+#include <math.h>
 
 using T = sycl::half;
 

--- a/benchmarks/xetla_kernel/flash_attention/fmha_utils.h
+++ b/benchmarks/xetla_kernel/flash_attention/fmha_utils.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "xetla.hpp"
+#include <math.h>
 
 namespace gpu::xetla {
 


### PR DESCRIPTION
`math.h` header needs to be added as a direct dependency for `INFINITY` constant which is used in these files.