### PR TITLE
Implement `spirv_utils` as pure DLL

### DIFF
--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -302,11 +302,8 @@ extern "C" EXPORT_FUNC PyObject *load_binary(PyObject *args) {
   }
 }
 
-extern "C" EXPORT_FUNC PyObject *init_context(PyObject *args) {
-  PyObject *cap;
+extern "C" EXPORT_FUNC PyObject *init_context(PyObject *cap) {
   void *queue = NULL;
-  if (!PyArg_ParseTuple(args, "O", &cap))
-    return NULL;
   if (!(queue = PyLong_AsVoidPtr(cap)))
     return NULL;
   sycl::queue *sycl_queue = static_cast<sycl::queue *>(queue);

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -41,11 +41,7 @@ static inline T checkSyclErrors(const std::tuple<T, ze_result_t> tuple) {
   return std::get<0>(tuple);
 }
 
-extern "C" EXPORT_FUNC PyObject *get_device_properties(PyObject *args) {
-  int device_id;
-  if (!PyArg_ParseTuple(args, "i", &device_id))
-    return NULL;
-
+extern "C" EXPORT_FUNC PyObject *get_device_properties(int device_id) {
   if (device_id > g_sycl_l0_device_list.size()) {
     std::cerr << "Device is not found " << std::endl;
     return NULL;
@@ -323,11 +319,8 @@ extern "C" EXPORT_FUNC PyObject *init_context(PyObject *cap) {
   return Py_BuildValue("(K)", (uint64_t)context);
 }
 
-extern "C" EXPORT_FUNC PyObject *init_devices(PyObject *args) {
-  PyObject *cap;
+extern "C" EXPORT_FUNC PyObject *init_devices(PyObject *cap) {
   void *queue = NULL;
-  if (!PyArg_ParseTuple(args, "O", &cap))
-    return NULL;
   if (!(queue = PyLong_AsVoidPtr(cap)))
     return NULL;
   sycl::queue *sycl_queue = static_cast<sycl::queue *>(queue);
@@ -350,11 +343,8 @@ extern "C" EXPORT_FUNC PyObject *init_devices(PyObject *args) {
   return Py_BuildValue("(i)", deviceCount);
 }
 
-extern "C" EXPORT_FUNC PyObject *wait_on_sycl_queue(PyObject *args) {
-  PyObject *cap;
+extern "C" EXPORT_FUNC PyObject *wait_on_sycl_queue(PyObject *cap) {
   void *queue = NULL;
-  if (!PyArg_ParseTuple(args, "O", &cap))
-    return NULL;
   if (!(queue = PyLong_AsVoidPtr(cap)))
     return NULL;
   sycl::queue *sycl_queue = static_cast<sycl::queue *>(queue);

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -184,10 +184,12 @@ class SpirvUtils:
 
     def __init__(self, cache_path: str):
         self.shared_library = ctypes.PyDLL(cache_path)
-        methods = ("get_device_properties", "init_context", "init_devices", "load_binary", "wait_on_sycl_queue")
+        methods = ("init_context", "init_devices", "load_binary", "wait_on_sycl_queue")
         for method in methods:
             getattr(self.shared_library, method).restype = ctypes.py_object
             getattr(self.shared_library, method).argtypes = (ctypes.py_object, )
+        self.shared_library.get_device_properties.restype = ctypes.py_object
+        self.shared_library.get_device_properties.argtypes = (ctypes.c_int, )
 
     def __getattribute__(self, name):
         if name in ("get_device_properties", "init_context", "init_devices", "load_binary", "wait_on_sycl_queue"):

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -192,11 +192,18 @@ class SpirvUtils:
         self.shared_library.get_device_properties.argtypes = (ctypes.c_int, )
 
     def __getattribute__(self, name):
-        if name in ("get_device_properties", "init_context", "init_devices", "load_binary", "wait_on_sycl_queue"):
+        if name in ("get_device_properties", "init_context", "init_devices", "wait_on_sycl_queue"):
             shared_library = super().__getattribute__("shared_library")
             return getattr(shared_library, name)
 
         return super().__getattribute__(name)
+
+    def load_binary(self, *args):
+        # if we don't use parameter passing in this way,
+        # we will need to rewrite the line in the general part of the code:
+        # driver.active.utils.load_binary(self.name, self.kernel, self.metadata.shared, self.metadata.build_flags, device) ->
+        # driver.active.utils.load_binary((self.name, self.kernel, self.metadata.shared, self.metadata.build_flags, device))
+        return self.shared_library.load_binary(args)
 
     if os.name != 'nt':
 
@@ -292,13 +299,15 @@ class XPUUtils(object):
 
     def __init__(self):
         dirname = os.path.dirname(os.path.realpath(__file__))
-        mod = compile_module_from_src(Path(os.path.join(dirname, "driver.c")).read_text(), "spirv_utils")
-        self.load_binary = mod.load_binary
-        self.get_device_properties = mod.get_device_properties
-        self.context = mod.init_context(self.get_sycl_queue())
-        self.device_count = mod.init_devices(self.get_sycl_queue())
+        # we save `spirv_utils` module so that the destructor is not called prematurely, which will unload the dll
+        # and can cause `Fatal Python error: Segmentation fault`
+        self.mod = compile_module_from_src(Path(os.path.join(dirname, "driver.c")).read_text(), "spirv_utils")
+        self.load_binary = self.mod.load_binary
+        self.get_device_properties = self.mod.get_device_properties
+        self.context = self.mod.init_context(self.get_sycl_queue())
+        self.device_count = self.mod.init_devices(self.get_sycl_queue())
         self.current_device = 0 if self.device_count[0] > 0 else -1
-        self.wait_on_sycl_queue = mod.wait_on_sycl_queue
+        self.wait_on_sycl_queue = self.mod.wait_on_sycl_queue
 
     def get_current_device(self):
         return self.current_device


### PR DESCRIPTION
The same motivation as for https://github.com/intel/intel-xpu-backend-for-triton/pull/3251 and https://github.com/intel/intel-xpu-backend-for-triton/pull/3230