### PR TITLE
[Windows] Use correct path for pass rate report

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -145,7 +145,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pass_rate
-          path: pass_rate*.json
+          path: ${{ env.NEW_WORKSPACE }}\pass_rate*.json
 
       - name: Clean up workspace
         if: ${{ always() }}

--- a/.github/workflows/pip-test-windows.yml
+++ b/.github/workflows/pip-test-windows.yml
@@ -160,7 +160,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pass_rate
-          path: pass_rate*.json
+          path: ${{ env.NEW_WORKSPACE }}\pass_rate*.json
 
       - name: Clean up workspace
         if: ${{ always() }}


### PR DESCRIPTION
The last pass rate report was not uploaded: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/13150645045/job/36697369180