### PR TITLE
Ignore `language/test_cublas.py` directly in `test-triton.sh`

### DIFF
--- a/python/test/unit/runtime/test_cublas.py
+++ b/python/test/unit/runtime/test_cublas.py
@@ -18,7 +18,7 @@ def is_cuda():
 def test_cublas(m, n, k, dtype_str, device):
     dtype = getattr(torch, dtype_str)
     if not is_cuda():
-        pytest.xfail("test_cublas is only supported on CUDA")
+        pytest.skip("test_cublas is only supported on CUDA")
     if dtype == torch.float8_e4m3fn and torch.cuda.get_device_capability()[0] < 9:
         pytest.skip("fp8 is only supported on CUDA with cc >= 90")
 

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -189,7 +189,7 @@ run_core_tests() {
 
   # run runtime tests serially to avoid race condition with cache handling.
   TRITON_DISABLE_LINE_INFO=1 TRITON_TEST_SUITE=runtime \
-    pytest --verbose --device xpu runtime/
+    pytest --verbose --device xpu runtime/ --ignore=language/test_cublas.py
 
   TRITON_TEST_SUITE=debug \
     pytest --verbose -n ${PYTEST_MAX_PROCESSES:-8} test_debug.py --forked --device xpu

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -189,7 +189,7 @@ run_core_tests() {
 
   # run runtime tests serially to avoid race condition with cache handling.
   TRITON_DISABLE_LINE_INFO=1 TRITON_TEST_SUITE=runtime \
-    pytest --verbose --device xpu runtime/ --ignore=language/test_cublas.py
+    pytest --verbose --device xpu runtime/ --ignore=runtime/test_cublas.py
 
   TRITON_TEST_SUITE=debug \
     pytest --verbose -n ${PYTEST_MAX_PROCESSES:-8} test_debug.py --forked --device xpu


### PR DESCRIPTION
Part of #2030

This change does not affect the pass rate.