### PR TITLE
Leave only one `ruff-pre-commit` hook in `.pre-commit-config.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     rev: v0.7.1
     hooks:
       - id: ruff
-        files: '^python/.*'
+        files: '^(python|benchmarks|third_party/intel|scripts)/.*'
         args: ["--fix", "--exit-non-zero-on-fix"]
         exclude: |
           (?x)(
@@ -68,14 +68,6 @@ repos:
       files: '^(benchmarks|scripts|third_party/intel)/.*\.py$'
       args: ["-c", "bandit.yaml", "-s", "B404,B603,B607"]
       stages: [pre-commit, pre-push, manual]
-
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.3
-    hooks:
-      - id: ruff
-        files: '^(benchmarks|third_party/intel|scripts)/.*'
-        args: ["--fix", "--line-length", "120"]
-        stages: [pre-commit, pre-push, manual]
 
   - repo: https://github.com/pycqa/pylint
     rev: v3.2.6


### PR DESCRIPTION
When merging code with upstream, it would be better if the styles were the same.