### PR TITLE
Extra `tl.constexpr` argument for kernel in `test_scaled_dot` test

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3985,16 +3985,8 @@ def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, nu
         tl.store(out_ptr, c.to(tl.bfloat16))
 
     @triton.jit
-    def mxfp_upcast_kernel(
-        x_ptr,
-        scale_ptr,
-        mxfp_ptr,
-        N,
-        e_bits: tl.constexpr,
-        m_bits: tl.constexpr,
-        to_type: tl.constexpr,
-        BLOCK_SIZE: tl.constexpr,
-    ):
+    def mxfp_upcast_kernel(x_ptr, scale_ptr, mxfp_ptr, N, e_bits: tl.constexpr, m_bits: tl.constexpr,
+                           to_type: tl.constexpr, BLOCK_SIZE: tl.constexpr, is_xpu: tl.constexpr):
         # x.shape ==     (N, 32) for fp8 or (N, 16) for fp4
         # scale.shape == (N,)
         # out.shape   == (N, 32)
@@ -4027,6 +4019,15 @@ def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, nu
             if e_bits == 5 and m_bits == 2:
                 x_f8 = x.to(tl.float8e5, bitcast=True)
                 upcasted_x = x_f8.to(to_type)
+                if not is_xpu:
+                    # Preserve infs and nans. FIXME Fp8E5M2_to_Bf16 doesn't preserve them!
+                    non_finite_mask: tl.constexpr = ((1 << e_bits) - 1) << m_bits
+                    non_finite_mask_16bit: tl.constexpr = ((1 << to_e_bits) - 1) << to_m_bits
+                    upcasted_x = tl.where(
+                        x & non_finite_mask == non_finite_mask,
+                        (upcasted_x.to(tl.uint16, bitcast=True) | non_finite_mask_16bit).to(to_type, bitcast=True),
+                        upcasted_x,
+                    )
             else:
                 tl.static_assert(e_bits == 4 and m_bits == 3)
                 x_f8 = x.to(tl.float8e4nv, bitcast=True)
@@ -4078,7 +4079,7 @@ def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, nu
             grid = ((N + BLOCK_SIZE - 1) // BLOCK_SIZE, )
             comp_dtype = tl.float16 if comp_dtype == torch.float16 else tl.bfloat16
             mxfp_upcast_kernel[grid](v, scale, v_upcast, scale.numel(), e_bits, m_bits, comp_dtype, BLOCK_SIZE,
-                                     num_warps=num_warps)
+                                     num_warps=num_warps, is_xpu=is_xpu())
             assert v_upcast.isfinite().all()
             if transposed:
                 v_upcast = v_upcast.mT

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3985,8 +3985,17 @@ def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, nu
         tl.store(out_ptr, c.to(tl.bfloat16))
 
     @triton.jit
-    def mxfp_upcast_kernel(x_ptr, scale_ptr, mxfp_ptr, N, e_bits: tl.constexpr, m_bits: tl.constexpr,
-                           to_type: tl.constexpr, BLOCK_SIZE: tl.constexpr, is_xpu: tl.constexpr):
+    def mxfp_upcast_kernel(
+        x_ptr,
+        scale_ptr,
+        mxfp_ptr,
+        N,
+        e_bits: tl.constexpr,
+        m_bits: tl.constexpr,
+        to_type: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+        is_xpu: tl.constexpr,
+    ):
         # x.shape ==     (N, 32) for fp8 or (N, 16) for fp4
         # scale.shape == (N,)
         # out.shape   == (N, 32)


### PR DESCRIPTION
Another approach to the same problem that was solved in https://github.com/intel/intel-xpu-backend-for-triton/commit/05cef6a99ddb774a53f04e68d929eb65e92b89b4