### PR TITLE
Replace `FetchContent_Populate` by `FetchContent_MakeAvailable`

### DIFF
--- a/benchmarks/cmake/FindCUTLASSLibrary.cmake
+++ b/benchmarks/cmake/FindCUTLASSLibrary.cmake
@@ -22,7 +22,7 @@ if (NOT CUTLASSLibrary_FOUND)
 
     FetchContent_GetProperties(cutlass-library)
     if(NOT cutlass-library_POPULATED)
-       FetchContent_Populate(cutlass-library)
+       FetchContent_MakeAvailable(cutlass-library)
     endif()
 
     set(CUTLASSLibrary_INCLUDE_DIR "${CUTLASSLibrary_SOURCE_DIR}/include" CACHE INTERNAL "CUTLASSLibrary_SOURCE_DIR")

--- a/benchmarks/cmake/FindXeTLALibrary.cmake
+++ b/benchmarks/cmake/FindXeTLALibrary.cmake
@@ -22,7 +22,7 @@ if (NOT XeTLALibrary_FOUND)
 
     FetchContent_GetProperties(xetla-library)
     if(NOT xetla-library_POPULATED)
-       FetchContent_Populate(xetla-library)
+       FetchContent_MakeAvailable(xetla-library)
     endif()
 
     set(XeTLALibrary_INCLUDE_DIR "${XeTLALibrary_SOURCE_DIR}/include"

--- a/third_party/intel/cmake/FindSPIRVToLLVMTranslator.cmake
+++ b/third_party/intel/cmake/FindSPIRVToLLVMTranslator.cmake
@@ -20,7 +20,7 @@ if (NOT SPIRVToLLVMTranslator_FOUND)
 
     FetchContent_GetProperties(spirv-llvm-translator)
     if(NOT spirv-llvm-translator_POPULATED)
-            FetchContent_Populate(spirv-llvm-translator)
+            FetchContent_MakeAvailable(spirv-llvm-translator)
 
             # FIXME: Don't apply patch when Agama driver is updated.
             execute_process(


### PR DESCRIPTION
```
  CMake Warning (dev) at C:/Users/vagrant/AppData/Local/Temp/pip-build-env-blxl_9th/overlay/Lib/site-packages/cmake/data/share/cmake-4.0/Modules/FetchContent.cmake:1953 (message):
    Calling FetchContent_Populate(spirv-llvm-translator) is deprecated, call
    FetchContent_MakeAvailable(spirv-llvm-translator) instead.  Policy CMP0169
    can be set to OLD to allow FetchContent_Populate(spirv-llvm-translator) to
    be called directly for now, but the ability to call it with declared
    details will be removed completely in a future version.
```