### PR TITLE
[FA] Remove `TRITON_INTEL_ENABLE_ADDRESS_PAYLOAD_OPT`

### DIFF
--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -250,7 +250,6 @@ jobs:
         run: |
           cd benchmarks/triton_kernels_benchmark
           TRITON_INTEL_ADVANCED_PATH=1 \
-          TRITON_INTEL_ENABLE_ADDRESS_PAYLOAD_OPT=1 \
           IGC_VISAOptions=" -enableBCR" \
           python flash_attention_fwd_benchmark.py --reports $REPORTS
 

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -284,7 +284,6 @@ run_benchmark_attention() {
 
   echo "Advanced path:"
   TRITON_INTEL_ADVANCED_PATH=1 \
-    TRITON_INTEL_ENABLE_ADDRESS_PAYLOAD_OPT=1 \
     IGC_VISAOptions=" -enableBCR" \
     python $TRITON_PROJ/benchmarks/triton_kernels_benchmark/flash_attention_fwd_benchmark.py
 }


### PR DESCRIPTION
Address payload optimization is already implemented in IGC.
Removing `TRITON_INTEL_ENABLE_ADDRESS_PAYLOAD_OPT` causes no performance impact.
CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/12152410219