### PR TITLE
Sync from upstream

### DIFF
--- a/python/test/unit/language/print_helper.py
+++ b/python/test/unit/language/print_helper.py
@@ -154,6 +154,7 @@ def test_print(func: str, data_type: str, device: str):
                                       BLOCK_SIZE_Y=BLOCK_SIZE_Y)
     else:
         assert f"Unknown kernel: {func}"
+
     if func != "print_no_arg" and func != "no_arg_print" and func != "device_print_large" and \
        func != "print_multiple_args" and func != "device_print_multiple_args" and \
        func != "device_print_pointer" and func != "device_print_scalar" and func != "device_print_2d_tensor":

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -414,7 +414,7 @@ class CodeGenerator(ast.NodeVisitor):
             self.builder.ret([])
             ret_ty = language.void
         elif isinstance(ret_value, language.tuple):
-            ret_values = [language.semantic.to_tensor(v, self.builder) for v in ret_value.values]
+            ret_values = [semantic.to_tensor(v, self.builder) for v in ret_value.values]
             ret_types = [v.type for v in ret_values]
             self.builder.ret([v.handle for v in ret_values])
             ret_ty = language.tuple_type(ret_types)
@@ -543,7 +543,7 @@ class CodeGenerator(ast.NodeVisitor):
             if value is not None and \
                 not _is_triton_value(value) and \
                 not isinstance(value, native_nontensor_types):
-                value = language.semantic.to_tensor(value, self.builder)
+                value = semantic.to_tensor(value, self.builder)
             return value
 
         values = _sanitize_value(self.visit(node.value))


### PR DESCRIPTION
Changes are made upstream in https://github.com/triton-lang/triton/commit/d7ebf7982adedb61095b93084dcbcaf1d28c8da4, but accidentally removed in https://github.com/intel/intel-xpu-backend-for-triton/commit/2347dbaec4797ecb1b7d591ae2238d7ebd1e550b.