### PR TITLE
[Intel] Port changes to support fp16 scaled dot

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/UpcastMXFPToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/UpcastMXFPToLLVM.cpp
@@ -16,6 +16,53 @@ using namespace mlir::triton::gpu::intel;
 
 namespace {
 
+SmallVector<Value> convertMxfp4x2ToFp16x2(RewriterBase &rewriter, Location loc,
+                                          ArrayRef<Value> values) {
+  SmallVector<Value> results;
+  for (auto v : values) {
+    auto em0 = and_(v, i8_val(0x7));
+    auto em1 = and_(v, i8_val(0x70));
+    // FP16 bits: sign = 1, exponent = 5, mantissa = 10
+    Value v0 = or_(shl(zext(i16_ty, em0), i16_val(10 - 1)),
+                   shl(zext(i16_ty, and_(v, i8_val(0x8))), i16_val(12)));
+    Value v1 = or_(shl(zext(i16_ty, em1), i16_val(10 - 1 - 4)),
+                   shl(zext(i16_ty, and_(v, i8_val(0x80))), i16_val(8)));
+
+    // Three cases:
+    // 1) x is normal and non-zero: Correct bias
+    v0 = select(icmp_ne(and_(em0, i8_val(0x6)), i8_val(0)),
+                add(v0, i16_val((15 - 1) << 10)), v0);
+    v1 = select(icmp_ne(and_(em1, i8_val(0x60)), i8_val(0)),
+                add(v1, i16_val((15 - 1) << 10)), v1);
+
+    // 2) x is subnormal (x == 0bs001 where s is the sign): Map to fp16 +-0.5
+    v0 = bitcast(select(icmp_eq(em0, i8_val(0x1)),
+                        or_(i16_val(0x3800), and_(v0, i16_val(0x8000))), v0),
+                 f16_ty);
+    v1 = bitcast(select(icmp_eq(em1, i8_val(0x10)),
+                        or_(i16_val(0x3800), and_(v1, i16_val(0x8000))), v1),
+                 f16_ty);
+    // 3) x is zero, nothing to do
+    results.push_back(v0);
+    results.push_back(v1);
+  }
+  return results;
+}
+
+Value mxfpScaleFp16(ConversionPatternRewriter &rewriter, Location loc, Value v,
+                    Value scale, bool fastMath) {
+  Value scaleF32 = bitcast(shl(zext(i32_ty, scale), i32_val(23)), f32_ty);
+  Value scaleF16 = LLVM::intel::convertFp32ToFp16(loc, rewriter, scaleF32,
+                                                  RoundingMode::RTNE);
+  Value mulF16 = fmul(v, scaleF16);
+  if (fastMath)
+    return mulF16;
+  // Account for NaN in the scale as per the mxfp specification.
+  Value scaleIsNan = icmp_eq(scale, i8_val(0xff));
+  Value nanF16 = bitcast(i16_val(0x7c01), f16_ty);
+  return select(scaleIsNan, nanF16, bitcast(mulF16, f16_ty));
+};
+
 static Value mxfpScaleBf16(ConversionPatternRewriter &rewriter, Location loc,
                            Value v, Value scale, bool fastMath) {
   Value vBf16 = bitcast(v, bf16_ty);
@@ -61,8 +108,11 @@ public:
     Value warpId = udiv(tid, warpSize);
     Value laneId = urem(tid, warpSize);
 
-    if (fpType == ScaleDotElemType::E2M1)
-      xVals = LLVM::convertMxfp4x2ToBf16x2(rewriter, loc, xVals);
+    bool useFp16 = op.getType().getElementType().isF16();
+    if (fpType == ScaleDotElemType::E2M1) {
+      xVals = useFp16 ? convertMxfp4x2ToFp16x2(rewriter, loc, xVals)
+                      : LLVM::convertMxfp4x2ToBf16x2(rewriter, loc, xVals);
+    }
 
     auto xType = cast<RankedTensorType>(op->getOperandTypes()[0]);
     auto dotEnc = cast<DotOperandEncodingAttr>(xType.getEncoding());
@@ -106,8 +156,11 @@ public:
             for (int k = 0; k < kWidth; ++k) {
               unsigned idx = i * scalingBlockSize + mxfp * mxfpSize +
                              rep * subTileSize * kWidth + subTile * kWidth + k;
-              xVals[idx] = mxfpScaleBf16(rewriter, loc, xVals[idx], si[subTile],
-                                         op.getFastMath());
+              xVals[idx] = useFp16
+                               ? mxfpScaleFp16(rewriter, loc, xVals[idx],
+                                               si[subTile], op.getFastMath())
+                               : mxfpScaleBf16(rewriter, loc, xVals[idx],
+                                               si[subTile], op.getFastMath());
             }
           }
         }


### PR DESCRIPTION
These changes are ported from f9d9fad1b7b648e73ef03332737f000bed258f13, but they are not enough to make fp16 scaled dot unit tests to pass, more investigation is needed to enable those test cases.

Part of #3141.