### PR TITLE
Introduce SPIRVTargetInfo to hold SPIRV-specific code for TargetInfo.

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/CMakeLists.txt
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/CMakeLists.txt
@@ -15,6 +15,7 @@ add_triton_library(TritonIntelGPUToLLVM
     ReduceOpToLLVM.cpp
     TritonGPUToLLVM.cpp
     SPMDOpToLLVM.cpp
+    SPIRVTargetInfo.cpp
     TargetInfo.cpp
     TensorPtrOpsToLLVM.cpp
     TritonGPUToLLVM.cpp

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/SPIRVTargetInfo.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/SPIRVTargetInfo.cpp
@@ -1,0 +1,74 @@
+//===- SPIRVTargetInfo.cpp - SPIRVTargetInfo implementation ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "SPIRVTargetInfo.h"
+#include "SPIRVSubgroupOps.h"
+#include "Utility.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+
+namespace mlir::triton::intel {
+
+namespace {
+
+template <typename GroupOp>
+Value createSPIRVGroupOp(RewriterBase &rewriter, Location loc, Type resultTy,
+                         Value acc, unsigned numLanesToReduce,
+                         unsigned warpSize) {
+  auto spvGroupOp = spirv::GroupOperation::Reduce;
+  Value clusterSize;
+  if (numLanesToReduce != warpSize) {
+    spvGroupOp = spirv::GroupOperation::ClusteredReduce;
+    clusterSize = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getI32Type(),
+        rewriter.getI32IntegerAttr(numLanesToReduce));
+  }
+
+  return rewriter.create<GroupOp>(loc, resultTy, spirv::Scope::Subgroup,
+                                  spvGroupOp, acc, clusterSize);
+}
+
+} // namespace
+
+bool SPIRVTargetInfo::isSupportedWarpReduceOp(Operation *op,
+                                              unsigned numLanesToReduce,
+                                              unsigned warpSize) const {
+  return isa<arith::AddFOp, arith::AddIOp, arith::MulFOp, arith::MulIOp,
+             arith::MaxSIOp, arith::MaxUIOp, arith::MinSIOp, arith::MinUIOp,
+             arith::MaxNumFOp, arith::MinNumFOp, arith::AndIOp, arith::OrIOp,
+             arith::XOrIOp>(op);
+}
+
+Value SPIRVTargetInfo::genWarpReduce(RewriterBase &rewriter, Location loc,
+                                     Value acc, Operation *reduceOp,
+                                     unsigned numLanesToReduce,
+                                     unsigned warpSize) const {
+  Type resultType = reduceOp->getResult(0).getType();
+  // Use bit-equivalent logical operation for Boolean values.
+  if (resultType.isInteger(1))
+    return TypeSwitch<mlir::Operation *, Value>(reduceOp)
+        .Case<arith::AddIOp, arith::MulIOp, arith::MaxSIOp, arith::MaxUIOp,
+              arith::MinSIOp, arith::MinUIOp, arith::AndIOp, arith::OrIOp,
+              arith::XOrIOp>([&](auto groupOp) {
+          return createSPIRVGroupOp<SPIRVLogicalGroupOpTy<decltype(groupOp)>>(
+              rewriter, loc, resultType, acc, numLanesToReduce, warpSize);
+        });
+  return TypeSwitch<mlir::Operation *, Value>(reduceOp)
+      .Case<arith::AddFOp, arith::AddIOp, arith::MulFOp, arith::MulIOp,
+            arith::MaxSIOp, arith::MaxUIOp, arith::MinSIOp, arith::MinUIOp,
+            arith::MaxNumFOp, arith::MinNumFOp, arith::AndIOp, arith::OrIOp,
+            arith::XOrIOp>([&](auto groupOp) {
+        return createSPIRVGroupOp<SPIRVGroupOpTy<decltype(groupOp)>>(
+            rewriter, loc, resultType, acc, numLanesToReduce, warpSize);
+      });
+}
+
+} // namespace mlir::triton::intel

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/SPIRVTargetInfo.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/SPIRVTargetInfo.h
@@ -1,0 +1,25 @@
+//===- SPIRVTargetInfo.h - Target dependent information for SPIRV arch ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TRITON_CONVERSION_TRITONGPU_TO_LLVM_SPIRVTARGETINFO_H
+#define TRITON_CONVERSION_TRITONGPU_TO_LLVM_SPIRVTARGETINFO_H
+
+#include "TargetInfo.h"
+
+namespace mlir::triton::intel {
+class SPIRVTargetInfo : public TargetInfo {
+protected:
+  bool isSupportedWarpReduceOp(Operation *op, unsigned numLanesToReduce,
+                               unsigned warpSize) const final;
+  Value genWarpReduce(RewriterBase &rewriter, Location loc, Value acc,
+                      Operation *reduceOp, unsigned numLanesToReduce,
+                      unsigned warpSize) const final;
+};
+} // namespace mlir::triton::intel
+
+#endif // TRITON_CONVERSION_TRITONGPU_TO_LLVM_SPIRVTARGETINFO_H

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.cpp
@@ -7,7 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "TargetInfo.h"
+#include "Dialect/TritonIntelGPU/IR/Utils.h"
 #include "SPIRVSubgroupOps.h"
+#include "SPIRVTargetInfo.h"
 #include "Utility.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -113,51 +115,6 @@ Value TargetInfo::programId(RewriterBase &rewriter, Location loc,
   return rewriter.create<arith::IndexCastOp>(loc, i32_ty, blockId);
 }
 
-namespace {
-
-template <typename GroupOp>
-Value createSPIRVGroupOp(RewriterBase &rewriter, Location loc, Type resultTy,
-                         Value acc, unsigned numLanesToReduce,
-                         unsigned warpSize) {
-  auto spvGroupOp = spirv::GroupOperation::Reduce;
-  Value clusterSize;
-  if (numLanesToReduce != warpSize) {
-    spvGroupOp = spirv::GroupOperation::ClusteredReduce;
-    clusterSize = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI32Type(),
-        rewriter.getI32IntegerAttr(numLanesToReduce));
-  }
-
-  Value result = rewriter.create<GroupOp>(loc, resultTy, spirv::Scope::Subgroup,
-                                          spvGroupOp, acc, clusterSize);
-  return result;
-}
-
-Value warpReduceHelper(RewriterBase &rewriter, Location loc, Value acc,
-                       Operation *reduceOp, unsigned numLanesToReduce,
-                       unsigned warpSize) {
-  auto resultType = reduceOp->getResult(0).getType();
-  // Use bit-equivalent logical operation for Boolean values.
-  if (resultType.isInteger(1))
-    return TypeSwitch<mlir::Operation *, Value>(reduceOp)
-        .Case<arith::AddIOp, arith::MulIOp, arith::MaxSIOp, arith::MaxUIOp,
-              arith::MinSIOp, arith::MinUIOp, arith::AndIOp, arith::OrIOp,
-              arith::XOrIOp>([&](auto groupOp) {
-          return createSPIRVGroupOp<SPIRVLogicalGroupOpTy<decltype(groupOp)>>(
-              rewriter, loc, resultType, acc, numLanesToReduce, warpSize);
-        });
-  return TypeSwitch<mlir::Operation *, Value>(reduceOp)
-      .Case<arith::AddFOp, arith::AddIOp, arith::MulFOp, arith::MulIOp,
-            arith::MaxSIOp, arith::MaxUIOp, arith::MinSIOp, arith::MinUIOp,
-            arith::MaxNumFOp, arith::MinNumFOp, arith::AndIOp, arith::OrIOp,
-            arith::XOrIOp>([&](auto groupOp) {
-        return createSPIRVGroupOp<SPIRVGroupOpTy<decltype(groupOp)>>(
-            rewriter, loc, resultType, acc, numLanesToReduce, warpSize);
-      });
-}
-
-} // namespace
-
 bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
                             SmallVector<Value> &acc, triton::ReduceOp op,
                             unsigned numLaneToReduce,
@@ -185,21 +142,15 @@ bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
       reduceOp->getOperand(1) != block.getArgument(1))
     return false;
 
-  auto supportedOp =
-      isa<arith::AddFOp, arith::AddIOp, arith::MulFOp, arith::MulIOp,
-          arith::MaxSIOp, arith::MaxUIOp, arith::MinSIOp, arith::MinUIOp,
-          arith::MaxNumFOp, arith::MinNumFOp, arith::AndIOp, arith::OrIOp,
-          arith::XOrIOp>(reduceOp);
-
-  if (!supportedOp)
-    return false;
-
   auto mod = op->getParentOfType<ModuleOp>();
   unsigned warpSize = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
 
+  if (!isSupportedWarpReduceOp(reduceOp, numLaneToReduce, warpSize))
+    return false;
+
   for (unsigned i = 0; i < acc.size(); ++i) {
-    acc[i] = warpReduceHelper(rewriter, loc, acc[i], reduceOp, numLaneToReduce,
-                              warpSize);
+    acc[i] = genWarpReduce(rewriter, loc, acc[i], reduceOp, numLaneToReduce,
+                           warpSize);
   }
 
   return true;
@@ -386,6 +337,12 @@ LLVM::GlobalOp TargetInfo::getGlobalString(Location loc, RewriterBase &rewriter,
   globals.try_emplace(cacheKey, global);
 
   return global;
+}
+
+std::unique_ptr<TargetInfo> createTargetInfo(ModuleOp mod) {
+  if (triton::gpu::intel::hasSpirvTargetArch(mod))
+    return std::unique_ptr<TargetInfo>(new SPIRVTargetInfo());
+  llvm_unreachable("createTargetInfo: unsupported target arch");
 }
 
 } // namespace mlir::triton::intel

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.h
@@ -75,6 +75,13 @@ public:
                              StringRef name, StringRef value,
                              unsigned addressSpace) const;
 
+protected:
+  virtual bool isSupportedWarpReduceOp(Operation *op, unsigned numLanesToReduce,
+                                       unsigned warpSize) const = 0;
+  virtual Value genWarpReduce(RewriterBase &rewriter, Location loc, Value acc,
+                              Operation *reduceOp, unsigned numLanesToReduce,
+                              unsigned warpSize) const = 0;
+
 private:
   LLVM::GlobalOp getGlobalString(Location loc, RewriterBase &rewriter,
                                  StringRef name, StringRef value,
@@ -83,5 +90,7 @@ private:
   mutable llvm::DenseMap<std::pair<unsigned, StringAttr>, LLVM::GlobalOp>
       globals;
 };
+
+std::unique_ptr<TargetInfo> createTargetInfo(ModuleOp mod);
 } // namespace mlir::triton::intel
 #endif // TRITON_CONVERSION_TRITONGPU_TO_LLVM_TARGETINFOINTEL_H

--- a/third_party/intel/lib/Utils/LLVMIntr.cpp
+++ b/third_party/intel/lib/Utils/LLVMIntr.cpp
@@ -5,7 +5,7 @@
 namespace mlir::triton::gpu::intel {
 
 LLVM::CallOp createDeviceFunctionCall(
-    ConversionPatternRewriter &rewriter, StringRef funcName, Type retType,
+    RewriterBase &rewriter, StringRef funcName, Type retType,
     ArrayRef<Type> argTypes, ArrayRef<Value> args,
     mlir::ArrayRef<std::pair<unsigned, mlir::StringRef>> paramAttrs,
     const LLVMFuncAttributeOptions &funcAttributeOptions,

--- a/third_party/intel/lib/Utils/LLVMIntr.h
+++ b/third_party/intel/lib/Utils/LLVMIntr.h
@@ -31,13 +31,14 @@ constexpr LLVMFuncAttributeOptions noUnwindWillReturnAttrs = {
 constexpr LLVMFuncAttributeOptions convergentNoUnwindWillReturnAttrs = {
     true, true, true, {}};
 
-LLVM::CallOp createDeviceFunctionCall(
-    ConversionPatternRewriter &rewriter, StringRef funcName, Type retType,
-    mlir::ArrayRef<mlir::Type> argTypes, ArrayRef<Value> args,
-    ArrayRef<std::pair<unsigned, StringRef>> paramAttrs,
-    const LLVMFuncAttributeOptions &funcAttributeOptions,
-    const AttributeList &passthroughAttrs = {},
-    LLVM::cconv::CConv cc = LLVM::cconv::CConv::SPIR_FUNC);
+LLVM::CallOp
+createDeviceFunctionCall(RewriterBase &rewriter, StringRef funcName,
+                         Type retType, mlir::ArrayRef<mlir::Type> argTypes,
+                         ArrayRef<Value> args,
+                         ArrayRef<std::pair<unsigned, StringRef>> paramAttrs,
+                         const LLVMFuncAttributeOptions &funcAttributeOptions,
+                         const AttributeList &passthroughAttrs = {},
+                         LLVM::cconv::CConv cc = LLVM::cconv::CConv::SPIR_FUNC);
 
 } // namespace mlir::triton::gpu::intel
 


### PR DESCRIPTION
This PR introduces `SPIRVTargetInfo` to use it for SPIRV-specific parts of `TargetInfo` implementation. This should provide us with better target code isolation and fewer merge conflicts.