### PR TITLE
Fix error: enumeration value 'OperandC' not handled in switch

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -397,6 +397,9 @@ private:
       repInner = repetitions[1];
       repClusterOuter = repCluster[rank - 1];
     } break;
+    case DpasEncodingAttr::OpIdx::OperandC: {
+      llvm_unreachable("unexpected OpIdx::OperandC");
+    } break;
     }
 
     // TODO: Operands B requires extra steps to combine [8, 16] to [16, 16].

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -861,6 +861,9 @@ struct LoadOpConversion
                           i32_val(outer * repOuterStride + rep * repStride));
             offsetY = i32_val(k * repKStride);
           } break;
+          case DpasEncodingAttr::OpIdx::OperandC: {
+            llvm_unreachable("unexpected OpIdx::OperandC");
+          } break;
           }
 
           offsetX = add(offsetX, offsetBaseX);
@@ -941,6 +944,9 @@ struct LoadOpConversion
                                 vblk * packedColNumPerVBlock + col,
                             k + row}] =
                       bitcast(loadVal, unpackedDPASOperandType);
+                } break;
+                case DpasEncodingAttr::OpIdx::OperandC: {
+                  llvm_unreachable("unexpected OpIdx::OperandC");
                 } break;
                 }
               }


### PR DESCRIPTION
When building with clang 14, the following warning, that is treated as error, occurs:
enumeration value 'OperandC' not handled in switch [-Werror,-Wswitch]
Fixes #3258
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it fixes a build failure`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
