### PR TITLE
Allow overriding the GPU_DEVICE variable for capture-hw-details.sh

### DIFF
--- a/scripts/capture-hw-details.sh
+++ b/scripts/capture-hw-details.sh
@@ -68,14 +68,17 @@ export LEVEL_ZERO_VERSION="$(level_zero_version)"
 # Use AGAMA_VERSION for GPU driver version on both Linux and Windows for backward compatibility.
 export AGAMA_VERSION="$(agama_version)"
 
-if command -v clinfo &> /dev/null; then
-    export GPU_DEVICE=$(clinfo --json | jq -r '[.devices[].online[] | select(.CL_DEVICE_TYPE.raw == 4)][0].CL_DEVICE_NAME')
-elif command -v nvidia-smi &> /dev/null; then
-    export GPU_DEVICE=$(nvidia-smi -L | sed -e 's,\(.*\) (UUID.*),\1,')
-elif command -v sycl-ls &> /dev/null; then
-    export GPU_DEVICE=$(ONEAPI_DEVICE_SELECTOR=level_zero:gpu sycl-ls --verbose 2>/dev/null | grep Name | sed -n '2p' | sed -E 's/\s+Name\s+:\s+(.+)$/\1/')
-else
-    export GPU_DEVICE="Not Installed"
+# Allow overriding GPU_DEVICE when other methods are unreliable (i.e. if reported name is too common)
+if [[ ! -v GPU_DEVICE ]]; then
+    if command -v clinfo &> /dev/null; then
+        export GPU_DEVICE=$(clinfo --json | jq -r '[.devices[].online[] | select(.CL_DEVICE_TYPE.raw == 4)][0].CL_DEVICE_NAME')
+    elif command -v nvidia-smi &> /dev/null; then
+        export GPU_DEVICE=$(nvidia-smi -L | sed -e 's,\(.*\) (UUID.*),\1,')
+    elif command -v sycl-ls &> /dev/null; then
+        export GPU_DEVICE=$(ONEAPI_DEVICE_SELECTOR=level_zero:gpu sycl-ls --verbose 2>/dev/null | grep Name | sed -n '2p' | sed -E 's/\s+Name\s+:\s+(.+)$/\1/')
+    else
+        export GPU_DEVICE="Not Installed"
+    fi
 fi
 
 if python -c "import torch" &> /dev/null; then


### PR DESCRIPTION
Allow overriding GPU_DEVICE when other methods are unreliable (i.e. if reported name is too common)