### PR TITLE
Ignore cleanup errors in cache teardown.

### DIFF
--- a/python/test/regression/conftest.py
+++ b/python/test/regression/conftest.py
@@ -14,7 +14,9 @@ def device(request):
 
 @pytest.fixture
 def fresh_triton_cache():
-    with tempfile.TemporaryDirectory() as tmpdir:
+    # Ignore cleanup errors to avoid PermissionError on Windows: certain .pyd files are locked by
+    # Python process and cannot be deleted.
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
         try:
             os.environ["TRITON_CACHE_DIR"] = tmpdir
             yield tmpdir

--- a/python/test/regression/conftest.py
+++ b/python/test/regression/conftest.py
@@ -14,11 +14,13 @@ def device(request):
 
 @pytest.fixture
 def fresh_triton_cache():
-    # Ignore cleanup errors to avoid PermissionError on Windows: certain .pyd files are locked by
-    # Python process and cannot be deleted.
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
-        try:
-            os.environ["TRITON_CACHE_DIR"] = tmpdir
-            yield tmpdir
-        finally:
-            os.environ.pop("TRITON_CACHE_DIR", None)
+    try:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+            try:
+                os.environ["TRITON_CACHE_DIR"] = tmpdir
+                yield tmpdir
+            finally:
+                os.environ.pop("TRITON_CACHE_DIR", None)
+    except OSError:
+        # Ignore errors, such as PermissionError, on Windows
+        pass

--- a/python/test/regression/conftest.py
+++ b/python/test/regression/conftest.py
@@ -15,7 +15,7 @@ def device(request):
 @pytest.fixture
 def fresh_triton_cache():
     try:
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with tempfile.TemporaryDirectory() as tmpdir:
             try:
                 os.environ["TRITON_CACHE_DIR"] = tmpdir
                 yield tmpdir

--- a/python/test/unit/conftest.py
+++ b/python/test/unit/conftest.py
@@ -14,7 +14,9 @@ def device(request):
 
 @pytest.fixture
 def fresh_triton_cache():
-    with tempfile.TemporaryDirectory() as tmpdir:
+    # Ignore cleanup errors to avoid PermissionError on Windows: certain .pyd files are locked by
+    # Python process and cannot be deleted.
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
         try:
             os.environ["TRITON_CACHE_DIR"] = tmpdir
             yield tmpdir

--- a/python/test/unit/conftest.py
+++ b/python/test/unit/conftest.py
@@ -14,11 +14,13 @@ def device(request):
 
 @pytest.fixture
 def fresh_triton_cache():
-    # Ignore cleanup errors to avoid PermissionError on Windows: certain .pyd files are locked by
-    # Python process and cannot be deleted.
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
-        try:
-            os.environ["TRITON_CACHE_DIR"] = tmpdir
-            yield tmpdir
-        finally:
-            os.environ.pop("TRITON_CACHE_DIR", None)
+    try:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+            try:
+                os.environ["TRITON_CACHE_DIR"] = tmpdir
+                yield tmpdir
+            finally:
+                os.environ.pop("TRITON_CACHE_DIR", None)
+    except OSError:
+        # Ignore errors, such as PermissionError, on Windows
+        pass

--- a/python/test/unit/conftest.py
+++ b/python/test/unit/conftest.py
@@ -15,7 +15,7 @@ def device(request):
 @pytest.fixture
 def fresh_triton_cache():
     try:
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with tempfile.TemporaryDirectory() as tmpdir:
             try:
                 os.environ["TRITON_CACHE_DIR"] = tmpdir
                 yield tmpdir


### PR DESCRIPTION
To avoid PermissionError on Windows where certain .pyd files are locked by current Python process and cannot be deleted.

Fixes #3019.