### PR TITLE
Don't specify `TritonSPIRV` translation library directly in main `CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,6 @@ if(TRITON_BUILD_PYTHON_MODULE)
   set(TRITON_LIBRARIES
     ${triton_libs}
     ${triton_plugins}
-    TritonSPIRV
 
     # mlir
     MLIRAMDGPUDialect

--- a/lib/Target/SPIRV/CMakeLists.txt
+++ b/lib/Target/SPIRV/CMakeLists.txt
@@ -15,3 +15,6 @@ add_mlir_translation_library(TritonSPIRV
 
 # Add SPIRV-LLVM-Translator include directory.
 target_include_directories(TritonSPIRV PRIVATE ${SPIRVToLLVMTranslator_INCLUDE_DIR})
+
+set_property(GLOBAL APPEND PROPERTY TRITON_LIBS TritonSPIRV)
+llvm_update_compile_flags(TritonSPIRV)


### PR DESCRIPTION
Part of #2030