### PR TITLE
Use pip cache per each parallel job

### DIFF
--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -103,7 +103,7 @@ jobs:
           CACHE_NUMBER: 1
         with:
           path: $HOME/.cache/pip
-          key: pip-${{ inputs.python_version }}-${{ hashFiles('pyproject.toml', 'setup.py') }}-${{ env.CACHE_NUMBER }}
+          key: pip-${{ inputs.python_version }}-${{ matrix.suite }}-${{ hashFiles('pyproject.toml', 'setup.py') }}-${{ env.CACHE_NUMBER }}
 
       - name: Install Python (using actions/setup-python) ${{ inputs.python_version }}
         if: ${{ !inputs.use_pyenv_python }}


### PR DESCRIPTION
To avoid errors when different jobs write the same wheel.

Example of the error: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/14719533707/job/41310492597?pr=4044
