### PR TITLE
Fixup null ptr dereference

### DIFF
--- a/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp
@@ -97,7 +97,7 @@ private:
         return getMakeTensorDescOp(initArgs[initArgIdx]);
       }
       LLVM_DEBUG(llvm::dbgs()
-                 << "TODO: Unhandled null defop from Value: " << base << "\n");
+                 << "TODO: Unhandled non operation: " << base << "\n");
       return nullptr;
     }
 

--- a/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp
@@ -96,7 +96,8 @@ private:
                "Unexpected 'initArgIdx' value");
         return getMakeTensorDescOp(initArgs[initArgIdx]);
       }
-      LLVM_DEBUG(llvm::dbgs() << "TODO: unhandled defOp: " << *defOp << "\n");
+      LLVM_DEBUG(llvm::dbgs()
+                 << "TODO: Unhandled null defop from Value: " << base << "\n");
       return nullptr;
     }
 


### PR DESCRIPTION
The `defOp` ptr in the debug print will be null (see the if statement on line 84). In my env this is causing a compiler error:

```
      FAILED: third_party/intel/lib/Dialect/Triton/Transforms/CMakeFiles/TritonIntelTransforms.dir/TensorDescToBlockPointer.cpp.o
      /usr/bin/c++ -DGTEST_HAS_RTTI=0 -I/home/jovyan/intel-xpu-backend-for-triton/python/build/cmake.linux-x86_64-cpython-3.10/third_party/intel/lib/Dialect/Triton/Transforms -I/home/jovyan/intel-xpu-backend-for-triton/third_party/intel/lib/Dialect/Triton/Transforms -I/home/jovyan/intel-xpu-backend-for-triton/include -I/home/jovyan/intel-xpu-backend-for-triton/. -I/home/jovyan/.triton/llvm/llvm-0ea4fb92-ubuntu-x64/include -I/home/jovyan/intel-xpu-backend-for-triton/python/build/cmake.linux-x86_64-cpython-3.10/include -I/home/jovyan/intel-xpu-backend-for-triton/third_party -I/home/jovyan/intel-xpu-backend-for-triton/python/build/cmake.linux-x86_64-cpython-3.10/third_party -I/home/jovyan/intel-xpu-backend-for-triton/python/src -I/home/jovyan/intel-xpu-backend-for-triton/third_party/intel/include -I/home/jovyan/intel-xpu-backend-for-triton/python/build/cmake.linux-x86_64-cpython-3.10/third_party/intel/include -I/home/jovyan/intel-xpu-backend-for-triton/third_party/intel/lib -D__STDC_FORMAT_MACROS  -fPIC -std=gnu++17 -Werror -Wno-covered-switch-default -fvisibility=hidden -O2 -g -std=gnu++17  -fno-exceptions -funwind-tables -fno-rtti -MD -MT third_party/intel/lib/Dialect/Triton/Transforms/CMakeFiles/TritonIntelTransforms.dir/TensorDescToBlockPointer.cpp.o -MF third_party/intel/lib/Dialect/Triton/Transforms/CMakeFiles/TritonIntelTransforms.dir/TensorDescToBlockPointer.cpp.o.d -o third_party/intel/lib/Dialect/Triton/Transforms/CMakeFiles/TritonIntelTransforms.dir/TensorDescToBlockPointer.cpp.o -c /home/jovyan/intel-xpu-backend-for-triton/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp
      In file included from /home/jovyan/.triton/llvm/llvm-0ea4fb92-ubuntu-x64/include/mlir/Pass/AnalysisManager.h:12,
                       from /home/jovyan/.triton/llvm/llvm-0ea4fb92-ubuntu-x64/include/mlir/Pass/Pass.h:13,
                       from /home/jovyan/intel-xpu-backend-for-triton/third_party/intel/include/Dialect/Triton/Transforms/Passes.h:12,
                       from /home/jovyan/intel-xpu-backend-for-triton/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp:1:
      In function ‘llvm::raw_ostream& mlir::operator<<(llvm::raw_ostream&, const mlir::Operation&)’,
          inlined from ‘mlir::triton::MakeTensorDescOp {anonymous}::TritonIntelTensorDescToBlockPointer::getMakeTensorDescOp(mlir::Value) const’ at /home/jovyan/intel-xpu-backend-for-triton/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp:99:7:
      /home/jovyan/.triton/llvm/llvm-0ea4fb92-ubuntu-x64/include/mlir/IR/Operation.h:1102:36: error: ‘this’ pointer is null [-Werror=nonnull]
       1102 |   const_cast<Operation &>(op).print(os, OpPrintingFlags().useLocalScope());
            |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      /home/jovyan/.triton/llvm/llvm-0ea4fb92-ubuntu-x64/include/mlir/IR/Operation.h: In function ‘mlir::triton::MakeTensorDescOp {anonymous}::TritonIntelTensorDescToBlockPointer::getMakeTensorDescOp(mlir::Value) const’:
      /home/jovyan/.triton/llvm/llvm-0ea4fb92-ubuntu-x64/include/mlir/IR/Operation.h:321:8: note: in a call to non-static member function ‘void mlir::Operation::print(llvm::raw_ostream&, const mlir::OpPrintingFlags&)’
        321 |   void print(raw_ostream &os, const OpPrintingFlags &flags = std::nullopt);
            |        ^~~~~
      At global scope:
      cc1plus: note: unrecognized command-line option ‘-Wno-covered-switch-default’ may have been intended to silence earlier diagnostics
      cc1plus: all warnings being treated as errors
      ninja: build stopped: subcommand failed.
```
Not sure why it works in CI. I changed the code to print the value instead of dereferencing the nullptr.