### PR TITLE
Allow Windows workflows running on different runners

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -1,4 +1,5 @@
 name: Build and test on Windows
+run-name: ${{ inputs.run_name }}
 
 on:
   workflow_dispatch:
@@ -11,9 +12,10 @@ on:
         description: Skip list
         type: string
         default: a770
-
-  schedule:
-    - cron: "1 5 * * *"
+      run_name:
+        description: Custom run name
+        type: string
+        default: Build and test on Windows
 
 permissions: read-all
 
@@ -22,13 +24,13 @@ env:
   NEW_WORKSPACE: C:\gh${{ github.run_id }}
   ZE_PATH: C:\level_zero
   PYTEST_MAX_PROCESSES: 8
-  SKIPLIST: --skip-list scripts/skiplist/${{ inputs.skip_list || 'a770' }}
-  TRITON_TEST_CMD: bash -x scripts/test-triton.sh --skip-pytorch-install --skip-pip-install --skip-list scripts/skiplist/${{ inputs.skip_list || 'a770' }} --reports-dir reports --ignore-errors
+  SKIPLIST: --skip-list scripts/skiplist/${{ inputs.skip_list }}
+  TRITON_TEST_CMD: bash -x scripts/test-triton.sh --skip-pytorch-install --skip-pip-install --skip-list scripts/skiplist/${{ inputs.skip_list }} --reports-dir reports --ignore-errors
 
 jobs:
   build:
     name: Build and test
-    runs-on: ${{ inputs.runner_label || 'win-a770' }}
+    runs-on: ${{ inputs.runner_label }}
     # Building PyTorch can take up to 4 hours on certain machines, increasing the timeout to 8 hours.
     timeout-minutes: 480
     steps:

--- a/.github/workflows/pip-test-windows.yml
+++ b/.github/workflows/pip-test-windows.yml
@@ -1,7 +1,21 @@
 name: Test with pip on Windows
+run-name: ${{ inputs.run_name }}
 
 on:
   workflow_dispatch:
+    inputs:
+      runner_label:
+        description: Runner label
+        type: string
+        default: win-a770
+      skip_list:
+        description: Skip list
+        type: string
+        default: a770
+      run_name:
+        description: Custom run name
+        type: string
+        default: Test with pip on Windows
 
   # run workflow on changes to the driver, which handles the libraries logic
   pull_request:
@@ -15,9 +29,6 @@ on:
     paths:
       - third_party/intel/backend/driver.py
 
-  schedule:
-    - cron: "3 5 * * *"
-
 permissions: read-all
 
 env:
@@ -25,13 +36,13 @@ env:
   NEW_WORKSPACE: C:\gh${{ github.run_id }}
   ZE_PATH: C:\level_zero
   PYTEST_MAX_PROCESSES: 8
-  SKIPLIST: --skip-list scripts/skiplist/a770
-  TRITON_TEST_CMD: bash -x scripts/test-triton.sh --skip-pytorch-install --skip-pip-install --skip-list scripts/skiplist/a770 --reports-dir reports --ignore-errors
+  SKIPLIST: --skip-list scripts/skiplist/${{ inputs.skip_list || 'a770' }}
+  TRITON_TEST_CMD: bash -x scripts/test-triton.sh --skip-pytorch-install --skip-pip-install --skip-list scripts/skiplist/${{ inputs.skip_list || 'a770' }} --reports-dir reports --ignore-errors
 
 jobs:
   build:
     name: Build and test
-    runs-on: win-a770
+    runs-on: ${{ inputs.runner_label || 'win-a770' }}
     steps:
       - name: Enable long paths
         run: |


### PR DESCRIPTION
Now we have two Windows runners (A770, B580) and we need a parameter to select a runner. Removing running on cron, because these workflows will be triggered externally.
