### PR TITLE
Add OS to pass rate report

### DIFF
--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -195,9 +195,9 @@ jobs:
       - name: Pass rate
         run: |
           source ./scripts/capture-hw-details.sh
-          python3 scripts/pass_rate.py --reports reports ${{ env.SKIPLIST }}
-          python3 scripts/pass_rate.py --reports reports --json ${{ env.SKIPLIST }} > pass_rate.json
-          python3 scripts/pass_rate.py --reports reports --suite tutorials --json ${{ env.SKIPLIST }} > pass_rate_tutorials.json
+          python scripts/pass_rate.py --reports reports ${{ env.SKIPLIST }}
+          python scripts/pass_rate.py --reports reports --json ${{ env.SKIPLIST }} > pass_rate.json
+          python scripts/pass_rate.py --reports reports --suite tutorials --json ${{ env.SKIPLIST }} > pass_rate_tutorials.json
 
       - name: Report environment details
         run: |

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -82,8 +82,6 @@ jobs:
           "
 
       - name: Upload pass rate report
-#        # upload reports only for the default branch
-#        if: github.ref_name == 'main'
         uses: actions/upload-artifact@v4
         with:
           name: pass_rate

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -71,9 +71,21 @@ jobs:
           ${{ env.TRITON_TEST_CMD }} --interpreter
 
       - name: Pass rate
+        shell: bash
         run: |
           pip install defusedxml
-          python scripts/pass_rate.py --reports reports --skip-list scripts/skiplist/a770
+          source ./scripts/capture-hw-details.sh
+          python scripts/pass_rate.py --reports reports ${{ env.SKIPLIST }}
+          python scripts/pass_rate.py --reports reports --json ${{ env.SKIPLIST }} > pass_rate.json
+          python scripts/pass_rate.py --reports reports --suite tutorials --json ${{ env.SKIPLIST }} > pass_rate_tutorials.json
+
+      - name: Upload pass rate report
+#        # upload reports only for the default branch
+#        if: github.ref_name == 'main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pass_rate
+          path: pass_rate*.json
 
       - name: Clean up workspace
         if: ${{ always() }}

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -71,13 +71,15 @@ jobs:
           ${{ env.TRITON_TEST_CMD }} --interpreter
 
       - name: Pass rate
-        shell: bash
         run: |
           pip install defusedxml
-          source ./scripts/capture-hw-details.sh
-          python scripts/pass_rate.py --reports reports ${{ env.SKIPLIST }}
-          python scripts/pass_rate.py --reports reports --json ${{ env.SKIPLIST }} > pass_rate.json
-          python scripts/pass_rate.py --reports reports --suite tutorials --json ${{ env.SKIPLIST }} > pass_rate_tutorials.json
+          Invoke-BatchFile "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+          bash -c "\
+            source ./scripts/capture-hw-details.sh; \
+            python scripts/pass_rate.py --reports reports ${{ env.SKIPLIST }}; \
+            python scripts/pass_rate.py --reports reports --json ${{ env.SKIPLIST }} > pass_rate.json; \
+            python scripts/pass_rate.py --reports reports --suite tutorials --json ${{ env.SKIPLIST }} > pass_rate_tutorials.json; \
+          "
 
       - name: Upload pass rate report
 #        # upload reports only for the default branch

--- a/scripts/pass_rate.py
+++ b/scripts/pass_rate.py
@@ -180,6 +180,7 @@ def print_json_stats(stats: ReportStats):
     """Print JSON stats."""
     data = {
         'ts': datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S'),
+        'os': platform.system(),
         'git_ref': os.getenv('GITHUB_REF_NAME', ''),
         'git_sha': os.getenv('GITHUB_SHA', ''),
         'libigc1_version': os.getenv('LIBIGC1_VERSION', ''),


### PR DESCRIPTION
Add `os` to the pass rate report. Make sure the report also contains `gpu_device`.

Fixes #3081.