### PR TITLE
Bump release of triton to 3.3.x

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -748,7 +748,7 @@ def get_git_version_suffix():
 
 setup(
     name=os.environ.get("TRITON_WHEEL_NAME", "triton"),
-    version="3.2.0" + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
+    version="3.3.0" + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
     author="Philippe Tillet",
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -1,5 +1,5 @@
 """isort:skip_file"""
-__version__ = '3.2.0'
+__version__ = '3.3.0'
 
 # ---------------------------------------
 # Note: import order is significant here.


### PR DESCRIPTION
Please see failure with triton xpu build when trying to advance the pin for the release: https://github.com/pytorch/pytorch/pull/148705

This is similar to: https://github.com/intel/intel-xpu-backend-for-triton/pull/2190