### PR TITLE
[FA] Fix compile failure on advanced path

### DIFF
--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -108,6 +108,11 @@ unsigned ReduceOpHelper::getIntraWarpSizeWithUniqueData() {
 }
 
 bool ReduceOpHelper::isWarpSynchronous() {
+  // FIXME: In the default path tensors will always have a layout. Tensors do
+  // not have a layout only in the advanced path. We need to find a workaround
+  // in order to remove this change.
+  if (!srcEncoding)
+    return true;
   return getWarpsPerCTAWithUniqueData(srcEncoding, srcShape)[axis] == 1;
 }
 


### PR DESCRIPTION
The workaround for advanced path was accidentally removed in dc237c2edb85e51661eda5b612bc745bb1d3bbb7.