### PR TITLE
Remove PYTEST_MAX_PROCESSES from the workflow

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -23,7 +23,6 @@ env:
   PYTHONIOENCODING: utf-8
   NEW_WORKSPACE: C:\gh${{ github.run_id }}
   ZE_PATH: C:\level_zero
-  PYTEST_MAX_PROCESSES: 8
   SKIPLIST: --skip-list scripts/skiplist/${{ inputs.skip_list }}
   TRITON_TEST_CMD: bash -x scripts/test-triton.sh --skip-pytorch-install --skip-pip-install --skip-list scripts/skiplist/${{ inputs.skip_list }} --reports-dir reports --ignore-errors
 


### PR DESCRIPTION
Instead, it should be set for each windows runner.