### PR TITLE
Fix SPIRVOps initialization

### DIFF
--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -105,8 +105,8 @@ public:
   SmallVectorBuffer(llvm::SmallVectorImpl<char> &O) : OS(O) {}
 };
 
-static SPIRV::TranslatorOpts getSPIRVOopts() {
-  SPIRV::TranslatorOpts SPIRVOpts;
+static SPIRV::TranslatorOpts getSPIRVOpts() {
+  SPIRV::TranslatorOpts SPIRVOpts {SPIRV::VersionNumber::SPIRV_1_4};
   static constexpr std::array<SPIRV::ExtensionID, 16> AllowedExtensions{
       SPIRV::ExtensionID::SPV_EXT_shader_atomic_float_add,
       SPIRV::ExtensionID::SPV_INTEL_arbitrary_precision_integers,
@@ -129,7 +129,6 @@ static SPIRV::TranslatorOpts getSPIRVOopts() {
   SPIRVOpts.setPreserveOCLKernelArgTypeMetadataThroughString(true);
   SPIRVOpts.setPreserveAuxData(false);
   SPIRVOpts.setSPIRVAllowUnknownIntrinsics({"llvm.genx.GenISA."});
-  SPIRV::TranslatorOpts TransOpt{SPIRV::VersionNumber::SPIRV_1_4};
 
   for (auto &Ext : AllowedExtensions)
     SPIRVOpts.setAllowedToUseExtension(Ext, true);
@@ -156,7 +155,7 @@ std::string translateLLVMIRToSPIRV(llvm::Module &module) {
   std::ostream OS(&StreamBuf);
   std::string Err;
 
-  SPIRV::TranslatorOpts SPIRVOpts = getSPIRVOopts();
+  SPIRV::TranslatorOpts SPIRVOpts = getSPIRVOpts();
 
 #if defined(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
   int SpvTranslateMode = 0;


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
