### PR TITLE
bump triton verion to 3.1.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,7 +145,7 @@ extensions = [
 autosummary_generate = True
 
 # versioning config
-smv_tag_whitelist = r'^(v3.2.0)$'
+smv_tag_whitelist = r'^(v3.1.0)$'
 smv_branch_whitelist = r'^main$'
 smv_remote_whitelist = None
 smv_released_pattern = r'^tags/.*$'

--- a/python/setup.py
+++ b/python/setup.py
@@ -702,7 +702,7 @@ def get_install_requires():
 
 setup(
     name=os.environ.get("TRITON_WHEEL_NAME", "triton"),
-    version="3.2.0" + get_git_commit_hash() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
+    version="3.1.0" + get_git_commit_hash() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
     author="Philippe Tillet",
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -1,5 +1,5 @@
 """isort:skip_file"""
-__version__ = '3.2.0'
+__version__ = '3.1.0'
 
 # ---------------------------------------
 # Note: import order is significant here.


### PR DESCRIPTION
# Motivation
Currently, stock PyTorch uses [3.1.0](https://github.com/pytorch/pytorch/blob/865a7c52382a3c829dfa6be6ae56020d242173d5/.ci/docker/triton_version.txt#L1) in CI and nightly build. We have to change the version to 3.1.0 to align to stock PyTorch temporarily.
And change it back to 3.2.0 when stock PyTorch decided to uplift to 3.2.0.