### PR TITLE
Use `os.sep` in `filter_traceback` function

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -190,9 +190,10 @@ def filter_traceback(e: BaseException):
         filter_traceback(e.__context__)
 
     # If a user has a file that matches one of these, they're out of luck.
+    sep = os.sep
     BAD_FILES = [
-        "/triton/compiler/code_generator.py",
-        "/ast.py",
+        f"{sep}triton{sep}compiler{sep}code_generator.py",
+        f"{sep}ast.py",
     ]
 
     tb = e.__traceback__


### PR DESCRIPTION
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/13076506814 (**pass rate: 86.96% -> 87.00%**)