### PR TITLE
Build PyTorch in Windows workflow

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -60,6 +60,10 @@ jobs:
         run: |
           .venv\Scripts\activate.ps1
           Invoke-BatchFile "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+          # Required to build on Windows
+          $env:CMAKE_SHARED_LINKER_FLAGS = "/FORCE:MULTIPLE"
+          $env:CMAKE_MODULE_LINKER_FLAGS = "/FORCE:MULTIPLE"
+          $env:CMAKE_EXE_LINKER_FLAGS = "/FORCE:MULTIPLE"
           bash -c "PYTORCH_PROJ=/c/pytorch ./scripts/install-pytorch.sh --source --check-wheel"
 
       - name: PyTorch version

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -19,8 +19,7 @@ env:
 jobs:
   build:
     name: Build and test
-    # FIXME
-    runs-on: win-b580
+    runs-on: win-a770
     steps:
       - name: Enable long paths
         run: |

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Install PyTorch (source)
         run: |
           .venv\Scripts\activate.ps1
+          Invoke-BatchFile "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           bash -c "PYTORCH_PROJ=/c/pytorch ./scripts/install-pytorch.sh --source --check-wheel"
 
       - name: PyTorch version

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -2,6 +2,15 @@ name: Build and test on Windows
 
 on:
   workflow_dispatch:
+    inputs:
+      runner_label:
+        description: Runner label
+        type: string
+        default: win-a770
+      skip_list:
+        description: Skip list
+        type: string
+        default: a770
 
   schedule:
     - cron: "1 5 * * *"
@@ -13,13 +22,13 @@ env:
   NEW_WORKSPACE: C:\gh${{ github.run_id }}
   ZE_PATH: C:\level_zero
   PYTEST_MAX_PROCESSES: 8
-  SKIPLIST: --skip-list scripts/skiplist/a770
-  TRITON_TEST_CMD: bash -x scripts/test-triton.sh --skip-pytorch-install --skip-pip-install --skip-list scripts/skiplist/a770 --reports-dir reports --ignore-errors
+  SKIPLIST: --skip-list scripts/skiplist/${{ inputs.skip_list || 'a770' }}
+  TRITON_TEST_CMD: bash -x scripts/test-triton.sh --skip-pytorch-install --skip-pip-install --skip-list scripts/skiplist/${{ inputs.skip_list || 'a770' }} --reports-dir reports --ignore-errors
 
 jobs:
   build:
     name: Build and test
-    runs-on: win-a770
+    runs-on: ${{ inputs.runner_label || 'win-a770' }}
     steps:
       - name: Enable long paths
         run: |

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -48,11 +48,10 @@ jobs:
         run:
           python -m venv .venv
 
-      # FIXME: the runner has PyTorch wheels pre-compiled from sources in a specific location
       - name: Install PyTorch (source)
         run: |
           .venv\Scripts\activate.ps1
-          pip install (Get-Item C:\pytorch\dist\*.whl)
+          bash -c "PYTORCH_PROJ=/c/pytorch ./scripts/install-pytorch.sh --source --check-wheel"
 
       - name: PyTorch version
         run: |

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -19,7 +19,8 @@ env:
 jobs:
   build:
     name: Build and test
-    runs-on: win-a770
+    # FIXME
+    runs-on: win-b580
     steps:
       - name: Enable long paths
         run: |

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -29,6 +29,8 @@ jobs:
   build:
     name: Build and test
     runs-on: ${{ inputs.runner_label || 'win-a770' }}
+    # Building PyTorch can take up to 4 hours on certain machines, increasing the timeout to 8 hours.
+    timeout-minutes: 480
     steps:
       - name: Enable long paths
         run: |

--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -152,10 +152,11 @@ function pytorch_wheel_exists {
   PYTORCH_COMMIT=${PYTORCH_PINNED_COMMIT:-main}
   if [[ $OSTYPE = msys ]]; then
     PYTORCH_OS=win
+    PYTORCH_ARCH="amd64"
   else
     PYTORCH_OS=linux
+    PYTORCH_ARCH="x86_64"
   fi
-  PYTORCH_ARCH="amd64"
   PYTORCH_WHEEL_NAME="torch-${PYTORCH_VERSION}+git${PYTORCH_COMMIT:0:7}-cp${PYTHON_VERSION}-cp${PYTHON_VERSION}-${PYTORCH_OS}_${PYTORCH_ARCH}.whl"
   if [[ -f $PYTORCH_PROJ/dist/$PYTORCH_WHEEL_NAME ]]; then
     echo "**** $PYTORCH_WHEEL_NAME exists ****"

--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -135,7 +135,7 @@ fi
 # Configure, build and install PyTorch from source.
 
 SCRIPTS_DIR=$ROOT/scripts
-PYTORCH_PROJ=${PYTORCH_PROJ:-$ROOT/.scripts_cache}
+PYTORCH_PROJ=${PYTORCH_PROJ:-$ROOT/.scripts_cache/pytorch}
 BASE=$(dirname "$PYTORCH_PROJ")
 
 echo "**** BASE is set to $BASE ****"

--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 BUILD_PYTORCH=false
 BUILD_LATEST=false
 FORCE_REINSTALL=false
+CHECK_WHEEL=false
 PYTORCH_CURRENT_COMMIT=""
 VENV=false
 CLEAN=true
@@ -22,6 +23,10 @@ for arg in "$@"; do
     --force-reinstall)
       FORCE_REINSTALL=true
       ;;
+    --check-wheel)
+      # Check if PyTorch wheel exists
+      CHECK_WHEEL=true
+      ;;
     --venv)
       VENV=true
       ;;
@@ -29,7 +34,7 @@ for arg in "$@"; do
       CLEAN=false
       ;;
     --help)
-      echo "Example usage: ./install-pytorch.sh [--source | --latest | --force-reinstall | --venv]"
+      echo "Example usage: ./install-pytorch.sh [--source | --latest | --force-reinstall | --check-wheel | --venv]"
       exit 1
       ;;
     *)
@@ -41,11 +46,15 @@ done
 
 if [ "$VENV" = true ]; then
   echo "**** Activate virtual environment *****"
-  source .venv/bin/activate
+  if [[ $OSTYPE = msys ]]; then
+    source .venv/Scripts/activate
+  else
+    source .venv/bin/activate
+  fi
 fi
 
 # intel-xpu-backend-for-triton project root
-ROOT=$(cd $(dirname "$0")/.. && pwd)
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
 
 ############################################################################
 # Check installed torch
@@ -125,50 +134,83 @@ fi
 ############################################################################
 # Configure, build and install PyTorch from source.
 
+BASE=$(cd "$ROOT/.." && pwd)
 SCRIPTS_DIR=$ROOT/scripts
-BASE=$ROOT/.scripts_cache
-PYTORCH_PROJ=$BASE/pytorch
+PYTORCH_PROJ=${PYTORCH_PROJ:-$BASE/pytorch}
+BASE=$(cd "$PYTORCH_PROJ/.." && pwd)
 
 echo "**** BASE is set to $BASE ****"
-if [ ! -d "$BASE" ]; then
-  mkdir $BASE
-fi
+echo "**** PYTORCH_PROJ is set to $PYTORCH_PROJ ****"
+mkdir -p $BASE
 
-if [ "$CLEAN" = true ]; then
-  [ "$BUILD_LATEST" = false ] || PYTORCH_PINNED_COMMIT=main
-  if [ -d "$PYTORCH_PROJ" ] && cd "$PYTORCH_PROJ" && \
-    git fetch --recurse-submodules && \
-    git reset --hard $PYTORCH_PINNED_COMMIT && \
-    git submodule update --init --recursive && \
-    git clean -xffd; then
-    echo "**** Cleaning $PYTORCH_PROJ before build ****"
+function pytorch_wheel_exists {
+  if [[ ! -d $PYTORCH_PROJ/dist ]]; then
+    return 1
+  fi
+  PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
+  PYTORCH_VERSION=$(<$PYTORCH_PROJ/version.txt)
+  PYTORCH_COMMIT=${PYTORCH_PINNED_COMMIT:-main}
+  if [[ $OSTYPE = msys ]]; then
+    PYTORCH_OS=win
   else
-    cd $BASE
-    rm -rf "$PYTORCH_PROJ"
-    echo "**** Cloning PyTorch into $PYTORCH_PROJ ****"
-    git clone --single-branch -b main --recurse-submodules https://github.com/pytorch/pytorch.git
-    cd "$PYTORCH_PROJ"
+    PYTORCH_OS=linux
+  fi
+  PYTORCH_ARCH="amd64"
+  PYTORCH_WHEEL_NAME="torch-${PYTORCH_VERSION}+git${PYTORCH_COMMIT:0:7}-cp${PYTHON_VERSION}-cp${PYTHON_VERSION}-${PYTORCH_OS}_${PYTORCH_ARCH}.whl"
+  if [[ -f $PYTORCH_PROJ/dist/$PYTORCH_WHEEL_NAME ]]; then
+    echo "**** $PYTORCH_WHEEL_NAME exists ****"
+    return 0
+  else
+    echo "**** $PYTORCH_WHEEL_NAME does not exist ****"
+    return 1
+  fi
+}
 
-    if [ "$BUILD_LATEST" = false ]; then
-      git checkout $PYTORCH_PINNED_COMMIT
-      git submodule update --init --recursive
-      git clean -xffd
+function build_pytorch {
+  if [ "$CLEAN" = true ]; then
+    if [ -d "$PYTORCH_PROJ" ] && cd "$PYTORCH_PROJ" && \
+      git fetch --recurse-submodules && \
+      git reset --hard ${PYTORCH_PINNED_COMMIT:-main} && \
+      git submodule update --init --recursive && \
+      git clean -xffd; then
+      echo "**** Cleaning $PYTORCH_PROJ before build ****"
+    else
+      cd $BASE
+      rm -rf "$PYTORCH_PROJ"
+      echo "**** Cloning PyTorch into $PYTORCH_PROJ ****"
+      git clone --single-branch -b main --recurse-submodules https://github.com/pytorch/pytorch.git
+      cd "$PYTORCH_PROJ"
+
+      if [ "$BUILD_LATEST" = false ]; then
+        git checkout $PYTORCH_PINNED_COMMIT
+        git submodule update --init --recursive
+        git clean -xffd
+      fi
     fi
+
+    # Apply Triton specific patches to PyTorch.
+    $SCRIPTS_DIR/patch-pytorch.sh
   fi
 
-  # Apply Triton specific patches to PyTorch.
-  $SCRIPTS_DIR/patch-pytorch.sh
-else
+  echo "****** Building $PYTORCH_PROJ ******"
   cd "$PYTORCH_PROJ"
+  pip install -r requirements.txt
+  pip install cmake ninja
+  USE_STATIC_MKL=1 python setup.py bdist_wheel
+}
+
+function install_pytorch {
+  echo "****** Installing PyTorch ******"
+  cd "$PYTORCH_PROJ"
+  pip install dist/*.whl
+}
+
+# TODO: add command line option to rebuild even if pytorch wheel exists
+if [ "$CHECK_WHEEL" = false ] || ! pytorch_wheel_exists; then
+  build_pytorch
 fi
+install_pytorch
 
-echo "****** Building $PYTORCH_PROJ ******"
-pip install -r requirements.txt
-pip install cmake ninja
-USE_STATIC_MKL=1 python setup.py bdist_wheel
-
-echo "****** Installing PyTorch ******"
-pip install dist/*.whl
 # Change working directory to avoid the following error:
 #
 # ImportError: Failed to load PyTorch C extensions:

--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -206,7 +206,6 @@ function install_pytorch {
   pip install dist/*.whl
 }
 
-# TODO: add command line option to rebuild even if pytorch wheel exists
 if [ "$CHECK_WHEEL" = false ] || ! pytorch_wheel_exists; then
   build_pytorch
 fi

--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -137,7 +137,7 @@ fi
 BASE=$(cd "$ROOT/.." && pwd)
 SCRIPTS_DIR=$ROOT/scripts
 PYTORCH_PROJ=${PYTORCH_PROJ:-$BASE/pytorch}
-BASE=$(cd "$PYTORCH_PROJ/.." && pwd)
+BASE=$(dirname "$PYTORCH_PROJ")
 
 echo "**** BASE is set to $BASE ****"
 echo "**** PYTORCH_PROJ is set to $PYTORCH_PROJ ****"

--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -134,9 +134,8 @@ fi
 ############################################################################
 # Configure, build and install PyTorch from source.
 
-BASE=$(cd "$ROOT/.." && pwd)
 SCRIPTS_DIR=$ROOT/scripts
-PYTORCH_PROJ=${PYTORCH_PROJ:-$BASE/pytorch}
+PYTORCH_PROJ=${PYTORCH_PROJ:-$ROOT/.scripts_cache}
 BASE=$(dirname "$PYTORCH_PROJ")
 
 echo "**** BASE is set to $BASE ****"


### PR DESCRIPTION
Added `--check-wheel` to `install-pytorch.sh`, which allows skipping building PyTorch if a wheel corresponding to the pinned commit exists.

Updated the workflow `Build and test on Windows` to use `install-pytorch.sh` with this option, so the workflow rebuilds PyTorch every time when PyTorch commit changes and uses the existing wheel when it exists and matches the pinned commit.

Also added `runner_label` and `skip_list` inputs to the workflow (defaults are for a770) to allow running the workflow on other Windows runners.