### PR TITLE
Fix issue in lowering the block pointer to gather/scatter IO.

### DIFF
--- a/test/TritonIntelGPU/blockptr_store.mlir
+++ b/test/TritonIntelGPU/blockptr_store.mlir
@@ -357,34 +357,29 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 4], order = [1, 0]}>
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  // CHECK-LABEL:   llvm.func spir_kernelcc @blocked_layout_no_boundary_check
-  // COM: Check mask is not generated when boundary_check is not set.
-  // CHECK-NOT: llvm.icmp "slt"
-  tt.func public @blocked_layout_no_boundary_check(%arg0: !tt.ptr<f16>, %col_stride: i64) {
+  // CHECK-LABEL:   llvm.func spir_kernelcc @boundary_check
+  tt.func public @boundary_check(%arg0: !tt.ptr<f16>, %col_stride: i64) {
       %cst = arith.constant dense<0.000000e+00> : tensor<64x16xf16, #blocked>
       %c64_i64 = arith.constant 64 : i64
       %c1_i64 = arith.constant 1 : i64
       %c0_i32 = arith.constant 0 : i32
       %0 = tt.make_tensor_ptr %arg0, [%c64_i64, %c64_i64], [%c1_i64, %col_stride], [%c0_i32, %c0_i32] {order = array<i32: 0, 1>} : <tensor<64x16xf16, #blocked>>
+      // CHECK-NOT: llvm.icmp "slt"
       // CHECK-COUNT-32: llvm.store
       tt.store %0, %cst : !tt.ptr<tensor<64x16xf16, #blocked>>
-      tt.return
-  }
-}
 
-// -----
+      // CHECK-COUNT-16: llvm.icmp "slt"
+      // CHECK-COUNT-32: llvm.store
+      tt.store %0, %cst {boundaryCheck = array<i32: 0>} : !tt.ptr<tensor<64x16xf16, #blocked>>
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 4], order = [1, 0]}>
-module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  // CHECK-LABEL:   llvm.func spir_kernelcc @blocked_layout
-  tt.func public @blocked_layout(%arg0: !tt.ptr<f16>, %col_stride: i64) {
-      %cst = arith.constant dense<0.000000e+00> : tensor<64x16xf16, #blocked>
-      %c64_i64 = arith.constant 64 : i64
-      %c1_i64 = arith.constant 1 : i64
-      %c0_i32 = arith.constant 0 : i32
-      %0 = tt.make_tensor_ptr %arg0, [%c64_i64, %c64_i64], [%c1_i64, %col_stride], [%c0_i32, %c0_i32] {order = array<i32: 0, 1>} : <tensor<64x16xf16, #blocked>>
+      // CHECK-COUNT-16: llvm.icmp "slt"
+      // CHECK-COUNT-32: llvm.store
+      tt.store %0, %cst {boundaryCheck = array<i32: 1>} : !tt.ptr<tensor<64x16xf16, #blocked>>
+
+      // CHECK-COUNT-32: llvm.icmp "slt"
       // CHECK-COUNT-32: llvm.store
       tt.store %0, %cst {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<64x16xf16, #blocked>>
+
       tt.return
   }
 }


### PR DESCRIPTION
`tt.load` or `tt.store` operation has the boundary check attributes if the pointer operand is block pointer. The semantic is to only check the boundary if the dimension is specified.
The original code checked all dimension regardless of its actual values when the boundary check attribute exists.