### PR TITLE
Explicitly enable used SPIRV extensions

### DIFF
--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -1,3 +1,4 @@
+
 #include "intel/include/Target/SPIRV/SPIRVTranslation.h"
 
 #include "LLVMSPIRVLib.h"
@@ -109,45 +110,8 @@ public:
 
 static SPIRV::TranslatorOpts getSPIRVOopts() {
   SPIRV::TranslatorOpts SPIRVOpts;
-  std::vector<SPIRV::ExtensionID> AllowedExtensions{
-      SPIRV::ExtensionID::SPV_KHR_bit_instructions,
-      SPIRV::ExtensionID::SPV_EXT_shader_atomic_float_add,
-      SPIRV::ExtensionID::SPV_EXT_shader_atomic_float_min_max,
-      SPIRV::ExtensionID::SPV_KHR_no_integer_wrap_decoration,
-      SPIRV::ExtensionID::SPV_KHR_float_controls,
-      SPIRV::ExtensionID::SPV_KHR_expect_assume,
-      SPIRV::ExtensionID::SPV_KHR_linkonce_odr,
-      SPIRV::ExtensionID::SPV_INTEL_subgroups,
-      SPIRV::ExtensionID::SPV_INTEL_media_block_io,
-      SPIRV::ExtensionID::SPV_INTEL_unstructured_loop_controls,
-      SPIRV::ExtensionID::SPV_INTEL_blocking_pipes,
-      SPIRV::ExtensionID::SPV_INTEL_function_pointers,
-      SPIRV::ExtensionID::SPV_INTEL_kernel_attributes,
-      SPIRV::ExtensionID::SPV_INTEL_inline_assembly,
-      SPIRV::ExtensionID::SPV_INTEL_arbitrary_precision_integers,
-      SPIRV::ExtensionID::SPV_INTEL_float_controls2,
-      SPIRV::ExtensionID::SPV_INTEL_vector_compute,
-      SPIRV::ExtensionID::SPV_INTEL_fast_composite,
-      SPIRV::ExtensionID::SPV_INTEL_arbitrary_precision_fixed_point,
-      SPIRV::ExtensionID::SPV_INTEL_arbitrary_precision_floating_point,
-      SPIRV::ExtensionID::SPV_INTEL_fp_fast_math_mode,
-      SPIRV::ExtensionID::SPV_INTEL_long_composites,
-      SPIRV::ExtensionID::SPV_INTEL_arithmetic_fence,
-      SPIRV::ExtensionID::SPV_INTEL_global_variable_decorations,
-      SPIRV::ExtensionID::SPV_INTEL_cache_controls,
-      SPIRV::ExtensionID::SPV_KHR_shader_clock,
-      SPIRV::ExtensionID::SPV_INTEL_bindless_images,
-      SPIRV::ExtensionID::SPV_INTEL_task_sequence,
-      SPIRV::ExtensionID::SPV_INTEL_bfloat16_conversion,
-      SPIRV::ExtensionID::SPV_INTEL_hw_thread_queries,
-      SPIRV::ExtensionID::SPV_KHR_uniform_group_instructions,
-      SPIRV::ExtensionID::SPV_INTEL_masked_gather_scatter,
-      SPIRV::ExtensionID::SPV_INTEL_tensor_float32_rounding,
-      SPIRV::ExtensionID::SPV_INTEL_optnone,
-      SPIRV::ExtensionID::SPV_KHR_non_semantic_info,
-      SPIRV::ExtensionID::SPV_KHR_cooperative_matrix,
-      SPIRV::ExtensionID::SPV_EXT_shader_atomic_float16_add,
-      SPIRV::ExtensionID::SPV_INTEL_fp_max_error};
+  std::vector<SPIRV::ExtensionID> AllowedExtensions{ SPIRV::ExtensionID::SPV_KHR_bit_instructions,SPIRV::ExtensionID::SPV_EXT_shader_atomic_float_add,SPIRV::ExtensionID::SPV_INTEL_arbitrary_precision_integers,SPIRV::ExtensionID::SPV_INTEL_vector_compute,SPIRV::ExtensionID::SPV_INTEL_bfloat16_conversion,
+ SPIRV::ExtensionID::SPV_INTEL_subgroups };
 
   SPIRVOpts.setMemToRegEnabled(true);
   SPIRVOpts.setPreserveOCLKernelArgTypeMetadataThroughString(true);
@@ -156,6 +120,9 @@ static SPIRV::TranslatorOpts getSPIRVOopts() {
 
   for (auto &Ext : AllowedExtensions)
       SPIRVOpts.setAllowedToUseExtension(Ext, true);
+  //SPIRVOpts.enableAllExtensions();
+  //SPIRVOpts.setAllowedToUseExtension(
+  //SPIRV::ExtensionID::SPV_KHR_untyped_pointers, false);
   return SPIRVOpts;
 }
 

--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -107,7 +107,7 @@ public:
   SmallVectorBuffer(llvm::SmallVectorImpl<char> &O) : OS(O) {}
 };
 
-static SPIRV::TranslatorOpts getAllowedExtensions() {
+static SPIRV::TranslatorOpts getSPIRVOopts() {
   SPIRV::TranslatorOpts SPIRVOpts;
   std::vector<SPIRV::ExtensionID> AllowedExtensions{
       SPIRV::ExtensionID::SPV_KHR_bit_instructions,
@@ -119,14 +119,10 @@ static SPIRV::TranslatorOpts getAllowedExtensions() {
       SPIRV::ExtensionID::SPV_KHR_linkonce_odr,
       SPIRV::ExtensionID::SPV_INTEL_subgroups,
       SPIRV::ExtensionID::SPV_INTEL_media_block_io,
-      SPIRV::ExtensionID::SPV_INTEL_device_side_avc_motion_estimation,
-      SPIRV::ExtensionID::SPV_INTEL_fpga_loop_controls,
       SPIRV::ExtensionID::SPV_INTEL_unstructured_loop_controls,
-      SPIRV::ExtensionID::SPV_INTEL_fpga_reg,
       SPIRV::ExtensionID::SPV_INTEL_blocking_pipes,
       SPIRV::ExtensionID::SPV_INTEL_function_pointers,
       SPIRV::ExtensionID::SPV_INTEL_kernel_attributes,
-      SPIRV::ExtensionID::SPV_INTEL_io_pipes,
       SPIRV::ExtensionID::SPV_INTEL_inline_assembly,
       SPIRV::ExtensionID::SPV_INTEL_arbitrary_precision_integers,
       SPIRV::ExtensionID::SPV_INTEL_float_controls2,
@@ -140,15 +136,10 @@ static SPIRV::TranslatorOpts getAllowedExtensions() {
       SPIRV::ExtensionID::SPV_INTEL_arithmetic_fence,
       SPIRV::ExtensionID::SPV_INTEL_global_variable_decorations,
       SPIRV::ExtensionID::SPV_INTEL_cache_controls,
-      SPIRV::ExtensionID::SPV_INTEL_fpga_buffer_location,
-      SPIRV::ExtensionID::SPV_INTEL_fpga_argument_interfaces,
-      SPIRV::ExtensionID::SPV_INTEL_fpga_invocation_pipelining_attributes,
-      SPIRV::ExtensionID::SPV_INTEL_fpga_latency_control,
       SPIRV::ExtensionID::SPV_KHR_shader_clock,
       SPIRV::ExtensionID::SPV_INTEL_bindless_images,
       SPIRV::ExtensionID::SPV_INTEL_task_sequence,
       SPIRV::ExtensionID::SPV_INTEL_bfloat16_conversion,
-      SPIRV::ExtensionID::SPV_INTEL_joint_matrix,
       SPIRV::ExtensionID::SPV_INTEL_hw_thread_queries,
       SPIRV::ExtensionID::SPV_KHR_uniform_group_instructions,
       SPIRV::ExtensionID::SPV_INTEL_masked_gather_scatter,
@@ -163,9 +154,6 @@ static SPIRV::TranslatorOpts getAllowedExtensions() {
   SPIRVOpts.setPreserveOCLKernelArgTypeMetadataThroughString(true);
   SPIRVOpts.setPreserveAuxData(false);
   SPIRVOpts.setSPIRVAllowUnknownIntrinsics({"llvm.genx.GenISA."});
-  //SPIRVOpts.enableAllExtensions();
-  //SPIRVOpts.setAllowedToUseExtension(
-  //SPIRV::ExtensionID::SPV_KHR_untyped_pointers, false);
 
   for (auto &Ext : AllowedExtensions)
       SPIRVOpts.setAllowedToUseExtension(Ext, true);
@@ -192,7 +180,7 @@ std::string translateLLVMIRToSPIRV(llvm::Module &module) {
   std::ostream OS(&StreamBuf);
   std::string Err;
 
-  SPIRV::TranslatorOpts SPIRVOpts = getAllowedExtensions();
+  SPIRV::TranslatorOpts SPIRVOpts = getSPIRVOopts();
 
 #if defined(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
   int SpvTranslateMode = 0;

--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -110,8 +110,14 @@ public:
 
 static SPIRV::TranslatorOpts getSPIRVOopts() {
   SPIRV::TranslatorOpts SPIRVOpts;
-  std::vector<SPIRV::ExtensionID> AllowedExtensions{ SPIRV::ExtensionID::SPV_KHR_bit_instructions,SPIRV::ExtensionID::SPV_EXT_shader_atomic_float_add,SPIRV::ExtensionID::SPV_INTEL_arbitrary_precision_integers,SPIRV::ExtensionID::SPV_INTEL_vector_compute,SPIRV::ExtensionID::SPV_INTEL_bfloat16_conversion,
- SPIRV::ExtensionID::SPV_INTEL_subgroups };
+  std::vector<SPIRV::ExtensionID> AllowedExtensions{
+      SPIRV::ExtensionID::SPV_INTEL_kernel_attributes,
+      SPIRV::ExtensionID::SPV_KHR_bit_instructions,
+      SPIRV::ExtensionID::SPV_EXT_shader_atomic_float_add,
+      SPIRV::ExtensionID::SPV_INTEL_arbitrary_precision_integers,
+      SPIRV::ExtensionID::SPV_INTEL_vector_compute,
+      SPIRV::ExtensionID::SPV_INTEL_bfloat16_conversion,
+      SPIRV::ExtensionID::SPV_INTEL_subgroups};
 
   SPIRVOpts.setMemToRegEnabled(true);
   SPIRVOpts.setPreserveOCLKernelArgTypeMetadataThroughString(true);
@@ -119,10 +125,7 @@ static SPIRV::TranslatorOpts getSPIRVOopts() {
   SPIRVOpts.setSPIRVAllowUnknownIntrinsics({"llvm.genx.GenISA."});
 
   for (auto &Ext : AllowedExtensions)
-      SPIRVOpts.setAllowedToUseExtension(Ext, true);
-  //SPIRVOpts.enableAllExtensions();
-  //SPIRVOpts.setAllowedToUseExtension(
-  //SPIRV::ExtensionID::SPV_KHR_untyped_pointers, false);
+    SPIRVOpts.setAllowedToUseExtension(Ext, true);
   return SPIRVOpts;
 }
 

--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -108,19 +108,24 @@ public:
 static SPIRV::TranslatorOpts getSPIRVOopts() {
   SPIRV::TranslatorOpts SPIRVOpts;
   std::vector<SPIRV::ExtensionID> AllowedExtensions{
-      SPIRV::ExtensionID::SPV_INTEL_cache_controls,
-      SPIRV::ExtensionID::SPV_INTEL_kernel_attributes,
-      SPIRV::ExtensionID::SPV_KHR_bit_instructions,
       SPIRV::ExtensionID::SPV_EXT_shader_atomic_float_add,
       SPIRV::ExtensionID::SPV_INTEL_arbitrary_precision_integers,
-      SPIRV::ExtensionID::SPV_INTEL_vector_compute,
+      SPIRV::ExtensionID::SPV_INTEL_arithmetic_fence,
       SPIRV::ExtensionID::SPV_INTEL_bfloat16_conversion,
-      SPIRV::ExtensionID::SPV_INTEL_subgroups};
+      SPIRV::ExtensionID::SPV_INTEL_cache_controls,
+      SPIRV::ExtensionID::SPV_INTEL_kernel_attributes,
+      SPIRV::ExtensionID::SPV_INTEL_memory_access_aliasing,
+      SPIRV::ExtensionID::SPV_INTEL_subgroups,
+      SPIRV::ExtensionID::SPV_INTEL_unstructured_loop_controls,
+      SPIRV::ExtensionID::SPV_INTEL_vector_compute,
+      SPIRV::ExtensionID::SPV_KHR_bit_instructions,
+      SPIRV::ExtensionID::SPV_KHR_non_semantic_info};
 
   SPIRVOpts.setMemToRegEnabled(true);
   SPIRVOpts.setPreserveOCLKernelArgTypeMetadataThroughString(true);
-  SPIRVOpts.setPreserveAuxData(false);
+  SPIRVOpts.setPreserveAuxData(true);
   SPIRVOpts.setSPIRVAllowUnknownIntrinsics({"llvm.genx.GenISA."});
+  SPIRV::TranslatorOpts TransOpt{SPIRV::VersionNumber::SPIRV_1_5};
 
   for (auto &Ext : AllowedExtensions)
     SPIRVOpts.setAllowedToUseExtension(Ext, true);

--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -125,7 +125,7 @@ static SPIRV::TranslatorOpts getSPIRVOopts() {
   SPIRVOpts.setPreserveOCLKernelArgTypeMetadataThroughString(true);
   SPIRVOpts.setPreserveAuxData(true);
   SPIRVOpts.setSPIRVAllowUnknownIntrinsics({"llvm.genx.GenISA."});
-  SPIRV::TranslatorOpts TransOpt{SPIRV::VersionNumber::SPIRV_1_5};
+  SPIRV::TranslatorOpts TransOpt{SPIRV::VersionNumber::SPIRV_1_4};
 
   for (auto &Ext : AllowedExtensions)
     SPIRVOpts.setAllowedToUseExtension(Ext, true);

--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -107,7 +107,7 @@ public:
 
 static SPIRV::TranslatorOpts getSPIRVOopts() {
   SPIRV::TranslatorOpts SPIRVOpts;
-  std::vector<SPIRV::ExtensionID> AllowedExtensions{
+  static constexpr std::array<SPIRV::ExtensionID, 12> AllowedExtensions{
       SPIRV::ExtensionID::SPV_EXT_shader_atomic_float_add,
       SPIRV::ExtensionID::SPV_INTEL_arbitrary_precision_integers,
       SPIRV::ExtensionID::SPV_INTEL_arithmetic_fence,

--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -1,14 +1,11 @@
-
 #include "intel/include/Target/SPIRV/SPIRVTranslation.h"
 
 #include "LLVMSPIRVLib.h"
-#include "LLVMSPIRVOpts.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Pass.h"
-#include "llvm/TargetParser/Triple.h"
 
 #if defined(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
 namespace llvm {

--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -108,6 +108,7 @@ public:
 static SPIRV::TranslatorOpts getSPIRVOopts() {
   SPIRV::TranslatorOpts SPIRVOpts;
   std::vector<SPIRV::ExtensionID> AllowedExtensions{
+      SPIRV::ExtensionID::SPV_INTEL_cache_controls,
       SPIRV::ExtensionID::SPV_INTEL_kernel_attributes,
       SPIRV::ExtensionID::SPV_KHR_bit_instructions,
       SPIRV::ExtensionID::SPV_EXT_shader_atomic_float_add,

--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -123,7 +123,7 @@ static SPIRV::TranslatorOpts getSPIRVOopts() {
 
   SPIRVOpts.setMemToRegEnabled(true);
   SPIRVOpts.setPreserveOCLKernelArgTypeMetadataThroughString(true);
-  SPIRVOpts.setPreserveAuxData(true);
+  SPIRVOpts.setPreserveAuxData(false);
   SPIRVOpts.setSPIRVAllowUnknownIntrinsics({"llvm.genx.GenISA."});
   SPIRV::TranslatorOpts TransOpt{SPIRV::VersionNumber::SPIRV_1_4};
 

--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -1,6 +1,7 @@
 #include "intel/include/Target/SPIRV/SPIRVTranslation.h"
 
 #include "LLVMSPIRVLib.h"
+#include "LLVMSPIRVOpts.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
@@ -109,6 +110,7 @@ public:
 static SPIRV::TranslatorOpts getAllowedExtensions() {
   SPIRV::TranslatorOpts SPIRVOpts;
   std::vector<SPIRV::ExtensionID> AllowedExtensions{
+      SPIRV::ExtensionID::SPV_KHR_bit_instructions,
       SPIRV::ExtensionID::SPV_EXT_shader_atomic_float_add,
       SPIRV::ExtensionID::SPV_EXT_shader_atomic_float_min_max,
       SPIRV::ExtensionID::SPV_KHR_no_integer_wrap_decoration,
@@ -161,6 +163,10 @@ static SPIRV::TranslatorOpts getAllowedExtensions() {
   SPIRVOpts.setPreserveOCLKernelArgTypeMetadataThroughString(true);
   SPIRVOpts.setPreserveAuxData(false);
   SPIRVOpts.setSPIRVAllowUnknownIntrinsics({"llvm.genx.GenISA."});
+  //SPIRVOpts.enableAllExtensions();
+  //SPIRVOpts.setAllowedToUseExtension(
+  //SPIRV::ExtensionID::SPV_KHR_untyped_pointers, false);
+
   for (auto &Ext : AllowedExtensions)
       SPIRVOpts.setAllowedToUseExtension(Ext, true);
   return SPIRVOpts;

--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -130,7 +130,6 @@ static SPIRV::TranslatorOpts getSPIRVOopts() {
       SPIRV::ExtensionID::SPV_INTEL_fast_composite,
       SPIRV::ExtensionID::SPV_INTEL_arbitrary_precision_fixed_point,
       SPIRV::ExtensionID::SPV_INTEL_arbitrary_precision_floating_point,
-      SPIRV::ExtensionID::SPV_INTEL_variable_length_array,
       SPIRV::ExtensionID::SPV_INTEL_fp_fast_math_mode,
       SPIRV::ExtensionID::SPV_INTEL_long_composites,
       SPIRV::ExtensionID::SPV_INTEL_arithmetic_fence,


### PR DESCRIPTION
This PR makes it so instead of enabling all the SPIRV extension and disabling the problematic ones, we only enable extensions that we actually use. To find out the list of extensions I've started out from the list of extensions used in other projects that use the SPIRV-LLVM tool ([DPC++](https://github.com/intel/llvm/blob/0d5266b566a920905c6f8a6767f3454c4268ca08/sycl-jit/jit-compiler/lib/translation/SPIRVLLVMTranslation.cpp#L29)), narrowed it down and added missing extensions.