### PR TITLE
[Intel] Cleanup `TritonGPUOpToLLVM` patterns

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM.cpp
@@ -53,7 +53,7 @@ struct DotOpConversion : public ConvertTritonGPUOpToLLVMPattern<triton::DotOp> {
 } // namespace
 
 void mlir::triton::intel::populateDotOpToLLVMPatterns(
-    TritonIntelGPUToLLVMTypeConverter &typeConverter,
-    RewritePatternSet &patterns, PatternBenefit benefit) {
+    LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    PatternBenefit benefit) {
   patterns.add<DotOpConversion>(typeConverter, benefit);
 }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -295,8 +295,7 @@ struct PrefetchOpConversion
       triton::gpu::intel::PrefetchOp>::ConvertTritonGPUOpToLLVMPattern;
 
   PrefetchOpConversion(
-      TritonGPUToLLVMTypeConverter &converter,
-      const triton::intel::TargetInfo &targetInfo,
+      LLVMTypeConverter &converter, const triton::intel::TargetInfo &targetInfo,
       const triton::intel::ModuleAxisInfoAnalysis &axisAnalysisPass,
       PatternBenefit benefit)
       : ConvertTritonGPUOpToLLVMPattern<triton::gpu::intel::PrefetchOp>(
@@ -473,8 +472,7 @@ struct LoadOpToBlockIOConversion
   using ValueTable = std::map<std::pair<int, int>, Value>;
 
   LoadOpToBlockIOConversion(
-      TritonIntelGPUToLLVMTypeConverter &converter,
-      const triton::intel::TargetInfo &targetInfo,
+      LLVMTypeConverter &converter, const triton::intel::TargetInfo &targetInfo,
       const triton::intel::ModuleAxisInfoAnalysis &axisAnalysisPass,
       PatternBenefit benefit)
       : ConvertTritonGPUOpToLLVMPattern<triton::LoadOp>(converter, benefit),
@@ -567,7 +565,7 @@ struct LoadOpToBlockIOConversion
                                               dpasInstShape[1]};
     unsigned elemsPerLanePerDPASInst =
         product<unsigned>(elemsPerDPASInst) / threadsPerWarp;
-    TritonGPUToLLVMTypeConverter *typeConverter = getTypeConverter();
+    LLVMTypeConverter *typeConverter = getTypeConverter();
     Type unpackedDPASOperandType = LLVM::getFixedVectorType(
         typeConverter->convertType(eltTy), elemsPerLanePerDPASInst);
 
@@ -964,8 +962,7 @@ struct LoadOpConversion
   using ValueTable = std::map<std::pair<int, int>, Value>;
 
   LoadOpConversion(
-      TritonIntelGPUToLLVMTypeConverter &converter,
-      const triton::intel::TargetInfo &targetInfo,
+      LLVMTypeConverter &converter, const triton::intel::TargetInfo &targetInfo,
       const triton::intel::ModuleAxisInfoAnalysis &axisAnalysisPass,
       PatternBenefit benefit, bool oneMatrixPerLoadForBT)
       : ConvertTritonGPUOpToLLVMPattern<triton::LoadOp>(converter, benefit),
@@ -1159,7 +1156,7 @@ struct LoadOpConversion
         }
       }
 
-      TritonGPUToLLVMTypeConverter *typeConverter = getTypeConverter();
+      LLVMTypeConverter *typeConverter = getTypeConverter();
       Type llvmResultStructTy = typeConverter->convertType(op.getType());
       Value resultStruct = packLLElements(
           loc, typeConverter, unpackedLoadedVals, rewriter, llvmResultStructTy);
@@ -1176,7 +1173,7 @@ struct LoadOpConversion
                                               dpasInstShape[1]};
     unsigned elemsPerLanePerDPASInst =
         product<unsigned>(elemsPerDPASInst) / threadsPerWarp;
-    TritonGPUToLLVMTypeConverter *typeConverter = getTypeConverter();
+    LLVMTypeConverter *typeConverter = getTypeConverter();
     Type unpackedDPASOperandType = LLVM::getFixedVectorType(
         typeConverter->convertType(eltTy), elemsPerLanePerDPASInst);
 
@@ -1640,8 +1637,7 @@ struct StoreOpConversion
       triton::StoreOp>::ConvertTritonGPUOpToLLVMPattern;
 
   StoreOpConversion(
-      TritonIntelGPUToLLVMTypeConverter &converter,
-      const triton::intel::TargetInfo &targetInfo,
+      LLVMTypeConverter &converter, const triton::intel::TargetInfo &targetInfo,
       const triton::intel::ModuleAxisInfoAnalysis &axisAnalysisPass,
       PatternBenefit benefit)
       : ConvertTritonGPUOpToLLVMPattern<triton::StoreOp>(converter, benefit),
@@ -1660,7 +1656,7 @@ struct StoreOpConversion
       return failure();
 
     auto dpasLayout = cast<DpasEncodingAttr>(tensorType.getEncoding());
-    TritonGPUToLLVMTypeConverter *typeConverter = getTypeConverter();
+    LLVMTypeConverter *typeConverter = getTypeConverter();
     MLIRContext *ctx = rewriter.getContext();
 
     Type eltTy = tensorType.getElementType();
@@ -1919,8 +1915,7 @@ struct AtomicCASOpConversion
       triton::AtomicCASOp>::ConvertTritonGPUOpToLLVMPattern;
 
   AtomicCASOpConversion(
-      TritonIntelGPUToLLVMTypeConverter &converter,
-      const triton::intel::TargetInfo &targetInfo,
+      LLVMTypeConverter &converter, const triton::intel::TargetInfo &targetInfo,
       const triton::intel::ModuleAxisInfoAnalysis &axisAnalysisPass,
       PatternBenefit benefit)
       : ConvertTritonGPUOpToLLVMPattern<triton::AtomicCASOp>(converter,
@@ -2044,8 +2039,7 @@ struct AtomicRMWOpConversion
       triton::AtomicRMWOp>::ConvertTritonGPUOpToLLVMPattern;
 
   AtomicRMWOpConversion(
-      TritonIntelGPUToLLVMTypeConverter &converter,
-      const triton::intel::TargetInfo &targetInfo,
+      LLVMTypeConverter &converter, const triton::intel::TargetInfo &targetInfo,
       const triton::intel::ModuleAxisInfoAnalysis &axisAnalysisPass,
       PatternBenefit benefit)
       : ConvertTritonGPUOpToLLVMPattern<triton::AtomicRMWOp>(converter,
@@ -2312,8 +2306,8 @@ struct AtomicRMWOpConversion
 } // namespace
 
 void mlir::triton::intel::populateLoadStoreOpToLLVMPatterns(
-    TritonIntelGPUToLLVMTypeConverter &typeConverter,
-    const TargetInfo &targetInfo, RewritePatternSet &patterns,
+    LLVMTypeConverter &typeConverter, const TargetInfo &targetInfo,
+    RewritePatternSet &patterns,
     const intel::ModuleAxisInfoAnalysis &axisInfoAnalysis,
     PatternBenefit benefit, bool oneMatrixPerLoadForBT) {
   patterns.add<AtomicCASOpConversion, AtomicRMWOpConversion, StoreOpConversion,

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -11,84 +11,76 @@ namespace mlir::triton::intel {
 
 constexpr int patternBenefitAddSPIRVEnv = 30;
 
-// Custom Arith Dialect patterns.
+/* Advanced path custom patterns start */
+
 void populateArithOpsToLLVMPatterns(
     TritonIntelGPUToLLVMTypeConverter &typeConverter,
     RewritePatternSet &patterns, PatternBenefit benefit);
+
+void populateBF16CastsLLVMPatterns(LLVMTypeConverter &typeConverter,
+                                   RewritePatternSet &patterns,
+                                   PatternBenefit benefit);
 
 void populateTritonOpsToLLVMPatterns(
     TritonIntelGPUToLLVMTypeConverter &typeConverter,
     RewritePatternSet &patterns, PatternBenefit benefit);
 
-void populateBarrierOpToLLVMPatterns(
-    TritonIntelGPUToLLVMTypeConverter &typeConverter,
-    RewritePatternSet &patterns, PatternBenefit benefit);
+/* Advanced path custom patterns end */
 
-void populateConvertLayoutOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
-                                           const TargetInfo &targetInfo,
-                                           RewritePatternSet &patterns,
-                                           PatternBenefit benefit);
-
-void populateDotOpToLLVMPatterns(
-    TritonIntelGPUToLLVMTypeConverter &typeConverter,
-    RewritePatternSet &patterns, PatternBenefit benefit);
+/* Specialized common patterns start */
 
 void populateElementwiseOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
     ModuleAxisInfoAnalysis &axisInfoAnalysis, const TargetInfoBase &targetInfo,
     PatternBenefit benefit);
 
-void populateFp4ToFpToLLVMPatterns(LLVMTypeConverter &typeConverter,
-                                   RewritePatternSet &patterns,
-                                   PatternBenefit benefit);
-
-void populateBF16CastsLLVMPatterns(LLVMTypeConverter &typeConverter,
-                                   RewritePatternSet &patterns,
-                                   PatternBenefit benefit);
-
 void populateHistogramOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                        RewritePatternSet &patterns,
                                        const TargetInfoBase &targetInfo,
                                        PatternBenefit benefit);
-
-void populateLoadStoreOpToLLVMPatterns(
-    TritonIntelGPUToLLVMTypeConverter &typeConverter,
-    const TargetInfo &targetInfo, RewritePatternSet &patterns,
-    const ModuleAxisInfoAnalysis &axisInfoAnalysis, PatternBenefit benefit,
-    bool oneMatrixPerLoadForBT);
 
 void populateReduceOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                     RewritePatternSet &patterns,
                                     const TargetInfoBase &targetInfo,
                                     PatternBenefit benefit);
 
-void populateTensorPtrOpsToLLVMPatterns(
-    TritonIntelGPUToLLVMTypeConverter &typeConverter,
-    RewritePatternSet &patterns, PatternBenefit benefit);
-
-void populateTritonGPUToLLVMPatterns(
-    TritonIntelGPUToLLVMTypeConverter &typeConverter,
-    RewritePatternSet &patterns, PatternBenefit benefit);
-
-void populatePrintOpToLLVMPattern(
-    TritonIntelGPUToLLVMTypeConverter &typeConverter,
-    RewritePatternSet &patterns, const TargetInfoBase &targetInfo,
-    PatternBenefit benefit);
-
-void populateMemoryOpToLLVMPattern(LLVMTypeConverter &typeConverter,
-                                   const TargetInfoBase &targetInfo,
-                                   RewritePatternSet &patterns,
-                                   PatternBenefit benefit);
-
-void populateControlFlowOpToLLVMPattern(LLVMTypeConverter &typeConverter,
-                                        RewritePatternSet &patterns,
-                                        const TargetInfoBase &targetInfo,
-                                        PatternBenefit benefit);
+void populateConvertLayoutOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
+                                           const TargetInfo &targetInfo,
+                                           RewritePatternSet &patterns,
+                                           PatternBenefit benefit);
 
 void populateSPMDOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                  RewritePatternSet &patterns,
                                  const TargetInfoBase &targetInfo,
                                  PatternBenefit benefit);
+
+void populatePrintOpToLLVMPattern(LLVMTypeConverter &typeConverter,
+                                  RewritePatternSet &patterns,
+                                  const TargetInfoBase &targetInfo,
+                                  PatternBenefit benefit);
+
+/* Specialized common patterns end */
+
+/* Third party patterns start */
+
+void populateDotOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
+                                 RewritePatternSet &patterns,
+                                 PatternBenefit benefit);
+
+void populateFp4ToFpToLLVMPatterns(LLVMTypeConverter &typeConverter,
+                                   RewritePatternSet &patterns,
+                                   PatternBenefit benefit);
+
+void populateLoadStoreOpToLLVMPatterns(
+    LLVMTypeConverter &typeConverter, const TargetInfo &targetInfo,
+    RewritePatternSet &patterns, const ModuleAxisInfoAnalysis &axisInfoAnalysis,
+    PatternBenefit benefit, bool oneMatrixPerLoadForBT);
+
+void populateTensorPtrOpsToLLVMPatterns(LLVMTypeConverter &typeConverter,
+                                        RewritePatternSet &patterns,
+                                        PatternBenefit benefit);
+
+/* Third party patterns end */
 
 } // namespace mlir::triton::intel
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PrintOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PrintOpToLLVM.cpp
@@ -241,8 +241,7 @@ protected:
 } // namespace
 
 void mlir::triton::intel::populatePrintOpToLLVMPattern(
-    TritonIntelGPUToLLVMTypeConverter &typeConverter,
-    RewritePatternSet &patterns, const TargetInfoBase &targetInfo,
-    PatternBenefit benefit) {
+    LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    const TargetInfoBase &targetInfo, PatternBenefit benefit) {
   patterns.add<PrintOpConversion>(typeConverter, targetInfo, benefit);
 }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TensorPtrOpsToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TensorPtrOpsToLLVM.cpp
@@ -97,8 +97,8 @@ struct AdvanceOpConversion
 } // namespace
 
 void mlir::triton::intel::populateTensorPtrOpsToLLVMPatterns(
-    TritonIntelGPUToLLVMTypeConverter &typeConverter,
-    RewritePatternSet &patterns, PatternBenefit benefit) {
+    LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    PatternBenefit benefit) {
   patterns.add<MakeTensorPtrOpConversion>(typeConverter, benefit);
   patterns.add<AdvanceOpConversion>(typeConverter, benefit);
   return;


### PR DESCRIPTION
- Remove unused pattern declarations.
- Reduce `TritonIntelGPUToLLVMTypeConverter` usage.
- NFC code reordering.