### PR TITLE
Change pytest-xdist distribution algorithm to `worksteal`

### DIFF
--- a/scripts/pytest-utils.sh
+++ b/scripts/pytest-utils.sh
@@ -16,7 +16,9 @@ fi
 TRITON_TEST_SKIPLIST_DIR="$(cd "$TRITON_TEST_SKIPLIST_DIR" && pwd)"
 
 pytest() {
-    pytest_extra_args=()
+    pytest_extra_args=(
+        "--dist=worksteal"
+    )
 
     if [[ -v TRITON_TEST_SUITE && $TRITON_TEST_REPORTS = true ]]; then
         mkdir -p "$TRITON_TEST_REPORTS_DIR"


### PR DESCRIPTION
This is similar to the `load` method (default), but `worksteal` should handle tests with significantly differing duration better.

Core time: 41m -> 25m
Total time: 53m -> 36m

Compared for the following runs:
* Before: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/14684415545
* After: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/14684687453
