### PR TITLE
Build PyTorch with USE_STATIC_MKL=1

### DIFF
--- a/.github/actions/setup-pytorch/action.yml
+++ b/.github/actions/setup-pytorch/action.yml
@@ -83,7 +83,7 @@ runs:
       uses: ./.github/actions/load
       env:
         # Increase this value to reset cache
-        CACHE_NUMBER: 13
+        CACHE_NUMBER: 14
       with:
         path: pytorch
         key: pytorch-$PYTORCH_CACHE_KEY-$CACHE_NUMBER
@@ -120,7 +120,7 @@ runs:
         cd pytorch
         pip install wheel
         pip install -r requirements.txt
-        USE_MKL_STATIC=1 python setup.py bdist_wheel
+        USE_STATIC_MKL=1 python setup.py bdist_wheel
 
     - name: Install PyTorch (built from source)
       if: ${{ inputs.mode == 'source' }}

--- a/.github/actions/setup-pytorch/action.yml
+++ b/.github/actions/setup-pytorch/action.yml
@@ -83,7 +83,7 @@ runs:
       uses: ./.github/actions/load
       env:
         # Increase this value to reset cache
-        CACHE_NUMBER: 12
+        CACHE_NUMBER: 13
       with:
         path: pytorch
         key: pytorch-$PYTORCH_CACHE_KEY-$CACHE_NUMBER
@@ -120,7 +120,7 @@ runs:
         cd pytorch
         pip install wheel
         pip install -r requirements.txt
-        python setup.py bdist_wheel
+        USE_MKL_STATIC=1 python setup.py bdist_wheel
 
     - name: Install PyTorch (built from source)
       if: ${{ inputs.mode == 'source' }}

--- a/scripts/compile-pytorch-ipex.sh
+++ b/scripts/compile-pytorch-ipex.sh
@@ -117,7 +117,7 @@ if [[ $BUILD_PYTORCH = true ]]; then
   echo "****** Building $PYTORCH_PROJ ******"
   pip install -r requirements.txt
   pip install cmake ninja "numpy<2.0"
-  python setup.py bdist_wheel
+  USE_MKL_STATIC=1 python setup.py bdist_wheel
 
   echo "****** Installing PyTorch ******"
   pip install dist/*.whl

--- a/scripts/compile-pytorch-ipex.sh
+++ b/scripts/compile-pytorch-ipex.sh
@@ -117,7 +117,7 @@ if [[ $BUILD_PYTORCH = true ]]; then
   echo "****** Building $PYTORCH_PROJ ******"
   pip install -r requirements.txt
   pip install cmake ninja "numpy<2.0"
-  USE_MKL_STATIC=1 python setup.py bdist_wheel
+  USE_STATIC_MKL=1 python setup.py bdist_wheel
 
   echo "****** Installing PyTorch ******"
   pip install dist/*.whl

--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -155,7 +155,7 @@ $SCRIPTS_DIR/patch-pytorch.sh
 echo "****** Building $PYTORCH_PROJ ******"
 pip install -r requirements.txt
 pip install cmake ninja
-USE_MKL_STATIC=1 python setup.py bdist_wheel
+USE_STATIC_MKL=1 python setup.py bdist_wheel
 
 echo "****** Installing PyTorch ******"
 pip install dist/*.whl

--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -155,7 +155,7 @@ $SCRIPTS_DIR/patch-pytorch.sh
 echo "****** Building $PYTORCH_PROJ ******"
 pip install -r requirements.txt
 pip install cmake ninja
-python setup.py bdist_wheel
+USE_MKL_STATIC=1 python setup.py bdist_wheel
 
 echo "****** Installing PyTorch ******"
 pip install dist/*.whl


### PR DESCRIPTION
Build PyTorch with static MKL to minimize the number of runtime dependencies.
Fixes #2791.