### PR TITLE
Use latest PyTorch wheel for Windows

### DIFF
--- a/.github/workflows/pip-test-windows.yml
+++ b/.github/workflows/pip-test-windows.yml
@@ -75,9 +75,7 @@ jobs:
       - name: Install PyTorch (wheels)
         run: |
           .venv\Scripts\activate.ps1
-          # The latest wheel does not work, see https://github.com/intel/intel-xpu-backend-for-triton/issues/3177#issuecomment-2599817729
-          # Use the latest good one
-          pip install torch==2.7.0.dev20250110+xpu --index-url https://download.pytorch.org/whl/nightly/xpu
+          pip install torch --index-url https://download.pytorch.org/whl/nightly/xpu
 
       - name: PyTorch version
         run: |


### PR DESCRIPTION
Previously we used a pinned version of PyTorch. Looks like the issue mentioned in https://github.com/intel/intel-xpu-backend-for-triton/issues/3177#issuecomment-2599817729 is now fixed, we can enable using the latest wheel.
