### PR TITLE
[NFC] Move `convertFp32ToFp16` to utility

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
@@ -88,6 +88,9 @@ static Value getModuleWarpSize(RewriterBase &rewriter, Location loc) {
   return i32_val(triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod));
 }
 
+Value convertFp32ToFp16(Location loc, ConversionPatternRewriter &rewriter,
+                        const Value &v, triton::RoundingMode rounding);
+
 } // namespace mlir::LLVM::intel
 
 using mlir::triton::gpu::intel::DpasEncodingAttr;


### PR DESCRIPTION
Similar to upstream commit f9d9fad1b7b648e73ef03332737f000bed258f13, this PR moves static function `convertFp32ToFp16` to utility, so it can be used to support fp16 upcast in scaled dot.

Part of #3141.