### PR TITLE
Refactor FP conversion code to provide a fallback option for non-SPIRV targets

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -5,6 +5,7 @@
 #include "TritonGPUToLLVMBase.h"
 #include "intel/include/Analysis/AxisInfo.h"
 #include "intel/include/TritonIntelGPUToLLVM/TypeConverter.h"
+#include "triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 
 namespace mlir::triton::intel {
@@ -84,7 +85,21 @@ void populateTensorPtrOpsToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                         RewritePatternSet &patterns,
                                         PatternBenefit benefit);
 
+void populateSPIRVFpConversionToLLVMPatterns(
+    LLVMTypeConverter &typeConverter, ModuleAxisInfoAnalysis &axisInfoAnalysis,
+    RewritePatternSet &patterns, PatternBenefit benefit);
+
 /* Third party patterns end */
+
+/* Lowering to LLVM helper functions */
+
+// Generic implementation of ElementwiseOpConversionBase::createDestOps for
+// FpToFp op that can be used by target-specific patterns as a fallback
+// option for conversions cases not supported by the HW.
+SmallVector<Value>
+genericFpToFpToLLVM(FpToFpOp op, ConversionPatternRewriter &rewriter,
+                    const TypeConverter *typeConverter, Type elemTy,
+                    triton::gpu::MultipleOperandsRange operands, Location loc);
 
 } // namespace mlir::triton::intel
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PipelineManager.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PipelineManager.h
@@ -254,9 +254,15 @@ public:
     triton::populateTritonGENToLLVMConversionPatterns(typeConverter, patterns);
     triton::populateGPUToTritonGENConversionPatterns(typeConverter, patterns);
     cf::populateControlFlowToLLVMConversionPatterns(typeConverter, patterns);
-    populateGpuToLLVMSPVConversionPatterns(typeConverter, patterns);
-    populateSPIRVToLLVMConversionPatterns(typeConverter, patterns,
-                                          spirv::ClientAPI::OpenCL);
+
+    if (gpu::intel::hasSpirvTargetArch(mod)) {
+      populateGpuToLLVMSPVConversionPatterns(typeConverter, patterns);
+      populateSPIRVToLLVMConversionPatterns(typeConverter, patterns,
+                                            spirv::ClientAPI::OpenCL);
+      if (!isAdvancedPathEnabled)
+        populateSPIRVFpConversionToLLVMPatterns(typeConverter, axisInfoAnalysis,
+                                                patterns, benefit);
+    }
   }
 
 private:

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
@@ -8,6 +8,8 @@
 
 #include "Utility.h"
 
+#include "mlir/Conversion/ArithCommon/AttrToLLVMConverter.h"
+
 using namespace mlir;
 using namespace mlir::triton;
 
@@ -97,6 +99,23 @@ Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, int i) {
 
 Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, Value i) {
   return shuffleCommon(loc, rewriter, val, i, mlir::gpu::ShuffleMode::IDX);
+}
+
+LLVM::RoundingMode
+convertTritonRoundingModeToLLVM(const triton::RoundingMode rounding) {
+  LLVM::RoundingMode roundingMode;
+  switch (rounding) {
+  case triton::RoundingMode::RTNE:
+    return LLVM::RoundingMode::NearestTiesToEven;
+  case triton::RoundingMode::RTZ:
+    return LLVM::RoundingMode::TowardZero;
+  default:
+    llvm_unreachable(("WARNING: unsupported rounding mode for f32->f16 "
+                      "conversion: " +
+                      stringifyRoundingMode(rounding))
+                         .str()
+                         .c_str());
+  }
 }
 
 } // namespace mlir::LLVM::intel

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
@@ -72,6 +72,9 @@ Block &createPredicatedBlock(RewriterBase &rewriter, Location loc, Value cond,
   return createPredicatedBlock(rewriter, loc, cond, {}, thenOpsFn);
 }
 
+LLVM::RoundingMode
+convertTritonRoundingModeToLLVM(const triton::RoundingMode rounding);
+
 } // namespace mlir::LLVM::intel
 
 namespace mlir::triton::intel {


### PR DESCRIPTION
The goal is to provide functions for the generic implementation of fp-to-fp conversions to be used as a fallback option when native support is missing.