### PR TITLE
[scripts/install-pytorch.sh] Do not delete pytorch on clean

### DIFF
--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -8,25 +8,25 @@ BUILD_LATEST=false
 FORCE_REINSTALL=false
 PYTORCH_CURRENT_COMMIT=""
 VENV=false
+NO_CLEAN=false
 for arg in "$@"; do
   case $arg in
     --source)
       BUILD_PYTORCH=true
-      shift
       ;;
     --latest)
       # Build from the latest pytorch commit in the main branch.
       BUILD_PYTORCH=true
       BUILD_LATEST=true
-      shift
       ;;
     --force-reinstall)
       FORCE_REINSTALL=true
-      shift
       ;;
     --venv)
       VENV=true
-      shift
+      ;;
+    -nc|--no-clean)
+      NO_CLEAN=true
       ;;
     --help)
       echo "Example usage: ./install-pytorch.sh [--source | --latest | --force-reinstall | --venv]"
@@ -134,23 +134,33 @@ if [ ! -d "$BASE" ]; then
   mkdir $BASE
 fi
 
-echo "**** Cleaning $PYTORCH_PROJ before build ****"
-rm -rf $PYTORCH_PROJ
+if [ "$NO_CLEAN" = false ]; then
+  [ "$BUILD_LATEST" = false ] || PYTORCH_PINNED_COMMIT=main
+  if [ -d "$PYTORCH_PROJ" ] && cd "$PYTORCH_PROJ" && \
+    git fetch --recurse-submodules && \
+    git reset --hard $PYTORCH_PINNED_COMMIT && \
+    git submodule update --init --recursive && \
+    git clean -xffd; then
+    echo "**** Cleaning $PYTORCH_PROJ before build ****"
+  else
+    cd $BASE
+    rm -rf "$PYTORCH_PROJ"
+    echo "**** Cloning PyTorch into $PYTORCH_PROJ ****"
+    git clone --single-branch -b main --recurse-submodules https://github.com/pytorch/pytorch.git
+    cd "$PYTORCH_PROJ"
 
-echo "**** Cloning $PYTORCH_PROJ ****"
-cd $BASE
-git clone --single-branch -b main --recurse-submodules https://github.com/pytorch/pytorch.git
+    if [ "$BUILD_LATEST" = false ]; then
+      git checkout $PYTORCH_PINNED_COMMIT
+      git submodule update --init --recursive
+      git clean -xffd
+    fi
+  fi
 
-cd $PYTORCH_PROJ
-
-if [ "$BUILD_LATEST" = false ]; then
-  git fetch --all
-  git checkout $PYTORCH_PINNED_COMMIT
-  git submodule update --recursive
+  # Apply Triton specific patches to PyTorch.
+  $SCRIPTS_DIR/patch-pytorch.sh
+else
+  cd "$PYTORCH_PROJ"
 fi
-
-# Apply Triton specific patches to PyTorch.
-$SCRIPTS_DIR/patch-pytorch.sh
 
 echo "****** Building $PYTORCH_PROJ ******"
 pip install -r requirements.txt

--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -8,7 +8,7 @@ BUILD_LATEST=false
 FORCE_REINSTALL=false
 PYTORCH_CURRENT_COMMIT=""
 VENV=false
-NO_CLEAN=false
+CLEAN=true
 for arg in "$@"; do
   case $arg in
     --source)
@@ -26,7 +26,7 @@ for arg in "$@"; do
       VENV=true
       ;;
     -nc|--no-clean)
-      NO_CLEAN=true
+      CLEAN=false
       ;;
     --help)
       echo "Example usage: ./install-pytorch.sh [--source | --latest | --force-reinstall | --venv]"
@@ -134,7 +134,7 @@ if [ ! -d "$BASE" ]; then
   mkdir $BASE
 fi
 
-if [ "$NO_CLEAN" = false ]; then
+if [ "$CLEAN" = true ]; then
   [ "$BUILD_LATEST" = false ] || PYTORCH_PINNED_COMMIT=main
   if [ -d "$PYTORCH_PROJ" ] && cd "$PYTORCH_PROJ" && \
     git fetch --recurse-submodules && \


### PR DESCRIPTION
Instead of deletion and clonning the repo again, use git reset + clean.
Also added the --no-clean option. It allows to proceed building after resolving an error.
Closes #3257

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `this is a build script enhancement`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
