### PR TITLE
Ignore tests errors when cleaning cache

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -513,7 +513,7 @@ def test_preload(device, fresh_triton_cache) -> None:
     assert specialization_data is not None
 
     # clear the cache
-    shutil.rmtree(fresh_triton_cache)
+    shutil.rmtree(fresh_triton_cache, ignore_errors=True)
     kernel_add.device_caches[device][0].clear()
 
     # preload the kernel

--- a/python/test/unit/runtime/test_subproc.py
+++ b/python/test/unit/runtime/test_subproc.py
@@ -92,7 +92,7 @@ def test_compile_in_forked_subproc_with_forced_gc(fresh_triton_cache) -> None:
     compile_empty_kernel_with_gc(config)
 
     # stage 2.p
-    shutil.rmtree(fresh_triton_cache)
+    shutil.rmtree(fresh_triton_cache, ignore_errors=True)
     mp_ctx = multiprocessing.get_context(start_method)
     proc = mp_ctx.Process(target=compile_empty_kernel_with_gc, args=(config, ))
 


### PR DESCRIPTION
More places in tests to ignore cleanup errors on Windows.

Fixes #3019.