### PR TITLE
Temporary disable 09-persistent-matmul on B580

### DIFF
--- a/scripts/skiplist/xe2/tutorials.txt
+++ b/scripts/skiplist/xe2/tutorials.txt
@@ -1,0 +1,1 @@
+09-persistent-matmul


### PR DESCRIPTION
The tutorial 09-persistent-matmul randomly hangs or gets aborted on B580.

This is a temporary work around for #3884 to enable daily CI runs.