### PR TITLE
[Debug] Test benchmarks on new agama without assert's relaxation

### DIFF
--- a/benchmarks/triton_kernels_benchmark/benchmark_testing.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_testing.py
@@ -159,8 +159,7 @@ def do_bench_upstream_pytorch_profiler(fn, n_warmup=25, n_repeat=100, grad_to_no
     # for correct registration of kernels.
     # For details: https://github.com/pytorch/pytorch/issues/144778
     kernels = [kernel for kernel in kernels if kernel != []]
-    # FIXME: relaxation for new agama release
-    assert len(kernels) >= n_repeat - 1, (
+    assert len(kernels) == n_repeat, (
         f"the profiling number not match; {n_repeat=}, {kernels=}, \n" +
         f"top functions by xpu_time:\n {prof.key_averages(group_by_stack_n=5).table(sort_by='xpu_time')}")
     # Make the time to the milliseconds.


### PR DESCRIPTION
In the past, the error was for agama 1077: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/12915920053/job/36018883887. It's not reproducible for agama 1099 now: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/14242289577/job/39914776221?pr=3826. I guess I can remove the workaround and see how the code behaves in the future.

Closes #3243 