### PR TITLE
Adjust workflows

### DIFF
--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -71,6 +71,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
       fail-fast: false
+      max-parallel: 2
 
     uses: ./.github/workflows/build-test-reusable.yml
     with:

--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -36,8 +36,6 @@ on:
         type: boolean
         default: false
 
-  schedule:
-    - cron: "5 23 * * *"
   pull_request:
     branches:
       - main


### PR DESCRIPTION
* Disable cron for triton-benchmarks. Instead, it will be triggered externally by Glados. This is to disable running this workflow by cron in forks.
* Limit concurrency for build-test-python.yml. Running 8 jobs in parallel creates unnecessary pressure on the servers.