### PR TITLE
[GEMM] Remove `TRITON_INTEL_ENABLE_ADDRESS_PAYLOAD_OPT`

### DIFF
--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -158,7 +158,6 @@ jobs:
           cd benchmarks/triton_kernels_benchmark
           # Default path:
           TRITON_INTEL_ADVANCED_PATH=0 \
-          TRITON_INTEL_ENABLE_ADDRESS_PAYLOAD_OPT=1 \
           IGC_VISAOptions=" -enableBCR -nolocalra" \
           IGC_DisableLoopUnroll=1 \
           python gemm_benchmark.py --reports $REPORTS
@@ -174,7 +173,6 @@ jobs:
           cd benchmarks/triton_kernels_benchmark
           # Advanced path:
           TRITON_INTEL_ADVANCED_PATH=1 \
-          TRITON_INTEL_ENABLE_ADDRESS_PAYLOAD_OPT=1 \
           IGC_VISAOptions=" -enableBCR -nolocalra" \
           IGC_DisableLoopUnroll=1 \
           python gemm_benchmark.py --reports $REPORTS

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -264,14 +264,12 @@ run_benchmark_gemm() {
 
   echo "Default path:"
   TRITON_INTEL_ADVANCED_PATH=0 \
-    TRITON_INTEL_ENABLE_ADDRESS_PAYLOAD_OPT=1 \
     IGC_VISAOptions=" -enableBCR -nolocalra" \
     IGC_DisableLoopUnroll=1 \
     python $TRITON_PROJ/benchmarks/triton_kernels_benchmark/gemm_benchmark.py
 
   echo "Advanced path:"
   TRITON_INTEL_ADVANCED_PATH=1 \
-    TRITON_INTEL_ENABLE_ADDRESS_PAYLOAD_OPT=1 \
     IGC_VISAOptions=" -enableBCR -nolocalra" \
     IGC_DisableLoopUnroll=1 \
     python $TRITON_PROJ/benchmarks/triton_kernels_benchmark/gemm_benchmark.py


### PR DESCRIPTION
Address payload optimization is already implemented in IGC.
Removing `TRITON_INTEL_ENABLE_ADDRESS_PAYLOAD_OPT` causes no performance impact.