### PR TITLE
Parse `architecture` from `PyTorch` instead of hard coding

### DIFF
--- a/third_party/intel/backend/arch_parser.c
+++ b/third_party/intel/backend/arch_parser.c
@@ -18,11 +18,23 @@ static PyObject *parseDeviceArch(PyObject *self, PyObject *args) {
 
   sycl::ext::oneapi::experimental::architecture sycl_arch =
       static_cast<sycl::ext::oneapi::experimental::architecture>(dev_arch);
-  // FIXME: Add support for other devices.
-  if (sycl_arch == sycl::ext::oneapi::experimental::architecture::intel_gpu_pvc)
-    return Py_BuildValue("s", "pvc");
+  // FIXME: Add support for more architectures.
+  std::string arch = "";
+  switch (sycl_arch) {
+  case sycl::ext::oneapi::experimental::architecture::intel_gpu_pvc:
+    arch = "pvc";
+    break;
+  case sycl::ext::oneapi::experimental::architecture::intel_gpu_bmg_g21:
+    arch = "bmg";
+    break;
+  case sycl::ext::oneapi::experimental::architecture::intel_gpu_lnl_m:
+    arch = "lnl";
+    break;
+  default:
+    printf("sycl_arch = %d", sycl_arch);
+  }
 
-  return Py_BuildValue("s", "");
+  return Py_BuildValue("s", arch.c_str());
 }
 
 static PyMethodDef ModuleMethods[] = {

--- a/third_party/intel/backend/arch_parser.c
+++ b/third_party/intel/backend/arch_parser.c
@@ -1,0 +1,45 @@
+//===- arch_parser.c ------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <sycl/sycl.hpp>
+
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <Python.h>
+#include <numpy/arrayobject.h>
+
+static PyObject *parseDeviceArch(PyObject *self, PyObject *args) {
+  uint64_t dev_arch;
+  assert(PyArg_ParseTuple(args, "K", &dev_arch) && "Expected an integer");
+
+  sycl::ext::oneapi::experimental::architecture sycl_arch =
+      static_cast<sycl::ext::oneapi::experimental::architecture>(dev_arch);
+  // FIXME: Add support for other devices.
+  if (sycl_arch == sycl::ext::oneapi::experimental::architecture::intel_gpu_pvc)
+    return Py_BuildValue("s", "pvc");
+
+  return Py_BuildValue("s", "");
+}
+
+static PyMethodDef ModuleMethods[] = {
+    {"parse_device_arch", parseDeviceArch, METH_VARARGS,
+     "parse device architecture"},
+    {NULL, NULL, 0, NULL} // sentinel
+};
+
+static struct PyModuleDef ModuleDef = {PyModuleDef_HEAD_INIT, "arch_utils",
+                                       NULL, // documentation
+                                       -1,   // size
+                                       ModuleMethods};
+
+PyMODINIT_FUNC PyInit_arch_utils(void) {
+  if (PyObject *m = PyModule_Create(&ModuleDef)) {
+    PyModule_AddFunctions(m, ModuleMethods);
+    return m;
+  }
+  return NULL;
+}

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -155,7 +155,7 @@ class XPUBackend(BaseBackend):
                 output = subprocess.check_output(ocloc_cmd, text=True, cwd=temp_dir)
         except subprocess.CalledProcessError:
             device_arch = ''
-        if device_arch != '':
+        if device_arch:
             try:
                 ocloc_cmd = ['ocloc', 'query', 'CL_DEVICE_EXTENSIONS', '-device', device_arch]
                 with tempfile.TemporaryDirectory() as temp_dir:

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -171,11 +171,6 @@ class XPUBackend(BaseBackend):
                 dev_prop['has_bfloat16_conversions'] = 'cl_intel_bfloat16_conversions' in supported_extensions
             except subprocess.CalledProcessError as e:
                 raise RuntimeError(f'`ocloc` failed with error code {e.returncode}')
-            # Temporary checks
-            assert(dev_prop['has_subgroup_matrix_multiply_accumulate'] == tgt_prop.get('has_subgroup_matrix_multiply_accumulate', False))
-            assert(dev_prop['has_subgroup_matrix_multiply_accumulate_tensor_float32'] == tgt_prop.get('has_subgroup_matrix_multiply_accumulate_tensor_float32', False))
-            assert(dev_prop['has_subgroup_2d_block_io'] == tgt_prop.get('has_subgroup_2d_block_io', False))
-            assert(dev_prop['has_bfloat16_conversions'] == tgt_prop.get('has_bfloat16_conversions', True))
         else:
             dev_prop['has_subgroup_matrix_multiply_accumulate'] = tgt_prop.get(
                 'has_subgroup_matrix_multiply_accumulate', False)

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -146,7 +146,15 @@ class XPUBackend(BaseBackend):
         dev_prop['max_num_sub_groups'] = tgt_prop.get('max_num_sub_groups', None)
         dev_prop['sub_group_sizes'] = tgt_prop.get('sub_group_sizes', None)
         dev_prop['has_fp64'] = tgt_prop.get('has_fp64', None)
+
         device_arch = self.parse_device_arch(tgt_prop.get('architecture', 0))
+        # Note: LTS driver does not support ocloc query CL_DEVICE_EXTENSIONS.
+        try:
+            ocloc_cmd = ['ocloc', 'query', 'CL_DEVICE_EXTENSIONS']
+            with tempfile.TemporaryDirectory() as temp_dir:
+                output = subprocess.check_output(ocloc_cmd, text=True, cwd=temp_dir)
+        except subprocess.CalledProcessError:
+            device_arch = ''
         if device_arch != '':
             try:
                 ocloc_cmd = ['ocloc', 'query', 'CL_DEVICE_EXTENSIONS', '-device', device_arch]

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -150,10 +150,8 @@ class XPUBackend(BaseBackend):
         if device_arch != '':
             try:
                 ocloc_cmd = ['ocloc', 'query', 'CL_DEVICE_EXTENSIONS', '-device', device_arch]
-                result = subprocess.run(ocloc_cmd, check=True, capture_output=True, text=True)
-                output = result.stdout
-                cleanup_cmd = ['rm', 'CL_DEVICE_EXTENSIONS']
-                result = subprocess.run(cleanup_cmd)
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    output = subprocess.check_output(ocloc_cmd, text=True, cwd=temp_dir)
                 supported_extensions = set()
                 for extension in output.split(' '):
                     supported_extensions.add(extension)

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -171,6 +171,11 @@ class XPUBackend(BaseBackend):
                 dev_prop['has_bfloat16_conversions'] = 'cl_intel_bfloat16_conversions' in supported_extensions
             except subprocess.CalledProcessError as e:
                 raise RuntimeError(f'`ocloc` failed with error code {e.returncode}')
+            # Temporary checks
+            assert(dev_prop['has_subgroup_matrix_multiply_accumulate'] == tgt_prop.get('has_subgroup_matrix_multiply_accumulate', False))
+            assert(dev_prop['has_subgroup_matrix_multiply_accumulate_tensor_float32'] == tgt_prop.get('has_subgroup_matrix_multiply_accumulate_tensor_float32', False))
+            assert(dev_prop['has_subgroup_2d_block_io'] == tgt_prop.get('has_subgroup_2d_block_io', False))
+            assert(dev_prop['has_bfloat16_conversions'] == tgt_prop.get('has_bfloat16_conversions', True))
         else:
             dev_prop['has_subgroup_matrix_multiply_accumulate'] = tgt_prop.get(
                 'has_subgroup_matrix_multiply_accumulate', False)


### PR DESCRIPTION
With https://github.com/pytorch/pytorch/pull/138186, `architecture` is added to XPU device property. 
Instead of hard coding `pvc` when invoking `ocloc`, this PR changed to dynamically passing the device architecture parsed. 