### PR TITLE
[Intel] special handling for transferWithinBlock for boolean values

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -190,6 +190,10 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
+    RankedTensorType srcTy = op.getSrc().getType();
+    auto srcElemTy = srcTy.getElementType();
+    const bool isInt1 = srcElemTy.isInteger(1);
+
     StringAttr kRegister = str_attr("register");
     StringAttr kLane = str_attr("lane");
     StringAttr kWarp = str_attr("warp");
@@ -348,8 +352,20 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
             targetInfo.loadDShared(rewriter, loc, vecAddr, std::nullopt,
                                    vec_ty(elemTy, scratchConfig.outVec),
                                    /*pred=*/b.true_val());
-        for (Value v : unpackLLVector(loc, valsVec, rewriter))
-          outVals[outRegSlice++] = v;
+        for (Value v : unpackLLVector(loc, valsVec, rewriter)) {
+          if (isInt1) {
+            // TODO(Intel): special handling for the boolean case required. Does
+            // this prevent a later optimization that we can't handle, or is
+            // there something about the layout/SLM loads and stores that
+            // requires special "transcribing" the boolean to the result of the
+            // cmp?
+            outVals[outRegSlice++] =
+                b.icmp_ne(v, rewriter.create<LLVM::ConstantOp>(
+                                 loc, i8_ty, rewriter.getI8IntegerAttr(0)));
+          } else {
+            outVals[outRegSlice++] = v;
+          }
+        }
       }
     }
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3275,7 +3275,7 @@ def test_convert1d_bool(M, src_layout, dst_layout, src_dim, dst_dim, device, tmp
     y_tri = torch.tensor(y, device=device)
     pgm = kernel[(1, 1, 1)](x_tri, y_tri)
     y_ref = x
-    np.testing.assert_allclose(y_ref, y_tri.cpu().numpy(), rtol=0.01, atol=1e-3)
+    np.testing.assert_allclose(y_ref, y_tri.cpu().numpy(), rtol=0, atol=0)
 
 
 @triton.jit

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3236,6 +3236,48 @@ def test_convert1d(M, src_layout, dst_layout, src_dim, dst_dim, device, tmp_path
     np.testing.assert_allclose(y_ref, y_tri.cpu().numpy(), rtol=0.01, atol=1e-3)
 
 
+@pytest.mark.parametrize("M", [64, 128, 256])
+@pytest.mark.parametrize("src_layout", filter_layouts(layouts))
+@pytest.mark.parametrize("dst_layout", filter_layouts(layouts))
+@pytest.mark.parametrize("src_dim", [0, 1])
+@pytest.mark.parametrize("dst_dim", [0, 1])
+def test_convert1d_bool(M, src_layout, dst_layout, src_dim, dst_dim, device, tmp_path: pathlib.Path):
+
+    ir = f"""
+    #dst = {dst_layout}
+    #src = {src_layout}
+    module attributes {{"{GPU_DIALECT}.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = {THREADS_PER_WARP} : i32}} {{
+        tt.func public @kernel(%arg0: !tt.ptr<i8> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<i32> {{tt.divisibility = 16 : i32}}) {{
+            %cst = arith.constant dense<0> : tensor<{M}xi8, #{GPU_DIALECT}.slice<{{dim = {src_dim}, parent = #src}}>>
+            %0 = tt.splat %arg0 : !tt.ptr<i8> -> tensor<{M}x!tt.ptr<i8>, #{GPU_DIALECT}.slice<{{dim = {src_dim}, parent = #src}}>>
+            %1 = tt.make_range {{end = {M} : i32, start = 0 : i32}} : tensor<{M}xi32, #{GPU_DIALECT}.slice<{{dim = {src_dim}, parent = #src}}>>
+            %2 = tt.addptr %0, %1 : tensor<{M}x!tt.ptr<i8>, #{GPU_DIALECT}.slice<{{dim = {src_dim}, parent = #src}}>>, tensor<{M}xi32, #{GPU_DIALECT}.slice<{{dim = {src_dim}, parent = #src}}>>
+            %3 = tt.load %2 : tensor<{M}x!tt.ptr<i8>, #{GPU_DIALECT}.slice<{{dim = {src_dim}, parent = #src}}>>
+            %4 = arith.cmpi ne, %3, %cst : tensor<{M}xi8, #{GPU_DIALECT}.slice<{{dim = {src_dim}, parent = #src}}>>
+            %5 = tt.splat %arg1 : !tt.ptr<i32> -> tensor<{M}x!tt.ptr<i32>, #{GPU_DIALECT}.slice<{{dim = {dst_dim}, parent = #dst}}>>
+            %6 = tt.make_range {{end = {M} : i32, start = 0 : i32}} : tensor<{M}xi32, #{GPU_DIALECT}.slice<{{dim = {dst_dim}, parent = #dst}}>>
+            %7 = tt.addptr %5, %6 : tensor<{M}x!tt.ptr<i32>, #{GPU_DIALECT}.slice<{{dim = {dst_dim}, parent = #dst}}>>, tensor<{M}xi32, #{GPU_DIALECT}.slice<{{dim = {dst_dim}, parent = #dst}}>>
+            %8 = {GPU_DIALECT}.convert_layout %4 : tensor<{M}xi1, #{GPU_DIALECT}.slice<{{dim = {src_dim}, parent = #src}}>> -> tensor<{M}xi1, #{GPU_DIALECT}.slice<{{dim = {dst_dim}, parent = #dst}}>>
+            %9 = arith.extui %8 : tensor<{M}xi1, #{GPU_DIALECT}.slice<{{dim = {dst_dim}, parent = #dst}}>> to tensor<{M}xi32, #{GPU_DIALECT}.slice<{{dim = {dst_dim}, parent = #dst}}>>
+            tt.store %7, %9 : tensor<{M}x!tt.ptr<i32>, #{GPU_DIALECT}.slice<{{dim = {dst_dim}, parent = #dst}}>>
+            tt.return
+        }}
+    }}
+    """
+    temp_file = tmp_path / "test_convert1d.ttgir"
+    temp_file.write_text(ir)
+    kernel = triton.compile(str(temp_file))
+
+    rs = RandomState(17)
+    x = rs.randint(0, 2, (M, )).astype('bool')
+    y = np.zeros((M, ), dtype='int32')
+    x_tri = torch.tensor(x, device=device)
+    y_tri = torch.tensor(y, device=device)
+    pgm = kernel[(1, 1, 1)](x_tri, y_tri)
+    y_ref = x
+    np.testing.assert_allclose(y_ref, y_tri.cpu().numpy(), rtol=0.01, atol=1e-3)
+
+
 @triton.jit
 def _welford_combine(mean_1, m2_1, weight_1, mean_2, m2_2, weight_2):
     delta = mean_2 - mean_1


### PR DESCRIPTION
Given this convert op layout lowering:

```
#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [16], order = [0]}>
#blocked1 = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [16], order = [0]}>

    %15 = arith.cmpi ne, %14, %cst : tensor<2048xi8, #blocked> loc(#loc9)
    %21 = ttg.convert_layout %15 : tensor<2048xi1, #blocked> -> tensor<2048xi1, #blocked1> loc(#loc15)
```

We discovered that the generated IR changed after https://github.com/intel/intel-xpu-backend-for-triton/pull/3515/files#diff-fd4c24537e95bcab1b909fd764c84d63e5a844e1aa1ffaf5354510572a7d8bc6 

Previously the shared memory load (after transformation) was returned as an `i8` pointer and each element was extracted using `gep` instructions: 
```
tail call spir_func void @_Z7barrierj(i32 1) #4, !dbg !33
  %54 = shl nuw nsw i32 %urem, 1, !dbg !33
  %55 = zext nneg i32 %54 to i64, !dbg !33
  %56 = getelementptr i8, ptr addrspace(3) %4, i64 %55, !dbg !33
  %57 = load i8, ptr addrspace(3) %56, align 2, !dbg !33
  %58 = icmp ne i8 %57, 0, !dbg !33
  %59 = getelementptr inbounds nuw i8, ptr addrspace(3) %56, i64 1, !dbg !33
  %60 = load i8, ptr addrspace(3) %59, align 1, !dbg !33
  %61 = icmp ne i8 %60, 0, !dbg !33
  %62 = or disjoint i32 %54, 1024, !dbg !33
  %63 = zext nneg i32 %62 to i64, !dbg !33
  %64 = getelementptr i8, ptr addrspace(3) %4, i64 %63, !dbg !33
  %65 = load i8, ptr addrspace(3) %64, align 2, !dbg !33
  %66 = icmp ne i8 %65, 0, !dbg !33
  %67 = getelementptr inbounds nuw i8, ptr addrspace(3) %64, i64 1, !dbg !33
  %68 = load i8, ptr addrspace(3) %67, align 1, !dbg !33
  %69 = icmp ne i8 %68, 0, !dbg !33
  %70 = zext i1 %58 to i64, !dbg !34
  %71 = zext i1 %61 to i64, !dbg !34
  %72 = zext i1 %66 to i64, !dbg !34
  %73 = zext i1 %69 to i64, !dbg !34
  %74 = zext i1 %34 to i64, !dbg !34
  %75 = zext i1 %35 to i64, !dbg !34
  %76 = zext i1 %36 to i64, !dbg !34
  %77 = zext i1 %37 to i64, !dbg !34
  tail call spir_func void @_Z7barrierj(i32 1) #4, !dbg !35
```

but using the upstream method of transferring between blocks using linear layout, the extract is using an `i1` vector of length 16:

```
 tail call spir_func void @_Z7barrierj(i32 1) #4, !dbg !33
  %53 = zext nneg i32 %17 to i64, !dbg !33
  %54 = getelementptr inbounds nuw i8, ptr addrspace(3) %4, i64 %53, !dbg !33
  %55 = load <16 x i1>, ptr addrspace(3) %54, align 2, !dbg !33
  %56 = zext nneg i32 %18 to i64, !dbg !33
  %57 = getelementptr inbounds nuw i8, ptr addrspace(3) %4, i64 %56, !dbg !33
  %58 = load <16 x i1>, ptr addrspace(3) %57, align 2, !dbg !33
  %59 = extractelement <16 x i1> %55, i64 0, !dbg !33
  %60 = extractelement <16 x i1> %55, i64 8, !dbg !33
  %61 = extractelement <16 x i1> %58, i64 0, !dbg !33
  %62 = extractelement <16 x i1> %58, i64 8, !dbg !33
  %63 = zext i1 %59 to i64, !dbg !34
  %64 = zext i1 %60 to i64, !dbg !34
  %65 = zext i1 %61 to i64, !dbg !34
  %66 = zext i1 %62 to i64, !dbg !34
  %67 = zext i1 %35 to i64, !dbg !34
  %68 = zext i1 %36 to i64, !dbg !34
  %69 = zext i1 %37 to i64, !dbg !34
  %70 = zext i1 %38 to i64, !dbg !34
  tail call spir_func void @_Z7barrierj(i32 1) #4, !dbg !35
```

this seems to be causing some trouble in the IGC lowering. 

Inserting the `icmp_ne` instruction (which was previously used in `processReplica` here: https://github.com/intel/intel-xpu-backend-for-triton/pull/3515/files#diff-3fa75fa6b39886d9576a671c306d98b0deb43f81c2fc7873ad08892d190d2622L215) forces us back to the existing method for doing the conversion. We need to figure out whether there is a true hardware limitation here or a bug, and it is possible there are better ways to handle this when converting the layouts. For now, I left the change in common upstream code and am marking this as a draft. But if this is the most expedient way to resolve the regression without side effect then I think we should move forward. 

cc #3570