### PR TITLE
fix cmake version for e2e benchmarks

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -86,7 +86,8 @@ jobs:
       - name: Install Python build dependencies
         run: |
           # cmake 3.22.1 does not work with the recent torchaudio: https://github.com/intel/intel-xpu-backend-for-triton/issues/2079
-          pip install wheel cmake
+          # cmake<4.0.0 is required as a workaround for CMake Error at third_party/double-conversion/CMakeLists.txt:1 (cmake_minimum_required)
+          pip install wheel cmake<4.0.0
 
       # https://github.com/pytorch/data/blob/e316c5ca1ab2a4f69dd6d48e8fc9c6f8d0c7c468/README.md?plain=1#L6-L15
       - name: Install pinned torchdata

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           # cmake 3.22.1 does not work with the recent torchaudio: https://github.com/intel/intel-xpu-backend-for-triton/issues/2079
           # cmake<4.0.0 is required as a workaround for CMake Error at third_party/double-conversion/CMakeLists.txt:1 (cmake_minimum_required)
-          pip install wheel cmake<4.0.0
+          pip install wheel 'cmake<4.0.0'
 
       # https://github.com/pytorch/data/blob/e316c5ca1ab2a4f69dd6d48e8fc9c6f8d0c7c468/README.md?plain=1#L6-L15
       - name: Install pinned torchdata


### PR DESCRIPTION
```
CMake Deprecation Warning at third_party/re2/CMakeLists.txt:6 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


CMake Error at third_party/double-conversion/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

before fix: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/14597596027/job/41022913205#step:20:570
after: [![E2E performance](https://github.com/intel/intel-xpu-backend-for-triton/actions/workflows/e2e-performance.yml/badge.svg?branch=fix%2Fcmake-for-benchmarks)](https://github.com/intel/intel-xpu-backend-for-triton/actions/workflows/e2e-performance.yml?query=branch%3Afix%2Fcmake-for-benchmarks)