### PR TITLE
[Windows] Fix '__builtin_clz' on windows

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -15,7 +15,7 @@
 static int __builtin_clz(unsigned x) {
   unsigned long r;
   _BitScanReverse(&r, x);
-  return static_cast<int>(r);
+  return static_cast<int>(r ^ 31);
 }
 
 static int __builtin_ctz(unsigned x) {


### PR DESCRIPTION
Closes #3273

This recent PR in upstream (triton-lang/triton#5621) brought a new faster logic for `pext_i32` that is used in `ReduceOpToLLVM` pattern. The new logic of `pext_i32` uses `__builtin_clz` intrinsic, that is natively available in GCC and Clang, but is missing in MSVC. It seems that the Windows version of this intrinsic was incorrectly copied from [the given source](https://gist.github.com/pps83/3210a2f980fd02bb2ba2e5a1fc4a2ef0#file-ctz_clz-cpp-L44-L55), so that it misses `r ^ 31` at the end of it, causing `tt.reduce(...)` lowering to produce incorrect llvm IR in some scenarious.



p.s. there's a plan to push this fix to upstream, after we test it on our side and make sure it works fine


CI without `test_reduce1d` and `test_reduce_layouts` being failed: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/13058121108/job/36434174997