### PR TITLE
Support 2D block read for FP8 with 1 and 2 vBlocks

### DIFF
--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -421,6 +421,12 @@ struct TritonMatrix2DBlockLoadLowering
   LogicalResult
   matchAndRewrite(TritonGEN::Matrix2DBlockLoadOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    if (op.getElemSizeInBits() == 8 && op.getVBlocks() != 4) {
+      // TODO: add ocl built/spirv intrinsics for 8b 1 vBlock & 2 vBlock reads
+      rewriter.replaceOp(op, createGenISA2DBlockRead(op, rewriter));
+      return success();
+    }
+
     MLIRContext *ctx = rewriter.getContext();
     Location loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);


### PR DESCRIPTION
This PR updates Tutorial 10 `Experimental Block Pointer` to include FP8 examples (I split the different examples into separate lists, so it is easier to turn individual examples on and off). To get the example to run I had to resort to IGC intrinsics for the 2D block reads. The 4 vBlock variant is supported in OpenCL:
```
intel_sub_group_2d_block_read_8b_32r16x4c
```
but we need the 1 and 2 vBlock variants also. Will discuss submitting a ticket to get that functionality implemented separately. 

Close #3801 