### PR TITLE
Enable `SPV_INTEL_fp_fast_math_mode`

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -183,9 +183,6 @@ class XPUBackend(BaseBackend):
                 dev_prop.update(ocloc_dev_prop)
             except subprocess.CalledProcessError:
                 # Note: LTS driver does not support ocloc query CL_DEVICE_EXTENSIONS.
-                # FIXME: SPIRV extension SPV_INTEL_fp_fast_math_mode requires
-                # SPIR-V version 1.6, which is not supported by current LTS driver.
-                os.environ['DISABLE_SPV_INTEL_FP_FAST_MATH_MODE'] = '1'
                 pass
         return dev_prop
 

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -183,6 +183,9 @@ class XPUBackend(BaseBackend):
                 dev_prop.update(ocloc_dev_prop)
             except subprocess.CalledProcessError:
                 # Note: LTS driver does not support ocloc query CL_DEVICE_EXTENSIONS.
+                # FIXME: SPIRV extension SPV_INTEL_fp_fast_math_mode requires
+                # SPIR-V version 1.6, which is not supported by current LTS driver.
+                os.environ['DISABLE_SPV_INTEL_FP_FAST_MATH_MODE'] = '1'
                 pass
         return dev_prop
 

--- a/third_party/intel/cmake/FindSPIRVToLLVMTranslator.cmake
+++ b/third_party/intel/cmake/FindSPIRVToLLVMTranslator.cmake
@@ -31,9 +31,26 @@ if (NOT SPIRVToLLVMTranslator_FOUND)
             if(NOT CURL_RESULT EQUAL 0)
                 message(FATAL_ERROR "Failed to download patch from https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3122.diff")
             endif()
-
             execute_process(
                 COMMAND git apply ${CMAKE_BINARY_DIR}/3122.diff
+                WORKING_DIRECTORY ${spirv-llvm-translator_SOURCE_DIR}
+                RESULT_VARIABLE PATCH_RESULT
+            )
+            if(NOT PATCH_RESULT EQUAL 0)
+                message(FATAL_ERROR "Failed to apply patch to SPIRV-LLVM-Translator")
+            endif()
+
+            # FIXME: Don't apply patch when Agama LTS driver is updated or https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/3137 is addressed.
+            execute_process(
+                COMMAND curl -sSL https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3138.diff
+                OUTPUT_FILE ${CMAKE_BINARY_DIR}/3138.diff
+                RESULT_VARIABLE CURL_RESULT
+            )
+            if(NOT CURL_RESULT EQUAL 0)
+                message(FATAL_ERROR "Failed to download patch from https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3138.diff")
+            endif()
+            execute_process(
+                COMMAND git apply ${CMAKE_BINARY_DIR}/3138.diff
                 WORKING_DIRECTORY ${spirv-llvm-translator_SOURCE_DIR}
                 RESULT_VARIABLE PATCH_RESULT
             )

--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -107,12 +107,13 @@ public:
 
 static SPIRV::TranslatorOpts getSPIRVOopts() {
   SPIRV::TranslatorOpts SPIRVOpts;
-  static constexpr std::array<SPIRV::ExtensionID, 15> AllowedExtensions{
+  static constexpr std::array<SPIRV::ExtensionID, 16> AllowedExtensions{
       SPIRV::ExtensionID::SPV_EXT_shader_atomic_float_add,
       SPIRV::ExtensionID::SPV_INTEL_arbitrary_precision_integers,
       SPIRV::ExtensionID::SPV_INTEL_arithmetic_fence,
       SPIRV::ExtensionID::SPV_INTEL_bfloat16_conversion,
       SPIRV::ExtensionID::SPV_INTEL_cache_controls,
+      SPIRV::ExtensionID::SPV_INTEL_fp_fast_math_mode,
       SPIRV::ExtensionID::SPV_INTEL_inline_assembly,
       SPIRV::ExtensionID::SPV_INTEL_kernel_attributes,
       SPIRV::ExtensionID::SPV_INTEL_memory_access_aliasing,

--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -107,12 +107,13 @@ public:
 
 static SPIRV::TranslatorOpts getSPIRVOopts() {
   SPIRV::TranslatorOpts SPIRVOpts;
-  static constexpr std::array<SPIRV::ExtensionID, 15> AllowedExtensions{
+  static constexpr std::array<SPIRV::ExtensionID, 16> AllowedExtensions{
       SPIRV::ExtensionID::SPV_EXT_shader_atomic_float_add,
       SPIRV::ExtensionID::SPV_INTEL_arbitrary_precision_integers,
       SPIRV::ExtensionID::SPV_INTEL_arithmetic_fence,
       SPIRV::ExtensionID::SPV_INTEL_bfloat16_conversion,
       SPIRV::ExtensionID::SPV_INTEL_cache_controls,
+      SPIRV::ExtensionID::SPV_INTEL_fp_fast_math_mode,
       SPIRV::ExtensionID::SPV_INTEL_inline_assembly,
       SPIRV::ExtensionID::SPV_INTEL_kernel_attributes,
       SPIRV::ExtensionID::SPV_INTEL_memory_access_aliasing,
@@ -132,9 +133,6 @@ static SPIRV::TranslatorOpts getSPIRVOopts() {
 
   for (auto &Ext : AllowedExtensions)
     SPIRVOpts.setAllowedToUseExtension(Ext, true);
-  SPIRVOpts.setAllowedToUseExtension(
-      SPIRV::ExtensionID::SPV_INTEL_fp_fast_math_mode,
-      !std::getenv("DISABLE_SPV_INTEL_FP_FAST_MATH_MODE"));
   return SPIRVOpts;
 }
 

--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -107,13 +107,12 @@ public:
 
 static SPIRV::TranslatorOpts getSPIRVOopts() {
   SPIRV::TranslatorOpts SPIRVOpts;
-  static constexpr std::array<SPIRV::ExtensionID, 16> AllowedExtensions{
+  static constexpr std::array<SPIRV::ExtensionID, 15> AllowedExtensions{
       SPIRV::ExtensionID::SPV_EXT_shader_atomic_float_add,
       SPIRV::ExtensionID::SPV_INTEL_arbitrary_precision_integers,
       SPIRV::ExtensionID::SPV_INTEL_arithmetic_fence,
       SPIRV::ExtensionID::SPV_INTEL_bfloat16_conversion,
       SPIRV::ExtensionID::SPV_INTEL_cache_controls,
-      SPIRV::ExtensionID::SPV_INTEL_fp_fast_math_mode,
       SPIRV::ExtensionID::SPV_INTEL_inline_assembly,
       SPIRV::ExtensionID::SPV_INTEL_kernel_attributes,
       SPIRV::ExtensionID::SPV_INTEL_memory_access_aliasing,
@@ -133,6 +132,9 @@ static SPIRV::TranslatorOpts getSPIRVOopts() {
 
   for (auto &Ext : AllowedExtensions)
     SPIRVOpts.setAllowedToUseExtension(Ext, true);
+  SPIRVOpts.setAllowedToUseExtension(
+      SPIRV::ExtensionID::SPV_INTEL_fp_fast_math_mode,
+      !std::getenv("DISABLE_SPV_INTEL_FP_FAST_MATH_MODE"));
   return SPIRVOpts;
 }
 


### PR DESCRIPTION
Triton generates fast math flags like `contract`, `SPV_INTEL_fp_fast_math_mode` SPIRV extension is required to have it translated correctly, or else it would be dropped.

A failure was encountered with LTS driver with the addition of `SPV_INTEL_fp_fast_math_mode` SPIRV extension, as the SPIRV translator increases the SPIRV version to v1.6. An issue https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/3137 is created to resolve this problem, in the meantime, a workaround is added in SPIRV translator. 

Benchmark CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/14745401109 (No performance degradation.)