### PR TITLE
Copy `triton-translate` to `triton_BINARY_DIR/bin` folder instead of modifying lit config file

### DIFF
--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -45,7 +45,6 @@ config.test_source_root = os.path.dirname(__file__)
 # test_exec_root: The root path where tests should be run.
 config.test_exec_root = os.path.join(config.triton_obj_root, 'test')
 config.triton_tools_dir = os.path.join(config.triton_obj_root, 'bin')
-config.triton_intel_plugin_tools_dir = os.path.join(config.triton_obj_root, 'third_party', 'intel', 'bin')
 config.filecheck_dir = os.path.join(config.triton_obj_root, 'bin', 'FileCheck')
 
 # FileCheck -enable-var-scope is enabled by default in MLIR test
@@ -53,7 +52,7 @@ config.filecheck_dir = os.path.join(config.triton_obj_root, 'bin', 'FileCheck')
 # it can be explicitly opted-in by prefixing the variable name with $
 config.environment["FILECHECK_OPTS"] = "--enable-var-scope"
 
-tool_dirs = [config.triton_tools_dir, config.triton_intel_plugin_tools_dir, config.llvm_tools_dir, config.filecheck_dir]
+tool_dirs = [config.triton_tools_dir, config.llvm_tools_dir, config.filecheck_dir]
 
 # Tweak the PATH to include the tools dir.
 for d in tool_dirs:

--- a/third_party/intel/bin/CMakeLists.txt
+++ b/third_party/intel/bin/CMakeLists.txt
@@ -22,3 +22,10 @@ target_link_libraries(triton-translate
   TritonGENToLLVMIRTranslation
 )
 mlir_check_link_libraries(triton-translate)
+
+# Move `triton-translate` to the folder where `lit` expects to find it
+add_custom_command(TARGET triton-translate  POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy
+  "$<TARGET_FILE:triton-translate>"
+  "${triton_BINARY_DIR}/bin"
+)


### PR DESCRIPTION
Part of #2030