### PR TITLE
[Intel]: Make inferReshapeOpEncoding optional in TTGIR

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -421,13 +421,14 @@ static Attribute inferReshapeOpDstEncoding(ArrayRef<int64_t> srcShape,
     return {};
 
   Attribute dstEnc;
-  auto result =
-      srcEnc.getDialect()
-          .getRegisteredInterface<triton::DialectInferLayoutInterface>()
-          ->inferReshapeOpEncoding(srcShape, srcEnc, dstShape, dstEnc,
-                                   /*loc=*/std::nullopt);
-  assert(succeeded(result));
-  return dstEnc;
+  if (succeeded(
+          srcEnc.getDialect()
+              .getRegisteredInterface<triton::DialectInferLayoutInterface>()
+              ->inferReshapeOpEncoding(srcShape, srcEnc, dstShape, dstEnc,
+                                       /*loc=*/std::nullopt))) {
+    return dstEnc;
+  }
+  return {};
 }
 
 static Attribute inferDstEncoding(triton::ReshapeOp op, Attribute encoding) {


### PR DESCRIPTION
59bd2dc5d1e05111538bc0eb1fc1c14285d853f7 reverted changes to `inferReshapeOpDstEncoding` which allowed the result to be optional. Since we do not implement `inferReshapeOpEncoding` in our dialect, the operation always fails and triggers the assert. The quickest fix currently is to make `inferReshapeOpEncoding` optional, which appears to be handled properly. Long term I think we need to implement `inferReshapeOpEncoding` in our dialect.

cc #3421 