### PR TITLE
Absolute path for --reports-dir, --skip-list in test-triton.sh

### DIFF
--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -96,7 +96,8 @@ while [ -v 1 ]; do
       ;;
     --reports-dir)
       TRITON_TEST_REPORTS=true
-      TRITON_TEST_REPORTS_DIR="$2"
+      # Must be absolute
+      TRITON_TEST_REPORTS_DIR="$(mkdir -p "$2" && cd "$2" && pwd)"
       shift 2
       ;;
     --warning-reports)
@@ -108,7 +109,8 @@ while [ -v 1 ]; do
       shift
       ;;
     --skip-list)
-      TRITON_TEST_SKIPLIST_DIR="$2"
+      # # Must be absolute
+      TRITON_TEST_SKIPLIST_DIR="$(mkdir -p "$2" && cd "$2" && pwd)"
       shift 2
       ;;
     --help)

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -109,7 +109,7 @@ while [ -v 1 ]; do
       shift
       ;;
     --skip-list)
-      # # Must be absolute
+      # Must be absolute
       TRITON_TEST_SKIPLIST_DIR="$(mkdir -p "$2" && cd "$2" && pwd)"
       shift 2
       ;;


### PR DESCRIPTION
The script `test-triton.sh` changes directories during the execution, so --reports-dir, --skip-list should be absolute paths.

Fixes #3031.