### PR TITLE
Port and enable `group_gemm_tma_fn` in tutorial `08-grouped-gemm.py`

### DIFF
--- a/python/tutorials/08-grouped-gemm.py
+++ b/python/tutorials/08-grouped-gemm.py
@@ -355,6 +355,8 @@ def group_gemm_tma_fn(group_A, group_B):
         g_sizes += [M, N, K]
         g_lds += [A.stride(0), B.stride(0), C.stride(0)]
     # note these are device tensors
+    # Required to avoid exception, see:
+    # https://discuss.pytorch.org/t/torch-tensor-throws-runtimeerror-overflow-when-unpacking-long-exception/209386
     d_a_ptrs = torch.tensor(A_addrs, device=DEVICE, dtype=torch.uint64)
     d_b_ptrs = torch.tensor(B_addrs, device=DEVICE, dtype=torch.uint64)
     d_c_ptrs = torch.tensor(C_addrs, device=DEVICE, dtype=torch.uint64)

--- a/python/tutorials/08-grouped-gemm.py
+++ b/python/tutorials/08-grouped-gemm.py
@@ -31,7 +31,6 @@ import torch
 
 import triton
 import triton.language as tl
-from triton._internal_testing import (is_xpu)
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
@@ -40,8 +39,12 @@ def is_cuda():
     return triton.runtime.driver.active.get_current_target().backend == "cuda"
 
 
+def is_xpu():
+    return triton.runtime.driver.active.get_current_target().backend == "xpu"
+
+
 def supports_tma():
-    return is_xpu or (is_cuda() and torch.cuda.get_device_capability()[0] >= 9)
+    return is_xpu() or (is_cuda() and torch.cuda.get_device_capability()[0] >= 9)
 
 
 def num_sms():

--- a/python/tutorials/08-grouped-gemm.py
+++ b/python/tutorials/08-grouped-gemm.py
@@ -31,6 +31,7 @@ import torch
 
 import triton
 import triton.language as tl
+from triton._internal_testing import (is_xpu)
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
@@ -40,12 +41,14 @@ def is_cuda():
 
 
 def supports_tma():
-    return is_cuda() and torch.cuda.get_device_capability()[0] >= 9
+    return is_xpu or (is_cuda() and torch.cuda.get_device_capability()[0] >= 9)
 
 
 def num_sms():
     if is_cuda():
         return torch.cuda.get_device_properties("cuda").multi_processor_count
+    if is_xpu():
+        return torch.xpu.get_device_properties("xpu").gpu_eu_count
     return 148
 
 
@@ -349,9 +352,9 @@ def group_gemm_tma_fn(group_A, group_B):
         g_sizes += [M, N, K]
         g_lds += [A.stride(0), B.stride(0), C.stride(0)]
     # note these are device tensors
-    d_a_ptrs = torch.tensor(A_addrs, device=DEVICE)
-    d_b_ptrs = torch.tensor(B_addrs, device=DEVICE)
-    d_c_ptrs = torch.tensor(C_addrs, device=DEVICE)
+    d_a_ptrs = torch.tensor(A_addrs, device=DEVICE, dtype=torch.uint64)
+    d_b_ptrs = torch.tensor(B_addrs, device=DEVICE, dtype=torch.uint64)
+    d_c_ptrs = torch.tensor(C_addrs, device=DEVICE, dtype=torch.uint64)
     d_g_sizes = torch.tensor(g_sizes, dtype=torch.int32, device=DEVICE)
     d_g_lds = torch.tensor(g_lds, dtype=torch.int32, device=DEVICE)
 
@@ -399,7 +402,7 @@ for i in range(group_size):
 if supports_tma():
     tri_tma_out = group_gemm_tma_fn(group_A, group_B_T)
     for i in range(group_size):
-        assert torch.allclose(ref_out[i], tri_tma_out[i], atol=1e-2, rtol=0)
+        assert torch.allclose(ref_out[i], tri_tma_out[i], atol=1e-2, rtol=1e-3)
 
 
 # only launch the kernel, no tensor preparation here to remove all overhead


### PR DESCRIPTION
Now that we can translate tensor descriptor APIs into block ptrs APIs we can enable (port) function `group_gemm_tma_fn` in tutorial `08-grouped-gemm.py`