### PR TITLE
Merge OpenAI Triton commit `df66eb5`

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -869,6 +869,7 @@ It is characterized by the following parameters:
   - 1.0: gfx908, i.e. MI100
   - 2.0: gfx90a: i.e. MI200, MI210, MI250
   - 3.0: gfx940, gfx941, gfx942: MI300
+  - 4.0: gfx950: MI350
 - `warpsPerCTA` indicates the warp layout in the block.
 - `MDim` and `NDim` indicate the dimension of the output of the mfma instruction.
 - `isTransposed` indicates the result tensor is transposed so that it can be converted to dotOperand layout
@@ -938,7 +939,7 @@ The data will be distributed between threads as follows:
 
 Example 3:
 Suppose we have a tensor with a shape of [8, 8], warpsPerCTA set to [2, 2] and nonKDim set to 4.
-The data will be distributed between threads as follows(note that each element is duploicated in 16 threads):
+The data will be distributed between threads as follows(note that each element is duplicated in 16 threads):
 Suppose we have a tensor with a shape of [8, 8], warpsPerCTA set to [2, 2] and MDim=NDim=4.
 The data will be distributed between threads as follows(note that each element is duplicated in 16 threads):
 

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -1237,7 +1237,19 @@ static LogicalResult verifyDesciptorLoadStoreType(Operation *op,
                                                   TensorDescType desc,
                                                   RankedTensorType tensor) {
   RankedTensorType block = desc.getBlockType();
-  if (block.getShape() == tensor.getShape() &&
+  ArrayRef<int64_t> blockShape = block.getShape();
+  ArrayRef<int64_t> tensorShape = tensor.getShape();
+  if (blockShape.size() > tensorShape.size()) {
+    // Allow ranked reduced load if the leading dimensions are all 1s.
+    for (int i = 0; i < blockShape.size() - tensorShape.size(); ++i) {
+      if (blockShape[i] != 1)
+        return op->emitOpError(
+            "ranked reduce load only allowed for unit dimension leading dim.");
+    }
+    blockShape = blockShape.take_back(tensorShape.size());
+  }
+
+  if (blockShape == tensorShape &&
       block.getElementType() == tensor.getElementType())
     return success();
   return op->emitOpError("tensor desciptor block and tensor types must match");

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1494,8 +1494,8 @@ AMDMfmaEncodingAttr::verify(function_ref<mlir::InFlightDiagnostic()> emitError,
                             llvm::ArrayRef<unsigned int> warpsPerCTA,
                             unsigned mDim, unsigned nDim, bool isTransposed,
                             mlir::triton::gpu::CTALayoutAttr) {
-  if (!(versionMajor >= 0 && versionMajor <= 3)) {
-    return emitError() << "major version must be in the [0, 3] range";
+  if (!(versionMajor >= 0 && versionMajor <= 4)) {
+    return emitError() << "major version must be in the [0, 4] range";
   }
   if (versionMinor != 0) {
     return emitError() << "minor version must be 0";
@@ -2249,10 +2249,11 @@ SmallVector<unsigned> DotOperandEncodingAttr::getSizePerThread() const {
   assert(parentLayout && "DotOperandEncodingAttr must have a parent");
   if (auto parentMmaLayout = mlir::dyn_cast<MmaEncodingTrait>(parentLayout)) {
     return parentMmaLayout.getSizePerThreadForOperand(getKWidth(), getOpIdx());
+  } else if (auto blocked = mlir::dyn_cast<BlockedEncodingAttr>(parentLayout)) {
+    return blocked.getSizePerThread();
   } else {
     llvm::report_fatal_error(
-        "DotOperandEncodingAttr non-NvidiaMmaEncodingAttr parent not "
-        "supported yet");
+        "getSizePerThread not implemented for DotOperandEncodingAttr");
     return {};
   }
 }

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -6,7 +6,7 @@ import triton.language as tl
 import triton.tools.experimental_descriptor
 from test_mxfp import MXFP4Tensor, MXScaleTensor
 import re
-from triton._internal_testing import is_cuda, is_hip, is_hip_mi200, is_xpu
+from triton._internal_testing import is_cuda, is_hip, is_hip_mi200, is_hip_mi350, is_hip_cdna, is_xpu
 
 
 def f8_to_f16(x, dtype):
@@ -723,11 +723,20 @@ def block_scale_fp4_matmul(  #
                                                        (128, 256, 256), (128, 128, 64), (128, 64, 128)])
 @pytest.mark.parametrize(("scale_type", "VEC_SIZE"), [("float8_e8m0fnu", 32), ("float8_e4m3fn", 16)],
                          ids=["mxfp4", "nvfp4"])
-@pytest.mark.skipif(is_cuda() and torch.cuda.get_device_capability()[0] < 10,
-                    reason="Requires compute capability >= 10")
-def test_block_scale_fp4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, VEC_SIZE, scale_type, device):
-    if is_xpu():
+@pytest.mark.parametrize("nonKDim", ([0, 16, 32] if is_hip_cdna() else []))
+def test_block_scale_fp4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, VEC_SIZE, scale_type, nonKDim, device):
+    if is_cuda() and torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("Requires compute capability >= 10")
+    elif is_hip():
+        if not is_hip_mi350():
+            pytest.skip("Scaled fp4 matmul is only natively supported on MI350")
+        if scale_type != 'float8_e8m0fnu':
+            pytest.skip("MI350 only supports E8M0 scale")
+        if (nonKDim == 16 and BLOCK_K < 128) or (nonKDim == 32 and BLOCK_K < 64):
+            pytest.skip(f"MI350 does not support {BLOCK_K=} for scaled mfma {nonKDim=} variants")
+    elif is_xpu():
         pytest.skip("FIXME: failed to legalize operation 'tt.dot_scaled' on XPU")
+
     NUM_STAGES = 1
     torch.manual_seed(42)
     a_mxfp4 = MXFP4Tensor(size=(M, K), device=device).random()
@@ -759,9 +768,12 @@ def test_block_scale_fp4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, VEC_SIZE, scale_typ
 
     output = a.new_empty((M, N), dtype=torch.float32)
     grid = (triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N), 1)
+    kernel_kwargs = {}
+    if is_hip():
+        kernel_kwargs["matrix_instr_nonkdim"] = nonKDim
     block_scale_fp4_matmul[grid](a, b, output, a_scale, b_scale, M, N, K, a_scale.stride(0), a.stride(0), a.stride(1),
                                  b.stride(0), b.stride(1), output.stride(0), output.stride(1), VEC_SIZE, BLOCK_M,
-                                 BLOCK_N, BLOCK_K, NUM_STAGES=NUM_STAGES)
+                                 BLOCK_N, BLOCK_K, NUM_STAGES=NUM_STAGES, **kernel_kwargs)
 
     torch.testing.assert_close(ref_out, output, atol=1e-2, rtol=1e-2)
 

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -60,8 +60,15 @@ def is_hip_mi300():
     return target.arch in ('gfx940', 'gfx941', 'gfx942')
 
 
+def is_hip_mi350():
+    target = get_current_target()
+    if target is None or target.backend != 'hip':
+        return False
+    return target.arch in ('gfx950')
+
+
 def is_hip_cdna():
-    return is_hip_mi200() or is_hip_mi300()
+    return is_hip_mi200() or is_hip_mi300() or is_hip_mi350()
 
 
 def is_xpu():

--- a/scripts/skiplist/default/language.txt
+++ b/scripts/skiplist/default/language.txt
@@ -1,4 +1,7 @@
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/2968
-test/unit/language/test_core.py::test_scaled_dot[32-64-128-False-True-True-e5m2-bf16-4-16-1]
-test/unit/language/test_core.py::test_scaled_dot[128-32-64-True-True-True-e4m3-fp16-4-16-1]
 test/unit/language/test_core.py::test_scaled_dot[128-32-64-True-False-True-e4m3-bf16-4-16-1]
+test/unit/language/test_core.py::test_scaled_dot[128-32-64-True-False-True-e4m3-fp16-4-16-1]
+test/unit/language/test_core.py::test_scaled_dot[128-32-64-True-True-True-e4m3-bf16-4-16-1]
+test/unit/language/test_core.py::test_scaled_dot[32-64-128-False-False-True-e5m2-bf16-4-16-1]
+test/unit/language/test_core.py::test_scaled_dot[64-32-64-False-False-True-e4m3-fp16-4-16-1]
+test/unit/language/test_core.py::test_scaled_dot[64-64-128-False-True-True-e5m2-bf16-4-16-1]

--- a/test/Conversion/amd/async_ops_to_llvm.mlir
+++ b/test/Conversion/amd/async_ops_to_llvm.mlir
@@ -193,25 +193,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 16 : i32, ttg.sha
     // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_ca]]
     %2 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = ca: tensor<32x32x!tt.ptr<f16>, #blocked> -> <32x32xf16, #shared, #smem, mutable>
     // CHECK: llvm.getelementptr
-    // CHECK: %[[aux_cg:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[aux_cg:.*]] = llvm.mlir.constant(3 : i32) : i32
     // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cg]]
     %3 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = cg: tensor<32x32x!tt.ptr<f16>, #blocked> -> <32x32xf16, #shared, #smem, mutable>
     // CHECK: llvm.getelementptr
-    // CHECK: %[[aux_cs:.*]] = llvm.mlir.constant(3 : i32) : i32
-    // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cs]]
-    %5 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = cs: tensor<32x32x!tt.ptr<f16>, #blocked> -> <32x32xf16, #shared, #smem, mutable>
-    // CHECK: llvm.getelementptr
-    // CHECK: %[[aux_cv:.*]] = llvm.mlir.constant(9 : i32) : i32
+    // CHECK: %[[aux_cv:.*]] = llvm.mlir.constant(11 : i32) : i32
     // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cv]]
-    %6 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = cv: tensor<32x32x!tt.ptr<f16>, #blocked> -> <32x32xf16, #shared, #smem, mutable>
-    // CHECK: llvm.getelementptr
-    // CHECK: %[[aux_wb:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_wb]]
-    %7 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = wb: tensor<32x32x!tt.ptr<f16>, #blocked> -> <32x32xf16, #shared, #smem, mutable>
-    // CHECK: llvm.getelementptr
-    // CHECK: %[[aux_wt:.*]] = llvm.mlir.constant(8 : i32) : i32
-    // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_wt]]
-    %8 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = wt: tensor<32x32x!tt.ptr<f16>, #blocked> -> <32x32xf16, #shared, #smem, mutable>
+    %4 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = cv: tensor<32x32x!tt.ptr<f16>, #blocked> -> <32x32xf16, #shared, #smem, mutable>
     tt.return
   }
 }

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -380,3 +380,13 @@ tt.func @test_reshape_reduce(%0: tensor<32x4x2xi32>) -> (i32, tensor<16xi32>) {
   %3 = tt.histogram %1 : tensor<256xi32> -> tensor<16xi32>
   tt.return %2, %3 : i32, tensor<16xi32>
 }
+
+// CHECK-LABEL: test_rank_reduce_desc_load
+tt.func @test_rank_reduce_desc_load(%0: !tt.tensordesc<tensor<1x128x64xf16>>) -> (tensor<128x64xf16>) {
+  %c0 = arith.constant 0 : i32
+  // CHECK: %[[R:.+]] = tt.experimental_descriptor_load {{.*}} : !tt.tensordesc<tensor<1x128x64xf16>> -> tensor<128x64xf16>
+  // CHECK: tt.return %[[R]]
+  %l = tt.experimental_descriptor_load %0[%c0, %c0, %c0] : !tt.tensordesc<tensor<1x128x64xf16>> -> tensor<1x128x64xf16>
+  %r = tt.reshape %l : tensor<1x128x64xf16> -> tensor<128x64xf16>
+  tt.return %r :  tensor<128x64xf16>
+}

--- a/test/Triton/invalid.mlir
+++ b/test/Triton/invalid.mlir
@@ -409,7 +409,7 @@ tt.func @gather_op(%arg0: tensor<128x16xf32>, %arg1: tensor<512x4xi32>) {
 
 tt.func @invalid_desc_load(%arg0: !tt.tensordesc<tensor<16x16xf32>>) {
   %c = arith.constant 0 : i32
-  // expected-error @below {{tensor desciptor block and tensor types must match}}
+  // expected-error @below {{ranked reduce load only allowed for unit dimension leading dim}}
   tt.experimental_descriptor_load %arg0[%c, %c] : !tt.tensordesc<tensor<16x16xf32>> -> tensor<16xf32>
   tt.return
 }

--- a/test/TritonGPU/invalid-attributes.mlir
+++ b/test/TritonGPU/invalid-attributes.mlir
@@ -64,7 +64,7 @@
 
 // -----
 
-// expected-error@+1 {{major version must be in the [0, 3] range}}
+// expected-error@+1 {{major version must be in the [0, 4] range}}
 #mfma = #ttg.amd_mfma<{versionMajor = 10, versionMinor = 0, warpsPerCTA = [1, 1, 1], instrShape = [32, 32], isTransposed = false}>
 
 // -----

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -99,7 +99,7 @@ class HIPBackend(BaseBackend):
 
         if "supported_fp8_dtypes" not in opts:
             supported_fp8_dtypes = set(HIPOptions.supported_fp8_dtypes)
-            if self.target.arch in ('gfx940', 'gfx941', 'gfx942'):
+            if self.target.arch in ('gfx940', 'gfx941', 'gfx942', 'gfx950'):
                 supported_fp8_dtypes.update({'fp8e4nv', 'fp8e4b8', 'fp8e5b16'})
             args["supported_fp8_dtypes"] = tuple(sorted(supported_fp8_dtypes))
 

--- a/third_party/amd/include/TritonAMDGPUTransforms/MfmaGroup.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/MfmaGroup.h
@@ -20,7 +20,8 @@ enum class MfmaTypeId : uint32_t {
   Fp8Fp8TyId,
   Fp8Bf8TyId,
   Bf8Fp8TyId,
-  Bf8Bf8TyId
+  Bf8Bf8TyId,
+  F8F6F4TyId,
 };
 
 struct MfmaInsnGroupSelectKey {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM.cpp
@@ -15,6 +15,11 @@ LogicalResult convertMFMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
                           const LLVMTypeConverter *typeConverter,
                           ConversionPatternRewriter &rewriter);
 
+LogicalResult convertScaledMFMA(triton::DotScaledOp op,
+                                triton::DotScaledOp::Adaptor adaptor,
+                                const LLVMTypeConverter *typeConverter,
+                                ConversionPatternRewriter &rewriter);
+
 LogicalResult convertWMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
                           const LLVMTypeConverter *typeConverter,
                           ConversionPatternRewriter &rewriter);
@@ -22,7 +27,7 @@ LogicalResult convertWMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
 
 namespace {
 struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
-  using ConvertOpToLLVMPattern<triton::DotOp>::ConvertOpToLLVMPattern;
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
   matchAndRewrite(triton::DotOp op, OpAdaptor adaptor,
@@ -47,6 +52,25 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
         "Unsupported DotOp found when converting TritonGPU to LLVM.");
   }
 };
+
+struct ScaledDotOpConversion
+    : public ConvertOpToLLVMPattern<triton::DotScaledOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+  int mfmaVersion;
+  int nonKDim;
+  int kPack;
+
+  ScaledDotOpConversion(LLVMTypeConverter &typeConverter, int mfmaVersion,
+                        int nonKDim, int kPack, PatternBenefit benefit = 1)
+      : ConvertOpToLLVMPattern(typeConverter, benefit),
+        mfmaVersion(mfmaVersion), nonKDim(nonKDim), kPack(kPack) {}
+
+  LogicalResult
+  matchAndRewrite(triton::DotScaledOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    return AMD::convertScaledMFMA(op, adaptor, getTypeConverter(), rewriter);
+  }
+};
 } // namespace
 
 namespace mlir::triton::AMD {
@@ -55,5 +79,6 @@ void populateDotOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                  ModuleAxisInfoAnalysis &axisInfoAnalysis,
                                  PatternBenefit benefit) {
   patterns.add<DotOpConversion>(typeConverter, benefit);
+  patterns.add<ScaledDotOpConversion>(typeConverter, benefit);
 }
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -25,18 +25,40 @@
 #include "TritonAMDGPUTransforms/MfmaGroup.h"
 #include "Utility.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 using namespace mlir;
 using namespace mlir::triton;
 
 namespace {
 
+using ::mlir::LLVM::AMD::scaleDotElemTypeToMLIRType;
 using ::mlir::LLVM::AMD::shuffleXor;
 using ::mlir::triton::gpu::AMDMfmaEncodingAttr;
 using ::mlir::triton::gpu::DotOperandEncodingAttr;
+using ::mlir::triton::gpu::LinearEncodingAttr;
 using ::mlir::triton::gpu::SwizzledSharedEncodingAttr;
 
 using ValueTable = std::map<std::array<int, 3>, Value>;
+
+/// Get matrix format flag passed through BLGP/CBSZ args in V_MFMA_*_F8F6F4
+/// instructions.
+///
+/// Values:
+/// - 0: E4M3(FP8)
+/// - 1: E5M2(BF8)
+/// - 2: E2M3(FP6)
+/// - 3: E3M2(BF6)
+/// - 4: E2M1(FP4)
+static inline int32_t getMfmaF8F6F4MatrixFormat(Type t) {
+  return llvm::TypeSwitch<Type, int32_t>(t)
+      .Case<Float8E4M3FNType>([](Type) { return 0; })
+      .Case<Float8E5M2Type>([](Type) { return 1; })
+      .Case<Float6E3M2FNType>([](Type) { return 2; })
+      .Case<Float6E2M3FNType>([](Type) { return 3; })
+      .Case<Float4E2M1FNType>([](Type) { return 4; })
+      .Default([](Type) { return -1; });
+}
 
 struct DotOpMFMAConversionHelper {
   AMDMfmaEncodingAttr mfmaLayout;
@@ -212,7 +234,8 @@ struct DotOpMFMAConversionHelper {
     }
   }
 
-  void packAndReplaceResult(DotOp &op, SmallVector<Value> &fc,
+  template <typename T>
+  void packAndReplaceResult(T &op, SmallVector<Value> &fc,
                             FailureOr<MfmaInsn> maybeMfmaInsn, Type dstElemTy,
                             Type elemtTy, size_t mmaCount) const {
     Type structTy = LLVM::LLVMStructType::getLiteral(
@@ -377,11 +400,17 @@ struct DotOpMFMAConversionHelper {
         }
       }
       if (type.getIntOrFloatBitWidth() == 8) {
+        if (1 == kBase)
+          // This is only for the scale operands of scaled mfma on MI350
+          results.push_back(b.zext(i32_ty, b.bitcast(vec, i8_ty)));
         if (4 == kBase)
           // This is for int8 on pre- MI300 GPUs
           results.push_back(b.bitcast(vec, i32_ty));
         if (8 == kBase)
           results.push_back(b.bitcast(vec, i64_ty));
+        if (16 == kBase)
+          // This is only for the scale operands of scaled mfma on MI350
+          results.push_back(b.bitcast(vec, vec_ty(i32_ty, 4)));
       } else {
         results.push_back(vec);
       }
@@ -391,7 +420,7 @@ struct DotOpMFMAConversionHelper {
 
   /// Converts dot operand structure to value table and converts types
   /// appropriate for mfma instructions
-  SmallVector<ValueTable>
+  virtual SmallVector<ValueTable>
   getValuesFromDotOperandLayoutStruct(Value value, int batch, int n0, int n1,
                                       int kWidth, int kBase, Type type,
                                       bool allowXF32) const {
@@ -440,6 +469,192 @@ struct DotOpMFMAConversionHelper {
   }
 };
 
+struct ScaledDotOpMFMAConversionHelper : DotOpMFMAConversionHelper {
+
+  ScaledDotOpMFMAConversionHelper(AMDMfmaEncodingAttr mfmaLayout,
+                                  ConversionPatternRewriter &rewriter,
+                                  const LLVMTypeConverter *typeConverter,
+                                  Location loc)
+      : DotOpMFMAConversionHelper(mfmaLayout, rewriter, typeConverter, loc) {}
+
+  Value generateScaledMFMAOp(MfmaInsn &mfmaInsn, Value valA, Value valB,
+                             Value valC, Value valScaleA,
+                             Value valScaleB) const {
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto resType = valC.getType();
+    Value zeroFlag = b.i32_val(0);
+    OperationState loweredOp(loc, mfmaInsn.getInsnName());
+    int32_t cbsz = getMfmaF8F6F4MatrixFormat(mfmaInsn.getElementTypeA());
+    int32_t blgp = getMfmaF8F6F4MatrixFormat(mfmaInsn.getElementTypeB());
+    assert((cbsz != -1) && (blgp != -1));
+    loweredOp.addTypes(resType);
+    loweredOp.addOperands({valA, valB, valC, b.i32_val(cbsz), b.i32_val(blgp),
+                           zeroFlag, valScaleA, zeroFlag, valScaleB});
+    return rewriter.create(loweredOp)->getResult(0);
+  }
+
+  LogicalResult convertScaledDot(DotScaledOp op,
+                                 DotScaledOpAdaptor adaptor) const {
+    // Check if this dot has come with priority set by setprio.
+    auto setPrioOp = dyn_cast_or_null<ROCDL::SetPrioOp>(op->getPrevNode());
+
+    auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
+    auto mDim = mfmaLayout.getMDim();
+    auto nDim = mfmaLayout.getNDim();
+    auto mfmaVersion = mfmaLayout.getVersionMajor();
+    assert((mDim == nDim && (mDim == 32 || mDim == 16 || mDim == 4)) ||
+           (mDim == 64 && nDim == 4) || (mDim == 4 && nDim == 64));
+
+    Value a = op.getLhs();
+    Value b = op.getRhs();
+    Value aScale = op.getLhsScale();
+    Value bScale = op.getRhsScale();
+    Value d = op.getD();
+    auto aTensorTy = cast<RankedTensorType>(a.getType());
+    auto bTensorTy = cast<RankedTensorType>(b.getType());
+    auto dTensorTy = cast<RankedTensorType>(d.getType());
+    auto elemTyA = aTensorTy.getElementType();
+    auto elemTyB = bTensorTy.getElementType();
+    ScaleDotElemType aElemType = op.getLhsType();
+    ScaleDotElemType bElemType = op.getRhsType();
+
+    auto supportsTypes = [](ScaleDotElemType elemType) {
+      return elemType == ScaleDotElemType::E2M1;
+    };
+
+    if (!supportsTypes(aElemType) || !supportsTypes(bElemType)) {
+      llvm::report_fatal_error("NYI: mxfp6, mxfp8\n");
+    }
+
+    auto ctx = op.getContext();
+    constexpr bool allowXF32 = false;
+    auto maybeMfmaInsn = MfmaInsn::selectMfma(
+        mDim, nDim, scaleDotElemTypeToMLIRType(ctx, aElemType),
+        scaleDotElemTypeToMLIRType(ctx, bElemType), mfmaVersion, allowXF32);
+    if (failed(maybeMfmaInsn))
+      llvm::report_fatal_error("No match found in MFMA database\n");
+
+    StringRef mfmaInsnName = maybeMfmaInsn->getInsnName();
+    unsigned kBase = maybeMfmaInsn->getKBase();
+    // Two fp4 are packed into an uint8.
+    if (aElemType == ScaleDotElemType::E2M1) {
+      kBase /= 2;
+    }
+
+    auto aEncoding = cast<DotOperandEncodingAttr>(aTensorTy.getEncoding());
+    auto bEncoding = cast<DotOperandEncodingAttr>(bTensorTy.getEncoding());
+    int kWidth = aEncoding.getKWidth();
+    auto rank = aTensorTy.getShape().size();
+    const auto kDimOperandSize = aTensorTy.getShape()[rank - 1];
+    const auto kDimInstrSize = mfmaLayout.getInstrShapeForOperand(kWidth, 0)[1];
+
+    auto repA = mfmaLayout.getRepForOperand(aTensorTy.getShape(), kWidth, 0);
+    auto repB = mfmaLayout.getRepForOperand(bTensorTy.getShape(), kWidth, 1);
+    assert(repA[2] == repB[1]);
+
+    auto aScaleTensorTy = cast<RankedTensorType>(aScale.getType());
+    auto bScaleTensorTy = cast<RankedTensorType>(bScale.getType());
+
+    // For fp4 scaled mfma, each thread takes 1 element from scale. Will have
+    // better way to get it when adapting other data types. Similar to
+    // scaleKBase
+    constexpr int scaleKWidth = 1;
+    constexpr int scaleKBase = 1;
+
+    Value loadedA = adaptor.getLhs();
+    Value loadedB = adaptor.getRhs();
+    Value loadedAScale = adaptor.getLhsScale();
+    Value loadedBScale = adaptor.getRhsScale();
+    Value loadedC = adaptor.getC();
+
+    auto numRepM = repA[1];
+    auto numRepN = repB[2];
+    auto numRepK = repA[2];
+    auto numRepB = repA[0];
+    assert(repA[0] == repB[0]);
+
+    auto operandA = getValuesFromDotOperandLayoutStruct(
+        loadedA, numRepB, numRepM, numRepK, kWidth, kBase,
+        aTensorTy.getElementType(), allowXF32);
+    auto operandB = getValuesFromDotOperandLayoutStruct(
+        loadedB, numRepB, numRepN, numRepK, kWidth, kBase,
+        bTensorTy.getElementType(), allowXF32);
+
+    // Scales have the same replica distributions as their corresponding
+    // operands.
+    auto operandAScale = getValuesFromDotOperandLayoutStruct(
+        loadedAScale, numRepB, numRepM, numRepK, scaleKWidth, scaleKBase,
+        aScaleTensorTy.getElementType(), allowXF32);
+    auto operandBScale = getValuesFromDotOperandLayoutStruct(
+        loadedBScale, numRepB, numRepN, numRepK, scaleKWidth, scaleKBase,
+        bScaleTensorTy.getElementType(), allowXF32);
+
+    auto dstElemTy = dTensorTy.getElementType();
+    auto fc = unpackLLElements(loc, loadedC, rewriter);
+
+    unsigned warpSize = triton::gpu::getWarpSize(mfmaLayout);
+    // compute number of output elements that each thread holds for one MFMA
+    // instruction. subBlocks
+    const int subBlocks =
+        getNumSubmatrices(aTensorTy.getElementType(), mDim, nDim);
+    auto elemsPerVec = mDim * nDim * subBlocks / warpSize;
+
+    Value firstMfma;
+    auto tb = TritonLLVMOpBuilder(loc, rewriter);
+    auto vecTy = vec_ty(dstElemTy, elemsPerVec);
+    for (int b = 0; b < numRepB; ++b) {
+      for (int m = 0; m < numRepM; ++m) {
+        for (int n = 0; n < numRepN; ++n) {
+          Value acc = tb.undef(vecTy);
+          for (unsigned v = 0; v < elemsPerVec; ++v) {
+            acc = tb.insert_element(
+                vecTy, acc,
+                fc[b * numRepM * numRepN * elemsPerVec +
+                   m * numRepN * elemsPerVec + n * elemsPerVec + v],
+                tb.i32_val(v));
+          }
+          acc = zeroAuxiliarBlocks(subBlocks, acc);
+          for (int k = 0; k < numRepK; k++) {
+            for (int kPack = 0; kPack < kWidth / kBase; ++kPack) {
+              acc = mfmaLayout.getIsTransposed()
+                        ? generateScaledMFMAOp(maybeMfmaInsn.value(),
+                                               operandB[kPack][{b, n, k}],
+                                               operandA[kPack][{b, m, k}], acc,
+                                               operandBScale[kPack][{b, n, k}],
+                                               operandAScale[kPack][{b, m, k}])
+                        : generateScaledMFMAOp(maybeMfmaInsn.value(),
+                                               operandA[kPack][{b, m, k}],
+                                               operandB[kPack][{b, n, k}], acc,
+                                               operandAScale[kPack][{b, m, k}],
+                                               operandBScale[kPack][{b, n, k}]);
+              if (!firstMfma)
+                firstMfma = acc;
+            }
+          }
+          acc = reduceSubBlocks(subBlocks, acc);
+          adjustAccForSmallKDim(fc, acc, dstElemTy, b, m, n, numRepM, numRepN,
+                                kDimInstrSize, kDimOperandSize, elemsPerVec);
+        }
+      }
+    }
+
+    // Originally, setprio (high) is set to the high-level dot op. After dot is
+    // being lowered to the series of mfma operations, it should be moved next
+    // to the first mfma leaving the first mfma staying at the low priority. In
+    // this way, incoming warp can be effectively waiting on the first mfma
+    // instruction (low priority) while the other warp is executing mfma with
+    // high priority. Otherwise, incoming warp can break the cluster.
+    if (setPrioOp && firstMfma)
+      setPrioOp->moveAfter(firstMfma.getDefiningOp());
+
+    const size_t mmaCount =
+        numRepB * numRepM * numRepN * numRepK * kWidth / kBase;
+    packAndReplaceResult(op, fc, maybeMfmaInsn, dstElemTy, elemTyA, mmaCount);
+
+    return success();
+  }
+};
+
 } // namespace
 
 namespace mlir::triton::AMD {
@@ -452,16 +667,16 @@ LogicalResult convertMFMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
 
   assert(isa<DotOperandEncodingAttr>(rankedTType(op.getA()).getEncoding()) &&
          isa<DotOperandEncodingAttr>(rankedTType(op.getB()).getEncoding()) &&
-         "Both $a and %b should be DotOperand layout.");
+         "Both A and B should be DotOperand layout.");
 
   auto cTensorTy = rankedTType(op.getC());
   auto dTensorTy = rankedTType(op.getD());
   assert(isa<AMDMfmaEncodingAttr>(cTensorTy.getEncoding()) &&
-         "Currently, we only support $c with a mfma layout.");
+         "Currently, we only support C with a mfma layout.");
 
   assert(cTensorTy.getShape()[0] == dTensorTy.getShape()[0] &&
          cTensorTy.getShape()[1] == dTensorTy.getShape()[1] &&
-         "DotOp's $c operand should pass the same number of values as $d");
+         "DotOp's C operand should pass the same number of values as D.");
 
   auto loc = op.getLoc();
   auto mfmaLayout = cast<AMDMfmaEncodingAttr>(
@@ -470,5 +685,36 @@ LogicalResult convertMFMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
   DotOpMFMAConversionHelper helper(mfmaLayout, rewriter, typeConverter, loc);
 
   return helper.convertDot(op, adaptor);
+}
+
+LogicalResult convertScaledMFMA(triton::DotScaledOp op,
+                                triton::DotScaledOp::Adaptor adaptor,
+                                const LLVMTypeConverter *typeConverter,
+                                ConversionPatternRewriter &rewriter) {
+  assert(isa<DotOperandEncodingAttr>(op.getLhs().getType().getEncoding()) &&
+         isa<DotOperandEncodingAttr>(op.getRhs().getType().getEncoding()) &&
+         "Both lhs and rhs should be DotOperand layout.");
+
+  assert(isa<LinearEncodingAttr>(op.getLhsScale().getType().getEncoding()) &&
+         isa<LinearEncodingAttr>(op.getRhsScale().getType().getEncoding()) &&
+         "Both LhsScale and RhsScale should be linear layout.");
+
+  auto cTensorTy = op.getC().getType();
+  auto dTensorTy = op.getD().getType();
+  assert(isa<AMDMfmaEncodingAttr>(cTensorTy.getEncoding()) &&
+         "Currently, we only support C with a mfma layout.");
+
+  assert(cTensorTy.getShape()[0] == dTensorTy.getShape()[0] &&
+         cTensorTy.getShape()[1] == dTensorTy.getShape()[1] &&
+         "DotOp's C operand should pass the same number of values as D.");
+
+  auto loc = op.getLoc();
+  auto mfmaLayout = cast<AMDMfmaEncodingAttr>(
+      cast<RankedTensorType>(op.getResult().getType()).getEncoding());
+
+  ScaledDotOpMFMAConversionHelper helper(mfmaLayout, rewriter, typeConverter,
+                                         loc);
+
+  return helper.convertScaledDot(op, adaptor);
 }
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -511,7 +511,7 @@ struct AsyncCopyGlobalToLocalOpConversion
 
     Value cacheModifiers =
         b.i32_val(mlir::LLVM::AMD::getCtrlBitsForCacheModifierOnTarget(
-            op.getCache(), false, targetInfo));
+            op.getCache(), /*isLoad=*/true, targetInfo));
 
     Value llMask = adaptor.getMask();
     SmallVector<Value> maskElems;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/SchedInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/SchedInstructions.cpp
@@ -26,7 +26,8 @@ using namespace mlir;
 // implementation.
 
 namespace mlir::triton {
-void setNumGeneratedMMAs(DotOp op, size_t mmaCount, unsigned m, unsigned n,
+template <typename DotOpType>
+void setNumGeneratedMMAs(DotOpType op, size_t mmaCount, unsigned m, unsigned n,
                          unsigned k, Type elementType) {
   auto *ctx = op->getContext();
   auto mmaType = RankedTensorType::get({m, n, k}, elementType);
@@ -37,6 +38,12 @@ void setNumGeneratedMMAs(DotOp op, size_t mmaCount, unsigned m, unsigned n,
     schedHint.setNumMMAsAttr(counterAttr);
   });
 }
+
+template void setNumGeneratedMMAs(triton::DotOp op, size_t mmaCount, unsigned m,
+                                  unsigned n, unsigned k, Type elementType);
+template void setNumGeneratedMMAs(triton::DotScaledOp op, size_t mmaCount,
+                                  unsigned m, unsigned n, unsigned k,
+                                  Type elementType);
 
 template <typename LoadOpType>
 void setNumGeneratedGlobalLoads(LoadOpType op, size_t globalLoadsCount,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/SchedInstructions.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/SchedInstructions.h
@@ -10,7 +10,8 @@
 // during to LLVM conversion/lowering to facilitate instruction scheduling
 // controls.
 namespace mlir::triton {
-void setNumGeneratedMMAs(DotOp op, size_t mmaCount, unsigned m, unsigned n,
+template <typename DotOpType>
+void setNumGeneratedMMAs(DotOpType op, size_t mmaCount, unsigned m, unsigned n,
                          unsigned k, Type elementType);
 
 template <typename LoadOpType>

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/UpcastMXFPToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/UpcastMXFPToLLVM.cpp
@@ -324,7 +324,7 @@ public:
     } else {
       assert(mDim == 16);
       // One mfma16 intrinsic processes a 16x16 A tensor slice. Similarly, we
-      // need to tile the warp 2 times to cover 32 valeus. So for a thread, the
+      // need to tile the warp 2 times to cover 32 values. So for a thread, the
       // first 2 1x4 vectors shares the first scale value at row (tid % mDim).
       std::array<Value, 4> scaleThreads = {offset, b.add(offset, b.i32_val(1)),
                                            b.add(offset, b.i32_val(2)),

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -455,19 +455,19 @@ getCacheModifierFlagsForPredicatedCall(LLVM::CallOp callOp) {
 // Load   | .ca |  0  |  0  | 0  |
 //        | .cg |  0  |  1  | 1  |
 //        | .cs |  0  |  1  | 1  |
-//        | .cv |  1  |  1  | x  |
+//        | .cv |  1  |  1  | 1  |
 // -------+-----+-----+-----+----+--
 // Store  | .wb |  0  |  0  | 0  |
 //        | .cg |  0  |  0  | 0  |
 //        | .cs |  0  |  1  | 1  |
-//        | .wt |  1  |  x  | x  |
+//        | .wt |  1  |  1  | 1  |
 // -------+-----+-----+-----+----+--
 // Atomic | N/A |  0  |  1  | x  | Setting sc0 returns the pre-op value
 //        | N/A |  1  |  0  | x  | Setting sc1 performs a system-scope atomic
 // -------+-----+-----+-----+----+--
 static int32_t
 getCtrlBitsForCacheModifierOnGFX_942_950(triton::CacheModifier cm,
-                                         bool isBufferLoad) {
+                                         bool isLoad) {
   const int sc0Bit = 0b1, ntBit = 0b10, sc1Bit = 0b1000;
   int32_t aux = 0;
   switch (cm) {
@@ -475,20 +475,23 @@ getCtrlBitsForCacheModifierOnGFX_942_950(triton::CacheModifier cm,
     aux = 0;
     break;
   case triton::CacheModifier::CG:
-    if (isBufferLoad)
+    if (isLoad)
       aux |= sc0Bit | ntBit;
     break;
   case triton::CacheModifier::CS:
     aux |= sc0Bit | ntBit;
     break;
   case triton::CacheModifier::CV:
-    aux |= sc0Bit | sc1Bit;
+    assert(isLoad);
+    aux |= sc0Bit | sc1Bit | ntBit;
     break;
   case triton::CacheModifier::WB:
+    assert(!isLoad);
     aux = 0;
     break;
   case triton::CacheModifier::WT:
-    aux |= sc1Bit;
+    assert(!isLoad);
+    aux |= sc0Bit | sc1Bit | ntBit;
     break;
   default:
     aux = 0;
@@ -521,12 +524,12 @@ static int32_t getDefaultCtrlBitsForCacheModifier(triton::CacheModifier cm) {
 // .wb: write-back, writes back data at all cache levels
 // .wt: write-through, write data directly to system memory
 int32_t getCtrlBitsForCacheModifierOnTarget(
-    triton::CacheModifier cm, bool isBufferLoad,
+    triton::CacheModifier cm, bool isLoad,
     const mlir::triton::AMD::TargetInfo &targetInfo) {
   switch (targetInfo.getGPUKind()) {
   case llvm::AMDGPU::GK_GFX942:
   case llvm::AMDGPU::GK_GFX950:
-    return getCtrlBitsForCacheModifierOnGFX_942_950(cm, isBufferLoad);
+    return getCtrlBitsForCacheModifierOnGFX_942_950(cm, isLoad);
   default:
     return getDefaultCtrlBitsForCacheModifier(cm);
   }
@@ -609,6 +612,27 @@ unsigned getVectorSize(Value ptr, Value offset,
   auto contiguity = getContiguity(ptr, offset, axisAnalysisPass);
   auto pointeeBitWidth = triton::getPointeeBitWidth(ptr.getType());
   return std::min<unsigned>(128 / pointeeBitWidth, contiguity);
+}
+
+Type scaleDotElemTypeToMLIRType(MLIRContext *ctx, triton::ScaleDotElemType t) {
+  switch (t) {
+  case triton::ScaleDotElemType::FP16:
+    return Float16Type::get(ctx);
+  case triton::ScaleDotElemType::BF16:
+    return BFloat16Type::get(ctx);
+  case triton::ScaleDotElemType::E4M3:
+    return Float8E4M3FNType::get(ctx);
+  case triton::ScaleDotElemType::E5M2:
+    return Float8E5M2Type::get(ctx);
+  case triton::ScaleDotElemType::E3M2:
+    return Float6E3M2FNType::get(ctx);
+  case triton::ScaleDotElemType::E2M3:
+    return Float6E2M3FNType::get(ctx);
+  case triton::ScaleDotElemType::E2M1:
+    return Float4E2M1FNType::get(ctx);
+  default:
+    llvm_unreachable("unsupported ScaleDotElemType!");
+  }
 }
 
 } // namespace mlir::LLVM::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -83,6 +83,8 @@ unsigned getVectorSize(Value ptr, ModuleAxisInfoAnalysis &axisAnalysisPass);
 unsigned getVectorSize(Value ptr, Value offset,
                        ModuleAxisInfoAnalysis &axisAnalysisPass);
 
+Type scaleDotElemTypeToMLIRType(MLIRContext *ctx, triton::ScaleDotElemType t);
+
 } // namespace mlir::LLVM::AMD
 
 #endif // TRITON_THIRD_PARTY_AMD_LIB_TRITONAMDGPUTOLLVM_UTILITY_H_

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -4,15 +4,19 @@
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Tools/LayoutUtils.h"
 #include <memory>
 
 using namespace mlir;
 namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
+using ::mlir::LLVM::AMD::scaleDotElemTypeToMLIRType;
+
 namespace {
 using triton::AMD::ISAFamily;
 
@@ -158,6 +162,21 @@ FailureOr<MfmaInsn> chooseMfmaInstruction(tt::DotOp dot, int mfmaVersion,
 }
 
 FailureOr<MfmaInsn> chooseMfmaInstruction(tt::DotScaledOp dot, int mfmaVersion,
+                                          int nonKDim) {
+  auto ctx = dot.getContext();
+  int64_t inputKDim = dot.getLhs().getType().getShape().back();
+  if (dot.getLhsType() == ScaleDotElemType::E2M1) {
+    // Since two fp4 are packed into int8, to get the correct K dim size, we
+    // need to multiply it by 2.
+    inputKDim *= 2;
+  }
+  return chooseMfmaInstruction(
+      dot.getC().getType(), scaleDotElemTypeToMLIRType(ctx, dot.getLhsType()),
+      scaleDotElemTypeToMLIRType(ctx, dot.getRhsType()), inputKDim, mfmaVersion,
+      /*allowXF32=*/false, nonKDim);
+}
+
+FailureOr<MfmaInsn> chooseMfmaInstruction(tt::DotScaledOp dot, int mfmaVersion,
                                           int nonKDim, bool useFp16) {
   // For scaled dot, we handle it with fp16 or bf16 emulation for now.
   Builder b(dot.getContext());
@@ -276,9 +295,9 @@ OperandTypesVector getOperandTypesForWmmaOp(PatternRewriter &rewriter,
 //
 // @param rewriter
 // @param value original tensor value, which we need to convert and cast
-// @param newEncoding new encoding for the tenosr
+// @param newEncoding new encoding for the tensor
 // @param newElemType new element type for the tensor
-// @return converted and optionaly casted tensor value
+// @return converted and optionally casted tensor value
 //===---------------------------------------------------------------------===//
 Value convertAndCastTensor(PatternRewriter &rewriter, Value value,
                            Attribute newEncoding, Type newElemType) {
@@ -576,7 +595,7 @@ public:
     bool isAPacked = aElemType == ScaleDotElemType::E2M1;
     bool isBPacked = bElemType == ScaleDotElemType::E2M1;
     bool isPacked = isAPacked || isBPacked;
-    unsigned kWdiths[] = {isPacked ? (isAPacked ? 4 : 8) : kBase * kPack,
+    unsigned kWidths[] = {isPacked ? (isAPacked ? 4 : 8) : kBase * kPack,
                           isPacked ? (isAPacked ? 8 : 4) : kBase * kPack};
 
     // For A/B tensor, 32 consecutive elements along K dim share the same scale.
@@ -603,7 +622,7 @@ public:
                             ScaleDotElemType type) -> TensorValue {
       auto vType = v.getType();
       auto newVEncoding = DotOperandEncodingAttr::get(
-          ctx, idx, newRetType.getEncoding(), kWdiths[idx]);
+          ctx, idx, newRetType.getEncoding(), kWidths[idx]);
       auto newVType = RankedTensorType::get(
           vType.getShape(), vType.getElementType(), newVEncoding);
       v = rewriter.create<ttg::ConvertLayoutOp>(v.getLoc(), newVType, v);
@@ -666,6 +685,228 @@ public:
         upcastMXFP(b, bScale, dotOp.getRhsType(), dotOp.getFastMath());
     auto newDot = rewriter.create<DotOp>(dotOp.getLoc(), newRetType, scaledA,
                                          scaledB, newAcc);
+    rewriter.replaceOpWithNewOp<ttg::ConvertLayoutOp>(dotOp, oldRetType,
+                                                      newDot);
+    return success();
+  }
+};
+
+class ScaledBlockedToScaledMFMAF8F6F4 final
+    : public OpRewritePattern<triton::DotScaledOp> {
+  int mfmaVersion;
+  int nonKDim;
+
+public:
+  ScaledBlockedToScaledMFMAF8F6F4(MLIRContext *context, int mfmaVersion,
+                                  int nonKDim, PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit), mfmaVersion(mfmaVersion),
+        nonKDim(nonKDim) {}
+
+  LogicalResult matchAndRewrite(triton::DotScaledOp dotOp,
+                                PatternRewriter &rewriter) const override {
+    using TensorValue = TypedValue<RankedTensorType>;
+
+    if (mfmaVersion != 4) {
+      return rewriter.notifyMatchFailure(
+          dotOp, "F8F6F4 scaled dot is only natively supported on gfx950");
+    }
+
+    RankedTensorType oldRetType = dotOp.getType();
+    if (!isa_and_nonnull<BlockedEncodingAttr>(oldRetType.getEncoding()))
+      return rewriter.notifyMatchFailure(
+          dotOp, "expected blocked encoding result tensor");
+
+    unsigned rank = oldRetType.getRank();
+    if (rank == 3)
+      return rewriter.notifyMatchFailure(dotOp, "NYI: 3d case");
+
+    TensorValue a = dotOp.getLhs();
+    TensorValue b = dotOp.getRhs();
+    TensorValue aScale = dotOp.getLhsScale();
+    TensorValue bScale = dotOp.getRhsScale();
+    auto oldShape = oldRetType.getShape();
+
+    if (!aScale || !bScale)
+      return rewriter.notifyMatchFailure(dotOp,
+                                         "expect scales for both A and B");
+
+    ScaleDotElemType aElemType = dotOp.getLhsType();
+    ScaleDotElemType bElemType = dotOp.getRhsType();
+    auto supportsTypes = [](ScaleDotElemType elemType) {
+      return elemType == ScaleDotElemType::E2M1;
+    };
+
+    if (!supportsTypes(aElemType) || !supportsTypes(bElemType))
+      return rewriter.notifyMatchFailure(dotOp, "NYI: mxfp6, mxfp8");
+
+    MLIRContext *ctx = dotOp.getContext();
+    auto moduleOp = dotOp->getParentOfType<ModuleOp>();
+
+    ttg::CTALayoutAttr ctaLayout = ttg::getCTALayout(oldRetType.getEncoding());
+    unsigned numWarps = ttg::TritonGPUDialect::getNumWarps(moduleOp);
+    if (numWarps == 1)
+      return rewriter.notifyMatchFailure(dotOp,
+                                         "num_warps==1 is not supported");
+
+    // Choose a suitable Scaled MFMA instruction for this scaled dot op.
+    FailureOr<MfmaInsn> mfmaInstr =
+        chooseMfmaInstruction(dotOp, mfmaVersion, nonKDim);
+    if (failed(mfmaInstr))
+      return rewriter.notifyMatchFailure(dotOp,
+                                         "cannot choose scaled mfma intrinsic");
+
+    unsigned mDim = mfmaInstr.value().getMDim();
+    unsigned nDim = mfmaInstr.value().getNDim();
+    unsigned kDim = mfmaInstr.value().getKDim();
+    unsigned kBase = mfmaInstr.value().getKBase();
+    assert(mDim == nDim);
+
+    auto warpsPerTile =
+        warpsPerTileMFMA(dotOp, oldShape, numWarps, {mDim, nDim});
+
+    // Always use transposed mfma layout. This enables larger vectorization
+    // for global store instructions.
+    auto mfmaEnc = ttg::AMDMfmaEncodingAttr::get(
+        ctx, /*versionMajor=*/mfmaVersion, /*versionMinor=*/0, warpsPerTile,
+        /*instrShape=*/mDim, nDim, /*isTransposed=*/true, ctaLayout);
+
+    auto newRetType =
+        RankedTensorType::get(oldShape, oldRetType.getElementType(), mfmaEnc);
+
+    auto newAcc = rewriter.create<ttg::ConvertLayoutOp>(
+        dotOp.getC().getLoc(), newRetType, dotOp.getC());
+
+    // For the mfma_scale_f32_*_f8f6f4 instructions, each thread consumes 32
+    // elements. But since two fp4 elements are packed into one int8, the
+    // kWidth is 16 for fp4.
+    unsigned kWidth = kBase;
+    auto newAEncoding = DotOperandEncodingAttr::get(
+        ctx, /*idx=*/0, newRetType.getEncoding(),
+        aElemType == ScaleDotElemType::E2M1 ? kWidth / 2 : kWidth);
+
+    auto newBEncoding = DotOperandEncodingAttr::get(
+        ctx, /*idx=*/1, newRetType.getEncoding(),
+        bElemType == ScaleDotElemType::E2M1 ? kWidth / 2 : kWidth);
+
+    auto convertInputLayout = [&](TensorValue v,
+                                  DotOperandEncodingAttr enc) -> TensorValue {
+      auto vType = v.getType();
+
+      auto newVType =
+          RankedTensorType::get(vType.getShape(), vType.getElementType(), enc);
+      return rewriter.create<ttg::ConvertLayoutOp>(v.getLoc(), newVType, v);
+    };
+    a = convertInputLayout(a, newAEncoding);
+    b = convertInputLayout(b, newBEncoding);
+
+    StringAttr kRegister = StringAttr::get(ctx, "register");
+    StringAttr kLane = StringAttr::get(ctx, "lane");
+    StringAttr kWarp = StringAttr::get(ctx, "warp");
+    StringAttr kBlock = StringAttr::get(ctx, "block");
+
+    auto order = ttg::getMatrixOrder(rank, /*rowMajor=*/true);
+
+    // Init register layout. Will be adjusted later
+    auto regs = tt::identityStandardND(kRegister, {1, 1}, order);
+
+    auto aEncLL = newAEncoding.toLinearLayout(a.getType().getShape());
+    auto standardOutDims = llvm::to_vector(aEncLL.getOutDimNames());
+
+    using basisT = std::vector<std::vector<int32_t>>;
+    auto createLinearLayout = [&](int idx, const basisT &warpBasis) {
+      LinearLayout lanes = LinearLayout::empty();
+      // In scaled dot, the shapes of operands(without batch dimension) are,
+      // respectively:
+      // - A: [M, K]
+      // - B: [K, N]
+      // - aScale: [M, K / 32]
+      // - bScale: [N, K / 32]
+      //
+      // To correctly feed A/B and its scale into instruction, we need to
+      // distribute aScale/bScale among warps in the same way as A/B. But bScale
+      // is not transposed like B. So we need to transpose the warp layout of
+      // bScale.
+      //
+      // The tricky part is, our desired outputs are [dim0, dim1], but
+      // at this position, the layouts are transposed to [dim1, dim0]. So
+      // instead of reverse bScale's layout, we need to reverse aScale's. There
+      // will be a transpose in the end to correct everything.
+      basisT warps = warpBasis;
+      if (idx == 0) {
+        for (auto &basis : warps) {
+          std::reverse(basis.begin(), basis.end());
+        }
+      }
+      // In general, for both 32x32 and 16x16 scaled mfma, and no matter what
+      // data type the A/B operand is, each lane takes 32 elements from A/B
+      // alone K dim, and 1 or 2 elements from scale accordingly. The number of
+      // scale's elements in a lane varies because the 32 elements from A/B may
+      // not be consecutive.
+      //
+      // For mxfp4, these 32 elements are consecutive, so only 1 scale element
+      // is required. But for mxfp6/mxfp8, there are 2 16-consecutive elements
+      // blocks, so 2 scale elements are required.
+      if (mDim == 32) {
+        // For ROCDL::mfma_scale_f32_32x32x64_f8f6f4 with fp4 input, each lane
+        // takes 32 consecutive elements from A alone K dimension. The first
+        // 32 lanes collectively handle A[0:32][0:32], and the other 32 lanes
+        // collectively handle A[0:32][32:64]. Each lane take 1 scale element
+        // accordingly. Similar to B and bScale.
+        lanes = LinearLayout(
+            {{kLane, {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {1, 0}}},
+             {kWarp, warps},
+             {kBlock, {}}},
+            {standardOutDims[order[0]], standardOutDims[order[1]]});
+      } else {
+        assert(mDim == 16);
+        // For ROCDL::mfma_scale_f32_16x16x128_f8f6f4 with fp4 input, each lane
+        // takes 32 consecutive elements from A alone K dimension. The first
+        // 16 lanes collectively handle A[0:16][0:32], and another 16 lanes
+        // collectively handle A[0:16][32:64] and so on. Each lane take 1 scale
+        // element accordingly. Similar to B and bScale.
+        lanes = LinearLayout(
+            {{kLane, {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {1, 0}, {2, 0}}},
+             {kWarp, warps},
+             {kBlock, {}}},
+            {standardOutDims[order[0]], standardOutDims[order[1]]});
+      }
+      return regs * lanes;
+    };
+
+    auto convertScaleLayout = [&](TensorValue val, TensorValue scale,
+                                  DotOperandEncodingAttr enc,
+                                  int idx) -> TensorValue {
+      auto dotLL = enc.toLinearLayout(val.getType().getShape());
+      LinearLayout::BasesT scaleBases = dotLL.getBases();
+      auto &warpBases = scaleBases[kWarp];
+
+      LinearLayout newLL = createLinearLayout(idx, warpBases);
+
+      auto shape = scale.getType().getShape();
+
+      // Adjust register-level layout to fill the shape, at this level, both
+      // aScale and bScale should align with A operand.
+      for (auto d : newAEncoding.getRepOrder()) {
+        auto outDim = standardOutDims[d];
+        auto dimSize = newLL.getOutDimSize(outDim);
+        newLL *=
+            LinearLayout::identity1D(shape[d] / dimSize, kRegister, outDim);
+      }
+      newLL = newLL.transposeOuts(standardOutDims);
+      Attribute newScaleEncoding = ttg::LinearEncodingAttr::get(ctx, newLL);
+
+      auto newScaleType = RankedTensorType::get(
+          shape, scale.getType().getElementType(), newScaleEncoding);
+      return rewriter.create<ttg::ConvertLayoutOp>(scale.getLoc(), newScaleType,
+                                                   scale);
+    };
+    aScale = convertScaleLayout(a, aScale, newAEncoding, 0);
+    bScale = convertScaleLayout(b, bScale, newBEncoding, 1);
+
+    auto newDot = rewriter.create<triton::DotScaledOp>(
+        dotOp.getLoc(), newRetType, a, b, newAcc, aScale, bScale, aElemType,
+        bElemType, dotOp.getFastMath());
+
     rewriter.replaceOpWithNewOp<ttg::ConvertLayoutOp>(dotOp, oldRetType,
                                                       newDot);
     return success();
@@ -1008,6 +1249,11 @@ public:
 
     RewritePatternSet patterns(context);
     switch (auto isaFamily = triton::AMD::deduceISAFamily(archGenerationName)) {
+    case ISAFamily::CDNA4:
+      patterns.add<::ScaledBlockedToScaledMFMAF8F6F4>(
+          context, getMfmaVersion(isaFamily), matrixInstructionSize,
+          /*benefit=*/10);
+      [[fallthrough]];
     case ISAFamily::CDNA1:
     case ISAFamily::CDNA2:
     case ISAFamily::CDNA3:


### PR DESCRIPTION
This PR change the Triton base from 089b8bc1249fbb6b7ab5590d3da02d653944ae8f to df66eb594d61b33295eabf67172ebbd1fddceae3 (Feb 11).
Pass rate: 98.1%->98.09% (#2968)

Please do not squash and merge this PR.