### PR TITLE
Check if `ocloc` in `PATH` before using it

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -156,7 +156,7 @@ class XPUBackend(BaseBackend):
         dev_prop['has_bfloat16_conversions'] = tgt_prop.get('has_bfloat16_conversions', True)
 
         device_arch = self.parse_device_arch(tgt_prop.get('architecture', 0))
-        if device_arch:
+        if device_arch and shutil.which('ocloc'):
             if device_arch in self.device_props:
                 dev_prop.update(self.device_props[device_arch])
                 return dev_prop


### PR DESCRIPTION
Part of #3177.

When running with pip dependencies, `ocloc` may not be present in `PATH`.