### PR TITLE
[Windows] Add `exe_extension` for `dst_path` argument of `download_and_copy` function

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -522,7 +522,7 @@ exe_extension = sysconfig.get_config_var("EXE")
 download_and_copy(
     name="nvcc",
     src_func=lambda system, arch, version: f"cuda_nvcc-{system}-{arch}-{version}-archive/bin/ptxas{exe_extension}",
-    dst_path="bin/ptxas",
+    dst_path=f"bin/ptxas{exe_extension}",
     variable="TRITON_PTXAS_PATH",
     version=NVIDIA_TOOLCHAIN_VERSION["ptxas"],
     url_func=lambda system, arch, version:
@@ -532,7 +532,7 @@ download_and_copy(
 download_and_copy(
     name="nvcc",
     src_func=lambda system, arch, version: f"cuda_nvcc-{system}-{arch}-{version}-archive/bin/ptxas{exe_extension}",
-    dst_path="bin/ptxas-blackwell",
+    dst_path=f"bin/ptxas-blackwell{exe_extension}",
     variable="TRITON_PTXAS_PATH",
     version=NVIDIA_TOOLCHAIN_VERSION["ptxas-blackwell"],
     url_func=lambda system, arch, version:
@@ -542,7 +542,7 @@ download_and_copy(
     name="cuobjdump",
     src_func=lambda system, arch, version:
     f"cuda_cuobjdump-{system}-{arch}-{version}-archive/bin/cuobjdump{exe_extension}",
-    dst_path="bin/cuobjdump",
+    dst_path=f"bin/cuobjdump{exe_extension}",
     variable="TRITON_CUOBJDUMP_PATH",
     version=NVIDIA_TOOLCHAIN_VERSION["cuobjdump"],
     url_func=lambda system, arch, version:
@@ -552,7 +552,7 @@ download_and_copy(
     name="nvdisasm",
     src_func=lambda system, arch, version:
     f"cuda_nvdisasm-{system}-{arch}-{version}-archive/bin/nvdisasm{exe_extension}",
-    dst_path="bin/nvdisasm",
+    dst_path=f"bin/nvdisasm{exe_extension}",
     variable="TRITON_NVDISASM_PATH",
     version=NVIDIA_TOOLCHAIN_VERSION["nvdisasm"],
     url_func=lambda system, arch, version:


### PR DESCRIPTION
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/13155450398

This fixes `RuntimeError: Cannot find ptxas-blackwell.exe`. However, this highlights a new problem: `PermissionError: [WinError 32] The process cannot access the file because it is being used by another process:  ''...\\AppData\\Local\\Temp\\tmpdm3gg6j5.ptx''`. The problem is most likely the same as with `pyd` files, but it will be easier to just skip these tests for the xpu backend.