### PR TITLE
Only print warning under `MLIR_ENABLE_DIAGNOSTICS`

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1680,11 +1680,11 @@ void init_triton_ir(py::module &&m) {
              if (haveDiagnostics) {
                context->printOpOnDiagnostic(true);
                context->printStackTraceOnDiagnostic(true);
+               context->getDiagEngine().registerHandler([](Diagnostic &diag) {
+                 llvm::outs() << diag << "\n";
+                 return success();
+               });
              }
-             context->getDiagEngine().registerHandler([](Diagnostic &diag) {
-               llvm::outs() << diag << "\n";
-               return success();
-             });
              if (haveDump) {
                auto printingFlags = OpPrintingFlags();
                printingFlags.elideLargeElementsAttrs(16);


### PR DESCRIPTION
As explained in https://github.com/intel/intel-xpu-backend-for-triton/pull/1048/files#r1871965306, we would like to be consistent with upstream to only print warning under env var `MLIR_ENABLE_DIAGNOSTICS`.