### PR TITLE
Fix FP16 to Fp8E4M3 RTNE Upper bound to +/-448

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -531,53 +531,89 @@ Fp16_to_Fp8E4M3Nv_RTNE(Location loc, ConversionPatternRewriter &rewriter,
   Value sign = b.and_(i32_ty, val, b.i32_val(0x8000));
   Value nosign = b.and_(i32_ty, val, b.i32_val(0x7fff));
 
-  Value exp = b.and_(i32_ty, b.lshr(nosign, b.i32_val(10)), b.i32_val(0x1f));
-  // Check if we need a translation to a subnormal value. This happens when
-  // exp value is in range [5, 8].
-  Value is_subnormal =
-      b.and_(b.icmp_uge(exp, b.i32_val(5)), b.icmp_ule(exp, b.i32_val(8)));
-  Value shift = b.sub(i32_ty, b.i32_val(8), exp);
-  Value subnormal = b.and_(i32_ty, nosign, b.i32_val(0x3ff));
-  subnormal = b.or_(i32_ty, subnormal, b.i32_val(0x400));
-  // Make rounding with respect to bits we are going to shift and cut off.
-  Value round_step = b.shl(i32_ty, b.i32_val(0x100), shift);
-  Value tail_mask = b.sub(i32_ty, round_step, b.i32_val(1));
-  Value tail = b.and_(i32_ty, subnormal, tail_mask);
-  Value threshold = b.shl(i32_ty, b.i32_val(0x80), shift);
-  Value odd_truncated =
-      b.icmp_ne(b.and_(i32_ty, subnormal, round_step), b.i32_val(0));
-  Value round_up = b.or_(b.icmp_ugt(tail, threshold),
-                         b.and_(b.icmp_eq(tail, threshold), odd_truncated));
-  subnormal =
-      b.select(round_up, b.add(i32_ty, subnormal, round_step), subnormal);
-  // Now shift to get the final result.
-  subnormal = b.lshr(i32_ty, subnormal, shift);
+  // Value exp = b.and_(i32_ty, b.lshr(nosign, b.i32_val(10)), b.i32_val(0x1f));
+  // // Check if we need a translation to a subnormal value. This happens when
+  // // exp value is in range [5, 8].
+  // Value is_subnormal =
+  //     b.and_(b.icmp_uge(exp, b.i32_val(5)), b.icmp_ule(exp, b.i32_val(8)));
+  // Value shift = b.sub(i32_ty, b.i32_val(8), exp);
+  // Value subnormal = b.and_(i32_ty, nosign, b.i32_val(0x3ff));
+  // subnormal = b.or_(i32_ty, subnormal, b.i32_val(0x400));
+  // // Make rounding with respect to bits we are going to shift and cut off.
+  // Value round_step = b.shl(i32_ty, b.i32_val(0x100), shift);
+  // Value tail_mask = b.sub(i32_ty, round_step, b.i32_val(1));
+  // Value tail = b.and_(i32_ty, subnormal, tail_mask);
+  // Value threshold = b.shl(i32_ty, b.i32_val(0x80), shift);
+  // Value odd_truncated =
+  //     b.icmp_ne(b.and_(i32_ty, subnormal, round_step), b.i32_val(0));
+  // Value round_up = b.or_(b.icmp_ugt(tail, threshold),
+  //                        b.and_(b.icmp_eq(tail, threshold), odd_truncated));
+  // subnormal =
+  //     b.select(round_up, b.add(i32_ty, subnormal, round_step), subnormal);
+  // // Now shift to get the final result.
+  // subnormal = b.lshr(i32_ty, subnormal, shift);
 
   // Normalized case. Start with rounding, then apply exp range to fit 4 bits,
   // adjust bias and shift left.
   // TODO: NaN values might be mishandled.
-  tail = b.and_(i32_ty, nosign, b.i32_val(0x7f));
-  odd_truncated =
-      b.icmp_ne(b.and_(i32_ty, nosign, b.i32_val(0x80)), b.i32_val(0));
-  round_up = b.or_(b.icmp_ugt(tail, b.i32_val(0x40)),
-                   b.and_(b.icmp_eq(tail, b.i32_val(0x40)), odd_truncated));
-  Value rounded =
-      b.and_(i32_ty, b.add(i32_ty, nosign, b.i32_val(0x80)), b.i32_val(0x7f80));
-  nosign = b.select(round_up, rounded, nosign);
+  // tail = b.and_(i32_ty, nosign, b.i32_val(0x7f));
+  // odd_truncated =
+  //     b.icmp_ne(b.and_(i32_ty, nosign, b.i32_val(0x80)), b.i32_val(0));
+  // round_up = b.or_(b.icmp_ugt(tail, b.i32_val(0x40)),
+  //                  b.and_(b.icmp_eq(tail, b.i32_val(0x40)), odd_truncated));
+  // Value rounded =
+  //     b.and_(i32_ty, b.add(i32_ty, nosign, b.i32_val(0x80)),
+  //     b.i32_val(0x7f80));
+  // nosign = b.select(round_up, rounded, nosign);
 
-  nosign = b.umax(i32_ty, nosign, b.i32_val(0x2000));
-  nosign = b.umin(i32_ty, nosign, b.i32_val(0x5c00));
-  nosign = b.sub(i32_ty, nosign, b.i32_val(0x2000));
-  nosign = b.shl(i32_ty, nosign, b.i32_val(1));
+  // nosign = b.umax(i32_ty, nosign, b.i32_val(0x2000));
+  // nosign = b.umin(i32_ty, nosign, b.i32_val(0x5c00));
+  // nosign = b.sub(i32_ty, nosign, b.i32_val(0x2000));
+  // nosign = b.shl(i32_ty, nosign, b.i32_val(1));
 
-  // Choose between subnormal and normal values.
-  nosign = b.select(is_subnormal, subnormal, nosign);
+  Value vi16 = b.bitcast(v[0], i16_ty);
+  sign = b.trunc(i8_ty, b.lshr(b.and_(vi16, b.i16_val(0x8000)), b.i16_val(8)));
+  vi16 = b.and_(vi16, b.i16_val(0x7FFF));
+  Value mantissa = b.lshr(b.and_(vi16, b.i16_val(0x0080)), b.i16_val(7));
+  Value roundinngBias = b.add(mantissa, b.i16_val(0x003f));
+  Value vFp8 = b.add(vi16, roundinngBias);
 
-  Value res_val = b.or_(i32_ty, nosign, sign);
-  auto fp8x4VecTy = vec_ty(i8_ty, 4);
-  Value res = b.bitcast(res_val, fp8x4VecTy);
+  vFp8 = b.and_(i16_ty, vFp8, b.i16_val(0xff80));
+  vFp8 = b.umax(vFp8, b.i16_val(0x2400));
+  vFp8 = b.sub(vFp8, b.i16_val(0x2000));
+  vFp8 = b.trunc(i8_ty, b.lshr(vFp8, b.i16_val(7)));
 
-  return {b.extract_element(i8_ty, res, b.i32_val(1))};
+  Value isOverflowOrInf = b.icmp_ugt(vi16, b.i16_val(0x5F7F));
+  vFp8 = b.select(isOverflowOrInf, b.i8_val(0x7E), vFp8);
+
+  constexpr size_t lutSize = 8;
+  constexpr float halfwayPointsLUT[lutSize] = {0x1400, 0x1A00, 0x1D00, 0x1F00,
+                                               0x2080, 0x2180, 0x2280, 0x2380};
+
+  for (int i = lutSize - 1; i >= 0; i--) {
+    Value cmp;
+    if (i % 2 == 0) {
+      cmp = b.icmp_ule(vi16, b.i16_val(halfwayPointsLUT[i]));
+    } else {
+      cmp = b.icmp_ult(vi16, b.i16_val(halfwayPointsLUT[i]));
+    }
+
+    vFp8 = b.select(cmp, b.i8_val(i), vFp8);
+  }
+
+  // Set sign bit
+  vFp8 = b.or_(vFp8, sign);
+
+  return {vFp8};
+
+  // // Choose between subnormal and normal values.
+  // nosign = b.select(is_subnormal, subnormal, nosign);
+
+  // Value res_val = b.or_(i32_ty, nosign, sign);
+  // auto fp8x4VecTy = vec_ty(i8_ty, 4);
+  // Value res = b.bitcast(res_val, fp8x4VecTy);
+
+  // return {b.extract_element(i8_ty, res, b.i32_val(1))};
 }
 
 static SmallVector<Value> Fp8E4M3Nv_to_Bf16(Location loc,

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -6,7 +6,6 @@
 #include "triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
-#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 
 using mlir::triton::gpu::ElementwiseOpConversionBase;
 using mlir::triton::gpu::MultipleOperandsRange;
@@ -568,11 +567,9 @@ Fp16_to_Fp8E4M3Nv_RTNE(Location loc, ConversionPatternRewriter &rewriter,
   Value normal = b.select(round_up, rounded, nosign);
 
   normal = b.umax(i16_ty, normal, b.i16_val(0x2000));
+  normal = b.umin(i16_ty, normal, b.i16_val(0x5f00));
   normal = b.sub(i16_ty, normal, b.i16_val(0x2000));
   normal = b.shl(i16_ty, normal, b.i16_val(1));
-
-  Value isOverflowOrInf = b.icmp_ugt(nosign, b.i16_val(0x5f7f));
-  normal = b.select(isOverflowOrInf, b.i16_val(0x007e), normal);
 
   // Choose between subnormal and normal values.
   Value res_val = b.select(is_subnormal, subnormal, normal);


### PR DESCRIPTION
This change fix previous FP16toFp8E4M3 RTNE upper bound from 256 to 448, according to https://www.opencompute.org/documents/ocp-8-bit-floating-point-specification-ofp8-revision-1-0-2023-12-01-pdf-1.
Page 13 table 2: "S.1111.1102 = ±448"
It helps to sovle SGLANG Group Quant UT failure https://github.com/intel/intel-xpu-backend-for-triton/issues/3613.

