### PR TITLE
Use Linear Layout to describe 2D block loads

### DIFF
--- a/test/TritonIntelGPU/blockptr_load.mlir
+++ b/test/TritonIntelGPU/blockptr_load.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm --check-prefixes=CHECK,LARGE-BLOCK-SIZE-TRANS-B
+// RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm --debug | FileCheck %s --implicit-check-not=llvm.inline_asm --check-prefixes=CHECK,LARGE-BLOCK-SIZE-TRANS-B
 // RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm=one_matrix_per_load_for_bt=1 | FileCheck %s --implicit-check-not=llvm.inline_asm --check-prefixes=CHECK,SMALL-BLOCK-SIZE-TRANS-B
 
 // CHECK-DAG: llvm.func spir_funccc @_Z38intel_sub_group_f16_f16_matrix_mad_k16Dv8_sDv8_iDv8_f(vector<8xi16>, vector<8xi32>, vector<8xf32>) -> vector<8xf32> attributes {convergent, memory_effects = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none>, no_unwind, will_return}

--- a/test/TritonIntelGPU/blockptr_load.mlir
+++ b/test/TritonIntelGPU/blockptr_load.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm --debug | FileCheck %s --implicit-check-not=llvm.inline_asm --check-prefixes=CHECK,LARGE-BLOCK-SIZE-TRANS-B
+// RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm --check-prefixes=CHECK,LARGE-BLOCK-SIZE-TRANS-B
 // RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm=one_matrix_per_load_for_bt=1 | FileCheck %s --implicit-check-not=llvm.inline_asm --check-prefixes=CHECK,SMALL-BLOCK-SIZE-TRANS-B
 
 // CHECK-DAG: llvm.func spir_funccc @_Z38intel_sub_group_f16_f16_matrix_mad_k16Dv8_sDv8_iDv8_f(vector<8xi16>, vector<8xi32>, vector<8xf32>) -> vector<8xf32> attributes {convergent, memory_effects = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none>, no_unwind, will_return}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -906,10 +906,18 @@ struct LoadOpConversion
         isOperandA ? numOperandsPer2DloadN : numOperandsPer2DLoadM;
 
     if (!isTransposeRequired) {
+#if 0 
+      tileLayout *= LinearLayout::identity1D(numIterationsOuterDimPerLoad,
+        kIteration, S("dim0"));
+      tileLayout *= LinearLayout::identity1D(numIterationsInnerDimPerLoad,
+        kIteration, S("dim1"));
+#else
       tileLayout *= LinearLayout::identity1D(numIterationsOuterDimPerLoad,
                                              kIteration, dimOuterStr);
       tileLayout *= LinearLayout::identity1D(numIterationsInnerDimPerLoad,
                                              kIteration, dimInnerStr);
+#endif 
+
       llvm::errs() << "\nnumOperandsOuterDimPerLoad: "
                    << numOperandsOuterDimPerLoad << "\n";
       llvm::errs() << "numOperandsInnerDimPerLoad: "
@@ -1309,8 +1317,12 @@ struct LoadOpConversion
             llvm::errs() << "tileWidth = " << tileWidth << "\n";
             llvm::errs() << "elemSizeInBits/16 = " << elemSizeInBits / 16
                          << "\n";
+#if 1
+            loadColStride = isOperandA ? tileHeight : tileWidth;
+#else
             loadColStride = isOperandA ? tileHeight / (elemSizeInBits / 16)
                                        : tileWidth / (elemSizeInBits / 16);
+#endif 
           }
 
           LLVM_DEBUG({

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -955,10 +955,6 @@ struct LoadOpConversion
       }
     }
 
-#if 1
-    llvm::errs() << "Block load tile layout after adding iterations: "
-                 << tileLayout << "\n";
-#else
     LLVM_DEBUG({
       llvm::dbgs() << "Block load tile layout after adding iterations: "
                    << tileLayout << "\n";
@@ -998,7 +994,6 @@ struct LoadOpConversion
       }
       llvm::dbgs() << "\n";
     });
-#endif
 
     unsigned numRepOuter = numReps[bool(opIdx) ? 2 : 1];
     unsigned numRepInner = numReps[bool(opIdx) ? 1 : 2];
@@ -1014,7 +1009,7 @@ struct LoadOpConversion
       std::swap(numIterationsOuterDimPerLoad, numIterationsInnerDimPerLoad);
     }
 
-#if 1
+#if 0
     llvm::errs() << "dim outer load: \n";
     llvm::errs() << "\tnumRepOuter: " << numRepOuter << "\n";
     llvm::errs() << "\tpackedElementsPerSlot: " << packedElementsPerSlot
@@ -1041,6 +1036,7 @@ struct LoadOpConversion
                  << numRepInner / numIterationsInnerDimPerLoad << "\n";
     llvm::errs() << "\tdimInner Val swapped iterations: "
                  << numRepInner / numIterationsOuterDimPerLoad << "\n";
+#endif
 
     tileLayout *= LinearLayout::identity1D(
         numRepInner / numIterationsInnerDimPerLoad, kLoad, dimInnerStr);
@@ -1053,21 +1049,6 @@ struct LoadOpConversion
               numIterationsOuterDimPerLoad,
           kLoad, dimOuterStr);
     }
-
-#else
-    if (isTransposeRequired && oneMatrixPerLoadForBT) {
-      tileLayout *= LinearLayout::identity1D(numRepOuter * repCluster[dimOuter],
-                                             kLoad, dimOuterStr);
-    } else {
-      tileLayout *= LinearLayout::identity1D(
-          (numRepOuter * packedElementsPerSlot * (isOperandA ? vBlocks : 1)) /
-              numOperandsOuterDimPerLoad,
-          kLoad, dimOuterStr);
-    }
-    tileLayout *= LinearLayout::identity1D(
-        (numRepInner * (isOperandA ? 1 : vBlocks)) / numOperandsInnerDimPerLoad,
-        kLoad, dimInnerStr);
-#endif
 
     LLVM_DEBUG({
       llvm::dbgs() << "Block load tile layout after adding loads: "
@@ -1210,19 +1191,11 @@ struct LoadOpConversion
                          << k << "\n";
           });
 
-#if 0
-          const int loadIdx = outer + (rep) +
-                              ((k / numOperandsInnerDimPerLoad) *
-                               numLoadPerOutRepCluster);
-          LLVM_DEBUG(llvm::dbgs() << "loadIdx: " << loadIdx << " (" << outer << " + " << rep << " + " << k << " / " << numOperandsInnerDimPerLoad << " * " << numLoadPerOutRepCluster << ")\n");
-          LLVM_DEBUG(llvm::dbgs() << "alt load idx: " << ((outer * numLoadPerOutRepCluster * numRepInner) + rep*numRepInner + k) << "\n");
-#else
           const int loadIdx = (outer * numLoadPerOutRepCluster *
                                (numRepInner / numOperandsInnerDimPerLoad)) +
                               rep * (numRepInner / numOperandsInnerDimPerLoad) +
                               k / numOperandsInnerDimPerLoad;
           LLVM_DEBUG(llvm::dbgs() << "loadIdx: " << loadIdx << "\n");
-#endif
 
           Value offsetX, offsetY;
           auto offset = tileLayout.apply(

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1204,9 +1204,9 @@ struct LoadOpConversion
           // adjust the load offset to compensate for strides related to the
           // DPAS layout
           LLVM_DEBUG({
-            llvm::dbgs() << "x offset from layout: " << offset[dimOuter].second
+            llvm::dbgs() << "x offset from layout: " << offset[0].second
                          << "\n";
-            llvm::dbgs() << "y offset from layout: " << offset[dimInner].second
+            llvm::dbgs() << "y offset from layout: " << offset[1].second
                          << "\n";
           });
           llvm::errs() << "outer dim warp num: " << outerDimWarpNum << "\n";
@@ -1218,23 +1218,8 @@ struct LoadOpConversion
                        << "\n";
           llvm::errs() << "packedElementsPerSlot: " << packedElementsPerSlot
                        << "\n";
-          llvm::errs() << "iteration / vblocks * load = "
-                       << offset[dimOuter].second *
-                              (tileLayout.getInDimSize(kIteration) / vBlocks) *
-                              tileLayout.getInDimSize(kLoad) *
-                              numLoadPerOutRepCluster
-                       << "\n";
-          llvm::errs() << "iteration * load = "
-                       << offset[dimOuter].second *
-                              tileLayout.getInDimSize(kIteration) *
-                              tileLayout.getInDimSize(kLoad) *
-                              numLoadPerOutRepCluster
-                       << "\n";
-          // TODO: should itr / vblocks be outer dim warp #? 
           const auto loadOffsetX =
-              offset[1].second *
-              (tileLayout.getInDimSize(kIteration) / vBlocks) *
-              tileLayout.getInDimSize(kLoad) * numLoadPerOutRepCluster;
+              isOperandA ? offset[1].second : offset[1].second * (tileLayout.getInDimSize(kIteration) / vBlocks) * tileLayout.getInDimSize(kLoad);
           llvm::errs() << "itr size: " << tileLayout.getInDimSize(kIteration) << "\n";
           llvm::errs() << "itr / vblocks: " << tileLayout.getInDimSize(kIteration) / vBlocks << "\n";
           llvm::errs() << "load size: " << tileLayout.getInDimSize(kLoad) << "\n";

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -884,8 +884,8 @@ struct LoadOpConversion
     unsigned totalBytesPerRowPerDPASOp = tileWidth * elemSizeInBits / 8;
     const auto origNumOperandsPer2DloadN = numOperandsPer2DloadN;
     if (numOperandsPer2DloadN > 64 / totalBytesPerRowPerDPASOp)
-      llvm::errs() << "enlarge vblocks : " << 64 / totalBytesPerRowPerDPASOp << " vs "
-                   << numOperandsPer2DloadN << "\n";
+      llvm::errs() << "enlarge vblocks : " << 64 / totalBytesPerRowPerDPASOp
+                   << " vs " << numOperandsPer2DloadN << "\n";
     numOperandsPer2DloadN =
         std::min(numOperandsPer2DloadN, 64 / totalBytesPerRowPerDPASOp);
     vBlocks = numOperandsPer2DloadN;

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -903,7 +903,7 @@ struct LoadOpConversion
     auto numIterationsOuterDimPerLoad =
         isOperandA ? numOperandsPer2DLoadM : origNumOperandsPer2DloadN;
     auto numIterationsInnerDimPerLoad =
-        isOperandA ? origNumOperandsPer2DloadN : numOperandsPer2DLoadM;
+        isOperandA ? numOperandsPer2DloadN : numOperandsPer2DLoadM;
 
     if (!isTransposeRequired) {
       tileLayout *= LinearLayout::identity1D(numIterationsOuterDimPerLoad,
@@ -955,6 +955,10 @@ struct LoadOpConversion
       }
     }
 
+#if 1
+    llvm::errs() << "Block load tile layout after adding iterations: "
+                 << tileLayout << "\n";
+#else
     LLVM_DEBUG({
       llvm::dbgs() << "Block load tile layout after adding iterations: "
                    << tileLayout << "\n";
@@ -994,6 +998,7 @@ struct LoadOpConversion
       }
       llvm::dbgs() << "\n";
     });
+#endif
 
     unsigned numRepOuter = numReps[bool(opIdx) ? 2 : 1];
     unsigned numRepInner = numReps[bool(opIdx) ? 1 : 2];
@@ -1037,6 +1042,8 @@ struct LoadOpConversion
     llvm::errs() << "\tdimInner Val swapped iterations: "
                  << numRepInner / numIterationsOuterDimPerLoad << "\n";
 
+    tileLayout *= LinearLayout::identity1D(
+        numRepInner / numIterationsInnerDimPerLoad, kLoad, dimInnerStr);
     if (isTransposeRequired && oneMatrixPerLoadForBT) {
       tileLayout *= LinearLayout::identity1D(numRepOuter * repCluster[dimOuter],
                                              kLoad, dimOuterStr);
@@ -1047,8 +1054,6 @@ struct LoadOpConversion
           kLoad, dimOuterStr);
     }
 
-    tileLayout *= LinearLayout::identity1D(
-        numRepInner / numIterationsInnerDimPerLoad, kLoad, dimInnerStr);
 #else
     if (isTransposeRequired && oneMatrixPerLoadForBT) {
       tileLayout *= LinearLayout::identity1D(numRepOuter * repCluster[dimOuter],

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1230,12 +1230,18 @@ struct LoadOpConversion
                               tileLayout.getInDimSize(kLoad) *
                               numLoadPerOutRepCluster
                        << "\n";
+          // TODO: should itr / vblocks be outer dim warp #? 
           const auto loadOffsetX =
-              offset[dimOuter].second *
+              offset[1].second *
               (tileLayout.getInDimSize(kIteration) / vBlocks) *
               tileLayout.getInDimSize(kLoad) * numLoadPerOutRepCluster;
-          const auto loadOffsetY = offset[dimInner].second;
+          llvm::errs() << "itr size: " << tileLayout.getInDimSize(kIteration) << "\n";
+          llvm::errs() << "itr / vblocks: " << tileLayout.getInDimSize(kIteration) / vBlocks << "\n";
+          llvm::errs() << "load size: " << tileLayout.getInDimSize(kLoad) << "\n";
+          llvm::errs() << "numLoadPerOutRepCluster: " << numLoadPerOutRepCluster << "\n";
+          const auto loadOffsetY = offset[0].second;
           LLVM_DEBUG({
+            llvm::dbgs() << "isOperandA? " << isOperandA << "\n";
             llvm::dbgs() << "x offset ll: " << loadOffsetX << "\n";
             llvm::dbgs() << "y offset ll: " << loadOffsetY << "\n";
           });

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -891,9 +891,9 @@ struct LoadOpConversion
                                                kIteration, dimInnerStr);
       } else {
         tileLayout *= LinearLayout::identity1D(repCluster[dimOuter], kIteration,
-                                               dimInnerStr);
+          dimOuterStr);
         tileLayout *= LinearLayout::identity1D(numReps[unsigned(opIdx) ? 1 : 2],
-                                               kIteration, dimOuterStr);
+                                               kIteration, dimInnerStr);
       }
     } else {
       if (isOperandA)

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1419,7 +1419,11 @@ struct LoadOpConversion
                     elemsPerDPASInst[0];
                 llvm::errs() << "\tshuffle y offset: " << y_offset << "\n";
 
-                y_offset *= isTransposeRequired ? 1 : elemsPerDPASInst[1];
+#if 1
+                y_offset *= isTransposeRequired ? 1 : tileHeight / opsPerChannel; 
+#else
+                y_offset *= isTransposeRequired ? 1 : (isOperandA ? elemsPerDPASInst[1] : packedElemsPerLanePerDPASInst);
+#endif 
                 llvm::errs() << "\tshuffle y stride: " << y_offset << "\n";
 
                 llvm::errs()
@@ -1456,6 +1460,9 @@ struct LoadOpConversion
                                     << ", " << tensorCoord[1].second << "\n");
             llvm::errs() << "packedElementsPerSlot: " << packedElementsPerSlot
                          << "\n";
+            llvm::errs() << "packedElemsPerLanePerDPASInst: " << packedElemsPerLanePerDPASInst << "\n";
+            llvm::errs() << "elemsPerLanePerDPASInst: " << elemsPerLanePerDPASInst << "\n";
+            llvm::errs() << "opsPerChannel: " << opsPerChannel << "\n";
             llvm::errs() << "elemsPerDPASInst: " << elemsPerDPASInst[0] << ", "
                          << elemsPerDPASInst[1] << "\n";
             llvm::errs() << "tile height, width: " << tileHeight << ", "

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -702,8 +702,10 @@ struct LoadOpConversion
                                               ? dpasLayout.getDPASInstShapeA()
                                               : dpasLayout.getDPASInstShapeB();
     const SmallVector<unsigned> elemsPerDPASInst = {dpasInstShape[0],
-                                              dpasInstShape[1]};
-    LLVM_DEBUG(llvm::dbgs() << "Elements per DPAS Instruction: " << elemsPerDPASInst[0] << ", " << elemsPerDPASInst[1] << "\n");
+                                                    dpasInstShape[1]};
+    LLVM_DEBUG(llvm::dbgs()
+               << "Elements per DPAS Instruction: " << elemsPerDPASInst[0]
+               << ", " << elemsPerDPASInst[1] << "\n");
     unsigned elemsPerLanePerDPASInst =
         product<unsigned>(elemsPerDPASInst) / threadsPerWarp;
     TritonGPUToLLVMTypeConverter *typeConverter = getTypeConverter();
@@ -740,8 +742,10 @@ struct LoadOpConversion
     }
 
     LLVM_DEBUG(llvm::dbgs() << "opsPerChannel: " << opsPerChannel << "\n");
-    LLVM_DEBUG(llvm::dbgs() << "elemsPerLanePerDPASInst: " << elemsPerLanePerDPASInst << "\n");
-    LLVM_DEBUG(llvm::dbgs() << "packedElemsPerLanePerDPASInst: " << packedElemsPerLanePerDPASInst << "\n");
+    LLVM_DEBUG(llvm::dbgs() << "elemsPerLanePerDPASInst: "
+                            << elemsPerLanePerDPASInst << "\n");
+    LLVM_DEBUG(llvm::dbgs() << "packedElemsPerLanePerDPASInst: "
+                            << packedElemsPerLanePerDPASInst << "\n");
 
     Type packedDPASOperandType = LLVM::getFixedVectorType(
         loadResultElemType, packedElemsPerLanePerDPASInst);
@@ -761,10 +765,6 @@ struct LoadOpConversion
         std::min<unsigned>(warpsPerCTA[dimOuter], outerDimRequiredWarpNum);
     Value outerDimWarpId =
         b.urem(multiDimWarpId[dimOuter], b.i32_val(outerDimWarpNum));
-    unsigned innerDimWarpNum = std::min<unsigned>(
-        warpsPerCTA[dimInner],
-        mlir::ceil<unsigned>(tensorShape[dimInner], repCluster[dimInner]));
-    ;
 
     auto [base, baseWidth, baseHeight, rowStride, colStride, offsetBaseX,
           offsetBaseY] =
@@ -805,28 +805,17 @@ struct LoadOpConversion
           auto totalOffsets = 1;
           assert(tileShapeIn.size() == 2); // TODO: dot 3d support?
 
-         auto tileShape = tileShapeIn; // make a copy so we can modify tile width if needed 
+          auto tileShape =
+              tileShapeIn; // make a copy so we can modify tile width if needed
 
-#if 1
           const unsigned originalElemBits = elemSizeInBits;
-          if (isTransposeRequired && opIdx == DpasEncodingAttr::OpIdx::OperandB){
-            llvm::errs() << "Modify tile width to align with hardware restriction: \n";
-            auto widthDim = threadOrder[rank - 2];
-            auto tileWidth = tileShape[widthDim];
-            llvm::errs() << "tileWidth before reduction: " << tileWidth << "\n";
-            tileWidth = tileWidth / (32 / originalElemBits);
-            llvm::errs() << "tileWidth after dividing (by " << 32 << " / " << originalElemBits << " = " << 32 / originalElemBits << ") = " << tileWidth << "\n";
-            tileShape[widthDim] = tileWidth; 
-          }
-#else
           if (isTransposeRequired &&
               opIdx == DpasEncodingAttr::OpIdx::OperandB) {
-            // Adjust the layout to handle the VNNI values
-            layout *= LinearLayout::zeros1D(2, kOffset, outDimNames[0]);
-            totalOffsets *= 2;
-            kOffsetDims.push_back(kOffset);
+            auto widthDim = threadOrder[rank - 2];
+            auto tileWidth = tileShape[widthDim];
+            tileWidth = tileWidth / (32 / originalElemBits);
+            tileShape[widthDim] = tileWidth;
           }
-#endif 
 
           for (int i = 0; i < tileShape.size(); i++) {
             int dim = threadOrder[i];
@@ -835,16 +824,9 @@ struct LoadOpConversion
             kOffsetDims.push_back(kOffset);
 
             assert(llvm::isPowerOf2_32(tileShape[dim]));
-            if (false && dim == 0 && isTransposeRequired &&
-                opIdx == DpasEncodingAttr::OpIdx::OperandB) {
-              layout *= LinearLayout::identity1D(tileShape[dim] / 2, kOffset,
-                                                 outDimNames[dim]);
-              totalOffsets *= tileShape[dim] / 2;
-            } else {
-              layout *= LinearLayout::identity1D(tileShape[dim], kOffset,
-                                                 outDimNames[dim]);
-              totalOffsets *= tileShape[dim];
-            }
+            layout *= LinearLayout::identity1D(tileShape[dim], kOffset,
+                                               outDimNames[dim]);
+            totalOffsets *= tileShape[dim];
           }
           StringAttr kBlock = S("block");
           SmallVector<StringAttr> newDims;
@@ -857,7 +839,9 @@ struct LoadOpConversion
 
     LLVM_DEBUG({
       llvm::dbgs() << "Block load tile layout: " << tileLayout << "\n";
-      for (size_t i = 0; i < tileLayout.getOutDimSize(dimOuterStr)*tileLayout.getOutDimSize(dimInnerStr); i++) {
+      for (size_t i = 0; i < tileLayout.getOutDimSize(dimOuterStr) *
+                                 tileLayout.getOutDimSize(dimInnerStr);
+           i++) {
         auto tensorVals = tileLayout.apply({{kOffset, i}});
         assert(tensorVals.size() == 2);
         llvm::dbgs() << i << " : " << tensorVals[0].second << ", "
@@ -878,8 +862,6 @@ struct LoadOpConversion
 
       if (!usePackedType)
         return failure();
-
-      std::swap(tileHeight, tileWidth);
 
       if (oneMatrixPerLoadForBT) {
         // Only load 1 operand per inst on row.
@@ -924,7 +906,6 @@ struct LoadOpConversion
 
       if (oneMatrixPerLoadForBT) {
         // Only load 1 operand per inst on row.
-        numOperandsPer2DLoadM = 1;
         tileLayout *= LinearLayout::identity1D(1, kIteration, dimInnerStr);
       } else {
         // We can decompose the matrix returned by transposed large 2d load
@@ -932,83 +913,58 @@ struct LoadOpConversion
         // operand per inst.
         // Note: the tileHeight and numOperandsPer2DLoadM are the column size
         // now.
-#if 0
-        auto tileHeightMultiple = std::min(numOperandsPer2DLoadM, 32 / tileHeight);
-        // TODO: may need to reverse these two
-        // wrong dimension - should be 32 by 8 not 16x16
-        tileLayout *= LinearLayout::zeros1D(tileHeightMultiple, kIteration, dimInnerStr);
-        llvm::errs() << "After tile height multiplication: " << tileLayout << "\n";
-#endif 
 
-        llvm::errs() << "threadsPerWarp <= tileHeight? " << threadsPerWarp << " <= " << tileHeight << "\n";
-        llvm::errs() << "repCluster[dimOuter]: " << repCluster[dimOuter] << "\n";
         tileLayout *= LinearLayout::identity1D(
             (threadsPerWarp <= tileHeight) ? repCluster[dimOuter] : 1,
             kIteration, dimOuterStr);
-        llvm::errs() << "numReps[unsigned(opIdx) ? 1 : 2]: " << numReps[unsigned(opIdx) ? 1 : 2] << "\n";
       }
-      // The transpose 2d load only support 1 operand per inst on column.
-      // (vBlocks = 1)
-      numOperandsPer2DloadN = 1;
-      // this give us the right value below when we compare to the B_AxB HW
-      // layout. But are we taking into account the vnni transform in addition
-      // to vblocks?
-      /*tileLayout *= LinearLayout::identity1D(numReps[unsigned(opIdx) ? 1 : 2],
-                                             kIteration, dimInnerStr);*/
     }
     // end LL duplicate code
 
     LLVM_DEBUG({
       llvm::dbgs() << "Block load tile layout after adding iterations: "
                    << tileLayout << "\n";
-        for (size_t itr = 0; itr < tileLayout.getInDimSize(kIteration); itr++) {
-          {
-            size_t offset = 0;
-            auto tensorVals = tileLayout.apply(
-                {{kOffset, offset}, {kIteration, itr}});
-            assert(tensorVals.size() == 2);
-            llvm::dbgs() <<  itr << ", " << offset << " : "
-                         << tensorVals[0].second << ", " << tensorVals[1].second
-                         << "\n";
-          }
-          {
-            size_t offset = 1;
-            auto tensorVals = tileLayout.apply(
-                {{kOffset, offset}, {kIteration, itr}});
-            assert(tensorVals.size() == 2);
-            llvm::dbgs() <<  itr << ", " << offset << " : "
-                         << tensorVals[0].second << ", " << tensorVals[1].second
-                         << "\n";
-          }
-          {
-            size_t offset = tileLayout.getInDimSize(kOffset) - 2;
-            auto tensorVals = tileLayout.apply(
-                {{kOffset, offset}, {kIteration, itr}});
-            assert(tensorVals.size() == 2);
-            llvm::dbgs() <<  itr << ", " << offset << " : "
-                         << tensorVals[0].second << ", " << tensorVals[1].second
-                         << "\n";
-          }
-          {
-            size_t offset = tileLayout.getInDimSize(kOffset) - 1;
-            auto tensorVals = tileLayout.apply(
-                {{kOffset, offset}, {kIteration, itr}});
-            assert(tensorVals.size() == 2);
-            llvm::dbgs() <<  itr << ", " << offset << " : "
-                         << tensorVals[0].second << ", " << tensorVals[1].second
-                         << "\n";
-          }
+      for (size_t itr = 0; itr < tileLayout.getInDimSize(kIteration); itr++) {
+        {
+          size_t offset = 0;
+          auto tensorVals =
+              tileLayout.apply({{kOffset, offset}, {kIteration, itr}});
+          assert(tensorVals.size() == 2);
+          llvm::dbgs() << itr << ", " << offset << " : " << tensorVals[0].second
+                       << ", " << tensorVals[1].second << "\n";
         }
-        llvm::dbgs() << "\n";
+        {
+          size_t offset = 1;
+          auto tensorVals =
+              tileLayout.apply({{kOffset, offset}, {kIteration, itr}});
+          assert(tensorVals.size() == 2);
+          llvm::dbgs() << itr << ", " << offset << " : " << tensorVals[0].second
+                       << ", " << tensorVals[1].second << "\n";
+        }
+        {
+          size_t offset = tileLayout.getInDimSize(kOffset) - 2;
+          auto tensorVals =
+              tileLayout.apply({{kOffset, offset}, {kIteration, itr}});
+          assert(tensorVals.size() == 2);
+          llvm::dbgs() << itr << ", " << offset << " : " << tensorVals[0].second
+                       << ", " << tensorVals[1].second << "\n";
+        }
+        {
+          size_t offset = tileLayout.getInDimSize(kOffset) - 1;
+          auto tensorVals =
+              tileLayout.apply({{kOffset, offset}, {kIteration, itr}});
+          assert(tensorVals.size() == 2);
+          llvm::dbgs() << itr << ", " << offset << " : " << tensorVals[0].second
+                       << ", " << tensorVals[1].second << "\n";
+        }
+      }
+      llvm::dbgs() << "\n";
     });
 
     // PVC 2D load supports 32 rows at most. Load multiple dot operands in by
     // enlarging the tileHeight.
-    llvm::errs() << "numOperandsPer2DLoadM before enlarging tile height (" << tileHeight << "): " << numOperandsPer2DLoadM << "\n";
     numOperandsPer2DLoadM = std::min(numOperandsPer2DLoadM, 32 / tileHeight);
-    llvm::errs() << "numOperandsPer2DLoadM after: " << numOperandsPer2DLoadM << "\n";
     tileHeight = tileHeight * numOperandsPer2DLoadM;
-    llvm::errs() << "tileHeight after: " << tileHeight << "\n";
 
     // PVC 2D load supports 64 bytes per row at most. Load multiple dot operands
     // by enlarging the vBlocks.
@@ -1072,23 +1028,14 @@ struct LoadOpConversion
     if (isOperandA) {
       tileLayout *= LinearLayout::identity1D(numRepOuter, kLoad, dimOuterStr);
     } else {
-      #if 0
-      auto loadIdentityLayout =
-          LinearLayout::identity1D(numRepOuter, kLoad, dimOuterStr) *
-          LinearLayout::identity1D(numOperandsPer2DLoadM,
-                                   kLoad, dimInnerStr);
-      llvm::errs() << "load identity layout: " << loadIdentityLayout << "\n";
-      #endif 
-      llvm::errs() << "operand B multiple " << numRepOuter * numOperandsPer2DLoadM << "\n";
       tileLayout *= LinearLayout::identity1D(numRepOuter, kLoad, dimOuterStr);
-      
-      tileLayout *= LinearLayout::identity1D(numOperandsPer2DLoadM,
-        kLoad, dimInnerStr);
+      tileLayout *=
+          LinearLayout::identity1D(numOperandsPer2DLoadM, kLoad, dimInnerStr);
     }
 
     LLVM_DEBUG({
-      llvm::dbgs() << "Block load tile layout after adding loads: " << tileLayout
-                   << "\n";
+      llvm::dbgs() << "Block load tile layout after adding loads: "
+                   << tileLayout << "\n";
       for (size_t load = 0; load < tileLayout.getInDimSize(kLoad); load++) {
         for (size_t itr = 0; itr < tileLayout.getInDimSize(kIteration); itr++) {
           {
@@ -1132,11 +1079,6 @@ struct LoadOpConversion
       }
     });
 
-    llvm::errs() << "width: " << baseWidth << "\n";
-    llvm::errs() << "height: " << baseHeight << "\n";
-    llvm::errs() << "rowStride: " << rowStride << "\n";
-    llvm::errs() << "colStride: " << colStride << "\n";
-
     Value pitch;
     if (memoryRowMajor) {
       pitch = b.trunc(i32_ty, rowStride);
@@ -1149,71 +1091,14 @@ struct LoadOpConversion
     baseWidth = b.trunc(i32_ty, baseWidth);
     baseHeight = b.trunc(i32_ty, baseHeight);
 
-    llvm::errs() << "After adjustment:\n";
-    llvm::errs() << "width: " << baseWidth << "\n";
-    llvm::errs() << "height: " << baseHeight << "\n";
-    llvm::errs() << "pitch: " << pitch << "\n";
-
     const unsigned originalElemBits = elemSizeInBits;
     if (isTransposeRequired) {
       // adjust the block io parameter to align HW's limitations on
       // transposing load.
-      llvm::errs() << "tileWidth before reduction: " << tileWidth << "\n";
       tileWidth = tileWidth / (32 / originalElemBits);
-      llvm::errs() << "tileWidth after dividing (by " << 32 << " / " << originalElemBits << " = " << 32 / originalElemBits << ") = " << tileWidth << "\n";
       elemSizeInBits = 32;
     }
     Value elemSizeInBytes = b.i32_val(originalElemBits / 8);
-
-  #if 0
-    if (isTransposeRequired) {
-      tileLayout = tileLayout.transposeOuts({dimOuterStr, dimInnerStr});
-      llvm::errs() << "tileLayout after transpose: " << tileLayout << "\n";
-      LLVM_DEBUG({
-        for (size_t load = 0; load < tileLayout.getInDimSize(kLoad); load++) {
-          for (size_t itr = 0; itr < tileLayout.getInDimSize(kIteration); itr++) {
-            {
-              size_t offset = 0;
-              auto tensorVals = tileLayout.apply(
-                  {{kOffset, offset}, {kIteration, itr}, {kLoad, load}});
-              assert(tensorVals.size() == 2);
-              llvm::dbgs() << load << ", " << itr << ", " << offset << " : "
-                           << tensorVals[0].second << ", " << tensorVals[1].second
-                           << "\n";
-            }
-            {
-              size_t offset = 1;
-              auto tensorVals = tileLayout.apply(
-                  {{kOffset, offset}, {kIteration, itr}, {kLoad, load}});
-              assert(tensorVals.size() == 2);
-              llvm::dbgs() << load << ", " << itr << ", " << offset << " : "
-                           << tensorVals[0].second << ", " << tensorVals[1].second
-                           << "\n";
-            }
-            {
-              size_t offset = tileLayout.getInDimSize(kOffset) - 2;
-              auto tensorVals = tileLayout.apply(
-                  {{kOffset, offset}, {kIteration, itr}, {kLoad, load}});
-              assert(tensorVals.size() == 2);
-              llvm::dbgs() << load << ", " << itr << ", " << offset << " : "
-                           << tensorVals[0].second << ", " << tensorVals[1].second
-                           << "\n";
-            }
-            {
-              size_t offset = tileLayout.getInDimSize(kOffset) - 1;
-              auto tensorVals = tileLayout.apply(
-                  {{kOffset, offset}, {kIteration, itr}, {kLoad, load}});
-              assert(tensorVals.size() == 2);
-              llvm::dbgs() << load << ", " << itr << ", " << offset << " : "
-                           << tensorVals[0].second << ", " << tensorVals[1].second
-                           << "\n";
-            }
-          }
-          llvm::dbgs() << "\n";
-        }
-      });
-    }
-#endif 
 
     auto ll = *llEncoding;
 
@@ -1223,13 +1108,6 @@ struct LoadOpConversion
     StringAttr kBlock = StringAttr::get(ctx, "block");
 
     LLVM_DEBUG(llvm::dbgs() << "DPAS Linear Layout: " << ll << "\n");
-
-    auto dpasToBlockLoadLayout = tileLayout.pseudoinvert();
-    LLVM_DEBUG(llvm::dbgs() << "Inverted block load layout: "
-                            << dpasToBlockLoadLayout << "\n");
-
-    auto llInvert = ll.pseudoinvert();
-    LLVM_DEBUG(llvm::dbgs() << "Inverted DPAS layout: " << llInvert << "\n");
 
     LLVM_DEBUG({
       llvm::dbgs() << "tileWidth: " << tileWidth << "\n";
@@ -1247,14 +1125,15 @@ struct LoadOpConversion
       llvm::dbgs() << "ll block size: " << ll.getInDimSize(kBlock) << "\n";
 
       llvm::dbgs() << "outerDimWarpNum: " << outerDimWarpNum << "\n";
-      llvm::dbgs() << "innerDimWarpNum: " << innerDimWarpNum << "\n";
     });
 
-    
-    // the transpose layout does not handle the vnni transform for us, we need to manually adjust the layout and indices to pack two elements per output buffer slot 
-    // TODO: can this also be computed as elemsPerLanePerDPASInst / packedElemsPerLanePerDPASInst?
-    unsigned packedElementsPerSlot = isTransposeRequired &&
-              opIdx == DpasEncodingAttr::OpIdx::OperandB ? 2 : 1;
+    LLVM_DEBUG({
+      llvm::dbgs() << "originalElemBits: " << originalElemBits << "\n";
+      llvm::dbgs() << "elemSizeInBits: " << elemSizeInBits << "\n";
+    });
+    const unsigned packedElementsPerSlot = elemSizeInBits / originalElemBits;
+    LLVM_DEBUG(llvm::dbgs() << "Packed elements per slot: "
+                            << packedElementsPerSlot << "\n");
 
 #if 0
     if (!memoryRowMajor) {
@@ -1262,11 +1141,7 @@ struct LoadOpConversion
       // support row major memory layout.
       std::swap(offsetBaseX, offsetBaseY);
     }
-#endif 
-
-
-    llvm::errs() << "elems per dpas inst: " << elemsPerDPASInst[0] << ", " << elemsPerDPASInst[1] << "\n";
-    llvm::errs() << "tile width, height: " << tileWidth << ", " << tileHeight << "\n";
+#endif
 
     ValueTable loadVals;
     for (int outer = 0; outer < numRepOuter; ++outer) {
@@ -1277,20 +1152,25 @@ struct LoadOpConversion
                          << k << "\n";
           });
 
-          // TODO: handle rep 
+          // TODO: handle rep
           const int loadIdx = outer + k * numRepOuter;
 
           Value offsetX, offsetY;
-          auto offset = tileLayout.apply({{kOffset, 0},
-                                          {kIteration, 0},
-                                          {kLoad, loadIdx}});
+          auto offset = tileLayout.apply(
+              {{kOffset, 0}, {kIteration, 0}, {kLoad, loadIdx}});
           assert(offset.size() == 2);
           // adjust the load offset to compensate for strides related to the
           // DPAS layout
-          llvm::errs() << "x offset from layout: " << offset[dimOuter].second << "\n";
-          llvm::errs() << "y offset from layout: " << offset[dimInner].second << "\n";
-          const auto loadOffsetX = offset[dimOuter].second * outerDimWarpNum * packedElementsPerSlot; 
-          const auto loadOffsetY = offset[dimInner].second; // * outerDimWarpNum;
+          LLVM_DEBUG({
+            llvm::dbgs() << "x offset from layout: " << offset[dimOuter].second
+                         << "\n";
+            llvm::dbgs() << "y offset from layout: " << offset[dimInner].second
+                         << "\n";
+          });
+          const auto loadOffsetX =
+              offset[dimOuter].second * outerDimWarpNum * packedElementsPerSlot;
+          const auto loadOffsetY =
+              offset[dimInner].second; // * outerDimWarpNum;
           LLVM_DEBUG({
             llvm::dbgs() << "x offset ll: " << loadOffsetX << "\n";
             llvm::dbgs() << "y offset ll: " << loadOffsetY << "\n";
@@ -1337,9 +1217,6 @@ struct LoadOpConversion
             offsetX = b.udiv(offsetX, b.i32_val(32 / originalElemBits));
           }
 
-          const bool vnni_transform = usePackedType && !isOperandA && !isTransposeRequired &&
-               originalElemBits != 32;
-
           auto load2dOp = rewriter.create<TritonGEN::Matrix2DBlockLoadOp>(
               loc, load2DGenXType,
               /*ptr*/ base,
@@ -1353,13 +1230,122 @@ struct LoadOpConversion
               /*tile_height*/ tileHeight,
               /*v_blocks*/ vBlocks,
               /*transpose*/ isTransposeRequired,
-              /*vnni_transform*/ vnni_transform);
+              /*vnni_transform*/
+              (usePackedType && !isOperandA && !isTransposeRequired &&
+               originalElemBits != 32));
           if (failed(load2dOp.verify())) {
             // Explicitly invoke verifier because `triton_gen` ops are
             // immediately lowered further to a builtin call.
             return failure();
           }
-          llvm::errs() << "load op: " << load2dOp << "\n";
+          LLVM_DEBUG(llvm::dbgs() << "Generated load op: " << load2dOp << "\n");
+
+          const auto loadRowOffset = (isTransposeRequired && !isOperandA)
+                                         ? 0
+                                         : packedElemsPerLanePerDPASInst;
+
+          unsigned loadColOffset;
+          if (isTransposeRequired && !isOperandA) {
+            loadColOffset = 1;
+          } else {
+            loadColOffset = isOperandA ? tileHeight : tileWidth;
+          }
+
+          LLVM_DEBUG(llvm::dbgs() << "num vblocks: " << vBlocks << "\n");
+          // these iterations are dpas iterations.
+          for (size_t i = 0; i < tileLayout.getInDimSize(kIteration); i++) {
+            LLVM_DEBUG(llvm::dbgs() << "Emitting shuffle vector for iteration "
+                                    << i << ", load: " << loadIdx << "\n");
+
+            SmallVector<int32_t> indices(packedElemsPerLanePerDPASInst);
+            {
+
+              // shuffle vector is local to the tile
+              auto tensorCoord =
+                  tileLayout.apply({{kLoad, 0}, {kOffset, 0}, {kIteration, i}});
+              assert(tensorCoord.size() == 2);
+              LLVM_DEBUG(llvm::dbgs()
+                         << "tensorCoord: " << tensorCoord[0].second << ", "
+                         << tensorCoord[1].second << "\n");
+              auto tensorRowCoord =
+                  (tensorCoord[0].second) / elemsPerDPASInst[0];
+              auto tensorColCoord =
+                  tensorCoord[1].second /
+                  (elemsPerDPASInst[1] / packedElementsPerSlot);
+
+              LLVM_DEBUG({
+                llvm::dbgs()
+                    << "row: " << tensorRowCoord << " = "
+                    << tensorCoord[0].second << " * " << packedElementsPerSlot
+                    << " / " << elemsPerDPASInst[0] << "\n";
+                llvm::dbgs()
+                    << "col: " << tensorColCoord << " = "
+                    << tensorCoord[1].second << " / "
+                    << (elemsPerDPASInst[1] / packedElementsPerSlot) << "\n";
+                llvm::dbgs() << "row stride: " << loadRowOffset << "\n";
+                llvm::dbgs() << "col stride: " << loadColOffset << "\n";
+              });
+              const auto rowOffset = tensorRowCoord * loadRowOffset;
+              const auto colOffset = tensorColCoord * loadColOffset;
+              LLVM_DEBUG({
+                llvm::dbgs() << "rowOffset: " << rowOffset << "\n";
+                llvm::dbgs() << "colOffset: " << colOffset << "\n";
+              });
+              for (int elemIdx = 0; elemIdx < packedElemsPerLanePerDPASInst;
+                   elemIdx += packedElementsPerSlot) {
+                auto blockLayoutOffset =
+                    tileLayout.apply({{kOffset, elemIdx * elemsPerDPASInst[1]},
+                                      {kIteration, i},
+                                      {kLoad, loadIdx}});
+                assert(blockLayoutOffset.size() == 2);
+                LLVM_DEBUG(llvm::dbgs() << "\tblock load offset: "
+                                        << blockLayoutOffset[0].second << ", "
+                                        << blockLayoutOffset[1].second << "\n");
+
+                for (size_t s = 0; s < packedElementsPerSlot; s++) {
+                  indices[elemIdx + s] = rowOffset + colOffset +
+                                         (blockLayoutOffset[0].second %
+                                          (packedElementsPerSlot *
+                                           packedElemsPerLanePerDPASInst)) +
+                                         s * packedElementsPerSlot;
+                  LLVM_DEBUG({
+                    llvm::dbgs() << "indices[" << elemIdx + s << "]" << " = "
+                                 << indices[elemIdx + s] << "\n";
+                  });
+                }
+              }
+            }
+
+            DenseI32ArrayAttr attr = rewriter.getDenseI32ArrayAttr(indices);
+            Value loadVal = rewriter.create<LLVM::ShuffleVectorOp>(
+                loc, packedDPASOperandType, load2dOp, load2dOp, attr);
+
+            auto tensorCoord = tileLayout.apply(
+                {{kLoad, loadIdx}, {kOffset, 0}, {kIteration, i}});
+            assert(tensorCoord.size() == 2);
+            LLVM_DEBUG(llvm::dbgs() << "tensorCoord: " << tensorCoord[0].second
+                                    << ", " << tensorCoord[1].second << "\n");
+            auto tensorRowCoord = (tensorCoord[0].second) / elemsPerDPASInst[0];
+            auto tensorColCoord = tensorCoord[1].second /
+                                  (elemsPerDPASInst[1] / packedElementsPerSlot);
+
+            const auto rowOffset = tensorRowCoord * loadRowOffset;
+            const auto colOffset = tensorColCoord * loadColOffset;
+
+            if (isOperandA) {
+              LLVM_DEBUG(llvm::dbgs()
+                         << "storing load vals index: " << tensorRowCoord
+                         << ", " << tensorColCoord << "\n");
+              loadVals[{tensorRowCoord, tensorColCoord}] =
+                  b.bitcast(loadVal, unpackedDPASOperandType);
+            } else {
+              LLVM_DEBUG(llvm::dbgs()
+                         << "storing load vals index: " << tensorColCoord
+                         << ", " << tensorRowCoord << "\n");
+              loadVals[{tensorColCoord, tensorRowCoord}] =
+                  b.bitcast(loadVal, unpackedDPASOperandType);
+            }
+          }
 
           unsigned packedRowNum = opIdx == DpasEncodingAttr::OpIdx::OperandA
                                       ? numOperandsOuterDimPerLoad
@@ -1368,90 +1354,12 @@ struct LoadOpConversion
                                       ? numOperandsInnerDimPerLoad
                                       : numOperandsOuterDimPerLoad;
           unsigned packedColNumPerVBlock = packedColNum / vBlocks;
-          llvm::errs() << "packedRowNum: " << packedRowNum << "\n";
-          llvm::errs() << "packedColNum: " << packedColNum << "\n";
-          llvm::errs() << "packedColNumPerVBlock: " << packedColNumPerVBlock << "\n";
-
-          // kind of a hack for vnni transform 
-          const auto loadRowOffset = (isTransposeRequired && !isOperandA) ? 0 : packedElemsPerLanePerDPASInst;
-          const auto loadColOffset = (isTransposeRequired && !isOperandA) ? 1 : packedElemsPerLanePerDPASInst * packedRowNum;
-
-          llvm::errs() << "num vblocks: " << vBlocks << "\n";
-          // these iterations are dpas iterations. 
-          for (size_t i = 0; i < tileLayout.getInDimSize(kIteration); i++) {
-            llvm::errs() << "Emitting shuffle vector for iteration " << i << ", load: " << loadIdx << "\n";
-
-            SmallVector<int32_t> indices(packedElemsPerLanePerDPASInst);
-            {
-
-              // shuffle vector is local to the tile 
-            auto tensorCoord = tileLayout.apply({{kLoad, 0}, {kOffset, 0},  {kIteration, i}});
-            assert(tensorCoord.size() == 2);
-            llvm::errs() << "tensorCoord: " << tensorCoord[0].second << ", " << tensorCoord[1].second << "\n";
-            auto tensorRowCoord = (tensorCoord[0].second) / elemsPerDPASInst[0];
-            auto tensorColCoord = tensorCoord[1].second / (elemsPerDPASInst[1] / packedElementsPerSlot);
-
-            llvm::errs() << "row: " << tensorRowCoord << " = " << tensorCoord[0].second << " * " << packedElementsPerSlot << " / " << elemsPerDPASInst[0] << "\n";
-            llvm::errs() << "col: "  << tensorColCoord << " = " << tensorCoord[1].second << " / " << (elemsPerDPASInst[1] / packedElementsPerSlot) << "\n";
-            llvm::errs() << "row stride: " << loadRowOffset << "\n";
-            llvm::errs() << "col stride: " << loadColOffset << "\n";
-           
-            const auto interleavedColOffset = (isTransposeRequired && !isOperandA) ? i % packedElementsPerSlot : 0;
-            llvm::errs() << "interleaved col offset: " << interleavedColOffset << "\n";
-
-           const auto rowOffset = tensorRowCoord * loadRowOffset;
-           const auto colOffset = tensorColCoord * loadColOffset; // + interleavedColOffset;
-           llvm::errs() << "rowOffset: " << rowOffset << "\n";
-           llvm::errs() << "colOffset: " << colOffset << "\n";
-
-            for (int elemIdx = 0; elemIdx < packedElemsPerLanePerDPASInst;
-                  elemIdx+=packedElementsPerSlot) {
-              auto blockLayoutOffset = tileLayout.apply({{kOffset, elemIdx * elemsPerDPASInst[1] }, {kIteration, i}, {kLoad, loadIdx}});
-              assert(blockLayoutOffset.size() == 2);
-              llvm::errs() << "\tblock load offset: " << blockLayoutOffset[0].second << ", " << blockLayoutOffset[1].second << "\n";
-
-              for (size_t s = 0; s < packedElementsPerSlot; s++) {
-                indices[elemIdx+s] = rowOffset + colOffset + (blockLayoutOffset[0].second % (packedElementsPerSlot*packedElemsPerLanePerDPASInst)) + s*packedElementsPerSlot;
-                LLVM_DEBUG({
-                  llvm::dbgs() << "indices[" << elemIdx+s << "]" << " = "
-                                << indices[elemIdx+s] << "\n";
-                });
-              }
-            }
-            }
-
-            DenseI32ArrayAttr attr = rewriter.getDenseI32ArrayAttr(indices);
-            Value loadVal = rewriter.create<LLVM::ShuffleVectorOp>(
-                loc, packedDPASOperandType, load2dOp, load2dOp, attr);
-
-            auto tensorCoord = tileLayout.apply({{kLoad, loadIdx}, {kOffset, 0},  {kIteration, i}});
-            assert(tensorCoord.size() == 2);
-            llvm::errs() << "tensorCoord: " << tensorCoord[0].second << ", " << tensorCoord[1].second << "\n";
-            auto tensorRowCoord = (tensorCoord[0].second) / elemsPerDPASInst[0];
-            auto tensorColCoord = tensorCoord[1].second / (elemsPerDPASInst[1] / packedElementsPerSlot);
-
-            llvm::errs() << "row: " << tensorRowCoord << " = " << tensorCoord[0].second << " * " << packedElementsPerSlot << " / " << elemsPerDPASInst[0] << "\n";
-            llvm::errs() << "col: "  << tensorColCoord << " = " << tensorCoord[1].second << " / " << (elemsPerDPASInst[1] / packedElementsPerSlot) << "\n";
-            llvm::errs() << "row stride: " << loadRowOffset << "\n";
-            llvm::errs() << "col stride: " << loadColOffset << "\n";
-            
-            const auto interleavedColOffset = (isTransposeRequired && !isOperandA) ? i % packedElementsPerSlot : 0;
-            llvm::errs() << "interleaved col offset: " << interleavedColOffset << "\n";
-
-            const auto rowOffset = tensorRowCoord * loadRowOffset;
-            const auto colOffset = tensorColCoord * loadColOffset; // + interleavedColOffset;
-            llvm::errs() << "rowOffset: " << rowOffset << "\n";
-            llvm::errs() << "colOffset: " << colOffset << "\n";
-
-            if (isOperandA) {
-              llvm::errs() << "storing load vals index: " << tensorRowCoord << ", " << tensorColCoord << "\n";
-              loadVals[{tensorRowCoord, tensorColCoord}] = b.bitcast(loadVal, unpackedDPASOperandType);
-            } else {
-              llvm::errs() << "storing load vals index: " << tensorColCoord << ", " << tensorRowCoord << "\n";
-              loadVals[{tensorColCoord, tensorRowCoord}] = b.bitcast(loadVal, unpackedDPASOperandType);
-            }
-          }
-
+          LLVM_DEBUG({
+            llvm::dbgs() << "packedRowNum: " << packedRowNum << "\n";
+            llvm::dbgs() << "packedColNum: " << packedColNum << "\n";
+            llvm::dbgs() << "packedColNumPerVBlock: " << packedColNumPerVBlock
+                         << "\n";
+          });
           // Decompose the return value to multiple operands.
           for (int vblk = 0; vblk < vBlocks; ++vblk)
             for (int row = 0; row < packedRowNum; ++row)
@@ -1463,7 +1371,6 @@ struct LoadOpConversion
                 unsigned operandStartOffset = (vblk * packedRowNum + row) *
                                               packedColNumPerVBlock *
                                               packedElemsPerLanePerDPASInst;
-                llvm::errs() << "operandStartOffset: " << operandStartOffset << "\n";
 
                 SmallVector<int32_t> indices(packedElemsPerLanePerDPASInst);
                 for (int elemIdx = 0; elemIdx < packedElemsPerLanePerDPASInst;
@@ -1475,11 +1382,6 @@ struct LoadOpConversion
                                  << indices[elemIdx] << "\n";
                   });
                 }
-#if 0
-                DenseI32ArrayAttr attr = rewriter.getDenseI32ArrayAttr(indices);
-                Value loadVal = rewriter.create<LLVM::ShuffleVectorOp>(
-                    loc, packedDPASOperandType, load2dOp, load2dOp, attr);
-#endif 
                 // Save the decomposed vals to the map;
                 switch (opIdx) {
                 case DpasEncodingAttr::OpIdx::OperandA: {
@@ -1493,12 +1395,6 @@ struct LoadOpConversion
                                         k + vblk * packedColNumPerVBlock + col)
                                  << "\n";
                   });
-#if 0
-                  loadVals[{outer * packedRowNum * numLoadPerOutRepCluster +
-                                rep * packedRowNum + row,
-                            k + vblk * packedColNumPerVBlock + col}] =
-                      b.bitcast(loadVal, unpackedDPASOperandType);
-#endif 
                 } break;
                 case DpasEncodingAttr::OpIdx::OperandB: {
                   LLVM_DEBUG({
@@ -1510,13 +1406,6 @@ struct LoadOpConversion
                                           vblk * packedColNumPerVBlock + col)
                         << ", " << std::to_string(k + row) << "\n";
                   });
-#if 0
-                  loadVals[{outer * packedColNum * numLoadPerOutRepCluster +
-                                rep * packedColNum +
-                                vblk * packedColNumPerVBlock + col,
-                            k + row}] =
-                      b.bitcast(loadVal, unpackedDPASOperandType);
-#endif
                 } break;
                 case DpasEncodingAttr::OpIdx::OperandC: {
                   llvm_unreachable("unexpected OpIdx::OperandC");
@@ -1533,8 +1422,11 @@ struct LoadOpConversion
     for (int outer = 0; outer < numRepOuter; ++outer) {
       for (int k = 0; k < numRepInner; ++k) {
         for (int rep = 0; rep < repCluster[unsigned(opIdx)]; ++rep) {
-          if (loadVals.find({outer * repCluster[unsigned(opIdx)] + rep, k}) == loadVals.end()) {
-            llvm::errs() << "Failed to find key at " << outer * repCluster[unsigned(opIdx)] + rep << ", " << k << "\n";
+          if (loadVals.find({outer * repCluster[unsigned(opIdx)] + rep, k}) ==
+              loadVals.end()) {
+            llvm::errs() << "Failed to find key at "
+                         << outer * repCluster[unsigned(opIdx)] + rep << ", "
+                         << k << "\n";
           }
           Value loadVal =
               loadVals.at({outer * repCluster[unsigned(opIdx)] + rep, k});

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -701,8 +701,9 @@ struct LoadOpConversion
     SmallVector<unsigned> dpasInstShape = isOperandA
                                               ? dpasLayout.getDPASInstShapeA()
                                               : dpasLayout.getDPASInstShapeB();
-    SmallVector<unsigned> elemsPerDPASInst = {dpasInstShape[0],
+    const SmallVector<unsigned> elemsPerDPASInst = {dpasInstShape[0],
                                               dpasInstShape[1]};
+    LLVM_DEBUG(llvm::dbgs() << "Elements per DPAS Instruction: " << elemsPerDPASInst[0] << ", " << elemsPerDPASInst[1] << "\n");
     unsigned elemsPerLanePerDPASInst =
         product<unsigned>(elemsPerDPASInst) / threadsPerWarp;
     TritonGPUToLLVMTypeConverter *typeConverter = getTypeConverter();
@@ -737,6 +738,10 @@ struct LoadOpConversion
                      : elemsPerLanePerDPASInst / opsPerChannel;
       usePackedType = true;
     }
+
+    LLVM_DEBUG(llvm::dbgs() << "opsPerChannel: " << opsPerChannel << "\n");
+    LLVM_DEBUG(llvm::dbgs() << "elemsPerLanePerDPASInst: " << elemsPerLanePerDPASInst << "\n");
+    LLVM_DEBUG(llvm::dbgs() << "packedElemsPerLanePerDPASInst: " << packedElemsPerLanePerDPASInst << "\n");
 
     Type packedDPASOperandType = LLVM::getFixedVectorType(
         loadResultElemType, packedElemsPerLanePerDPASInst);
@@ -792,21 +797,36 @@ struct LoadOpConversion
     StringAttr kLoad = S("load");           // 2D block load invocation
     auto createSimpleLinearLayout =
         [&](const SmallVector<unsigned> &threadOrder,
-            const SmallVector<unsigned> &tileShape) {
+            const SmallVector<unsigned> &tileShapeIn) {
           auto outDimNames = standardOutDimNames(ctx, tensorShape.size());
           LinearLayout layout = LinearLayout::empty();
           SmallVector<StringAttr> kOffsetDims;
           auto totalIters = 1;
           auto totalOffsets = 1;
-          assert(tileShape.size() == 2); // TODO: dot 3d support?
+          assert(tileShapeIn.size() == 2); // TODO: dot 3d support?
 
+         auto tileShape = tileShapeIn; // make a copy so we can modify tile width if needed 
+
+#if 1
+          const unsigned originalElemBits = elemSizeInBits;
+          if (isTransposeRequired && opIdx == DpasEncodingAttr::OpIdx::OperandB){
+            llvm::errs() << "Modify tile width to align with hardware restriction: \n";
+            auto widthDim = threadOrder[rank - 2];
+            auto tileWidth = tileShape[widthDim];
+            llvm::errs() << "tileWidth before reduction: " << tileWidth << "\n";
+            tileWidth = tileWidth / (32 / originalElemBits);
+            llvm::errs() << "tileWidth after dividing (by " << 32 << " / " << originalElemBits << " = " << 32 / originalElemBits << ") = " << tileWidth << "\n";
+            tileShape[widthDim] = tileWidth; 
+          }
+#else
           if (isTransposeRequired &&
               opIdx == DpasEncodingAttr::OpIdx::OperandB) {
             // Adjust the layout to handle the VNNI values
-            layout *= LinearLayout::identity1D(2, kOffset, outDimNames[0]);
+            layout *= LinearLayout::zeros1D(2, kOffset, outDimNames[0]);
             totalOffsets *= 2;
             kOffsetDims.push_back(kOffset);
           }
+#endif 
 
           for (int i = 0; i < tileShape.size(); i++) {
             int dim = threadOrder[i];
@@ -815,7 +835,7 @@ struct LoadOpConversion
             kOffsetDims.push_back(kOffset);
 
             assert(llvm::isPowerOf2_32(tileShape[dim]));
-            if (dim == 0 && isTransposeRequired &&
+            if (false && dim == 0 && isTransposeRequired &&
                 opIdx == DpasEncodingAttr::OpIdx::OperandB) {
               layout *= LinearLayout::identity1D(tileShape[dim] / 2, kOffset,
                                                  outDimNames[dim]);
@@ -837,7 +857,7 @@ struct LoadOpConversion
 
     LLVM_DEBUG({
       llvm::dbgs() << "Block load tile layout: " << tileLayout << "\n";
-      for (size_t i = 0; i < elemsPerDPASInst[0] * elemsPerDPASInst[1]; i++) {
+      for (size_t i = 0; i < tileLayout.getOutDimSize(dimOuterStr)*tileLayout.getOutDimSize(dimInnerStr); i++) {
         auto tensorVals = tileLayout.apply({{kOffset, i}});
         assert(tensorVals.size() == 2);
         llvm::dbgs() << i << " : " << tensorVals[0].second << ", "
@@ -889,9 +909,9 @@ struct LoadOpConversion
                                                kIteration, dimInnerStr);
       } else {
         tileLayout *= LinearLayout::identity1D(repCluster[dimOuter], kIteration,
-                                               dimOuterStr);
+                                               dimInnerStr);
         tileLayout *= LinearLayout::identity1D(numReps[unsigned(opIdx) ? 1 : 2],
-                                               kIteration, dimInnerStr);
+                                               kIteration, dimOuterStr);
       }
     } else {
       if (isOperandA)
@@ -905,16 +925,27 @@ struct LoadOpConversion
       if (oneMatrixPerLoadForBT) {
         // Only load 1 operand per inst on row.
         numOperandsPer2DLoadM = 1;
-        tileLayout *= LinearLayout::identity1D(1, kIteration, dimOuterStr);
+        tileLayout *= LinearLayout::identity1D(1, kIteration, dimInnerStr);
       } else {
         // We can decompose the matrix returned by transposed large 2d load
         // when threads per warp < column size. Otherwise we have to load one
         // operand per inst.
         // Note: the tileHeight and numOperandsPer2DLoadM are the column size
         // now.
+#if 0
+        auto tileHeightMultiple = std::min(numOperandsPer2DLoadM, 32 / tileHeight);
+        // TODO: may need to reverse these two
+        // wrong dimension - should be 32 by 8 not 16x16
+        tileLayout *= LinearLayout::zeros1D(tileHeightMultiple, kIteration, dimInnerStr);
+        llvm::errs() << "After tile height multiplication: " << tileLayout << "\n";
+#endif 
+
+        llvm::errs() << "threadsPerWarp <= tileHeight? " << threadsPerWarp << " <= " << tileHeight << "\n";
+        llvm::errs() << "repCluster[dimOuter]: " << repCluster[dimOuter] << "\n";
         tileLayout *= LinearLayout::identity1D(
             (threadsPerWarp <= tileHeight) ? repCluster[dimOuter] : 1,
             kIteration, dimOuterStr);
+        llvm::errs() << "numReps[unsigned(opIdx) ? 1 : 2]: " << numReps[unsigned(opIdx) ? 1 : 2] << "\n";
       }
       // The transpose 2d load only support 1 operand per inst on column.
       // (vBlocks = 1)
@@ -922,20 +953,62 @@ struct LoadOpConversion
       // this give us the right value below when we compare to the B_AxB HW
       // layout. But are we taking into account the vnni transform in addition
       // to vblocks?
-      tileLayout *= LinearLayout::identity1D(numReps[unsigned(opIdx) ? 1 : 2],
-                                             kIteration, dimInnerStr);
+      /*tileLayout *= LinearLayout::identity1D(numReps[unsigned(opIdx) ? 1 : 2],
+                                             kIteration, dimInnerStr);*/
     }
     // end LL duplicate code
 
     LLVM_DEBUG({
       llvm::dbgs() << "Block load tile layout after adding iterations: "
                    << tileLayout << "\n";
+        for (size_t itr = 0; itr < tileLayout.getInDimSize(kIteration); itr++) {
+          {
+            size_t offset = 0;
+            auto tensorVals = tileLayout.apply(
+                {{kOffset, offset}, {kIteration, itr}});
+            assert(tensorVals.size() == 2);
+            llvm::dbgs() <<  itr << ", " << offset << " : "
+                         << tensorVals[0].second << ", " << tensorVals[1].second
+                         << "\n";
+          }
+          {
+            size_t offset = 1;
+            auto tensorVals = tileLayout.apply(
+                {{kOffset, offset}, {kIteration, itr}});
+            assert(tensorVals.size() == 2);
+            llvm::dbgs() <<  itr << ", " << offset << " : "
+                         << tensorVals[0].second << ", " << tensorVals[1].second
+                         << "\n";
+          }
+          {
+            size_t offset = tileLayout.getInDimSize(kOffset) - 2;
+            auto tensorVals = tileLayout.apply(
+                {{kOffset, offset}, {kIteration, itr}});
+            assert(tensorVals.size() == 2);
+            llvm::dbgs() <<  itr << ", " << offset << " : "
+                         << tensorVals[0].second << ", " << tensorVals[1].second
+                         << "\n";
+          }
+          {
+            size_t offset = tileLayout.getInDimSize(kOffset) - 1;
+            auto tensorVals = tileLayout.apply(
+                {{kOffset, offset}, {kIteration, itr}});
+            assert(tensorVals.size() == 2);
+            llvm::dbgs() <<  itr << ", " << offset << " : "
+                         << tensorVals[0].second << ", " << tensorVals[1].second
+                         << "\n";
+          }
+        }
+        llvm::dbgs() << "\n";
     });
 
     // PVC 2D load supports 32 rows at most. Load multiple dot operands in by
     // enlarging the tileHeight.
+    llvm::errs() << "numOperandsPer2DLoadM before enlarging tile height (" << tileHeight << "): " << numOperandsPer2DLoadM << "\n";
     numOperandsPer2DLoadM = std::min(numOperandsPer2DLoadM, 32 / tileHeight);
+    llvm::errs() << "numOperandsPer2DLoadM after: " << numOperandsPer2DLoadM << "\n";
     tileHeight = tileHeight * numOperandsPer2DLoadM;
+    llvm::errs() << "tileHeight after: " << tileHeight << "\n";
 
     // PVC 2D load supports 64 bytes per row at most. Load multiple dot operands
     // by enlarging the vBlocks.
@@ -999,20 +1072,45 @@ struct LoadOpConversion
     if (isOperandA) {
       tileLayout *= LinearLayout::identity1D(numRepOuter, kLoad, dimOuterStr);
     } else {
+      #if 0
       auto loadIdentityLayout =
-          LinearLayout::identity1D(numRepOuter, kLoad, dimInnerStr) *
-          LinearLayout::identity1D(numRepInner / numOperandsInnerDimPerLoad,
-                                   kLoad, dimOuterStr);
-      tileLayout *= loadIdentityLayout;
+          LinearLayout::identity1D(numRepOuter, kLoad, dimOuterStr) *
+          LinearLayout::identity1D(numOperandsPer2DLoadM,
+                                   kLoad, dimInnerStr);
+      llvm::errs() << "load identity layout: " << loadIdentityLayout << "\n";
+      #endif 
+      llvm::errs() << "operand B multiple " << numRepOuter * numOperandsPer2DLoadM << "\n";
+      tileLayout *= LinearLayout::identity1D(numRepOuter, kLoad, dimOuterStr);
+      
+      tileLayout *= LinearLayout::identity1D(numOperandsPer2DLoadM,
+        kLoad, dimInnerStr);
     }
 
     LLVM_DEBUG({
-      llvm::dbgs() << "Block load tile layout after adding: " << tileLayout
+      llvm::dbgs() << "Block load tile layout after adding loads: " << tileLayout
                    << "\n";
       for (size_t load = 0; load < tileLayout.getInDimSize(kLoad); load++) {
         for (size_t itr = 0; itr < tileLayout.getInDimSize(kIteration); itr++) {
           {
             size_t offset = 0;
+            auto tensorVals = tileLayout.apply(
+                {{kOffset, offset}, {kIteration, itr}, {kLoad, load}});
+            assert(tensorVals.size() == 2);
+            llvm::dbgs() << load << ", " << itr << ", " << offset << " : "
+                         << tensorVals[0].second << ", " << tensorVals[1].second
+                         << "\n";
+          }
+          {
+            size_t offset = 1;
+            auto tensorVals = tileLayout.apply(
+                {{kOffset, offset}, {kIteration, itr}, {kLoad, load}});
+            assert(tensorVals.size() == 2);
+            llvm::dbgs() << load << ", " << itr << ", " << offset << " : "
+                         << tensorVals[0].second << ", " << tensorVals[1].second
+                         << "\n";
+          }
+          {
+            size_t offset = tileLayout.getInDimSize(kOffset) - 2;
             auto tensorVals = tileLayout.apply(
                 {{kOffset, offset}, {kIteration, itr}, {kLoad, load}});
             assert(tensorVals.size() == 2);
@@ -1030,8 +1128,14 @@ struct LoadOpConversion
                          << "\n";
           }
         }
+        llvm::dbgs() << "\n";
       }
     });
+
+    llvm::errs() << "width: " << baseWidth << "\n";
+    llvm::errs() << "height: " << baseHeight << "\n";
+    llvm::errs() << "rowStride: " << rowStride << "\n";
+    llvm::errs() << "colStride: " << colStride << "\n";
 
     Value pitch;
     if (memoryRowMajor) {
@@ -1045,14 +1149,71 @@ struct LoadOpConversion
     baseWidth = b.trunc(i32_ty, baseWidth);
     baseHeight = b.trunc(i32_ty, baseHeight);
 
+    llvm::errs() << "After adjustment:\n";
+    llvm::errs() << "width: " << baseWidth << "\n";
+    llvm::errs() << "height: " << baseHeight << "\n";
+    llvm::errs() << "pitch: " << pitch << "\n";
+
     const unsigned originalElemBits = elemSizeInBits;
     if (isTransposeRequired) {
       // adjust the block io parameter to align HW's limitations on
       // transposing load.
+      llvm::errs() << "tileWidth before reduction: " << tileWidth << "\n";
       tileWidth = tileWidth / (32 / originalElemBits);
+      llvm::errs() << "tileWidth after dividing (by " << 32 << " / " << originalElemBits << " = " << 32 / originalElemBits << ") = " << tileWidth << "\n";
       elemSizeInBits = 32;
     }
     Value elemSizeInBytes = b.i32_val(originalElemBits / 8);
+
+  #if 0
+    if (isTransposeRequired) {
+      tileLayout = tileLayout.transposeOuts({dimOuterStr, dimInnerStr});
+      llvm::errs() << "tileLayout after transpose: " << tileLayout << "\n";
+      LLVM_DEBUG({
+        for (size_t load = 0; load < tileLayout.getInDimSize(kLoad); load++) {
+          for (size_t itr = 0; itr < tileLayout.getInDimSize(kIteration); itr++) {
+            {
+              size_t offset = 0;
+              auto tensorVals = tileLayout.apply(
+                  {{kOffset, offset}, {kIteration, itr}, {kLoad, load}});
+              assert(tensorVals.size() == 2);
+              llvm::dbgs() << load << ", " << itr << ", " << offset << " : "
+                           << tensorVals[0].second << ", " << tensorVals[1].second
+                           << "\n";
+            }
+            {
+              size_t offset = 1;
+              auto tensorVals = tileLayout.apply(
+                  {{kOffset, offset}, {kIteration, itr}, {kLoad, load}});
+              assert(tensorVals.size() == 2);
+              llvm::dbgs() << load << ", " << itr << ", " << offset << " : "
+                           << tensorVals[0].second << ", " << tensorVals[1].second
+                           << "\n";
+            }
+            {
+              size_t offset = tileLayout.getInDimSize(kOffset) - 2;
+              auto tensorVals = tileLayout.apply(
+                  {{kOffset, offset}, {kIteration, itr}, {kLoad, load}});
+              assert(tensorVals.size() == 2);
+              llvm::dbgs() << load << ", " << itr << ", " << offset << " : "
+                           << tensorVals[0].second << ", " << tensorVals[1].second
+                           << "\n";
+            }
+            {
+              size_t offset = tileLayout.getInDimSize(kOffset) - 1;
+              auto tensorVals = tileLayout.apply(
+                  {{kOffset, offset}, {kIteration, itr}, {kLoad, load}});
+              assert(tensorVals.size() == 2);
+              llvm::dbgs() << load << ", " << itr << ", " << offset << " : "
+                           << tensorVals[0].second << ", " << tensorVals[1].second
+                           << "\n";
+            }
+          }
+          llvm::dbgs() << "\n";
+        }
+      });
+    }
+#endif 
 
     auto ll = *llEncoding;
 
@@ -1066,6 +1227,9 @@ struct LoadOpConversion
     auto dpasToBlockLoadLayout = tileLayout.pseudoinvert();
     LLVM_DEBUG(llvm::dbgs() << "Inverted block load layout: "
                             << dpasToBlockLoadLayout << "\n");
+
+    auto llInvert = ll.pseudoinvert();
+    LLVM_DEBUG(llvm::dbgs() << "Inverted DPAS layout: " << llInvert << "\n");
 
     LLVM_DEBUG({
       llvm::dbgs() << "tileWidth: " << tileWidth << "\n";
@@ -1086,6 +1250,24 @@ struct LoadOpConversion
       llvm::dbgs() << "innerDimWarpNum: " << innerDimWarpNum << "\n";
     });
 
+    
+    // the transpose layout does not handle the vnni transform for us, we need to manually adjust the layout and indices to pack two elements per output buffer slot 
+    // TODO: can this also be computed as elemsPerLanePerDPASInst / packedElemsPerLanePerDPASInst?
+    unsigned packedElementsPerSlot = isTransposeRequired &&
+              opIdx == DpasEncodingAttr::OpIdx::OperandB ? 2 : 1;
+
+#if 0
+    if (!memoryRowMajor) {
+      // Column major memory. We need to swap the X and Y because HW only
+      // support row major memory layout.
+      std::swap(offsetBaseX, offsetBaseY);
+    }
+#endif 
+
+
+    llvm::errs() << "elems per dpas inst: " << elemsPerDPASInst[0] << ", " << elemsPerDPASInst[1] << "\n";
+    llvm::errs() << "tile width, height: " << tileWidth << ", " << tileHeight << "\n";
+
     ValueTable loadVals;
     for (int outer = 0; outer < numRepOuter; ++outer) {
       for (int rep = 0; rep < numLoadPerOutRepCluster; ++rep) {
@@ -1095,15 +1277,20 @@ struct LoadOpConversion
                          << k << "\n";
           });
 
+          // TODO: handle rep 
+          const int loadIdx = outer + k * numRepOuter;
+
           Value offsetX, offsetY;
           auto offset = tileLayout.apply({{kOffset, 0},
                                           {kIteration, 0},
-                                          {kLoad, outer + k * numRepOuter}});
+                                          {kLoad, loadIdx}});
           assert(offset.size() == 2);
           // adjust the load offset to compensate for strides related to the
           // DPAS layout
-          const auto loadOffsetX = offset[0].second * outerDimWarpNum;
-          const auto loadOffsetY = offset[1].second / numRepOuter;
+          llvm::errs() << "x offset from layout: " << offset[dimOuter].second << "\n";
+          llvm::errs() << "y offset from layout: " << offset[dimInner].second << "\n";
+          const auto loadOffsetX = offset[dimOuter].second * outerDimWarpNum * packedElementsPerSlot; 
+          const auto loadOffsetY = offset[dimInner].second; // * outerDimWarpNum;
           LLVM_DEBUG({
             llvm::dbgs() << "x offset ll: " << loadOffsetX << "\n";
             llvm::dbgs() << "y offset ll: " << loadOffsetY << "\n";
@@ -1150,6 +1337,9 @@ struct LoadOpConversion
             offsetX = b.udiv(offsetX, b.i32_val(32 / originalElemBits));
           }
 
+          const bool vnni_transform = usePackedType && !isOperandA && !isTransposeRequired &&
+               originalElemBits != 32;
+
           auto load2dOp = rewriter.create<TritonGEN::Matrix2DBlockLoadOp>(
               loc, load2DGenXType,
               /*ptr*/ base,
@@ -1163,14 +1353,13 @@ struct LoadOpConversion
               /*tile_height*/ tileHeight,
               /*v_blocks*/ vBlocks,
               /*transpose*/ isTransposeRequired,
-              /*vnni_transform*/
-              (usePackedType && !isOperandA && !isTransposeRequired &&
-               originalElemBits != 32));
+              /*vnni_transform*/ vnni_transform);
           if (failed(load2dOp.verify())) {
             // Explicitly invoke verifier because `triton_gen` ops are
             // immediately lowered further to a builtin call.
             return failure();
           }
+          llvm::errs() << "load op: " << load2dOp << "\n";
 
           unsigned packedRowNum = opIdx == DpasEncodingAttr::OpIdx::OperandA
                                       ? numOperandsOuterDimPerLoad
@@ -1179,6 +1368,89 @@ struct LoadOpConversion
                                       ? numOperandsInnerDimPerLoad
                                       : numOperandsOuterDimPerLoad;
           unsigned packedColNumPerVBlock = packedColNum / vBlocks;
+          llvm::errs() << "packedRowNum: " << packedRowNum << "\n";
+          llvm::errs() << "packedColNum: " << packedColNum << "\n";
+          llvm::errs() << "packedColNumPerVBlock: " << packedColNumPerVBlock << "\n";
+
+          // kind of a hack for vnni transform 
+          const auto loadRowOffset = (isTransposeRequired && !isOperandA) ? 0 : packedElemsPerLanePerDPASInst;
+          const auto loadColOffset = (isTransposeRequired && !isOperandA) ? 1 : packedElemsPerLanePerDPASInst * packedRowNum;
+
+          llvm::errs() << "num vblocks: " << vBlocks << "\n";
+          // these iterations are dpas iterations. 
+          for (size_t i = 0; i < tileLayout.getInDimSize(kIteration); i++) {
+            llvm::errs() << "Emitting shuffle vector for iteration " << i << ", load: " << loadIdx << "\n";
+
+            SmallVector<int32_t> indices(packedElemsPerLanePerDPASInst);
+            {
+
+              // shuffle vector is local to the tile 
+            auto tensorCoord = tileLayout.apply({{kLoad, 0}, {kOffset, 0},  {kIteration, i}});
+            assert(tensorCoord.size() == 2);
+            llvm::errs() << "tensorCoord: " << tensorCoord[0].second << ", " << tensorCoord[1].second << "\n";
+            auto tensorRowCoord = (tensorCoord[0].second) / elemsPerDPASInst[0];
+            auto tensorColCoord = tensorCoord[1].second / (elemsPerDPASInst[1] / packedElementsPerSlot);
+
+            llvm::errs() << "row: " << tensorRowCoord << " = " << tensorCoord[0].second << " * " << packedElementsPerSlot << " / " << elemsPerDPASInst[0] << "\n";
+            llvm::errs() << "col: "  << tensorColCoord << " = " << tensorCoord[1].second << " / " << (elemsPerDPASInst[1] / packedElementsPerSlot) << "\n";
+            llvm::errs() << "row stride: " << loadRowOffset << "\n";
+            llvm::errs() << "col stride: " << loadColOffset << "\n";
+           
+            const auto interleavedColOffset = (isTransposeRequired && !isOperandA) ? i % packedElementsPerSlot : 0;
+            llvm::errs() << "interleaved col offset: " << interleavedColOffset << "\n";
+
+           const auto rowOffset = tensorRowCoord * loadRowOffset;
+           const auto colOffset = tensorColCoord * loadColOffset; // + interleavedColOffset;
+           llvm::errs() << "rowOffset: " << rowOffset << "\n";
+           llvm::errs() << "colOffset: " << colOffset << "\n";
+
+            for (int elemIdx = 0; elemIdx < packedElemsPerLanePerDPASInst;
+                  elemIdx+=packedElementsPerSlot) {
+              auto blockLayoutOffset = tileLayout.apply({{kOffset, elemIdx * elemsPerDPASInst[1] }, {kIteration, i}, {kLoad, loadIdx}});
+              assert(blockLayoutOffset.size() == 2);
+              llvm::errs() << "\tblock load offset: " << blockLayoutOffset[0].second << ", " << blockLayoutOffset[1].second << "\n";
+
+              for (size_t s = 0; s < packedElementsPerSlot; s++) {
+                indices[elemIdx+s] = rowOffset + colOffset + (blockLayoutOffset[0].second % (packedElementsPerSlot*packedElemsPerLanePerDPASInst)) + s*packedElementsPerSlot;
+                LLVM_DEBUG({
+                  llvm::dbgs() << "indices[" << elemIdx+s << "]" << " = "
+                                << indices[elemIdx+s] << "\n";
+                });
+              }
+            }
+            }
+
+            DenseI32ArrayAttr attr = rewriter.getDenseI32ArrayAttr(indices);
+            Value loadVal = rewriter.create<LLVM::ShuffleVectorOp>(
+                loc, packedDPASOperandType, load2dOp, load2dOp, attr);
+
+            auto tensorCoord = tileLayout.apply({{kLoad, loadIdx}, {kOffset, 0},  {kIteration, i}});
+            assert(tensorCoord.size() == 2);
+            llvm::errs() << "tensorCoord: " << tensorCoord[0].second << ", " << tensorCoord[1].second << "\n";
+            auto tensorRowCoord = (tensorCoord[0].second) / elemsPerDPASInst[0];
+            auto tensorColCoord = tensorCoord[1].second / (elemsPerDPASInst[1] / packedElementsPerSlot);
+
+            llvm::errs() << "row: " << tensorRowCoord << " = " << tensorCoord[0].second << " * " << packedElementsPerSlot << " / " << elemsPerDPASInst[0] << "\n";
+            llvm::errs() << "col: "  << tensorColCoord << " = " << tensorCoord[1].second << " / " << (elemsPerDPASInst[1] / packedElementsPerSlot) << "\n";
+            llvm::errs() << "row stride: " << loadRowOffset << "\n";
+            llvm::errs() << "col stride: " << loadColOffset << "\n";
+            
+            const auto interleavedColOffset = (isTransposeRequired && !isOperandA) ? i % packedElementsPerSlot : 0;
+            llvm::errs() << "interleaved col offset: " << interleavedColOffset << "\n";
+
+            const auto rowOffset = tensorRowCoord * loadRowOffset;
+            const auto colOffset = tensorColCoord * loadColOffset; // + interleavedColOffset;
+            llvm::errs() << "rowOffset: " << rowOffset << "\n";
+            llvm::errs() << "colOffset: " << colOffset << "\n";
+
+            if (isOperandA) {
+              llvm::errs() << "storing load vals index: " << tensorRowCoord << ", " << tensorColCoord << "\n";
+              loadVals[{tensorRowCoord, tensorColCoord}] = b.bitcast(loadVal, unpackedDPASOperandType);
+            } else {
+              llvm::errs() << "storing load vals index: " << tensorColCoord << ", " << tensorRowCoord << "\n";
+              loadVals[{tensorColCoord, tensorRowCoord}] = b.bitcast(loadVal, unpackedDPASOperandType);
+            }
+          }
 
           // Decompose the return value to multiple operands.
           for (int vblk = 0; vblk < vBlocks; ++vblk)
@@ -1191,6 +1463,7 @@ struct LoadOpConversion
                 unsigned operandStartOffset = (vblk * packedRowNum + row) *
                                               packedColNumPerVBlock *
                                               packedElemsPerLanePerDPASInst;
+                llvm::errs() << "operandStartOffset: " << operandStartOffset << "\n";
 
                 SmallVector<int32_t> indices(packedElemsPerLanePerDPASInst);
                 for (int elemIdx = 0; elemIdx < packedElemsPerLanePerDPASInst;
@@ -1202,10 +1475,11 @@ struct LoadOpConversion
                                  << indices[elemIdx] << "\n";
                   });
                 }
+#if 0
                 DenseI32ArrayAttr attr = rewriter.getDenseI32ArrayAttr(indices);
                 Value loadVal = rewriter.create<LLVM::ShuffleVectorOp>(
                     loc, packedDPASOperandType, load2dOp, load2dOp, attr);
-
+#endif 
                 // Save the decomposed vals to the map;
                 switch (opIdx) {
                 case DpasEncodingAttr::OpIdx::OperandA: {
@@ -1219,10 +1493,12 @@ struct LoadOpConversion
                                         k + vblk * packedColNumPerVBlock + col)
                                  << "\n";
                   });
+#if 0
                   loadVals[{outer * packedRowNum * numLoadPerOutRepCluster +
                                 rep * packedRowNum + row,
                             k + vblk * packedColNumPerVBlock + col}] =
                       b.bitcast(loadVal, unpackedDPASOperandType);
+#endif 
                 } break;
                 case DpasEncodingAttr::OpIdx::OperandB: {
                   LLVM_DEBUG({
@@ -1234,11 +1510,13 @@ struct LoadOpConversion
                                           vblk * packedColNumPerVBlock + col)
                         << ", " << std::to_string(k + row) << "\n";
                   });
+#if 0
                   loadVals[{outer * packedColNum * numLoadPerOutRepCluster +
                                 rep * packedColNum +
                                 vblk * packedColNumPerVBlock + col,
                             k + row}] =
                       b.bitcast(loadVal, unpackedDPASOperandType);
+#endif
                 } break;
                 case DpasEncodingAttr::OpIdx::OperandC: {
                   llvm_unreachable("unexpected OpIdx::OperandC");
@@ -1255,6 +1533,9 @@ struct LoadOpConversion
     for (int outer = 0; outer < numRepOuter; ++outer) {
       for (int k = 0; k < numRepInner; ++k) {
         for (int rep = 0; rep < repCluster[unsigned(opIdx)]; ++rep) {
+          if (loadVals.find({outer * repCluster[unsigned(opIdx)] + rep, k}) == loadVals.end()) {
+            llvm::errs() << "Failed to find key at " << outer * repCluster[unsigned(opIdx)] + rep << ", " << k << "\n";
+          }
           Value loadVal =
               loadVals.at({outer * repCluster[unsigned(opIdx)] + rep, k});
           VectorType loadTy = cast<VectorType>(loadVal.getType());

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -876,6 +876,10 @@ struct LoadOpConversion
 
     // PVC 2D load supports 32 rows at most. Load multiple dot operands in by
     // enlarging the tileHeight.
+    if (numOperandsPer2DLoadM > (32 / tileHeight)) {
+      llvm::errs() << "replacing " << numOperandsPer2DLoadM << " with "
+                   << 32 / tileHeight << "\n";
+    }
     numOperandsPer2DLoadM = std::min(numOperandsPer2DLoadM, 32 / tileHeight);
     tileHeight = tileHeight * numOperandsPer2DLoadM;
 
@@ -902,9 +906,9 @@ struct LoadOpConversion
         isOperandA ? origNumOperandsPer2DloadN : numOperandsPer2DLoadM;
 
     if (!isTransposeRequired) {
-      tileLayout *= LinearLayout::identity1D(numOperandsOuterDimPerLoad,
+      tileLayout *= LinearLayout::identity1D(numIterationsOuterDimPerLoad,
                                              kIteration, dimOuterStr);
-      tileLayout *= LinearLayout::identity1D(numOperandsInnerDimPerLoad,
+      tileLayout *= LinearLayout::identity1D(numIterationsInnerDimPerLoad,
                                              kIteration, dimInnerStr);
       llvm::errs() << "\nnumOperandsOuterDimPerLoad: "
                    << numOperandsOuterDimPerLoad << "\n";
@@ -1407,8 +1411,17 @@ struct LoadOpConversion
             assert(tensorCoord.size() == 2);
             LLVM_DEBUG(llvm::dbgs() << "tensorCoord: " << tensorCoord[0].second
                                     << ", " << tensorCoord[1].second << "\n");
+            llvm::errs() << "elemsPerDPASInst: " << elemsPerDPASInst[0] << ", "
+                         << elemsPerDPASInst[1] << "\n";
+
             auto tensorRowCoord = (tensorCoord[0].second) / elemsPerDPASInst[0];
-            auto tensorColCoord = tensorCoord[1].second / tileWidth;
+            auto tensorColCoord = tensorCoord[1].second /
+                                  (elemsPerDPASInst[1] / packedElementsPerSlot);
+            if (oneMatrixPerLoadForBT) {
+              // HACK
+              llvm::errs() << "overwriting tensor col coord\n";
+              tensorColCoord = tensorCoord[1].second / tileWidth;
+            }
 
             if (isOperandA) {
               LLVM_DEBUG(llvm::dbgs()

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -3,6 +3,7 @@
 #include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/TypeUtilities.h"
+#include "triton/Tools/LayoutUtils.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -17,6 +18,9 @@ using namespace mlir;
 using namespace mlir::triton;
 using namespace mlir::triton::gpu;
 using namespace mlir::triton::gpu::intel;
+
+#define S(v) StringAttr::get(ctx, (v))
+
 namespace {
 
 // Return the mask for the unique data accessed by given tensor type.
@@ -534,6 +538,9 @@ struct LoadOpConversion
     };
     auto opIdx = getOpIdx();
 
+    LLVM_DEBUG(llvm::dbgs() << "Tensor type for op " << int(opIdx) << ": "
+                            << tensorType << "\n");
+
     std::optional<LinearLayout> llEncoding =
         cast<DistributedEncodingTrait>(encoding).toLinearLayout(
             tensorType.getShape());
@@ -742,12 +749,17 @@ struct LoadOpConversion
 
     unsigned dimOuter = bool(opIdx) ? rank - 1 : rank - 2;
     unsigned dimInner = bool(opIdx) ? rank - 2 : rank - 1;
+
     unsigned outerDimRequiredWarpNum =
         mlir::ceil<unsigned>(tensorShape[dimOuter], warpShape[dimOuter]);
     unsigned outerDimWarpNum =
         std::min<unsigned>(warpsPerCTA[dimOuter], outerDimRequiredWarpNum);
     Value outerDimWarpId =
         b.urem(multiDimWarpId[dimOuter], b.i32_val(outerDimWarpNum));
+    unsigned innerDimWarpNum = std::min<unsigned>(
+        warpsPerCTA[dimInner],
+        mlir::ceil<unsigned>(tensorShape[dimInner], repCluster[dimInner]));
+    ;
 
     auto [base, baseWidth, baseHeight, rowStride, colStride, offsetBaseX,
           offsetBaseY] =
@@ -755,9 +767,84 @@ struct LoadOpConversion
 
     unsigned tileWidth = elemsPerDPASInst[threadOrder[rank - 2]];
     unsigned tileHeight = elemsPerDPASInst[threadOrder[rank - 1]];
+
     unsigned vBlocks = 1;
     unsigned numOperandsOuterDimPerLoad = 1;
     unsigned numOperandsInnerDimPerLoad = 1;
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "dimOuter: " << dimOuter << "\n";
+      llvm::dbgs() << "dimInner: " << dimInner << "\n";
+      llvm::dbgs() << "width (elemsPerDPASInst[" << threadOrder[rank - 2]
+                   << "]): " << elemsPerDPASInst[threadOrder[rank - 2]] << "\n";
+      llvm::dbgs() << "height: (elemsPerDPASInst[" << threadOrder[rank - 1]
+                   << "]): " << elemsPerDPASInst[threadOrder[rank - 1]] << "\n";
+    });
+
+    MLIRContext *ctx = rewriter.getContext();
+    auto dimOuterStr = S("dim" + std::to_string(dimOuter));
+    auto dimInnerStr = S("dim" + std::to_string(dimInner));
+
+    StringAttr kOffset =
+        S("offset"); // Row-major offset into the data from a single block load
+    StringAttr kIteration = S("iteration"); // DPAS invocation operating on a
+                                            // sub-block from the loaded data
+    StringAttr kLoad = S("load");           // 2D block load invocation
+    auto createSimpleLinearLayout =
+        [&](const SmallVector<unsigned> &threadOrder,
+            const SmallVector<unsigned> &tileShape) {
+          auto outDimNames = standardOutDimNames(ctx, tensorShape.size());
+          LinearLayout layout = LinearLayout::empty();
+          SmallVector<StringAttr> kOffsetDims;
+          auto totalIters = 1;
+          auto totalOffsets = 1;
+          assert(tileShape.size() == 2); // TODO: dot 3d support?
+
+          if (isTransposeRequired &&
+              opIdx == DpasEncodingAttr::OpIdx::OperandB) {
+            // Adjust the layout to handle the VNNI values
+            layout *= LinearLayout::identity1D(2, kOffset, outDimNames[0]);
+            totalOffsets *= 2;
+            kOffsetDims.push_back(kOffset);
+          }
+
+          for (int i = 0; i < tileShape.size(); i++) {
+            int dim = threadOrder[i];
+            StringAttr kOffset = S("offset" + std::to_string(dim));
+
+            kOffsetDims.push_back(kOffset);
+
+            assert(llvm::isPowerOf2_32(tileShape[dim]));
+            if (dim == 0 && isTransposeRequired &&
+                opIdx == DpasEncodingAttr::OpIdx::OperandB) {
+              layout *= LinearLayout::identity1D(tileShape[dim] / 2, kOffset,
+                                                 outDimNames[dim]);
+              totalOffsets *= tileShape[dim] / 2;
+            } else {
+              layout *= LinearLayout::identity1D(tileShape[dim], kOffset,
+                                                 outDimNames[dim]);
+              totalOffsets *= tileShape[dim];
+            }
+          }
+          StringAttr kBlock = S("block");
+          SmallVector<StringAttr> newDims;
+          newDims.append(kOffsetDims.begin(), kOffsetDims.end());
+          auto ret = layout.transposeIns(newDims);
+          ret = ret.transposeOuts(outDimNames);
+          return ret.reshapeIns({{kOffset, totalOffsets}});
+        };
+    auto tileLayout = createSimpleLinearLayout(threadOrder, elemsPerDPASInst);
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "Block load tile layout: " << tileLayout << "\n";
+      for (size_t i = 0; i < elemsPerDPASInst[0] * elemsPerDPASInst[1]; i++) {
+        auto tensorVals = tileLayout.apply({{kOffset, i}});
+        assert(tensorVals.size() == 2);
+        llvm::dbgs() << i << " : " << tensorVals[0].second << ", "
+                     << tensorVals[1].second << "\n";
+      }
+      llvm::dbgs() << "tile layout done\n";
+    });
 
     unsigned numOperandsPer2DLoadM, numOperandsPer2DloadN;
     if (!isTransposeRequired) {
@@ -791,6 +878,60 @@ struct LoadOpConversion
       numOperandsPer2DloadN = 1;
     }
 
+    // begin LL duplicate code
+    if (isOperandA || !isTransposeRequired) { // TODO: hack to avoid duplicating
+                                              // operandA layout code
+      if (isOperandA) {
+        assert(!isTransposeRequired);
+        tileLayout *= LinearLayout::identity1D(repCluster[dimOuter], kIteration,
+                                               dimOuterStr);
+        tileLayout *= LinearLayout::identity1D(numReps[unsigned(opIdx) ? 1 : 2],
+                                               kIteration, dimInnerStr);
+      } else {
+        tileLayout *= LinearLayout::identity1D(repCluster[dimOuter], kIteration,
+                                               dimOuterStr);
+        tileLayout *= LinearLayout::identity1D(numReps[unsigned(opIdx) ? 1 : 2],
+                                               kIteration, dimInnerStr);
+      }
+    } else {
+      if (isOperandA)
+        return failure();
+
+      if (!usePackedType)
+        return failure();
+
+      std::swap(tileHeight, tileWidth);
+
+      if (oneMatrixPerLoadForBT) {
+        // Only load 1 operand per inst on row.
+        numOperandsPer2DLoadM = 1;
+        tileLayout *= LinearLayout::identity1D(1, kIteration, dimOuterStr);
+      } else {
+        // We can decompose the matrix returned by transposed large 2d load
+        // when threads per warp < column size. Otherwise we have to load one
+        // operand per inst.
+        // Note: the tileHeight and numOperandsPer2DLoadM are the column size
+        // now.
+        tileLayout *= LinearLayout::identity1D(
+            (threadsPerWarp <= tileHeight) ? repCluster[dimOuter] : 1,
+            kIteration, dimOuterStr);
+      }
+      // The transpose 2d load only support 1 operand per inst on column.
+      // (vBlocks = 1)
+      numOperandsPer2DloadN = 1;
+      // this give us the right value below when we compare to the B_AxB HW
+      // layout. But are we taking into account the vnni transform in addition
+      // to vblocks?
+      tileLayout *= LinearLayout::identity1D(numReps[unsigned(opIdx) ? 1 : 2],
+                                             kIteration, dimInnerStr);
+    }
+    // end LL duplicate code
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "Block load tile layout after adding iterations: "
+                   << tileLayout << "\n";
+    });
+
     // PVC 2D load supports 32 rows at most. Load multiple dot operands in by
     // enlarging the tileHeight.
     numOperandsPer2DLoadM = std::min(numOperandsPer2DLoadM, 32 / tileHeight);
@@ -822,6 +963,7 @@ struct LoadOpConversion
 
     // The stride for the replicates.
     unsigned repOuterStride = warpShape[dimOuter] * outerDimWarpNum;
+
     unsigned repStride =
         elemsPerDPASInst[dimOuter] * numOperandsOuterDimPerLoad;
     unsigned warpOuterStride = warpShape[dimOuter];
@@ -829,6 +971,67 @@ struct LoadOpConversion
 
     unsigned numRepOuter = numReps[bool(opIdx) ? 2 : 1];
     unsigned numRepInner = numReps[bool(opIdx) ? 1 : 2];
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "numRepOuter: " << numRepOuter
+                   << ", repOuterStride: " << repOuterStride << "\n";
+      llvm::dbgs() << "numLoadPerOutRepCluster: " << numLoadPerOutRepCluster
+                   << ", repStride: " << repStride << "\n";
+      llvm::dbgs() << "numRepInner: " << numRepInner
+                   << ", numOperandsInnerDimPerLoad: "
+                   << numOperandsInnerDimPerLoad << "\n";
+
+      llvm::dbgs() << "numOperandsOuterDimPerLoad: "
+                   << numOperandsOuterDimPerLoad << "\n";
+      llvm::dbgs() << "numOperandsInnerDimPerLoad: "
+                   << numOperandsInnerDimPerLoad << "\n";
+      llvm::dbgs() << "repOuterStride = " << repOuterStride
+                   << " (warpShape[dimOuter] * outerDimWarpNum : "
+                   << warpShape[dimOuter] << " * " << outerDimWarpNum << ")\n";
+      llvm::dbgs()
+          << "repStride = " << repStride
+          << " (elemsPerDPASInst[dimOuter] * numOperandsOuterDimPerLoad) "
+          << elemsPerDPASInst[dimOuter] << " * " << numOperandsOuterDimPerLoad
+          << "\n";
+    });
+
+    // handle loads
+    if (isOperandA) {
+      tileLayout *= LinearLayout::identity1D(numRepOuter, kLoad, dimOuterStr);
+    } else {
+      auto loadIdentityLayout =
+          LinearLayout::identity1D(numRepOuter, kLoad, dimInnerStr) *
+          LinearLayout::identity1D(numRepInner / numOperandsInnerDimPerLoad,
+                                   kLoad, dimOuterStr);
+      tileLayout *= loadIdentityLayout;
+    }
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "Block load tile layout after adding: " << tileLayout
+                   << "\n";
+      for (size_t load = 0; load < tileLayout.getInDimSize(kLoad); load++) {
+        for (size_t itr = 0; itr < tileLayout.getInDimSize(kIteration); itr++) {
+          {
+            size_t offset = 0;
+            auto tensorVals = tileLayout.apply(
+                {{kOffset, offset}, {kIteration, itr}, {kLoad, load}});
+            assert(tensorVals.size() == 2);
+            llvm::dbgs() << load << ", " << itr << ", " << offset << " : "
+                         << tensorVals[0].second << ", " << tensorVals[1].second
+                         << "\n";
+          }
+          {
+            size_t offset = tileLayout.getInDimSize(kOffset) - 1;
+            auto tensorVals = tileLayout.apply(
+                {{kOffset, offset}, {kIteration, itr}, {kLoad, load}});
+            assert(tensorVals.size() == 2);
+            llvm::dbgs() << load << ", " << itr << ", " << offset << " : "
+                         << tensorVals[0].second << ", " << tensorVals[1].second
+                         << "\n";
+          }
+        }
+      }
+    });
 
     Value pitch;
     if (memoryRowMajor) {
@@ -851,29 +1054,85 @@ struct LoadOpConversion
     }
     Value elemSizeInBytes = b.i32_val(originalElemBits / 8);
 
+    auto ll = *llEncoding;
+
+    StringAttr kRegister = StringAttr::get(ctx, "register");
+    StringAttr kLane = StringAttr::get(ctx, "lane");
+    StringAttr kWarp = StringAttr::get(ctx, "warp");
+    StringAttr kBlock = StringAttr::get(ctx, "block");
+
+    LLVM_DEBUG(llvm::dbgs() << "DPAS Linear Layout: " << ll << "\n");
+
+    auto dpasToBlockLoadLayout = tileLayout.pseudoinvert();
+    LLVM_DEBUG(llvm::dbgs() << "Inverted block load layout: "
+                            << dpasToBlockLoadLayout << "\n");
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "tileWidth: " << tileWidth << "\n";
+      llvm::dbgs() << "tileHeight: " << tileHeight << "\n";
+
+      llvm::dbgs() << "offset dim size: " << tileLayout.getInDimSize(kOffset)
+                   << "\n";
+      llvm::dbgs() << "iteration dim size: "
+                   << tileLayout.getInDimSize(kIteration) << "\n";
+
+      llvm::dbgs() << "ll lane size: " << ll.getInDimSize(kLane) << "\n";
+      llvm::dbgs() << "ll warp size: " << ll.getInDimSize(kWarp) << "\n";
+      llvm::dbgs() << "ll register size: " << ll.getInDimSize(kRegister)
+                   << "\n";
+      llvm::dbgs() << "ll block size: " << ll.getInDimSize(kBlock) << "\n";
+
+      llvm::dbgs() << "outerDimWarpNum: " << outerDimWarpNum << "\n";
+      llvm::dbgs() << "innerDimWarpNum: " << innerDimWarpNum << "\n";
+    });
+
     ValueTable loadVals;
     for (int outer = 0; outer < numRepOuter; ++outer) {
       for (int rep = 0; rep < numLoadPerOutRepCluster; ++rep) {
         for (int k = 0; k < numRepInner; k += numOperandsInnerDimPerLoad) {
+          LLVM_DEBUG({
+            llvm::dbgs() << "outer, rep, k: " << outer << ", " << rep << ", "
+                         << k << "\n";
+          });
+
           Value offsetX, offsetY;
+          auto offset = tileLayout.apply({{kOffset, 0},
+                                          {kIteration, 0},
+                                          {kLoad, outer + k * numRepOuter}});
+          assert(offset.size() == 2);
+          // adjust the load offset to compensate for strides related to the
+          // DPAS layout
+          const auto loadOffsetX = offset[0].second * outerDimWarpNum;
+          const auto loadOffsetY = offset[1].second / numRepOuter;
+          LLVM_DEBUG({
+            llvm::dbgs() << "x offset ll: " << loadOffsetX << "\n";
+            llvm::dbgs() << "y offset ll: " << loadOffsetY << "\n";
+          });
+
           switch (opIdx) {
           case DpasEncodingAttr::OpIdx::OperandA: {
-            // A
-            offsetY =
-                b.add(b.mul(outerDimWarpId, b.i32_val(warpOuterStride)),
-                      b.i32_val(outer * repOuterStride + rep * repStride));
-            offsetX = b.i32_val(k * repKStride);
+            LLVM_DEBUG({
+              llvm::dbgs() << "x offset: " << k * repKStride << "\n";
+              llvm::dbgs() << "y offset: "
+                           << outer * repOuterStride + rep * repStride << "\n";
+            });
+            offsetY = b.add(b.mul(outerDimWarpId, b.i32_val(warpOuterStride)),
+                            b.i32_val(loadOffsetY));
+            offsetX = b.i32_val(loadOffsetX);
           } break;
           case DpasEncodingAttr::OpIdx::OperandB: {
-            // B
-            offsetX =
-                b.add(b.mul(outerDimWarpId, b.i32_val(warpOuterStride)),
-                      b.i32_val(outer * repOuterStride + rep * repStride));
-            offsetY = b.i32_val(k * repKStride);
+            LLVM_DEBUG({
+              llvm::dbgs() << "x offset: "
+                           << outer * repOuterStride + rep * repStride << "\n";
+              llvm::dbgs() << "y offset: " << k * repKStride << "\n";
+            });
+            offsetX = b.add(b.mul(outerDimWarpId, b.i32_val(warpOuterStride)),
+                            b.i32_val(loadOffsetX));
+            offsetY = b.i32_val(loadOffsetY);
           } break;
           case DpasEncodingAttr::OpIdx::OperandC: {
             llvm_unreachable("unexpected OpIdx::OperandC");
-          } break;
+          }
           }
 
           offsetX = b.add(offsetX, offsetBaseX);
@@ -919,13 +1178,16 @@ struct LoadOpConversion
           unsigned packedColNum = opIdx == DpasEncodingAttr::OpIdx::OperandA
                                       ? numOperandsInnerDimPerLoad
                                       : numOperandsOuterDimPerLoad;
+          unsigned packedColNumPerVBlock = packedColNum / vBlocks;
 
           // Decompose the return value to multiple operands.
-          unsigned packedColNumPerVBlock = packedColNum / vBlocks;
           for (int vblk = 0; vblk < vBlocks; ++vblk)
             for (int row = 0; row < packedRowNum; ++row)
               for (int col = 0; col < packedColNumPerVBlock; ++col) {
-
+                LLVM_DEBUG({
+                  llvm::dbgs() << "Generating shuffle vector " << vblk << ", "
+                               << row << ", " << col << "\n";
+                });
                 unsigned operandStartOffset = (vblk * packedRowNum + row) *
                                               packedColNumPerVBlock *
                                               packedElemsPerLanePerDPASInst;
@@ -935,6 +1197,10 @@ struct LoadOpConversion
                      ++elemIdx) {
                   indices[elemIdx] = operandStartOffset +
                                      elemIdx * packedColNumPerVBlock + col;
+                  LLVM_DEBUG({
+                    llvm::dbgs() << "indices[" << elemIdx << "]" << " = "
+                                 << indices[elemIdx] << "\n";
+                  });
                 }
                 DenseI32ArrayAttr attr = rewriter.getDenseI32ArrayAttr(indices);
                 Value loadVal = rewriter.create<LLVM::ShuffleVectorOp>(
@@ -943,12 +1209,31 @@ struct LoadOpConversion
                 // Save the decomposed vals to the map;
                 switch (opIdx) {
                 case DpasEncodingAttr::OpIdx::OperandA: {
+                  LLVM_DEBUG({
+                    llvm::dbgs() << "load vals index: "
+                                 << std::to_string(outer * packedRowNum *
+                                                       numLoadPerOutRepCluster +
+                                                   rep * packedRowNum + row)
+                                 << ", "
+                                 << std::to_string(
+                                        k + vblk * packedColNumPerVBlock + col)
+                                 << "\n";
+                  });
                   loadVals[{outer * packedRowNum * numLoadPerOutRepCluster +
                                 rep * packedRowNum + row,
                             k + vblk * packedColNumPerVBlock + col}] =
                       b.bitcast(loadVal, unpackedDPASOperandType);
                 } break;
                 case DpasEncodingAttr::OpIdx::OperandB: {
+                  LLVM_DEBUG({
+                    llvm::dbgs()
+                        << "load vals index: "
+                        << std::to_string(outer * packedColNum *
+                                              numLoadPerOutRepCluster +
+                                          rep * packedColNum +
+                                          vblk * packedColNumPerVBlock + col)
+                        << ", " << std::to_string(k + row) << "\n";
+                  });
                   loadVals[{outer * packedColNum * numLoadPerOutRepCluster +
                                 rep * packedColNum +
                                 vblk * packedColNumPerVBlock + col,

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1240,8 +1240,7 @@ struct LoadOpConversion
                        << itrOffsetCoord[1].second << "\n");
             auto itrOffsetRowCoord =
                 itrOffsetCoord[0].second / elemsPerDPASInst[0];
-            auto itrOffsetColCoord =
-                itrOffsetCoord[1].second / tileWidth; 
+            auto itrOffsetColCoord = itrOffsetCoord[1].second / tileWidth;
             LLVM_DEBUG({
               llvm::dbgs() << "row: " << itrOffsetRowCoord << "\n";
               llvm::dbgs() << "col: " << itrOffsetColCoord << "\n";

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1030,7 +1030,7 @@ struct LoadOpConversion
     } else {
       tileLayout *= LinearLayout::identity1D(numRepOuter, kLoad, dimOuterStr);
       tileLayout *=
-          LinearLayout::identity1D(numOperandsPer2DLoadM, kLoad, dimInnerStr);
+          LinearLayout::identity1D(numRepInner, kLoad, dimInnerStr);
     }
 
     LLVM_DEBUG({

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1241,9 +1241,7 @@ struct LoadOpConversion
             auto itrOffsetRowCoord =
                 itrOffsetCoord[0].second / elemsPerDPASInst[0];
             auto itrOffsetColCoord =
-                itrOffsetCoord[1].second /
-                (elemsPerDPASInst[1] /
-                 packedElementsPerSlot); // TODO: try tileWidth
+                itrOffsetCoord[1].second / tileWidth; 
             LLVM_DEBUG({
               llvm::dbgs() << "row: " << itrOffsetRowCoord << "\n";
               llvm::dbgs() << "col: " << itrOffsetColCoord << "\n";

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -901,22 +901,10 @@ struct LoadOpConversion
     auto numIterationsInnerDimPerLoad =
         isOperandA ? origNumOperandsPer2DloadN : numOperandsPer2DLoadM;
 
-    if (isTransposeRequired) {
-      std::swap(numOperandsOuterDimPerLoad, numOperandsInnerDimPerLoad);
-      std::swap(numIterationsOuterDimPerLoad, numIterationsInnerDimPerLoad);
-    }
-
-    unsigned numLoadPerOutRepCluster =
-        mlir::ceil<unsigned>(repCluster[dimOuter], numOperandsOuterDimPerLoad);
-
-    unsigned numValuesPerLoad = packedElemsPerLanePerDPASInst *
-                                numOperandsOuterDimPerLoad *
-                                numOperandsInnerDimPerLoad;
-
     if (!isTransposeRequired) {
-      tileLayout *= LinearLayout::identity1D(numIterationsOuterDimPerLoad,
+      tileLayout *= LinearLayout::identity1D(numOperandsOuterDimPerLoad,
                                              kIteration, dimOuterStr);
-      tileLayout *= LinearLayout::identity1D(numIterationsInnerDimPerLoad,
+      tileLayout *= LinearLayout::identity1D(numOperandsInnerDimPerLoad,
                                              kIteration, dimInnerStr);
       llvm::errs() << "\nnumOperandsOuterDimPerLoad: "
                    << numOperandsOuterDimPerLoad << "\n";
@@ -946,6 +934,17 @@ struct LoadOpConversion
         // operand per inst.
         // Note: the tileHeight and numOperandsPer2DLoadM are the column size
         // now.
+        llvm::errs() << "\n"
+                     << std::to_string((threadsPerWarp <= tileHeight)) << " ? "
+                     << repCluster[dimOuter] << " : " << 1 << "\n";
+        llvm::errs() << "numOperandsOuterDimPerLoad: "
+                     << numOperandsOuterDimPerLoad << "\n";
+        llvm::errs() << "numOperandsInnerDimPerLoad: "
+                     << numOperandsInnerDimPerLoad << "\n";
+        llvm::errs() << "numIterationsOuterDimPerLoad: "
+                     << numIterationsOuterDimPerLoad << "\n";
+        llvm::errs() << "numIterationsInnerDimPerLoad: "
+                     << numIterationsInnerDimPerLoad << "\n";
         tileLayout *= LinearLayout::identity1D(
             (threadsPerWarp <= tileHeight) ? repCluster[dimOuter] : 1,
             kIteration, dimOuterStr);
@@ -992,16 +991,6 @@ struct LoadOpConversion
       llvm::dbgs() << "\n";
     });
 
-    Type load2DGenXType =
-        LLVM::getFixedVectorType(loadResultElemType, numValuesPerLoad);
-
-    // The stride for the replicates.
-    unsigned repOuterStride = warpShape[dimOuter] * outerDimWarpNum;
-    unsigned repStride =
-        elemsPerDPASInst[dimOuter] * numOperandsOuterDimPerLoad;
-    unsigned warpOuterStride = warpShape[dimOuter];
-    unsigned repKStride = elemsPerDPASInst[dimInner];
-
     unsigned numRepOuter = numReps[bool(opIdx) ? 2 : 1];
     unsigned numRepInner = numReps[bool(opIdx) ? 1 : 2];
 
@@ -1010,16 +999,40 @@ struct LoadOpConversion
     LLVM_DEBUG(llvm::dbgs() << "Packed elements per slot: "
                             << packedElementsPerSlot << "\n");
 
+    if (isTransposeRequired) {
+      llvm::errs() << "transpose required!\n";
+      std::swap(numOperandsOuterDimPerLoad, numOperandsInnerDimPerLoad);
+      std::swap(numIterationsOuterDimPerLoad, numIterationsInnerDimPerLoad);
+    }
+
 #if 1
-    llvm::errs() << "numRepOuter: " << numRepOuter << " vs "
+    llvm::errs() << "dim outer load: \n";
+    llvm::errs() << "\tnumRepOuter: " << numRepOuter << "\n";
+    llvm::errs() << "\tpackedElementsPerSlot: " << packedElementsPerSlot
+                 << "\n";
+    llvm::errs() << "\tvblocks: " << vBlocks << "\n";
+    llvm::errs() << "\tnumRepOuter * packedElementsPerSlot * vBlocks: "
+                 << numRepOuter * packedElementsPerSlot * vBlocks << "\n";
+    llvm::errs() << "\tnumIterationsOuterDimPerLoad: "
+                 << numIterationsOuterDimPerLoad << "\n";
+    llvm::errs() << "\tdimOuter Val: "
                  << (numRepOuter * packedElementsPerSlot * vBlocks) /
                         numIterationsOuterDimPerLoad
                  << "\n";
-    llvm::errs() << "numRepInner: " << numRepInner << " vs "
-                 << (numRepInner) / numIterationsInnerDimPerLoad << "\n";
-    llvm::errs() << "vblocks: " << vBlocks << "\n";
-    llvm::errs() << "numRepOuter * repCluster[dimOuter]: "
-                 << numRepOuter * repCluster[dimOuter] << "\n";
+    llvm::errs() << "\tdimOuter Val swapped iterations: "
+                 << (numRepOuter * packedElementsPerSlot * vBlocks) /
+                        numIterationsInnerDimPerLoad
+                 << "\n";
+
+    llvm::errs() << "dim inner load: \n";
+    llvm::errs() << "\tnumRepInner: " << numRepInner << "\n";
+    llvm::errs() << "\tnumIterationsInnerDimPerLoad: "
+                 << numIterationsInnerDimPerLoad << "\n";
+    llvm::errs() << "\tdimInner Val: "
+                 << numRepInner / numIterationsInnerDimPerLoad << "\n";
+    llvm::errs() << "\tdimInner Val swapped iterations: "
+                 << numRepInner / numIterationsOuterDimPerLoad << "\n";
+
     if (isTransposeRequired && oneMatrixPerLoadForBT) {
       tileLayout *= LinearLayout::identity1D(numRepOuter * repCluster[dimOuter],
                                              kLoad, dimOuterStr);
@@ -1092,6 +1105,23 @@ struct LoadOpConversion
         llvm::dbgs() << "\n";
       }
     });
+
+    unsigned numLoadPerOutRepCluster =
+        mlir::ceil<unsigned>(repCluster[dimOuter], numOperandsOuterDimPerLoad);
+
+    unsigned numValuesPerLoad = packedElemsPerLanePerDPASInst *
+                                numOperandsOuterDimPerLoad *
+                                numOperandsInnerDimPerLoad;
+
+    Type load2DGenXType =
+        LLVM::getFixedVectorType(loadResultElemType, numValuesPerLoad);
+
+    // The stride for the replicates.
+    unsigned repOuterStride = warpShape[dimOuter] * outerDimWarpNum;
+    unsigned repStride =
+        elemsPerDPASInst[dimOuter] * numOperandsOuterDimPerLoad;
+    unsigned warpOuterStride = warpShape[dimOuter];
+    unsigned repKStride = elemsPerDPASInst[dimInner];
 
     Value pitch;
     if (memoryRowMajor) {
@@ -1197,9 +1227,31 @@ struct LoadOpConversion
             llvm::dbgs() << "y offset from layout: " << offset[dimInner].second
                          << "\n";
           });
-          const auto loadOffsetX = offset[dimOuter].second * outerDimWarpNum *
-                                   numLoadPerOutRepCluster *
-                                   packedElementsPerSlot;
+          llvm::errs() << "outer dim warp num: " << outerDimWarpNum << "\n";
+          llvm::errs() << "iteration num: "
+                       << tileLayout.getInDimSize(kIteration) << "\n";
+          llvm::errs() << "load num: " << tileLayout.getInDimSize(kLoad)
+                       << "\n";
+          llvm::errs() << "numLoadPerOutRepCluster: " << numLoadPerOutRepCluster
+                       << "\n";
+          llvm::errs() << "packedElementsPerSlot: " << packedElementsPerSlot
+                       << "\n";
+          llvm::errs() << "iteration / vblocks * load = "
+                       << offset[dimOuter].second *
+                              (tileLayout.getInDimSize(kIteration) / vBlocks) *
+                              tileLayout.getInDimSize(kLoad) *
+                              numLoadPerOutRepCluster
+                       << "\n";
+          llvm::errs() << "iteration * load = "
+                       << offset[dimOuter].second *
+                              tileLayout.getInDimSize(kIteration) *
+                              tileLayout.getInDimSize(kLoad) *
+                              numLoadPerOutRepCluster
+                       << "\n";
+          const auto loadOffsetX =
+              offset[dimOuter].second *
+              (tileLayout.getInDimSize(kIteration) / vBlocks) *
+              tileLayout.getInDimSize(kLoad) * numLoadPerOutRepCluster;
           const auto loadOffsetY = offset[dimInner].second;
           LLVM_DEBUG({
             llvm::dbgs() << "x offset ll: " << loadOffsetX << "\n";
@@ -1281,10 +1333,11 @@ struct LoadOpConversion
                                 ? tileHeight / elemsPerDPASInst[dimOuter] - 1
                                 : tileHeight;
           } else {
-            loadColStride = isOperandA ? tileHeight
-                            : (ll.getOutDimSize(dimInnerStr) > tileWidth)
-                                ? tileWidth
-                                : packedElemsPerLanePerDPASInst;
+            llvm::errs() << "tileWidth = " << tileWidth << "\n";
+            llvm::errs() << "elemSizeInBits/16 = " << elemSizeInBits / 16
+                         << "\n";
+            loadColStride = isOperandA ? tileHeight / (elemSizeInBits / 16)
+                                       : tileWidth / (elemSizeInBits / 16);
           }
 
           LLVM_DEBUG({

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -863,6 +863,8 @@ struct LoadOpConversion
       if (!usePackedType)
         return failure();
 
+      std::swap(tileHeight, tileWidth);
+
       if (oneMatrixPerLoadForBT) {
         // Only load 1 operand per inst on row.
         numOperandsPer2DLoadM = 1;
@@ -881,28 +883,17 @@ struct LoadOpConversion
     }
 
     // begin LL duplicate code
-    if (isOperandA || !isTransposeRequired) { // TODO: hack to avoid duplicating
-                                              // operandA layout code
-      if (isOperandA) {
-        assert(!isTransposeRequired);
-        tileLayout *= LinearLayout::identity1D(repCluster[dimOuter], kIteration,
-                                               dimOuterStr);
-        tileLayout *= LinearLayout::identity1D(numReps[unsigned(opIdx) ? 1 : 2],
-                                               kIteration, dimInnerStr);
-      } else {
-        tileLayout *= LinearLayout::identity1D(repCluster[dimOuter], kIteration,
-          dimOuterStr);
-        tileLayout *= LinearLayout::identity1D(numReps[unsigned(opIdx) ? 1 : 2],
-                                               kIteration, dimInnerStr);
-      }
+    if (!isTransposeRequired) { 
+      tileLayout *= LinearLayout::identity1D(repCluster[dimOuter], kIteration,
+                                              dimOuterStr);
+      tileLayout *= LinearLayout::identity1D(numReps[unsigned(opIdx) ? 1 : 2],
+                                              kIteration, dimInnerStr);
     } else {
       if (isOperandA)
         return failure();
 
       if (!usePackedType)
         return failure();
-
-      std::swap(tileHeight, tileWidth);
 
       if (oneMatrixPerLoadForBT) {
         // Only load 1 operand per inst on row.
@@ -1131,16 +1122,12 @@ struct LoadOpConversion
       llvm::dbgs() << "originalElemBits: " << originalElemBits << "\n";
       llvm::dbgs() << "elemSizeInBits: " << elemSizeInBits << "\n";
     });
-    llvm::errs() << "dim Str: " << dimInnerStr << "\n";
-#if 0
-    const unsigned packedElementsPerSlot = isTransposeRequired ? elemSizeInBits / originalElemBits : 1;
-#else
+
     LLVM_DEBUG(llvm::dbgs() << "out dim size: " << tileLayout.getOutDimSize(dimOuterStr) << "\n");
     LLVM_DEBUG(llvm::dbgs() << "elems per dpas: " << elemsPerDPASInst[dimInner] << "\n");
     const unsigned packedElementsPerSlot = isTransposeRequired ? tileHeight / elemsPerDPASInst[dimInner] : 1;
     LLVM_DEBUG(llvm::dbgs() << "other out dim size: " << tileLayout.getOutDimSize(dimInnerStr) << "\n");
     LLVM_DEBUG(llvm::dbgs() << "other elems per dpas: " << elemsPerDPASInst[dimOuter] << "\n");
-#endif
     LLVM_DEBUG(llvm::dbgs() << "Packed elements per slot: "
                             << packedElementsPerSlot << "\n");
 
@@ -1254,12 +1241,14 @@ struct LoadOpConversion
                                          : packedElemsPerLanePerDPASInst;
 
           unsigned loadColOffset;
+          // detect interrleaved transposed results 
           if (isTransposeRequired && !isOperandA) {
-            loadColOffset = tileHeight / elemsPerDPASInst[dimOuter] - 1;
+            loadColOffset = ( ll.getOutDimSize(dimOuterStr) >= tileHeight) ? tileHeight / elemsPerDPASInst[dimOuter] - 1 : tileHeight;
+            LLVM_DEBUG(llvm::dbgs() << "loadColOffset transpose: " << loadColOffset << "\n");
           } else {
             loadColOffset = isOperandA ? tileHeight : tileWidth;
+            LLVM_DEBUG(llvm::dbgs() << "loadColOffset no transpose: " << loadColOffset << "\n");
           }
-          LLVM_DEBUG(llvm::dbgs() << "loadColOffset: " << loadColOffset << "\n");
 
           LLVM_DEBUG(llvm::dbgs() << "num vblocks: " << vBlocks << "\n");
           // these iterations are dpas iterations.
@@ -1303,8 +1292,11 @@ struct LoadOpConversion
               });
               for (int elemIdx = 0; elemIdx < packedElemsPerLanePerDPASInst;
                    elemIdx += packedElementsPerSlot) {
+                // TODO: is this stride right? 
+                // llvm::errs() << "\ttile width: " << tileWidth << " vs elems per dpas: " << elemsPerDPASInst[1] << "\n";
+                // llvm::errs() << "\toffset idx: " << elemIdx * tileWidth << "\n";
                 auto blockLayoutOffset =
-                    tileLayout.apply({{kOffset, elemIdx * elemsPerDPASInst[1]},
+                    tileLayout.apply({{kOffset, elemIdx * tileWidth * packedElementsPerSlot},
                                       {kIteration, i},
                                       {kLoad, loadIdx}});
                 assert(blockLayoutOffset.size() == 2);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -906,7 +906,7 @@ struct LoadOpConversion
         isOperandA ? numOperandsPer2DloadN : numOperandsPer2DLoadM;
 
     if (!isTransposeRequired) {
-#if 0 
+#if 0
       tileLayout *= LinearLayout::identity1D(numIterationsOuterDimPerLoad,
         kIteration, S("dim0"));
       tileLayout *= LinearLayout::identity1D(numIterationsInnerDimPerLoad,
@@ -916,7 +916,7 @@ struct LoadOpConversion
                                              kIteration, dimOuterStr);
       tileLayout *= LinearLayout::identity1D(numIterationsInnerDimPerLoad,
                                              kIteration, dimInnerStr);
-#endif 
+#endif
 
       llvm::errs() << "\nnumOperandsOuterDimPerLoad: "
                    << numOperandsOuterDimPerLoad << "\n";
@@ -1227,11 +1227,18 @@ struct LoadOpConversion
           llvm::errs() << "packedElementsPerSlot: " << packedElementsPerSlot
                        << "\n";
           const auto loadOffsetX =
-              isOperandA ? offset[1].second : offset[1].second * (tileLayout.getInDimSize(kIteration) / vBlocks) * tileLayout.getInDimSize(kLoad);
-          llvm::errs() << "itr size: " << tileLayout.getInDimSize(kIteration) << "\n";
-          llvm::errs() << "itr / vblocks: " << tileLayout.getInDimSize(kIteration) / vBlocks << "\n";
-          llvm::errs() << "load size: " << tileLayout.getInDimSize(kLoad) << "\n";
-          llvm::errs() << "numLoadPerOutRepCluster: " << numLoadPerOutRepCluster << "\n";
+              isOperandA ? offset[1].second
+                         : offset[1].second *
+                               (tileLayout.getInDimSize(kIteration) / vBlocks) *
+                               tileLayout.getInDimSize(kLoad);
+          llvm::errs() << "itr size: " << tileLayout.getInDimSize(kIteration)
+                       << "\n";
+          llvm::errs() << "itr / vblocks: "
+                       << tileLayout.getInDimSize(kIteration) / vBlocks << "\n";
+          llvm::errs() << "load size: " << tileLayout.getInDimSize(kLoad)
+                       << "\n";
+          llvm::errs() << "numLoadPerOutRepCluster: " << numLoadPerOutRepCluster
+                       << "\n";
           const auto loadOffsetY = offset[0].second;
           LLVM_DEBUG({
             llvm::dbgs() << "isOperandA? " << isOperandA << "\n";
@@ -1322,7 +1329,7 @@ struct LoadOpConversion
 #else
             loadColStride = isOperandA ? tileHeight / (elemSizeInBits / 16)
                                        : tileWidth / (elemSizeInBits / 16);
-#endif 
+#endif
           }
 
           LLVM_DEBUG({
@@ -1330,9 +1337,18 @@ struct LoadOpConversion
             llvm::dbgs() << "col stride: " << loadColStride << "\n";
           });
 
+          auto itrOffsetCoord_ = tileLayout.apply(
+              {{kLoad, loadIdx}, {kOffset, 0}, {kIteration, 0}});
+          assert(itrOffsetCoord_.size() == 2);
+          LLVM_DEBUG(llvm::dbgs()
+                     << "itrOffsetCoord_: " << itrOffsetCoord_[0].second << ", "
+                     << itrOffsetCoord_[1].second << "\n");
+
           for (size_t i = 0; i < tileLayout.getInDimSize(kIteration); i++) {
             LLVM_DEBUG(llvm::dbgs() << "Emitting shuffle vector for iteration "
                                     << i << ", load: " << loadIdx << "\n");
+
+#if 0
 
             // Use the tile layout to determine the starting coordinate for
             // this iteration in a generic load
@@ -1350,12 +1366,18 @@ struct LoadOpConversion
               llvm::dbgs() << "col: " << itrOffsetColCoord << "\n";
             });
 
+#if 0
+            const auto itrRowOffset = itrOffsetRowCoord * loadColStride;
+            const auto itrColOffset = itrOffsetColCoord * loadRowStride;
+#else
             const auto itrRowOffset = itrOffsetRowCoord * loadRowStride;
             const auto itrColOffset = itrOffsetColCoord * loadColStride;
+#endif
             LLVM_DEBUG({
               llvm::dbgs() << "row offset: " << itrRowOffset << "\n";
               llvm::dbgs() << "col offset: " << itrColOffset << "\n";
             });
+#endif
 
             SmallVector<int32_t> indices(packedElemsPerLanePerDPASInst);
             for (int elemIdx = 0; elemIdx < packedElemsPerLanePerDPASInst;
@@ -1366,16 +1388,56 @@ struct LoadOpConversion
                    {kIteration, i},
                    {kLoad, loadIdx}});
               assert(shuffleVectorOffset.size() == 2);
-              LLVM_DEBUG(llvm::dbgs() << "\tblock load offset: "
+              LLVM_DEBUG(llvm::dbgs() << "\tshuffle vector offset: "
                                       << shuffleVectorOffset[0].second << ", "
                                       << shuffleVectorOffset[1].second << "\n");
+              shuffleVectorOffset[0].second -= itrOffsetCoord_[0].second;
+              shuffleVectorOffset[1].second -= itrOffsetCoord_[1].second;
+              LLVM_DEBUG(llvm::dbgs()
+                         << "\tshuffle vector offset after handing loads: "
+                         << shuffleVectorOffset[0].second << ", "
+                         << shuffleVectorOffset[1].second << "\n");
 
               for (size_t s = 0; s < packedElementsPerSlot; s++) {
+                // TODO: this indexing is wrong, we don't care about
+                // itrRowOffset or itrColOffset. we care about how many
+                // iterations have come before us in this load, and what the
+                // last offset was.
+#if 1
+                llvm::errs()
+                    << "\tshuffle x coord: " << (shuffleVectorOffset[0].second)
+                    << "\n";
+                llvm::errs()
+                    << "\tshuffle y coord: " << shuffleVectorOffset[1].second
+                    << "\n";
+
+                const auto x_offset =
+                    (shuffleVectorOffset[0].second / elemsPerDPASInst[0]) *
+                    packedElemsPerLanePerDPASInst;
+                auto y_offset =
+                    (shuffleVectorOffset[1].second * packedElementsPerSlot) /
+                    elemsPerDPASInst[0];
+                llvm::errs() << "\tshuffle y offset: " << y_offset << "\n";
+
+                y_offset *= isTransposeRequired ? 1 : elemsPerDPASInst[1];
+                llvm::errs() << "\tshuffle y stride: " << y_offset << "\n";
+
+                llvm::errs()
+                    << "\tshuffle slot offset: " << s * packedElementsPerSlot
+                    << "\n";
+
+                indices[elemIdx + s] =
+                    x_offset + y_offset +
+                    (shuffleVectorOffset[0].second %
+                     (packedElementsPerSlot * packedElemsPerLanePerDPASInst)) +
+                    s * packedElementsPerSlot;
+#else
                 indices[elemIdx + s] =
                     itrRowOffset + itrColOffset +
                     (shuffleVectorOffset[0].second %
                      (packedElementsPerSlot * packedElemsPerLanePerDPASInst)) +
                     s * packedElementsPerSlot;
+#endif
                 LLVM_DEBUG({
                   llvm::dbgs() << "indices[" << elemIdx + s << "]" << " = "
                                << indices[elemIdx + s] << "\n";
@@ -1392,8 +1454,12 @@ struct LoadOpConversion
             assert(tensorCoord.size() == 2);
             LLVM_DEBUG(llvm::dbgs() << "tensorCoord: " << tensorCoord[0].second
                                     << ", " << tensorCoord[1].second << "\n");
+            llvm::errs() << "packedElementsPerSlot: " << packedElementsPerSlot
+                         << "\n";
             llvm::errs() << "elemsPerDPASInst: " << elemsPerDPASInst[0] << ", "
                          << elemsPerDPASInst[1] << "\n";
+            llvm::errs() << "tile height, width: " << tileHeight << ", "
+                         << tileWidth << "\n";
 
             auto tensorRowCoord = (tensorCoord[0].second) / elemsPerDPASInst[0];
             auto tensorColCoord = tensorCoord[1].second /


### PR DESCRIPTION
This PR introduces a new linear layout in the Triton Load to LLVM lowering for block loads. The layout describes the block load in terms of three input parameters:
 - `offset` which is the 1D offset into the loaded data for a single DPAS invocation inside a sub-group
 - `iteration` which identifies the DPAS invocation when multiple DPAS invocations share a single load
 - `load` which identifies the load index when multiple loads occur for a given operand 

The output of the layout function identifies the global `(x,y)` tensor coordinate. This was designed to allow composition of the DPAS layout and the load layout to go from `offset, iteration, load` to `block, warp, lane, register` or vice versa. Note that I do not encode all the information about the load into the layout currently - I wanted to maintain surjective properties of the layout and it's a bit easier to construct this way. So, sometimes a manual offset must be applied depending on the desired layout parameter. 

Currently the block load / tile layout is implemented within the existing loop structure. But, the layout was designed to be used to generate the 2D block loads. I left the existing loop structure in-place along with lots of debug info so we can more easily check any regressions. I am planning to remove the existing loop structure and generate loads only using layout parameters in a follow-up PR. 

Close #3008 