### PR TITLE
Add input use_system_python

### DIFF
--- a/.github/workflows/build-test-gpu.yml
+++ b/.github/workflows/build-test-gpu.yml
@@ -39,6 +39,10 @@ on:
         description: Ignore pytest.skip
         type: boolean
         default: false
+      use_system_python:
+        description: Use system Python
+        type: boolean
+        default: false
 
 permissions: read-all
 
@@ -60,3 +64,4 @@ jobs:
       skip_list: ${{ inputs.skip_list }}
       run_name: ${{ inputs.run_name || format('Build and test {0}', inputs.runner_label) }}
       enable_unskip: ${{ inputs.enable_unskip }}
+      use_system_python: ${{ inputs.use_system_python || false }}

--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -56,6 +56,10 @@ on:
         description: Runner label for version
         type: string
         default: runner-0.0.20
+      use_system_python:
+        description: Use system Python
+        type: boolean
+        default: false
 
 permissions: read-all
 
@@ -91,9 +95,15 @@ jobs:
           key: pip-${{ inputs.python_version }}-${{ hashFiles('python/pyproject.toml', 'python/setup.py') }}-${{ env.CACHE_NUMBER }}
 
       - name: Install Python ${{ inputs.python_version }}
+        if: ${{ !inputs.use_system_python }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
+
+      - name: Identify Python version
+        run: |
+          PYTHON_VERSION="$(python -c 'import sys; print(f"{sys.version_info[0]}.{ sys.version_info[1]}")')"
+          echo "PYTHON_VERSION=$PYTHON_VERSION" | tee -a $GITHUB_ENV
 
       - name: Setup PyTorch
         uses: ./.github/actions/setup-pytorch

--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -28,6 +28,10 @@ on:
         description: JSON list of benchmarks to skip
         type: string
         default: "[]"
+      use_system_python:
+        description: Use system Python
+        type: boolean
+        default: false
   schedule:
     - cron: "5 23 * * *"
   pull_request:
@@ -67,9 +71,15 @@ jobs:
           key: pip-$PYTHON_VERSION-$GITHUB_SHA
 
       - name: Install Python
+        if: ${{ !(inputs.use_system_python || false) }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Identify Python version
+        run: |
+          PYTHON_VERSION="$(python -c 'import sys; print(f"{sys.version_info[0]}.{ sys.version_info[1]}")')"
+          echo "PYTHON_VERSION=$PYTHON_VERSION" | tee -a $GITHUB_ENV
 
       - name: Install Python build dependencies
         run: |


### PR DESCRIPTION
It is false by default. When set to true the workflow uses the existing system python installed in the runner.

Fixes #2722.