### PR TITLE
Prevent 2d block loads with dimensions larger than the tensor block size

### DIFF
--- a/test/TritonIntelGPU/blockptr_load.mlir
+++ b/test/TritonIntelGPU/blockptr_load.mlir
@@ -274,7 +274,7 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
 // -----
 
 // COM: 2D block load reduced to be <= block size
-// CHECK-DAG: llvm.func spir_funccc @_Z51intel_sub_group_2d_block_read_transform_8b_32r16x2cPU3AS1viiiDv2_iPj(!llvm.ptr<1> {llvm.nonnull, llvm.readonly}, i32, i32, i32, vector<2xi32>, !llvm.ptr {llvm.nonnull, llvm.writeonly}) attributes {no_unwind, will_return}
+// CHECK: llvm.func spir_funccc @_Z51intel_sub_group_2d_block_read_transform_8b_32r16x2cPU3AS1viiiDv2_iPj(!llvm.ptr<1> {llvm.nonnull, llvm.readonly}, i32, i32, i32, vector<2xi32>, !llvm.ptr {llvm.nonnull, llvm.writeonly}) attributes {no_unwind, will_return}
 #dpas = #triton_intel_gpu.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 4, threadsPerWarp = 16, warpsPerCTA = [1, 4], repCluster = [1, 2], A = [8, 32], B = [32, 32], C = [8, 32]}>
 #dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth=4}>
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1635,16 +1635,14 @@ struct LoadOpConversion
       llvm::dbgs() << "numOperandsInnerDimPerLoad before downscaling = "
                    << numOperandsInnerDimPerLoad << "\n";
     });
-    numOperandsOuterDimPerLoad =
-        std::max(std::min(numOperandsOuterDimPerLoad,
-                          static_cast<unsigned>(tensorShape[dimOuter] /
-                                                elemsPerDPASInst[0])),
-                 1u);
-    numOperandsInnerDimPerLoad =
-        std::max(std::min(numOperandsInnerDimPerLoad,
-                          static_cast<unsigned>(tensorShape[dimInner] /
-                                                elemsPerDPASInst[1])),
-                 1u);
+
+    numOperandsOuterDimPerLoad = std::min(
+        numOperandsOuterDimPerLoad,
+        mlir::ceil<unsigned>(tensorShape[dimOuter], elemsPerDPASInst[0]));
+
+    numOperandsInnerDimPerLoad = std::min(
+        numOperandsInnerDimPerLoad,
+        mlir::ceil<unsigned>(tensorShape[dimInner], elemsPerDPASInst[1]));
 
     LLVM_DEBUG({
       llvm::dbgs() << "numOperandsOuterDimPerLoad = "

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1628,6 +1628,24 @@ struct LoadOpConversion
     numOperandsInnerDimPerLoad =
         isOperandA ? numOperandsPer2DloadN : numOperandsPer2DLoadM;
 
+    // downscale if the load size is bigger than the block size
+    LLVM_DEBUG({
+      llvm::dbgs() << "numOperandsOuterDimPerLoad before downscaling = "
+                   << numOperandsOuterDimPerLoad << "\n";
+      llvm::dbgs() << "numOperandsInnerDimPerLoad before downscaling = "
+                   << numOperandsInnerDimPerLoad << "\n";
+    });
+    numOperandsOuterDimPerLoad =
+        std::max(std::min(numOperandsOuterDimPerLoad,
+                          static_cast<unsigned>(tensorShape[dimOuter] /
+                                                elemsPerDPASInst[0])),
+                 1u);
+    numOperandsInnerDimPerLoad =
+        std::max(std::min(numOperandsInnerDimPerLoad,
+                          static_cast<unsigned>(tensorShape[dimInner] /
+                                                elemsPerDPASInst[1])),
+                 1u);
+
     LLVM_DEBUG({
       llvm::dbgs() << "numOperandsOuterDimPerLoad = "
                    << numOperandsOuterDimPerLoad << "\n";


### PR DESCRIPTION
While working to generate shuffle vectors using chained linear layouts, I noticed that the size of the 2D block load can exceed the Tensor block size. In that case we generate and provide extra shuffle vectors for the values that are > the block size, but it appears those shuffle vectors are never used. This behavior makes it challenging to use linear layouts, since the layout ends up generating a different sequence of shuffle vectors - I can work around it, but it didn't make sense to me to generate big loads if we are not using all the data. So, this PR attempts to downscale a 2D block load to be equal to or less than the block size. I ran the benchmarks and, surprisingly, there appears to be a noticeable uplift in softmax but no change in gemm. 
<img width="689" alt="image" src="https://github.com/user-attachments/assets/facfb6da-3841-445e-bfbf-d302532cd7d8" />
there may be a very, very small uplift in attn as well - or it could just be noise. 
<img width="689" alt="image" src="https://github.com/user-attachments/assets/a12c1e77-0ed5-4959-a06f-5e82952990eb" />

I tried interpreting the `attn` tables, but the numbers are all over the place, with this PR benchmarks tag generally being better than or worse than the default tag by about 10 tflops. 

Regardless, even if this is performance neutral it makes it much cleaner to generate the 2D block loads from linear layouts, so I'd like to land it if possible. 