### PR TITLE
Merge OpenAI Triton commit `31d1e38`

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
@@ -252,8 +252,10 @@ struct AsyncRef {
     return createSingleBufferView(b, emptyBars, idx);
   }
   auto getView(ImplicitLocOpBuilder &b, Value idx) const {
-    return std::make_tuple(getValueView(b, idx), getReadyView(b, idx),
-                           getEmptyView(b, idx));
+    auto valView = getValueView(b, idx);
+    auto readyView = getReadyView(b, idx);
+    auto emptyView = getEmptyView(b, idx);
+    return std::make_tuple(valView, readyView, emptyView);
   }
 
   unsigned multiplicitySize;

--- a/test/TritonGPU/amd/amd-block-pingpong.mlir
+++ b/test/TritonGPU/amd/amd-block-pingpong.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --tritonamdgpu-block-pingpong | FileCheck %s
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-block-pingpong='num-stages=2' | FileCheck %s
 
 //CHECK-LABEL: pingpong_small
 //CHECK: ttg.local_load

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -264,7 +264,7 @@ class HIPBackend(BaseBackend):
             amd.passes.ttgpuir.add_reorder_instructions(pm)
             use_block_pingpong = is_pingpong_enabled(options.arch)
             if use_block_pingpong and options.num_stages == 2:
-                amd.passes.ttgpuir.add_block_pingpong(pm)
+                amd.passes.ttgpuir.add_block_pingpong(pm, options.num_stages)
 
         if HIPBackend.use_buffer_ops():
             amd.passes.ttgpuir.add_canonicalize_pointers(pm)

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
@@ -32,7 +32,8 @@ std::unique_ptr<Pass> createTritonAMDGPUCanonicalizePointersPass();
 std::unique_ptr<Pass> createTritonAMDGPUConvertToBufferOpsPass(
     std::string archGenName = std::string());
 
-std::unique_ptr<Pass> createTritonAMDGPUBlockPingpongPass();
+std::unique_ptr<Pass>
+createTritonAMDGPUBlockPingpongPass(int32_t numStages = 2);
 
 std::unique_ptr<Pass> createTritonAMDGPUInThreadTransposePass();
 

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -164,6 +164,12 @@ def TritonAMDGPUBlockPingpong: Pass<"tritonamdgpu-block-pingpong", "mlir::Module
   let constructor = "mlir::createTritonAMDGPUBlockPingpongPass()";
 
   let dependentDialects = ["mlir::ROCDL::ROCDLDialect, mlir::triton::amdgpu::TritonAMDGPUDialect"];
+
+  let options = [
+    Option<"numStages", "num-stages",
+        "int32_t", /*default*/"2",
+        "Number of Pipeline stages">,
+    ];
 }
 
 def TritonAMDGPUInThreadTranspose: Pass<"tritonamdgpu-in-thread-transpose", "mlir::triton::FuncOp"> {

--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -55,10 +55,11 @@ class Pingponger {
   int highPriority = 1;
   int32_t kWidth;
   int32_t numWarps;
+  int32_t numStages;
 
 public:
-  Pingponger(scf::ForOp forOp, int32_t numWarps)
-      : forOp(forOp), numWarps(numWarps) {}
+  Pingponger(scf::ForOp forOp, int32_t numWarps, int32_t numStages)
+      : forOp(forOp), numWarps(numWarps), numStages(numStages) {}
   void getDotPingponged();
 
 private:
@@ -527,6 +528,14 @@ void Pingponger::addAsymmetricSyncToLoop(OpBuilder &builder, Location loc) {
 }
 
 void Pingponger::getDotPingponged() {
+  if (numStages != 2) {
+    std::stringstream message;
+    message << "All ping pong scheduling requires 2 stages. Found " << numStages
+            << " stages";
+    LDBG(message.str());
+    return;
+  }
+
   OpBuilder builder(forOp);
   MLIRContext *ctx = forOp.getContext();
   Location loc = forOp.getLoc();
@@ -712,11 +721,14 @@ class TritonAMDGPUBlockPingpongPass
     : public TritonAMDGPUBlockPingpongBase<TritonAMDGPUBlockPingpongPass> {
 public:
   TritonAMDGPUBlockPingpongPass() = default;
+  TritonAMDGPUBlockPingpongPass(int32_t numStages) {
+    this->numStages = numStages;
+  }
   void runOnOperation() override {
     ModuleOp m = getOperation();
     for (auto funcOp : m.getOps<tt::FuncOp>()) {
       funcOp.walk([&](scf::ForOp forOp) {
-        Pingponger pingponger(forOp, ttg::lookupNumWarps(forOp));
+        Pingponger pingponger(forOp, ttg::lookupNumWarps(forOp), numStages);
         pingponger.getDotPingponged();
       });
     }
@@ -724,6 +736,7 @@ public:
 };
 } // namespace
 
-std::unique_ptr<Pass> mlir::createTritonAMDGPUBlockPingpongPass() {
-  return std::make_unique<TritonAMDGPUBlockPingpongPass>();
+std::unique_ptr<Pass>
+mlir::createTritonAMDGPUBlockPingpongPass(int32_t numStages) {
+  return std::make_unique<TritonAMDGPUBlockPingpongPass>(numStages);
 }

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -79,8 +79,8 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
                      const std::string &);
   ADD_PASS_WRAPPER_0("add_reorder_instructions",
                      mlir::createTritonAMDGPUReorderInstructionsPass);
-  ADD_PASS_WRAPPER_0("add_block_pingpong",
-                     mlir::createTritonAMDGPUBlockPingpongPass);
+  ADD_PASS_WRAPPER_1("add_block_pingpong",
+                     mlir::createTritonAMDGPUBlockPingpongPass, int32_t);
   ADD_PASS_WRAPPER_3("add_stream_pipeline",
                      mlir::createTritonAMDGPUStreamPipelinePass, int, int, int);
   m.def("add_in_thread_transpose", [](mlir::PassManager &pm) {


### PR DESCRIPTION
This PR change the Triton base from 3b4a9fbfa8e2028323faf130525389969f75bbe1 to 31d1e38f8fa1128b13bfe7b6b443e72b7e81833f (Mar 20).
Pass rate: 89.76%

Please do not squash and merge this PR.