### PR TITLE
Remove workaround for `torch.nn.functional.scaled_dot_product_attention`

### DIFF
--- a/benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py
@@ -256,13 +256,8 @@ def benchmark(Z, H, N_CTX, D_HEAD, CAUSAL, provider):
 
     elif provider == 'triton':
         triton_fn = lambda: forward(q, k, v, CAUSAL, sm_scale)
-        if benchmark_suit.USE_IPEX_OPTION:
-            torch_fn = lambda: torch.nn.functional.scaled_dot_product_attention(
-                q, k, v, attn_mask=None, dropout_p=0.0, is_causal=CAUSAL, scale=sm_scale).to(torch.float32)
-        else:
-            # FIXME: use torch sdpa for result check after https://github.com/intel/intel-xpu-backend-for-triton/issues/2042 fixed
-            torch_fn = lambda: torch.nn.functional.scaled_dot_product_attention(q.cpu(), k.cpu(), v.cpu(
-            ), attn_mask=None, dropout_p=0.0, is_causal=CAUSAL, scale=sm_scale).to(torch.float32)
+        torch_fn = lambda: torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, attn_mask=None, dropout_p=0.0, is_causal=CAUSAL, scale=sm_scale).to(torch.float32)
         atol = 1e-1 if N_CTX == 16384 else 1e-2
         benchmark_suit.assert_close(triton_fn(), torch_fn(), atol=atol, rtol=1e-3, err_msg='triton to torch')
         _, min_ms, max_ms, mean, cv = benchmark_suit.do_bench(triton_fn, n_warmup=10, n_repeat=10, quantiles=quantiles,


### PR DESCRIPTION
CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/12031671033 (still hanging)