### PR TITLE
Remove linker options for static libraries and conditionally set gcc specific linux options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,6 @@ else()
   set(CMAKE_EXE_LINKER_FLAGS_TRITONRELBUILDWITHASSERTS "/debug:fastlink /INCREMENTAL")
   set(CMAKE_MODULE_LINKER_FLAGS_TRITONRELBUILDWITHASSERTS "/debug:fastlink /INCREMENTAL")
   set(CMAKE_SHARED_LINKER_FLAGS_TRITONRELBUILDWITHASSERTS "/debug:fastlink /INCREMENTAL")
-  set(CMAKE_STATIC_LINKER_FLAGS_TRITONRELBUILDWITHASSERTS "/debug:fastlink /INCREMENTAL")
 endif()
 
 # Default build type
@@ -153,7 +152,7 @@ endfunction()
 if(NOT MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-covered-switch-default -fvisibility=hidden")
 else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX- /wd4244 /wd4624 /wd4715 /wd4530")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244 /wd4624 /wd4715 /wd4530")
 endif()
 
 include_directories(".")

--- a/cmake/AddTritonUnitTest.cmake
+++ b/cmake/AddTritonUnitTest.cmake
@@ -28,7 +28,9 @@ function(add_triton_ut)
           gmock
           ${__LIBS})
 
-  target_compile_options(${__NAME} PRIVATE -fno-rtti)
+  if(NOT MSVC)
+    target_compile_options(${__NAME} PRIVATE -fno-rtti)
+  endif()
 
   target_compile_definitions(${__NAME} PRIVATE ${__DEFS})
 

--- a/lib/Instrumentation/CMakeLists.txt
+++ b/lib/Instrumentation/CMakeLists.txt
@@ -36,5 +36,7 @@ foreach( plugin ${GPU_INSTRUMENTATION_PASSES} )
      # This is set to -fvisibility=hidden in the top level CMake file
      # which causes the llvmGetPassPluginInfo symbol to be hidden and
      # an "entry point not found" error. Reset it just for this target
-     target_compile_options(${plugin} PRIVATE -fvisibility=default -fno-rtti)
+     if(NOT MSVC)
+         target_compile_options(${plugin} PRIVATE -fvisibility=default -fno-rtti)
+     endif()
 endforeach()

--- a/test/lib/Instrumentation/CMakeLists.txt
+++ b/test/lib/Instrumentation/CMakeLists.txt
@@ -34,5 +34,7 @@ foreach( plugin ${GPU_INSTRUMENTATION_PASSES} )
      # This is set to -fvisibility=hidden in the top level CMake file
      # which causes the llvmGetPassPluginInfo symbol to be hidden and
      # an "entry point not found" error. Reset it just for this target
-     target_compile_options(${plugin} PRIVATE -fvisibility=default)
+     if(NOT MSVC)
+         target_compile_options(${plugin} PRIVATE -fvisibility=default)
+     endif()
 endforeach()


### PR DESCRIPTION
Fixes #2855 

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it only changes build options`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
