### PR TITLE
[PROTON] Fix ImportError: `libproton.so: undefined symbol: _ZTIN6proton14XpuptiProfilerE`

### DIFF
--- a/third_party/proton/CMakeLists.txt
+++ b/third_party/proton/CMakeLists.txt
@@ -3,6 +3,9 @@ project(Proton LANGUAGES CXX)
 set(PROTON_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/csrc")
 
 option(TRITON_BUILD_PROTON_XPU "Build Proton with XPU support" OFF)
+if(TRITON_BUILD_PROTON_XPU)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTRITON_BUILD_PROTON_XPU")
+endif()
 
 # ============ Check for includes =============
 if(NOT CUPTI_INCLUDE_DIR)

--- a/third_party/proton/csrc/lib/Driver/Device.cpp
+++ b/third_party/proton/csrc/lib/Driver/Device.cpp
@@ -1,7 +1,9 @@
 #include "Driver/Device.h"
 #include "Driver/GPU/CudaApi.h"
 #include "Driver/GPU/HipApi.h"
+#ifdef TRITON_BUILD_PROTON_XPU
 #include "Driver/GPU/XpuApi.h"
+#endif
 
 #include "Utility/Errors.h"
 
@@ -14,9 +16,11 @@ Device getDevice(DeviceType type, uint64_t index) {
   if (type == DeviceType::HIP) {
     return hip::getDevice(index);
   }
+#ifdef TRITON_BUILD_PROTON_XPU
   if (type == DeviceType::XPU) {
     return xpu::getDevice(index);
   }
+#endif
   throw std::runtime_error("DeviceType not supported");
 }
 

--- a/third_party/proton/csrc/lib/Session/Session.cpp
+++ b/third_party/proton/csrc/lib/Session/Session.cpp
@@ -4,7 +4,9 @@
 #include "Data/TreeData.h"
 #include "Profiler/Cupti/CuptiProfiler.h"
 #include "Profiler/Roctracer/RoctracerProfiler.h"
+#ifdef TRITON_BUILD_PROTON_XPU
 #include "Profiler/Xpupti/XpuptiProfiler.h"
+#endif
 #include "Utility/String.h"
 
 namespace proton {
@@ -19,11 +21,13 @@ Profiler *getProfiler(const std::string &name, const std::string &path,
   if (proton::toLower(name) == "cupti_pcsampling") {
     return &CuptiProfiler::instance().setLibPath(path).enablePCSampling();
   }
+#ifdef TRITON_BUILD_PROTON_XPU
   if (proton::toLower(name) == "xpupti") {
     return &XpuptiProfiler::instance()
                 .setSyclQueue(sycl_queue)
                 .setUtilsCachePath(utils_cache_path);
   }
+#endif
   if (proton::toLower(name) == "roctracer") {
     return &RoctracerProfiler::instance();
   }


### PR DESCRIPTION
Test with pip CI (old): https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/14684390264/job/41211129850
new: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/14705967044 (passed)

The problem started to appear after: https://github.com/intel/intel-xpu-backend-for-triton/pull/4018

This change is necessary for `import triton.profiler` to work even if the xpu profiler is not built, which happens for example in tutorial 9.