### PR TITLE
Remove scaled_dot from skiplist

### DIFF
--- a/scripts/skiplist/default/language.txt
+++ b/scripts/skiplist/default/language.txt
@@ -1,11 +1,2 @@
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/2968
-test/unit/language/test_core.py::test_scaled_dot[128-32-64-True-False-True-e4m3-bf16-4-16-1]
-test/unit/language/test_core.py::test_scaled_dot[128-32-64-True-False-True-e4m3-fp16-4-16-1]
-test/unit/language/test_core.py::test_scaled_dot[128-32-64-True-True-True-e4m3-bf16-4-16-1]
-test/unit/language/test_core.py::test_scaled_dot[32-64-128-False-False-True-e5m2-bf16-4-16-1]
-test/unit/language/test_core.py::test_scaled_dot[64-32-64-False-False-True-e4m3-fp16-4-16-1]
-test/unit/language/test_core.py::test_scaled_dot[64-64-128-False-True-True-e5m2-bf16-4-16-1]
-test/unit/language/test_core.py::test_scaled_dot[128-128-128-True-False-False-e4m3-bf16-4-16-1]
-test/unit/language/test_core.py::test_scaled_dot[128-128-128-True-False-False-e4m3-fp16-4-16-1]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/3556
 test/unit/language/test_core.py::test_convert_mma2mma[mma_pair0-float16-256-256]

--- a/scripts/skiplist/xe2/language.txt
+++ b/scripts/skiplist/xe2/language.txt
@@ -1,2 +1,0 @@
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/2968
-test/unit/language/test_core.py::test_scaled_dot[128-32-64-False-False-True-e4m3-bf16-4-16-1]


### PR DESCRIPTION
With fix in #3606 and #3607 , it can pass these failed case now.