### PR TITLE
Fix default runner label for Windows runners.

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -7,7 +7,7 @@ on:
       runner_label:
         description: Runner label
         type: string
-        default: win-a770
+        default: a770
       skip_list:
         description: Skip list
         type: string

--- a/.github/workflows/pip-test-windows.yml
+++ b/.github/workflows/pip-test-windows.yml
@@ -7,7 +7,7 @@ on:
       runner_label:
         description: Runner label
         type: string
-        default: win-a770
+        default: a770
       skip_list:
         description: Skip list
         type: string
@@ -44,7 +44,7 @@ jobs:
     name: Build and test
     runs-on:
       - windows
-      - ${{ inputs.runner_label || 'win-a770' }}
+      - ${{ inputs.runner_label || 'a770' }}
     steps:
       - name: Enable long paths
         run: |


### PR DESCRIPTION
Follow-up for #3532 to use consistent runner labels, for example `windows, a770` to select a runner.