### PR TITLE
Better support for Windows in shell scripts

### DIFF
--- a/scripts/capture-hw-details.sh
+++ b/scripts/capture-hw-details.sh
@@ -42,6 +42,8 @@ if command -v clinfo &> /dev/null; then
     export GPU_DEVICE=$(clinfo --json | jq -r '[.devices[].online[] | select(.CL_DEVICE_TYPE.raw == 4)][0].CL_DEVICE_NAME')
 elif command -v nvidia-smi &> /dev/null; then
     export GPU_DEVICE=$(nvidia-smi -L | sed -e 's,\(.*\) (UUID.*),\1,')
+elif command -v sycl-ls &> /dev/null; then
+    export GPU_DEVICE=$(ONEAPI_DEVICE_SELECTOR=level_zero:gpu sycl-ls --verbose 2>/dev/null | grep Name | sed -n '2p' | sed -E 's/\s+Name\s+:\s+(.+)$/\1/')
 else
     export GPU_DEVICE="Not Installed"
 fi

--- a/scripts/pytest-utils.sh
+++ b/scripts/pytest-utils.sh
@@ -140,6 +140,10 @@ capture_runtime_env() {
 }
 
 ensure_spirv_dis() {
+    # Does not work on Windows
+    if [[ $OSTYPE = msys ]]; then
+        return
+    fi
     export PATH="$HOME/.local/bin:$PATH"
     local spirv_dis="$(which spirv-dis || true)"
     if [[ $spirv_dis ]]; then


### PR DESCRIPTION
* Do not install spirv-dis on Windows (will revisit if this is required).
* Use sycl-ls as last resort to identify GPU (works on Windows).

Fixes #3033.