### PR TITLE
SPIRV Runner: User driven generic SYCL output buffer copy (D2H)

### DIFF
--- a/utils/SPIRVRunner/SPIRVRunner.cpp
+++ b/utils/SPIRVRunner/SPIRVRunner.cpp
@@ -386,8 +386,9 @@ std::vector<TensorBuffer> launchKernel(sycl::queue stream, sycl::kernel kernel,
           tb.index = triton_args.dev_buffers.size() - 1;
           triton_args.host_outbuffers.push_back(tb);
           std::cout
-              << "Tensor output: "
-              << triton_args.host_outbuffers.back().buffer_ptr.sizes() << ", "
+              << "Tensor output[" << tb.index
+              << "]: " << triton_args.host_outbuffers.back().buffer_ptr.sizes()
+              << ", "
               << triton_args.host_outbuffers.back().buffer_ptr.scalar_type()
               << " (" << triton_args.host_outbuffers.back().buffer_ptr.nbytes()
               << " bytes)" << std::endl;

--- a/utils/SPIRVRunner/SPIRVRunner.cpp
+++ b/utils/SPIRVRunner/SPIRVRunner.cpp
@@ -386,7 +386,7 @@ std::vector<TensorBuffer> launchKernel(sycl::queue stream, sycl::kernel kernel,
           tb.index = triton_args.dev_buffers.size() - 1;
           triton_args.host_outbuffers.push_back(tb);
           std::cout
-              << "Tensor output[" << tb.index
+              << "Tensor output[" << triton_args.host_outbuffers.back().index
               << "]: " << triton_args.host_outbuffers.back().buffer_ptr.sizes()
               << ", "
               << triton_args.host_outbuffers.back().buffer_ptr.scalar_type()
@@ -403,7 +403,7 @@ std::vector<TensorBuffer> launchKernel(sycl::queue stream, sycl::kernel kernel,
   sycl_kernel_launch(stream, kernel, triton_args, get_kernel_time);
 
   // copy back the output tensors
-  for (auto &item : triton_args.host_outbuffers) {
+  for (const auto &item : triton_args.host_outbuffers) {
     stream
         .memcpy(tensor_ptr(item.buffer_ptr),
                 triton_args.dev_buffers.at(item.index),

--- a/utils/SPIRVRunner/SPIRVRunner.cpp
+++ b/utils/SPIRVRunner/SPIRVRunner.cpp
@@ -355,7 +355,8 @@ at::TensorOptions getTensorOptions(const std::string &dtype) {
 }
 
 std::vector<TensorBuffer> launchKernel(sycl::queue stream, sycl::kernel kernel,
-                        KernelArguments triton_args, bool get_kernel_time) {
+                                       KernelArguments triton_args,
+                                       bool get_kernel_time) {
 
   auto tensor_ptr = [](const torch::Tensor &t) -> void * {
     return static_cast<void *>(t.data_ptr());

--- a/utils/SPIRVRunner/llvm_parser.cpp
+++ b/utils/SPIRVRunner/llvm_parser.cpp
@@ -6,7 +6,10 @@ command_line_parser::command_line_parser(int argc, char **argv)
 command_line_parser::options command_line_parser::parse() {
   options opts;
   llvm::cl::list<std::string> output_tensors(
-      "o", llvm::cl::desc("<Specify Output Tensor Names (Ex: -o tensor_1,tensor_2 or skip)>"), llvm::cl::CommaSeparated);
+      "o",
+      llvm::cl::desc(
+          "<Specify Output Tensor Names (Ex: -o tensor_1,tensor_2 or skip)>"),
+      llvm::cl::CommaSeparated);
   llvm::cl::opt<bool> enable_profiling(
       "p", llvm::cl::desc("Enable kernel time profiling"),
       llvm::cl::init(opts.get_kernel_time));

--- a/utils/SPIRVRunner/llvm_parser.cpp
+++ b/utils/SPIRVRunner/llvm_parser.cpp
@@ -5,15 +5,15 @@ command_line_parser::command_line_parser(int argc, char **argv)
 
 command_line_parser::options command_line_parser::parse() {
   options opts;
-  llvm::cl::opt<std::string> output_tensor(
-      "o", llvm::cl::desc("<Specify Output Tensor Name>"), llvm::cl::Required);
+  llvm::cl::list<std::string> output_tensors(
+      "o", llvm::cl::desc("<Specify Output Tensor Names (Ex: -o tensor_1,tensor_2 or skip)>"), llvm::cl::CommaSeparated);
   llvm::cl::opt<bool> enable_profiling(
       "p", llvm::cl::desc("Enable kernel time profiling"),
       llvm::cl::init(opts.get_kernel_time));
 
   llvm::cl::ParseCommandLineOptions(argc, argv, "SPIRVRunner\n");
 
-  opts.output_tensor = output_tensor;
+  opts.output_tensors.assign(output_tensors.begin(), output_tensors.end());
   opts.get_kernel_time = enable_profiling;
 
   return opts;

--- a/utils/SPIRVRunner/llvm_parser.h
+++ b/utils/SPIRVRunner/llvm_parser.h
@@ -6,7 +6,7 @@
 class command_line_parser {
 public:
   struct options {
-    std::string output_tensor;
+    std::vector<std::string> output_tensors;
     bool get_kernel_time = false;
   };
 


### PR DESCRIPTION

This PR conditionally copies the output buffers (buffer_cnt >= 0) based on the CLI option (-o) with tensor names (comma separated). Previously we used to support single output tensor copy.

```
utils/SPIRVRunner$ ./build/SPIRVRunner -o tensor_2,tensor_1,tensor_0
Running on device: Intel(R) Data Center GPU Max 1100
Read 3772 byte kernel.
Loaded kernel with 0 registers and 0 register spills.
Tensor output[0]: [98432], Float (393728 bytes)
Tensor output[1]: [98432], Float (393728 bytes)
Tensor output[2]: [98432], Float (393728 bytes)
Output Tensor Path: /utils/SPIRVRunner/cpp_outs_0.pt
Output Tensor Path: /utils/SPIRVRunner/cpp_outs_1.pt
Output Tensor Path: /utils/SPIRVRunner/cpp_outs_2.pt

/utils/SPIRVRunner$ ./build/SPIRVRunner -p
Running on device: Intel(R) Data Center GPU Max 1100
Read 3772 byte kernel.
Loaded kernel with 0 registers and 0 register spills.
Kernel execution time: 0.00944 ms
```

Closes: https://github.com/intel/intel-xpu-backend-for-triton/issues/2569