### PR TITLE
Use max1550 runners instead of max1100 to reduce cache consumption

### DIFF
--- a/.github/workflows/auto-update-translator-cid.yml
+++ b/.github/workflows/auto-update-translator-cid.yml
@@ -44,13 +44,13 @@ jobs:
           CACHE_NUMBER: 1
         with:
           path: $HOME/.cache/pip
-          key: pip-3.10-${{ hashFiles('python/pyproject.toml', 'python/setup.py') }}-${{ env.CACHE_NUMBER }}
+          key: pip-3.9-${{ hashFiles('python/pyproject.toml', 'python/setup.py') }}-${{ env.CACHE_NUMBER }}
 
-      - name: Install Python 3.10
+      - name: Install Python 3.9
         if: ${{ env.TARGET_PRID == null }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.9'
 
       - name: Setup PyTorch
         if: ${{ env.TARGET_PRID == null }}

--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -74,6 +74,8 @@ jobs:
 
     uses: ./.github/workflows/build-test-reusable.yml
     with:
+      # For this workflow, use max1550 runners to reduce cache consumption on max1100 runners.
+      device: ${{ matrix.driver == 'rolling' && 'max1550' || 'max1100' }}
       driver_version: ${{ matrix.driver }}
       runner_label: ${{ inputs.runner_label }}
       pytorch_ref: ${{ inputs.pytorch_ref }}

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: Build
     runs-on:
-      - max1100
+      - max1550
       - rolling
       - runner-0.0.21
     strategy:


### PR DESCRIPTION
Each Python version used in workflow requires separate cached artifacts. Since max1100 runners have issues with cache capacity (I am working in parallel to increase it), we temporary will use max1550 runners for workflows that use Python version different from 3.9, which is used in workflow "Build and test".