### PR TITLE
[05-layer-norm] Increase number of subgroups on XPU

### DIFF
--- a/python/tutorials/05-layer-norm.py
+++ b/python/tutorials/05-layer-norm.py
@@ -247,6 +247,8 @@ class LayerNorm(torch.autograd.Function):
             raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
         # heuristics for number of warps
         num_warps = min(max(BLOCK_SIZE // 256, 1), 8)
+        if is_xpu():
+            num_warps = 32
         # enqueue kernel
         _layer_norm_fwd_fused[(M, )](  #
             x_arg, y, weight, bias, mean, rstd,  #
@@ -267,8 +269,6 @@ class LayerNorm(torch.autograd.Function):
         if N <= 8192: GROUP_SIZE_M = 96
         if N <= 4096: GROUP_SIZE_M = 128
         if N <= 1024: GROUP_SIZE_M = 256
-        if is_xpu():
-            GROUP_SIZE_M = 256
         # allocate output
         locks = torch.zeros(2 * GROUP_SIZE_M, dtype=torch.int32, device=w.device)
         _dw = torch.zeros((GROUP_SIZE_M, N), dtype=x.dtype, device=w.device)

--- a/python/tutorials/05-layer-norm.py
+++ b/python/tutorials/05-layer-norm.py
@@ -291,7 +291,7 @@ class LayerNorm(torch.autograd.Function):
         _layer_norm_bwd_dwdb[grid](
             _dw, _db, dw, db, min(GROUP_SIZE_M, M), N,  #
             BLOCK_SIZE_M=32,  #
-            BLOCK_SIZE_N=128, num_ctas=1)
+            BLOCK_SIZE_N=128, num_warps=ctx.num_warps, num_ctas=1)
         return dx, None, dw, db, None
 
 


### PR DESCRIPTION
`05-layer-norm` performance on Max1100:

Before | After | Ratio
-- | -- | --
67.67681 | 96.3707 | 1.423984

It is beneficial to increase number of subgroups on XPU, because it 
improves thread-level parallelism, and increases registers per workgroup.