### PR TITLE
remove F8E4M3B11FNUZ from frontend

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonTypes.td
+++ b/include/triton/Dialect/Triton/IR/TritonTypes.td
@@ -15,7 +15,7 @@ class TritonTypeDef<string name, string _mnemonic, list<Trait> traits = []>
 }
 
 // Floating-point Type
-def TT_Float : AnyTypeOf<[F8E4M3FN, F8E4M3FNUZ, F8E4M3B11FNUZ, F8E5M2, F8E5M2FNUZ, F16, BF16, F32, F64], "floating-point">;
+def TT_Float : AnyTypeOf<[F8E4M3FN, F8E4M3FNUZ, F8E5M2, F8E5M2FNUZ, F16, BF16, F32, F64], "floating-point">;
 def TT_FloatTensor : RankedTensorOf<[TT_Float]>;
 def TT_FloatLike : AnyTypeOf<[TT_Float, TT_FloatTensor]>;
 

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -818,11 +818,6 @@ void init_triton_ir(py::module &&m) {
            [](TritonOpBuilder &self) -> Type {
              return self.getBuilder().getI8Type();
            })
-      .def("get_fp8e4m3b11fnuz_ty",
-           [](TritonOpBuilder &self) -> Type {
-             // TODO: align with upstream code to use i8
-             return self.getBuilder().getType<Float8E4M3B11FNUZType>();
-           })
       .def("get_fp8e5_ty",
            [](TritonOpBuilder &self) -> Type {
              return self.getBuilder().getType<Float8E5M2Type>();

--- a/third_party/intel/language/intel/utils.py
+++ b/third_party/intel/language/intel/utils.py
@@ -25,7 +25,7 @@ def num_warps(_builder=None):
 
 def convert_fp8e4b15_to_float16(arg, _builder):
     # Need to bitcast the source first because it's represented as tensor of i8 in MLIR.
-    tmp_ty = _builder.get_block_ty(_builder.get_fp8e4m3b11fnuz_ty(), arg.type.shape)
+    tmp_ty = _builder.get_block_ty(_builder.get_fp8e4nv_ty(), arg.type.shape)
     tmp = _builder.create_bitcast(arg.handle, tmp_ty)
     # Now generate FpToFp op for upcast.
     dst_ty = core.block_type(core.float16, arg.type.get_block_shapes())


### PR DESCRIPTION
This PR is to remove `F8E4M3B11FNUZ ` in our code. But removing the type can lead to the following failures.
```
test_dot_max_num_imprecise_acc[32-float8e4b15-64-64-64-128-256-256]
test_dot_max_num_imprecise_acc[0-float8e4b15-128-256-128-128-256-256]
test_dot_max_num_imprecise_acc[32-float8e4b15-128-256-128-128-256-256]
test_dot_max_num_imprecise_acc[128-float8e4b15-128-256-128-128-256-256]
test_dot_max_num_imprecise_acc[64-float8e4b15-128-256-128-128-256-256]
test_dot_max_num_imprecise_acc[64-float8e4b15-64-64-64-128-256-256]
test_dot_max_num_imprecise_acc[128-float8e4b15-64-64-64-128-256-256]
```
Seems `get_fp8e4nv_ty` works for resoving these failures.
