### PR TITLE
[BENCHMARK][GEMM] Append missing wait to cutlass kernel

### DIFF
--- a/benchmarks/cutlass_kernel/python_main.cpp
+++ b/benchmarks/cutlass_kernel/python_main.cpp
@@ -139,19 +139,17 @@ static auto gemm_run(const at::Tensor &A, const at::Tensor &B, at::Tensor &C,
     size_t workspace_size = Gemm::get_workspace_size(arguments);
     cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
 
-    {
-      CUTLASS_CHECK(gemm_op.can_implement(arguments));
-    }
-    {
-      CUTLASS_CHECK(gemm_op.initialize(arguments, workspace.get()));
-    }
-    {
-      CUTLASS_CHECK(gemm_op.run());
-    }
+    CUTLASS_CHECK(gemm_op.can_implement(arguments));
+    CUTLASS_CHECK(gemm_op.initialize(arguments, workspace.get()));
+    CUTLASS_CHECK(gemm_op.run());
+
+    syclcompat::wait();
+
   } catch (std::exception &e) {
     std::cerr << "Runtime error: " << e.what() << std::endl;
     return -1;
   } catch (...) {
+    std::cerr << "Unexpected error" << std::endl;
     return -1;
   }
 


### PR DESCRIPTION
# Description

This PR updates the GEMM invoker by appending the missing wait after the GEMM invocation. The absence of this wait was causing incorrect results in the benchmarking table shown below

```
matmul-performance:
        B    M      N        K  CUTLASS-GB/s  CUTLASS-GB/s-min  CUTLASS-GB/s-max  CUTLASS-TFlops  CUTLASS-TFlops-min  CUTLASS-TFlops-max  CUTLASS-CV
0  1024.0  8.0  128.0  16384.0    663.445529        658.732307      1.019553e+06        4.990767            4.955312         7669.584252    0.004058

matmul-performance:
        B    M      N        K  CUTLASS-GB/s  CUTLASS-GB/s-min  CUTLASS-GB/s-max  CUTLASS-TFlops  CUTLASS-TFlops-min  CUTLASS-TFlops-max  CUTLASS-CV
0  1024.0  8.0  128.0  16384.0    664.932928         661.40312        669.719935        5.001956            4.975403            5.037967     0.00255
```
