### PR TITLE
Move pass rate files back to workspace

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -145,8 +145,6 @@ jobs:
           Move-Item -Path ${{ env.NEW_WORKSPACE }}\pass_rate*.json -Destination .
 
       - name: Upload pass rate report
-        # upload reports only for the default branch
-        if: github.ref_name == 'main'
         uses: actions/upload-artifact@v4
         with:
           name: pass_rate

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -139,13 +139,18 @@ jobs:
             python scripts/pass_rate.py --reports reports --suite tutorials --json ${{ env.SKIPLIST }} > pass_rate_tutorials.json; \
           "
 
+      # upload-artifacts works only for files in WORKSPACE
+      - name: Collect pass rate files
+        run: |
+          Move-Item -Path ${{ env.NEW_WORKSPACE }}\pass_rate*.json -Destination .
+
       - name: Upload pass rate report
         # upload reports only for the default branch
         if: github.ref_name == 'main'
         uses: actions/upload-artifact@v4
         with:
           name: pass_rate
-          path: ${{ env.NEW_WORKSPACE }}\pass_rate*.json
+          path: pass_rate*.json
 
       - name: Clean up workspace
         if: ${{ always() }}

--- a/.github/workflows/pip-test-windows.yml
+++ b/.github/workflows/pip-test-windows.yml
@@ -160,8 +160,6 @@ jobs:
           Move-Item -Path ${{ env.NEW_WORKSPACE }}\pass_rate*.json -Destination .
 
       - name: Upload pass rate report
-        # upload reports only for the default branch
-        if: github.ref_name == 'main'
         uses: actions/upload-artifact@v4
         with:
           name: pass_rate

--- a/.github/workflows/pip-test-windows.yml
+++ b/.github/workflows/pip-test-windows.yml
@@ -154,13 +154,18 @@ jobs:
             python scripts/pass_rate.py --reports reports --suite tutorials --json ${{ env.SKIPLIST }} > pass_rate_tutorials.json; \
           "
 
+      # upload-artifacts works only for files in WORKSPACE
+      - name: Collect pass rate files
+        run: |
+          Move-Item -Path ${{ env.NEW_WORKSPACE }}\pass_rate*.json -Destination .
+
       - name: Upload pass rate report
         # upload reports only for the default branch
         if: github.ref_name == 'main'
         uses: actions/upload-artifact@v4
         with:
           name: pass_rate
-          path: ${{ env.NEW_WORKSPACE }}\pass_rate*.json
+          path: pass_rate*.json
 
       - name: Clean up workspace
         if: ${{ always() }}


### PR DESCRIPTION
`actions/upload-artifact` works only for files in the workspace.

This is to fix 

```
Warning: No files were found with the provided path: pass_rate*.json. No artifacts will be uploaded.
```

after #3346.

Example: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/13150645045/job/36697369180