### PR TITLE
[tensor-descriptor]: Add `test_tensor_descriptor_reshape_matmul` test

### DIFF
--- a/python/test/unit/intel/test_tensor_descriptor.py
+++ b/python/test/unit/intel/test_tensor_descriptor.py
@@ -10,8 +10,9 @@ from typing import Optional
 
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
+@pytest.mark.parametrize("num_ctas", [1])
 @pytest.mark.parametrize("M_BLOCK,N_BLOCK", [(2, 16), (8, 16), (8, 32), (8, 128)])
-def test_tensor_descriptor_load(dtype_str, M_BLOCK, N_BLOCK):
+def test_tensor_descriptor_load(dtype_str, num_ctas, M_BLOCK, N_BLOCK):
 
     @triton.jit
     def kernel(out_ptr, a_ptr, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
@@ -32,7 +33,7 @@ def test_tensor_descriptor_load(dtype_str, M_BLOCK, N_BLOCK):
         tl.store(out_ptr + idx, block)
 
     def alloc_fn(size: int, align: int, stream: Optional[int]):
-        assert size == 128
+        assert size == 128 * num_ctas
         assert align == 128
         assert stream == 0
         return torch.empty(size, dtype=torch.int8, device="xpu")
@@ -43,7 +44,7 @@ def test_tensor_descriptor_load(dtype_str, M_BLOCK, N_BLOCK):
     inp = to_triton(numpy_random((M, N), dtype_str), device="xpu", dst_type=dtype_str)
     out = inp.new_empty((M_BLOCK, N_BLOCK))
 
-    kernel[(1, )](out, inp, M, N, M_BLOCK, N_BLOCK)
+    kernel[(1, )](out, inp, M, N, M_BLOCK, N_BLOCK, num_ctas=num_ctas)
 
     expect = unwrap_tensor(inp)[1 * M_BLOCK:2 * M_BLOCK, 2 * N_BLOCK:3 * N_BLOCK]
     torch.testing.assert_close(expect, unwrap_tensor(out))
@@ -51,8 +52,9 @@ def test_tensor_descriptor_load(dtype_str, M_BLOCK, N_BLOCK):
 
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
+@pytest.mark.parametrize("num_ctas", [1])
 @pytest.mark.parametrize("M_BLOCK,N_BLOCK", [(2, 16), (8, 16), (8, 32), (8, 128)])
-def test_tensor_descriptor_store(dtype_str, M_BLOCK, N_BLOCK):
+def test_tensor_descriptor_store(dtype_str, num_ctas, M_BLOCK, N_BLOCK):
 
     @triton.jit
     def kernel(out_ptr, a_ptr, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
@@ -87,14 +89,14 @@ def test_tensor_descriptor_store(dtype_str, M_BLOCK, N_BLOCK):
     grid_n = N // N_BLOCK
 
     def alloc_fn(size: int, align: int, stream: Optional[int]):
-        assert size == 128 * (grid_m * grid_n)
+        assert size == 128 * (grid_m * grid_n) * num_ctas
         assert align == 128
         assert stream == 0
         return torch.empty(size, dtype=torch.int8, device="xpu")
 
     triton.set_allocator(alloc_fn)
 
-    kernel[(grid_m, grid_n)](out, inp, M, N, M_BLOCK, N_BLOCK)
+    kernel[(grid_m, grid_n)](out, inp, M, N, M_BLOCK, N_BLOCK, num_ctas=num_ctas)
 
     torch.testing.assert_close(unwrap_tensor(inp), unwrap_tensor(out))
 
@@ -411,6 +413,7 @@ def matmul_kernel_make_tensor_descriptor(a_ptr, b_ptr, c_ptr,  #
 
 
 @pytest.mark.interpreter
+@pytest.mark.parametrize("num_ctas", [1])
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K, num_stages", [
     (128, 128, 16, 1),
     (256, 64, 32, 2),
@@ -420,7 +423,7 @@ def matmul_kernel_make_tensor_descriptor(a_ptr, b_ptr, c_ptr,  #
     (32, 32, 32, 4),
     (256, 128, 32, 4),
 ])
-def test_make_tensor_descriptor_matmul(num_stages, BLOCK_M, BLOCK_N, BLOCK_K):
+def test_make_tensor_descriptor_matmul(num_stages, num_ctas, BLOCK_M, BLOCK_N, BLOCK_K):
     device = "xpu"
     if is_interpreter():
         M, N, K = BLOCK_M, BLOCK_N, BLOCK_K
@@ -437,7 +440,7 @@ def test_make_tensor_descriptor_matmul(num_stages, BLOCK_M, BLOCK_N, BLOCK_K):
     grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N), 1)
 
     def alloc_fn(size: int, align: int, stream: Optional[int]):
-        assert size == 3 * 128 * grid[0] * grid[1]
+        assert size == 3 * 128 * grid[0] * grid[1] * num_ctas
         assert align == 128
         assert stream == 0
         return torch.empty(size, dtype=torch.int8, device="xpu")
@@ -456,6 +459,7 @@ def test_make_tensor_descriptor_matmul(num_stages, BLOCK_M, BLOCK_N, BLOCK_K):
         BLOCK_K,
         num_warps=8,
         num_stages=num_stages,
+        num_ctas=num_ctas,
     )
     ref_out = torch.matmul(A.to(torch.float32), B.to(torch.float32)).to(torch.float16)
     torch.testing.assert_close(ref_out, C, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
This PR adds a new test (test_tensor_descriptor_reshape_matmul) to verify matmul functionality using reshaped tensor descriptors while also updating existing tests. Key changes include:

Adding an extra (8, 128) configuration for M_BLOCK/N_BLOCK parameters in load and store tests.
Changing test control flow from pytest.skip to pytest.xfail under certain conditions and renaming a misnamed kernel function.
Introducing a new JIT kernel (matmul_kernel_reshape) and associated test to validate reshaped tensor descriptors.