### PR TITLE
Make convertTritonRoundingModeToLLVM public

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -915,22 +915,6 @@ struct FpToFpOpConversion
     return rewriter.create<LLVM::FPExtOp>(loc, f32_ty, v);
   }
 
-  static LLVM::RoundingMode
-  convertTritonRoundingModeToLLVM(const triton::RoundingMode rounding) {
-    LLVM::RoundingMode roundingMode;
-    switch (rounding) {
-    case triton::RoundingMode::RTNE:
-      return LLVM::RoundingMode::NearestTiesToEven;
-    case triton::RoundingMode::RTZ:
-      return LLVM::RoundingMode::TowardZero;
-    default:
-      llvm::errs() << "WARNING: unsupported rounding mode for f32->f16 "
-                      "conversion: "
-                   << stringifyRoundingMode(rounding) << "\n";
-      llvm_unreachable("");
-    }
-  }
-
   static Value convertFp32ToFp16(Location loc,
                                  ConversionPatternRewriter &rewriter,
                                  const Value &v,
@@ -938,8 +922,8 @@ struct FpToFpOpConversion
     MLIRContext *ctx = rewriter.getContext();
     return rewriter.create<LLVM::ConstrainedFPTruncIntr>(
         loc, f16_ty, v,
-        LLVM::RoundingModeAttr::get(ctx,
-                                    convertTritonRoundingModeToLLVM(rounding)),
+        LLVM::RoundingModeAttr::get(
+            ctx, LLVM::intel::convertTritonRoundingModeToLLVM(rounding)),
         arith::getLLVMDefaultFPExceptionBehavior(*ctx));
   }
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.cpp
@@ -8,6 +8,8 @@
 
 #include "Utility.h"
 
+#include "mlir/Conversion/ArithCommon/AttrToLLVMConverter.h"
+
 using namespace mlir;
 using namespace mlir::triton;
 
@@ -97,6 +99,23 @@ Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, int i) {
 
 Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, Value i) {
   return shuffleCommon(loc, rewriter, val, i, mlir::gpu::ShuffleMode::IDX);
+}
+
+LLVM::RoundingMode
+convertTritonRoundingModeToLLVM(const triton::RoundingMode rounding) {
+  LLVM::RoundingMode roundingMode;
+  switch (rounding) {
+  case triton::RoundingMode::RTNE:
+    return LLVM::RoundingMode::NearestTiesToEven;
+  case triton::RoundingMode::RTZ:
+    return LLVM::RoundingMode::TowardZero;
+  default:
+    llvm_unreachable(("WARNING: unsupported rounding mode for f32->f16 "
+                      "conversion: " +
+                      stringifyRoundingMode(rounding))
+                         .str()
+                         .c_str());
+  }
 }
 
 } // namespace mlir::LLVM::intel

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
@@ -72,6 +72,9 @@ Block &createPredicatedBlock(RewriterBase &rewriter, Location loc, Value cond,
   return createPredicatedBlock(rewriter, loc, cond, {}, thenOpsFn);
 }
 
+LLVM::RoundingMode
+convertTritonRoundingModeToLLVM(const triton::RoundingMode rounding);
+
 } // namespace mlir::LLVM::intel
 
 namespace mlir::triton::intel {


### PR DESCRIPTION
With benefits applied to target-specific FP conversion patterns, as was suggested in #3948, required changes in the common part were reduced to a single function. This PR moves `convertTritonRoundingModeToLLVM` to utilities to make it available in target-specific patterns.