### PR TITLE
Allow inductor-tests to run all tests

### DIFF
--- a/.github/workflows/inductor-tests-reusable.yml
+++ b/.github/workflows/inductor-tests-reusable.yml
@@ -8,7 +8,7 @@ on:
         type: string
         default: ""
       suite:
-        description: Space separated lists of test suites, all if empty
+        description: Space separated lists of test suites or "all"
         type: string
         default: ""
       runner_label:
@@ -76,7 +76,7 @@ jobs:
           export PYTORCH_TESTING_DEVICE_ONLY_FOR="xpu"
 
           test_cmd="python test/run_test.py --include "
-          if [[ -z "${{ inputs.suite }}" ]]; then
+          if [[ "${{ inputs.suite }}" = "all" ]]; then
             for test in $(ls test/inductor | grep test);
             do
               test_cmd="${test_cmd} inductor/$test"

--- a/.github/workflows/inductor-tests-reusable.yml
+++ b/.github/workflows/inductor-tests-reusable.yml
@@ -10,7 +10,7 @@ on:
       suite:
         description: Space separated lists of test suites or "all"
         type: string
-        default: ""
+        default: "all"
       runner_label:
         description: Runner label, keep empty for default
         type: string

--- a/.github/workflows/inductor-tests.yml
+++ b/.github/workflows/inductor-tests.yml
@@ -8,7 +8,7 @@ on:
         type: string
         default: ""
       suite:
-        description: Space separated lists of test suites, all if empty
+        description: Space separated lists of test suites or "all"
         type: string
         default: >-
           inductor/test_codegen_triton.py


### PR DESCRIPTION
Allow using "all" for the "suite" input parameter to run all inductor tests. Previously the empty value used for all tests that was replaced by the default value, so this mode never worked.

Fixes #3545.