### PR TITLE
Fix AOT compilation failed in Test with pip workflow

### DIFF
--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -34,8 +34,7 @@ def find_sycl(include_dir: list[str]) -> tuple[list[str], str]:
     icpx_path = shutil.which("icpx")
     if icpx_path and os.name != "nt":
         # only `icpx` compiler knows where sycl runtime binaries and header files are
-        icpx_dir = os.path.dirname(icpx_path)
-        compiler_root = os.path.dirname(icpx_dir)
+        compiler_root = os.path.abspath(f"{icpx_path}/../..")
         include_dir += [os.path.join(compiler_root, "include"), os.path.join(compiler_root, "include/sycl")]
         sycl_dir = os.path.join(compiler_root, "lib")
         return include_dir, sycl_dir


### PR DESCRIPTION
Use g++ instead of icpx when DLE/PTDB/ONEAPI not installed.

Information about `sycl` usage in Triton XPU.
![image](https://github.com/user-attachments/assets/4ea4b253-9785-454c-b8df-072b7b7a86bb)
