### PR TITLE
Enable the 2d block IO for tensor of pointer when the tensor on memory are contiguous.

### DIFF
--- a/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
+++ b/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
@@ -1,0 +1,137 @@
+// RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm
+
+// CHECK:   llvm.func spir_funccc @_Z41intel_sub_group_2d_block_read_16b_8r16x2cPU3AS1viiiDv2_iPt
+#mma = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [2, 4], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>
+module attributes {triton_intel_gpu.min_sg_size = 16 : i32, triton_intel_gpu.support_bf16_conversion, triton_intel_gpu.support_dpas, triton_intel_gpu.support_sg_2d_block, triton_intel_gpu.target_arch = "spir64", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shared = 33280 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32} {
+  tt.func public @matmul_tensor_pointer_kernel(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: !llvm.ptr<3>) attributes {noinline = false} {
+    %c63_i32 = arith.constant 63 : i32
+    %c255_i32 = arith.constant 255 : i32
+    %c127_i32 = arith.constant 127 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c256_i32 = arith.constant 256 : i32
+    %cst_0 = arith.constant dense<64> : tensor<128x64xi32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %cst_2 = arith.constant dense<0> : tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>}>>
+    %cst_3 = arith.constant dense<0.000000e+00> : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %0 = tt.get_program_id x : i32
+    %1 = arith.addi %arg3, %c127_i32 : i32
+    %2 = arith.divsi %1, %c128_i32 : i32
+    %3 = arith.addi %arg4, %c255_i32 : i32
+    %4 = arith.divsi %3, %c256_i32 : i32
+    %5 = arith.muli %4, %c8_i32 : i32
+    %6 = arith.divsi %0, %5 : i32
+    %7 = arith.muli %6, %c8_i32 : i32
+    %8 = arith.subi %2, %7 : i32
+    %9 = arith.minsi %8, %c8_i32 : i32
+    %10 = arith.remsi %0, %9 : i32
+    %11 = arith.addi %7, %10 : i32
+    %14 = arith.muli %11, %c128_i32 : i32
+    %16 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>}>>
+    %18 = tt.splat %14 : i32 -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>}>>
+    %20 = arith.addi %18, %16 : tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>}>>
+    %28 = tt.splat %arg3 : i32 -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>}>>
+    %29 = arith.cmpi slt, %20, %28 : tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>}>>
+    %30 = arith.select %29, %20, %cst_2 {tt.contiguity = dense<128> : tensor<1xi32>, tt.divisibility = dense<128> : tensor<1xi32>} : tensor<128xi1, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>}>>, tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>}>>
+    %34 = tt.expand_dims %30 {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>}>> -> tensor<128x1xi32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %35 = tt.splat %arg6 : i32 -> tensor<128x1xi32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %36 = arith.muli %34, %35 : tensor<128x1xi32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %37 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>}>>
+    %38 = tt.expand_dims %37 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>}>> -> tensor<1x64xi32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %39 = tt.broadcast %36 : tensor<128x1xi32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> -> tensor<128x64xi32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %40 = tt.broadcast %38 : tensor<1x64xi32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> -> tensor<128x64xi32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %41 = arith.addi %39, %40 : tensor<128x64xi32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %42 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %43 = tt.addptr %42, %41 : tensor<128x64x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>, tensor<128x64xi32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %54 = arith.addi %arg5, %c63_i32 : i32
+    %55 = arith.divsi %54, %c64_i32 : i32
+    cf.br ^bb1(%c0_i32, %43 : i32, tensor<128x64x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>)
+  ^bb1(%58: i32, %60: tensor<128x64x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>):  // 2 preds: ^bb0, ^bb2
+    %62 = arith.cmpi slt, %58, %55 : i32
+    cf.cond_br %62, ^bb2, ^bb3
+  ^bb2:  // pred: ^bb1
+    %63 = arith.muli %58, %c64_i32 : i32
+    %64 = arith.subi %arg5, %63 : i32
+    %65 = tt.splat %64 : i32 -> tensor<1x64xi32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %66 = arith.cmpi slt, %38, %65 : tensor<1x64xi32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %67 = tt.broadcast %66 : tensor<1x64xi1, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> -> tensor<128x64xi1, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    // CHECK-32: llvm.call spir_funccc @_Z41intel_sub_group_2d_block_read_16b_8r16x2cPU3AS1viiiDv2_iPt
+    %68 = tt.load %60, %67, %cst_3 {triton_intel_gpu.block_io = "row_major"} : tensor<128x64x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %74 = tt.addptr %60, %cst_0 : tensor<128x64x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>, tensor<128x64xi32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %76 = arith.addi %58, %c1_i32 : i32
+    cf.br ^bb1(%76, %74 : i32, tensor<128x64x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>)
+  ^bb3:  // pred: ^bb1
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK:   llvm.func spir_funccc @_Z52intel_sub_group_2d_block_read_transform_16b_32r16x1cPU3AS1viiiDv2_iPj
+#mma = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [2, 4], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>
+module attributes {triton_intel_gpu.min_sg_size = 16 : i32, triton_intel_gpu.support_bf16_conversion, triton_intel_gpu.support_dpas, triton_intel_gpu.support_sg_2d_block, triton_intel_gpu.target_arch = "spir64", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shared = 33280 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32} {
+  tt.func public @matmul_tensor_pointer_kernel(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: !llvm.ptr<3>) attributes {noinline = false} {
+    %c63_i32 = arith.constant 63 : i32
+    %c255_i32 = arith.constant 255 : i32
+    %c127_i32 = arith.constant 127 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c256_i32 = arith.constant 256 : i32
+    %cst_1 = arith.constant dense<0> : tensor<256xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>>
+    %cst_4 = arith.constant dense<0.000000e+00> : tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %0 = tt.get_program_id x : i32
+    %1 = arith.addi %arg3, %c127_i32 : i32
+    %2 = arith.divsi %1, %c128_i32 : i32
+    %3 = arith.addi %arg4, %c255_i32 : i32
+    %4 = arith.divsi %3, %c256_i32 : i32
+    %5 = arith.muli %4, %c8_i32 : i32
+    %6 = arith.divsi %0, %5 : i32
+    %7 = arith.muli %6, %c8_i32 : i32
+    %8 = arith.subi %2, %7 : i32
+    %9 = arith.minsi %8, %c8_i32 : i32
+    %12 = arith.remsi %0, %5 : i32
+    %13 = arith.divsi %12, %9 : i32
+    %15 = arith.muli %13, %c256_i32 : i32
+    %22 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>>
+    %24 = tt.splat %15 : i32 -> tensor<256xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>>
+    %26 = arith.addi %24, %22 : tensor<256xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>>%31 = tt.splat %arg4 : i32 -> tensor<256xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>>
+    %32 = arith.cmpi slt, %26, %31 : tensor<256xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>>
+    %33 = arith.select %32, %26, %cst_1 {tt.contiguity = dense<256> : tensor<1xi32>, tt.divisibility = dense<256> : tensor<1xi32>} : tensor<256xi1, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>>, tensor<256xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>>
+    %44 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>>
+    %45 = tt.expand_dims %44 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>> -> tensor<64x1xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %46 = tt.splat %arg7 : i32 -> tensor<64x1xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %47 = arith.muli %45, %46 : tensor<64x1xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %48 = tt.expand_dims %33 {axis = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>> -> tensor<1x256xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %49 = tt.broadcast %47 : tensor<64x1xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<64x256xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %50 = tt.broadcast %48 : tensor<1x256xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<64x256xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %51 = arith.addi %49, %50 : tensor<64x256xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %52 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<64x256x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %53 = tt.addptr %52, %51 : tensor<64x256x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>, tensor<64x256xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %54 = arith.addi %arg5, %c63_i32 : i32
+    %55 = arith.divsi %54, %c64_i32 : i32
+    %56 = arith.muli %arg7, %c64_i32 : i32
+    %57 = tt.splat %56 : i32 -> tensor<64x256xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    cf.br ^bb1(%c0_i32, %53 : i32, tensor<64x256x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>)
+  ^bb1(%58: i32, %61: tensor<64x256x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>):  // 2 preds: ^bb0, ^bb2
+    %62 = arith.cmpi slt, %58, %55 : i32
+    cf.cond_br %62, ^bb2, ^bb3
+  ^bb2:  // pred: ^bb1
+    %63 = arith.muli %58, %c64_i32 : i32
+    %64 = arith.subi %arg5, %63 : i32
+    %69 = tt.splat %64 : i32 -> tensor<64x1xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %70 = arith.cmpi slt, %45, %69 : tensor<64x1xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %71 = tt.broadcast %70 : tensor<64x1xi1, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<64x256xi1, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    // CHECK-16:   llvm.call spir_funccc @_Z52intel_sub_group_2d_block_read_transform_16b_32r16x1cPU3AS1viiiDv2_iPj
+    %72 = tt.load %61, %71, %cst_4 {triton_intel_gpu.block_io = "row_major"} : tensor<64x256x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %75 = tt.addptr %61, %57 : tensor<64x256x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>, tensor<64x256xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %76 = arith.addi %58, %c1_i32 : i32
+    cf.br ^bb1(%76, %75 : i32, tensor<64x256x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>)
+  ^bb3:  // pred: ^bb1
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -464,6 +464,497 @@ struct PrefetchOpConversion
   }
 };
 
+struct LoadOpToBlockIOConversion
+    : public ConvertTritonGPUOpToLLVMPattern<triton::LoadOp>,
+      public LoadStoreConversionBase {
+  using ConvertTritonGPUOpToLLVMPattern<
+      triton::LoadOp>::ConvertTritonGPUOpToLLVMPattern;
+
+  using ValueTable = std::map<std::pair<int, int>, Value>;
+
+  LoadOpToBlockIOConversion(
+      TritonIntelGPUToLLVMTypeConverter &converter,
+      const triton::intel::TargetInfo &targetInfo,
+      const triton::intel::ModuleAxisInfoAnalysis &axisAnalysisPass,
+      PatternBenefit benefit)
+      : ConvertTritonGPUOpToLLVMPattern<triton::LoadOp>(converter, benefit),
+        LoadStoreConversionBase(targetInfo, axisAnalysisPass) {}
+
+  LogicalResult
+  matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    Attribute blockIOAttr =
+        op->getAttr(TritonIntelGPUDialect::getBlockIOAttrName());
+    if (!blockIOAttr)
+      return failure();
+
+    Location loc = op.getLoc();
+    MLIRContext *ctx = rewriter.getContext();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    Value ptr = op.getPtr();
+    Value mask = op.getMask();
+    Value other = op.getOther();
+    Type resultType = op.getType();
+    auto tensorType = cast<RankedTensorType>(resultType);
+
+    const bool hasDpasLayout = hasDpasEncoding(tensorType);
+    if (!hasDpasLayout && !hasDotDpasEncoding(tensorType))
+      return failure();
+
+    // Only lower loadOp with dpas layout encoding.
+    auto encoding = tensorType.getEncoding();
+
+    // TODO: To support more layouts on memory.
+    // Only support rank 2 dot layout, either row major or column major.
+    StringRef memoryLayoutInfo = cast<StringAttr>(blockIOAttr).getValue();
+    assert((memoryLayoutInfo == "row_major" ||
+            memoryLayoutInfo == "column_major") &&
+           "Only row_major or column_major is supported");
+    const bool memoryRowMajor = (memoryLayoutInfo == "row_major");
+
+    auto getOpIdx = [&]() -> DpasEncodingAttr::OpIdx {
+      if (hasDpasLayout)
+        return DpasEncodingAttr::OpIdx::OperandC;
+
+      assert(hasDotDpasEncoding(tensorType) && "Expecting dot layout");
+      DotOperandEncodingAttr dotLayout = getDotEncoding(tensorType).value();
+      return static_cast<DpasEncodingAttr::OpIdx>(dotLayout.getOpIdx());
+    };
+    DpasEncodingAttr::OpIdx opIdx = getOpIdx();
+
+    std::optional<LinearLayout> llEncoding =
+        cast<DistributedEncodingTrait>(encoding).toLinearLayout(
+            tensorType.getShape());
+    assert(llEncoding.has_value() && "invalid dot layout to linear layout");
+    auto llAttr = LinearEncodingAttr::get(rewriter.getContext(), *llEncoding);
+    SmallVector<unsigned> threadOrder(llAttr.getThreadOrder());
+    size_t rank = threadOrder.size();
+    const bool valueRowMajor =
+        (threadOrder[rank - 2] == 1 && threadOrder[rank - 1] == 0);
+    assert((valueRowMajor ||
+            (threadOrder[rank - 2] == 0 && threadOrder[rank - 1] == 1)) &&
+           "Only row_major or column_major is allowed");
+    const bool isTransposeRequired = valueRowMajor ^ memoryRowMajor;
+
+    Type eltTy = tensorType.getElementType();
+    unsigned elemSizeInBits = eltTy.getIntOrFloatBitWidth();
+
+    auto dpasLayout = hasDpasLayout
+                          ? cast<DpasEncodingAttr>(encoding)
+                          : cast<DpasEncodingAttr>(
+                                getDotEncoding(tensorType).value().getParent());
+
+    const ArrayRef<int64_t> tensorShape = tensorType.getShape();
+    unsigned numElems = getTotalElemsPerThread(resultType);
+    SmallVector<int64_t> numReps =
+        dpasLayout.getDPASRepetitions(tensorShape, opIdx);
+    const SmallVector<unsigned> warpsPerCTA = dpasLayout.getWarpsPerCTA();
+    SmallVector<unsigned> dpasWarpsOrder = triton::gpu::getOrder(tensorType);
+    unsigned threadsPerWarp = triton::gpu::getWarpSize(dpasLayout);
+
+    Value warpId = rewriter.create<arith::IndexCastOp>(
+        loc, i32_ty,
+        rewriter.create<mlir::gpu::SubgroupIdOp>(loc, /*upperBound=*/nullptr));
+
+    SmallVector<Value> multiDimWarpId =
+        delinearize(rewriter, loc, warpId, warpsPerCTA, dpasWarpsOrder);
+
+    bool isOperandA = (opIdx == DpasEncodingAttr::OpIdx::OperandA);
+    SmallVector<unsigned> dpasInstShape = isOperandA
+                                              ? dpasLayout.getDPASInstShapeA()
+                                              : dpasLayout.getDPASInstShapeB();
+    SmallVector<unsigned> elemsPerDPASInst = {dpasInstShape[0],
+                                              dpasInstShape[1]};
+    unsigned elemsPerLanePerDPASInst =
+        product<unsigned>(elemsPerDPASInst) / threadsPerWarp;
+    TritonGPUToLLVMTypeConverter *typeConverter = getTypeConverter();
+    Type unpackedDPASOperandType = LLVM::getFixedVectorType(
+        typeConverter->convertType(eltTy), elemsPerLanePerDPASInst);
+
+    // By default, use the unpacked type for the 2D load result type.
+    Type loadResultElemType = typeConverter->convertType(eltTy);
+    bool usePackedType = false;
+    unsigned packedElemsNum = 1;
+    unsigned packedElemsPerLanePerDPASInst = elemsPerLanePerDPASInst;
+    // The tensor values are distributed as DotOp layout of DPAS.
+    // If the element size of the tensor matches the DPAS packed layout, then
+    // use the packed type for the 2D load result type. For example,
+    // The intermediate ops generated by ConvertTritonGPUToLLVM:
+    //   %0 = load_2d %ptr : vector<8 x i32>
+    //   %1 = bitcast %0 : vector<8 x i32> -> vector<16 x f16>
+    //   %2 = bitcast %1 : vector<16 x f16> -> vector<8 x i32>
+    //   %3 = dpas %2
+    // And the LLVM dialect optimization pass can eliminate the duplicated
+    // bitcast. Then there is a shortcut to use the load result directly as the
+    // input operands to DPAS.
+    // TODO: add support for int4 and int2.
+    unsigned opsPerChannel = dpasLayout.getOpsPerChannel();
+    if ((opsPerChannel == 4 && elemSizeInBits == 8) ||
+        (opsPerChannel == 2 && elemSizeInBits == 16) ||
+        (opsPerChannel == 1 && elemSizeInBits == 32)) {
+      loadResultElemType =
+          (isOperandA && elemSizeInBits != 32) ? i16_ty : i32_ty;
+      packedElemsNum =
+          isOperandA ? (opsPerChannel == 4 ? 2 : 1) : opsPerChannel;
+      packedElemsPerLanePerDPASInst = elemsPerLanePerDPASInst / packedElemsNum;
+      usePackedType = true;
+    } else {
+      if (isOperandA && opsPerChannel == 4) {
+        packedElemsNum = 2;
+        unsigned packedBitWidht = elemSizeInBits * packedElemsNum;
+        if (packedBitWidht > 64) {
+          // Be conservative to avoid the packed type exceeds 64 bits.
+          return failure();
+        }
+        // Need to pack two column into one to work around vectorization
+        // limitation.
+        loadResultElemType = int_ty(packedBitWidht);
+        packedElemsPerLanePerDPASInst =
+            elemsPerLanePerDPASInst / packedElemsNum;
+        usePackedType = true;
+      }
+    }
+
+    Type packedDPASOperandType = LLVM::getFixedVectorType(
+        loadResultElemType, packedElemsPerLanePerDPASInst);
+
+    // Outer dim: Dim M or N. Inner dim: Dim K.
+    // Round the warp id fit into the tensor shape.
+    ArrayRef<unsigned> repCluster = dpasLayout.getRepCluster();
+    SmallVector<unsigned> warpShape =
+        isOperandA ? dpasLayout.getShapeA() : dpasLayout.getShapeB();
+
+    assert(rank == 2 && "unexpected rank");
+    unsigned dimOuter = bool(opIdx) ? rank - 1 : rank - 2;
+    unsigned dimInner = bool(opIdx) ? rank - 2 : rank - 1;
+    unsigned outerDimRequiredWarpNum =
+        mlir::ceil<unsigned>(tensorShape[dimOuter], warpShape[dimOuter]);
+    unsigned outerDimWarpNum =
+        std::min<unsigned>(warpsPerCTA[dimOuter], outerDimRequiredWarpNum);
+    Value outerDimWarpId =
+        b.urem(multiDimWarpId[dimOuter], b.i32_val(outerDimWarpNum));
+
+    unsigned tileWidth = elemsPerDPASInst[threadOrder[rank - 2]];
+    unsigned tileHeight = elemsPerDPASInst[threadOrder[rank - 1]];
+    unsigned vBlocks = 1;
+    unsigned numOperandsOuterDimPerLoad = 1;
+    unsigned numOperandsInnerDimPerLoad = 1;
+    unsigned maskConstancyHor = 1, maskConstancyVer = 1;
+    unsigned instWidth = elemsPerDPASInst[threadOrder[rank - 2]];
+    unsigned instHeight = elemsPerDPASInst[threadOrder[rank - 1]];
+
+    bool otherIsSplatConstInt = false;
+    int64_t splatVal = 0;
+
+    std::map<SmallVector<unsigned>, Value> ptrs;
+    std::map<SmallVector<unsigned>, Value> masks;
+    std::map<SmallVector<unsigned>, Value> others;
+    if (isTensorPointerType(ptr.getType())) {
+      // TODO: move the tensor pointer rewrite code here.
+      return failure();
+    } else {
+      Value llPtr = adaptor.getPtr();
+      Value llMask = adaptor.getMask();
+      Value llOther = adaptor.getOther();
+
+      SmallVector<Value> ptrElems, maskElems, otherElems;
+      // Get the LLVM values for pointers
+      ptrElems = unpackLLElements(loc, llPtr, rewriter);
+      assert(ptrElems.size() == numElems &&
+             "the number of pointer values is not matched with the number of "
+             "elements");
+
+      // Get the LLVM values for mask
+      if (llMask) {
+        maskElems = unpackLLElements(loc, llMask, rewriter);
+        assert(maskElems.size() == numElems &&
+               "the number of mask values is not matched with the number of "
+               "elements");
+        auto axisInfo = const_cast<triton::intel::ModuleAxisInfoAnalysis &>(
+                            axisAnalysisPass)
+                            .getAxisInfo(mask);
+        if (axisInfo) {
+          maskConstancyHor = axisInfo->getConstancy(rank - 1);
+          maskConstancyVer = axisInfo->getConstancy(rank - 2);
+        } else {
+          maskConstancyHor = 1;
+          maskConstancyVer = 1;
+        }
+      } else {
+        // no mask
+        maskConstancyHor = std::numeric_limits<unsigned>::max();
+        maskConstancyVer = std::numeric_limits<unsigned>::max();
+      }
+
+      // Check the constancy of the mask support to load the memory in 2D block.
+      if (!(maskConstancyHor >= instWidth && maskConstancyVer >= instHeight))
+        return failure();
+
+      // Get the LLVM values for `other`
+      DenseElementsAttr constAttr;
+      if (other && isa<IntegerType>(eltTy) &&
+          matchPattern(other, m_Constant(&constAttr)) && constAttr.isSplat() &&
+          isa<IntegerType>(constAttr.getElementType())) {
+        otherIsSplatConstInt = true;
+        splatVal = constAttr.getSplatValue<APInt>().getSExtValue();
+      }
+      if (other) {
+        otherElems = unpackLLElements(loc, llOther, rewriter);
+      }
+
+      // re-arrange the ptrs and masks to for large 2D block IO.
+      // Layout is unrelated to the scalar type.
+      SmallVector<SmallVector<unsigned>> offsets =
+          mlir::emitOffsetForLayout(encoding, tensorType);
+      for (size_t i = 0; i < ptrElems.size(); ++i) {
+        SmallVector<unsigned> offset = offsets[i];
+        ptrs[offset] = ptrElems[i];
+        if (llMask)
+          masks[offset] = maskElems[i];
+        if (otherElems.size())
+          others[offset] = otherElems[i];
+      }
+    }
+
+    unsigned numOperandsPer2DLoadM, numOperandsPer2DloadN;
+    if (!isTransposeRequired) {
+      numOperandsPer2DLoadM =
+          isOperandA ? repCluster[dimOuter] : numReps[unsigned(opIdx) ? 1 : 2];
+      numOperandsPer2DloadN =
+          isOperandA ? numReps[unsigned(opIdx) ? 1 : 2] : repCluster[dimOuter];
+    } else {
+      if (isOperandA)
+        return failure();
+
+      if (!usePackedType)
+        return failure();
+
+      std::swap(tileHeight, tileWidth);
+
+      // We can decompose the matrix returned by transposed large 2d load
+      // when threads per warp < column size. Otherwise we have to load one
+      // operand per inst.
+      // Note: the tileHeight and numOperandsPer2DLoadM are the column size
+      // now.
+      numOperandsPer2DLoadM =
+          (threadsPerWarp <= tileHeight) ? repCluster[rank - 1] : 1;
+      // The transpose 2d load only support 1 operand per inst on column.
+      // (vBlocks = 1)
+      numOperandsPer2DloadN = 1;
+    }
+
+    // adjust the mask constancy to fit the 2D load.
+    numOperandsPer2DLoadM =
+        std::min(numOperandsPer2DLoadM, maskConstancyHor / instWidth);
+    numOperandsPer2DloadN =
+        std::min(numOperandsPer2DloadN, maskConstancyVer / instHeight);
+
+    // PVC 2D load supports 32 rows at most. Load multiple dot operands in by
+    // enlarging the tileHeight.
+    numOperandsPer2DLoadM = std::min(numOperandsPer2DLoadM, 32 / tileHeight);
+
+    // PVC 2D load supports 64 bytes per row at most. Load multiple dot operands
+    // by enlarging the vBlocks.
+    unsigned totalBytesPerRowPerDPASOp = tileWidth * elemSizeInBits / 8;
+    numOperandsPer2DloadN =
+        std::min(numOperandsPer2DloadN, 64 / totalBytesPerRowPerDPASOp);
+
+    tileHeight = instHeight * numOperandsPer2DLoadM;
+    tileWidth = instWidth;
+    vBlocks = numOperandsPer2DloadN;
+
+    numOperandsOuterDimPerLoad =
+        isOperandA ? numOperandsPer2DLoadM : numOperandsPer2DloadN;
+    numOperandsInnerDimPerLoad =
+        isOperandA ? numOperandsPer2DloadN : numOperandsPer2DLoadM;
+
+    if (isTransposeRequired)
+      std::swap(numOperandsOuterDimPerLoad, numOperandsInnerDimPerLoad);
+
+    unsigned numLoadPerOutRepCluster =
+        mlir::ceil<unsigned>(repCluster[dimOuter], numOperandsOuterDimPerLoad);
+
+    unsigned numValuesPerLoad = packedElemsPerLanePerDPASInst *
+                                numOperandsOuterDimPerLoad *
+                                numOperandsInnerDimPerLoad;
+    Type load2DGenXType =
+        LLVM::getFixedVectorType(loadResultElemType, numValuesPerLoad);
+
+    // The stride for the replicates.
+    unsigned repOuterStride = warpShape[dimOuter] * outerDimWarpNum;
+    unsigned repStride =
+        elemsPerDPASInst[dimOuter] * numOperandsOuterDimPerLoad;
+    unsigned warpOuterStride = warpShape[dimOuter];
+    unsigned repKStride = elemsPerDPASInst[dimInner];
+
+    unsigned numRepOuter = numReps[bool(opIdx) ? 2 : 1];
+    unsigned numRepInner = numReps[bool(opIdx) ? 1 : 2];
+
+    Value baseWidth = b.i32_val(vBlocks * tileWidth * (elemSizeInBits / 8));
+    Value baseHeight = b.i32_val(tileHeight);
+    Value pitch = b.sub(b.ptrtoint(i64_ty, ptrs[{1, 0}]),
+                        b.ptrtoint(i64_ty, ptrs[{0, 0}]));
+    pitch = targetInfo.shuffleIdx(rewriter, loc, pitch, 0);
+    pitch = b.umax(b.trunc(i32_ty, pitch), baseWidth);
+
+    StringAttr kRegister = str_attr("register");
+    StringAttr kLane = str_attr("lane");
+    StringAttr kWarp = str_attr("warp");
+    StringAttr kBlock = str_attr("block");
+
+    ValueTable loadVals;
+    for (int inner = 0; inner < numRepInner;
+         inner += numOperandsInnerDimPerLoad) {
+      for (int outer = 0; outer < numRepOuter; ++outer) {
+        for (int rep = 0; rep < numLoadPerOutRepCluster; ++rep) {
+          unsigned offsetOuter =
+              outer * repOuterStride +
+              rep * dpasInstShape[dimOuter] * numOperandsOuterDimPerLoad;
+          unsigned offsetInner = inner * dpasInstShape[dimInner];
+          unsigned offsetM = (isOperandA ? offsetOuter : offsetInner);
+          unsigned offsetN = (isOperandA ? offsetInner : offsetOuter);
+
+          Value pred =
+              masks.size() ? masks[{offsetM, offsetN}] : b.int_val(1, 1);
+          pred = targetInfo.shuffleIdx(rewriter, loc, pred, 0);
+          Value other_ = b.undef(load2DGenXType);
+          if (others.size()) {
+            VectorType vecTy = vec_ty(eltTy, numValuesPerLoad * packedElemsNum);
+
+            Value v = b.undef(vecTy);
+            unsigned nWords = 0;
+            for (int vblk = 0; vblk < vBlocks; ++vblk)
+              for (int i = 0; i < tileHeight; ++i) {
+                unsigned numColPerPackedValue = isOperandA ? packedElemsNum : 1;
+                unsigned numPackedValuesPerRow = mlir::ceil<unsigned>(
+                    (tileWidth / numColPerPackedValue), threadsPerWarp);
+                for (int col = 0; col < numPackedValuesPerRow; ++col) {
+                  for (int packedCol = 0; packedCol < numColPerPackedValue;
+                       ++packedCol) {
+                    unsigned N = packedCol +
+                                 col * threadsPerWarp * numColPerPackedValue +
+                                 vblk * tileWidth + offsetN;
+                    unsigned M = i + offsetM;
+                    Value falseVal = others[{M, N}];
+                    Value sVal = createIndexAttrConstant(
+                        rewriter, loc, typeConverter->getIndexType(), nWords++);
+                    v = b.insert_element(vecTy, v, falseVal, sVal);
+                  }
+                }
+              }
+
+            other_ = b.bitcast(v, load2DGenXType);
+
+          } else {
+            other_ = rewriter.create<LLVM::ConstantOp>(
+                loc, load2DGenXType, rewriter.getZeroAttr(load2DGenXType));
+          }
+
+          // Create a predicated load operation.
+          Block &endBlock = LLVM::intel::createPredicatedBlock(
+              rewriter, loc, pred, SmallVector<Value, 1>{other_}, [&]() {
+                // Use the top-left address of the block to load the data.
+                Value addrElem = b.bitcast(ptrs[{offsetM, offsetN}],
+                                           ptr_ty(ctx, 1 /*global*/));
+                addrElem = targetInfo.shuffleIdx(rewriter, loc, addrElem, 0);
+
+                auto load2dOp = rewriter.create<TritonGEN::Matrix2DBlockLoadOp>(
+                    loc, load2DGenXType,
+                    /*ptr*/ addrElem,
+                    /*base_width*/ baseWidth,
+                    /*base_height*/ baseHeight,
+                    /*base_pitch*/ pitch,
+                    /*x*/ b.i32_val(0),
+                    /*y*/ b.i32_val(0),
+                    /*elem_size_in_bits*/ elemSizeInBits,
+                    /*tile_width*/ tileWidth,
+                    /*tile_height*/ tileHeight,
+                    /*v_blocks*/ vBlocks,
+                    /*transpose*/ false,
+                    /*vnni_transform*/ opIdx ==
+                            DpasEncodingAttr::OpIdx::OperandB &&
+                        usePackedType);
+                return SmallVector<Value, 1>{load2dOp};
+              });
+          Value ret = *endBlock.args_begin();
+
+          unsigned packedRowNum = opIdx == DpasEncodingAttr::OpIdx::OperandA
+                                      ? numOperandsOuterDimPerLoad
+                                      : numOperandsInnerDimPerLoad;
+          unsigned packedColNum = opIdx == DpasEncodingAttr::OpIdx::OperandA
+                                      ? numOperandsInnerDimPerLoad
+                                      : numOperandsOuterDimPerLoad;
+
+          // Decompose the return value to multiple operands.
+          unsigned packedColNumPerVBlock = packedColNum / vBlocks;
+          for (int vblk = 0; vblk < vBlocks; ++vblk)
+            for (int row = 0; row < packedRowNum; ++row)
+              for (int col = 0; col < packedColNumPerVBlock; ++col) {
+
+                unsigned operandStartOffset = (vblk * packedRowNum + row) *
+                                              packedColNumPerVBlock *
+                                              packedElemsPerLanePerDPASInst;
+
+                SmallVector<int32_t> indices(packedElemsPerLanePerDPASInst);
+                for (int elemIdx = 0; elemIdx < packedElemsPerLanePerDPASInst;
+                     ++elemIdx) {
+                  indices[elemIdx] = operandStartOffset +
+                                     elemIdx * packedColNumPerVBlock + col;
+                }
+                DenseI32ArrayAttr attr = rewriter.getDenseI32ArrayAttr(indices);
+                Value loadVal = rewriter.create<LLVM::ShuffleVectorOp>(
+                    loc, packedDPASOperandType, ret, ret, attr);
+
+                // Save the decomposed vals to the map;
+                switch (opIdx) {
+                case DpasEncodingAttr::OpIdx::OperandA: {
+                  loadVals[{outer * packedRowNum * numLoadPerOutRepCluster +
+                                rep * packedRowNum + row,
+                            inner + vblk * packedColNumPerVBlock + col}] =
+                      b.bitcast(loadVal, unpackedDPASOperandType);
+                } break;
+                case DpasEncodingAttr::OpIdx::OperandB: {
+                  loadVals[{outer * packedColNum * numLoadPerOutRepCluster +
+                                rep * packedColNum +
+                                vblk * packedColNumPerVBlock + col,
+                            inner + row}] =
+                      b.bitcast(loadVal, unpackedDPASOperandType);
+                } break;
+                case DpasEncodingAttr::OpIdx::OperandC: {
+                  llvm_unreachable("unexpected OpIdx::OperandC");
+                } break;
+                }
+              }
+        }
+      }
+    }
+
+    // Extract the value returned by the load ops. And put the values in the
+    // expected order for the layout.
+    SmallVector<Value> unpackedLoadedVals;
+    for (int outer = 0; outer < numRepOuter; ++outer) {
+      for (int k = 0; k < numRepInner; ++k) {
+        for (int rep = 0; rep < repCluster[unsigned(opIdx)]; ++rep) {
+          Value loadVal =
+              loadVals.at({outer * repCluster[unsigned(opIdx)] + rep, k});
+          VectorType loadTy = cast<VectorType>(loadVal.getType());
+          for (int i = 0; i < loadTy.getNumElements(); ++i) {
+            auto val = b.extract_element(loadVal, b.i32_val(i));
+            unpackedLoadedVals.push_back(val);
+          }
+        }
+      }
+    }
+
+    Type llvmResultStructTy = typeConverter->convertType(op.getType());
+    Value resultStruct = packLLElements(loc, typeConverter, unpackedLoadedVals,
+                                        rewriter, llvmResultStructTy);
+    rewriter.replaceOp(op, {resultStruct});
+
+    return success();
+  }
+};
+
 struct LoadOpConversion
     : public ConvertTritonGPUOpToLLVMPattern<triton::LoadOp>,
       public LoadStoreConversionBase {
@@ -1828,6 +2319,9 @@ void mlir::triton::intel::populateLoadStoreOpToLLVMPatterns(
   patterns.add<AtomicCASOpConversion, AtomicRMWOpConversion, StoreOpConversion,
                PrefetchOpConversion>(typeConverter, targetInfo,
                                      axisInfoAnalysis, benefit);
+  // BlockIO is more efficient than gather load.
+  patterns.add<LoadOpToBlockIOConversion>(
+      typeConverter, targetInfo, axisInfoAnalysis, benefit.getBenefit() + 2);
   patterns.add<LoadOpConversion>(typeConverter, targetInfo, axisInfoAnalysis,
                                  benefit, oneMatrixPerLoadForBT);
 }


### PR DESCRIPTION
### General
This is an alternative way to lower the `tt.load` with tensor of pointers to the 2D block IO.
It depends on the analysis result from the `ModuleAxisInfoAnalysis` about the pointers and masks.

### Background
Both the block pointer type (e:g: `!tt.ptr<tensor<64x32xf16>`) and the tensor of pointer type (e.g: `tensor<64x32x!tt.ptr<f16>>`) are used to describe a tensor resident on global memory. 
The difference is that the tensor of pointers contains more "entropy" than block pointer. The tensor of pointers can describe a tensor on global memory which is randomly distributed, of cause it can be used to describe the structed distribution as block pointer.

There already is a optimization pass to raise the tensor of pointer to the block pointer for some cases with limitation. 
This way supports more cases with less limitation to lower the `tt.load` with tensor of pointer to 2D block IO.

### Idea
The `ModuleAxisInfoAnalysis` analysis the axis information such as, contiguity, divisibility and constancy of the value of the tensor for pointers and masks. 
In general, we can use the 2D block IO lowering as long as:
1. the contiguity of the pointers is multiple of the threadsPerWarp size in the same Dim D. 
2. The constancy of the masks is multiple of the threadsPerWarp size in the same Dim D.

We start with the case of the `tt.load` with DotOp and DPAS layout. To generalize the lowering code for more cases with LinearLayout in future.

