### PR TITLE
Reduce memory usage for gemm postop addmatrix by removing unnecessary 'to' casts and update required memory calculation

### DIFF
--- a/benchmarks/triton_kernels_benchmark/gemm_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_benchmark.py
@@ -256,7 +256,8 @@ def is_enough_memory(x_val):
     # a: (B, M, K) bfloat16
     # b: (B, N, K) bfloat16
     # c: (B, M, N) float32
-    required_memory = B * M * K * 2 + B * N * K * 2 + B * M * N * 4
+    # pytorch reference: (B, M, N) float32
+    required_memory = B * M * K * 2 + B * N * K * 2 + 2 * B * M * N * 4
     enough_memory = required_memory < DEVICE_TOTAL_MEMORY
     if not enough_memory:
         print(f"'{x_val}' combination skipped for '{DEVICE_NAME}'; {required_memory=} but {DEVICE_TOTAL_MEMORY=}")

--- a/benchmarks/triton_kernels_benchmark/gemm_postop_addmatrix_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_postop_addmatrix_benchmark.py
@@ -327,12 +327,7 @@ def benchmark(B, M, N, K, dtype, provider):
             assert len(a.shape) == 2, 'Expecting shape of length 2'
             c = torch.empty((M, N), device='xpu', dtype=res_dtype)
         triton_fn = lambda: matmul(a, b, d, c)
-        # Torch does not support integer calculation in matmul
-        torch_device = 'xpu' if dtype.is_floating_point else 'cpu'
-        torch_dtype = dtype if dtype.is_floating_point else res_dtype
-        torch_fn = lambda: torch.matmul(a.to(device=torch_device, dtype=torch_dtype),
-                                        b.to(device=torch_device, dtype=torch_dtype)).to(device='xpu', dtype=res_dtype
-                                                                                         ) + d
+        torch_fn = lambda: torch.matmul(a, b) + d
         rtol = 1e-2 if a.dtype == torch.bfloat16 else 1e-3
         if dtype.is_floating_point or [B, M, N, K] in [[1, 1024, 1024, 1024], [1, 2048, 2048, 2048],
                                                        [1, 512, 8192, 32768], [4, 32768, 4096, 128]]:

--- a/benchmarks/triton_kernels_benchmark/gemm_postop_gelu_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_postop_gelu_benchmark.py
@@ -241,7 +241,8 @@ def is_enough_memory(x_val):
     # a: (B, M, K) bfloat16
     # b: (B, K, N) bfloat16
     # c: (B, M, N) float32
-    required_memory = B * M * K * 2 + B * K * N * 2 + B * M * N * 4
+    # pytorch reference: (B, M, N) float32
+    required_memory = B * M * K * 2 + B * K * N * 2 + 2 * B * M * N * 4
     enough_memory = required_memory < DEVICE_TOTAL_MEMORY
     if not enough_memory:
         print(f"'{x_val}' combination skipped for '{DEVICE_NAME}'; {required_memory=} but {DEVICE_TOTAL_MEMORY=}")

--- a/benchmarks/triton_kernels_benchmark/gemm_preop_exp_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_preop_exp_benchmark.py
@@ -229,7 +229,8 @@ def is_enough_memory(x_val):
     # a: (B, M, K) bfloat16
     # b: (B, K, N) bfloat16
     # c: (B, M, N) float32
-    required_memory = B * M * K * 2 + B * K * N * 2 + B * M * N * 4
+    # pytorch reference: (B, M, N) float32
+    required_memory = B * M * K * 2 + B * K * N * 2 + 2 * B * M * N * 4
     enough_memory = required_memory < DEVICE_TOTAL_MEMORY
     if not enough_memory:
         print(f"'{x_val}' combination skipped for '{DEVICE_NAME}'; {required_memory=} but {DEVICE_TOTAL_MEMORY=}")


### PR DESCRIPTION
Relates to #3406