### PR TITLE
Fix `GEMM + PostOp (add matrix) kernel benchmark int8` on BMG

### DIFF
--- a/benchmarks/setup.py
+++ b/benchmarks/setup.py
@@ -116,6 +116,7 @@ setup(
     install_requires=[
         "torch",
         "pandas",
+        "psutil",
         "tabulate",
         "matplotlib",
     ],


### PR DESCRIPTION
2 main points:
* skip combinations, by the number of available RAM (using `psutil`)
* inplace add operation to reduce device memory consumption