### PR TITLE
Add ASM builder for Xe GPU. 

### DIFF
--- a/third_party/intel/include/TritonIntelGPUToLLVM/XeAsmFormat.h
+++ b/third_party/intel/include/TritonIntelGPUToLLVM/XeAsmFormat.h
@@ -1,0 +1,321 @@
+#ifndef TRITON_CONVERSION_TRITON_GPU_TO_LLVM_XE_ASM_FORMAT_H
+#define TRITON_CONVERSION_TRITON_GPU_TO_LLVM_XE_ASM_FORMAT_H
+
+#include "mlir/IR/Value.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include <memory>
+#include <string>
+
+namespace mlir {
+class ConversionPatternRewriter;
+class Location;
+
+namespace triton {
+using llvm::StringRef;
+
+struct XeInstr;
+struct XeInstrCommon;
+struct XeInstrExecution;
+
+// XeBuilder helps to manage a Xe asm program on consists of one or multiple
+// instructions.
+//
+// A helper for building an ASM program, the objective of XeBuilder is to give
+// a thin encapsulation and make the ASM code for MLIR LLVM Dialect more clear.
+// Currently, several factors are introduced to reduce the need for mixing
+// string and C++ if-else code.
+//
+// Usage:
+// To build: @$3 asm("@%3 add.s32 %0, %1, %2;" : "=r"(i) : "r"(j), "r"(k),
+// "b"(p));
+//
+// XeBuilder builder;
+// auto& add = builder.create<>();
+// add.predicate(pVal).o("lo").o("u32"); // add any suffix
+// // predicate here binds %0 to pVal, pVal is a mlir::Value
+//
+// auto* iOpr = builder.newOperand(iVal, "r"); // %1 bind to iVal
+// auto* jOpr = builder.newOperand(jVal, "r"); // %2 bind to jVal
+// auto* kOpr = builder.newOperand(kVal, "r"); // %3 bind to kVal
+// add(iOpr, jOpr, kOpr).predicate(predVal);   // set operands and predicate
+//
+// To get the asm code:
+// builder.dump()
+//
+// To get all the mlir::Value used in the Xe code,
+//
+// builder.getAllMlirArgs() // get {pVal, iVal, jVal, kVal}
+//
+// To get the string containing all the constraints with "," separated,
+// builder.getConstraints() // get "=r,r,k"
+//
+// XeBuilder can build a Xe asm with multiple instructions, sample code:
+//
+// XeBuilder builder;
+// auto& mov = builder.create("mov");
+// auto& cp = builder.create("cp");
+// mov(...);
+// cp(...);
+// This will get a Xe code with two instructions.
+//
+// Similar to a C function, a declared XeInstr instance can be launched
+// multiple times with different operands, e.g.
+//
+//   auto& mov = builder.create("mov");
+//   mov(... some operands ...);
+//   mov(... some different operands ...);
+//
+// Finally, we will get a Xe code with two mov instructions.
+//
+// There are several derived instruction type for typical instructions, for
+// example, the PtxIOInstr for ld and st instructions.
+struct XeBuilder {
+  struct Operand {
+    std::string constraint;
+    Value value;
+    int idx{-1};
+    llvm::SmallVector<Operand *> list;
+    std::function<std::string(int idx)> repr;
+
+    // for list
+    Operand() = default;
+    Operand(const Operation &) = delete;
+    Operand(Value value, StringRef constraint)
+        : constraint(constraint), value(value) {}
+
+    bool isList() const { return !value && constraint.empty(); }
+
+    Operand *listAppend(Operand *arg) {
+      list.push_back(arg);
+      return this;
+    }
+
+    Operand *listGet(size_t nth) const {
+      assert(nth < list.size() &&
+             "get asm operands of Xe assembler out of range.");
+      return list[nth];
+    }
+
+    std::string dump() const;
+  };
+
+  template <typename INSTR = XeInstr, typename... Args>
+  INSTR *create(Args &&...args) {
+    instrs.emplace_back(std::make_unique<INSTR>(this, args...));
+    return static_cast<INSTR *>(instrs.back().get());
+  }
+
+  // Create a list of operands.
+  Operand *newListOperand() { return newOperand(); }
+
+  Operand *newListOperand(ArrayRef<std::pair<mlir::Value, std::string>> items) {
+    auto *list = newOperand();
+    for (auto &item : items) {
+      list->listAppend(newOperand(item.first, item.second));
+    }
+    return list;
+  }
+
+  Operand *newListOperand(unsigned count, mlir::Value val,
+                          const std::string &constraint) {
+    auto *list = newOperand();
+    for (unsigned i = 0; i < count; ++i) {
+      list->listAppend(newOperand(val, constraint));
+    }
+    return list;
+  }
+
+  Operand *newListOperand(unsigned count, const std::string &constraint) {
+    auto *list = newOperand();
+    for (unsigned i = 0; i < count; ++i) {
+      list->listAppend(newOperand(constraint));
+    }
+    return list;
+  }
+
+  // Create a new operand. It will not add to operand list.
+  // @value: the MLIR value bind to this operand.
+  // @constraint: ASM operand constraint, .e.g. "=r"
+  // @formatter: extra format to represent this operand in ASM code, default is
+  //             "%{0}".format(operand.idx).
+  Operand *newOperand(mlir::Value value, StringRef constraint,
+                      std::function<std::string(int idx)> formatter = nullptr);
+
+  // Create a new operand which is written to, that is, the constraint starts
+  // with "=", e.g. "=r".
+  // If the operand will be used in predicated execution,
+  // users may want to initialize it before use.
+  // Otherwise if the register is only used in the true branch or the false
+  // branch but not both, the register is undefined and ptxas can perform
+  // aggressive optimizations that may lead to incorrect results.
+  Operand *newOperand(StringRef constraint, bool init = false);
+
+  // Create a new operand that is tied to a previous operand. In this case the
+  // asm would be permitted to write to an input register. Instead of providing
+  // constraint code for this operand, the constraint code of the tied operand
+  // is used.
+  Operand *newOperand(unsigned operandIndex);
+
+  // Create a constant integer operand.
+  Operand *newConstantOperand(int64_t v);
+  // Create a constant operand with explicit code specified.
+  Operand *newConstantOperand(const std::string &v);
+
+  Operand *newAddrOperand(mlir::Value addr, StringRef constraint, int off = 0);
+
+  llvm::SmallVector<Operand *, 4> getAllArgs() const;
+
+  llvm::SmallVector<Value, 4> getAllMLIRArgs() const;
+
+  std::string getConstraints() const;
+
+  std::string dump() const;
+
+  mlir::Value launch(OpBuilder &rewriter, Location loc, Type resTy,
+                     bool hasSideEffect = true, bool isAlignStack = false,
+                     ArrayRef<Attribute> attrs = {}) const;
+
+private:
+  Operand *newOperand() {
+    argArchive.emplace_back(std::make_unique<Operand>());
+    return argArchive.back().get();
+  }
+
+  void initOperand(Operand *opr);
+
+  // Make the operands in argArchive follow the provided \param order.
+  void reorderArgArchive(ArrayRef<Operand *> order) {
+    assert(order.size() == argArchive.size());
+    // The order in argArchive is unnecessary when onlyAttachMLIRArgs=false, but
+    // it does necessary when onlyAttachMLIRArgs is true for the $0, $1... are
+    // determined by Xe code snippet passed from external.
+    sort(argArchive.begin(), argArchive.end(),
+         [&](std::unique_ptr<Operand> &a, std::unique_ptr<Operand> &b) {
+           auto ida = std::find(order.begin(), order.end(), a.get());
+           auto idb = std::find(order.begin(), order.end(), b.get());
+           assert(ida != order.end());
+           assert(idb != order.end());
+           return ida < idb;
+         });
+  }
+
+  friend struct XeInstr;
+  friend struct XeInstrCommon;
+
+protected:
+  llvm::SmallVector<std::unique_ptr<Operand>, 6> argArchive;
+  llvm::SmallVector<std::unique_ptr<XeInstrCommon>, 2> instrs;
+  llvm::SmallVector<std::unique_ptr<XeInstrExecution>, 4> executions;
+  int oprCounter{};
+};
+
+// Xe instruction common interface.
+// Put the generic logic for all the instructions here.
+struct XeInstrCommon {
+  explicit XeInstrCommon(XeBuilder *builder) : builder(builder) {}
+
+  using Operand = XeBuilder::Operand;
+
+  template <typename... ARGS,
+            std::enable_if_t<std::conjunction_v<std::is_same<ARGS, Operand>...>,
+                             int> = 0>
+  XeInstrExecution &operator()(ARGS *...args) {
+    return call({args...});
+  }
+
+  // Set operands of this instruction.
+  XeInstrExecution &operator()(llvm::ArrayRef<Operand *> oprs,
+                               bool onlyAttachMLIRArgs = false);
+
+protected:
+  // "Call" the instruction with operands.
+  // \param oprs The operands of this instruction.
+  // \param onlyAttachMLIRArgs Indicate that it simply attach the MLIR Arguments
+  // to the inline Asm without generating the operand ids(such as $0, $1) in
+  // Xe code.
+  XeInstrExecution &call(llvm::ArrayRef<Operand *> oprs,
+                         bool onlyAttachMLIRArgs = false);
+
+  XeBuilder *builder{};
+  llvm::SmallVector<std::string, 4> instrParts;
+
+  friend struct XeInstrExecution;
+};
+
+template <class ConcreteT> struct XeInstrBase : public XeInstrCommon {
+  using Operand = XeBuilder::Operand;
+
+  explicit XeInstrBase(XeBuilder *builder, const std::string &name)
+      : XeInstrCommon(builder) {
+    o(name);
+  }
+
+  // Append a suffix to the instruction.
+  // e.g. XeInstr("add").o("s32") get a add.s32.
+  // A predicate is used to tell whether to apply the suffix, so that no if-else
+  // code needed. e.g. `XeInstr("add").o("s32", isS32).o("u32", !isS32);` will
+  // get a `add.s32` if isS32 is true.
+  ConcreteT &o(const std::string &suffix, bool predicate = true) {
+    if (predicate)
+      instrParts.push_back(suffix);
+    return *static_cast<ConcreteT *>(this);
+  }
+};
+
+struct XeInstr : public XeInstrBase<XeInstr> {
+  using XeInstrBase<XeInstr>::XeInstrBase;
+
+  // Append a ".global" to the instruction.
+  XeInstr &global();
+
+  // Append a ".shared" to the instruction.
+  XeInstr &shared();
+
+  // Append a ".v[0-9]+" to the instruction
+  XeInstr &v(int vecWidth, bool predicate = true);
+
+  // Append a".b[0-9]+" to the instruction
+  XeInstr &b(int width);
+};
+
+// Record the operands and context for "launching" a XeInstr.
+struct XeInstrExecution {
+  using Operand = XeBuilder::Operand;
+
+  llvm::SmallVector<Operand *> argsInOrder;
+
+  XeInstrExecution() = default;
+  explicit XeInstrExecution(XeInstrCommon *instr,
+                            llvm::ArrayRef<Operand *> oprs,
+                            bool onlyAttachMLIRArgs)
+      : argsInOrder(oprs.begin(), oprs.end()), instr(instr),
+        onlyAttachMLIRArgs(onlyAttachMLIRArgs) {}
+
+  // Prefix a predicate to the instruction.
+  XeInstrExecution &predicate(mlir::Value value, StringRef constraint = "b") {
+    pred = instr->builder->newOperand(value, constraint);
+    return *this;
+  }
+
+  // Prefix a !predicate to the instruction.
+  XeInstrExecution &predicateNot(mlir::Value value, StringRef constraint) {
+    pred = instr->builder->newOperand(value, constraint);
+    pred->repr = [](int idx) { return "@!$" + std::to_string(idx); };
+    return *this;
+  }
+
+  std::string dump() const;
+
+  SmallVector<Operand *> getArgList() const;
+
+  XeInstrCommon *instr{};
+  Operand *pred{};
+  bool onlyAttachMLIRArgs{};
+};
+
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_CONVERSION_TRITON_GPU_TO_LLVM_XE_ASM_FORMAT_H

--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -107,12 +107,13 @@ public:
 
 static SPIRV::TranslatorOpts getSPIRVOopts() {
   SPIRV::TranslatorOpts SPIRVOpts;
-  static constexpr std::array<SPIRV::ExtensionID, 13> AllowedExtensions{
+  static constexpr std::array<SPIRV::ExtensionID, 14> AllowedExtensions{
       SPIRV::ExtensionID::SPV_EXT_shader_atomic_float_add,
       SPIRV::ExtensionID::SPV_INTEL_arbitrary_precision_integers,
       SPIRV::ExtensionID::SPV_INTEL_arithmetic_fence,
       SPIRV::ExtensionID::SPV_INTEL_bfloat16_conversion,
       SPIRV::ExtensionID::SPV_INTEL_cache_controls,
+      SPIRV::ExtensionID::SPV_INTEL_inline_assembly,
       SPIRV::ExtensionID::SPV_INTEL_kernel_attributes,
       SPIRV::ExtensionID::SPV_INTEL_memory_access_aliasing,
       SPIRV::ExtensionID::SPV_INTEL_subgroups,

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/CMakeLists.txt
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/CMakeLists.txt
@@ -21,6 +21,7 @@ add_triton_library(TritonIntelGPUToLLVM
     TritonOpsToLLVM.cpp
     TypeConverter.cpp
     Utility.cpp
+    XeAsmFormat.cpp
 
     DEPENDS
     TritonIntelGPUConversionPassIncGen

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/XeAsmFormat.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/XeAsmFormat.cpp
@@ -1,0 +1,234 @@
+#include "intel/include/TritonIntelGPUToLLVM/XeAsmFormat.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "triton/Conversion/TritonGPUToLLVM/AsmFormat.h"
+#include "llvm/Support/raw_ostream.h"
+#include <sstream>
+
+namespace mlir {
+namespace triton {
+
+XeInstr::Operand *
+XeBuilder::newOperand(mlir::Value value, StringRef constraint,
+                      std::function<std::string(int)> formatter) {
+  argArchive.emplace_back(std::make_unique<Operand>(value, constraint));
+  auto *opr = argArchive.back().get();
+  opr->repr = formatter;
+  opr->idx = oprCounter++;
+  return opr;
+}
+
+void XeBuilder::initOperand(Operand *opr) {
+  auto numBits = 0;
+  // Derive numBits from the constraint.
+  if (opr->constraint[1] == 'c' || opr->constraint[1] == 'h')
+    numBits = 16;
+  else if (opr->constraint[1] == 'r')
+    numBits = 32;
+  else if (opr->constraint[1] == 'l')
+    numBits = 64;
+  else
+    llvm_unreachable(("Unknown constraint: " + opr->constraint).c_str());
+  // If numBits is less than 16, we use 16 as default because Xe does not
+  // support 8-bit mov.
+  numBits = numBits < 16 ? 16 : numBits;
+  auto *zero = newConstantOperand(0);
+  auto &init = create<>("mov")->o("u" + std::to_string(numBits));
+  init(opr, zero);
+}
+
+XeBuilder::Operand *XeBuilder::newOperand(StringRef constraint, bool init) {
+  // Constraint should be something like "=rw"
+  assert(constraint[0] == '=');
+  auto *opr = newOperand();
+  opr->idx = oprCounter++;
+  opr->constraint = constraint;
+  if (init) {
+    initOperand(opr);
+  }
+  return opr;
+}
+
+XeBuilder::Operand *XeBuilder::newOperand(unsigned operandIndex) {
+  assert(operandIndex < oprCounter && "operand index out of range");
+  auto *opr = newOperand();
+  opr->idx = oprCounter++;
+  opr->constraint = std::to_string(operandIndex);
+  return opr;
+}
+
+XeBuilder::Operand *XeBuilder::newConstantOperand(const std::string &v) {
+  argArchive.emplace_back(std::make_unique<Operand>());
+  argArchive.back()->repr = [v](int idx) { return v; };
+  return argArchive.back().get();
+}
+
+XeBuilder::Operand *XeBuilder::newConstantOperand(int64_t v) {
+  std::stringstream ss;
+  ss << "0x" << std::hex << v;
+  return newConstantOperand(ss.str());
+}
+
+std::string XeBuilder::getConstraints() const {
+  auto args = getAllArgs();
+  llvm::SmallVector<std::string, 4> argReprs;
+  for (auto arg : args)
+    argReprs.push_back(arg->constraint);
+  return strJoin(argReprs, ",");
+}
+
+llvm::SmallVector<Value, 4> XeBuilder::getAllMLIRArgs() const {
+  llvm::SmallVector<Value, 4> res;
+  for (auto &arg : argArchive) {
+    if (!arg->isList() && arg->value)
+      res.push_back(arg->value);
+  }
+  return res;
+}
+
+SmallVector<XeBuilder::Operand *, 4> XeBuilder::getAllArgs() const {
+  llvm::SmallVector<Operand *, 4> res;
+  for (auto &x : argArchive)
+    if (!x->isList())
+      res.push_back(x.get());
+  return res;
+}
+
+mlir::Value XeBuilder::launch(OpBuilder &rewriter, Location loc, Type resTy,
+                              bool hasSideEffect, bool isAlignStack,
+                              ArrayRef<Attribute> attrs) const {
+  auto *ctx = rewriter.getContext();
+  auto inlineAsm = rewriter.create<LLVM::InlineAsmOp>(
+      loc, resTy, getAllMLIRArgs(), // operands
+      dump(),                       // asm_string
+      getConstraints(),             // constraints
+      hasSideEffect,                // has_side_effects
+      isAlignStack,                 // is_align_stack
+      LLVM::AsmDialectAttr::get(ctx,
+                                LLVM::AsmDialect::AD_ATT), // asm_dialect
+      ArrayAttr::get(ctx, attrs)                           // operand_attrs
+  );
+
+  return inlineAsm.getRes();
+}
+
+std::string XeInstr::Operand::dump() const {
+  if (repr)
+    return repr(idx);
+  if (!isList())
+    return "$" + std::to_string(idx);
+
+  llvm::SmallVector<std::string> oprs;
+  for (auto *opr : list)
+    oprs.push_back(opr->dump());
+  return "{ " + strJoin(oprs, ", ") + " }";
+}
+
+XeInstr::Operand *XeBuilder::newAddrOperand(mlir::Value addr,
+                                            StringRef constraint, int off) {
+  auto *opr = newOperand(addr, constraint);
+  opr->repr = [off](int idx) -> std::string {
+    std::stringstream ss;
+    ss << "[ $" << idx << " + " << off << " ]";
+    return ss.str();
+  };
+
+  return opr;
+}
+
+std::string XeBuilder::dump() const {
+  llvm::SmallVector<std::string> lines;
+  for (auto &exec : executions) {
+    lines.push_back(exec->dump());
+  }
+
+  return strJoin(lines, "\n\t");
+}
+
+XeInstrExecution &XeInstrCommon::call(ArrayRef<Operand *> oprs,
+                                      bool onlyAttachMLIRArgs) {
+  if (onlyAttachMLIRArgs) {
+    // Nearly impossible to make the $0,$1 in two Xe code snippets to point to
+    // the same MLIR values in onlyAttachMLIRArgs mode.
+    assert(builder->executions.empty() &&
+           "builder can only hold a single execution when onlyAttachMIIRArgs "
+           "is true.");
+    builder->reorderArgArchive(oprs);
+  }
+
+  builder->executions.emplace_back(
+      std::make_unique<XeInstrExecution>(this, oprs, onlyAttachMLIRArgs));
+
+  return *builder->executions.back();
+}
+
+XeInstrExecution &XeInstrCommon::operator()(ArrayRef<Operand *> oprs,
+                                            bool onlyAttachMLIRArgs) {
+  return call(oprs, onlyAttachMLIRArgs);
+}
+
+std::string XeInstrExecution::dump() const {
+  std::string osStr;
+  llvm::raw_string_ostream os(osStr);
+
+  if (pred) {
+    if (!pred->repr)
+      os << "@" << pred->dump() << " ";
+    else
+      os << pred->repr(pred->idx) << " ";
+  }
+
+  std::string instrRepr = strJoin(instr->instrParts, ".");
+  if (onlyAttachMLIRArgs) {
+    os << instrRepr;
+    os.flush();
+    return osStr;
+  }
+
+  llvm::SmallVector<std::string, 4> argReprs;
+  for (auto *arg : argsInOrder) {
+    argReprs.push_back(arg->dump());
+  }
+
+  std::string argsRepr = strJoin(argReprs, ", ");
+
+  os << instrRepr << " " << argsRepr << ";";
+  os.flush();
+  return osStr;
+}
+
+SmallVector<XeInstrExecution::Operand *> XeInstrExecution::getArgList() const {
+  SmallVector<Operand *> args;
+  for (auto *arg : argsInOrder) {
+    if (arg->isList())
+      args.insert(args.end(), arg->list.begin(), arg->list.end());
+    else
+      args.push_back(arg);
+  }
+  return args;
+}
+
+XeInstr &XeInstr::global() {
+  o("global");
+  return *this;
+}
+
+XeInstr &XeInstr::shared() {
+  o("shared");
+  return *this;
+}
+
+XeInstr &XeInstr::v(int vecWidth, bool predicate) {
+  if (vecWidth > 1) {
+    o("v" + std::to_string(vecWidth), predicate);
+  }
+  return *this;
+}
+
+XeInstr &XeInstr::b(int width) {
+  o("b" + std::to_string(width));
+  return *this;
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/intel/unittest/CMakeLists.txt
+++ b/third_party/intel/unittest/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(Dialect)
+add_subdirectory(Conversion)

--- a/third_party/intel/unittest/Conversion/CMakeLists.txt
+++ b/third_party/intel/unittest/Conversion/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(TritonIntelGPUToLLVM)

--- a/third_party/intel/unittest/Conversion/TritonIntelGPUToLLVM/CMakeLists.txt
+++ b/third_party/intel/unittest/Conversion/TritonIntelGPUToLLVM/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_triton_ut(
+	NAME TestXeAsmFormat
+	SRCS XeAsmFormatTest.cpp
+	LIBS TritonGPUToLLVM TritonIntelGPUToLLVM
+)

--- a/third_party/intel/unittest/Conversion/TritonIntelGPUToLLVM/XeAsmFormatTest.cpp
+++ b/third_party/intel/unittest/Conversion/TritonIntelGPUToLLVM/XeAsmFormatTest.cpp
@@ -1,0 +1,88 @@
+#include "intel/include/TritonIntelGPUToLLVM/XeAsmFormat.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Builders.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "llvm/Support/Signals.h"
+
+#include <gtest/gtest.h>
+
+namespace mlir {
+namespace triton {
+class XeAsmFormatTest : public ::testing::Test {
+protected:
+  static constexpr int numValues = 4;
+
+  XeAsmFormatTest() {
+    ctx.loadDialect<arith::ArithDialect>();
+
+    createValues();
+  }
+
+  // Creates the test values.
+  void createValues() {
+    OpBuilder builder(&ctx);
+    builder.setInsertionPointToStart(&block);
+
+    // a b1 value for predicate.
+    v[0] = builder.create<arith::ConstantIntOp>(builder.getUnknownLoc(), 1, 1);
+    for (int i = 0; i < numValues; i++) {
+      v[i + 1] =
+          builder.create<arith::ConstantIntOp>(builder.getUnknownLoc(), i, 32);
+    }
+  }
+
+  MLIRContext ctx;
+  Block block;
+  Value v[numValues + 1];
+};
+
+TEST_F(XeAsmFormatTest, VISA_basic) {
+  XeBuilder builder;
+
+  // Create the operands needed by the instructions in the Xe code.
+  auto *cst = builder.newConstantOperand(1);
+  auto *val = builder.newOperand(v[0], "=r");
+
+  // create an instruction
+  auto &mov = *builder.create("mov (M1_NM, 1)");
+
+  mov(val, cst);
+  ASSERT_EQ(builder.dump(), "mov (M1_NM, 1) $0, 0x1;");
+
+  auto values = builder.getAllMLIRArgs();
+  ASSERT_EQ(values[0], v[0]); // $0 -> v[1]
+
+  auto constraints = builder.getConstraints();
+  ASSERT_EQ(constraints, "=r"); // $0 -> =r
+}
+
+TEST_F(XeAsmFormatTest, MultiLineXe) {
+  XeBuilder builder;
+
+  auto *constVal = builder.newConstantOperand(1);
+  auto *valVal0 = builder.newOperand(v[1], "=r");
+  auto *valVal1 = builder.newOperand(v[2], "=r");
+
+  auto &mov = *builder.create("mov");
+
+  mov(valVal0, constVal);
+  mov(valVal1, constVal);
+  mov(valVal1, valVal0);
+
+  EXPECT_EQ(builder.dump(), "mov $0, 0x1;\n\t"
+                            "mov $1, 0x1;\n\t"
+                            "mov $1, $0;");
+
+  auto values = builder.getAllMLIRArgs();
+  EXPECT_EQ(values[0], v[1]); // $0 -> v[1]
+  EXPECT_EQ(values[1], v[2]); // $1 -> v[2]
+}
+
+} // namespace triton
+} // namespace mlir
+
+int main(int argc, char *argv[]) {
+  llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
The XeAsmFormat.h and XeAsmFormat.cpp are almost same to the PTX ASM helper for NV backend to keep the feature for SIMT ISA.