### PR TITLE
Small windows-related cleanup for `third_party/nvidia/backend/driver.py`

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -2,10 +2,8 @@ import functools
 import os
 import sysconfig
 import hashlib
-import sysconfig
 import subprocess
 import tempfile
-import sys
 from pathlib import Path
 from triton.runtime.build import _build
 from triton.runtime.cache import get_cache_manager


### PR DESCRIPTION
Part of #2824

One import was duplicated, the other is not used.