### PR TITLE
Use `time.perf_counter_ns` instead of `time.time_ns` to have sub-microsecond precision on both Linux and Windows

### DIFF
--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -54,7 +54,7 @@ class WallEvent():
         self.record()
 
     def record(self):
-        self.timestamp = time.time_ns() / 1_000_000
+        self.timestamp = time.perf_counter_ns() / 1_000_000
 
     def elapsed_time(self, end):
         return end.timestamp - self.timestamp


### PR DESCRIPTION
Refs:
* https://docs.python.org/3.9/library/time.html#time.perf_counter_ns
* https://stackoverflow.com/a/38319607

Part of #3072