### PR TITLE
[PyTorch] Update timeout for inductor test suite: +4hours

### DIFF
--- a/.github/workflows/inductor-tests-reusable.yml
+++ b/.github/workflows/inductor-tests-reusable.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on:
       - linux
       - ${{ inputs.runner_label || 'rolling' }}
-    timeout-minutes: 720
+    timeout-minutes: 960
     defaults:
       run:
         shell: bash -noprofile --norc -eo pipefail -c "source /opt/intel/oneapi/2025.0/oneapi-vars.sh > /dev/null; source {0}"


### PR DESCRIPTION
12 hours isn't enough for all test suite: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/13632302494/job/38102585706

@pbchekin Is it possible/does it make sense to complicate and increase the timeout only for "all" test suite run?