### PR TITLE
[DEBUG] Disable loop versioning to check compile time

### DIFF
--- a/third_party/intel/lib/Dialect/Triton/Transforms/RemoveMasks.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RemoveMasks.cpp
@@ -329,6 +329,7 @@ public:
                       MaskedOpsCollector<CanonicalMaskValidator> &collector) {
     assert(!collector.getMaskedOps().empty() &&
            "Expecting a non-empty collection of masked operations");
+    return false;
 
     // Limitation
     // Currently we can version the loop only if it doesn't have downward


### PR DESCRIPTION
* `test_scaled_dot` does not include a loop, so versioning does not affect its execution time
* `test_mxfp` includes a loop, I ran one test combination `test_mxfp[0-4-3-128-256-128-2-4-32]` and got the following numbers: `22.06s` (turned off versioning) vs `30.33s` (turned on versioning). This time includes compilation (clean cache) and the launch itself.

сс @whitneywhtsang 