### PR TITLE
Skip test_mxfp on A770

### DIFF
--- a/scripts/skiplist/a770/language.txt
+++ b/scripts/skiplist/a770/language.txt
@@ -349,3 +349,6 @@ test/unit/language/test_pipeliner.py::test_indirect_matmul[1-128-64-128]
 test/unit/language/test_pipeliner.py::test_indirect_matmul[5-128-128-128]
 test/unit/language/test_pipeliner.py::test_indirect_matmul[5-128-128-64]
 test/unit/language/test_pipeliner.py::test_indirect_matmul[5-128-64-128]
+
+# mxfp 
+test/unit/language/test_matmul.py::test_mxfp


### PR DESCRIPTION
The A770 job recently increased to 5+ hours. See if skipping mxfp brings the job back to taking a reasonable amount of time to complete.