### PR TITLE
Add `dot3d[8-2-64-64-64-32-32-float32-float32]` to `skiplists`

### DIFF
--- a/scripts/skiplist/default/language.txt
+++ b/scripts/skiplist/default/language.txt
@@ -1,2 +1,4 @@
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/3556
 test/unit/language/test_core.py::test_convert_mma2mma[mma_pair0-float16-256-256]
+# https://github.com/intel/intel-xpu-backend-for-triton/issues/3870
+test/unit/language/test_core.py::test_dot3d[8-2-64-64-64-32-32-float32-float32]

--- a/scripts/skiplist/xe2/language.txt
+++ b/scripts/skiplist/xe2/language.txt
@@ -1,0 +1,2 @@
+# https://github.com/intel/intel-xpu-backend-for-triton/issues/3870
+test/unit/language/test_core.py::test_dot3d[8-2-64-64-64-32-32-float32-float32]

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM/DPAS.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM/DPAS.cpp
@@ -338,11 +338,8 @@ private:
         totalElems /
         ((batch * outer * inner) * (repClusterOuter * repClusterInner));
     VectorType dotOpTy = vec_ty(elemTy, numElemsPerOperand);
-    // TODO: IGC bug, Update isFToTF32Enabled as follows once issue #3870 is
-    // fixed. isFToTF32Enabled = elemTy.isFloat(32) && (isOperandA ||
-    // isOperandB)
-    isFToTF32Enabled = elemTy.isFloat(32) &&
-                       ((rank == 3) ? isOperandA : (isOperandA || isOperandB));
+
+    isFToTF32Enabled = elemTy.isFloat(32) && (isOperandA || isOperandB);
 
     auto tb = TritonLLVMOpBuilder(loc, rewriter);
     int offset = 0;


### PR DESCRIPTION
Add `dot3d[8-2-64-64-64-32-32-float32-float32]` to `skiplists`

[Build and test B580](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/14488314755)
