### PR TITLE
Make sure install `setuptools>=78.1.0` in `setup-triton`

### DIFF
--- a/.github/actions/setup-triton/action.yml
+++ b/.github/actions/setup-triton/action.yml
@@ -99,6 +99,7 @@ runs:
       run: |
         cd python
         pip install wheel pybind11
+        pip install -U "setuptools>=78.1.0"
         ${{ inputs.command }}
 
     - name: Save Triton cache


### PR DESCRIPTION
Consistent with `setup.py`,
https://github.com/intel/intel-xpu-backend-for-triton/blob/75c82bd4d0eaaa344566cabcae2263e50e3cdcc6/python/setup.py#L758

otherwise, some workflows (build triton with `DEBUG=1 python setup.py bdist_wheel`) may use existed older `setuptools`, like this [run](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/14347902219/job/40221049156#step:4:30)