### PR TITLE
Return `elapsed_time` patch

### DIFF
--- a/scripts/patch-pytorch.sh
+++ b/scripts/patch-pytorch.sh
@@ -16,3 +16,4 @@ echo "Applying PyTorch patches in $REPO_ROOT"
 cd "$REPO_ROOT"
 
 curl -sSL https://github.com/pytorch/pytorch/pull/126516.diff | git apply -
+curl -sSL https://github.com/pytorch/pytorch/pull/126456.diff | git apply -


### PR DESCRIPTION
Otherwise we use an imprecise implementation:
`WARNING:root:Wall time is used instead of elapsed_time (not supported). The timing measurements could be innacurate.`

Ref: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/12030035565/job/33536601898

We need to do that after PyTorch pin update: https://github.com/intel/intel-xpu-backend-for-triton/commit/d8045021fc6c81addb6d6633c1951c1f15031d53