### PR TITLE
Enable xccl in pytorch

### DIFF
--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -196,7 +196,7 @@ function build_pytorch {
   cd "$PYTORCH_PROJ"
   pip install -r requirements.txt
   pip install cmake ninja
-  USE_STATIC_MKL=1 python setup.py bdist_wheel
+  USE_XCCL=1 USE_STATIC_MKL=1 python setup.py bdist_wheel
 }
 
 function install_pytorch {


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
With https://github.com/pytorch/pytorch/pull/141856, XCCL has been enabled natively in PyTorch.
With https://github.com/intel/torch-xpu-ops/pull/1441, ```USE_XCCL``` is the option to turn on XCCL.
Users of Intel triton need XCCL enabled to run distributed inference and further test distributed kernels.

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
