### PR TITLE
Do not disable verification

### DIFF
--- a/benchmarks/triton_kernels_benchmark/benchmark_testing.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_testing.py
@@ -361,8 +361,6 @@ class Mark:
         for bench in benchmarks:
             benchmark_dfs = []
             for run_counter in range(args.n_runs):
-                if run_counter > 0:
-                    disable_verification()
                 df = self._run(bench, args.reports, show_plots, print_data, run_counter=run_counter, **kwargs)
                 df["datetime"] = datetime.datetime.now()
                 df["run_counter"] = run_counter + 1


### PR DESCRIPTION
Disabling verification makes runs 2 and others slower than the first run. Without disabling verification the variation in general is smaller, and there is no such difference between the first and other runs.

Fixes #4094.