### PR TITLE
[FASTMATH] Allow contract by default

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -358,8 +358,7 @@ class XPUBackend(BaseBackend):
         context = llvm.context()
         llvm_mod = llvm.to_module(mod, context)
         intel.set_spv_target_triple(llvm_mod)
-        if os.getenv("TRITON_INTEL_FAST_MATH", "0") == "1":
-            intel.set_fast_math(llvm_mod)
+        intel.set_fast_math(llvm_mod)
         if options.extern_libs:
             paths = [path for (name, path) in options.extern_libs]
             llvm.link_extern_libs(llvm_mod, paths)

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -273,12 +273,24 @@ void init_triton_intel(py::module &&m) {
   // fast math semantics on all arithmetic operations.
   // https://github.com/intel/intel-xpu-backend-for-triton/issues/3862
   m.def("set_fast_math", [](llvm::Module *mod) {
+    std::optional<bool> fastMath = mlir::triton::tools::isEnvValueBool(
+        mlir::triton::tools::getStrEnv("TRITON_INTEL_FAST_MATH"));
+    std::optional<bool> enableFpFusion = mlir::triton::tools::isEnvValueBool(
+        mlir::triton::tools::getStrEnv("TRITON_DEFAULT_FP_FUSION"));
+    if (fastMath.has_value() && !fastMath.value())
+      return;
+
     using namespace llvm;
     for (Function &func : *mod) {
       for (Instruction &inst : instructions(func)) {
         if (auto *op = dyn_cast<FPMathOperator>(&inst)) {
           FastMathFlags FMF;
-          FMF.setFast(true);
+          // Default to allow contract when default fp fusion is not disabled.
+          if ((!enableFpFusion.has_value() || enableFpFusion.value()) &&
+              !fastMath.has_value())
+            FMF.setAllowContract(true);
+          else if (fastMath.has_value() && fastMath.value())
+            FMF.setFast(true);
           inst.setFastMathFlags(FMF);
         }
       }


### PR DESCRIPTION
This PR set the fast math flag to allow contract by default.
> A floating expression may be contracted, that is, evaluated as though it were a single operation, thereby omitting rounding errors implied by the source code and the expression evaluation method.

The single most common contracted expression is FMA operations: `a * b + c → fma(a, b, c)`.

Notes: 
- All Triton unit tests and benchmarks pass with this change.
- `TRITON_DEFAULT_FP_FUSION` is an existing Triton env var, it is enabled by default.