### PR TITLE
[NFC] Cleanup `TritonIntelGPUToLLVM` utility

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1,4 +1,5 @@
 #include "PatternTritonGPUOpToLLVM.h"
+#include "mlir/Conversion/ArithCommon/AttrToLLVMConverter.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/MLIRContext.h"
 #include "third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Utility.h"

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -916,6 +916,34 @@ struct FpToFpOpConversion
     return rewriter.create<LLVM::FPExtOp>(loc, f32_ty, v);
   }
 
+  static LLVM::RoundingMode
+  convertTritonRoundingModeToLLVM(const triton::RoundingMode rounding) {
+    LLVM::RoundingMode roundingMode;
+    switch (rounding) {
+    case triton::RoundingMode::RTNE:
+      return LLVM::RoundingMode::NearestTiesToEven;
+    case triton::RoundingMode::RTZ:
+      return LLVM::RoundingMode::TowardZero;
+    default:
+      llvm::errs() << "WARNING: unsupported rounding mode for f32->f16 "
+                      "conversion: "
+                   << stringifyRoundingMode(rounding) << "\n";
+      llvm_unreachable("");
+    }
+  }
+
+  static Value convertFp32ToFp16(Location loc,
+                                 ConversionPatternRewriter &rewriter,
+                                 const Value &v,
+                                 const triton::RoundingMode rounding) {
+    MLIRContext *ctx = rewriter.getContext();
+    return rewriter.create<LLVM::ConstrainedFPTruncIntr>(
+        loc, f16_ty, v,
+        LLVM::RoundingModeAttr::get(ctx,
+                                    convertTritonRoundingModeToLLVM(rounding)),
+        arith::getLLVMDefaultFPExceptionBehavior(*ctx));
+  }
+
   std::pair<ConverterT, size_t>
   getConversionFunc(Type srcTy, Type dstTy,
                     std::optional<RoundingMode> roundingMode) const {
@@ -1014,8 +1042,8 @@ struct FpToFpOpConversion
              "rounding mode must be specified for fp32->fp16 conversion");
       SmallVector<Value> outVals;
       for (Value v : operands[0]) {
-        outVals.push_back(LLVM::intel::convertFp32ToFp16(loc, rewriter, v,
-                                                         roundingMode.value()));
+        outVals.push_back(
+            convertFp32ToFp16(loc, rewriter, v, roundingMode.value()));
       }
       return outVals;
     }
@@ -1044,8 +1072,7 @@ struct FpToFpOpConversion
     }
     if (useFP16IntermediateSrc)
       for (Value &v : inVals)
-        v = LLVM::intel::convertFp32ToFp16(loc, rewriter, v,
-                                           roundingMode.value());
+        v = convertFp32ToFp16(loc, rewriter, v, roundingMode.value());
     inVals.resize(numElements, b.undef(typeConverter->convertType(srcType)));
     SmallVector<Value> outVals = cvtFunc(loc, rewriter, inVals);
     assert(outVals.size() == inVals.size());

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "Utility.h"
-#include "mlir/Conversion/ArithCommon/AttrToLLVMConverter.h"
-#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -69,8 +67,8 @@ static Value shuffleCommonImpl(Location loc, RewriterBase &rewriter, Value val,
 
 static Value shuffleCommon(Location loc, RewriterBase &rewriter, Value val,
                            Value i, mlir::gpu::ShuffleMode mode) {
-  // To shuffle pointers, convert them to i64.
   auto b = TritonLLVMOpBuilder(loc, rewriter);
+  // To shuffle pointers, convert them to i64.
   Type valTy = val.getType();
   if (isa<LLVM::LLVMPointerType>(valTy))
     val = b.ptrtoint(i64_ty, val);
@@ -99,59 +97,6 @@ Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, int i) {
 
 Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, Value i) {
   return shuffleCommon(loc, rewriter, val, i, mlir::gpu::ShuffleMode::IDX);
-}
-
-// declare __spirv_ocl_printf(i8*, ...) as external function
-LLVM::LLVMFuncOp getSpirvPrintfDeclaration(RewriterBase &rewriter) {
-  auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
-  StringRef funcName("_Z18__spirv_ocl_printf");
-  Operation *funcOp = moduleOp.lookupSymbol(funcName);
-  if (funcOp)
-    return cast<LLVM::LLVMFuncOp>(*funcOp);
-
-  MLIRContext *context = rewriter.getContext();
-  auto ptrTy = LLVM::LLVMPointerType::get(
-      context, TritonGEN::TritonGENMemorySpace::kUniformConstant);
-  SmallVector<Type> argsType{ptrTy};
-  auto retType = i32_ty;
-  auto funcType =
-      LLVM::LLVMFunctionType::get(retType, argsType, /*isVarArg*/ true);
-
-  ConversionPatternRewriter::InsertionGuard guard(rewriter);
-  rewriter.setInsertionPointToStart(moduleOp.getBody());
-
-  auto printFunc = rewriter.create<LLVM::LLVMFuncOp>(
-      UnknownLoc::get(context), funcName, funcType, LLVM::Linkage::External,
-      /*dsoLocal*/ false, LLVM::CConv::SPIR_FUNC, /*comdat=*/SymbolRefAttr{});
-  printFunc->setAttr("nounwind", rewriter.getUnitAttr());
-
-  return printFunc;
-}
-
-static LLVM::RoundingMode
-convertTritonRoundingModeToLLVM(const triton::RoundingMode rounding) {
-  LLVM::RoundingMode roundingMode;
-  switch (rounding) {
-  case triton::RoundingMode::RTNE:
-    return LLVM::RoundingMode::NearestTiesToEven;
-  case triton::RoundingMode::RTZ:
-    return LLVM::RoundingMode::TowardZero;
-  default:
-    llvm::errs() << "WARNING: unsupported rounding mode for f32->f16 "
-                    "conversion: "
-                 << stringifyRoundingMode(rounding) << "\n";
-    llvm_unreachable("");
-  }
-}
-
-Value convertFp32ToFp16(Location loc, ConversionPatternRewriter &rewriter,
-                        const Value &v, const triton::RoundingMode rounding) {
-  MLIRContext *ctx = rewriter.getContext();
-  return rewriter.create<LLVM::ConstrainedFPTruncIntr>(
-      loc, f16_ty, v,
-      LLVM::RoundingModeAttr::get(ctx,
-                                  convertTritonRoundingModeToLLVM(rounding)),
-      arith::getLLVMDefaultFPExceptionBehavior(*ctx));
 }
 
 } // namespace mlir::LLVM::intel

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
@@ -9,15 +9,14 @@
 #ifndef TRITON_CONVERSION_TRITONINTELGPU_TO_LLVM_UTILITY_H
 #define TRITON_CONVERSION_TRITONINTELGPU_TO_LLVM_UTILITY_H
 
-#include "intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h"
-#include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
-#include "intel/include/Dialect/TritonIntelGPU/Transforms/Utility.h"
-#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
-#include "triton/Dialect/Triton/IR/Utility.h"
-#include "llvm/Support/ErrorHandling.h"
 
 namespace mlir::LLVM::intel {
+
+Value shuffleXor(Location loc, RewriterBase &rewriter, Value val, int i);
+Value shuffleUp(Location loc, RewriterBase &rewriter, Value val, int i);
+Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, int i);
+Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, Value i);
 
 /// Create a predicated block, using \p cond as the condition and \p ops for the
 /// values supplied by the conditional branch to the exit block. The \p
@@ -72,22 +71,6 @@ Block &createPredicatedBlock(RewriterBase &rewriter, Location loc, Value cond,
                              ThenOpsFn &&thenOpsFn) {
   return createPredicatedBlock(rewriter, loc, cond, {}, thenOpsFn);
 }
-
-Value shuffleXor(Location loc, RewriterBase &rewriter, Value val, int i);
-Value shuffleUp(Location loc, RewriterBase &rewriter, Value val, int i);
-Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, int i);
-Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, Value i);
-
-LLVM::LLVMFuncOp getSpirvPrintfDeclaration(RewriterBase &rewriter);
-
-static Value getModuleWarpSize(RewriterBase &rewriter, Location loc) {
-  auto b = TritonLLVMOpBuilder(loc, rewriter);
-  auto mod = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
-  return b.i32_val(triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod));
-}
-
-Value convertFp32ToFp16(Location loc, ConversionPatternRewriter &rewriter,
-                        const Value &v, triton::RoundingMode rounding);
 
 } // namespace mlir::LLVM::intel
 


### PR DESCRIPTION
This PR makes `TritonIntelGPUToLLVM` utility closer to `TritonNvidiaGPUToLLVM` utility, so it is easier to sync changes when needed.