### PR TITLE
Unskip `08-grouped-gemm` on A770

### DIFF
--- a/scripts/skiplist/a770/tutorials.txt
+++ b/scripts/skiplist/a770/tutorials.txt
@@ -1,5 +1,4 @@
 02-fused-softmax
 06-fused-attention
-08-grouped-gemm
 10-experimental-block-pointer
 10i-experimental-block-pointer

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -187,30 +187,6 @@ run_core_tests() {
   echo "***************************************************"
   cd $TRITON_PROJ/python/test/unit
   ensure_spirv_dis
-
-  TRITON_DISABLE_LINE_INFO=1 TRITON_TEST_SUITE=language \
-    pytest -vvv -n ${PYTEST_MAX_PROCESSES:-8} --device xpu language/ --ignore=language/test_line_info.py --ignore=language/test_subprocess.py
-
-  TRITON_DISABLE_LINE_INFO=1 TRITON_TEST_SUITE=subprocess \
-    pytest -vvv -n ${PYTEST_MAX_PROCESSES:-8} --device xpu language/test_subprocess.py
-
-  # run runtime tests serially to avoid race condition with cache handling.
-  TRITON_DISABLE_LINE_INFO=1 TRITON_TEST_SUITE=runtime \
-    pytest -k "not test_within_2gb" --verbose --device xpu runtime/ --ignore=runtime/test_cublas.py
-
-  TRITON_TEST_SUITE=debug \
-    pytest --verbose -n ${PYTEST_MAX_PROCESSES:-8} test_debug.py --forked --device xpu
-
-  # run test_line_info.py separately with TRITON_DISABLE_LINE_INFO=0
-  TRITON_DISABLE_LINE_INFO=0 TRITON_TEST_SUITE=line_info \
-    pytest -k "not test_line_info_interpreter" --verbose --device xpu language/test_line_info.py
-
-  TRITON_DISABLE_LINE_INFO=1 TRITON_TEST_SUITE=tools \
-    pytest -k "not test_disam_cubin" --verbose tools
-
-  cd $TRITON_PROJ/third_party/intel/python/test
-  TRITON_DISABLE_LINE_INFO=1 TRITON_TEST_SUITE=third_party \
-  pytest --device xpu .
 }
 
 run_regression_tests() {
@@ -241,16 +217,7 @@ run_tutorial_tests() {
   python -m pip install matplotlib pandas tabulate -q
   cd $TRITON_PROJ/python/tutorials
 
-  run_tutorial_test "01-vector-add"
-  run_tutorial_test "02-fused-softmax"
-  run_tutorial_test "03-matrix-multiplication"
-  run_tutorial_test "04-low-memory-dropout"
-  run_tutorial_test "05-layer-norm"
-  run_tutorial_test "06-fused-attention"
-  run_tutorial_test "07-extern-functions"
   run_tutorial_test "08-grouped-gemm"
-  run_tutorial_test "10-experimental-block-pointer"
-  run_tutorial_test "10i-experimental-block-pointer"
 }
 
 run_microbench_tests() {

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -187,6 +187,30 @@ run_core_tests() {
   echo "***************************************************"
   cd $TRITON_PROJ/python/test/unit
   ensure_spirv_dis
+
+  TRITON_DISABLE_LINE_INFO=1 TRITON_TEST_SUITE=language \
+    pytest -vvv -n ${PYTEST_MAX_PROCESSES:-8} --device xpu language/ --ignore=language/test_line_info.py --ignore=language/test_subprocess.py
+
+  TRITON_DISABLE_LINE_INFO=1 TRITON_TEST_SUITE=subprocess \
+    pytest -vvv -n ${PYTEST_MAX_PROCESSES:-8} --device xpu language/test_subprocess.py
+
+  # run runtime tests serially to avoid race condition with cache handling.
+  TRITON_DISABLE_LINE_INFO=1 TRITON_TEST_SUITE=runtime \
+    pytest -k "not test_within_2gb" --verbose --device xpu runtime/ --ignore=runtime/test_cublas.py
+
+  TRITON_TEST_SUITE=debug \
+    pytest --verbose -n ${PYTEST_MAX_PROCESSES:-8} test_debug.py --forked --device xpu
+
+  # run test_line_info.py separately with TRITON_DISABLE_LINE_INFO=0
+  TRITON_DISABLE_LINE_INFO=0 TRITON_TEST_SUITE=line_info \
+    pytest -k "not test_line_info_interpreter" --verbose --device xpu language/test_line_info.py
+
+  TRITON_DISABLE_LINE_INFO=1 TRITON_TEST_SUITE=tools \
+    pytest -k "not test_disam_cubin" --verbose tools
+
+  cd $TRITON_PROJ/third_party/intel/python/test
+  TRITON_DISABLE_LINE_INFO=1 TRITON_TEST_SUITE=third_party \
+  pytest --device xpu .
 }
 
 run_regression_tests() {

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -217,7 +217,16 @@ run_tutorial_tests() {
   python -m pip install matplotlib pandas tabulate -q
   cd $TRITON_PROJ/python/tutorials
 
+  run_tutorial_test "01-vector-add"
+  run_tutorial_test "02-fused-softmax"
+  run_tutorial_test "03-matrix-multiplication"
+  run_tutorial_test "04-low-memory-dropout"
+  run_tutorial_test "05-layer-norm"
+  run_tutorial_test "06-fused-attention"
+  run_tutorial_test "07-extern-functions"
   run_tutorial_test "08-grouped-gemm"
+  run_tutorial_test "10-experimental-block-pointer"
+  run_tutorial_test "10i-experimental-block-pointer"
 }
 
 run_microbench_tests() {


### PR DESCRIPTION
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/13112833913 (passed, 12 times successfully)
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/13137228399 (check the influence of tutorials on each other; 6 times successfully)

Relates to #2737