### PR TITLE
Add a770 arch to `arch_parser.c`

### DIFF
--- a/third_party/intel/backend/arch_parser.c
+++ b/third_party/intel/backend/arch_parser.c
@@ -32,6 +32,9 @@ static PyObject *parseDeviceArch(PyObject *self, PyObject *args) {
   case sycl::ext::oneapi::experimental::architecture::intel_gpu_lnl_m:
     arch = "lnl";
     break;
+  case sycl::ext::oneapi::experimental::architecture::intel_gpu_dg2_g10:
+    arch = "dg2";
+    break;
   default:
     std::cerr << "sycl_arch not recognized: " << (int)sycl_arch << std::endl;
   }


### PR DESCRIPTION
https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/12846719530 (I don't observe `sycl_arch not recognized` messages in logs)

Refs:
* https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_architecture.asciidoc
* https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/developer-guide-reference/2025-0/ahead-of-time-compilation.html