### PR TITLE
Fix the total number of tests for LTS

### DIFF
--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -348,13 +348,6 @@ run_benchmarks() {
 }
 
 run_instrumentation_tests() {
-  # FIXME: the "instrumentation" test suite currently contains only one test, when all tests
-  # are skipped pytest reports an error. If the only test is the skip list, then we shouldn't
-  # run pytest at all. This must be changed when there is more than one instrumentation test.
-  if [[ $TEST_UNSKIP = false && -s $TRITON_TEST_SKIPLIST_DIR/instrumentation.txt ]]; then
-    return
-  fi
-
   INSTRUMENTATION_LIB_DIR=$(ls -1d $TRITON_PROJ/python/build/*lib*/triton/instrumentation) || err "Could not find $TRITON_PROJ/python/build/*lib*/triton/instrumentation, build Triton first"
   INSTRUMENTATION_LIB_NAME=$(ls -1 $INSTRUMENTATION_LIB_DIR/*GPUInstrumentationTestLib* | head -n1)
 


### PR DESCRIPTION
Previously for LTS we didn't run the instrumentation test, because pytest does not work when all tests are deselected. Now, with the new pytest-skip plugin, the test is skipped, and it is safe to remove the old code for LTS. This should fix the long living issue with the total number of tests for LTS is less than for rolling.
