### PR TITLE
Hot fix for corrupt pytorch patch

### DIFF
--- a/scripts/pytorch.patch
+++ b/scripts/pytorch.patch
@@ -42,3 +42,4 @@ index db0f0f1081b..1be4ec37dfe 100644
 +#include <algorithm>
  #include <cstdlib>
  #include <cstring>
+ 


### PR DESCRIPTION
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/13202041680 (not relevant launch, because it does not rebuild pytorch, so I rechecked locally - it works)

I lost a line when copying, which broke the patch.