### PR TITLE
[PROTON] Use CMake mechanism to find sycl headers

### DIFF
--- a/third_party/proton/CMakeLists.txt
+++ b/third_party/proton/CMakeLists.txt
@@ -18,7 +18,6 @@ else()
   find_path(SYCL_INCLUDE_DIR
     NAMES "sycl/sycl.hpp"
     HINTS "/opt/intel/oneapi/compiler/latest/include"
-    PATHS ${CMAKE_PREFIX_PATH}
   )
 
   if(SYCL_INCLUDE_DIR)

--- a/third_party/proton/CMakeLists.txt
+++ b/third_party/proton/CMakeLists.txt
@@ -15,17 +15,17 @@ else()
   option(ENABLE_XPUTPI_PROFILER "Enable Xpupti Profiler" ON)
   set(ENABLE_XPUTPI_PROFILER ${ENABLE_XPUTPI_PROFILER} CACHE BOOL "Enable Xpupti Profiler" FORCE)
 
-  if(EXISTS "/opt/intel/oneapi/compiler/latest/include")
-    list(APPEND XPUPTI_INCLUDE_DIR "/opt/intel/oneapi/compiler/latest/include")
-  else()
-    message(WARNING "SYCL FOLDER /opt/intel/oneapi/compiler/latest/include not found")
-    set(ENABLE_XPUTPI_PROFILER, OFF)
-  endif()
+  find_path(SYCL_INCLUDE_DIR
+    NAMES "sycl/sycl.hpp"
+    HINTS "/opt/intel/oneapi/compiler/latest/include"
+    PATHS ${CMAKE_PREFIX_PATH}
+  )
 
-  if(EXISTS "/opt/intel/oneapi/compiler/latest/include/sycl")
-    list(APPEND XPUPTI_INCLUDE_DIR "/opt/intel/oneapi/compiler/latest/include/sycl")
+  if(SYCL_INCLUDE_DIR)
+    list(APPEND XPUPTI_INCLUDE_DIR "${SYCL_INCLUDE_DIR}")
+    list(APPEND XPUPTI_INCLUDE_DIR "${SYCL_INCLUDE_DIR}/sycl")
   else()
-    message(WARNING "SYCL FOLDER /opt/intel/oneapi/compiler/latest/include/sycl not found")
+    message(WARNING "SYCL FOLDER not found")
     set(ENABLE_XPUTPI_PROFILER, OFF)
   endif()
 endif()
@@ -93,7 +93,11 @@ endforeach()
 add_library(proton SHARED ${_proton_obj_sources})
 
 target_link_libraries(proton PRIVATE Python3::Module)
-find_library(SYCL_LIB NAMES sycl PATHS /opt/intel/oneapi/compiler/latest/lib)
+find_library(SYCL_LIB
+  NAMES sycl
+  HINTS "/opt/intel/oneapi/compiler/latest/lib"
+  PATHS "${CMAKE_PREFIX_PATH}/lib"
+)
 find_library(ZE_TRACING_LIB NAMES ze_tracing_layer PATHS /usr/lib/x86_64-linux-gnu)
 find_library(ZE_LOADER_LIB NAMES ze_loader PATHS /usr/lib/x86_64-linux-gnu)
 

--- a/third_party/proton/CMakeLists.txt
+++ b/third_party/proton/CMakeLists.txt
@@ -96,7 +96,6 @@ target_link_libraries(proton PRIVATE Python3::Module)
 find_library(SYCL_LIB
   NAMES sycl
   HINTS "/opt/intel/oneapi/compiler/latest/lib"
-  PATHS "${CMAKE_PREFIX_PATH}/lib"
 )
 find_library(ZE_TRACING_LIB NAMES ze_tracing_layer PATHS /usr/lib/x86_64-linux-gnu)
 find_library(ZE_LOADER_LIB NAMES ze_loader PATHS /usr/lib/x86_64-linux-gnu)


### PR DESCRIPTION
# Description

This PR replaces the hardcoded path checks with CMake’s `find_path` mechanism to better support non-standard installations.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it only modifies build-time include path detection logic and does not affect runtime behavior or functionality`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
