### PR TITLE
Remove duplication of usage of XPU specific libraries in `bin/CMakeLists.txt`

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -13,8 +13,6 @@ target_link_libraries(triton-opt PRIVATE
   TritonTransforms
   TritonGPUTransforms
   TritonNvidiaGPUTransforms
-  TritonIntelGPUIR
-  TritonIntelGPUTransforms
   MLIRGPUToROCDLTransforms
   ${dialect_libs}
   ${conversion_libs}
@@ -25,7 +23,6 @@ target_link_libraries(triton-opt PRIVATE
   MLIROptLib
   MLIRPass
   MLIRTransforms
-  MLIRSPIRVDialect
 )
 
 mlir_check_all_link_libraries(triton-opt)
@@ -40,7 +37,6 @@ target_link_libraries(triton-reduce PRIVATE
   TritonTransforms
   TritonGPUTransforms
   TritonNvidiaGPUTransforms
-  TritonIntelGPUTransforms
   ${dialect_libs}
   ${conversion_libs}
   ${triton_libs}
@@ -62,7 +58,6 @@ target_link_libraries(triton-lsp PRIVATE
   TritonTransforms
   TritonGPUTransforms
   TritonNvidiaGPUTransforms
-  TritonIntelGPUTransforms
   ${dialect_libs}
   ${conversion_libs}
   ${triton_libs}
@@ -102,7 +97,6 @@ add_llvm_executable(triton-tensor-layout triton-tensor-layout.cpp PARTIAL_SOURCE
 target_link_libraries(triton-tensor-layout PRIVATE
   TritonGPUIR
   TritonNvidiaGPUIR
-  TritonIntelGPUIR
   ${triton_libs}
   ${conversion_libs}
   ${dialect_libs}
@@ -125,7 +119,6 @@ target_link_libraries(triton-translate
   MLIRIR
   MLIRParser
   MLIRPass
-  MLIRSPIRVDialect
   MLIRTranslateLib
   MLIRSupport
   TritonGENToLLVMIRTranslation


### PR DESCRIPTION
Part of https://github.com/intel/intel-xpu-backend-for-triton/issues/2030