### PR TITLE
Move `convertTritonPointerType` to `third_party/intel`

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/TypeConverter.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TypeConverter.h
@@ -18,7 +18,6 @@ public:
                                const TargetInfoBase &targetInfo,
                                const DataLayoutAnalysis *analysis = nullptr);
 
-  Type convertTritonPointerType(triton::PointerType type);
   Type convertTritonTensorType(RankedTensorType type,
                                const TargetInfoBase &targetInfo);
   Type convertMemDescType(triton::gpu::MemDescType type,

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -15,8 +15,8 @@ TritonGPUToLLVMTypeConverter::TritonGPUToLLVMTypeConverter(
     MLIRContext *ctx, LowerToLLVMOptions &options,
     const TargetInfoBase &targetInfo, const DataLayoutAnalysis *analysis)
     : LLVMTypeConverter(ctx, options, analysis) {
-  addConversion([&](triton::PointerType type) -> std::optional<Type> {
-    return convertTritonPointerType(type);
+  addConversion([ctx](triton::PointerType type) -> std::optional<Type> {
+    return LLVM::LLVMPointerType::get(ctx, type.getAddressSpace());
   });
   addConversion([ctx](TensorDescType type) -> std::optional<Type> {
     return LLVM::LLVMPointerType::get(ctx, 1);
@@ -33,31 +33,6 @@ TritonGPUToLLVMTypeConverter::TritonGPUToLLVMTypeConverter(
 
   convertFP8Type<mlir::Float8E4M3FNUZType, mlir::Float8E4M3FNType,
                  mlir::Float8E5M2Type, mlir::Float8E5M2FNUZType>();
-}
-
-Type TritonGPUToLLVMTypeConverter::convertTritonPointerType(
-    triton::PointerType type) {
-  auto ctx = type.getContext();
-  auto pointeeType = type.getPointeeType();
-  if (isa<RankedTensorType>(pointeeType)) {
-    auto rankedTensorType = cast<RankedTensorType>(pointeeType);
-    // struct { offset0, offset1, shape0, shape1, stride0,
-    // stride1, base_ptr};
-    auto eleType = rankedTensorType.getElementType();
-    auto shape = rankedTensorType.getShape();
-    SmallVector<Type, 4> types;
-    // offsets
-    for (size_t i = 0; i < shape.size(); ++i)
-      types.push_back(IntegerType::get(ctx, 32));
-    // shapes, strides
-    for (size_t i = 0; i < 2 * shape.size(); ++i)
-      types.push_back(IntegerType::get(ctx, 64));
-
-    types.push_back(LLVM::LLVMPointerType::get(ctx, type.getAddressSpace()));
-
-    return LLVM::LLVMStructType::getLiteral(ctx, types);
-  }
-  return LLVM::LLVMPointerType::get(ctx, type.getAddressSpace());
 }
 
 Type TritonGPUToLLVMTypeConverter::convertTritonTensorType(


### PR DESCRIPTION
The conversion of pointers to tensors is removed upstream in commit https://github.com/intel/intel-xpu-backend-for-triton/commit/5c2e2bcfddbc6ae11102bf677ad2d1f7f1c24d6c, but it is required by Intel for handling blocked pointer, so this PR moves the conversion to `third_party/intel`. 

Closes #3228.