### PR TITLE
[test_mxfp8_mxfp4_matmul] error: ttg.dot_op kWidth parameter must match the parent's opsPerChannel

### DIFF
--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -922,7 +922,31 @@ def test_mxfp8_mxfp4_matmul(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, B_TR
         pytest.xfail("Pack along K can only be False for float4")
 
     if is_xpu():
-        pytest.skip("FIXME: failed to legalize operation 'tt.dot_scaled' on XPU")
+        if A_DATA_TYPE == B_DATA_TYPE == "float4":
+            pytest.skip("https://github.com/intel/intel-xpu-backend-for-triton/issues/3777")
+        elif not (WITH_B_SCALE or PACK_B_ALONG_K) and B_DATA_TYPE == "float4" and \
+                 A_DATA_TYPE in ("float8e5", "float8e4nv"):
+            pytest.skip("https://github.com/intel/intel-xpu-backend-for-triton/issues/4045")
+        elif WITH_B_SCALE and not PACK_B_ALONG_K and B_DATA_TYPE == "float4" and \
+                A_DATA_TYPE in ("float8e5", "float8e4nv"):
+            pytest.skip("https://github.com/intel/intel-xpu-backend-for-triton/issues/3908")
+        elif (BLOCK_M, BLOCK_N, BLOCK_K) == (128, 256, 256):
+            if triton.runtime.driver.active.utils.get_device_properties(
+                    triton.runtime.driver.active.get_current_device())["max_shared_mem"] < 196608:
+                pytest.xfail("Not enough shared memory")
+            else:
+                pass
+        elif (BLOCK_M, BLOCK_N, BLOCK_K) in ((128, 64, 128), (128, 128, 128)):
+            pass
+        elif (BLOCK_M, BLOCK_N, BLOCK_K) in (128, 128, 64):
+            if A_DATA_TYPE in ("float8e5", "float8e4nv") and B_DATA_TYPE in ("float8e5", "float8e4nv") \
+                    and WITH_B_SCALE == CONST_SCALE \
+                    and WITH_A_SCALE and B_TRANS and PACK_B_ALONG_K:
+                pytest.skip("https://github.com/intel/intel-xpu-backend-for-triton/issues/3677")
+            pass
+        else:
+            # Some tests pass, but it's difficult to filter them out
+            pytest.skip("https://github.com/intel/intel-xpu-backend-for-triton/issues/3677")
 
     if BLOCK_N == 256 and BLOCK_K == 256:
         NUM_STAGES = 2

--- a/scripts/skiplist/lts/mxfp.txt
+++ b/scripts/skiplist/lts/mxfp.txt
@@ -1,1 +1,2 @@
 python/test/unit/language/test_matmul.py::test_mxfp
+python/test/unit/language/test_matmul.py::test_mxfp8_mxfp4_matmul

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
@@ -913,7 +913,37 @@ struct TritonIntelGPUInferLayoutInterface
   inferFp4ToFpOpEncoding(ArrayRef<int64_t> shape, int axis, Attribute inEnc,
                          Attribute &outEnc, bool fwdInference,
                          std::optional<Location> loc) const override {
-    // Not required to support Fp4ToFpOp on DPAS layout.
+    if (getOrder(cast<DistributedEncodingTrait>(inEnc), shape)[axis] == 0) {
+      // Dot operand: double kWidth if kDim == axis.
+      if (auto dotEnc = mlir::dyn_cast<DotOperandEncodingAttr>(inEnc)) {
+        auto dpasEnc = mlir::dyn_cast<DpasEncodingAttr>(dotEnc.getParent());
+        int opsPerChan = dpasEnc.getOpsPerChannel();
+        auto kWidth = dotEnc.getKWidth();
+        if (fwdInference) {
+          kWidth *= 2;
+          opsPerChan *= 2;
+        } else {
+          if (kWidth > 1) {
+            // bwd inference
+            kWidth /= 2;
+            opsPerChan /= 2;
+          } else {
+            return emitOptionalError(loc,
+                                     "Fp4ToFpOp requires at least 2 elements "
+                                     "per thread in the axis dimension");
+          }
+        }
+
+        auto *ctx = getContext();
+        auto newDpasEnc = DpasEncodingAttr::get(
+            ctx, dpasEnc.getRepeatCount(), dpasEnc.getSystolicDepth(),
+            dpasEnc.getExecutionSize(), opsPerChan, dpasEnc.getWarpsPerCTA(),
+            dpasEnc.getRepCluster(), dpasEnc.getThreadsPerWarp());
+        outEnc = DotOperandEncodingAttr::get(ctx, dotEnc.getOpIdx(), newDpasEnc,
+                                             kWidth);
+        return success();
+      }
+    }
     return failure();
   }
 };


### PR DESCRIPTION
Fixes #3903
