### PR TITLE
Run `elapsed_time` in `_support_elapsed_time` several times to detect the bug with negative timings and use Wall timing instead

### DIFF
--- a/benchmarks/triton_kernels_benchmark/benchmark_testing.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_testing.py
@@ -51,7 +51,6 @@ def do_bench_elapsed_time(fn, n_warmup=25, n_repeat=100, grad_to_none=None, quan
     """
     assert return_mode in ["min", "max", "mean", "median"]
     import torch
-    import triton
     from triton.testing import do_bench as triton_do_bench
 
     # We maintain a buffer of 256 MB that we clear
@@ -69,7 +68,6 @@ def do_bench_elapsed_time(fn, n_warmup=25, n_repeat=100, grad_to_none=None, quan
         fn()
     end_event.record()
     synchronize()
-    triton.runtime.driver.active.utils.wait()
     estimate_ms = start_event.elapsed_time(end_event) / 5
 
     # The cache is also maintained in `triton_do_bench` function,

--- a/benchmarks/triton_kernels_benchmark/benchmark_testing.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_testing.py
@@ -51,6 +51,7 @@ def do_bench_elapsed_time(fn, n_warmup=25, n_repeat=100, grad_to_none=None, quan
     """
     assert return_mode in ["min", "max", "mean", "median"]
     import torch
+    import triton
     from triton.testing import do_bench as triton_do_bench
 
     # We maintain a buffer of 256 MB that we clear
@@ -68,6 +69,9 @@ def do_bench_elapsed_time(fn, n_warmup=25, n_repeat=100, grad_to_none=None, quan
         fn()
     end_event.record()
     synchronize()
+    # FIXME: to avoid negative timings before DLE 2025.1;
+    # this workaround doesn't work for BMG.
+    triton.runtime.driver.active.utils.wait()
     estimate_ms = start_event.elapsed_time(end_event) / 5
 
     # The cache is also maintained in `triton_do_bench` function,

--- a/benchmarks/triton_kernels_benchmark/benchmark_testing.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_testing.py
@@ -51,6 +51,7 @@ def do_bench_elapsed_time(fn, n_warmup=25, n_repeat=100, grad_to_none=None, quan
     """
     assert return_mode in ["min", "max", "mean", "median"]
     import torch
+    import triton
     from triton.testing import do_bench as triton_do_bench
 
     # We maintain a buffer of 256 MB that we clear
@@ -68,6 +69,7 @@ def do_bench_elapsed_time(fn, n_warmup=25, n_repeat=100, grad_to_none=None, quan
         fn()
     end_event.record()
     synchronize()
+    triton.runtime.driver.active.utils.wait()
     estimate_ms = start_event.elapsed_time(end_event) / 5
 
     # The cache is also maintained in `triton_do_bench` function,

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -15,9 +15,14 @@ import logging
 @functools.cache
 def _support_elapsed_time():
     import torch
-    import triton
 
     support = True
+    message_unsupported = "Wall time is used instead of elapsed_time (not supported). \
+        The timing measurements could be innacurate."
+
+    message_bug = "Wall time is used instead of elapsed_time because of the bug ('negative timings'). \
+        Should be fixed in DLE 2025.1. The timing measurements could be innacurate."
+
     for _ in range(5):
         e1 = torch.xpu.Event(enable_timing=True)
         e1.record()
@@ -28,16 +33,14 @@ def _support_elapsed_time():
         e2.synchronize()
 
         try:
-            triton.runtime.driver.active.utils.wait()
-            support = e1.elapsed_time(e2) > 0
+            if e1.elapsed_time(e2) <= 0:
+                logging.warning(message_bug)
+                support = False
+                break
         except Exception:
+            logging.warning(message_unsupported)
             support = False
-        if not support:
             break
-
-    if not support:
-        logging.warning("Wall time is used instead of elapsed_time (not supported). "
-                        "The timing measurements could be innacurate.")
 
     return support
 
@@ -192,7 +195,6 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, return_m
     :type return_mode: str
     """
     assert return_mode in ["min", "max", "mean", "median", "all"]
-    import triton
 
     di = runtime.driver.active.get_device_interface()
 
@@ -215,7 +217,6 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, return_m
     end_event.record()
     if not USE_WALL_TIME:
         di.synchronize()
-    triton.runtime.driver.active.utils.wait()
     estimate_ms = start_event.elapsed_time(end_event) / 5
 
     # compute number of warmup and repeat
@@ -247,7 +248,6 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, return_m
     # Record clocks
     if not USE_WALL_TIME:
         di.synchronize()
-    triton.runtime.driver.active.utils.wait()
     times = [s.elapsed_time(e) for s, e in zip(start_event, end_event)]
     return _summarize_statistics(times, quantiles, return_mode)
 

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -15,6 +15,7 @@ import logging
 @functools.cache
 def _support_elapsed_time():
     import torch
+    import triton
 
     support = True
     message_unsupported = "Wall time is used instead of elapsed_time (not supported). \
@@ -23,16 +24,18 @@ def _support_elapsed_time():
     message_bug = "Wall time is used instead of elapsed_time because of the bug ('negative timings'). \
         Should be fixed in DLE 2025.1. The timing measurements could be innacurate."
 
+    # FIXME: 5 iterations to detect negative timings bug; 1 should be enough for DLE 2025.1
     for _ in range(5):
         e1 = torch.xpu.Event(enable_timing=True)
         e1.record()
-        e1.synchronize()
 
         e2 = torch.xpu.Event(enable_timing=True)
         e2.record()
-        e2.synchronize()
 
         try:
+            # FIXME: to avoid negative timings before DLE 2025.1;
+            # this workaround doesn't work for BMG.
+            triton.runtime.driver.active.utils.wait()
             if e1.elapsed_time(e2) <= 0:
                 logging.warning(message_bug)
                 support = False
@@ -195,6 +198,7 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, return_m
     :type return_mode: str
     """
     assert return_mode in ["min", "max", "mean", "median", "all"]
+    import triton
 
     di = runtime.driver.active.get_device_interface()
 
@@ -217,6 +221,10 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, return_m
     end_event.record()
     if not USE_WALL_TIME:
         di.synchronize()
+
+    # FIXME: to avoid negative timings before DLE 2025.1;
+    # this workaround doesn't work for BMG.
+    triton.runtime.driver.active.utils.wait()
     estimate_ms = start_event.elapsed_time(end_event) / 5
 
     # compute number of warmup and repeat
@@ -248,6 +256,10 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, return_m
     # Record clocks
     if not USE_WALL_TIME:
         di.synchronize()
+
+    # FIXME: to avoid negative timings before DLE 2025.1;
+    # this workaround doesn't work for BMG.
+    triton.runtime.driver.active.utils.wait()
     times = [s.elapsed_time(e) for s, e in zip(start_event, end_event)]
     return _summarize_statistics(times, quantiles, return_mode)
 

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -17,23 +17,27 @@ def _support_elapsed_time():
     import torch
     import triton
 
-    e1 = torch.xpu.Event(enable_timing=True)
-    e1.record()
-    e1.synchronize()
+    support = True
+    for _ in range(5):
+        e1 = torch.xpu.Event(enable_timing=True)
+        e1.record()
+        e1.synchronize()
 
-    e2 = torch.xpu.Event(enable_timing=True)
-    e2.record()
-    e2.synchronize()
+        e2 = torch.xpu.Event(enable_timing=True)
+        e2.record()
+        e2.synchronize()
 
-    try:
-        triton.runtime.driver.active.utils.wait()
-        support = e1.elapsed_time(e2) > 0
-    except Exception:
-        support = False
+        try:
+            triton.runtime.driver.active.utils.wait()
+            support = e1.elapsed_time(e2) > 0
+        except Exception:
+            support = False
+        if not support:
+            break
 
     if not support:
-        logging.warn("Wall time is used instead of elapsed_time (not supported). "
-                     "The timing measurements could be innacurate.")
+        logging.warning("Wall time is used instead of elapsed_time (not supported). "
+                        "The timing measurements could be innacurate.")
 
     return support
 


### PR DESCRIPTION
https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/12774115900 (elapsed_time)