### PR TITLE
[AMD][NFC] Add missing target dependency in CMake (#6086)

### DIFF
--- a/third_party/amd/test/lib/Analysis/CMakeLists.txt
+++ b/third_party/amd/test/lib/Analysis/CMakeLists.txt
@@ -1,6 +1,12 @@
 add_mlir_library(TritonAMDGPUTestAnalysis
   TestAMDRangeAnalysis.cpp
 
+  DEPENDS
+  TritonTableGen
+  TritonGPUTableGen
+  TritonGPUAttrDefsIncGen
+  TritonGPUTypeInterfacesIncGen
+
   LINK_LIBS PUBLIC
   MLIRPass
   ${triton_libs}


### PR DESCRIPTION
Add dependency to the target `TritonAMDGPUTestAnalysis` to fix issue in parallel building.