### PR TITLE
Update oneapi version in `inductor-tests-reusable.yml`: 2025.0 -> 2025.1

### DIFF
--- a/.github/workflows/inductor-tests-reusable.yml
+++ b/.github/workflows/inductor-tests-reusable.yml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 960
     defaults:
       run:
-        shell: bash -noprofile --norc -eo pipefail -c "source /opt/intel/oneapi/2025.0/oneapi-vars.sh > /dev/null; source {0}"
+        shell: bash -noprofile --norc -eo pipefail -c "source /opt/intel/oneapi/2025.1/oneapi-vars.sh > /dev/null; source {0}"
     steps:
       - name: Print inputs
         run: |


### PR DESCRIPTION
Hot-fix after https://github.com/intel/intel-xpu-backend-for-triton/pull/4154

PyTorch CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/14947174960