### PR TITLE
Improve UT pass rate

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1702,7 +1702,7 @@ def test_tensor_atomic_cas(sem, num_ctas, device):
 
 
 @pytest.mark.interpreter
-@pytest.mark.skipif(not is_xpu() and (not is_cuda() or torch.cuda.get_device_capability()[0] < 9),
+@pytest.mark.skipif(not (is_xpu() or is_interpreter()) and (not is_cuda() or torch.cuda.get_device_capability()[0] < 9),
                     reason="Requires compute capability >= 9 for NV")
 def test_load_scope_sem_coop_grid_cta_not_one(device):
 

--- a/scripts/skiplist/default/debug.txt
+++ b/scripts/skiplist/default/debug.txt
@@ -1,4 +1,4 @@
-https://github.com/intel/intel-xpu-backend-for-triton/issues/2755
+# https://github.com/intel/intel-xpu-backend-for-triton/issues/2755
 test/unit/test_debug.py::test_device_assert[True-True-True-False]
 test/unit/test_debug.py::test_device_assert[True-False-None-False]
 test/unit/test_debug.py::test_device_assert[False-True-True-False]


### PR DESCRIPTION
This is the last PR to improve UT pass rate for PVC rolling driver. 
There are 21 remaining failures, which are tracked in https://github.com/intel/intel-xpu-backend-for-triton/issues/2755 and https://github.com/intel/intel-xpu-backend-for-triton/issues/2968.

Before:
```
debug: passed: 28, failed: 0, skipped: 20, xfailed: 0, total: 48, fixme: 0, pass rate (w/o xfailed): 58.33%
interpreter: passed: 6364, failed: 0, skipped: 1, xfailed: 697, total: 7062, fixme: 0, pass rate (w/o xfailed): 99.98%
all: passed: 18671, failed: 0, skipped: 23, xfailed: 1309, total: 20003, fixme: 48, pass rate (w/o xfailed): 99.88%
```
After:
```
debug: passed: 28, failed: 0, skipped: 19, xfailed: 0, total: 47, fixme: 0, pass rate (w/o xfailed): 59.57%
interpreter: passed: 6365, failed: 0, skipped: 0, xfailed: 697, total: 7062, fixme: 0, pass rate (w/o xfailed): 100.0%
all: passed: 18672, failed: 0, skipped: 21, xfailed: 1309, total: 20002, fixme: 48, pass rate (w/o xfailed): 99.89%
```