### PR TITLE
Add input `pytorch_mode` to workflow `build-test-windows`

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -44,19 +44,26 @@ jobs:
         run: |
           Copy-Item -Path ${{ github.workspace }} -Destination ${{ env.NEW_WORKSPACE }} -Recurse
 
+      - name: Create venv
+        run:
+          python -m venv ${{ env.NEW_WORKSPACE }}\venv
+
       # FIXME: the runner has PyTorch wheels pre-compiled from sources in a specific location
       - name: Install PyTorch (source)
         if: ${{ (inputs.pytorch_mode || 'source') == 'source' }}
         run: |
+          ${{ env.NEW_WORKSPACE }}\venv\Scripts\Activate.ps1
           pip install (Get-Item C:\pytorch\dist\*.whl)
 
       - name: Install PyTorch (wheels)
         if: ${{ (inputs.pytorch_mode || 'source') == 'wheels' }}
         run: |
+          ${{ env.NEW_WORKSPACE }}\venv\Scripts\Activate.ps1
           pip install torch --index-url https://download.pytorch.org/whl/nightly/xpu
 
       - name: PyTorch version
         run: |
+          ${{ env.NEW_WORKSPACE }}\venv\Scripts\Activate.ps1
           Invoke-BatchFile "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           python -c 'import torch;print(torch.__version__)'
 
@@ -65,6 +72,7 @@ jobs:
       # runner.
       - name: Setup Triton
         run: |
+          ${{ env.NEW_WORKSPACE }}\venv\Scripts\Activate.ps1
           cd ${{ env.NEW_WORKSPACE }}
           Invoke-BatchFile "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
           cd python
@@ -73,25 +81,30 @@ jobs:
 
       - name: Triton version
         run: |
+          ${{ env.NEW_WORKSPACE }}\venv\Scripts\Activate.ps1
           Invoke-BatchFile "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           python -c 'import triton; print(triton.__version__)'
 
       - name: Install test dependencies
         run: |
+          ${{ env.NEW_WORKSPACE }}\venv\Scripts\Activate.ps1
           pip install -r scripts\requirements-test.txt
 
       - name: Run core tests
         run: |
+          ${{ env.NEW_WORKSPACE }}\venv\Scripts\Activate.ps1
           Invoke-BatchFile "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           ${{ env.TRITON_TEST_CMD }} --core
 
       - name: Run interpreter tests
         run: |
+          ${{ env.NEW_WORKSPACE }}\venv\Scripts\Activate.ps1
           Invoke-BatchFile "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           ${{ env.TRITON_TEST_CMD }} --interpreter
 
       - name: Pass rate
         run: |
+          ${{ env.NEW_WORKSPACE }}\venv\Scripts\Activate.ps1
           pip install defusedxml
           Invoke-BatchFile "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           bash -c "\

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -2,6 +2,15 @@ name: Build and test on Windows
 
 on:
   workflow_dispatch:
+    inputs:
+      pytorch_mode:
+        description: PyTorch mode, source or wheels
+        type: choice
+        options:
+          - source
+          - wheels
+        default: source
+
   schedule:
     - cron: "1 5 * * *"
 
@@ -34,6 +43,17 @@ jobs:
       - name: Copy workspace
         run: |
           Copy-Item -Path ${{ github.workspace }} -Destination ${{ env.NEW_WORKSPACE }} -Recurse
+
+      # FIXME: the runner has PyTorch wheels pre-compiled from sources in a specific location
+      - name: Install PyTorch (source)
+        if: ${{ (inputs.pytorch_mode || 'source') == 'source' }}
+        run: |
+          pip install (Get-Item C:\pytorch\dist\*.whl)
+
+      - name: Install PyTorch (wheels)
+        if: ${{ (inputs.pytorch_mode || 'source') == 'wheels' }}
+        run: |
+          pip install torch --index-url https://download.pytorch.org/whl/nightly/xpu
 
       - name: PyTorch version
         run: |


### PR DESCRIPTION
By default PyTorch compiled from sources will be used.

Fixes #3188.