### PR TITLE
Generalize Intel coalescing pass to handle users of `scf.for` with coalesced load

### DIFF
--- a/test/TritonIntelGPU/coalesce.mlir
+++ b/test/TritonIntelGPU/coalesce.mlir
@@ -397,20 +397,15 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 16 
     %4 = arith.divsi %1, %c512_i32 : i32
     %5 = arith.remsi %1, %c512_i32 : i32
     // CHECK: [[PTR1:%.*]] = tt.make_tensor_ptr %arg0, {{.*}} : <tensor<1x32x128xf32, [[BLOCKED_LAYOUT1]]>>
-    %x = tt.make_tensor_ptr %arg0, [%c512_i64, %c512_i64, %c512_i64], [%c1_i64, %c512_i64, %c262144_i64], [%4, %5, %c0_i32] {order = array<i32: 2, 1, 0>} : <tensor<1x32x128xf32, #blocked1>>
-    // CHECK: [[PTR2:%.*]] = tt.make_tensor_ptr %arg0, {{.*}} : <tensor<1x32x128xf32, [[BLOCKED_LAYOUT1]]>>
     %y = tt.make_tensor_ptr %arg0, [%c512_i64, %c512_i64, %c512_i64], [%c1_i64, %c512_i64, %c262144_i64], [%4, %5, %c0_i32] {order = array<i32: 2, 1, 0>} : <tensor<1x32x128xf32, #blocked1>>
-    // CHECK: [[RES:%.*]]:2 = scf.for {{.*}} iter_args([[ARG1:%.*]] = [[PTR1]], [[ARG2:%.*]] = [[PTR2]]) -> (!tt.ptr<tensor<1x32x128xf32, [[BLOCKED_LAYOUT1]]>>, !tt.ptr<tensor<1x32x128xf32, [[BLOCKED_LAYOUT1]]>>)
-    %8:2 = scf.for %arg5 = %c0_i32 to %c512_i32 step %c128_i32 iter_args(%arg6 = %x, %arg7 = %y) -> (!tt.ptr<tensor<1x32x128xf32, #blocked1>>, !tt.ptr<tensor<1x32x128xf32, #blocked1>>) : i32 {
-      // CHECK: [[LOAD:%.*]] = tt.load [[ARG1]] evictionPolicy = evict_last {boundaryCheck = array<i32: 2>, padding = 1 : i32} : !tt.ptr<tensor<1x32x128xf32, [[BLOCKED_LAYOUT1]]>>
-      // CHECK-NEXT: triton_gpu.convert_layout [[LOAD]] : tensor<1x32x128xf32, [[BLOCKED_LAYOUT1]]> -> tensor<1x32x128xf32, [[BLOCKED_LAYOUT2]]>
-      %17 = tt.load %arg6 evictionPolicy = evict_last {boundaryCheck = array<i32: 2>, padding = 1 : i32} : !tt.ptr<tensor<1x32x128xf32, #blocked1>>
-      // CHECK: scf.yield [[ARG1]], [[ARG2]] : !tt.ptr<tensor<1x32x128xf32, [[BLOCKED_LAYOUT1]]>>, !tt.ptr<tensor<1x32x128xf32, [[BLOCKED_LAYOUT1]]>>
-      scf.yield %arg6, %arg7 : !tt.ptr<tensor<1x32x128xf32, #blocked1>>, !tt.ptr<tensor<1x32x128xf32, #blocked1>>
+    // CHECK: [[RES:%.*]] = scf.for {{.*}} iter_args([[ARG1:%.*]] = [[PTR1]]) -> (!tt.ptr<tensor<1x32x128xf32, [[BLOCKED_LAYOUT1]]>>)
+    %8:1 = scf.for %arg5 = %c0_i32 to %c512_i32 step %c128_i32 iter_args(%arg7 = %y) -> (!tt.ptr<tensor<1x32x128xf32, #blocked1>>) : i32 {
+      // CHECK: scf.yield [[ARG1]] : !tt.ptr<tensor<1x32x128xf32, [[BLOCKED_LAYOUT1]]>>
+      scf.yield %arg7 : !tt.ptr<tensor<1x32x128xf32, #blocked1>>
     }
-    // CHECK: [[LOAD_RES:%.*]] = tt.load [[RES]]#1 : !tt.ptr<tensor<1x32x128xf32, [[BLOCKED_LAYOUT1]]>>
+    // CHECK: [[LOAD_RES:%.*]] = tt.load [[RES]] : !tt.ptr<tensor<1x32x128xf32, [[BLOCKED_LAYOUT1]]>>
     // CHECK: triton_gpu.convert_layout [[LOAD_RES]] : tensor<1x32x128xf32, [[BLOCKED_LAYOUT1]]> -> tensor<1x32x128xf32, [[BLOCKED_LAYOUT2]]>
-    %res = tt.load %8#1 : !tt.ptr<tensor<1x32x128xf32, #blocked1>>
+    %res = tt.load %8#0 : !tt.ptr<tensor<1x32x128xf32, #blocked1>>
     tt.return
   }
 }

--- a/test/TritonIntelGPU/coalesce.mlir
+++ b/test/TritonIntelGPU/coalesce.mlir
@@ -383,8 +383,8 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 16 
     tt.return
   }
 
-  // CHECK: @issue_2752
-  tt.func public @issue_2752(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+  // CHECK: @issue_2762
+  tt.func public @issue_2762(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
     %c128_i32 = arith.constant 128 : i32
     %c0_i32 = arith.constant 0 : i32
     %c262144_i64 = arith.constant 262144 : i64

--- a/test/TritonIntelGPU/coalesce.mlir
+++ b/test/TritonIntelGPU/coalesce.mlir
@@ -404,7 +404,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 16 
       scf.yield %arg7 : !tt.ptr<tensor<1x32x128xf32, #blocked1>>
     }
     // CHECK: [[LOAD_RES:%.*]] = tt.load [[RES]] : !tt.ptr<tensor<1x32x128xf32, [[BLOCKED_LAYOUT1]]>>
-    // CHECK: triton_gpu.convert_layout [[LOAD_RES]] : tensor<1x32x128xf32, [[BLOCKED_LAYOUT1]]> -> tensor<1x32x128xf32, [[BLOCKED_LAYOUT2]]>
+    // CHECK: ttg.convert_layout [[LOAD_RES]] : tensor<1x32x128xf32, [[BLOCKED_LAYOUT1]]> -> tensor<1x32x128xf32, [[BLOCKED_LAYOUT2]]>
     %res = tt.load %8#0 : !tt.ptr<tensor<1x32x128xf32, #blocked1>>
     tt.return
   }


### PR DESCRIPTION
Ensure that loads of a `scf.for` yielded value with block ptr type can be coalesced 