### PR TITLE
Set TORCH_XPU_ARCH_LIST when building PyTorch

### DIFF
--- a/.github/actions/setup-pytorch/action.yml
+++ b/.github/actions/setup-pytorch/action.yml
@@ -110,9 +110,6 @@ runs:
       shell: bash
       run: |
         source ${{ inputs.oneapi }}/setvars.sh
-        cd pytorch
-        pip install wheel
-        pip install -r requirements.txt
 
         # Limit AOT to PVC when compiling with LTS driver
         # See https://github.com/intel/intel-xpu-backend-for-triton/pull/3548#issuecomment-2685718019
@@ -123,6 +120,9 @@ runs:
           export TORCH_XPU_ARCH_LIST="pvc"
         fi
 
+        cd pytorch
+        pip install wheel
+        pip install -r requirements.txt
         USE_STATIC_MKL=1 CFLAGS="-Wno-error=maybe-uninitialized" python setup.py bdist_wheel 2>&1 | grep -v \
           "Double arithmetic operation is not supported on this platform with FP64 conversion emulation mode (poison FP64 kernels is enabled)." | grep -v '^$'
 

--- a/.github/actions/setup-pytorch/action.yml
+++ b/.github/actions/setup-pytorch/action.yml
@@ -115,9 +115,9 @@ runs:
         # See https://github.com/intel/intel-xpu-backend-for-triton/pull/3548#issuecomment-2685718019
         source ./scripts/capture-hw-details.sh
         if [[ $AGAMA_VERSION =~ 803 ]]; then
-          export TORCH_XPU_ARCH_LIST="pvc,bmg,dg2,arl-h,mtl-h"
-        else
           export TORCH_XPU_ARCH_LIST="pvc"
+        else
+          export TORCH_XPU_ARCH_LIST="pvc,bmg,dg2,arl-h,mtl-h"
         fi
 
         cd pytorch

--- a/.github/actions/setup-pytorch/action.yml
+++ b/.github/actions/setup-pytorch/action.yml
@@ -113,6 +113,16 @@ runs:
         cd pytorch
         pip install wheel
         pip install -r requirements.txt
+
+        # Limit AOT to PVC when compiling with LTS driver
+        # See https://github.com/intel/intel-xpu-backend-for-triton/pull/3548#issuecomment-2685718019
+        source ./scripts/capture-hw-details.sh
+        if [[ $AGAMA_VERSION =~ 803 ]]; then
+          export TORCH_XPU_ARCH_LIST="pvc,bmg,dg2,arl-h,mtl-h"
+        else
+          export TORCH_XPU_ARCH_LIST="pvc"
+        fi
+
         USE_STATIC_MKL=1 CFLAGS="-Wno-error=maybe-uninitialized" python setup.py bdist_wheel 2>&1 | grep -v \
           "Double arithmetic operation is not supported on this platform with FP64 conversion emulation mode (poison FP64 kernels is enabled)." | grep -v '^$'
 

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -72,6 +72,7 @@ jobs:
           $env:CMAKE_SHARED_LINKER_FLAGS = "/FORCE:MULTIPLE"
           $env:CMAKE_MODULE_LINKER_FLAGS = "/FORCE:MULTIPLE"
           $env:CMAKE_EXE_LINKER_FLAGS = "/FORCE:MULTIPLE"
+          $env:TORCH_XPU_ARCH_LIST = "bmg,dg2,arl-h,mtl-h"
           bash -c "PYTORCH_PROJ=/c/pytorch ./scripts/install-pytorch.sh --source --check-wheel"
 
       - name: PyTorch version


### PR DESCRIPTION
Set TORCH_XPU_ARCH_LIST to "pvc" only when compiling with LTS driver.

Fixes #3146.