### PR TITLE
Use TritonGPUDialect::getThreadsPerWarp instead of TritonGEN::getSubgroupSize

### DIFF
--- a/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h
+++ b/third_party/intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h
@@ -40,9 +40,6 @@ enum TritonGENMemorySpace {
   kGeneric = 4          // OpenCL Generic memory
 };
 
-/// Get the subgroup size from the target.
-int getSubgroupSize(Operation *op);
-
 } // namespace mlir::triton::TritonGEN
 
 #endif // TRITON_DIALECT_TRITONGENDIALECT_H

--- a/third_party/intel/lib/Dialect/TritonGEN/IR/TritonGENDialect.cpp
+++ b/third_party/intel/lib/Dialect/TritonGEN/IR/TritonGENDialect.cpp
@@ -36,12 +36,6 @@ void TritonGENDialect::initialize() {
       >();
 }
 
-int triton::TritonGEN::getSubgroupSize(Operation *op) {
-  spirv::TargetEnvAttr attr = spirv::lookupTargetEnv(op);
-  assert(attr && "Expecting valid target env attribute");
-  return attr.getResourceLimits().getSubgroupSize();
-}
-
 #include "intel/include/Dialect/TritonGEN/IR/TritonGENDialect.cpp.inc"
 #include "intel/include/Dialect/TritonGEN/IR/TritonGENOpsEnums.cpp.inc"
 #define GET_ATTRDEF_CLASSES

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TritonOpsToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TritonOpsToLLVM.cpp
@@ -782,7 +782,7 @@ class ConvertLayoutOpConversion : public ConvertTritonGPUOpToLLVMPattern<
       return failure();
 
     auto m = op->getParentOfType<ModuleOp>();
-    int size = TritonGEN::getSubgroupSize(m);
+    int size = triton::gpu::TritonGPUDialect::getThreadsPerWarp(m);
 
     Value res = rewriter.create<LLVM::PoisonOp>(loc, type);
     for (int i = 0; i < size; ++i) {

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
@@ -48,7 +48,8 @@ static Value shuffleCommonImpl(Location loc, RewriterBase &rewriter, Value val,
     }
   }
 
-  int width = TritonGEN::getSubgroupSize(i.getDefiningOp());
+  int width = triton::gpu::TritonGPUDialect::getThreadsPerWarp(
+      i.getDefiningOp()->getParentOfType<ModuleOp>());
   Value widthConstant = b.i32_val(width);
   Value result =
       rewriter.create<mlir::gpu::ShuffleOp>(loc, val, i, widthConstant, mode)


### PR DESCRIPTION
This is to replace the SPIRV-specific method with a more generic one.