### PR TITLE
Enable the SLPVectorizer on Triton side with no scheduling

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -310,7 +310,7 @@ class XPUBackend(BaseBackend):
             paths = [path for (name, path) in options.extern_libs]
             llvm.link_extern_libs(llvm_mod, paths)
         intel.optimize_module(llvm_mod, llvm.OPTIMIZE_O3)
-        if os.getenv("TRITON_INTEL_ENABLE_POST_PROCESS_LLIR", "0") == "1":
+        if os.getenv("TRITON_INTEL_ENABLE_POST_PROCESS_LLIR", "1") == "1":
             intel.post_process_llir(llvm_mod)
 
         # Get some metadata
@@ -334,6 +334,9 @@ class XPUBackend(BaseBackend):
             metadata["build_flags"] = "-cl-intel-enable-auto-large-GRF-mode"
         else:
             metadata["build_flags"] = ""
+
+        if os.getenv("TRITON_INTEL_ENABLE_POST_PROCESS_LLIR", "1") == "1":
+            metadata["build_flags"] += " -igc_opts 'DisablePHIScalarization=1'"
 
         if options.generate_native_code:
             with tempfile.NamedTemporaryFile(delete=False, mode='wb', suffix='.spv') as fsrc, \


### PR DESCRIPTION
The IGCVectorizer doesn't support the flash attention kernel so far.
To enable the SLPVectorizer on Triton side with no scheduling in basic block will get better performance for now.
