### PR TITLE
spirvrunner:  default add tutorial fails

### DIFF
--- a/utils/SPIRVRunner/args_data.json
+++ b/utils/SPIRVRunner/args_data.json
@@ -32,5 +32,6 @@
   "threads_per_warp": 32,
   "shared_memory": 0,
   "kernel_name": "add_kernel",
-  "spv_name": "add_kernel.spv"
+  "spv_name": "add_kernel.spv",
+  "build_flags": ""
 }


### PR DESCRIPTION
This PR addresses the issue of the tutorial addition failure in SPIRVRunner.
Currently, the default add tutorial sample, which runs as part of SPIRVRunner, fails with the following error:

```
intel-xpu-backend-for-triton/utils/SPIRVRunner$ ./build/SPIRVRunner tensor_2
Running on device: Intel(R) Data Center GPU Max 1100
terminate called after throwing an instance of 'nlohmann::json_abi_v3_11_2::detail::out_of_range'
  what():  [json.exception.out_of_range.403] key 'build_flags' not found
Aborted (core dumped)
```