### PR TITLE
[Intel] Rework load-store redundant data masking 

### DIFF
--- a/python/test/unit/intel/test_block_load.py
+++ b/python/test/unit/intel/test_block_load.py
@@ -15,8 +15,6 @@ from triton._internal_testing import is_xpu
 def test_block_load_dpas_layout(M, N, dtype_str, transpose, device, tmp_path: pathlib.Path):
     # modify the layouts to ensure the correct OCL/SPIRV intrinsic is called for each datatype
     if dtype_str == "int8":
-        if M == 128 and N == 16 or N == 8:
-            pytest.skip("TODO: test fails verification")
         A_width = 2
         B_width = 4
         layouts = "#mma = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 4, threadsPerWarp = 16, warpsPerCTA = [1, 4], repCluster = [1, 2], A = [8, 32], B = [32, 32], C = [8, 32]}>"
@@ -25,8 +23,6 @@ def test_block_load_dpas_layout(M, N, dtype_str, transpose, device, tmp_path: pa
         B_width = 1
         layouts = "#mma = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 1, threadsPerWarp = 16, warpsPerCTA = [8, 4], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>"
     else:
-        if M == 128 and N == 8:
-            pytest.skip("TODO: test fails verification")
         A_width = 1
         B_width = 2
         layouts = "#mma = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [8, 4], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>"

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -23,16 +23,75 @@ using namespace mlir::triton::gpu::intel;
 
 namespace {
 
+// Returns a Value for the format string, which you can reuse. Writes the byte
+// count for the string to |formatStrByteCount| if not null.
+Value llPrintf(StringRef msg, ValueRange args, ArrayRef<bool> isSigned,
+               ConversionPatternRewriter &rewriter,
+               const triton::intel::TargetInfo &targetInfo,
+               int *formatStrByteCount = nullptr) {
+  assert(!msg.empty() && "printf with empty string not supported");
+  llvm::SmallString<64> msgNewline(msg);
+  msgNewline.push_back('\n');
+  msgNewline.push_back('\0');
+  Value msgValue = targetInfo.getGlobalStringStart(
+      rewriter.getUnknownLoc(), rewriter, "printfFormat_", msgNewline,
+      /*addressSpace=*/TritonGEN::kUniformConstant);
+  targetInfo.printf(rewriter, msgValue, msgNewline.size_in_bytes(), args,
+                    isSigned);
+  return msgValue;
+}
+
+Value maybeAnd(RewriterBase &rewriter, Location loc, Value a, Value b) {
+  auto tb = TritonLLVMOpBuilder(loc, rewriter);
+  if (a && b) {
+    return tb.and_(a, b);
+  }
+  return a ? a : b;
+}
+
+// Return a predicate that is true only if the current thread holds unique data,
+// according to freeVarsMask. The predicate may be null to indicate no
+// predication is required.
+Value emitRedundantThreadPredicate(
+    const llvm::MapVector<StringAttr, int32_t> &freeVarMasks,
+    ConversionPatternRewriter &rewriter, Location loc,
+    const triton::intel::TargetInfo &targetInfo) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  auto ctx = rewriter.getContext();
+  auto kLane = str_attr("lane");
+  auto kWarp = str_attr("warp");
+  auto kBlock = str_attr("block");
+
+  Value zero = b.i32_val(0);
+  auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
+  Value blockId = freeVarMasks.lookup(kBlock) == 0
+                      ? zero
+                      : targetInfo.getClusterCTAId(rewriter, loc);
+
+  Value pred;
+  auto dimNames = {kLane, kWarp, kBlock};
+  auto dimIds = {laneId, warpId, blockId};
+  for (auto [dimName, dimId] : llvm::zip(dimNames, dimIds)) {
+    int32_t mask = freeVarMasks.lookup(dimName);
+    if (mask != 0) {
+      auto dimPred = b.icmp_eq(b.and_(dimId, b.i32_val(mask)), zero);
+      pred = maybeAnd(rewriter, loc, pred, dimPred);
+    }
+  }
+  return pred;
+}
+
 // Return the mask for the unique data accessed by given tensor type.
 // Used to mask out the redundant data accessed by threads.
 Value redundantDataMask(Type valueTy, ConversionPatternRewriter &rewriter,
                         Location loc,
                         const triton::intel::TargetInfo &targetInfo) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  auto tensorTy = dyn_cast<RankedTensorType>(valueTy);
+
   Value mask = b.true_val();
-  auto tid = getThreadId(rewriter, loc);
   auto clusterCTAId = targetInfo.getClusterCTAId(rewriter, loc);
+
+  auto tensorTy = dyn_cast<RankedTensorType>(valueTy);
   if (tensorTy) {
     // To remove this use, port https://github.com/triton-lang/triton/pull/5432
     // to the INTELGPU dialect
@@ -81,6 +140,7 @@ Value redundantDataMask(Type valueTy, ConversionPatternRewriter &rewriter,
     // If the tensor is not ranked, then it is a scalar and only thread 0 of
     // CTA0 can write
     mask = b.and_(mask, b.icmp_eq(clusterCTAId, b.i32_val(0)));
+    auto tid = getThreadId(rewriter, loc);
     mask = b.and_(mask, b.icmp_eq(tid, b.i32_val(0)));
   }
   return mask;
@@ -2147,7 +2207,20 @@ struct StoreOpConversion
     assert(!maskElems.size() ||
            valueElems.size() == maskElems.size() && "Mask size mismatch");
 
-    mask = redundantDataMask(valueTy, rewriter, loc, targetInfo);
+    auto freeVarMasks = getFreeVariableMasks(valueTy);
+#if 0
+    for (auto mask : freeVarMasks) {
+      llvm::errs() << mask.first << " = " << mask.second << " ("
+                   << std::to_string(1 << mask.second) << ")\n";
+    }
+#endif
+    // mask = redundantDataMask(valueTy, rewriter, loc, targetInfo);
+    // TODO: do we care about the original mask here? we seem to be overwriting
+    // it in the previous version.
+    Value threadPred =
+        emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
+    uint32_t regMask = freeVarMasks[str_attr("register")];
+
     const size_t dtsize =
         std::max<int>(1, valueElemTy.getIntOrFloatBitWidth() / 8);
     const size_t valueElemNBits = dtsize * 8;
@@ -2155,6 +2228,10 @@ struct StoreOpConversion
     unsigned elemsPerThread = getTotalElemsPerThread(valueTy);
     const int numVecs = elemsPerThread / vec;
     for (size_t vecStart = 0; vecStart < elemsPerThread; vecStart += vec) {
+      if (!isCanonicalIndex(vecStart, regMask)) {
+        // Don't emit store ops for redundant elements within a thread
+        continue;
+      }
       // TODO: optimization when ptr is AddPtr with constant offset
       size_t in_off = 0;
 
@@ -2192,8 +2269,11 @@ struct StoreOpConversion
         asmArgs.emplace_back(llWord, constraint);
       }
 
-      Value maskVal =
-          maskElems.size() ? b.and_(mask, maskElems[vecStart]) : mask;
+      Value maskVal = threadPred;
+      if (llMask) {
+        auto mask = maskElems[vecStart];
+        maskVal = maybeAnd(rewriter, loc, maskVal, mask);
+      }
 
       auto vecTy = vec_ty(valArgTy, nWords);
       Value vecWord = b.undef(vecTy);
@@ -2201,6 +2281,22 @@ struct StoreOpConversion
         auto llWord = asmArgs[index].first;
         vecWord = b.insert_element(vecTy, vecWord, llWord, b.i32_val(index));
       }
+
+#if 0
+      auto vecTestElem = b.extract_element(valArgTy, vecWord, b.i32_val(0));
+      auto testElemBitcast = b.bitcast(vecTestElem, wordTy);
+      auto testElemVal =
+          b.extract_element(valueElemTy, testElemBitcast, b.i32_val(0));
+
+      Value addrElem = b.bitcast(ptrElems[vecStart], ptr_ty(ctx, 1 /*global*/));
+
+      auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
+      llPrintf("warp %d lane %d mask %d & %d = %d addr %p val %f vec %d",
+               {warpId, laneId, threadPred, maskElems[vecStart], maskVal, addrElem,
+                testElemVal, b.i32_val(vecStart)},
+               {true, true, true, true, true, true, true, true}, rewriter,
+               targetInfo);
+#endif
 
       // Create a predicated store operation.
       LLVM::intel::createPredicatedBlock(rewriter, loc, maskVal, [&] {

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2409,7 +2409,7 @@ struct AtomicCASOpConversion
             spirv::MemorySemantics::SequentiallyConsistent |
                 spirv::MemorySemantics::CrossWorkgroupMemory);
       Value ret;
-      // TODO: de-duplicate 
+      // TODO: de-duplicate
       if (mask) {
         Block &endBlock = LLVM::intel::createPredicatedBlock(
             rewriter, loc, mask, {zero}, [&] {
@@ -2531,7 +2531,9 @@ struct AtomicRMWOpConversion
       // mask
       numElems = tensorTy.getNumElements();
     }
-    Value mask = redundantDataMask(valueTy, rewriter, loc, targetInfo);
+    auto freeVarMasks = getFreeVariableMasks(valueTy);
+    Value threadPred =
+        emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
 
     auto vecTy = vec_ty(valueElemTy, vec);
     SmallVector<Value> resultVals(elemsPerThread);
@@ -2544,7 +2546,9 @@ struct AtomicRMWOpConversion
       }
 
       Value rmwPtr = ptrElements[i];
-      Value rmwMask = llMask ? b.and_(mask, maskElements[i]) : mask;
+      Value rmwMask = llMask
+                          ? maybeAnd(rewriter, loc, maskElements[i], threadPred)
+                          : threadPred;
 
       assert((valueElemNBits == 16 || valueElemNBits == 32 ||
               valueElemNBits == 64) &&
@@ -2561,64 +2565,110 @@ struct AtomicRMWOpConversion
       Block *endBlock = nullptr;
       // TODO: check device capabilities to avoid unnecessary emulation or
       // emit unsupported feature error.
+      Value ret;
+
       if (valueElemNBits == 16) {
         op.emitWarning(
             "'tt.atomic_rmw' op fp16 datatype is not supported in the target "
             "HW, software emulation is an experimental feature (use at own "
             "risk)");
-        endBlock =
-            emulateFp16AtomicRmw(rewriter, loc, atomicRmwAttr, valueElemTy,
-                                 rmwPtr, rmwVal, rmwMask, {zero});
+        endBlock = emulateFp16AtomicRmw(
+            rewriter, loc, atomicRmwAttr, valueElemTy, rmwPtr, rmwVal,
+            maybeAnd(rewriter, loc, b.true_val(), rmwMask), {zero});
       } else {
         if (!atomicNeedsSharedMemory(op.getResult()))
           rewriter.create<spirv::ControlBarrierOp>(
               loc, spirv::Scope::Workgroup, spirv::Scope::Workgroup,
               spirv::MemorySemantics::SequentiallyConsistent |
                   spirv::MemorySemantics::CrossWorkgroupMemory);
-        endBlock = &LLVM::intel::createPredicatedBlock(
-            rewriter, loc, rmwMask, {zero}, [&] {
-              mlir::LLVM::AtomicBinOp rmwKind;
-              switch (atomicRmwAttr) {
-              case RMWOp::AND:
-                rmwKind = LLVM::AtomicBinOp::_and;
-                break;
-              case RMWOp::OR:
-                rmwKind = LLVM::AtomicBinOp::_or;
-                break;
-              case RMWOp::XOR:
-                rmwKind = LLVM::AtomicBinOp::_xor;
-                break;
-              case RMWOp::ADD:
-                rmwKind = LLVM::AtomicBinOp::add;
-                break;
-              case RMWOp::FADD:
-                rmwKind = LLVM::AtomicBinOp::fadd;
-                break;
-              case RMWOp::MAX:
-                rmwKind = LLVM::AtomicBinOp::max;
-                break;
-              case RMWOp::UMAX:
-                rmwKind = LLVM::AtomicBinOp::umax;
-                break;
-              case RMWOp::MIN:
-                rmwKind = LLVM::AtomicBinOp::min;
-                break;
-              case RMWOp::UMIN:
-                rmwKind = LLVM::AtomicBinOp::umin;
-                break;
-              case RMWOp::XCHG:
-                rmwKind = LLVM::AtomicBinOp::xchg;
-                break;
-              }
 
-              rmwVal = b.bitcast(rmwVal, valueElemTy);
-              auto atomRMW = rewriter.create<LLVM::AtomicRMWOp>(
-                  loc, rmwKind, rmwPtr, rmwVal, llvmMemOrdering);
-              return SmallVector<Value, 1>{atomRMW.getRes()};
-            });
+        // TODO: de-duplicate
+        if (rmwMask) {
+          endBlock = &LLVM::intel::createPredicatedBlock(
+              rewriter, loc, rmwMask, {zero}, [&] {
+                mlir::LLVM::AtomicBinOp rmwKind;
+                switch (atomicRmwAttr) {
+                case RMWOp::AND:
+                  rmwKind = LLVM::AtomicBinOp::_and;
+                  break;
+                case RMWOp::OR:
+                  rmwKind = LLVM::AtomicBinOp::_or;
+                  break;
+                case RMWOp::XOR:
+                  rmwKind = LLVM::AtomicBinOp::_xor;
+                  break;
+                case RMWOp::ADD:
+                  rmwKind = LLVM::AtomicBinOp::add;
+                  break;
+                case RMWOp::FADD:
+                  rmwKind = LLVM::AtomicBinOp::fadd;
+                  break;
+                case RMWOp::MAX:
+                  rmwKind = LLVM::AtomicBinOp::max;
+                  break;
+                case RMWOp::UMAX:
+                  rmwKind = LLVM::AtomicBinOp::umax;
+                  break;
+                case RMWOp::MIN:
+                  rmwKind = LLVM::AtomicBinOp::min;
+                  break;
+                case RMWOp::UMIN:
+                  rmwKind = LLVM::AtomicBinOp::umin;
+                  break;
+                case RMWOp::XCHG:
+                  rmwKind = LLVM::AtomicBinOp::xchg;
+                  break;
+                }
+
+                rmwVal = b.bitcast(rmwVal, valueElemTy);
+                auto atomRMW = rewriter.create<LLVM::AtomicRMWOp>(
+                    loc, rmwKind, rmwPtr, rmwVal, llvmMemOrdering);
+                return SmallVector<Value, 1>{atomRMW.getRes()};
+              });
+        } else {
+          mlir::LLVM::AtomicBinOp rmwKind;
+          switch (atomicRmwAttr) {
+          case RMWOp::AND:
+            rmwKind = LLVM::AtomicBinOp::_and;
+            break;
+          case RMWOp::OR:
+            rmwKind = LLVM::AtomicBinOp::_or;
+            break;
+          case RMWOp::XOR:
+            rmwKind = LLVM::AtomicBinOp::_xor;
+            break;
+          case RMWOp::ADD:
+            rmwKind = LLVM::AtomicBinOp::add;
+            break;
+          case RMWOp::FADD:
+            rmwKind = LLVM::AtomicBinOp::fadd;
+            break;
+          case RMWOp::MAX:
+            rmwKind = LLVM::AtomicBinOp::max;
+            break;
+          case RMWOp::UMAX:
+            rmwKind = LLVM::AtomicBinOp::umax;
+            break;
+          case RMWOp::MIN:
+            rmwKind = LLVM::AtomicBinOp::min;
+            break;
+          case RMWOp::UMIN:
+            rmwKind = LLVM::AtomicBinOp::umin;
+            break;
+          case RMWOp::XCHG:
+            rmwKind = LLVM::AtomicBinOp::xchg;
+            break;
+          }
+
+          rmwVal = b.bitcast(rmwVal, valueElemTy);
+          auto atomRMW = rewriter.create<LLVM::AtomicRMWOp>(
+              loc, rmwKind, rmwPtr, rmwVal, llvmMemOrdering);
+          ret = atomRMW.getResult();
+        }
       }
 
-      Value ret = endBlock->getArgument(0);
+      ret = endBlock ? endBlock->getArgument(0) : ret; 
+      assert(ret);
       Type retType = (!tensorTy || vec == 1) ? valueElemTy : vecTy;
       ret = b.bitcast(ret, retType);
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2175,7 +2175,6 @@ struct StoreOpConversion
     auto *typeConverter = getTypeConverter();
     MLIRContext *ctx = rewriter.getContext();
     Value ptr = op.getPtr();
-    Value mask = op.getMask();
     Value llMask = adaptor.getMask();
 
     // Determine the vectorization size
@@ -2185,7 +2184,7 @@ struct StoreOpConversion
     SmallVector<Value> ptrElems, maskElems;
     unsigned vec = getVectorSize(ptr);
     if (llMask)
-      vec = std::min<size_t>(vec, getMaskAlignment(mask));
+      vec = std::min<size_t>(vec, getMaskAlignment(op.getMask()));
 
     if (isTensorPointerType(ptr.getType())) {
       // fallback to scatter store.
@@ -2269,7 +2268,7 @@ struct StoreOpConversion
         asmArgs.emplace_back(llWord, constraint);
       }
 
-      Value maskVal = threadPred;
+      Value maskVal = threadPred ? threadPred : b.true_val();
       if (llMask) {
         auto mask = maskElems[vecStart];
         maskVal = maybeAnd(rewriter, loc, maskVal, mask);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2213,9 +2213,6 @@ struct StoreOpConversion
                    << std::to_string(1 << mask.second) << ")\n";
     }
 #endif
-    // mask = redundantDataMask(valueTy, rewriter, loc, targetInfo);
-    // TODO: do we care about the original mask here? we seem to be overwriting
-    // it in the previous version.
     Value threadPred =
         emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
     uint32_t regMask = freeVarMasks[str_attr("register")];
@@ -2381,7 +2378,9 @@ struct AtomicCASOpConversion
       vec = std::min<unsigned>(vec, valTy.getElementType().isF16() ? 2 : 1);
     }
 
-    Value mask = redundantDataMask(valueTy, rewriter, loc, targetInfo);
+    auto freeVarMasks = getFreeVariableMasks(valueTy);
+    Value mask =
+        emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
     auto vecTy = vec_ty(valueElemTy, vec);
     SmallVector<Value> resultVals(elemsPerThread);
 
@@ -2409,20 +2408,33 @@ struct AtomicCASOpConversion
             loc, spirv::Scope::Workgroup, spirv::Scope::Workgroup,
             spirv::MemorySemantics::SequentiallyConsistent |
                 spirv::MemorySemantics::CrossWorkgroupMemory);
-      Block &endBlock =
-          LLVM::intel::createPredicatedBlock(rewriter, loc, mask, {zero}, [&] {
-            // casPtr = b.bitcast(casPtr, ptr_ty(ctx, 1));
-            casCmp = b.bitcast(casCmp, zero.getType());
-            casVal = b.bitcast(casVal, zero.getType());
+      Value ret;
+      // TODO: de-duplicate 
+      if (mask) {
+        Block &endBlock = LLVM::intel::createPredicatedBlock(
+            rewriter, loc, mask, {zero}, [&] {
+              // casPtr = b.bitcast(casPtr, ptr_ty(ctx, 1));
+              casCmp = b.bitcast(casCmp, zero.getType());
+              casVal = b.bitcast(casVal, zero.getType());
 
-            auto cmpxchg = rewriter.create<LLVM::AtomicCmpXchgOp>(
-                loc, casPtr, casCmp, casVal, successOrdering, failureOrdering);
-            Value newLoaded =
-                rewriter.create<LLVM::ExtractValueOp>(loc, cmpxchg, 0);
-            return SmallVector<Value, 1>{newLoaded};
-          });
+              auto cmpxchg = rewriter.create<LLVM::AtomicCmpXchgOp>(
+                  loc, casPtr, casCmp, casVal, successOrdering,
+                  failureOrdering);
+              Value newLoaded =
+                  rewriter.create<LLVM::ExtractValueOp>(loc, cmpxchg, 0);
+              return SmallVector<Value, 1>{newLoaded};
+            });
 
-      Value ret = endBlock.getArgument(0);
+        ret = endBlock.getArgument(0);
+      } else {
+        // casPtr = b.bitcast(casPtr, ptr_ty(ctx, 1));
+        casCmp = b.bitcast(casCmp, zero.getType());
+        casVal = b.bitcast(casVal, zero.getType());
+
+        auto cmpxchg = rewriter.create<LLVM::AtomicCmpXchgOp>(
+            loc, casPtr, casCmp, casVal, successOrdering, failureOrdering);
+        ret = rewriter.create<LLVM::ExtractValueOp>(loc, cmpxchg, 0);
+      }
       Type retType = (!tensorTy || vec == 1) ? valueElemTy : vecTy;
       ret = b.bitcast(ret, retType);
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -23,24 +23,6 @@ using namespace mlir::triton::gpu::intel;
 
 namespace {
 
-// Returns a Value for the format string, which you can reuse. Writes the byte
-// count for the string to |formatStrByteCount| if not null.
-Value llPrintf(StringRef msg, ValueRange args, ArrayRef<bool> isSigned,
-               ConversionPatternRewriter &rewriter,
-               const triton::intel::TargetInfo &targetInfo,
-               int *formatStrByteCount = nullptr) {
-  assert(!msg.empty() && "printf with empty string not supported");
-  llvm::SmallString<64> msgNewline(msg);
-  msgNewline.push_back('\n');
-  msgNewline.push_back('\0');
-  Value msgValue = targetInfo.getGlobalStringStart(
-      rewriter.getUnknownLoc(), rewriter, "printfFormat_", msgNewline,
-      /*addressSpace=*/TritonGEN::kUniformConstant);
-  targetInfo.printf(rewriter, msgValue, msgNewline.size_in_bytes(), args,
-                    isSigned);
-  return msgValue;
-}
-
 Value maybeAnd(RewriterBase &rewriter, Location loc, Value a, Value b) {
   auto tb = TritonLLVMOpBuilder(loc, rewriter);
   if (a && b) {
@@ -79,71 +61,6 @@ Value emitRedundantThreadPredicate(
     }
   }
   return pred;
-}
-
-// Return the mask for the unique data accessed by given tensor type.
-// Used to mask out the redundant data accessed by threads.
-Value redundantDataMask(Type valueTy, ConversionPatternRewriter &rewriter,
-                        Location loc,
-                        const triton::intel::TargetInfo &targetInfo) {
-  auto b = TritonLLVMOpBuilder(loc, rewriter);
-
-  Value mask = b.true_val();
-  auto clusterCTAId = targetInfo.getClusterCTAId(rewriter, loc);
-
-  auto tensorTy = dyn_cast<RankedTensorType>(valueTy);
-  if (tensorTy) {
-    // To remove this use, port https://github.com/triton-lang/triton/pull/5432
-    // to the INTELGPU dialect
-    auto layout = cast<DistributedEncodingTrait>(tensorTy.getEncoding());
-    auto shape = tensorTy.getShape();
-    auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
-    auto kLane = StringAttr::get(rewriter.getContext(), "lane");
-    auto kWarp = StringAttr::get(rewriter.getContext(), "warp");
-    auto maskLane =
-        std::get<1>(delinearize(rewriter, loc, layout, shape, kLane, laneId));
-    auto maskWarp =
-        std::get<1>(delinearize(rewriter, loc, layout, shape, kWarp, warpId));
-    mask = b.and_(maskLane, maskWarp);
-
-    // Do not write duplicated data when multicast is enabled
-    if (triton::gpu::getNumCTAs(layout) > 1) {
-      auto _0 = b.i32_val(0);
-      auto CTAsPerCGA = triton::gpu::getCTAsPerCGA(layout);
-      auto CTASplitNum = triton::gpu::getCTASplitNum(layout);
-      auto CTAOrder = triton::gpu::getCTAOrder(layout);
-
-      auto multiDimClusterCTAId =
-          delinearize(rewriter, loc, clusterCTAId, CTAsPerCGA, CTAOrder);
-
-      auto rank = tensorTy.getRank();
-      for (unsigned dim = 0; dim < rank; ++dim) {
-        // Skip when multicast is not enabled in this dimension
-        if (CTAsPerCGA[dim] == CTASplitNum[dim])
-          continue;
-        // This wrapping rule must be consistent with emitCTAOffsetForLayout
-        unsigned splitNum = std::min<unsigned>(shape[dim], CTASplitNum[dim]);
-        Value repId = b.udiv(multiDimClusterCTAId[dim], b.i32_val(splitNum));
-        // Consider the example where CTAsPerCGA = [4] and CTASplitNum = [2]:
-        //     CTA0 and CTA2 holds data of block0,
-        //     CTA1 and CTA3 holds data of block1.
-        // Only CTA0 and CTA1 are expected to write while CTA2 and CTA3 should
-        // be masked. We add the following mask:
-        //     multiDimClusterCTAId[dim] / splitNum == 0
-        // Actually in all existing cases of multicast, splitNum is always 1.
-        // The mask is equivalent to:
-        //     multiDimClusterCTAId[dim] == 0
-        mask = b.and_(mask, b.icmp_eq(repId, _0));
-      }
-    }
-  } else {
-    // If the tensor is not ranked, then it is a scalar and only thread 0 of
-    // CTA0 can write
-    mask = b.and_(mask, b.icmp_eq(clusterCTAId, b.i32_val(0)));
-    auto tid = getThreadId(rewriter, loc);
-    mask = b.and_(mask, b.icmp_eq(tid, b.i32_val(0)));
-  }
-  return mask;
 }
 
 /// Holds the values related to a block pointer.
@@ -2207,12 +2124,6 @@ struct StoreOpConversion
            valueElems.size() == maskElems.size() && "Mask size mismatch");
 
     auto freeVarMasks = getFreeVariableMasks(valueTy);
-#if 0
-    for (auto mask : freeVarMasks) {
-      llvm::errs() << mask.first << " = " << mask.second << " ("
-                   << std::to_string(1 << mask.second) << ")\n";
-    }
-#endif
     Value threadPred =
         emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
     uint32_t regMask = freeVarMasks[str_attr("register")];
@@ -2277,22 +2188,6 @@ struct StoreOpConversion
         auto llWord = asmArgs[index].first;
         vecWord = b.insert_element(vecTy, vecWord, llWord, b.i32_val(index));
       }
-
-#if 0
-      auto vecTestElem = b.extract_element(valArgTy, vecWord, b.i32_val(0));
-      auto testElemBitcast = b.bitcast(vecTestElem, wordTy);
-      auto testElemVal =
-          b.extract_element(valueElemTy, testElemBitcast, b.i32_val(0));
-
-      Value addrElem = b.bitcast(ptrElems[vecStart], ptr_ty(ctx, 1 /*global*/));
-
-      auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
-      llPrintf("warp %d lane %d mask %d & %d = %d addr %p val %f vec %d",
-               {warpId, laneId, threadPred, maskElems[vecStart], maskVal, addrElem,
-                testElemVal, b.i32_val(vecStart)},
-               {true, true, true, true, true, true, true, true}, rewriter,
-               targetInfo);
-#endif
 
       // Create a predicated store operation.
       LLVM::intel::createPredicatedBlock(rewriter, loc, maskVal, [&] {
@@ -2667,7 +2562,7 @@ struct AtomicRMWOpConversion
         }
       }
 
-      ret = endBlock ? endBlock->getArgument(0) : ret; 
+      ret = endBlock ? endBlock->getArgument(0) : ret;
       assert(ret);
       Type retType = (!tensorTy || vec == 1) ? valueElemTy : vecTy;
       ret = b.bitcast(ret, retType);


### PR DESCRIPTION
Upstream updated the masking logic when generating vectorized loads/stores to use linear layout free variable masks: https://github.com/triton-lang/triton/pull/5432/files#diff-7147172e5de66b21e7447a220f435a703df5302dd91a41a5be9683e5396652c5

The free variable mask essentially finds inputs to the linear layout that do not change the output - these inputs are duplicates and should be masked when doing loads or stores. This PR applies that work to the Intel backend. Previously, we were ignoring duplicates in the registers which could result in incorrect results if the tensor size of the load/store operand was smaller than the DPAS tile size in a particular dimension. A nice side effect here is we generate fewer stores - from 32 `<1 x i16>` store instructions in the LLVM IR previously to 16 instructions now for the B operand in the float16 128x8 test case. 

I have one TODO remaining in this PR which is to de-duplicate the code blocks in atomic rmw/cas. Previously, we always generated a mask. But now the mask is only generated if there are duplicate values (i.e. the layout is not injective) or if one is provided as part of the load/store op. If there is no mask, there is no need to generate the predicated block. I applied this optimization in atomic rmw/cas and want to see how the test suite runs - but if everything looks good I will clean up the code to reduce duplication, either by introducing a lambda or by pushing the logic into createPredicatedBlock and having a short circuit to handle an null mask value in that function. 

I also noticed that upstream uses "reg" instead of "register" for the in dimension when getting the register mask. I am not sure why this is - in our DPAS generated linear layouts we use "register". I have asked for clarification. 

Close #3841 