### PR TITLE
Fix E2E performance workload

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -208,7 +208,7 @@ jobs:
         if: ${{ inputs.suite == 'torchbench' }}
         run: |
           cd benchmark
-          python install.py
+          pip install -r requirements.txt
           pip install -e .
 
       - name: Run e2e ${{ inputs.test_mode }} tests


### PR DESCRIPTION
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/13529417038 (passed)

For some reason `install.py` tried to install numba `0.51.2` which doesn't support python 3.10. Using `install.py` doesn't seem necessary, so we could try to use `pip install -r requirement.txt` directly. 