### PR TITLE
Revert "bump triton verion to 3.1.0 (#2716)"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,7 +145,7 @@ extensions = [
 autosummary_generate = True
 
 # versioning config
-smv_tag_whitelist = r'^(v3.1.0)$'
+smv_tag_whitelist = r'^(v3.2.0)$'
 smv_branch_whitelist = r'^main$'
 smv_remote_whitelist = None
 smv_released_pattern = r'^tags/.*$'

--- a/python/setup.py
+++ b/python/setup.py
@@ -702,7 +702,7 @@ def get_install_requires():
 
 setup(
     name=os.environ.get("TRITON_WHEEL_NAME", "triton"),
-    version="3.1.0" + get_git_commit_hash() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
+    version="3.2.0" + get_git_commit_hash() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
     author="Philippe Tillet",
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -1,5 +1,5 @@
 """isort:skip_file"""
-__version__ = '3.1.0'
+__version__ = '3.2.0'
 
 # ---------------------------------------
 # Note: import order is significant here.


### PR DESCRIPTION
This reverts commit 74cde3c6aa0e1b307938a74d995278da4c546875.

# Motivation
PyTorch community has uplifted triton to 3.2.0 in https://github.com/pytorch/pytorch/pull/139206. We should follow it.

# Solution
Revert this commit introduced in https://github.com/intel/intel-xpu-backend-for-triton/pull/2716
