### PR TITLE
Fix regression issue in flex decoding. 

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2232,7 +2232,7 @@ struct StoreOpConversion
       }
 
       Value maskVal = threadPred;
-      if (llMask) {
+      if (maskElems.size() > 0) {
         auto mask = maskElems[vecStart];
         maskVal = maybeAnd(rewriter, loc, threadPred, mask);
       }


### PR DESCRIPTION
The `tt.store` operation with BlockPointer fallbacks to scatter store if the BLOCK shape or the value layout was not supported by the 2D BLOCK IO.
The lowering code would transform the BlockPointer to the pointers and masks.

The scatter store should apply the `and` to the `maskElems` if the `llMask` doesn't exsits.

