### PR TITLE
[FA] Add script to run the FlashAttention benchmark

### DIFF
--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -218,10 +218,6 @@ jobs:
           AGAMA_VERSION=$AGAMA_VERSION
           EOF
 
-      - name: Run model scripts
-        run: |
-          ./scripts/flash_attention.py -Z 64 -H 64 -N-CTX 64 -D-HEAD 64
-
       - name: Upload pass rate report
         # upload reports only for the default branch
         if: github.ref_name == 'main'

--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -218,6 +218,10 @@ jobs:
           AGAMA_VERSION=$AGAMA_VERSION
           EOF
 
+      - name: Run model scripts
+        run: |
+          ./scripts/flash_attention.py -Z 64 -H 64 -N-CTX 64 -D-HEAD 64
+
       - name: Upload pass rate report
         # upload reports only for the default branch
         if: github.ref_name == 'main'

--- a/scripts/flash_attention.py
+++ b/scripts/flash_attention.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import argparse
+
+from triton_kernels_benchmark.flash_attention_benchmark import benchmark
+
+
+def get_options():
+    parser = argparse.ArgumentParser(prog='flash-attention', description='Run Intel XPU Flash-Attention implementation')
+    parser.add_argument('-Z', type=int, required=True, help='Batch size')
+    parser.add_argument('-H', type=int, required=True, help='Head count')
+    parser.add_argument('-N-CTX', type=int, required=True, help='Sequence length')
+    parser.add_argument('-D-HEAD', type=int, required=True, help='Embedding dimension')
+    parser.add_argument('-causal', action='store_true', help='Run causal attention')
+    parser.add_argument('-backward', action='store_true', help='Run backward attention')
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    options = get_options()
+    PROVIDER = 'triton'
+    MODE = 'bwd' if options.backward else 'fwd'
+    benchmark.fn(options.Z, options.H, options.N_CTX, options.D_HEAD, options.causal, MODE, PROVIDER)


### PR DESCRIPTION
Add script to run the FlashAttention benchmark implementation passing the same arguments as the `benchmark` function.

Run script in CI (single FA run) to make sure it remains usable and signatures remain up to date.