### PR TITLE
Use upstream LLVM location

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -207,7 +207,7 @@ def get_llvm_package_info():
     with open(llvm_hash_path, "r") as llvm_hash_file:
         rev = llvm_hash_file.read(8)
     name = f"llvm-{rev}-{system_suffix}"
-    url = f"https://github.com/intel/intel-xpu-backend-for-triton/releases/download/llvm-{rev}/{name}.tar.gz"
+    url = f"https://oaitriton.blob.core.windows.net/public/llvm-builds/{name}.tar.gz"
     return Package("llvm", name, url, "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR", "LLVM_SYSPATH")
 
 


### PR DESCRIPTION
There is LLVM for CentOS in upstream again.
Fixes #2738.