### PR TITLE
Do not create symlink $HOME/packages

### DIFF
--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -80,9 +80,6 @@ fi
 if [ ! -d "$PACKAGES_DIR" ]; then
   mkdir $PACKAGES_DIR
 fi
-if [ $BASE != $HOME ]; then
-  ln -sfT $PACKAGES_DIR $HOME/packages
-fi
 
 ############################################################################
 # Clone the Triton project fork if it does not exists.


### PR DESCRIPTION
The directory `packages` is no longer required in user home. Tested with the local build with custom LLVM:
```
./scripts/compile-triton.sh --llvm --triton`
```