### PR TITLE
[UT] enable common loop fusion optimization

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6709,8 +6709,6 @@ def test_tl_range_num_stages(device):
 
 
 def test_tl_range_fuse():
-    if is_xpu():
-        pytest.skip("loop fusion is not enabled on XPU")
     if is_hip():
         pytest.skip("loop fusion is not enabled on AMD")
 

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -283,6 +283,9 @@ class XPUBackend(BaseBackend):
             intel.passes.ttgpuir.add_rewrite_tensor_pointer(pm)
         intel.passes.ttgpuir.add_pipeline(pm, opt.num_stages, False)
 
+        passes.ttgpuir.add_fuse_nested_loops(pm)
+        passes.common.add_canonicalizer(pm)
+        passes.common.add_licm(pm)
         passes.ttgpuir.add_optimize_thread_locality(pm)
         passes.ttgpuir.add_optimize_dot_operands(pm, True)
         passes.common.add_cse(pm)


### PR DESCRIPTION
**FuseNestedLoopsPass** is a common pass independent with backend, so we just enable it in our backend.