### PR TITLE
[LoadStoreConversion] Handle negative indices in boundary checks

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -265,7 +265,9 @@ struct LoadStoreConversionBase {
             [&](const Value &index, const Value &shape, const Value &mask) {
               // mask = mask && (index < shape) && idx > 0
               auto is_pos_idx = b.icmp_sge(index, b.int_val(32, 0));
-              return b.and_(b.and_(b.icmp_slt(index, b.trunc(i32_ty, shape)), mask), is_pos_idx);
+              return b.and_(
+                  b.and_(b.icmp_slt(index, b.trunc(i32_ty, shape)), mask),
+                  is_pos_idx);
             }));
       }
     }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -263,7 +263,7 @@ struct LoadStoreConversionBase {
             {blockPtr.begin() + blockShape, blockPtr.begin() + blockStride},
             b.int_val(1, 1),
             [&](const Value &index, const Value &shape, const Value &mask) {
-              // mask = mask && (index < shape) && idx > 0
+              // mask = mask && (index < shape) && idx >= 0
               auto is_pos_idx = b.icmp_sge(index, b.int_val(32, 0));
               return b.and_(
                   b.and_(b.icmp_slt(index, b.trunc(i32_ty, shape)), mask),

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -263,8 +263,9 @@ struct LoadStoreConversionBase {
             {blockPtr.begin() + blockShape, blockPtr.begin() + blockStride},
             b.int_val(1, 1),
             [&](const Value &index, const Value &shape, const Value &mask) {
-              // mask = mask && (index < shape)
-              return b.and_(b.icmp_slt(index, b.trunc(i32_ty, shape)), mask);
+              // mask = mask && (index < shape) && idx > 0
+              auto is_pos_idx = b.icmp_sge(index, b.int_val(32, 0));
+              return b.and_(b.and_(b.icmp_slt(index, b.trunc(i32_ty, shape)), mask), is_pos_idx);
             }));
       }
     }


### PR DESCRIPTION
Fixes #3240

The issue appeared after disabling [`RewriteTensorPointerPass`](https://github.com/intel/intel-xpu-backend-for-triton/blob/8b1aee9d0f8b82d719162e0a001860bbbc3bd184/third_party/intel/lib/TritonIntelGPUTransforms/RewriteTensorPointer.cpp#L284) in [this PR](https://github.com/intel/intel-xpu-backend-for-triton/pull/2584) (#2584). The disabled pass was responsible for the [creation of boundary-check-masks](https://github.com/intel/intel-xpu-backend-for-triton/blob/8b1aee9d0f8b82d719162e0a001860bbbc3bd184/third_party/intel/lib/TritonIntelGPUTransforms/RewriteTensorPointer.cpp#L195) and checked that [the offset index is greater that zero](https://github.com/intel/intel-xpu-backend-for-triton/blob/8b1aee9d0f8b82d719162e0a001860bbbc3bd184/third_party/intel/lib/TritonIntelGPUTransforms/RewriteTensorPointer.cpp#L207-L213) avoiding out-of-bound loads/stores in case of a negative pointer offsets (exactly the case we see in [the problematic test](https://github.com/intel/intel-xpu-backend-for-triton/blob/8b1aee9d0f8b82d719162e0a001860bbbc3bd184/python/test/unit/language/test_block_pointer.py#L14-L15)). The [`LoadStoreConversion`](https://github.com/intel/intel-xpu-backend-for-triton/blob/main/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp#L164) that was supposed to "replace" the disabled pass in terms of boundary checks, [doesn't have "index >= 0" check](https://github.com/intel/intel-xpu-backend-for-triton/blob/main/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp#L164), causing invalid reads/writes in case of negative indices.

We don't see any issues in PVC's CI since the driver doesn't seem to report segfaults to sycl, causing them to be ignored. But on our testing BMG machine, the driver blocks all following commands to the GPU after a segfault, causing the test to fail.

The test (`language/test_block_pointer.py::test_block_copy`) passes on the test BMG machine after this fix.

