### PR TITLE
[GEMM] Fix bug from `3ddd34b`

### DIFF
--- a/benchmarks/triton_kernels_benchmark/gemm_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_benchmark.py
@@ -354,8 +354,8 @@ def get_benchmark(
                 a,
                 b,
                 c,
-                matmul_kernel=matmul_kernel_with_block_pointers,
-                matmul_kernel_batched=matmul_kernel_with_block_pointers_batched,
+                matmul_kernel=matmul_kernel,
+                matmul_kernel_batched=matmul_kernel_batched,
                 transpose_a=transpose_a,
                 transpose_b=transpose_b,
             )


### PR DESCRIPTION
This PR fixes a bug introduced from https://github.com/intel/intel-xpu-backend-for-triton/commit/3ddd34b7f3fe7645ed95332883b691646b4389f2. The block pointer implementation was incorrectly used for all GEMM implementations, including tensor of pointer and tensor descriptor.