### PR TITLE
[XPU][TritonIntelGPUToLLVM] Do not generate duplicated string constants

### DIFF
--- a/test/Conversion/intel/tritonintelgpu_to_llvm.mlir
+++ b/test/Conversion/intel/tritonintelgpu_to_llvm.mlir
@@ -1,5 +1,88 @@
 // RUN: triton-opt %s --convert-triton-intel-gpu-to-llvm | FileCheck %s
 
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [16], warpsPerCTA = [4], order = [0]}>
+
 // COM: check that the spirv target env is inserted
 // CHECK: module attributes {{{.*}}spirv.target_env{{.*}}#spirv.resource_limits<subgroup_size = 16>
-module attributes { "ttg.threads-per-warp" = 16 : i32, "ttg.num-warps" = 4 : i32 } { }
+module attributes { "ttg.threads-per-warp" = 16 : i32, "ttg.num-warps" = 4 : i32 } {
+  // As the assert message is shared, a single instance is emitted.
+
+  // CHECK:         llvm.mlir.global internal constant @assertFunc_0("unknown\00") {addr_space = 1 : i32}
+  // CHECK:         llvm.mlir.global internal constant @assertFile_0("{{.*}}/test/Conversion/intel/tritonintelgpu_to_llvm.mlir\00") {addr_space = 1 : i32}
+  // CHECK:         llvm.mlir.global internal constant @assertMessage_0("assert text\00") {addr_space = 1 : i32}
+  // CHECK:         llvm.func spir_funccc @__assert_fail(!llvm.ptr<4>, !llvm.ptr<4>, i32, !llvm.ptr<4>)
+
+  // CHECK:   llvm.func spir_kernelcc @assert(%[[VAL_0:.*]]: !llvm.struct<(i1)>, %[[VAL_1:.*]]: !llvm.struct<(i1)>, %[[VAL_2:.*]]: !llvm.struct<(i1)>)
+  tt.func public @assert(%arg0: tensor<1xi1, #blocked>, %arg1: tensor<1xi1, #blocked>, %arg2: tensor<1xi1, #blocked>) {
+    // CHECK:           %[[VAL_3:.*]] = llvm.extractvalue %[[VAL_0]][0] : !llvm.struct<(i1)>
+    // CHECK:           %[[VAL_4:.*]] = llvm.mlir.constant(false) : i1
+    // CHECK:           %[[VAL_5:.*]] = llvm.mlir.constant(false) : i1
+    // CHECK:           %[[VAL_6:.*]] = llvm.icmp "eq" %[[VAL_3]], %[[VAL_5]] : i1
+    // CHECK:           %[[VAL_7:.*]] = llvm.or %[[VAL_4]], %[[VAL_6]] : i1
+    // CHECK:           llvm.cond_br %[[VAL_7]], ^bb1, ^bb2
+    // CHECK:         ^bb1:
+    // CHECK:           %[[VAL_8:.*]] = llvm.mlir.addressof @assertMessage_0 : !llvm.ptr<1>
+    // CHECK:           %[[VAL_9:.*]] = llvm.getelementptr %[[VAL_8]][0] : (!llvm.ptr<1>) -> !llvm.ptr<1>, i8
+    // CHECK:           %[[VAL_10:.*]] = llvm.mlir.addressof @assertFile_0 : !llvm.ptr<1>
+    // CHECK:           %[[VAL_11:.*]] = llvm.getelementptr %[[VAL_10]][0] : (!llvm.ptr<1>) -> !llvm.ptr<1>, i8
+    // CHECK:           %[[VAL_12:.*]] = llvm.mlir.addressof @assertFunc_0 : !llvm.ptr<1>
+    // CHECK:           %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_12]][0] : (!llvm.ptr<1>) -> !llvm.ptr<1>, i8
+    // CHECK:           %[[VAL_14:.*]] = llvm.mlir.constant
+    // CHECK:           %[[VAL_15:.*]] = llvm.addrspacecast %[[VAL_9]] : !llvm.ptr<1> to !llvm.ptr<4>
+    // CHECK:           %[[VAL_16:.*]] = llvm.addrspacecast %[[VAL_11]] : !llvm.ptr<1> to !llvm.ptr<4>
+    // CHECK:           %[[VAL_17:.*]] = llvm.addrspacecast %[[VAL_13]] : !llvm.ptr<1> to !llvm.ptr<4>
+    // CHECK:           llvm.call spir_funccc @__assert_fail(%[[VAL_15]], %[[VAL_16]], %[[VAL_14]], %[[VAL_17]]) : (!llvm.ptr<4>, !llvm.ptr<4>, i32, !llvm.ptr<4>) -> ()
+    // CHECK:           llvm.br ^bb2
+    // CHECK:         ^bb2:
+    // CHECK:           %[[VAL_18:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK:           llvm.call spir_funccc @_Z7barrierj(%[[VAL_18]]) {convergent, no_unwind, will_return} : (i32) -> ()
+    tt.assert %arg0, "assert text" : tensor<1xi1, #blocked>
+    // CHECK:           %[[VAL_19:.*]] = llvm.extractvalue %[[VAL_1]][0] : !llvm.struct<(i1)>
+    // CHECK:           %[[VAL_20:.*]] = llvm.mlir.constant(false) : i1
+    // CHECK:           %[[VAL_21:.*]] = llvm.mlir.constant(false) : i1
+    // CHECK:           %[[VAL_22:.*]] = llvm.icmp "eq" %[[VAL_19]], %[[VAL_21]] : i1
+    // CHECK:           %[[VAL_23:.*]] = llvm.or %[[VAL_20]], %[[VAL_22]] : i1
+    // CHECK:           llvm.cond_br %[[VAL_23]], ^bb3, ^bb4
+    // CHECK:         ^bb3:
+    // CHECK:           %[[VAL_24:.*]] = llvm.mlir.addressof @assertMessage_0 : !llvm.ptr<1>
+    // CHECK:           %[[VAL_25:.*]] = llvm.getelementptr %[[VAL_24]][0] : (!llvm.ptr<1>) -> !llvm.ptr<1>, i8
+    // CHECK:           %[[VAL_26:.*]] = llvm.mlir.addressof @assertFile_0 : !llvm.ptr<1>
+    // CHECK:           %[[VAL_27:.*]] = llvm.getelementptr %[[VAL_26]][0] : (!llvm.ptr<1>) -> !llvm.ptr<1>, i8
+    // CHECK:           %[[VAL_28:.*]] = llvm.mlir.addressof @assertFunc_0 : !llvm.ptr<1>
+    // CHECK:           %[[VAL_29:.*]] = llvm.getelementptr %[[VAL_28]][0] : (!llvm.ptr<1>) -> !llvm.ptr<1>, i8
+    // CHECK:           %[[VAL_30:.*]] = llvm.mlir.constant
+    // CHECK:           %[[VAL_31:.*]] = llvm.addrspacecast %[[VAL_25]] : !llvm.ptr<1> to !llvm.ptr<4>
+    // CHECK:           %[[VAL_32:.*]] = llvm.addrspacecast %[[VAL_27]] : !llvm.ptr<1> to !llvm.ptr<4>
+    // CHECK:           %[[VAL_33:.*]] = llvm.addrspacecast %[[VAL_29]] : !llvm.ptr<1> to !llvm.ptr<4>
+    // CHECK:           llvm.call spir_funccc @__assert_fail(%[[VAL_31]], %[[VAL_32]], %[[VAL_30]], %[[VAL_33]]) : (!llvm.ptr<4>, !llvm.ptr<4>, i32, !llvm.ptr<4>) -> ()
+    // CHECK:           llvm.br ^bb4
+    // CHECK:         ^bb4:
+    // CHECK:           %[[VAL_34:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK:           llvm.call spir_funccc @_Z7barrierj(%[[VAL_34]]) {convergent, no_unwind, will_return} : (i32) -> ()
+    tt.assert %arg1, "assert text" : tensor<1xi1, #blocked>
+    // CHECK:           %[[VAL_35:.*]] = llvm.extractvalue %[[VAL_2]][0] : !llvm.struct<(i1)>
+    // CHECK:           %[[VAL_36:.*]] = llvm.mlir.constant(false) : i1
+    // CHECK:           %[[VAL_37:.*]] = llvm.mlir.constant(false) : i1
+    // CHECK:           %[[VAL_38:.*]] = llvm.icmp "eq" %[[VAL_35]], %[[VAL_37]] : i1
+    // CHECK:           %[[VAL_39:.*]] = llvm.or %[[VAL_36]], %[[VAL_38]] : i1
+    // CHECK:           llvm.cond_br %[[VAL_39]], ^bb5, ^bb6
+    // CHECK:         ^bb5:
+    // CHECK:           %[[VAL_40:.*]] = llvm.mlir.addressof @assertMessage_0 : !llvm.ptr<1>
+    // CHECK:           %[[VAL_41:.*]] = llvm.getelementptr %[[VAL_40]][0] : (!llvm.ptr<1>) -> !llvm.ptr<1>, i8
+    // CHECK:           %[[VAL_42:.*]] = llvm.mlir.addressof @assertFile_0 : !llvm.ptr<1>
+    // CHECK:           %[[VAL_43:.*]] = llvm.getelementptr %[[VAL_42]][0] : (!llvm.ptr<1>) -> !llvm.ptr<1>, i8
+    // CHECK:           %[[VAL_44:.*]] = llvm.mlir.addressof @assertFunc_0 : !llvm.ptr<1>
+    // CHECK:           %[[VAL_45:.*]] = llvm.getelementptr %[[VAL_44]][0] : (!llvm.ptr<1>) -> !llvm.ptr<1>, i8
+    // CHECK:           %[[VAL_46:.*]] = llvm.mlir.constant
+    // CHECK:           %[[VAL_47:.*]] = llvm.addrspacecast %[[VAL_41]] : !llvm.ptr<1> to !llvm.ptr<4>
+    // CHECK:           %[[VAL_48:.*]] = llvm.addrspacecast %[[VAL_43]] : !llvm.ptr<1> to !llvm.ptr<4>
+    // CHECK:           %[[VAL_49:.*]] = llvm.addrspacecast %[[VAL_45]] : !llvm.ptr<1> to !llvm.ptr<4>
+    // CHECK:           llvm.call spir_funccc @__assert_fail(%[[VAL_47]], %[[VAL_48]], %[[VAL_46]], %[[VAL_49]]) : (!llvm.ptr<4>, !llvm.ptr<4>, i32, !llvm.ptr<4>) -> ()
+    // CHECK:           llvm.br ^bb6
+    // CHECK:         ^bb6:
+    // CHECK:           %[[VAL_50:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK:           llvm.call spir_funccc @_Z7barrierj(%[[VAL_50]]) {convergent, no_unwind, will_return} : (i32) -> ()
+    tt.assert %arg2, "assert text" : tensor<1xi1, #blocked>
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PrintOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PrintOpToLLVM.cpp
@@ -223,9 +223,11 @@ struct PrintOpConversion
     llvm::SmallString<64> msgNewline(msg);
     msgNewline.push_back('\n');
     msgNewline.push_back('\0');
-    Value msgValue = LLVM::intel::addStringToModule(
-        UnknownLoc::get(rewriter.getContext()), rewriter, "printfFormat_",
-        msgNewline, TritonGEN::TritonGENMemorySpace::kUniformConstant);
+    Value msgValue =
+        static_cast<const intel::TargetInfo &>(targetInfo)
+            .getGlobalStringStart(rewriter.getUnknownLoc(), rewriter,
+                                  "printfFormat_", msgNewline,
+                                  /*addressSpace=*/TritonGEN::kUniformConstant);
     targetInfo.printf(rewriter, msgValue, msgNewline.size_in_bytes(), args);
     if (formatStrByteCount)
       *formatStrByteCount = msgNewline.size_in_bytes();

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.cpp
@@ -229,9 +229,9 @@ void TargetInfo::printf(RewriterBase &rewriter, StringRef msg,
   llvm::SmallString<64> msgNewline(msg);
   msgNewline.push_back('\n');
   msgNewline.push_back('\0');
-  Value msgValue = LLVM::intel::addStringToModule(
-      UnknownLoc::get(rewriter.getContext()), rewriter, "printfFormat_",
-      msgNewline, /*AddressSpace*/ TritonGEN::kUniformConstant);
+  Value msgValue = getGlobalStringStart(
+      rewriter.getUnknownLoc(), rewriter, "printfFormat_", msgNewline,
+      /*addressSpace=*/TritonGEN::kUniformConstant);
   printf(rewriter, msgValue, msgNewline.size_in_bytes(), args);
 }
 
@@ -271,12 +271,15 @@ void TargetInfo::assertFail(RewriterBase &rewriter, Location loc,
   messageString.push_back('\0');
   fileString.push_back('\0');
   funcString.push_back('\0');
-  Value messageStringVal = LLVM::intel::addStringToModule(
-      loc, rewriter, "assertMessage_", messageString, addrSpace);
-  Value fileStringVal = LLVM::intel::addStringToModule(
-      loc, rewriter, "assertFile_", fileString, addrSpace);
-  Value funcStringVal = LLVM::intel::addStringToModule(
-      loc, rewriter, "assertFunc_", funcString, addrSpace);
+  Value messageStringVal =
+      getGlobalStringStart(loc, rewriter, "assertMessage_", messageString,
+                           /*addressSpace=*/TritonGEN::kCrossWorkgroup);
+  Value fileStringVal =
+      getGlobalStringStart(loc, rewriter, "assertFile_", fileString,
+                           /*addressSpace=*/TritonGEN::kCrossWorkgroup);
+  Value funcStringVal =
+      getGlobalStringStart(loc, rewriter, "assertFunc_", funcString,
+                           /*addressSpace=*/TritonGEN::kCrossWorkgroup);
   Value lineNumber = i32_val(line);
 
   auto *ctx = rewriter.getContext();
@@ -310,6 +313,52 @@ Value TargetInfo::getStackPointer(RewriterBase &rewriter,
   if (mod->getAttrOfType<IntegerAttr>("ttg.shared").getInt() == 0)
     return rewriter.create<LLVM::PoisonOp>(funcOp.getLoc(), ptrTy);
   return funcOp.getArgument(funcOp.getNumArguments() - 1);
+}
+
+Value TargetInfo::getGlobalStringStart(Location loc, RewriterBase &rewriter,
+                                       StringRef name, StringRef value,
+                                       unsigned addressSpace) const {
+  LLVM::GlobalOp global =
+      getGlobalString(loc, rewriter, name, value, addressSpace);
+  MLIRContext *ctx = rewriter.getContext();
+  Type globalPtrType = ptr_ty(ctx, addressSpace);
+  Value globalPtr = rewriter.create<LLVM::AddressOfOp>(loc, global);
+  return gep(globalPtrType, i8_ty, globalPtr, LLVM::GEPArg{0});
+}
+
+LLVM::GlobalOp TargetInfo::getGlobalString(Location loc, RewriterBase &rewriter,
+                                           StringRef name, StringRef value,
+                                           unsigned addressSpace) const {
+  StringAttr valueAttr = rewriter.getStringAttr(value);
+  std::pair<unsigned, StringAttr> cacheKey{addressSpace, valueAttr};
+  auto pos = globals.find(cacheKey);
+  if (pos != globals.end())
+    return pos->second;
+  ModuleOp moduleOp = rewriter.getInsertionPoint()->getParentOfType<ModuleOp>();
+  unsigned stringNumber = 0;
+  SmallString<16> stringConstName;
+  do {
+    stringConstName.clear();
+    (name + Twine(stringNumber++)).toStringRef(stringConstName);
+  } while (moduleOp.lookupSymbol(stringConstName));
+
+  llvm::SmallString<64> contentStr(value);
+  size_t contentSize = contentStr.size_in_bytes();
+  auto globalType = LLVM::LLVMArrayType::get(i8_ty, contentSize);
+
+  LLVM::GlobalOp global;
+  {
+    RewriterBase::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(moduleOp.getBody());
+    global = rewriter.create<LLVM::GlobalOp>(
+        rewriter.getUnknownLoc(), globalType,
+        /*isConstant=*/true, LLVM::Linkage::Internal, stringConstName,
+        valueAttr, /*alignment=*/0, addressSpace);
+  }
+
+  globals.try_emplace(cacheKey, global);
+
+  return global;
 }
 
 } // namespace mlir::triton::intel

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.h
@@ -11,6 +11,8 @@
 
 #include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
 
+#include <mlir/Dialect/LLVMIR/LLVMDialect.h>
+
 namespace mlir::triton::intel {
 class TargetInfo : public mlir::triton::TargetInfoBase {
 public:
@@ -69,7 +71,17 @@ public:
   Value getStackPointer(RewriterBase &rewriter,
                         FunctionOpInterface funcOp) const override;
 
+  Value getGlobalStringStart(Location loc, RewriterBase &rewriter,
+                             StringRef name, StringRef value,
+                             unsigned addressSpace) const;
+
 private:
+  LLVM::GlobalOp getGlobalString(Location loc, RewriterBase &rewriter,
+                                 StringRef name, StringRef value,
+                                 unsigned addressSpace) const;
+
+  mutable llvm::DenseMap<std::pair<unsigned, StringAttr>, LLVM::GlobalOp>
+      globals;
 };
 } // namespace mlir::triton::intel
 #endif // TRITON_CONVERSION_TRITONGPU_TO_LLVM_TARGETINFOINTEL_H

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
@@ -82,40 +82,6 @@ Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, Value i) {
   return shuffleCommon(loc, rewriter, val, i, mlir::gpu::ShuffleMode::IDX);
 }
 
-Value addStringToModule(Location loc, RewriterBase &rewriter, StringRef key,
-                        StringRef content, unsigned addressSpace) {
-  auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
-  auto ctx = moduleOp.getContext();
-  unsigned stringNumber = 0;
-  SmallString<16> stringConstName;
-  do {
-    stringConstName.clear();
-    (key + Twine(stringNumber++)).toStringRef(stringConstName);
-  } while (moduleOp.lookupSymbol(stringConstName));
-
-  llvm::SmallString<64> contentStr(content);
-  size_t contentSize = contentStr.size_in_bytes();
-  auto globalType = LLVM::LLVMArrayType::get(i8_ty, contentSize);
-
-  LLVM::GlobalOp global;
-  {
-    RewriterBase::InsertionGuard guard(rewriter);
-    rewriter.setInsertionPointToStart(moduleOp.getBody());
-    global = rewriter.create<LLVM::GlobalOp>(
-        UnknownLoc::get(ctx), globalType,
-        /*isConstant=*/true, LLVM::Linkage::Internal, stringConstName,
-        rewriter.getStringAttr(contentStr), /*alignment=*/0, addressSpace);
-  }
-
-  Value zero = i32_val(0);
-  Type globalPtrType = LLVM::LLVMPointerType::get(ctx, global.getAddrSpace());
-  Value globalPtr = rewriter.create<LLVM::AddressOfOp>(
-      UnknownLoc::get(ctx), globalPtrType, global.getSymName());
-  Value stringStart = gep(ptr_ty(ctx, global.getAddrSpace()), i8_ty, globalPtr,
-                          SmallVector<Value>({zero}));
-  return stringStart;
-}
-
 // declare __spirv_ocl_printf(i8*, ...) as external function
 LLVM::LLVMFuncOp getSpirvPrintfDeclaration(RewriterBase &rewriter) {
   auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
@@ -78,9 +78,6 @@ Value shuffleUp(Location loc, RewriterBase &rewriter, Value val, int i);
 Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, int i);
 Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, Value i);
 
-Value addStringToModule(Location loc, RewriterBase &rewriter, StringRef key,
-                        StringRef content, unsigned addressSpace);
-
 LLVM::LLVMFuncOp getSpirvPrintfDeclaration(RewriterBase &rewriter);
 
 static Value getModuleWarpSize(RewriterBase &rewriter, Location loc) {


### PR DESCRIPTION
Do not generate duplicated string constants as result of `tt.assert` or `tt.print` operations. Use a string constant cache to avoid duplication.

Closes #3054.