### PR TITLE
Fix multiple `triton-kernels-benchmark` bug

### DIFF
--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -113,7 +113,7 @@ jobs:
         id: install
         run: |
           cd benchmarks
-          python setup.py install
+          pip install .
 
       - name: Run Triton Softmax kernel benchmark
         if: ${{ steps.install.outcome == 'success' && !cancelled() && !contains(fromJson(inputs.skip_benchmarks || '[]'), 'fused_softmax.py') }}

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -261,7 +261,7 @@ run_benchmark_softmax() {
   echo "*****             Running Softmax              *****"
   echo "****************************************************"
   cd $TRITON_PROJ/benchmarks
-  python setup.py install
+  pip install .
   python $TRITON_PROJ/benchmarks/triton_kernels_benchmark/fused_softmax.py
 }
 
@@ -270,7 +270,7 @@ run_benchmark_gemm() {
   echo "*****              Running GEMM                *****"
   echo "****************************************************"
   cd $TRITON_PROJ/benchmarks
-  python setup.py install
+  pip install .
 
   echo "Default path:"
   python $TRITON_PROJ/benchmarks/triton_kernels_benchmark/gemm_benchmark.py
@@ -287,7 +287,7 @@ run_benchmark_attention() {
   echo "*****            Running ATTENTION             *****"
   echo "****************************************************"
   cd $TRITON_PROJ/benchmarks
-  python setup.py install
+  pip install .
 
   echo "Forward - Default path:"
   python $TRITON_PROJ/benchmarks/triton_kernels_benchmark/flash_attention_benchmark.py
@@ -305,7 +305,7 @@ run_benchmark_attention() {
 
 run_benchmarks() {
   cd $TRITON_PROJ/benchmarks
-  python setup.py install
+  pip install .
   for file in $TRITON_PROJ/benchmarks/triton_kernels_benchmark/*.py; do
     benchmark=$(basename -- "$file" .py)
     if [[ $benchmark = @("__init__"|"benchmark_driver"|"benchmark_testing") ]]; then


### PR DESCRIPTION
Before this PR different versions of `triton-kernels-benchmark` can coexist, which is an unexpected/incorrect behavior. And it is possible that the old version has a hash that is lexicographically higher in the sort, which causes the old version to be unexpectedly used.

More details can be found here: https://github.com/pypa/pip/issues/12330