### PR TITLE
Use standard action setup-triton in benchmarks

### DIFF
--- a/.github/workflows/third-party-benchmarks.yml
+++ b/.github/workflows/third-party-benchmarks.yml
@@ -69,14 +69,8 @@ jobs:
       - name: Setup PyTorch
         uses: ./.github/actions/setup-pytorch
 
-      - name: Build Triton wheels
+      - name: Setup Triton
         uses: ./.github/actions/setup-triton
-        with:
-          command: DEBUG=1 python setup.py bdist_wheel
-
-      - name: Install Triton
-        run: |
-          pip install python/dist/*.whl
 
       - name: Install benchmark dependencies
         id: install

--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -109,18 +109,8 @@ jobs:
       - name: Setup PyTorch
         uses: ./.github/actions/setup-pytorch
 
-      - name: Build Triton wheels
+      - name: Setup Triton
         uses: ./.github/actions/setup-triton
-        with:
-          command: DEBUG=1 python setup.py bdist_wheel
-
-      - name: Install Triton
-        run: |
-          pip install python/dist/*.whl
-
-      - name: Install benchmark dependencies
-        run: |
-          pip install matplotlib pandas tabulate
 
       - name: Create reports dir
         run: |


### PR DESCRIPTION
There is no need to build Triton wheel in benchmarking workflows, just installed Triton. 