### PR TITLE
[PrefetchBlock] Do not use location from an erased loop

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp
@@ -454,7 +454,7 @@ void PrefetchBlockPass::injectPrefetchOpsInBody(
 
   // FIXME: try to use a named barrier to increase performance.
   if (injectSplitBarriers) {
-    Location loc = loop.getLoc();
+    Location loc = newLoop.getLoc();
     b.setInsertionPoint(yield);
     b.create<spirv::INTELControlBarrierWaitOp>(loc, spirv::Scope::Workgroup,
                                                spirv::Scope::Workgroup,


### PR DESCRIPTION
Closes #3314

The creation of barriers in this pass uses a location obtained from the `loop` entity that [was erased earlier](https://github.com/intel/intel-xpu-backend-for-triton/blob/cc1774086e9ec75567b3d0b6ab4d54de3e4fba6e/third_party/intel/lib/TritonIntelGPUTransforms/PrefetchBlock.cpp#L404). Surprisingly, it works on Linux but fails on Windows. Replaced the erased `loop` with `newLoop`.

Windows CI with `TritonIntelGPU/prefetch-block.mlir` test passing: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/13138880536/job/36660853060#step:13:789