### PR TITLE
Reduce PyTorch logs from build step

### DIFF
--- a/.github/actions/setup-pytorch/action.yml
+++ b/.github/actions/setup-pytorch/action.yml
@@ -113,7 +113,8 @@ runs:
         cd pytorch
         pip install wheel
         pip install -r requirements.txt
-        USE_STATIC_MKL=1 CFLAGS="-Wno-error=maybe-uninitialized" python setup.py bdist_wheel
+        USE_STATIC_MKL=1 CFLAGS="-Wno-error=maybe-uninitialized" python setup.py bdist_wheel 2>&1 | grep -v \
+          "Double arithmetic operation is not supported on this platform with FP64 conversion emulation mode (poison FP64 kernels is enabled)." | grep -v '^$'
 
     - name: Install PyTorch (built from source)
       if: ${{ inputs.mode == 'source' }}


### PR DESCRIPTION
This will reduce the volume of logs by about 10 times, filtering out duplicate warnings. Tested in https://github.com/intel/intel-xpu-backend-for-triton/pull/3126.