### PR TITLE
[ElementwiseOpToLLVM] Do not call 'maybeDeduplicate' for dpas encoding

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
@@ -1,6 +1,7 @@
 #ifndef TRITON_CONVERSION_TRITONGPU_TO_ELEMENTWISE_OP_H
 #define TRITON_CONVERSION_TRITONGPU_TO_ELEMENTWISE_OP_H
 
+#include "intel/include/Dialect/TritonIntelGPU/IR/Attributes.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Support/LLVM.h"
@@ -86,7 +87,8 @@ public:
       return resultVals;
     while (auto sliced = dyn_cast<SliceEncodingAttr>(baseEncoding))
       baseEncoding = sliced.getParent();
-    if (isa<LinearEncodingAttr, DotOperandEncodingAttr>(baseEncoding)) {
+    if (isa<LinearEncodingAttr, DotOperandEncodingAttr,
+            intel::DpasEncodingAttr>(baseEncoding)) {
       // TODO: this logic seems incorrect for mma layout. Skip for now.
       // The following test crashes and some other miscompile:
       // test_core::test_fp8_dot_acc


### PR DESCRIPTION
Closes #3380 

The problem occurs when we try to lower an `arith.andi` op in a chain of `tl.dot + tl.where + tl.dot`. The `maybeDeduplicate` function seems to handle dot/dpas layouts incorrectly. When trying to deduplicate mask values for each 16-col block it seems to mishandle strides & constancy somehow leading to the mask values for the second 16-col block to be ignored. More details in this mlir snippet:

<details><summary>mlir</summary>

```mlir
; ElementwiseOpToLLVM lowers this op '"arith.andi"(%1360, %1394) : (tensor<16x32xi1, #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 1, threadsPerWarp = 16, warpsPerCTA = [4, 1], repCluster = [1, 1], A = [8, 8], B = [8, 16], C = [8, 16]}>>, tensor<16x32xi1, #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 1, threadsPerWarp = 16, warpsPerCTA = [4, 1], repCluster = [1, 1], A = [8, 8], B = [8, 16], C = [8, 16]}>>) -> tensor<16x32xi1, #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 1, threadsPerWarp = 16, warpsPerCTA = [4, 1], repCluster = [1, 1], A = [8, 8], B = [8, 16], C = [8, 16]}>>'
; into this:

%0 = "llvm.and"(%1395, %1411) : (i1, i1) -> i1
%1 = "llvm.and"(%1396, %1412) : (i1, i1) -> i1
%2 = "llvm.and"(%1397, %1413) : (i1, i1) -> i1
%3 = "llvm.and"(%1398, %1414) : (i1, i1) -> i1
%4 = "llvm.and"(%1399, %1415) : (i1, i1) -> i1
%5 = "llvm.and"(%1400, %1416) : (i1, i1) -> i1
%6 = "llvm.and"(%1401, %1417) : (i1, i1) -> i1
%7 = "llvm.and"(%1402, %1418) : (i1, i1) -> i1   <--- mask values for the first 16-column block (%0 == %1 == %2 ... == %7)
-------------------------------------------------------
%8 = "llvm.and"(%1403, %1419) : (i1, i1) -> i1   <--- mask values for the second 16-column block (%8 == %9 == %10 ... == %15)
%9 = "llvm.and"(%1404, %1420) : (i1, i1) -> i1        ; %7 != %8
%10 = "llvm.and"(%1405, %1421) : (i1, i1) -> i1
%11 = "llvm.and"(%1406, %1422) : (i1, i1) -> i1
%12 = "llvm.and"(%1407, %1423) : (i1, i1) -> i1
%13 = "llvm.and"(%1408, %1424) : (i1, i1) -> i1
%14 = "llvm.and"(%1409, %1425) : (i1, i1) -> i1
%15 = "llvm.and"(%1410, %1426) : (i1, i1) -> i1

; maybeDeduplicate produces the following output completely ignoring values for the second 16-col block:
%.. = "llvm.insertvalue"(%.., %0) <{position = array<i64: 0>}>
%.. = "llvm.insertvalue"(%.., %1) <{position = array<i64: 1>}> 
%.. = "llvm.insertvalue"(%.., %0) <{position = array<i64: 2>}> 
%.. = "llvm.insertvalue"(%.., %1) <{position = array<i64: 3>}> 
%.. = "llvm.insertvalue"(%.., %0) <{position = array<i64: 4>}> 
%.. = "llvm.insertvalue"(%.., %1) <{position = array<i64: 5>}> 
%.. = "llvm.insertvalue"(%.., %0) <{position = array<i64: 6>}> 
%.. = "llvm.insertvalue"(%.., %1) <{position = array<i64: 7>}> 
%.. = "llvm.insertvalue"(%.., %0) <{position = array<i64: 8>}> 
%.. = "llvm.insertvalue"(%.., %1) <{position = array<i64: 9>}> 
%.. = "llvm.insertvalue"(%.., %0) <{position = array<i64: 10>}>
%.. = "llvm.insertvalue"(%.., %1) <{position = array<i64: 11>}>
%.. = "llvm.insertvalue"(%.., %0) <{position = array<i64: 12>}>
%.. = "llvm.insertvalue"(%.., %1) <{position = array<i64: 13>}>
%.. = "llvm.insertvalue"(%.., %0) <{position = array<i64: 14>}>
%.. = "llvm.insertvalue"(%.., %1) <{position = array<i64: 15>}>

; maybeDeduplicate should have produced this instead, using both first and second block values:
%.. = "llvm.insertvalue"(%.., %0) <{position = array<i64: 0>}>
%.. = "llvm.insertvalue"(%.., %0) <{position = array<i64: 1>}> 
%.. = "llvm.insertvalue"(%.., %0) <{position = array<i64: 2>}> 
%.. = "llvm.insertvalue"(%.., %0) <{position = array<i64: 3>}> 
%.. = "llvm.insertvalue"(%.., %0) <{position = array<i64: 4>}> 
%.. = "llvm.insertvalue"(%.., %0) <{position = array<i64: 5>}> 
%.. = "llvm.insertvalue"(%.., %0) <{position = array<i64: 6>}> 
%.. = "llvm.insertvalue"(%.., %0) <{position = array<i64: 7>}> 
%.. = "llvm.insertvalue"(%.., %8) <{position = array<i64: 8>}> 
%.. = "llvm.insertvalue"(%.., %8) <{position = array<i64: 9>}> 
%.. = "llvm.insertvalue"(%.., %8) <{position = array<i64: 10>}>
%.. = "llvm.insertvalue"(%.., %8) <{position = array<i64: 11>}>
%.. = "llvm.insertvalue"(%.., %8) <{position = array<i64: 12>}>
%.. = "llvm.insertvalue"(%.., %8) <{position = array<i64: 13>}>
%.. = "llvm.insertvalue"(%.., %8) <{position = array<i64: 14>}>
%.. = "llvm.insertvalue"(%.., %8) <{position = array<i64: 15>}>
```

</details>

In case of [this reproducer](https://github.com/intel/intel-xpu-backend-for-triton/issues/3380#issuecomment-2674730581), the flow enters [this loop](https://github.com/intel/intel-xpu-backend-for-triton/blob/99027d2df3a345aa6ac4bc9f4afc62eb92b7612c/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h#L151) in `maybeDeduplicate` with the following values: (note that `elemsPerThread` and `constancy` [were reordered](https://github.com/intel/intel-xpu-backend-for-triton/blob/99027d2df3a345aa6ac4bc9f4afc62eb92b7612c/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h#L135-L143) with `order = [1, 0]`)
```c++
elemsPerThread = {2, 8};
constancy = {1, 8};
rank = 2;
strides = {1, 2};
```
https://github.com/intel/intel-xpu-backend-for-triton/blob/99027d2df3a345aa6ac4bc9f4afc62eb92b7612c/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h#L151-L163