### PR TITLE
[tensor_desc_to_block_ptr]: Create pass to transform `tt.descriptor_load` into `tt.load` with block ptr

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -66,6 +66,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::test::registerTestTritonAMDGPURangeAnalysis();
   mlir::triton::registerConvertTritonToTritonGPUPass();
   mlir::triton::intel::registerConvertTritonToTritonGPUWarpPass();
+  mlir::triton::intel::registerTritonIntelTensorDescToBlockPointer();
   mlir::triton::intel::registerTritonIntelRemoveMasks();
   mlir::triton::intel::registerTritonRaiseBlockPointer();
   mlir::triton::gpu::registerAllocateSharedMemoryPass();

--- a/test/Triton/Intel/TensorDescToBlockPointer/basic.mlir
+++ b/test/Triton/Intel/TensorDescToBlockPointer/basic.mlir
@@ -12,14 +12,15 @@ module {
   }
 
   // CHECK:      tt.func public @test1([[PARAM_0:%.+]]: !tt.ptr<i16>, [[PARAM_1:%.+]]: i32, [[PARAM_2:%.+]]: i32) {
-  // CHECK-DAG:     [[CST_1_i64:%.+]] = arith.constant 1 : i64
-  // CHECK-DAG:     [[CST_64_i32:%.+]] = arith.constant 64 : i32
-  // CHECK-DAG:     [[CST_8_i32:%.+]] = arith.constant 8 : i32
-  // CHECK-NOT: separator of consecutive DAGs
-  // CHECK-DAG:     [[EXTSI_PARAM_1:%.+]] = arith.extsi [[PARAM_1]] : i32 to i64
-  // CHECK-DAG:     [[EXTSI_PARAM_2:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
-  // CHECK:         [[TENSOR_PTR:%.+]] = tt.make_tensor_ptr [[PARAM_0]], {{\[}}[[EXTSI_PARAM_1]], [[EXTSI_PARAM_2]]], {{\[}}[[EXTSI_PARAM_2]], [[CST_1_i64]]], {{\[}}[[CST_8_i32]], [[CST_64_i32]]] {{.*}} : <tensor<8x32xi16>>
-  // CHECK:         [[LOAD:%.+]] = tt.load [[TENSOR_PTR]] : !tt.ptr<tensor<8x32xi16>>
-  // CHECK:         tt.return
-  // CHECK:       }
+  // CHECK-NOT:    tt.make_tensor_descriptor
+  // CHECK-NOT:    tt.descriptor_load
+  // CHECK-DAG:    [[CST_1_i64:%.+]] = arith.constant 1 : i64
+  // CHECK-DAG:    [[CST_64_i32:%.+]] = arith.constant 64 : i32
+  // CHECK-DAG:    [[CST_8_i32:%.+]] = arith.constant 8 : i32
+  // CHECK-DAG:    [[EXTSI_PARAM_1:%.+]] = arith.extsi [[PARAM_1]] : i32 to i64
+  // CHECK-DAG:    [[EXTSI_PARAM_2:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
+  // CHECK:        [[TENSOR_PTR:%.+]] = tt.make_tensor_ptr [[PARAM_0]], {{\[}}[[EXTSI_PARAM_1]], [[EXTSI_PARAM_2]]], {{\[}}[[EXTSI_PARAM_2]], [[CST_1_i64]]], {{\[}}[[CST_8_i32]], [[CST_64_i32]]] {{.*}} : <tensor<8x32xi16>>
+  // CHECK:        [[LOAD:%.+]] = tt.load [[TENSOR_PTR]] : !tt.ptr<tensor<8x32xi16>>
+  // CHECK:        tt.return
+  // CHECK:      }
 }

--- a/test/Triton/Intel/TensorDescToBlockPointer/basic.mlir
+++ b/test/Triton/Intel/TensorDescToBlockPointer/basic.mlir
@@ -12,14 +12,14 @@ module {
   }
 
   // CHECK:      tt.func public @test1([[PARAM_0:%.+]]: !tt.ptr<i16>, [[PARAM_1:%.+]]: i32, [[PARAM_2:%.+]]: i32) {
-  // CHECK-DAG:       [[CST_1_i64:%.+]] = arith.constant 1 : i64
-  // CHECK-DAG:       [[CST_64_i32:%.+]] = arith.constant 64 : i32
-  // CHECK-DAG:       [[CST_8_i32:%.+]] = arith.constant 8 : i32
+  // CHECK-DAG:     [[CST_1_i64:%.+]] = arith.constant 1 : i64
+  // CHECK-DAG:     [[CST_64_i32:%.+]] = arith.constant 64 : i32
+  // CHECK-DAG:     [[CST_8_i32:%.+]] = arith.constant 8 : i32
   // CHECK-NOT: separator of consecutive DAGs
-  // CHECK-DAG:       [[EXTSI_PARAM_1:%.+]] = arith.extsi [[PARAM_1]] : i32 to i64
-  // CHECK-DAG:       [[EXTSI_PARAM_2:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
-  // CHECK:           [[TENSOR_PTR:%.+]] = tt.make_tensor_ptr [[PARAM_0]], {{\[}}[[EXTSI_PARAM_1]], [[EXTSI_PARAM_2]]], {{\[}}[[EXTSI_PARAM_2]], [[CST_1_i64]]], {{\[}}[[CST_8_i32]], [[CST_64_i32]]] {{.*}} : <tensor<8x32xi16>>
-  // CHECK:           [[LOAD:%.+]] = tt.load [[TENSOR_PTR]] : !tt.ptr<tensor<8x32xi16>>
-  // CHECK:           tt.return
+  // CHECK-DAG:     [[EXTSI_PARAM_1:%.+]] = arith.extsi [[PARAM_1]] : i32 to i64
+  // CHECK-DAG:     [[EXTSI_PARAM_2:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
+  // CHECK:         [[TENSOR_PTR:%.+]] = tt.make_tensor_ptr [[PARAM_0]], {{\[}}[[EXTSI_PARAM_1]], [[EXTSI_PARAM_2]]], {{\[}}[[EXTSI_PARAM_2]], [[CST_1_i64]]], {{\[}}[[CST_8_i32]], [[CST_64_i32]]] {{.*}} : <tensor<8x32xi16>>
+  // CHECK:         [[LOAD:%.+]] = tt.load [[TENSOR_PTR]] : !tt.ptr<tensor<8x32xi16>>
+  // CHECK:         tt.return
   // CHECK:       }
 }

--- a/test/Triton/Intel/TensorDescToBlockPointer/basic.mlir
+++ b/test/Triton/Intel/TensorDescToBlockPointer/basic.mlir
@@ -16,7 +16,7 @@ module {
   // CHECK-DAG:       [[CST_64_i32:%.+]] = arith.constant 64 : i32
   // CHECK-DAG:       [[CST_8_i32:%.+]] = arith.constant 8 : i32
   // CHECK-NOT: separator of consecutive DAGs
-  // CHECK-DAG:       [[EXTSI_PARAM_1:%.+]] = arith.extsi [[PARAM_1]] : i32 to i64  
+  // CHECK-DAG:       [[EXTSI_PARAM_1:%.+]] = arith.extsi [[PARAM_1]] : i32 to i64
   // CHECK-DAG:       [[EXTSI_PARAM_2:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
   // CHECK:           [[TENSOR_PTR:%.+]] = tt.make_tensor_ptr [[PARAM_0]], {{\[}}[[EXTSI_PARAM_1]], [[EXTSI_PARAM_2]]], {{\[}}[[EXTSI_PARAM_2]], [[CST_1_i64]]], {{\[}}[[CST_8_i32]], [[CST_64_i32]]] {{.*}} : <tensor<8x32xi16>>
   // CHECK:           [[LOAD:%.+]] = tt.load [[TENSOR_PTR]] : !tt.ptr<tensor<8x32xi16>>

--- a/test/Triton/Intel/TensorDescToBlockPointer/basic.mlir
+++ b/test/Triton/Intel/TensorDescToBlockPointer/basic.mlir
@@ -1,0 +1,25 @@
+// RUN: triton-opt %s -triton-intel-tdesc-to-block-pointer  | FileCheck %s
+
+module {
+  tt.func public @test1(%arg0: !tt.ptr<i16>, %arg1: i32, %arg2: i32) {
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i32 = arith.constant 64 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %0 = arith.extsi %arg2 : i32 to i64
+    %1 = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%0, %c1_i64] : <i16>, <tensor<8x32xi16>>
+    %2 = tt.descriptor_load %1[%c8_i32, %c64_i32] : !tt.tensordesc<tensor<8x32xi16>> -> tensor<8x32xi16>
+    tt.return
+  }
+
+  // CHECK:      tt.func public @test1([[PARAM_0:%.+]]: !tt.ptr<i16>, [[PARAM_1:%.+]]: i32, [[PARAM_2:%.+]]: i32) {
+  // CHECK-DAG:       [[CST_1_i64:%.+]] = arith.constant 1 : i64
+  // CHECK-DAG:       [[CST_64_i32:%.+]] = arith.constant 64 : i32
+  // CHECK-DAG:       [[CST_8_i32:%.+]] = arith.constant 8 : i32
+  // CHECK-NOT: separator of consecutive DAGs
+  // CHECK-DAG:       [[EXTSI_PARAM_1:%.+]] = arith.extsi [[PARAM_1]] : i32 to i64  
+  // CHECK-DAG:       [[EXTSI_PARAM_2:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
+  // CHECK:           [[TENSOR_PTR:%.+]] = tt.make_tensor_ptr [[PARAM_0]], {{\[}}[[EXTSI_PARAM_1]], [[EXTSI_PARAM_2]]], {{\[}}[[EXTSI_PARAM_2]], [[CST_1_i64]]], {{\[}}[[CST_8_i32]], [[CST_64_i32]]] {{.*}} : <tensor<8x32xi16>>
+  // CHECK:           [[LOAD:%.+]] = tt.load [[TENSOR_PTR]] : !tt.ptr<tensor<8x32xi16>>
+  // CHECK:           tt.return
+  // CHECK:       }
+}

--- a/test/Triton/Intel/TensorDescToBlockPointer/loop.mlir
+++ b/test/Triton/Intel/TensorDescToBlockPointer/loop.mlir
@@ -1,0 +1,38 @@
+// RUN: triton-opt %s -triton-intel-tdesc-to-block-pointer  | FileCheck %s
+
+module {
+  tt.func public @load_in_loop(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index    
+    %c10 = arith.constant 10 : index
+    %c1_i64 = arith.constant 1 : i64
+    %c8_i32 = arith.constant 8 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<16x32xf16>
+    %0 = arith.extsi %arg2 : i32 to i64
+    %tdesc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%0, %c1_i64] : <f16>, <tensor<16x32xf16>>
+    %tdesc_out, %sum_out = scf.for %i = %c0 to %c10 step %c1 iter_args(%ptr_iter = %tdesc, %sum_iter = %cst) -> (!tt.tensordesc<tensor<16x32xf16>>, tensor<16x32xf16>) {
+      %cast_i = arith.index_cast %i : index to i32
+      %load1 = tt.descriptor_load %ptr_iter[%c8_i32, %cast_i] : !tt.tensordesc<tensor<16x32xf16>> -> tensor<16x32xf16>
+      %sum_next = arith.addf %sum_iter, %load1 : tensor<16x32xf16>
+      scf.yield %ptr_iter, %sum_next : !tt.tensordesc<tensor<16x32xf16>>, tensor<16x32xf16>
+    }
+    tt.return
+  }
+
+  // CHECK:      tt.func public @load_in_loop([[PARAM_0:%.+]]: !tt.ptr<f16>, [[PARAM_1:%.+]]: i32, [[PARAM_2:%.+]]: i32) {
+  // CHECK-DAG:     [[CST_1_i64:%.+]] = arith.constant 1 : i64
+  // CHECK-DAG:     [[CST_8_i32:%.+]] = arith.constant 8 : i32
+  // CHECK-DAG:     [[CST:%.+]] = arith.constant dense<0.000000e+00> : tensor<16x32xf16>  
+  // CHECK-DAG:     [[EXTSI_PARAM_2a:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
+  // CHECK:         [[FOR_RES:%.+]]:2 = scf.for [[IV:%.+]] = {{.*}} iter_args([[VAR_arg1:%.+]] = {{.*}}, [[VAR_arg2:%.+]] = [[CST]]) -> (!tt.tensordesc<tensor<16x32xf16>>, tensor<16x32xf16>) {  
+  // CHECK-DAG:       [[IDX_CAST_1:%.+]] = arith.index_cast [[IV]] : index to i32
+  // CHECK-DAG:       [[EXTSI_PARAM_1:%.+]] = arith.extsi [[PARAM_1]] : i32 to i64
+  // CHECK-DAG:       [[EXTSI_PARAM_2b:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
+  // CHECK:           [[TENSOR_PTR:%.+]] = tt.make_tensor_ptr [[PARAM_0]], {{\[}}[[EXTSI_PARAM_1]], [[EXTSI_PARAM_2b]]], {{\[}}[[EXTSI_PARAM_2a]], [[CST_1_i64]]], {{\[}}[[CST_8_i32]], [[IDX_CAST_1]]] {{.*}} : <tensor<16x32xf16>>
+  // CHECK:           [[LOAD:%.+]] = tt.load [[TENSOR_PTR]] : !tt.ptr<tensor<16x32xf16>>
+  // CHECK:           [[ADD:%.+]] = arith.addf [[VAR_arg2]], [[LOAD]] : tensor<16x32xf16>  
+  // CHECK:           scf.yield {{.*}}, [[ADD]] : !tt.tensordesc<tensor<16x32xf16>>, tensor<16x32xf16>
+  // CHECK:         }
+  // CHECK:         tt.return
+  // CHECK:       }
+}

--- a/test/Triton/Intel/TensorDescToBlockPointer/loop.mlir
+++ b/test/Triton/Intel/TensorDescToBlockPointer/loop.mlir
@@ -4,7 +4,7 @@ module {
   // COM: Loop containing a tensor descriptor load operation using a loop invariant tensor descriptor.
   tt.func public @load_in_loop1(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32) {
     %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index    
+    %c1 = arith.constant 1 : index
     %c10 = arith.constant 10 : index
     %c1_i64 = arith.constant 1 : i64
     %c8_i32 = arith.constant 8 : i32
@@ -20,17 +20,19 @@ module {
     tt.return
   }
   // CHECK:      tt.func public @load_in_loop1([[PARAM_0:%.+]]: !tt.ptr<f16>, [[PARAM_1:%.+]]: i32, [[PARAM_2:%.+]]: i32) {
+  // CHECK-NOT:    tt.make_tensor_descriptor
+  // CHECK-NOT:    tt.descriptor_load
   // CHECK-DAG:    [[CST_1_i64:%.+]] = arith.constant 1 : i64
   // CHECK-DAG:    [[CST_8_i32:%.+]] = arith.constant 8 : i32
-  // CHECK-DAG:    [[CST:%.+]] = arith.constant dense<0.000000e+00> : tensor<16x32xf16>  
+  // CHECK-DAG:    [[CST:%.+]] = arith.constant dense<0.000000e+00> : tensor<16x32xf16>
   // CHECK-DAG:    [[EXTSI_PARAM_2a:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
-  // CHECK:        [[FOR_RES:%.+]]:2 = scf.for [[IV:%.+]] = {{.*}} iter_args([[VAR_arg1:%.+]] = {{.*}}, [[VAR_arg2:%.+]] = [[CST]]) -> (!tt.tensordesc<tensor<16x32xf16>>, tensor<16x32xf16>) {  
+  // CHECK:        [[FOR_RES:%.+]]:2 = scf.for [[IV:%.+]] = {{.*}} iter_args([[VAR_arg1:%.+]] = {{.*}}, [[VAR_arg2:%.+]] = [[CST]]) -> (!tt.tensordesc<tensor<16x32xf16>>, tensor<16x32xf16>) {
   // CHECK-DAG:      [[IDX_CAST_1:%.+]] = arith.index_cast [[IV]] : index to i32
   // CHECK-DAG:      [[EXTSI_PARAM_1:%.+]] = arith.extsi [[PARAM_1]] : i32 to i64
   // CHECK-DAG:      [[EXTSI_PARAM_2b:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
   // CHECK:          [[TENSOR_PTR:%.+]] = tt.make_tensor_ptr [[PARAM_0]], {{\[}}[[EXTSI_PARAM_1]], [[EXTSI_PARAM_2b]]], {{\[}}[[EXTSI_PARAM_2a]], [[CST_1_i64]]], {{\[}}[[CST_8_i32]], [[IDX_CAST_1]]] {{.*}} : <tensor<16x32xf16>>
   // CHECK:          [[LOAD:%.+]] = tt.load [[TENSOR_PTR]] : !tt.ptr<tensor<16x32xf16>>
-  // CHECK:          [[ADD:%.+]] = arith.addf [[VAR_arg2]], [[LOAD]] : tensor<16x32xf16>  
+  // CHECK:          [[ADD:%.+]] = arith.addf [[VAR_arg2]], [[LOAD]] : tensor<16x32xf16>
   // CHECK:          scf.yield {{.*}}, [[ADD]] : !tt.tensordesc<tensor<16x32xf16>>, tensor<16x32xf16>
   // CHECK:        }
   // CHECK:        tt.return
@@ -39,7 +41,7 @@ module {
   // COM: Loop containing a tensor descriptor load operation using a loop variant tensor descriptor.
   tt.func public @load_in_loop2(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32) {
     %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index    
+    %c1 = arith.constant 1 : index
     %c10 = arith.constant 10 : index
     %c1_i64 = arith.constant 1 : i64
     %c8_i32 = arith.constant 8 : i32
@@ -58,10 +60,10 @@ module {
     tt.return
   }
   // CHECK:      tt.func public @load_in_loop2({{.*}}) {
+  // CHECK-NOT:    tt.make_tensor_ptr
+  // CHECK-NOT:    tt.load
   // CHECK:        tt.make_tensor_descriptor
-  // CHECK:        [[FOR_RES:%.+]]:2 = scf.for [[IV:%.+]] = {{.*}} -> (!tt.tensordesc<tensor<16x32xf16>>, tensor<16x32xf16>) {  
-  // CHECK-NOT:      tt.make_tensor_ptr  
-  // CHECK-NOT:      tt.load
+  // CHECK:        [[FOR_RES:%.+]]:2 = scf.for [[IV:%.+]] = {{.*}} -> (!tt.tensordesc<tensor<16x32xf16>>, tensor<16x32xf16>) {
   // CHECK:          tt.descriptor_load
   // CHECK:          tt.make_tensor_descriptor
   // CHECK:        }
@@ -71,7 +73,7 @@ module {
   // COM: Loop yields a tensor descriptor used by a tensor descriptor load.
   tt.func public @load_uses_loop_result(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32) {
     %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index    
+    %c1 = arith.constant 1 : index
     %c10 = arith.constant 10 : index
     %c1_i64 = arith.constant 1 : i64
     %c8_i32 = arith.constant 8 : i32
@@ -83,14 +85,12 @@ module {
     }
     %cast_c10 = arith.index_cast %c10 : index to i32
     %load2 = tt.descriptor_load %tdesc_out[%c8_i32, %cast_c10] : !tt.tensordesc<tensor<16x32xf16>> -> tensor<16x32xf16>
-    tt.return  
+    tt.return
   }
   // CHECK:      tt.func public @load_uses_loop_result({{.*}}) {
-  // CHECK:        tt.make_tensor_descriptor  
-  // CHECK:        [[FOR_RES:%.+]] = scf.for [[IV:%.+]] = {{.*}} -> (!tt.tensordesc<tensor<16x32xf16>>) {
-  // CHECK:        }
-  // CHECK-NOT:    tt.make_tensor_ptr  
-  // CHECK-NOT:    tt.load  
+  // CHECK-NOT:    tt.make_tensor_ptr
+  // CHECK-NOT:    tt.load
+  // CHECK:        tt.make_tensor_descriptor
   // CHECK:        tt.descriptor_load
   // CHECK:        tt.return
   // CHECK:      }

--- a/test/Triton/Intel/TensorDescToBlockPointer/loop.mlir
+++ b/test/Triton/Intel/TensorDescToBlockPointer/loop.mlir
@@ -1,7 +1,8 @@
 // RUN: triton-opt %s -triton-intel-tdesc-to-block-pointer  | FileCheck %s
 
 module {
-  tt.func public @load_in_loop(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32) {
+  // COM: Loop containing a tensor descriptor load operation using a loop invariant tensor descriptor.
+  tt.func public @load_in_loop1(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index    
     %c10 = arith.constant 10 : index
@@ -18,21 +19,79 @@ module {
     }
     tt.return
   }
+  // CHECK:      tt.func public @load_in_loop1([[PARAM_0:%.+]]: !tt.ptr<f16>, [[PARAM_1:%.+]]: i32, [[PARAM_2:%.+]]: i32) {
+  // CHECK-DAG:    [[CST_1_i64:%.+]] = arith.constant 1 : i64
+  // CHECK-DAG:    [[CST_8_i32:%.+]] = arith.constant 8 : i32
+  // CHECK-DAG:    [[CST:%.+]] = arith.constant dense<0.000000e+00> : tensor<16x32xf16>  
+  // CHECK-DAG:    [[EXTSI_PARAM_2a:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
+  // CHECK:        [[FOR_RES:%.+]]:2 = scf.for [[IV:%.+]] = {{.*}} iter_args([[VAR_arg1:%.+]] = {{.*}}, [[VAR_arg2:%.+]] = [[CST]]) -> (!tt.tensordesc<tensor<16x32xf16>>, tensor<16x32xf16>) {  
+  // CHECK-DAG:      [[IDX_CAST_1:%.+]] = arith.index_cast [[IV]] : index to i32
+  // CHECK-DAG:      [[EXTSI_PARAM_1:%.+]] = arith.extsi [[PARAM_1]] : i32 to i64
+  // CHECK-DAG:      [[EXTSI_PARAM_2b:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
+  // CHECK:          [[TENSOR_PTR:%.+]] = tt.make_tensor_ptr [[PARAM_0]], {{\[}}[[EXTSI_PARAM_1]], [[EXTSI_PARAM_2b]]], {{\[}}[[EXTSI_PARAM_2a]], [[CST_1_i64]]], {{\[}}[[CST_8_i32]], [[IDX_CAST_1]]] {{.*}} : <tensor<16x32xf16>>
+  // CHECK:          [[LOAD:%.+]] = tt.load [[TENSOR_PTR]] : !tt.ptr<tensor<16x32xf16>>
+  // CHECK:          [[ADD:%.+]] = arith.addf [[VAR_arg2]], [[LOAD]] : tensor<16x32xf16>  
+  // CHECK:          scf.yield {{.*}}, [[ADD]] : !tt.tensordesc<tensor<16x32xf16>>, tensor<16x32xf16>
+  // CHECK:        }
+  // CHECK:        tt.return
+  // CHECK:      }
 
-  // CHECK:      tt.func public @load_in_loop([[PARAM_0:%.+]]: !tt.ptr<f16>, [[PARAM_1:%.+]]: i32, [[PARAM_2:%.+]]: i32) {
-  // CHECK-DAG:     [[CST_1_i64:%.+]] = arith.constant 1 : i64
-  // CHECK-DAG:     [[CST_8_i32:%.+]] = arith.constant 8 : i32
-  // CHECK-DAG:     [[CST:%.+]] = arith.constant dense<0.000000e+00> : tensor<16x32xf16>  
-  // CHECK-DAG:     [[EXTSI_PARAM_2a:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
-  // CHECK:         [[FOR_RES:%.+]]:2 = scf.for [[IV:%.+]] = {{.*}} iter_args([[VAR_arg1:%.+]] = {{.*}}, [[VAR_arg2:%.+]] = [[CST]]) -> (!tt.tensordesc<tensor<16x32xf16>>, tensor<16x32xf16>) {  
-  // CHECK-DAG:       [[IDX_CAST_1:%.+]] = arith.index_cast [[IV]] : index to i32
-  // CHECK-DAG:       [[EXTSI_PARAM_1:%.+]] = arith.extsi [[PARAM_1]] : i32 to i64
-  // CHECK-DAG:       [[EXTSI_PARAM_2b:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
-  // CHECK:           [[TENSOR_PTR:%.+]] = tt.make_tensor_ptr [[PARAM_0]], {{\[}}[[EXTSI_PARAM_1]], [[EXTSI_PARAM_2b]]], {{\[}}[[EXTSI_PARAM_2a]], [[CST_1_i64]]], {{\[}}[[CST_8_i32]], [[IDX_CAST_1]]] {{.*}} : <tensor<16x32xf16>>
-  // CHECK:           [[LOAD:%.+]] = tt.load [[TENSOR_PTR]] : !tt.ptr<tensor<16x32xf16>>
-  // CHECK:           [[ADD:%.+]] = arith.addf [[VAR_arg2]], [[LOAD]] : tensor<16x32xf16>  
-  // CHECK:           scf.yield {{.*}}, [[ADD]] : !tt.tensordesc<tensor<16x32xf16>>, tensor<16x32xf16>
-  // CHECK:         }
-  // CHECK:         tt.return
-  // CHECK:       }
+  // COM: Loop containing a tensor descriptor load operation using a loop variant tensor descriptor.
+  tt.func public @load_in_loop2(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index    
+    %c10 = arith.constant 10 : index
+    %c1_i64 = arith.constant 1 : i64
+    %c8_i32 = arith.constant 8 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<16x32xf16>
+    %0 = arith.extsi %arg2 : i32 to i64
+    %tdesc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%0, %c1_i64] : <f16>, <tensor<16x32xf16>>
+    %tdesc_out, %sum_out = scf.for %i = %c0 to %c10 step %c1 iter_args(%ptr_iter = %tdesc, %sum_iter = %cst) -> (!tt.tensordesc<tensor<16x32xf16>>, tensor<16x32xf16>) {
+      %cast_i = arith.index_cast %i : index to i32
+      %load1 = tt.descriptor_load %ptr_iter[%c8_i32, %cast_i] : !tt.tensordesc<tensor<16x32xf16>> -> tensor<16x32xf16>
+      %sum_next = arith.addf %sum_iter, %load1 : tensor<16x32xf16>
+      %tdesc_in_loop = tt.make_tensor_descriptor %arg0, [%arg2, %arg1], [%c1_i64, %0] : <f16>, <tensor<16x32xf16>>
+      %cmp = arith.cmpi eq, %cast_i, %c8_i32 : i32
+      %sel_tdesc = arith.select %cmp, %ptr_iter, %tdesc_in_loop : !tt.tensordesc<tensor<16x32xf16>>
+      scf.yield %sel_tdesc, %sum_next : !tt.tensordesc<tensor<16x32xf16>>, tensor<16x32xf16>
+    }
+    tt.return
+  }
+  // CHECK:      tt.func public @load_in_loop2({{.*}}) {
+  // CHECK:        tt.make_tensor_descriptor
+  // CHECK:        [[FOR_RES:%.+]]:2 = scf.for [[IV:%.+]] = {{.*}} -> (!tt.tensordesc<tensor<16x32xf16>>, tensor<16x32xf16>) {  
+  // CHECK-NOT:      tt.make_tensor_ptr  
+  // CHECK-NOT:      tt.load
+  // CHECK:          tt.descriptor_load
+  // CHECK:          tt.make_tensor_descriptor
+  // CHECK:        }
+  // CHECK:        tt.return
+  // CHECK:      }
+
+  // COM: Loop yields a tensor descriptor used by a tensor descriptor load.
+  tt.func public @load_uses_loop_result(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index    
+    %c10 = arith.constant 10 : index
+    %c1_i64 = arith.constant 1 : i64
+    %c8_i32 = arith.constant 8 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<16x32xf16>
+    %0 = arith.extsi %arg2 : i32 to i64
+    %tdesc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%0, %c1_i64] : <f16>, <tensor<16x32xf16>>
+    %tdesc_out = scf.for %i = %c0 to %c10 step %c1 iter_args(%ptr_iter = %tdesc) -> (!tt.tensordesc<tensor<16x32xf16>>) {
+      scf.yield %ptr_iter : !tt.tensordesc<tensor<16x32xf16>>
+    }
+    %cast_c10 = arith.index_cast %c10 : index to i32
+    %load2 = tt.descriptor_load %tdesc_out[%c8_i32, %cast_c10] : !tt.tensordesc<tensor<16x32xf16>> -> tensor<16x32xf16>
+    tt.return  
+  }
+  // CHECK:      tt.func public @load_uses_loop_result({{.*}}) {
+  // CHECK:        tt.make_tensor_descriptor  
+  // CHECK:        [[FOR_RES:%.+]] = scf.for [[IV:%.+]] = {{.*}} -> (!tt.tensordesc<tensor<16x32xf16>>) {
+  // CHECK:        }
+  // CHECK-NOT:    tt.make_tensor_ptr  
+  // CHECK-NOT:    tt.load  
+  // CHECK:        tt.descriptor_load
+  // CHECK:        tt.return
+  // CHECK:      }
 }

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -226,8 +226,7 @@ class XPUBackend(BaseBackend):
         passes.ttir.add_combine(pm)
         passes.common.add_cse(pm)
         passes.common.add_licm(pm)
-        intel.passes.ttir.add_convert_tdesc_to_block_pointer(pm)
-        intel.passes.ttir.add_remove_masks(pm)
+         intel.passes.ttir.add_remove_masks(pm)
         if raise_block_ptr_flags['enabled']:
             ignore_masks = True if raise_block_ptr_flags['ignore-masks'] else False
             intel.passes.ttir.add_raise_block_pointer(pm, ignore_masks)

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -226,7 +226,7 @@ class XPUBackend(BaseBackend):
         passes.ttir.add_combine(pm)
         passes.common.add_cse(pm)
         passes.common.add_licm(pm)
-         intel.passes.ttir.add_remove_masks(pm)
+        intel.passes.ttir.add_remove_masks(pm)
         if raise_block_ptr_flags['enabled']:
             ignore_masks = True if raise_block_ptr_flags['ignore-masks'] else False
             intel.passes.ttir.add_raise_block_pointer(pm, ignore_masks)

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -226,6 +226,7 @@ class XPUBackend(BaseBackend):
         passes.ttir.add_combine(pm)
         passes.common.add_cse(pm)
         passes.common.add_licm(pm)
+        intel.passes.ttir.add_convert_tdesc_to_block_pointer(pm)
         intel.passes.ttir.add_remove_masks(pm)
         if raise_block_ptr_flags['enabled']:
             ignore_masks = True if raise_block_ptr_flags['ignore-masks'] else False

--- a/third_party/intel/include/Dialect/Triton/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/Triton/Transforms/Passes.td
@@ -11,6 +11,21 @@
 
 include "mlir/Pass/PassBase.td"
 
+def TritonIntelTensorDescToBlockPointer
+    : Pass<"triton-intel-tdesc-to-block-pointer", "mlir::ModuleOp"> {
+  let summary = "Convert tensor descriptors into block pointers";
+
+  let description = [{
+    This pass attempts to convert tensor descriptors into block pointers.
+  }];
+
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::scf::SCFDialect",
+    "mlir::triton::TritonDialect"
+  ];
+}
+
 def TritonIntelRemoveMasks
     : Pass<"triton-intel-remove-masks", "mlir::ModuleOp"> {
   let summary = "Remove masks from tt.load and tt.store operations";

--- a/third_party/intel/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_triton_library(TritonIntelTransforms
   RemoveMasks.cpp
+  TensorDescToBlockPointer.cpp
 
   DEPENDS
   TritonIntelTransformsIncGen

--- a/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp
@@ -1,0 +1,226 @@
+#include "intel/include/Dialect/Triton/Transforms/Passes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Verifier.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/LogicalResult.h"
+#include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "triton-intel-tdesc-to-block-pointer"
+
+using namespace mlir;
+namespace tt = mlir::triton;
+
+namespace mlir::triton::intel {
+#define GEN_PASS_DEF_TRITONINTELTENSORDESCTOBLOCKPOINTER
+#include "intel/include/Dialect/Triton/Transforms/Passes.h.inc"
+} // namespace mlir::triton::intel
+
+namespace {
+
+constexpr unsigned offsetBitwidth = 32u;
+constexpr unsigned shapeAndStridesBitwidth = 64u;
+
+Value findOrCreateCast(Location loc, Value val, Type tgtType,
+                       OpBuilder &builder) {
+  if (val.getType() == tgtType)
+    return val;
+
+  Block *block = builder.getInsertionBlock();
+  const Block::iterator insertPoint = builder.getInsertionPoint();
+
+  auto it = std::find_if(block->begin(), insertPoint, [&](Operation &op) {
+    if (auto castOp = dyn_cast<arith::ExtSIOp>(op))
+      return castOp.getIn() == val && castOp.getType() == tgtType;
+    return false;
+  });
+
+  return (it != insertPoint)
+             ? cast<arith::ExtSIOp>(*it)
+             : getValueOrCreateCastToIndexLike(builder, loc, tgtType, val);
+}
+
+struct TritonIntelTensorDescToBlockPointer
+    : tt::intel::impl::TritonIntelTensorDescToBlockPointerBase<
+          TritonIntelTensorDescToBlockPointer> {
+public:
+  using Base::Base;
+  using IndexMapSet = std::map<int, std::set<int>>;
+
+  void runOnOperation() final {
+    ModuleOp moduleOp = getOperation();
+    // Version loops containing masked operation in canonical form.
+    moduleOp->walk<WalkOrder::PreOrder>([&](Operation *op) {
+      return TypeSwitch<Operation *, WalkResult>(op)
+          .Case<tt::DescriptorLoadOp>([&](auto loadOp) {
+            if (failed(rewriteDescriptorLoadOp(loadOp)))
+              loadOp->emitRemark(
+                  "TritonRaiseToBlockPointer: Failed to rewrite load");
+            return WalkResult::advance();
+          })
+          .Default([&](auto) { return WalkResult::advance(); });
+    });
+
+    finalize();
+    assert(succeeded(verify(moduleOp)) && "Module verification failed");
+  }
+
+private:
+  tt::MakeTensorDescOp getMakeTensorDescOp(Value base) const {
+    assert(base && isa<tt::TensorDescType>(base.getType()) &&
+           "Expecting tensor desc");
+
+    Operation *defOp = base.getDefiningOp();
+    if (!defOp) {
+      BlockArgument blockArg = cast<BlockArgument>(base);
+      Operation *parentOp = blockArg.getOwner()->getParentOp();
+      if (scf::ForOp forOp = dyn_cast<scf::ForOp>(parentOp)) {
+        int numIVs = forOp.getNumInductionVars();
+        int initArgIdx = blockArg.getArgNumber() - numIVs;
+        auto initArgs = forOp.getInitArgs();
+        assert(initArgIdx >= 0 && initArgIdx < initArgs.size() &&
+               "Unexpected 'initArgIdx' value");
+        return getMakeTensorDescOp(initArgs[initArgIdx]);
+      }
+      llvm_unreachable("TODO: Handle other operations with init arguments");
+    }
+
+    return cast<tt::MakeTensorDescOp>(defOp);
+  }
+
+  Value findOrCreateMakeTensorPtr(Location loc, Value base, ValueRange shape,
+                                  ValueRange strides, ValueRange offsets,
+                                  ArrayRef<int32_t> sizes, OpBuilder &builder) {
+    Block *block = builder.getInsertionBlock();
+    const Block::iterator insertPoint = builder.getInsertionPoint();
+
+    auto it = std::find_if(block->begin(), insertPoint, [&](Operation &op) {
+      if (auto makeTensorPtrOp = dyn_cast<tt::MakeTensorPtrOp>(op)) {
+        triton::PointerType resType = makeTensorPtrOp.getResult().getType();
+        auto tensorType = cast<RankedTensorType>(resType.getPointeeType());
+        auto sameShape = [](ArrayRef<int64_t> arr1, ArrayRef<int32_t> arr2) {
+          for (auto [dim1, dim2] : llvm::zip(arr1, arr2)) {
+            if (dim1 != dim2)
+              return false;
+          }
+          return true;
+        };
+        return makeTensorPtrOp.getBase() == base &&
+               makeTensorPtrOp.getShape() == shape &&
+               makeTensorPtrOp.getStrides() == strides &&
+               makeTensorPtrOp.getOffsets() == offsets &&
+               sameShape(tensorType.getShape(), sizes);
+      }
+      return false;
+    });
+
+    return (it != insertPoint) ? cast<tt::MakeTensorPtrOp>(*it)
+                               : builder.createOrFold<tt::MakeTensorPtrOp>(
+                                     loc, base, shape, strides, offsets, sizes,
+                                     builder.getDenseI32ArrayAttr({1, 0}));
+  }
+
+  void visitMakeTensorDescOp(tt::MakeTensorDescOp op) {
+    OpBuilder builder(op);
+    Location loc = op.getLoc();
+    Value ptr = op.getBase();
+    OperandRange shape = op.getShape();
+    OperandRange strides = op.getStrides();
+
+    LLVM_DEBUG(llvm::dbgs() << "Visiting: " << *op << "\n");
+
+    // Case 1: the ptr has been already been mapped.
+    if (Value mappedV = ptrMap.lookupOrNull(ptr)) {
+    }
+
+    // Case 2: the ptr has not previously been mapped.
+
+    // Create a new block pointer.
+  }
+
+  LogicalResult rewriteDescriptorLoadOp(tt::DescriptorLoadOp descLoadOp) {
+    OpBuilder builder(descLoadOp);
+    Location loc = descLoadOp.getLoc();
+    RankedTensorType resType = descLoadOp.getResult().getType();
+
+    tt::MakeTensorDescOp makeTensorDescOp =
+        getMakeTensorDescOp(descLoadOp.getDesc());
+    assert(makeTensorDescOp && "Expected a MakeTensorDescOp");
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "Rewriting: " << descLoadOp << "\n";
+      llvm::dbgs() << "where tensor desc is: " << makeTensorDescOp << "\n";
+    });
+
+    // Create a new block pointer if a suitable one doesn't already exist.
+    SmallVector<Value> shapes, strides, offsets;
+    SmallVector<int32_t> sizes;
+    for (const auto [shape, stride, offset, size] :
+         llvm::zip(makeTensorDescOp.getShape(), makeTensorDescOp.getStrides(),
+                   descLoadOp.getIndices(), resType.getShape())) {
+      shapes.push_back(findOrCreateCast(
+          loc, shape, builder.getIntegerType(shapeAndStridesBitwidth),
+          builder));
+      strides.push_back(findOrCreateCast(
+          loc, stride, builder.getIntegerType(shapeAndStridesBitwidth),
+          builder));
+      offsets.push_back(findOrCreateCast(
+          loc, offset, builder.getIntegerType(offsetBitwidth), builder));
+      sizes.push_back(static_cast<int32_t>(size));
+    }
+
+    Value makeTensorPtrOp =
+        findOrCreateMakeTensorPtr(loc, makeTensorDescOp.getBase(), shapes,
+                                  strides, offsets, sizes, builder);
+    // Replace the DescriptorLoadOp load with a LoadOp.
+    auto loadOp = builder.createOrFold<tt::LoadOp>(
+        loc, makeTensorPtrOp, descLoadOp.getCache(), descLoadOp.getEvict(),
+        /*volatile*/ false);
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "With:\n";
+      llvm::dbgs().indent(2) << makeTensorPtrOp << "\n";
+      llvm::dbgs().indent(2) << loadOp << "\n";
+    });
+
+    descLoadOp.replaceAllUsesWith(loadOp);
+    cleanUp.insert(descLoadOp);
+    cleanUp.insert(makeTensorDescOp);
+
+    return success();
+  }
+
+  void finalize() {
+    // Cleanup unused operations.
+    bool erasedOperation;
+    do {
+      erasedOperation = false;
+      SmallPtrSet<Operation *, 8> erased;
+      for (Operation *op : cleanUp) {
+        if (!op->getUsers().empty() || !op->getRegions().empty())
+          continue;
+
+        erased.insert(op);
+        op->erase();
+        erasedOperation = true;
+      }
+      cleanUp.remove_if([&](Operation *op) { return erased.contains(op); });
+    } while (erasedOperation);
+
+    // Remove operations that contain a region.
+    for (Operation *op : cleanUp) {
+      if (!op->getUsers().empty())
+        continue;
+      op->erase();
+    }
+  }
+
+private:
+  SmallPtrSet<Operation *, 8> cleanUp;
+  IRMapping ptrMap;
+};
+
+} // namespace

--- a/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp
@@ -27,6 +27,12 @@ constexpr unsigned shapeAndStridesBitwidth = 64u;
 
 Value findOrCreateCast(Location loc, Value val, Type tgtType,
                        OpBuilder &builder) {
+  assert(isa<IntegerType>(tgtType) && isa<IntegerType>(val.getType()) &&
+         "Expecting integer types");
+  assert(val.getType().getIntOrFloatBitWidth() <=
+             tgtType.getIntOrFloatBitWidth() &&
+         "Expecting smaller type");
+
   if (val.getType() == tgtType)
     return val;
 
@@ -53,7 +59,7 @@ public:
 
   void runOnOperation() final {
     ModuleOp moduleOp = getOperation();
-    // Version loops containing masked operation in canonical form.
+
     moduleOp->walk<WalkOrder::PreOrder>([&](Operation *op) {
       return TypeSwitch<Operation *, WalkResult>(op)
           .Case<tt::DescriptorLoadOp>([&](auto loadOp) {
@@ -82,7 +88,7 @@ private:
         unsigned numIVs = forOp.getNumInductionVars();
         int initArgIdx = blockArg.getArgNumber() - numIVs;
         if (isModifiedInLoop(forOp, blockArg)) {
-          LLVM_DEBUG(llvm::dbgs() << blockArg << "is not loop invariant");
+          LLVM_DEBUG(llvm::dbgs() << blockArg << "is loop variant");
           return nullptr;
         }
         Operation::operand_range initArgs = forOp.getInitArgs();

--- a/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp
@@ -88,7 +88,11 @@ private:
       llvm_unreachable("TODO: Handle other operations with init arguments");
     }
 
-    return cast<tt::MakeTensorDescOp>(defOp);
+    if (auto makeTensorDescOp = dyn_cast<tt::MakeTensorDescOp>(defOp))
+      return makeTensorDescOp;
+
+    llvm_unreachable("TODO: Unhandled defOp kind");
+    return nullptr;
   }
 
   Value findOrCreateMakeTensorPtr(Location loc, Value base, ValueRange shape,
@@ -175,7 +179,6 @@ private:
     Value makeTensorPtrOp =
         findOrCreateMakeTensorPtr(loc, makeTensorDescOp.getBase(), shapes,
                                   strides, offsets, sizes, builder);
-    // Replace the DescriptorLoadOp load with a LoadOp.
     auto loadOp = builder.createOrFold<tt::LoadOp>(
         loc, makeTensorPtrOp, descLoadOp.getCache(), descLoadOp.getEvict(),
         /*volatile*/ false);
@@ -220,7 +223,6 @@ private:
 
 private:
   SmallPtrSet<Operation *, 8> cleanUp;
-  IRMapping ptrMap;
 };
 
 } // namespace

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -66,6 +66,8 @@ static uint32_t findKernels(llvm::Module &M,
 }
 
 void init_triton_intel_passes_ttir(py::module &&m) {
+  ADD_PASS_WRAPPER_0("add_convert_tdesc_to_block_pointer",
+                     intel::createTritonIntelTensorDescToBlockPointer);
   ADD_PASS_WRAPPER_0("add_remove_masks", intel::createTritonIntelRemoveMasks);
   ADD_PASS_WRAPPER_OPT_1("add_raise_block_pointer",
                          intel::createTritonRaiseBlockPointer, bool);


### PR DESCRIPTION
Our backend doesn't handle (yet) the `tt.descriptor_load` operation. As a temporary "stop gap" create a new transformation at the Triton language level to replace `tt.descriptor_load` with a `tt.load` and replace its associated `tt.make_tensor_descriptor` operation with a `tt.make_block_ptr` operation.