### PR TITLE
Properly specify `std:c++17` for msvc

### DIFF
--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -11,7 +11,7 @@ def is_xpu():
 
 def _cc_cmd(cc, src, out, include_dirs, library_dirs, libraries):
     if "cl.EXE" in cc or "clang-cl" in cc:
-        cc_cmd = [cc, "/Zc:__cplusplus", src, "/nologo", "/O2", "/LD"]
+        cc_cmd = [cc, "/Zc:__cplusplus", "/std:c++17", src, "/nologo", "/O2", "/LD"]
         cc_cmd += [f"/I{dir}" for dir in include_dirs]
         cc_cmd += [f"/Fo{os.path.join(os.path.dirname(out), 'main.obj')}"]
         cc_cmd += ["/link"]
@@ -77,7 +77,8 @@ def _build(name, src, srcdir, library_dirs, include_dirs, libraries, extra_compi
         if cxx is icpx:
             extra_compile_args += ["-fsycl"]
         else:
-            extra_compile_args += ["--std=c++17"]
+            if os.name != "nt":
+                extra_compile_args += ["--std=c++17"]
         if os.name == "nt":
             library_dirs = library_dirs + [
                 os.path.abspath(os.path.join(sysconfig.get_paths(scheme=scheme)["stdlib"], "..", "libs"))


### PR DESCRIPTION
Checked in https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/12853365457.

Ref: https://github.com/microsoft/vscode-cpptools/issues/10510#issuecomment-1435090442. Both options should be the same for the compiler. However, in the previous case c++17 option was specified after `link`, maybe that's why it didn't work.