### PR TITLE
Implement `arch_parser.c` as pure dll

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -132,7 +132,7 @@ class XPUBackend(BaseBackend):
             raise TypeError("target.arch is not a dict")
         dirname = os.path.dirname(os.path.realpath(__file__))
         mod = compile_module_from_src(Path(os.path.join(dirname, "arch_parser.c")).read_text(), "arch_utils")
-        self.parse_device_arch = mod.parse_device_arch
+        self.device_arch = mod.parse_device_arch(target.arch.get('architecture', 0))
         self.properties = self.parse_target(target.arch)
         self.binary_ext = "spv"
 
@@ -155,13 +155,12 @@ class XPUBackend(BaseBackend):
         dev_prop['has_subgroup_2d_block_io'] = tgt_prop.get('has_subgroup_2d_block_io', False)
         dev_prop['has_bfloat16_conversions'] = tgt_prop.get('has_bfloat16_conversions', True)
 
-        device_arch = self.parse_device_arch(tgt_prop.get('architecture', 0))
-        if device_arch and shutil.which('ocloc'):
-            if device_arch in self.device_props:
-                dev_prop.update(self.device_props[device_arch])
+        if self.device_arch and shutil.which('ocloc'):
+            if self.device_arch in self.device_props:
+                dev_prop.update(self.device_props[self.device_arch])
                 return dev_prop
             try:
-                ocloc_cmd = ['ocloc', 'query', 'CL_DEVICE_EXTENSIONS', '-device', device_arch]
+                ocloc_cmd = ['ocloc', 'query', 'CL_DEVICE_EXTENSIONS', '-device', self.device_arch]
                 with tempfile.TemporaryDirectory() as temp_dir:
                     output = subprocess.check_output(ocloc_cmd, text=True, cwd=temp_dir)
                 supported_extensions = set()
@@ -174,7 +173,7 @@ class XPUBackend(BaseBackend):
                     'has_subgroup_matrix_multiply_accumulate_tensor_float32'] = 'cl_intel_subgroup_matrix_multiply_accumulate_tensor_float32' in supported_extensions
                 ocloc_dev_prop['has_subgroup_2d_block_io'] = 'cl_intel_subgroup_2d_block_io' in supported_extensions
                 ocloc_dev_prop['has_bfloat16_conversions'] = 'cl_intel_bfloat16_conversions' in supported_extensions
-                self.device_props[device_arch] = ocloc_dev_prop
+                self.device_props[self.device_arch] = ocloc_dev_prop
                 dev_prop.update(ocloc_dev_prop)
             except subprocess.CalledProcessError:
                 # Note: LTS driver does not support ocloc query CL_DEVICE_EXTENSIONS.

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -154,7 +154,6 @@ class ArchParser:
 
         return super().__getattribute__(name)
 
-
     if os.name != 'nt':
 
         def __del__(self):

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -2,6 +2,7 @@ import importlib.metadata
 import os
 import hashlib
 import shutil
+import ctypes
 import sysconfig
 import tempfile
 from pathlib import Path
@@ -134,6 +135,40 @@ class CompilationHelper:
 COMPILATION_HELPER = CompilationHelper()
 
 
+class ArchParser:
+
+    def __init__(self, cache_path: str):
+        self.shared_library = ctypes.CDLL(cache_path)
+        self.shared_library.parse_device_arch.restype = ctypes.c_char_p
+        self.shared_library.parse_device_arch.argtypes = (ctypes.c_uint64, )
+
+    def __getattribute__(self, name):
+        if name == "parse_device_arch":
+            shared_library = super().__getattribute__("shared_library")
+            attr = getattr(shared_library, name)
+
+            def wrapper(*args, **kwargs):
+                return attr(*args, **kwargs).decode("utf-8")
+
+            return wrapper
+
+        return super().__getattribute__(name)
+
+
+    if os.name != 'nt':
+
+        def __del__(self):
+            handle = self.shared_library._handle
+            self.shared_library.dlclose.argtypes = (ctypes.c_void_p, )
+            self.shared_library.dlclose(handle)
+    else:
+
+        def __del__(self):
+            handle = self.shared_library._handle
+            ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64, )
+            ctypes.windll.kernel32.FreeLibrary(handle)
+
+
 def compile_module_from_src(src, name):
     key = hashlib.sha256(src.encode("utf-8")).hexdigest()
     cache = get_cache_manager(key)
@@ -155,6 +190,10 @@ def compile_module_from_src(src, name):
                         COMPILATION_HELPER.libraries, extra_compile_args=extra_compiler_args)
             with open(so, "rb") as f:
                 cache_path = cache.put(f.read(), file_name, binary=True)
+
+    if name == 'arch_utils':
+        return ArchParser(cache_path)
+
     import importlib.util
     spec = importlib.util.spec_from_file_location(name, cache_path)
     mod = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
This should avoid issues like: `ImportError: DLL load failed while importing arch_utils: The parameter is incorrect.` on windows. One could see this issue here: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/12901598261/job/35973923326.

As a result, this may solve the following problem (if we make such a change for all modules): https://github.com/intel/intel-xpu-backend-for-triton/issues/3090

After this PR this issue still exists, for example for `__triton_launcher`:
<img width="725" alt="image" src="https://github.com/user-attachments/assets/7f429536-5804-42a8-bed2-40e20bbf1cd1" />


CI: 
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/12918288250 (**Pass rate: 93.2%**, ~30 fixed tests in comparison with https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/12901598261/job/35973923326)

Ref: https://github.com/python/cpython/issues/114538