### PR TITLE
Revert "Workaround for PyTorch compilation issue on Windows (#3523)"

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -65,8 +65,6 @@ jobs:
         run: |
           .venv\Scripts\activate.ps1
           Invoke-BatchFile "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
-          # FIXME: https://github.com/intel/intel-xpu-backend-for-triton/issues/3522
-          $env:INCLUDE += ";C:\Program Files (x86)\Intel\oneAPI\dnnl\latest\include\oneapi\dnnl"
           # Required to build on Windows
           $env:CMAKE_SHARED_LINKER_FLAGS = "/FORCE:MULTIPLE"
           $env:CMAKE_MODULE_LINKER_FLAGS = "/FORCE:MULTIPLE"


### PR DESCRIPTION
This reverts commit 877260fa418c9b2883b7aebf57b09a66d6487e55.

Looks like it's fixed in https://github.com/pytorch/pytorch/commit/2c35af4def76ce46a5f7acb62888664279d04d85. We have a newer PyTorch pin now.