### PR TITLE
Workflow to test Triton XPU with SPIR-V backend

### DIFF
--- a/.github/actions/setup-triton/action.yml
+++ b/.github/actions/setup-triton/action.yml
@@ -23,16 +23,23 @@ runs:
         LLVM_COMMIT_ID=$(<cmake/llvm-hash.txt)
         echo "LLVM_COMMIT_ID=$LLVM_COMMIT_ID" | tee -a $GITHUB_ENV
 
+    - name: Generate LLVM cache key
+      if: ${{ inputs.build_llvm == 'true' }}
+      shell: bash
+      run: |
+        LLVM_CACHE_KEY=$(echo $LLVM_COMMIT_ID ${{ inputs.use_spirv_backend }} | sha256sum - | cut -d\  -f1)
+        echo "LLVM_CACHE_KEY=$LLVM_CACHE_KEY" | tee -a $GITHUB_ENV
+
     - name: Load LLVM cache
       if: ${{ inputs.build_llvm == 'true' }}
       id: llvm-cache
       uses: ./.github/actions/load
       env:
         # Increase this value to reset cache
-        CACHE_NUMBER: 2
+        CACHE_NUMBER: 3
       with:
         path: $HOME/packages
-        key: packages-${{ env.LLVM_COMMIT_ID }}-${{ env.CACHE_NUMBER }}
+        key: packages-${{ env.LLVM_CACHE_KEY }}-${{ env.CACHE_NUMBER }}
 
     - name: Clone LLVM
       if: ${{ inputs.build_llvm == 'true' && steps.llvm-cache.outputs.status == 'miss' }}

--- a/.github/actions/setup-triton/action.yml
+++ b/.github/actions/setup-triton/action.yml
@@ -1,11 +1,16 @@
 # Builds and installs Triton. Uses git clone in the current directory.
 # Sets the following environment variables:
 # * LLVM_COMMIT_ID
+# * TRITON_USE_SPIRV_BACKEND (if use_spirv_backend is true)
+name: setup-triton
 description: Build and install Triton
 inputs:
   build_llvm:
     description: Build LLVM
-    default: false
+    default: "false"
+  use_spirv_backend:
+    description: Use SPIR-V backend
+    default: "false"
   command:
     description: Command to execute
     default: DEBUG=1 pip install -v --no-build-isolation '.[build,tests,tutorials]'
@@ -37,6 +42,12 @@ runs:
         ref: ${{ env.LLVM_COMMIT_ID }}
         path: llvm
         submodules: recursive
+
+    - name: Use SPIR-V backend
+      if: ${{ inputs.use_spirv_backend == 'true' }}
+      shell: bash
+      run: |
+        echo "TRITON_USE_SPIRV_BACKEND=1" | tee -a $GITHUB_ENV
 
     - name: Build LLVM
       if: ${{ inputs.build_llvm == 'true' && steps.llvm-cache.outputs.status == 'miss' }}

--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -60,6 +60,10 @@ on:
         description: Use Python built with pyenv
         type: boolean
         default: false
+      use_spirv_backend:
+        description: Use SPIR-V backend
+        type: boolean
+        default: false
 
 permissions: read-all
 
@@ -125,6 +129,7 @@ jobs:
         uses: ./.github/actions/setup-triton
         with:
           build_llvm: ${{ inputs.build_llvm }}
+          use_spirv_backend: ${{ inputs.use_spirv_backend }}
 
       - name: Create test-triton command line
         run: |

--- a/.github/workflows/build-test-spirv.yml
+++ b/.github/workflows/build-test-spirv.yml
@@ -1,0 +1,21 @@
+name: Build and test SPIR-V backend
+
+on:
+  workflow_dispatch:
+
+  pull_request:
+    branches:
+      - main
+      - release/**
+
+permissions: read-all
+
+jobs:
+  integration-tests:
+    name: Integration tests matrix
+    uses: ./.github/workflows/build-test-reusable.yml
+    with:
+      python_version: "3.9"
+      skip_list: default
+      build_llvm: true
+      use_spirv_backend: true

--- a/.github/workflows/build-test-spirv.yml
+++ b/.github/workflows/build-test-spirv.yml
@@ -3,11 +3,6 @@ name: Build and test SPIR-V backend
 on:
   workflow_dispatch:
 
-  pull_request:
-    branches:
-      - main
-      - release/**
-
 permissions: read-all
 
 jobs:


### PR DESCRIPTION
Currently this workflow can be started manually for a selected branch (after merging to main).

Fixes #3247.
