### PR TITLE
Use DLE specific vars file

### DIFF
--- a/.github/workflows/inductor-tests-reusable.yml
+++ b/.github/workflows/inductor-tests-reusable.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 720
     defaults:
       run:
-        shell: bash -noprofile --norc -eo pipefail -c "source /opt/intel/oneapi/setvars.sh > /dev/null; source {0}"
+        shell: bash -noprofile --norc -eo pipefail -c "source /opt/intel/oneapi/2025.0/oneapi-vars.sh > /dev/null; source {0}"
     steps:
       - name: Print inputs
         run: |

--- a/.github/workflows/inductor-tests-reusable.yml
+++ b/.github/workflows/inductor-tests-reusable.yml
@@ -34,7 +34,7 @@ jobs:
   build:
     name: Test
     runs-on:
-      - ${{ inputs.runner_label || 'max1550' }}
+      - ${{ inputs.runner_label || 'rolling' }}
     timeout-minutes: 720
     defaults:
       run:


### PR DESCRIPTION
There is a PyTorch regression (see https://github.com/pytorch/pytorch/pull/142242) that requires a different ONEAPI_ROOT for inductor tests.