### PR TITLE
[XPU][TritonGEN] Replace split barrier ops usages with SPIR-V ops

### DIFF
--- a/test/TritonGEN/tritongen-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-to-llvm.mlir
@@ -1,23 +1,5 @@
 // RUN: triton-opt -convert-tritongen-to-llvm -split-input-file %s | FileCheck %s
 
-// CHECK-DAG: llvm.func spir_funccc @_Z31intel_work_group_barrier_arriveii(i32, i32) attributes {convergent, no_unwind, will_return}
-// CHECK-DAG: llvm.func spir_funccc @_Z29intel_work_group_barrier_waitii(i32, i32) attributes {convergent, no_unwind, will_return}
-
-llvm.func @triton_gen.split_barrier() {
-  // CHECK-LABEL: triton_gen.split_barrier() {
-  // CHECK-DAG: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-  // CHECK-DAG: [[ONE:%.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK:     llvm.call spir_funccc @_Z31intel_work_group_barrier_arriveii([[ZERO]], [[ONE]]) {{.*}} : (i32, i32) -> ()
-  // CHECK-DAG: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
-  // CHECK-DAG: [[ONE:%.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK:     llvm.call spir_funccc @_Z29intel_work_group_barrier_waitii([[ZERO]], [[ONE]]) {{.*}} : (i32, i32) -> ()
-  triton_gen.split_barrier_signal {mem_fence=None, mem_scope=WorkGroup}
-  triton_gen.split_barrier_wait {mem_fence=None, mem_scope=WorkGroup}
-  llvm.return
-}
-
-// -----
-
 // CHECK-DAG: llvm.func spir_funccc @_Z30sub_group_clustered_reduce_addij(i32, i32) -> i32 attributes {convergent, no_unwind, will_return}
 // CHECK-DAG: llvm.func spir_funccc @_Z30sub_group_clustered_reduce_mulij(i32, i32) -> i32 attributes {convergent, no_unwind, will_return}
 // CHECK-DAG: llvm.func spir_funccc @_Z30sub_group_clustered_reduce_maxij(i32, i32) -> i32 attributes {convergent, no_unwind, will_return}

--- a/test/TritonGEN/tritongen.mlir
+++ b/test/TritonGEN/tritongen.mlir
@@ -1,21 +1,5 @@
 // RUN: triton-opt %s -split-input-file -verify-diagnostics | FileCheck %s
 
-llvm.func @triton_gen.split_barrier_signal() {
-  // CHECK-LABEL: triton_gen.split_barrier_signal
-  // CHECK: triton_gen.split_barrier_signal {mem_fence = None, mem_scope = WorkGroup}
-  triton_gen.split_barrier_signal {mem_fence=None, mem_scope=WorkGroup}
-  llvm.return
-}
-
-llvm.func @triton_gen.split_barrier_wait() {
-  // CHECK-LABEL: triton_gen.split_barrier_wait
-  // CHECK: triton_gen.split_barrier_wait {mem_fence = Local, mem_scope = SubGroup}
-  triton_gen.split_barrier_wait {mem_fence=Local, mem_scope=SubGroup}
-  llvm.return
-}
-
-// -----
-
 module attributes {
   spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Kernel, Addresses, GroupNonUniformShuffle, Int64], []>, #spirv.resource_limits<subgroup_size = 32>>
 } {

--- a/test/TritonIntelGPU/prefetch-block.mlir
+++ b/test/TritonIntelGPU/prefetch-block.mlir
@@ -33,7 +33,7 @@ module attributes {"triton_gpu.num-warps" = 32 : i32, "triton_gpu.threads-per-wa
     // CHECK-NEXT: [[B3:%.*]] = tt.advance [[B2]], {{.*}} : <tensor<32x256xf16, #blocked2>>
     // CHECK-NEXT: [[B4:%.*]] = tt.make_tensor_ptr %arg1, {{.*}} : <tensor<32x256xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>>
 
-    // CHECK:      triton_gen.split_barrier_signal {mem_fence = None, mem_scope = WorkGroup}
+    // CHECK:      spirv.INTEL.ControlBarrierArrive <Workgroup>, <Workgroup>, <None>
     // CHECK-NEXT: scf.for [[IV:%.*]] = [[CST_ZERO]] to [[CST_4096]] step [[CST_32]]
     // CHECK-SAME:      iter_args([[CST:%.*]] = {{.*}}, [[A6:%.*]] = [[A4]], [[B6:%.*]] = [[B4]], [[A5:%.*]] = [[A3]], [[B5:%.*]] = [[B3]])
     // CHECK-NEXT:   [[LD_A:%.*]] = tt.load [[A6]]
@@ -45,11 +45,11 @@ module attributes {"triton_gpu.num-warps" = 32 : i32, "triton_gpu.threads-per-wa
     // CHECK-DAG:    tt.advance [[A6]], {{.*}} : <tensor<256x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>>
     // CHECK-NEXT:   tt.advance [[B5]], {{.*}} : <tensor<32x256xf16, #blocked2>>
     // CHECK-DAG:    tt.advance [[B6]], {{.*}} : <tensor<32x256xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>>
-    // CHECK:        triton_gen.split_barrier_wait {mem_fence = None, mem_scope = WorkGroup}
-    // CHECK-NEXT:   triton_gen.split_barrier_signal {mem_fence = None, mem_scope = WorkGroup}
+    // CHECK:        spirv.INTEL.ControlBarrierWait <Workgroup>, <Workgroup>, <None>
+    // CHECK-NEXT:   spirv.INTEL.ControlBarrierArrive <Workgroup>, <Workgroup>, <None>
     // CHECK-NEXT:   scf.yield {{.*}}
     // CHECK-NEXT: }
-    // CHECK-NEXT: triton_gen.split_barrier_wait {mem_fence = None, mem_scope = WorkGroup}
+    // CHECK-NEXT: spirv.INTEL.ControlBarrierWait <Workgroup>, <Workgroup>, <None>
 
     %c64_i32 = arith.constant 64 : i32
     %c16_i32 = arith.constant 16 : i32

--- a/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENOps.td
+++ b/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENOps.td
@@ -32,49 +32,6 @@ class TritonGEN_Op<string mnemonic, list<Trait> traits = []> :
 // Synchronization
 //===----------------------------------------------------------------------===//
 
-def TritonGEN_SplitBarrierSignalOp : TritonGEN_Op<"split_barrier_signal"> {
-  let summary = "Split barrier signal";
-  let description = [{
-    The `triton_gen.split_barrier_signal` operation signals the arrival of a
-    workgroup thread at the current program point; the issuing thread continue
-    execution.
-    Once all threads in a workgroup have signaled their arrival, any other thread
-    waiting at the `triton_gen.split_barrier_wait` operation can exit it.
-    The '$mem_fence' attribute is a bitfield that specifies the memory address
-    spaces to apply the memory ordering constraints. The '$mem_scope' attribute
-    describes the work-items to apply the memory ordering constraints.
-    Behavior is undefined:
-      - unless all threads in a workgroup participate in the barrier
-      - a thread waits on a barrier before signaling
-      - the '$mem_fence' and '$mem_scope' attributes aren't the same for all
-        threads in a workgroup
-    Furthermore, if the `$mem_fence` argument differs between the barrier signal
-    and wait operation, then only memory operations for the address spaces specified
-    by the intersection of the two flags arguments are visible.
-  }];
-  let arguments = (ins TritonGEN_MemFence:$mem_fence, TritonGEN_MemScope:$mem_scope);
-  let results = (outs);
-  let assemblyFormat = [{
-    ` ` `{` `mem_fence` `=` $mem_fence `,` `mem_scope` `=` $mem_scope `}` attr-dict
-  }];
-}
-
-def TritonGEN_SplitBarrierWaitOp : TritonGEN_Op<"split_barrier_wait"> {
-  let summary = "Split barrier wait";
-  let description = [{
-    The `triton_gen.split_barrier_wait` operation blocks the issuing workgroup
-    thread until all other threads arrive at the corresponding
-    `triton_gen.split_barrier_arrive` operation. Please refer to the
-    `triton_gen.split_barrier_signal` documentation for the description of the
-    attributes and the constrains on the operation.
-  }];
-  let arguments = (ins TritonGEN_MemFence:$mem_fence, TritonGEN_MemScope:$mem_scope);
-  let results = (outs);
-  let assemblyFormat = [{
-    ` ` `{` `mem_fence` `=` $mem_fence `,` `mem_scope` `=` $mem_scope `}` attr-dict
-  }];
-}
-
 def TritonGEN_SubGroupReduceOp : TritonGEN_Op<"sub_group_reduce", [
       AllTypesMatch<["res", "value"]>]>,
   Results<(outs SignlessIntegerOrFloatLike:$res)>,

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -203,6 +203,7 @@ def TritonIntelGPUPrefetchBlock : Pass<"tritonintelgpu-prefetch-block", "mlir::M
                            "mlir::triton::TritonGEN::TritonGENDialect",
                            "mlir::triton::gpu::intel::TritonIntelGPUDialect",
                            "mlir::scf::SCFDialect",
+                           "mlir::spirv::SPIRVDialect",
                            "mlir::gpu::GPUDialect"];
   let options = [
     Option<"numAdvancePrefetches", "num-advance-prefetches",

--- a/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
@@ -20,6 +20,7 @@ add_triton_library(TritonIntelGPUTransforms
 
   LINK_LIBS PUBLIC
   MLIRSCFTransforms
+  MLIRSPIRVDialect
   MLIRTransforms
   MLIRTransformUtils
   TritonIntelAnalysis

--- a/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
@@ -39,6 +39,8 @@
 
 #include "TritonToTritonGPUWarp/TritonToTritonGPUWarpPass.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/PatternMatch.h"
 
@@ -367,13 +369,13 @@ void PrefetchBlockPass::injectPrefetchOpsInPreheader(
   if (injectSplitBarriers) {
     Location loc = loop.getLoc();
     b.setInsertionPoint(loop);
-    b.create<tt::TritonGEN::SplitBarrierSignalOp>(
-        loc, tt::TritonGEN::MemFence::NONE,
-        tt::TritonGEN::MemScope::WORK_GROUP);
+    b.create<spirv::INTELControlBarrierArriveOp>(loc, spirv::Scope::Workgroup,
+                                                 spirv::Scope::Workgroup,
+                                                 spirv::MemorySemantics::None);
     b.setInsertionPoint(loop->getNextNode());
-    b.create<tt::TritonGEN::SplitBarrierWaitOp>(
-        loc, tt::TritonGEN::MemFence::NONE,
-        tt::TritonGEN::MemScope::WORK_GROUP);
+    b.create<spirv::INTELControlBarrierWaitOp>(loc, spirv::Scope::Workgroup,
+                                               spirv::Scope::Workgroup,
+                                               spirv::MemorySemantics::None);
   }
 }
 
@@ -454,12 +456,12 @@ void PrefetchBlockPass::injectPrefetchOpsInBody(
   if (injectSplitBarriers) {
     Location loc = loop.getLoc();
     b.setInsertionPoint(yield);
-    b.create<tt::TritonGEN::SplitBarrierWaitOp>(
-        loc, tt::TritonGEN::MemFence::NONE,
-        tt::TritonGEN::MemScope::WORK_GROUP);
-    b.create<tt::TritonGEN::SplitBarrierSignalOp>(
-        loc, tt::TritonGEN::MemFence::NONE,
-        tt::TritonGEN::MemScope::WORK_GROUP);
+    b.create<spirv::INTELControlBarrierWaitOp>(loc, spirv::Scope::Workgroup,
+                                               spirv::Scope::Workgroup,
+                                               spirv::MemorySemantics::None);
+    b.create<spirv::INTELControlBarrierArriveOp>(loc, spirv::Scope::Workgroup,
+                                                 spirv::Scope::Workgroup,
+                                                 spirv::MemorySemantics::None);
   }
 
   yield.getResultsMutable().append(advances);


### PR DESCRIPTION
Use SPIR-V operations to encode split barriers.

Semantics are exactly the same. As memory semantics are `None`, memory scope is omitted. Execution scope value is maintained.