### PR TITLE
[triton-raise-block-ptr]: Fix tt.advance codegen

### DIFF
--- a/test/Triton/Intel/RaiseToBlockPointers/addptr_dim1.mlir
+++ b/test/Triton/Intel/RaiseToBlockPointers/addptr_dim1.mlir
@@ -85,7 +85,7 @@ module {
 // CHECK-DAG:       [[VAR_3_:%.+]] = tt.make_tensor_ptr [[PARAM_0_]], {{\[}}[[CST_0_i64]], [[CST_0_i64]]], {{\[}}[[CST_0_i64]], [[CST_1_i64]]], {{\[}}[[CST_0_i32]], [[CST_0_i32]]] {{.*}} : <tensor<1x256xbf16>>
 // CHECK-DAG:       [[VAR_4_:%.+]] = tt.addptr [[VAR_2_]], [[VAR_1_]] : tensor<1x256x!tt.ptr<bf16>>, tensor<1x256xi32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = tt.load [[VAR_3_]] : !tt.ptr<tensor<1x256xbf16>>
-// CHECK-DAG:       [[VAR_6_:%.+]] = tt.advance [[VAR_3_]], {{\[}}[[PARAM_1_]], [[CST_0_i32]]] : <tensor<1x256xbf16>>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tt.advance [[VAR_3_]], {{\[}}[[CST_0_i32]], [[PARAM_1_]]] : <tensor<1x256xbf16>>
 // CHECK:           tt.store [[VAR_6_]], [[VAR_5_]] : !tt.ptr<tensor<1x256xbf16>>
 // CHECK:           [[VAR_7_:%.+]]:2 = scf.for [[VAR_arg2_:%.+]] = {{.*}} iter_args([[VAR_arg3_:%.+]] = [[CST_0_]], [[VAR_arg4_:%.+]] = [[VAR_4_]]) -> (tensor<4x256xbf16>, tensor<1x256x!tt.ptr<bf16>>) {
 // CHECK:             [[VAR_9_:%.+]] = tt.broadcast [[VAR_arg4_]] : tensor<1x256x!tt.ptr<bf16>> -> tensor<4x256x!tt.ptr<bf16>>

--- a/test/Triton/Intel/RaiseToBlockPointers/kernel-03-matrix-multiplication.mlir
+++ b/test/Triton/Intel/RaiseToBlockPointers/kernel-03-matrix-multiplication.mlir
@@ -1,143 +1,130 @@
 // RUN: triton-opt %s -triton-raise-block-pointer -canonicalize | FileCheck %s
+// TODO: change to out tutorial 03
 
 module {
-  tt.func public @matmul_kernel_0123456789101112131415(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<bf16>, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32, %arg8: i32, %arg9: i32, %arg10: i32, %arg11: i32) {
-    %c63_i32 = arith.constant 63 : i32
-    %c255_i32 = arith.constant 255 : i32
+  tt.func public @matmul_kernel(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}) {
+    %c31_i32 = arith.constant 31 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf32>
     %c127_i32 = arith.constant 127 : i32
+    %c63_i32 = arith.constant 63 : i32
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<32x128xf16>
+    %cst_1 = arith.constant dense<0.000000e+00> : tensor<64x32xf16>
     %c1_i32 = arith.constant 1 : i32
     %c0_i32 = arith.constant 0 : i32
-    %c64_i32 = arith.constant 64 : i32
-    %cst = arith.constant 0.000000e+00 : f32
-    %c256_i32 = arith.constant 256 : i32
+    %cst_2 = arith.constant dense<32> : tensor<64x32xi32>
+    %c32_i32 = arith.constant 32 : i32
     %c128_i32 = arith.constant 128 : i32
-    %c8_i32 = arith.constant 8 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c4_i32 = arith.constant 4 : i32
     %0 = tt.get_program_id x : i32
-    %1 = arith.addi %arg3, %c127_i32 : i32
-    %2 = arith.divsi %1, %c128_i32 : i32
-    %3 = arith.addi %arg4, %c255_i32 : i32
-    %4 = arith.divsi %3, %c256_i32 : i32
-    %5 = arith.addi %arg5, %c63_i32 : i32
-    %6 = arith.divsi %5, %c64_i32 : i32
-    %7 = arith.muli %4, %c8_i32 : i32
-    %8 = arith.divsi %0, %7 : i32
-    %9 = arith.muli %8, %c8_i32 : i32
-    %10 = arith.subi %2, %9 : i32
-    %11 = arith.cmpi slt, %10, %c8_i32 : i32
-    %12 = arith.select %11, %10, %c8_i32 : i32
-    %13 = arith.remsi %0, %12 : i32
-    %14 = arith.addi %9, %13 : i32
-    %15 = arith.remsi %0, %7 : i32
-    %16 = arith.divsi %15, %12 : i32
-    %17 = arith.muli %14, %c128_i32 : i32
-    %18 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
-    %19 = tt.splat %17 : i32 -> tensor<128xi32>
-    %20 = arith.addi %19, %18 : tensor<128xi32>
-    %21 = arith.muli %16, %c256_i32 : i32
-    %22 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
-    %23 = tt.splat %21 : i32 -> tensor<256xi32>
-    %24 = arith.addi %23, %22 : tensor<256xi32>
-    %25 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
-    %26 = tt.expand_dims %20 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
-    %27 = tt.splat %arg6 : i32 -> tensor<128x1xi32>
-    %28 = arith.muli %26, %27 : tensor<128x1xi32>
-    %29 = tt.expand_dims %25 {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
-    %30 = tt.splat %arg7 : i32 -> tensor<1x64xi32>
-    %31 = arith.muli %29, %30 : tensor<1x64xi32>
-    %32 = tt.broadcast %28 : tensor<128x1xi32> -> tensor<128x64xi32>
-    %33 = tt.broadcast %31 : tensor<1x64xi32> -> tensor<128x64xi32>
-    %34 = arith.addi %32, %33 : tensor<128x64xi32>
-    %35 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<128x64x!tt.ptr<bf16>>
-    %36 = tt.addptr %35, %34 : tensor<128x64x!tt.ptr<bf16>>, tensor<128x64xi32>
-    %37 = tt.expand_dims %25 {axis = 1 : i32} : tensor<64xi32> -> tensor<64x1xi32>
-    %38 = tt.splat %arg8 : i32 -> tensor<64x1xi32>
-    %39 = arith.muli %37, %38 : tensor<64x1xi32>
-    %40 = tt.expand_dims %24 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
-    %41 = tt.splat %arg9 : i32 -> tensor<1x256xi32>
-    %42 = arith.muli %40, %41 : tensor<1x256xi32>
-    %43 = tt.broadcast %39 : tensor<64x1xi32> -> tensor<64x256xi32>
-    %44 = tt.broadcast %42 : tensor<1x256xi32> -> tensor<64x256xi32>
-    %45 = arith.addi %43, %44 : tensor<64x256xi32>
-    %46 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<64x256x!tt.ptr<bf16>>
-    %47 = tt.addptr %46, %45 : tensor<64x256x!tt.ptr<bf16>>, tensor<64x256xi32>
-    %48 = tt.splat %cst : f32 -> tensor<128x256xf32>
-    %49 = arith.muli %arg7, %c64_i32 : i32
-    %50 = tt.splat %49 : i32 -> tensor<128x64xi32>
-    %51 = arith.muli %arg8, %c64_i32 : i32
-    %52 = tt.splat %51 : i32 -> tensor<64x256xi32>
-    %53:3 = scf.for %arg12 = %c0_i32 to %6 step %c1_i32 iter_args(%arg13 = %48, %arg14 = %36, %arg15 = %47) -> (tensor<128x256xf32>, tensor<128x64x!tt.ptr<bf16>>, tensor<64x256x!tt.ptr<bf16>>)  : i32 {
-      %71 = tt.load %arg14 : tensor<128x64x!tt.ptr<bf16>>
-      %72 = tt.load %arg15 : tensor<64x256x!tt.ptr<bf16>>
-      %73 = tt.dot %71, %72, %48 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xf32>
-      %74 = arith.addf %arg13, %73 : tensor<128x256xf32>
-      %75 = tt.addptr %arg14, %50 : tensor<128x64x!tt.ptr<bf16>>, tensor<128x64xi32>
-      %76 = tt.addptr %arg15, %52 : tensor<64x256x!tt.ptr<bf16>>, tensor<64x256xi32>
-      scf.yield %74, %75, %76 : tensor<128x256xf32>, tensor<128x64x!tt.ptr<bf16>>, tensor<64x256x!tt.ptr<bf16>>
+    %1 = arith.addi %arg3, %c63_i32 : i32
+    %2 = arith.divsi %1, %c64_i32 : i32
+    %3 = arith.addi %arg4, %c127_i32 : i32
+    %4 = arith.divsi %3, %c128_i32 : i32
+    %5 = arith.muli %4, %c4_i32 : i32
+    %6 = arith.divsi %0, %5 : i32
+    %7 = arith.muli %6, %c4_i32 : i32
+    %8 = arith.subi %2, %7 : i32
+    %9 = arith.minsi %8, %c4_i32 : i32
+    %10 = arith.remsi %0, %5 : i32
+    %11 = arith.remsi %10, %9 : i32
+    %12 = arith.addi %7, %11 : i32
+    %13 = arith.divsi %10, %9 : i32
+    %14 = arith.muli %12, %c64_i32 : i32
+    %15 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+    %16 = tt.splat %14 : i32 -> tensor<64xi32>
+    %17 = arith.addi %16, %15 : tensor<64xi32>
+    %18 = tt.splat %arg3 : i32 -> tensor<64xi32>
+    %19 = arith.remsi %17, %18 : tensor<64xi32>
+    %20 = arith.muli %13, %c128_i32 : i32
+    %21 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %22 = tt.splat %20 : i32 -> tensor<128xi32>
+    %23 = arith.addi %22, %21 : tensor<128xi32>
+    %24 = tt.splat %arg4 : i32 -> tensor<128xi32>
+    %25 = arith.remsi %23, %24 : tensor<128xi32>
+    %26 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %27 = tt.expand_dims %19 {axis = 1 : i32} : tensor<64xi32> -> tensor<64x1xi32>
+    %28 = tt.splat %arg6 : i32 -> tensor<64x1xi32>
+    %29 = arith.muli %27, %28 : tensor<64x1xi32>
+    %30 = tt.expand_dims %26 {axis = 0 : i32} : tensor<32xi32> -> tensor<1x32xi32>
+    %31 = tt.broadcast %29 : tensor<64x1xi32> -> tensor<64x32xi32>
+    %32 = tt.broadcast %30 : tensor<1x32xi32> -> tensor<64x32xi32>
+    %33 = arith.addi %31, %32 : tensor<64x32xi32>
+    %34 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x32x!tt.ptr<f16>>
+    %35 = tt.addptr %34, %33 : tensor<64x32x!tt.ptr<f16>>, tensor<64x32xi32>
+    %36 = tt.expand_dims %26 {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+    %37 = tt.splat %arg7 : i32 -> tensor<32x1xi32>
+    %38 = arith.muli %36, %37 : tensor<32x1xi32>
+    %39 = tt.expand_dims %25 {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+    %40 = tt.broadcast %38 : tensor<32x1xi32> -> tensor<32x128xi32>
+    %41 = tt.broadcast %39 : tensor<1x128xi32> -> tensor<32x128xi32>
+    %42 = arith.addi %40, %41 : tensor<32x128xi32>
+    %43 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<32x128x!tt.ptr<f16>>
+    %44 = tt.addptr %43, %42 : tensor<32x128x!tt.ptr<f16>>, tensor<32x128xi32>
+    %45 = arith.addi %arg5, %c31_i32 : i32
+    %46 = arith.divsi %45, %c32_i32 : i32
+    %47 = arith.muli %arg7, %c32_i32 : i32
+    %48 = tt.splat %47 : i32 -> tensor<32x128xi32>
+    %49:3 = scf.for %arg9 = %c0_i32 to %46 step %c1_i32 iter_args(%arg10 = %cst, %arg11 = %35, %arg12 = %44) -> (tensor<64x128xf32>, tensor<64x32x!tt.ptr<f16>>, tensor<32x128x!tt.ptr<f16>>)  : i32 {
+      %67 = arith.muli %arg9, %c32_i32 : i32
+      %68 = arith.subi %arg5, %67 : i32
+      %69 = tt.splat %68 : i32 -> tensor<1x32xi32>
+      %70 = arith.cmpi slt, %30, %69 : tensor<1x32xi32>
+      %71 = tt.broadcast %70 : tensor<1x32xi1> -> tensor<64x32xi1>
+      %72 = tt.load %arg11, %71, %cst_1 : tensor<64x32x!tt.ptr<f16>>
+      %73 = tt.splat %68 : i32 -> tensor<32x1xi32>
+      %74 = arith.cmpi slt, %36, %73 : tensor<32x1xi32>
+      %75 = tt.broadcast %74 : tensor<32x1xi1> -> tensor<32x128xi1>
+      %76 = tt.load %arg12, %75, %cst_0 : tensor<32x128x!tt.ptr<f16>>
+      %77 = tt.dot %72, %76, %arg10, inputPrecision = tf32 : tensor<64x32xf16> * tensor<32x128xf16> -> tensor<64x128xf32>
+      %78 = tt.addptr %arg11, %cst_2 : tensor<64x32x!tt.ptr<f16>>, tensor<64x32xi32>
+      %79 = tt.addptr %arg12, %48 : tensor<32x128x!tt.ptr<f16>>, tensor<32x128xi32>
+      scf.yield %77, %78, %79 : tensor<64x128xf32>, tensor<64x32x!tt.ptr<f16>>, tensor<32x128x!tt.ptr<f16>>
     }
-    %54 = arith.truncf %53#0 : tensor<128x256xf32> to tensor<128x256xbf16>
-    %55 = tt.splat %arg10 : i32 -> tensor<128x1xi32>
-    %56 = arith.muli %55, %26 : tensor<128x1xi32>
-    %57 = tt.splat %arg2 : !tt.ptr<bf16> -> tensor<128x1x!tt.ptr<bf16>>
-    %58 = tt.addptr %57, %56 : tensor<128x1x!tt.ptr<bf16>>, tensor<128x1xi32>
-    %59 = tt.splat %arg11 : i32 -> tensor<1x256xi32>
-    %60 = arith.muli %59, %40 : tensor<1x256xi32>
-    %61 = tt.broadcast %58 : tensor<128x1x!tt.ptr<bf16>> -> tensor<128x256x!tt.ptr<bf16>>
-    %62 = tt.broadcast %60 : tensor<1x256xi32> -> tensor<128x256xi32>
-    %63 = tt.addptr %61, %62 : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
-    %64 = tt.splat %arg3 : i32 -> tensor<128x1xi32>
-    %65 = arith.cmpi slt, %26, %64 : tensor<128x1xi32>
-    %66 = tt.splat %arg4 : i32 -> tensor<1x256xi32>
-    %67 = arith.cmpi slt, %40, %66 : tensor<1x256xi32>
-    %68 = tt.broadcast %65 : tensor<128x1xi1> -> tensor<128x256xi1>
-    %69 = tt.broadcast %67 : tensor<1x256xi1> -> tensor<128x256xi1>
-    %70 = arith.andi %68, %69 : tensor<128x256xi1>
-    // TODO: add back once masked stores are supported
-    // tt.store %63, %54, %70 : tensor<128x256x!tt.ptr<bf16>>
-    tt.store %63, %54 : tensor<128x256x!tt.ptr<bf16>>
+    %50 = arith.truncf %49#0 : tensor<64x128xf32> to tensor<64x128xf16>
+    %51 = tt.expand_dims %17 {axis = 1 : i32} : tensor<64xi32> -> tensor<64x1xi32>
+    %52 = tt.splat %arg8 : i32 -> tensor<64x1xi32>
+    %53 = arith.muli %52, %51 : tensor<64x1xi32>
+    %54 = tt.splat %arg2 : !tt.ptr<f16> -> tensor<64x1x!tt.ptr<f16>>
+    %55 = tt.addptr %54, %53 : tensor<64x1x!tt.ptr<f16>>, tensor<64x1xi32>
+    %56 = tt.expand_dims %23 {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+    %57 = tt.broadcast %55 : tensor<64x1x!tt.ptr<f16>> -> tensor<64x128x!tt.ptr<f16>>
+    %58 = tt.broadcast %56 : tensor<1x128xi32> -> tensor<64x128xi32>
+    %59 = tt.addptr %57, %58 : tensor<64x128x!tt.ptr<f16>>, tensor<64x128xi32>
+    %60 = tt.splat %arg3 : i32 -> tensor<64x1xi32>
+    %61 = arith.cmpi slt, %51, %60 : tensor<64x1xi32>
+    %62 = tt.splat %arg4 : i32 -> tensor<1x128xi32>
+    %63 = arith.cmpi slt, %56, %62 : tensor<1x128xi32>
+    %64 = tt.broadcast %61 : tensor<64x1xi1> -> tensor<64x128xi1>
+    %65 = tt.broadcast %63 : tensor<1x128xi1> -> tensor<64x128xi1>
+    %66 = arith.andi %64, %65 : tensor<64x128xi1>
+    tt.store %59, %50, %66 : tensor<64x128x!tt.ptr<f16>>
     tt.return
   }
 }
 
-// CHECK:         tt.func public @matmul_kernel_0123456789101112131415([[PARAM_0_:%.+]]: !tt.ptr<bf16>, [[PARAM_1_:%.+]]: !tt.ptr<bf16>, [[PARAM_2_:%.+]]: !tt.ptr<bf16>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32) {
-// CHECK-DAG:       [[VAR_cst_:%.+]] = arith.constant dense<0.000000e+00> : tensor<128x256xf32>
+// CHECK:         tt.func public @matmul_kernel([[PARAM_0_:%.+]]: !tt.ptr<f16> {tt.divisibility = 16 : i32}, [[PARAM_1_:%.+]]: !tt.ptr<f16> {tt.divisibility = 16 : i32}, [[PARAM_2_:%.+]]: !tt.ptr<f16> {tt.divisibility = 16 : i32}, [[PARAM_3_:%.+]]: i32 {tt.divisibility = 16 : i32}, [[PARAM_4_:%.+]]: i32 {tt.divisibility = 16 : i32}, [[PARAM_5_:%.+]]: i32 {tt.divisibility = 16 : i32}, [[PARAM_6_:%.+]]: i32 {tt.divisibility = 16 : i32}, [[PARAM_7_:%.+]]: i32 {tt.divisibility = 16 : i32}, [[PARAM_8_:%.+]]: i32 {tt.divisibility = 16 : i32}) {
 // CHECK-DAG:       [[CST_0_i64:%.+]] = arith.constant 0 : i64
-// CHECK-DAG:       [[CST_256_i32:%.+]] = arith.constant 256 : i32
-// CHECK-DAG:       [[CST_128_i32:%.+]] = arith.constant 128 : i32
-// CHECK-DAG:       [[CST_64_i32:%.+]] = arith.constant 64 : i32
 // CHECK-DAG:       [[CST_0_i32:%.+]] = arith.constant 0 : i32
-// CHECK-DAG:       [[CST_1_i32:%.+]] = arith.constant 1 : i32
-// CHECK:           [[VAR_17_:%.+]] = arith.muli {{.*}}, [[CST_128_i32]] : i32
-// CHECK:           [[VAR_18_:%.+]] = arith.muli {{.*}}, [[CST_256_i32]] : i32
-// CHECK:           [[VAR_20_:%.+]] = arith.extsi [[PARAM_6_]] : i32 to i64
-// CHECK:           [[VAR_21_:%.+]] = arith.extsi [[PARAM_7_]] : i32 to i64
-// CHECK:           [[VAR_22_:%.+]] = arith.divui {{.*}}, [[PARAM_6_]] : i32
-// CHECK:           [[VAR_23_:%.+]] = tt.make_tensor_ptr [[PARAM_0_]], {{\[}}[[CST_0_i64]], [[CST_0_i64]]], {{\[}}[[VAR_20_]], [[VAR_21_]]], {{\[}}[[VAR_22_]], [[CST_0_i32]]] {{.*}} : <tensor<128x64xbf16>>
-// CHECK:           [[VAR_24_:%.+]] = arith.extsi [[PARAM_8_]] : i32 to i64
-// CHECK:           [[VAR_25_:%.+]] = arith.muli {{.*}}, [[PARAM_9_]] : i32
-// CHECK:           [[VAR_26_:%.+]] = arith.extsi [[PARAM_9_]] : i32 to i64
-// CHECK:           [[VAR_27_:%.+]] = arith.divui [[VAR_25_]], [[PARAM_9_]] : i32
-// CHECK:           [[VAR_28_:%.+]] = tt.make_tensor_ptr [[PARAM_1_]], {{\[}}[[CST_0_i64]], [[CST_0_i64]]], {{\[}}[[VAR_24_]], [[VAR_26_]]], {{\[}}[[CST_0_i32]], [[VAR_27_]]] {{.*}} : <tensor<64x256xbf16>>
-// CHECK-DAG:       [[VAR_29_:%.+]] = arith.muli [[PARAM_7_]], [[CST_64_i32]] : i32
-// CHECK-DAG:       [[VAR_30_:%.+]] = arith.muli [[PARAM_8_]], [[CST_64_i32]] : i32
-// CHECK:           [[VAR_31_:%.+]]:3 = scf.for {{.*}} iter_args([[VAR_arg13_:%.+]] = [[VAR_cst_]], [[VAR_arg14_:%.+]] = [[VAR_23_]], [[VAR_arg15_:%.+]] = [[VAR_28_]]) -> (tensor<128x256xf32>, !tt.ptr<tensor<128x64xbf16>>, !tt.ptr<tensor<64x256xbf16>>)  : i32 {
-// CHECK-DAG:         [[VAR_40_:%.+]] = tt.load [[VAR_arg14_]] : !tt.ptr<tensor<128x64xbf16>>
-// CHECK-DAG:         [[VAR_41_:%.+]] = tt.load [[VAR_arg15_]] : !tt.ptr<tensor<64x256xbf16>>
-// CHECK:             [[VAR_42_:%.+]] = tt.dot [[VAR_40_]], [[VAR_41_]], [[VAR_cst_]], inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xf32>
-// CHECK-DAG:         [[VAR_43_:%.+]] = arith.addf [[VAR_arg13_]], [[VAR_42_]] : tensor<128x256xf32>
-// CHECK-DAG:         [[VAR_44_:%.+]] = arith.divui [[VAR_29_]], [[PARAM_6_]] : i32
-// CHECK-DAG:         [[VAR_45_:%.+]] = tt.advance [[VAR_arg14_]], {{\[}}[[VAR_44_]], [[CST_0_i32]]] : <tensor<128x64xbf16>>
-// CHECK-DAG:         [[VAR_46_:%.+]] = arith.divui [[VAR_30_]], [[PARAM_8_]] : i32
-// CHECK-DAG:         [[VAR_47_:%.+]] = tt.advance [[VAR_arg15_]], {{\[}}[[VAR_46_]], [[CST_0_i32]]] : <tensor<64x256xbf16>>
-// CHECK:             scf.yield [[VAR_43_]], [[VAR_45_]], [[VAR_47_]] : tensor<128x256xf32>, !tt.ptr<tensor<128x64xbf16>>, !tt.ptr<tensor<64x256xbf16>>
+// CHECK-DAG:       [[CST_32_i32:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_1_i64:%.+]] = arith.constant 1 : i64
+// CHECK-DAG:       [[CST_128_i32:%.+]] = arith.constant 128 : i32
+// CHECK-DAG:       [[VAR_cst_:%.+]] = arith.constant dense<0.000000e+00> : tensor<64x128xf32>
+// CHECK:           [[VAR_18_:%.+]] = arith.muli {{.*}}, [[CST_128_i32]] : i32
+// CHECK:           [[VAR_25_:%.+]] = arith.extsi [[PARAM_6_]] : i32 to i64
+// CHECK:           [[VAR_26_:%.+]] = arith.divui {{.*}}, [[PARAM_6_]] : i32
+// CHECK:           [[VAR_27_:%.+]] = tt.make_tensor_ptr [[PARAM_0_]], {{\[}}[[CST_0_i64]], [[CST_0_i64]]], {{\[}}[[VAR_25_]], [[CST_1_i64]]], {{\[}}[[VAR_26_]], [[CST_0_i32]]] {{.*}} : <tensor<64x32xf16>>
+// CHECK:           [[VAR_29_:%.+]] = arith.extsi [[PARAM_7_]] : i32 to i64
+// CHECK:           [[VAR_30_:%.+]] = tt.make_tensor_ptr [[PARAM_1_]], {{\[}}[[CST_0_i64]], [[CST_0_i64]]], {{\[}}[[VAR_29_]], [[CST_1_i64]]], {{\[}}[[CST_0_i32]], [[VAR_18_]]] {{.*}} : <tensor<32x128xf16>>
+// CHECK:           [[VAR_33_:%.+]] = arith.muli [[PARAM_7_]], [[CST_32_i32]] : i32
+// CHECK:           [[VAR_34_:%.+]]:3 = scf.for {{.*}} iter_args([[VAR_arg10_:%.+]] = [[VAR_cst_]], [[VAR_arg11_:%.+]] = [[VAR_27_]], [[VAR_arg12_:%.+]] = [[VAR_30_]]) -> (tensor<64x128xf32>, !tt.ptr<tensor<64x32xf16>>, !tt.ptr<tensor<32x128xf16>>)  : i32 {
+// CHECK:             [[VAR_57_:%.+]] = tt.load [[VAR_arg11_]], {{.*}}, {{.*}} : !tt.ptr<tensor<64x32xf16>>
+// CHECK:             [[VAR_61_:%.+]] = tt.load [[VAR_arg12_]], {{.*}}, {{.*}} : !tt.ptr<tensor<32x128xf16>>
+// CHECK:             [[VAR_62_:%.+]] = tt.dot [[VAR_57_]], [[VAR_61_]], [[VAR_arg10_]], inputPrecision = tf32 : tensor<64x32xf16> * tensor<32x128xf16> -> tensor<64x128xf32>
+// CHECK-DAG:         [[VAR_63_:%.+]] = tt.advance [[VAR_arg11_]], {{\[}}[[CST_0_i32]], [[CST_32_i32]]] : <tensor<64x32xf16>>
+// CHECK-DAG:         [[VAR_64_:%.+]] = tt.advance [[VAR_arg12_]], {{\[}}[[CST_0_i32]], [[VAR_33_]]] : <tensor<32x128xf16>>
+// CHECK:             scf.yield [[VAR_62_]], [[VAR_63_]], [[VAR_64_]] : tensor<64x128xf32>, !tt.ptr<tensor<64x32xf16>>, !tt.ptr<tensor<32x128xf16>>
 // CHECK:           }
-// CHECK-DAG:       [[VAR_32_:%.+]] = arith.truncf [[VAR_31_]]#0 : tensor<128x256xf32> to tensor<128x256xbf16>
-// CHECK-DAG:       [[VAR_33_:%.+]] = arith.muli [[VAR_17_]], [[PARAM_10_]] : i32
-// CHECK-DAG:       [[VAR_34_:%.+]] = arith.extsi [[PARAM_10_]] : i32 to i64
-// CHECK-DAG:       [[VAR_35_:%.+]] = arith.muli [[VAR_18_]], [[PARAM_11_]] : i32
-// CHECK-DAG:       [[VAR_36_:%.+]] = arith.extsi [[PARAM_11_]] : i32 to i64
-// CHECK-DAG:       [[VAR_37_:%.+]] = arith.divui [[VAR_33_]], [[PARAM_10_]] : i32
-// CHECK-DAG:       [[VAR_38_:%.+]] = arith.divui [[VAR_35_]], [[PARAM_11_]] : i32
-// CHECK:           [[VAR_39_:%.+]] = tt.make_tensor_ptr [[PARAM_2_]], {{\[}}[[CST_0_i64]], [[CST_0_i64]]], {{\[}}[[VAR_34_]], [[VAR_36_]]], {{\[}}[[VAR_37_]], [[VAR_38_]]] {{.*}} : <tensor<128x256xbf16>>
-// CHECK:           tt.store [[VAR_39_]], [[VAR_32_]] : !tt.ptr<tensor<128x256xbf16>>
+// CHECK:           tt.store {{.*}} : tensor<64x128x!tt.ptr<f16>>
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Triton/Intel/RaiseToBlockPointers/kernel-03-matrix-multiplication.mlir
+++ b/test/Triton/Intel/RaiseToBlockPointers/kernel-03-matrix-multiplication.mlir
@@ -1,5 +1,4 @@
 // RUN: triton-opt %s -triton-raise-block-pointer -canonicalize | FileCheck %s
-// TODO: change to out tutorial 03
 
 module {
   tt.func public @matmul_kernel(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}) {
@@ -98,7 +97,9 @@ module {
     %64 = tt.broadcast %61 : tensor<64x1xi1> -> tensor<64x128xi1>
     %65 = tt.broadcast %63 : tensor<1x128xi1> -> tensor<64x128xi1>
     %66 = arith.andi %64, %65 : tensor<64x128xi1>
-    tt.store %59, %50, %66 : tensor<64x128x!tt.ptr<f16>>
+    // TODO: add back once masked stores are supported  
+    // tt.store %59, %50, %66 : tensor<64x128x!tt.ptr<f16>>  
+    tt.store %59, %50 : tensor<64x128x!tt.ptr<f16>>  
     tt.return
   }
 }
@@ -110,21 +111,26 @@ module {
 // CHECK-DAG:       [[CST_1_i64:%.+]] = arith.constant 1 : i64
 // CHECK-DAG:       [[CST_128_i32:%.+]] = arith.constant 128 : i32
 // CHECK-DAG:       [[VAR_cst_:%.+]] = arith.constant dense<0.000000e+00> : tensor<64x128xf32>
-// CHECK:           [[VAR_18_:%.+]] = arith.muli {{.*}}, [[CST_128_i32]] : i32
-// CHECK:           [[VAR_25_:%.+]] = arith.extsi [[PARAM_6_]] : i32 to i64
-// CHECK:           [[VAR_26_:%.+]] = arith.divui {{.*}}, [[PARAM_6_]] : i32
-// CHECK:           [[VAR_27_:%.+]] = tt.make_tensor_ptr [[PARAM_0_]], {{\[}}[[CST_0_i64]], [[CST_0_i64]]], {{\[}}[[VAR_25_]], [[CST_1_i64]]], {{\[}}[[VAR_26_]], [[CST_0_i32]]] {{.*}} : <tensor<64x32xf16>>
-// CHECK:           [[VAR_29_:%.+]] = arith.extsi [[PARAM_7_]] : i32 to i64
-// CHECK:           [[VAR_30_:%.+]] = tt.make_tensor_ptr [[PARAM_1_]], {{\[}}[[CST_0_i64]], [[CST_0_i64]]], {{\[}}[[VAR_29_]], [[CST_1_i64]]], {{\[}}[[CST_0_i32]], [[VAR_18_]]] {{.*}} : <tensor<32x128xf16>>
-// CHECK:           [[VAR_33_:%.+]] = arith.muli [[PARAM_7_]], [[CST_32_i32]] : i32
-// CHECK:           [[VAR_34_:%.+]]:3 = scf.for {{.*}} iter_args([[VAR_arg10_:%.+]] = [[VAR_cst_]], [[VAR_arg11_:%.+]] = [[VAR_27_]], [[VAR_arg12_:%.+]] = [[VAR_30_]]) -> (tensor<64x128xf32>, !tt.ptr<tensor<64x32xf16>>, !tt.ptr<tensor<32x128xf16>>)  : i32 {
-// CHECK:             [[VAR_57_:%.+]] = tt.load [[VAR_arg11_]], {{.*}}, {{.*}} : !tt.ptr<tensor<64x32xf16>>
-// CHECK:             [[VAR_61_:%.+]] = tt.load [[VAR_arg12_]], {{.*}}, {{.*}} : !tt.ptr<tensor<32x128xf16>>
-// CHECK:             [[VAR_62_:%.+]] = tt.dot [[VAR_57_]], [[VAR_61_]], [[VAR_arg10_]], inputPrecision = tf32 : tensor<64x32xf16> * tensor<32x128xf16> -> tensor<64x128xf32>
-// CHECK-DAG:         [[VAR_63_:%.+]] = tt.advance [[VAR_arg11_]], {{\[}}[[CST_0_i32]], [[CST_32_i32]]] : <tensor<64x32xf16>>
-// CHECK-DAG:         [[VAR_64_:%.+]] = tt.advance [[VAR_arg12_]], {{\[}}[[CST_0_i32]], [[VAR_33_]]] : <tensor<32x128xf16>>
-// CHECK:             scf.yield [[VAR_62_]], [[VAR_63_]], [[VAR_64_]] : tensor<64x128xf32>, !tt.ptr<tensor<64x32xf16>>, !tt.ptr<tensor<32x128xf16>>
+// CHECK:           [[VAR_15_:%.+]] = arith.muli {{.*}}, [[CST_128_i32]] : i32
+// CHECK:           [[VAR_19_:%.+]] = arith.extsi [[PARAM_6_]] : i32 to i64
+// CHECK:           [[VAR_20_:%.+]] = arith.divui {{.*}}, [[PARAM_6_]] : i32
+// CHECK:           [[VAR_21_:%.+]] = tt.make_tensor_ptr [[PARAM_0_]], {{\[}}[[CST_0_i64]], [[CST_0_i64]]], {{\[}}[[VAR_19_]], [[CST_1_i64]]], {{\[}}[[VAR_20_]], [[CST_0_i32]]] {{.*}} : <tensor<64x32xf16>>
+// CHECK:           [[VAR_23_:%.+]] = arith.extsi [[PARAM_7_]] : i32 to i64
+// CHECK:           [[VAR_24_:%.+]] = tt.make_tensor_ptr [[PARAM_1_]], {{\[}}[[CST_0_i64]], [[CST_0_i64]]], {{\[}}[[VAR_23_]], [[CST_1_i64]]], {{\[}}[[CST_0_i32]], [[VAR_15_]]] {{.*}} : <tensor<32x128xf16>>
+// CHECK:           [[VAR_27_:%.+]] = arith.muli [[PARAM_7_]], [[CST_32_i32]] : i32
+// CHECK:           [[VAR_28_:%.+]]:3 = scf.for {{.*}} iter_args([[VAR_arg10_:%.+]] = [[VAR_cst_]], [[VAR_arg11_:%.+]] = [[VAR_21_]], [[VAR_arg12_:%.+]] = [[VAR_24_]]) -> (tensor<64x128xf32>, !tt.ptr<tensor<64x32xf16>>, !tt.ptr<tensor<32x128xf16>>)  : i32 {
+// CHECK:             [[VAR_39_:%.+]] = tt.load [[VAR_arg11_]], {{.*}}, {{.*}} : !tt.ptr<tensor<64x32xf16>>
+// CHECK:             [[VAR_43_:%.+]] = tt.load [[VAR_arg12_]], {{.*}}, {{.*}} : !tt.ptr<tensor<32x128xf16>>
+// CHECK:             [[VAR_44_:%.+]] = tt.dot [[VAR_39_]], [[VAR_43_]], [[VAR_arg10_]], inputPrecision = tf32 : tensor<64x32xf16> * tensor<32x128xf16> -> tensor<64x128xf32>
+// CHECK-DAG:         [[VAR_45_:%.+]] = tt.advance [[VAR_arg11_]], {{\[}}[[CST_0_i32]], [[CST_32_i32]]] : <tensor<64x32xf16>>
+// CHECK-DAG:         [[VAR_46_:%.+]] = tt.advance [[VAR_arg12_]], {{\[}}[[CST_0_i32]], [[VAR_27_]]] : <tensor<32x128xf16>>
+// CHECK:             scf.yield [[VAR_44_]], [[VAR_45_]], [[VAR_46_]] : tensor<64x128xf32>, !tt.ptr<tensor<64x32xf16>>, !tt.ptr<tensor<32x128xf16>>
 // CHECK:           }
-// CHECK:           tt.store {{.*}} : tensor<64x128x!tt.ptr<f16>>
+// CHECK:           [[VAR_29_:%.+]] = arith.truncf [[VAR_28_]]#0 : tensor<64x128xf32> to tensor<64x128xf16>
+// CHECK:           [[VAR_30_:%.+]] = arith.muli {{.*}}, [[PARAM_8_]] : i32
+// CHECK:           [[VAR_31_:%.+]] = arith.extsi [[PARAM_8_]] : i32 to i64
+// CHECK:           [[VAR_32_:%.+]] = arith.divui [[VAR_30_]], [[PARAM_8_]] : i32
+// CHECK:           [[VAR_33_:%.+]] = tt.make_tensor_ptr [[PARAM_2_]], {{\[}}[[CST_0_i64]], [[CST_0_i64]]], {{\[}}[[VAR_31_]], [[CST_1_i64]]], {{\[}}[[VAR_32_]], [[VAR_15_]]] {{.*}} : <tensor<64x128xf16>>
+// CHECK:           tt.store [[VAR_33_]], [[VAR_29_]] : !tt.ptr<tensor<64x128xf16>>
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Triton/Intel/RaiseToBlockPointers/kernel-03-matrix-multiplication.mlir
+++ b/test/Triton/Intel/RaiseToBlockPointers/kernel-03-matrix-multiplication.mlir
@@ -97,9 +97,9 @@ module {
     %64 = tt.broadcast %61 : tensor<64x1xi1> -> tensor<64x128xi1>
     %65 = tt.broadcast %63 : tensor<1x128xi1> -> tensor<64x128xi1>
     %66 = arith.andi %64, %65 : tensor<64x128xi1>
-    // TODO: add back once masked stores are supported  
-    // tt.store %59, %50, %66 : tensor<64x128x!tt.ptr<f16>>  
-    tt.store %59, %50 : tensor<64x128x!tt.ptr<f16>>  
+    // TODO: add back once masked stores are supported
+    // tt.store %59, %50, %66 : tensor<64x128x!tt.ptr<f16>>
+    tt.store %59, %50 : tensor<64x128x!tt.ptr<f16>>
     tt.return
   }
 }

--- a/test/Triton/Intel/RaiseToBlockPointers/raise-block-pointer.mlir
+++ b/test/Triton/Intel/RaiseToBlockPointers/raise-block-pointer.mlir
@@ -262,21 +262,16 @@ tt.func @test_addptr_broadcast_rank_3(%arg0 : !tt.ptr<f32>) -> tensor<128x2x128x
 // CHECK-DAG:   [[CST_2_i32:%.+]] = arith.constant 2 : i32
 // CHECK:       [[VAR_0_:%.+]] = arith.muli [[PARAM_3_]], [[CST_2_i32]] : i32
 // CHECK:       [[VAR_1_:%.+]] = arith.extsi [[PARAM_3_]] : i32 to i64
-// CHECK:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
-// CHECK:       [[VAR_4_:%.+]] = arith.index_cast [[VAR_3_]] : index to i64
-// CHECK:       [[VAR_5_:%.+]] = arith.muli [[PARAM_4_]], [[CST_6_i32]] : i32
-// CHECK:       [[VAR_6_:%.+]] = arith.extsi [[PARAM_4_]] : i32 to i64
-// CHECK:       [[VAR_7_:%.+]] = arith.index_cast [[VAR_2_]] : index to i64
-// CHECK:       [[VAR_8_:%.+]] = arith.muli [[VAR_7_]], [[VAR_4_]] : i64
-// CHECK:       [[VAR_9_:%.+]] = arith.divui [[VAR_0_]], [[PARAM_3_]] : i32
-// CHECK:       [[VAR_10_:%.+]] = arith.divui [[VAR_5_]], [[PARAM_4_]] : i32
-// CHECK:       [[VAR_11_:%.+]] = tt.make_tensor_ptr [[PARAM_0_]], {{\[}}[[CST_0_i64]], [[VAR_8_]]], {{\[}}[[VAR_1_]], [[VAR_6_]]], {{\[}}[[VAR_9_]], [[VAR_10_]]] {order = array<i32>} : <tensor<4x4xf32>>
-// CHECK:       [[VAR_12_:%.+]] = arith.extsi [[PARAM_5_]] : i32 to i64
-// CHECK:       [[VAR_13_:%.+]] = arith.extsi [[PARAM_6_]] : i32 to i64
-// CHECK:       [[VAR_14_:%.+]] = tt.make_tensor_ptr [[PARAM_1_]], {{\[}}[[CST_0_i64]], [[CST_0_i64]]], {{\[}}[[VAR_12_]], [[VAR_13_]]], {{\[}}[[CST_0_i32]], [[CST_0_i32]]] {order = array<i32>} : <tensor<4x4xf32>>
-// CHECK:       [[VAR_15_:%.+]] = tt.load [[VAR_11_]] {boundaryCheck = array<i32: 1>} : !tt.ptr<tensor<4x4xf32>>
-// CHECK:	      tt.store [[VAR_14_]], [[VAR_15_]] : !tt.ptr<tensor<4x4xf32>>
+// CHECK:       [[VAR_2_:%.+]] = arith.muli [[PARAM_4_]], [[CST_6_i32]] : i32
+// CHECK:       [[VAR_3_:%.+]] = arith.extsi [[PARAM_4_]] : i32 to i64
+// CHECK:       [[VAR_4_:%.+]] = arith.divui [[VAR_0_]], [[PARAM_3_]] : i32
+// CHECK:       [[VAR_5_:%.+]] = arith.divui [[VAR_2_]], [[PARAM_4_]] : i32
+// CHECK:       [[VAR_6_:%.+]] = tt.make_tensor_ptr [[PARAM_0_]], {{\[}}[[CST_0_i64]], [[CST_0_i64]]], {{\[}}[[VAR_1_]], [[VAR_3_]]], {{\[}}[[VAR_4_]], [[VAR_5_]]] {order = array<i32>} : <tensor<4x4xf32>>
+// CHECK:       [[VAR_7_:%.+]] = arith.extsi [[PARAM_5_]] : i32 to i64
+// CHECK:       [[VAR_8_:%.+]] = arith.extsi [[PARAM_6_]] : i32 to i64
+// CHECK:       [[VAR_9_:%.+]] = tt.make_tensor_ptr [[PARAM_1_]], {{\[}}[[CST_0_i64]], [[CST_0_i64]]], {{\[}}[[VAR_7_]], [[VAR_8_]]], {{\[}}[[CST_0_i32]], [[CST_0_i32]]] {order = array<i32>} : <tensor<4x4xf32>>
+// CHECK:       [[VAR_10_:%.+]] = tt.load [[VAR_6_]] {boundaryCheck = array<i32: 1>} : !tt.ptr<tensor<4x4xf32>>
+// CHECK:	      tt.store [[VAR_9_]], [[VAR_10_]] : !tt.ptr<tensor<4x4xf32>>
 // CHECK:       tt.return
 module {
 tt.func public @wrap_side_by_side_masked(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32) {
@@ -415,23 +410,18 @@ module {
 // CHECK-DAG:   [[CST_2_i32:%.+]] = arith.constant 2 : i32
 // CHECK-DAG:   [[CST_0_i64:%.+]] = arith.constant 0 : i64
 // CHECK-DAG:   [[CST_0_i32:%.+]] = arith.constant 0 : i32
-// CHECK:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:       [[VAR_1_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
-// CHECK:       [[VAR_2_:%.+]] = arith.muli [[PARAM_3_]], [[CST_2_i32]] : i32
-// CHECK:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_1_]] : index to i64
-// CHECK:       [[VAR_4_:%.+]] = arith.extsi [[PARAM_3_]] : i32 to i64
-// CHECK:       [[VAR_5_:%.+]] = arith.index_cast [[VAR_0_]] : index to i64
-// CHECK:       [[VAR_6_:%.+]] = arith.muli [[VAR_5_]], [[VAR_3_]] : i64
-// CHECK:       [[VAR_7_:%.+]] = arith.muli [[PARAM_4_]], [[CST_3_i32]] : i32
-// CHECK:       [[VAR_8_:%.+]] = arith.extsi [[PARAM_4_]] : i32 to i64
-// CHECK:       [[VAR_9_:%.+]] = arith.divui [[VAR_2_]], [[PARAM_3_]] : i32
-// CHECK:       [[VAR_10_:%.+]] = arith.divui [[VAR_7_]], [[PARAM_4_]] : i32
-// CHECK:       [[VAR_11:%.+]] = tt.make_tensor_ptr [[PARAM_0_]], {{\[}}[[VAR_6_]], [[CST_0_i64]]], {{\[}}[[VAR_4_]], [[VAR_8_]]], {{\[}}[[VAR_9_]], [[VAR_10_]]] {order = array<i32>} : <tensor<4x4xf32>>
-// CHECK:       [[VAR_12_:%.+]] = arith.extsi [[PARAM_5_]] : i32 to i64
-// CHECK:       [[VAR_13_:%.+]] = arith.extsi [[PARAM_6_]] : i32 to i64
-// CHECK:       [[VAR_14:%.+]] = tt.make_tensor_ptr [[PARAM_1_]], {{\[}}[[CST_0_i64]], [[CST_0_i64]]], {{\[}}[[VAR_12_]], [[VAR_13_]]], {{\[}}[[CST_0_i32]], [[CST_0_i32]]] {order = array<i32>} : <tensor<4x4xf32>>
-// CHECK:       [[VAR_15:%.+]] = tt.load [[VAR_11]] {boundaryCheck = array<i32: 0>} : !tt.ptr<tensor<4x4xf32>>
-// CHECK:     	tt.store [[VAR_14]], [[VAR_15]] : !tt.ptr<tensor<4x4xf32>>
+// CHECK:       [[VAR_0_:%.+]] = arith.muli [[PARAM_3_]], [[CST_2_i32]] : i32
+// CHECK:       [[VAR_1_:%.+]] = arith.extsi [[PARAM_3_]] : i32 to i64
+// CHECK:       [[VAR_2_:%.+]] = arith.muli [[PARAM_4_]], [[CST_3_i32]] : i32
+// CHECK:       [[VAR_3_:%.+]] = arith.extsi [[PARAM_4_]] : i32 to i64
+// CHECK:       [[VAR_4_:%.+]] = arith.divui [[VAR_0_]], [[PARAM_3_]] : i32
+// CHECK:       [[VAR_5_:%.+]] = arith.divui [[VAR_2_]], [[PARAM_4_]] : i32
+// CHECK:       [[VAR_6:%.+]] = tt.make_tensor_ptr [[PARAM_0_]], {{\[}}[[CST_0_i64]], [[CST_0_i64]]], {{\[}}[[VAR_1_]], [[VAR_3_]]], {{\[}}[[VAR_4_]], [[VAR_5_]]] {order = array<i32>} : <tensor<4x4xf32>>
+// CHECK:       [[VAR_7_:%.+]] = arith.extsi [[PARAM_5_]] : i32 to i64
+// CHECK:       [[VAR_8_:%.+]] = arith.extsi [[PARAM_6_]] : i32 to i64
+// CHECK:       [[VAR_9:%.+]] = tt.make_tensor_ptr [[PARAM_1_]], {{\[}}[[CST_0_i64]], [[CST_0_i64]]], {{\[}}[[VAR_7_]], [[VAR_8_]]], {{\[}}[[CST_0_i32]], [[CST_0_i32]]] {order = array<i32>} : <tensor<4x4xf32>>
+// CHECK:       [[VAR_10:%.+]] = tt.load [[VAR_6]] {boundaryCheck = array<i32: 0>} : !tt.ptr<tensor<4x4xf32>>
+// CHECK:     	tt.store [[VAR_9]], [[VAR_10]] : !tt.ptr<tensor<4x4xf32>>
 // CHECK:       tt.return
 module {
   tt.func public @wrap_stacked_masked_loop(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32) {

--- a/test/Triton/Intel/RaiseToBlockPointers/wraparound_side_by_side.mlir
+++ b/test/Triton/Intel/RaiseToBlockPointers/wraparound_side_by_side.mlir
@@ -1,4 +1,6 @@
 // RUN: triton-opt %s -triton-raise-block-pointer -canonicalize | FileCheck %s
+// XFAIL: *
+// Note: Cannot generate tt.advance because block ptrs are created with unknown strides
 
 module {
   tt.func public @wrap_side_by_side_masked_loop_01234567(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32) {

--- a/test/Triton/Intel/RaiseToBlockPointers/wraparound_stacked.mlir
+++ b/test/Triton/Intel/RaiseToBlockPointers/wraparound_stacked.mlir
@@ -1,4 +1,6 @@
 // RUN: triton-opt %s -triton-raise-block-pointer -canonicalize | FileCheck %s
+// XFAIL: *
+// Note: Cannot generate tt.advance because block ptrs are created with unknown strides
 
 module {
   tt.func public @wrap_stacked_masked_loop_01234567(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32) {

--- a/test/Triton/Intel/RaiseToBlockPointers/wraparound_unsupported_add_offset.mlir
+++ b/test/Triton/Intel/RaiseToBlockPointers/wraparound_unsupported_add_offset.mlir
@@ -1,4 +1,6 @@
 // RUN: triton-opt %s -triton-raise-block-pointer -canonicalize | FileCheck %s
+// XFAIL: *
+// Note: Cannot generate tt.advance because block ptrs are created with unknown strides
 
 
 // We currently do not support this kind of modulo pattern:

--- a/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
+++ b/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
@@ -432,12 +432,9 @@ struct PtrState {
 
     // Case 2: at least one offset is zero.
     assert(offsets.size() == 2 && "Expecting two offsets");
-    Value nonZeroOffset = ttgi::isConstant(getFinalValue(offsets[0]), 0)
-                              ? offsets[1]
-                              : offsets[0];
-    Value zeroOffset = ttgi::isConstant(getFinalValue(offsets[0]), 0)
-                           ? offsets[0]
-                           : offsets[1];
+    bool zeroIdx = !ttgi::isConstant(getFinalValue(offsets[0]), 0);
+    Value nonZeroOffset = offsets[!zeroIdx];
+    Value zeroOffset = offsets[zeroIdx];
 
     if (ttgi::isConstant(getFinalValue(makeTPtrOp.getStrides()[0]), 1))
       newOffsets = {nonZeroOffset, zeroOffset};
@@ -515,7 +512,7 @@ public:
     assert(rootOp && "Expected a valid operation");
 
     bool fail = false;
-    auto res = rootOp->walk<WalkOrder::PreOrder>([&](Operation *op) {
+    rootOp->walk<WalkOrder::PreOrder>([&](Operation *op) {
       if (op == rootOp)
         return WalkResult::advance();
 

--- a/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
+++ b/third_party/intel/lib/TritonRaiseBlockPointer/TritonRaiseBlockPointer.cpp
@@ -102,8 +102,8 @@ Value findOrCreateMakeTensorPtr(Location loc, Value source, ValueRange shape,
     return false;
   });
 
-  // Note: We are forcing an unknown shape to allow us to do pointer increments
-  // that may wrap around (via the tt.advance operation) .
+  // Note: We are forcing the shape to be unknown to pointer increments that may
+  // wrap around (via the tt.advance operation).
   Value zero = findOrCreateConstant(loc, 0, shapeAndStridesBitwidth, builder);
   SmallVector<Value> zeros;
   for (int i = 0; i < shape.size(); ++i)
@@ -404,16 +404,20 @@ struct PtrState {
       return std::nullopt;
 
     // We can generate a tt.advance operation as follow:
-    //   Case 1: both offsets are non-zero ==> both strides must be one
+    //   Case 1: all offsets are non-zero ==> all strides must be one
     //   Case 2: one offset is zero
     //     2a) offsets: (0, off1) strides: (*, 1) ==> tt.advance ptr, (0, off1)
     //     2b) offsets: (off0, 0) strides: (*, 1) ==> tt.advance ptr, (0, off0)
 
-    bool bothOffsetsNotZero = llvm::all_of(offsets, [&](Value offset) {
+    bool allOffsetsNotZero = llvm::all_of(offsets, [&](Value offset) {
       return !ttgi::isConstant(getFinalValue(offset), 0);
     });
 
-    if (bothOffsetsNotZero) {
+    // Case 1: all offsets are non-zero.
+    if (allOffsetsNotZero) {
+      assert(offsets.size() == 1 &&
+             "TODO: can we generate tt.advance ptr, (0, off0*str0 + off1) ?");
+
       if (llvm::any_of(makeTPtrOp.getStrides(), [&](Value stride) {
             return !ttgi::isConstant(getFinalValue(stride), 1);
           }))
@@ -421,24 +425,24 @@ struct PtrState {
 
       for (Value offset : offsets)
         newOffsets.push_back(offset);
-    } else {
-      Value nonZeroOffset = ttgi::isConstant(getFinalValue(offsets[0]), 0)
-                                ? offsets[1]
-                                : offsets[0];
-      Value zeroOffset = ttgi::isConstant(getFinalValue(offsets[0]), 0)
-                             ? offsets[0]
-                             : offsets[1];
 
-      if (ttgi::isConstant(getFinalValue(makeTPtrOp.getStrides()[0]), 1)) {
-        newOffsets.push_back(nonZeroOffset);
-        newOffsets.push_back(zeroOffset);
-      } else {
-        assert(ttgi::isConstant(getFinalValue(makeTPtrOp.getStrides()[1]), 1) &&
-               "Expecting stride 1 for the second dimension");
-        newOffsets.push_back(zeroOffset);
-        newOffsets.push_back(nonZeroOffset);
-      }
+      return builder.createOrFold<tt::AdvanceOp>(loc, ptr.getType(), ptr,
+                                                 newOffsets);
     }
+
+    // Case 2: at least one offset is zero.
+    assert(offsets.size() == 2 && "Expecting two offsets");
+    Value nonZeroOffset = ttgi::isConstant(getFinalValue(offsets[0]), 0)
+                              ? offsets[1]
+                              : offsets[0];
+    Value zeroOffset = ttgi::isConstant(getFinalValue(offsets[0]), 0)
+                           ? offsets[0]
+                           : offsets[1];
+
+    if (ttgi::isConstant(getFinalValue(makeTPtrOp.getStrides()[0]), 1))
+      newOffsets = {nonZeroOffset, zeroOffset};
+    else
+      newOffsets = {zeroOffset, nonZeroOffset};
 
     return builder.createOrFold<tt::AdvanceOp>(loc, ptr.getType(), ptr,
                                                newOffsets);


### PR DESCRIPTION
In order to increment a block ptr via the `tt.advance` operation the block ptr must have at least one of the stride to be unit stride. 