### PR TITLE
Introduce Subgroup 2D Block Encoding

### DIFF
--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/LinearLayoutConversions.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/LinearLayoutConversions.h
@@ -21,7 +21,7 @@ LinearLayout dotOperandDpasToLinearLayout(DotOperandEncodingAttr dotDpasLayout,
 LinearLayout
 subgroup2DBlockToLinearLayout(ArrayRef<int64_t> shape,
                               intel::Subgroup2DBlockEncodingAttr layout,
-                              unsigned kWidth, unsigned opIdx = 2);
+                              unsigned kWidth);
 
 } // namespace mlir::triton::gpu
 

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/LinearLayoutConversions.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/LinearLayoutConversions.h
@@ -18,6 +18,11 @@ LinearLayout DPAStoLinearLayout(ArrayRef<int64_t> shape, Attribute layout,
 LinearLayout dotOperandDpasToLinearLayout(DotOperandEncodingAttr dotDpasLayout,
                                           ArrayRef<int64_t> shape);
 
+LinearLayout
+subgroup2DBlockToLinearLayout(ArrayRef<int64_t> shape,
+                              intel::Subgroup2DBlockEncodingAttr layout,
+                              unsigned kWidth, unsigned opIdx = 2);
+
 } // namespace mlir::triton::gpu
 
 #endif // TRITON_DIALECT_TRITONINTELGPU_IR_LINEARLAYOUTCONVERSIONS_H

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.td
@@ -290,8 +290,19 @@ def Subgroup2DBlockEncodingAttr : DistributedEncoding<"Subgroup2DBlockEncoding",
   let description = [{
     An encoding for tensors produced via Intel Subgroup 2D Block IO operations.
 
-    instrShape - the height/width for the block load
-    numBlocks / numVBlocks - number of blocks to simultaneously load (for making most use of cache)
+    The subgroup 2D block IO operations read or write two-dimensional blocks of data from a two-dimensional region of memory. The Subgroup 2D Block Encoding layout is parameterized by the block width, block height, and block count for the individual load instructions and the distribution and replication of loads across warps.
+
+    The SPV_INTEL_2d_block_io extension documentation provides more information on the subgroup 2D block IO operations and parameters: https://github.khronos.org/SPIRV-Registry/extensions/INTEL/SPV_INTEL_2d_block_io.html
+
+    For the layout, the following parameters are required:
+    - `instrShape` : contains the (height, width) block parameters for the block io operation
+    - `numBlocks` : the block count parameter allows a single load to load multiple blocks in row-major order (useful for increasing cache line utilization)
+    - `threadsPerWarp` : currently a scalar, this parameter allows us to support different subgroup / warp configurations. Because the 2d block io operation is a subgroup operation, the size of the subgroup is important in determining the ordering of the loaded tensor.
+    - `warpsPerCTA` : the number of warps per block / subgroups per workgroup and their distribution
+    - `order` : The order within the block, used to determine along which dimension to broadcast.
+    - `kWidth` : used?
+    - `numReps` : unused?
+    - `CTALayout` : ??
   }];
 
   let parameters = (

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.td
@@ -289,6 +289,9 @@ def Subgroup2DBlockEncodingAttr : DistributedEncoding<"Subgroup2DBlockEncoding",
 
   let description = [{
     An encoding for tensors produced via Intel Subgroup 2D Block IO operations.
+
+    instrShape - the height/width for the block load
+    numBlocks / numVBlocks - number of blocks to simultaneously load (for making most use of cache)
   }];
 
   let parameters = (
@@ -296,6 +299,7 @@ def Subgroup2DBlockEncodingAttr : DistributedEncoding<"Subgroup2DBlockEncoding",
     ArrayRefParameter<"unsigned">:$warpsPerCTA,
     "CTALayoutAttr":$CTALayout,
     ArrayRefParameter<"unsigned">:$instrShape,
+    "unsigned":$numBlocks,
     ArrayRefParameter<"unsigned">:$numReps,
     "unsigned":$kWidth,
     "unsigned":$threadsPerWarp

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.td
@@ -280,4 +280,35 @@ def WarpEncodingAttr : DistributedEncoding<"WarpEncoding", "intel_warp_encoding"
   let hasCustomAssemblyFormat = 1;
 }
 
+//===----------------------------------------------------------------------===//
+// Intel Subgroup2DBlock Encoding
+//===----------------------------------------------------------------------===//
+
+def Subgroup2DBlockEncodingAttr : DistributedEncoding<"Subgroup2DBlockEncoding", "subgroup_2d_block_encoding", [MmaEncodingTrait], TritonIntelGPU_Dialect> {
+  let mnemonic = "subgroup_2d_block";
+
+  let description = [{
+    An encoding for tensors produced via Intel Subgroup 2D Block IO operations.
+  }];
+
+  let parameters = (
+    ins
+    ArrayRefParameter<"unsigned">:$warpsPerCTA,
+    "CTALayoutAttr":$CTALayout,
+    ArrayRefParameter<"unsigned">:$instrShape,
+    ArrayRefParameter<"unsigned">:$numReps,
+    "unsigned":$kWidth,
+    "unsigned":$threadsPerWarp
+  );
+
+  let extraClassDeclaration = extraDistributedDeclaration # [{
+    SmallVector<int64_t> getRepForOperand(ArrayRef<int64_t> shape,
+                                          int opIdx) const;
+    SmallVector<unsigned> getRepOrderForOperand(int opIdx) const;
+  }];
+
+  let hasCustomAssemblyFormat = 1;
+  let genVerifyDecl = 1;
+}
+
 #endif

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.td
@@ -300,9 +300,8 @@ def Subgroup2DBlockEncodingAttr : DistributedEncoding<"Subgroup2DBlockEncoding",
     - `threadsPerWarp` : currently a scalar, this parameter allows us to support different subgroup / warp configurations. Because the 2d block io operation is a subgroup operation, the size of the subgroup is important in determining the ordering of the loaded tensor.
     - `warpsPerCTA` : the number of warps per block / subgroups per workgroup and their distribution
     - `order` : The order within the block, used to determine along which dimension to broadcast.
-    - `kWidth` : used?
-    - `numReps` : unused?
-    - `CTALayout` : ??
+    - `kWidth` : Currently unused, but keeping because we will likely need it for layout conversions.
+    - `CTALayout` : Describes how blocks are distributed among work-groups/thread blocks.
   }];
 
   let parameters = (

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.td
@@ -301,6 +301,7 @@ def Subgroup2DBlockEncodingAttr : DistributedEncoding<"Subgroup2DBlockEncoding",
     ArrayRefParameter<"unsigned">:$instrShape,
     "unsigned":$numBlocks,
     ArrayRefParameter<"unsigned">:$numReps,
+    ArrayRefParameter<"unsigned">:$order,
     "unsigned":$kWidth,
     "unsigned":$threadsPerWarp
   );

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.td
@@ -307,8 +307,6 @@ def Subgroup2DBlockEncodingAttr : DistributedEncoding<"Subgroup2DBlockEncoding",
   );
 
   let extraClassDeclaration = extraDistributedDeclaration # [{
-    SmallVector<int64_t> getRepForOperand(ArrayRef<int64_t> shape,
-                                          int opIdx) const;
     SmallVector<unsigned> getRepOrderForOperand(int opIdx) const;
   }];
 

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.td
@@ -311,7 +311,6 @@ def Subgroup2DBlockEncodingAttr : DistributedEncoding<"Subgroup2DBlockEncoding",
     "CTALayoutAttr":$CTALayout,
     ArrayRefParameter<"unsigned">:$instrShape,
     "unsigned":$numBlocks,
-    ArrayRefParameter<"unsigned">:$numReps,
     ArrayRefParameter<"unsigned">:$order,
     "unsigned":$kWidth,
     "unsigned":$threadsPerWarp

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
@@ -631,15 +631,7 @@ Attribute Subgroup2DBlockEncodingAttr::parse(AsmParser &parser, Type type) {
       numReps, order, kWidth, threadsPerWarp);
 }
 
-SmallVector<int64_t>
-Subgroup2DBlockEncodingAttr::getRepForOperand(ArrayRef<int64_t> shape,
-                                              int opIdx) const {
-  assert(false && "TODO");
-  return {};
-}
-
 SmallVector<unsigned> Subgroup2DBlockEncodingAttr::getRepOrder() const {
-  // TODO: used?
   return getMatrixOrder(getRank(), /*rowMajor*/ true);
 }
 
@@ -657,7 +649,6 @@ SmallVector<unsigned> Subgroup2DBlockEncodingAttr::getCTASplitNum() const {
 
 SmallVector<unsigned>
 Subgroup2DBlockEncodingAttr::getRepOrderForOperand(int opIdx) const {
-  // TODO: used?
   return getOrderForDotOperand(opIdx, getRank(), /*kContig*/ true);
 }
 

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
@@ -531,8 +531,7 @@ void maybePrintCTALayout(mlir::MLIRContext *context, mlir::AsmPrinter &printer,
 LogicalResult Subgroup2DBlockEncodingAttr::verify(
     function_ref<InFlightDiagnostic()> emitError,
     ArrayRef<unsigned> warpsPerCTA, CTALayoutAttr CTALayout,
-    ArrayRef<unsigned> instrShape, unsigned numBlocks,
-    ArrayRef<unsigned> numReps, ArrayRef<unsigned> order, unsigned kWidth,
+    ArrayRef<unsigned> instrShape, unsigned numBlocks, ArrayRef<unsigned> order, unsigned kWidth,
     unsigned threadsPerWarp) {
   if (instrShape.size() != 2) {
     return emitError() << "instrShape must be rank 2 but was: "
@@ -570,7 +569,6 @@ Attribute Subgroup2DBlockEncodingAttr::parse(AsmParser &parser, Type type) {
   std::optional<SmallVector<unsigned>> CTAOrder;
   SmallVector<unsigned> instrShape;
   unsigned numBlocks = 0;
-  SmallVector<unsigned> numReps;
   SmallVector<unsigned> order;
   unsigned kWidth = 0;
   unsigned threadsPerWarp = 0;
@@ -603,10 +601,6 @@ Attribute Subgroup2DBlockEncodingAttr::parse(AsmParser &parser, Type type) {
       if (parseUInt(parser, attr, numBlocks, "numBlocks").failed())
         return {};
     }
-    if (attr.getName() == "numReps") {
-      if (parseIntArrayAttr(parser, attr, numReps, "numReps").failed())
-        return {};
-    }
     if (attr.getName() == "order") {
       if (parseIntArrayAttr(parser, attr, order, "order").failed())
         return {};
@@ -628,7 +622,7 @@ Attribute Subgroup2DBlockEncodingAttr::parse(AsmParser &parser, Type type) {
 
   return parser.getChecked<Subgroup2DBlockEncodingAttr>(
       parser.getContext(), warpsPerCTA, *CTALayout, instrShape, numBlocks,
-      numReps, order, kWidth, threadsPerWarp);
+      order, kWidth, threadsPerWarp);
 }
 
 SmallVector<unsigned> Subgroup2DBlockEncodingAttr::getRepOrder() const {
@@ -658,8 +652,7 @@ void Subgroup2DBlockEncodingAttr::print(AsmPrinter &printer) const {
   maybePrintCTALayout(getContext(), printer, getCTALayout(), getRank());
 
   printer << ", instrShape = [" << getInstrShape()
-          << "], numBlocks=" << getNumBlocks() << ", numReps=[" << getNumReps()
-          << "], order=[" << getOrder() << "], kWidth=" << getKWidth()
+          << "], numBlocks=" << getNumBlocks() << ", order=[" << getOrder() << "], kWidth=" << getKWidth()
           << ", threadsPerWarp=" << getThreadsPerWarp() << "}>";
 }
 

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
@@ -531,8 +531,8 @@ void maybePrintCTALayout(mlir::MLIRContext *context, mlir::AsmPrinter &printer,
 LogicalResult Subgroup2DBlockEncodingAttr::verify(
     function_ref<InFlightDiagnostic()> emitError,
     ArrayRef<unsigned> warpsPerCTA, CTALayoutAttr CTALayout,
-    ArrayRef<unsigned> instrShape, unsigned numBlocks, ArrayRef<unsigned> order, unsigned kWidth,
-    unsigned threadsPerWarp) {
+    ArrayRef<unsigned> instrShape, unsigned numBlocks, ArrayRef<unsigned> order,
+    unsigned kWidth, unsigned threadsPerWarp) {
   if (instrShape.size() != 2) {
     return emitError() << "instrShape must be rank 2 but was: "
                        << instrShape.size();
@@ -652,7 +652,8 @@ void Subgroup2DBlockEncodingAttr::print(AsmPrinter &printer) const {
   maybePrintCTALayout(getContext(), printer, getCTALayout(), getRank());
 
   printer << ", instrShape = [" << getInstrShape()
-          << "], numBlocks=" << getNumBlocks() << ", order=[" << getOrder() << "], kWidth=" << getKWidth()
+          << "], numBlocks=" << getNumBlocks() << ", order=[" << getOrder()
+          << "], kWidth=" << getKWidth()
           << ", threadsPerWarp=" << getThreadsPerWarp() << "}>";
 }
 

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/LinearLayoutConversions.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/LinearLayoutConversions.cpp
@@ -580,24 +580,6 @@ subgroup2DBlockToLinearLayout(ArrayRef<int64_t> blockShape,
   StringAttr kWarp = S("warp");
   auto warpOrder = getMatrixOrder(rank, /*rowMajor*/ true);
 
-  auto printVector = [](const auto vec) {
-    for (size_t i = 0; i < vec.size(); i++) {
-      llvm::errs() << vec[i] << " ";
-    }
-  };
-
-  llvm::errs() << "blockShape: ";
-  printVector(blockShape);
-  llvm::errs() << "\n";
-
-  auto printBases = [&printVector](const auto base) {
-    for (size_t i = 0; i < base.size(); i++) {
-      llvm::errs() << i << " : ";
-      printVector(base[i]);
-      llvm::errs() << "\n";
-    }
-  };
-
   auto order = layout.getOrder();
   unsigned inner = order[0];
   unsigned outer = order[1];
@@ -607,7 +589,6 @@ subgroup2DBlockToLinearLayout(ArrayRef<int64_t> blockShape,
   LinearLayout::BasesT bases;
 
   // start with the DPAS tile
-  int opsPerChannel = 2; // TODO: how to get this?
   auto [regBases, laneBases] =
       createRegisterLaneTileLayout(loadTileSize[0], loadTileSize[1]);
 
@@ -616,7 +597,8 @@ subgroup2DBlockToLinearLayout(ArrayRef<int64_t> blockShape,
 
   auto ctaLayout = LinearLayout(bases, dimNames);
   llvm::errs() << "ctaLayer pre vblocks: " << ctaLayout << "\n";
-  // handle num blocks
+
+  // Handle block count
   ctaLayout *=
       LinearLayout::identity1D(layout.getNumBlocks(), kRegister, dimNames[1]);
 

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/LinearLayoutConversions.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/LinearLayoutConversions.cpp
@@ -551,8 +551,10 @@ using basisT = std::vector<std::vector<int32_t>>;
 
 std::pair<basisT, basisT>
 createRegisterLaneTileLayout(const int height, const int width,
-                             const unsigned threadsPerWarp) {
+                             const unsigned threadsPerWarp,
+                             const unsigned kWidth) {
 
+  llvm::errs() << "kWidth = " << kWidth << "\n";
   const unsigned packedElementsPerLane =
       mlir::ceil<unsigned>(width, threadsPerWarp);
   llvm::errs() << "packedElementsPerLane = " << packedElementsPerLane << "\n";
@@ -602,7 +604,8 @@ subgroup2DBlockToLinearLayout(ArrayRef<int64_t> blockShape,
   // start with the DPAS tile
   // TODO: strided version, 32x32x1
   auto [regBases, laneBases] = createRegisterLaneTileLayout(
-      loadTileSize[0], loadTileSize[1], layout.getThreadsPerWarp());
+      loadTileSize[0], loadTileSize[1], layout.getThreadsPerWarp(),
+      layout.getKWidth());
 
   bases[kRegister] = regBases;
   bases[kLane] = laneBases;

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/LinearLayoutConversions.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/LinearLayoutConversions.cpp
@@ -523,4 +523,258 @@ LinearLayout dotOperandDpasToLinearLayout(DotOperandEncodingAttr dotDpasLayout,
   return DPAStoLinearLayout(shape, dpasLayout, dotDpasLayout.getOpIdx());
 }
 
+namespace {
+
+// maybe unused?
+static LinearLayout broadcastedDotOperandLayout(MLIRContext *ctx,
+                                                ArrayRef<unsigned> shape,
+                                                ArrayRef<unsigned> order,
+                                                unsigned broadcastDim,
+                                                StringAttr inDimName) {
+  int rank = shape.size();
+  auto dimNames = standardOutDimNames(ctx, rank);
+  LinearLayout layout = LinearLayout::empty();
+
+  for (auto d : order) {
+    if (d == broadcastDim) {
+      layout *= LinearLayout::zeros1D(shape[d], inDimName, dimNames[d]);
+    } else {
+      layout *= LinearLayout::identity1D(shape[d], inDimName, dimNames[d]);
+    }
+  }
+  return layout;
+}
+
+} // namespace
+
+LinearLayout
+subgroup2DBlockToLinearLayout(ArrayRef<int64_t> shape,
+                              intel::Subgroup2DBlockEncodingAttr layout,
+                              unsigned kWidth, unsigned opIdx) {
+  auto ctx = layout.getContext();
+  int rank = shape.size();
+  assert(rank == layout.getRank());
+  auto dimNames = standardOutDimNames(ctx, rank);
+  auto instrShapeMNK = layout.getInstrShape();
+  StringAttr kRegister = S("register");
+  StringAttr kLane = S("lane");
+  StringAttr kWarp = S("warp");
+  auto trivialShape = SmallVector<unsigned>(rank, 1);
+  auto warpOrder = getMatrixOrder(rank, /*rowMajor*/ true);
+
+  auto printVector = [](const auto vec) {
+    for (size_t i = 0; i < vec.size(); i++) {
+      llvm::errs() << vec[i] << " ";
+    }
+  };
+
+  auto ctaLayout = layout.getCTALayout();
+  llvm::errs() << "ctaLayout: " << ctaLayout << "\n";
+  auto ctaSplitNum = ctaLayout.getCTASplitNum();
+  llvm::errs() << "ctaSplitNum: ";
+  printVector(ctaSplitNum);
+  llvm::errs() << "\n";
+
+  auto ctasPerCGA = ctaLayout.getCTAsPerCGA();
+  llvm::errs() << "ctasPerCGA: ";
+  printVector(ctasPerCGA);
+  llvm::errs() << "\n";
+
+  auto ctaOrder = ctaLayout.getCTAOrder();
+  llvm::errs() << "ctaOrder: ";
+  printVector(ctaOrder);
+  llvm::errs() << "\n";
+
+  auto printBases = [&printVector](const auto base) {
+    for (size_t i = 0; i < base.size(); i++) {
+      llvm::errs() << i << " : ";
+      printVector(base[i]);
+      llvm::errs() << "\n";
+    }
+  };
+
+  if (opIdx == 0) {
+    SmallVector<int64_t> blockShape({instrShapeMNK[0], instrShapeMNK[2]});
+
+    LinearLayout::BasesT bases;
+
+    // start with the DPAS tile
+    int opsPerChannel = 2; // TODO: how to get this?
+    auto regBases = DPASRegBasesA(
+        opsPerChannel, DpasEncodingAttr::DPASCapability::repeatCount,
+        layout.getThreadsPerWarp(),
+        DpasEncodingAttr::DPASCapability::systolicDepth);
+
+    llvm::errs() << "regBases\n";
+    printBases(regBases);
+
+    bases[kRegister] = regBases;
+
+    auto laneBases =
+        DPASLaneBasesA(opsPerChannel, layout.getThreadsPerWarp(),
+                       DpasEncodingAttr::DPASCapability::systolicDepth);
+
+    llvm::errs() << "laneBases:\n";
+    printBases(laneBases);
+
+    bases[kLane] = laneBases;
+
+    auto ctaLayout = LinearLayout(bases, dimNames);
+    llvm::errs() << "ctaLayer based on DPAS tile: " << ctaLayout << "\n";
+
+    auto order = getOrderForDotOperand(opIdx, rank, /*kContig*/ true);
+    // auto repOrder = layout.getRepOrderForOperand(opIdx);
+
+    unsigned inner = order[0];
+    unsigned outer = order[1];
+    llvm::errs() << "outer = " << outer << "\n";
+    llvm::errs() << "inner = " << inner << "\n";
+
+    // expand the DPAS tile to match the desired load size
+    auto numDPASInstPerOuterDim =
+        shape[outer] / ctaLayout.getOutDimSize(dimNames[outer]);
+    auto numDPASInstPerInnerDim =
+        shape[inner] / ctaLayout.getOutDimSize(dimNames[inner]);
+    llvm::errs() << "numDPASInstPerOuterDim = " << numDPASInstPerOuterDim
+                 << "\n";
+    llvm::errs() << "numDPASInstPerInnerDim = " << numDPASInstPerInnerDim
+                 << "\n";
+
+    ctaLayout *= LinearLayout::identity1D(numDPASInstPerOuterDim, kRegister,
+                                          dimNames[outer]);
+    ctaLayout *= LinearLayout::identity1D(numDPASInstPerInnerDim, kRegister,
+                                          dimNames[inner]);
+
+    // replicate the tile
+    auto numReps = layout.getNumReps();
+    assert(numReps.size() == 2);
+    llvm::errs() << "numReps: ";
+    printVector(numReps);
+    llvm::errs() << "\n";
+
+    ctaLayout *=
+        LinearLayout::identity1D(numReps[outer], kRegister, dimNames[outer]);
+    ctaLayout *= LinearLayout::identity1D(
+        numReps[inner] / numDPASInstPerInnerDim, kRegister, dimNames[inner]);
+    llvm::errs() << "ctaLayout after replicating: " << ctaLayout << "\n";
+
+    // Apply warp layout.
+    ctaLayout *=
+        broadcastedDotOperandLayout(ctx, layout.getWarpsPerCTA(), warpOrder,
+                                    rank - 1, kWarp)
+            .transposeOuts(llvm::to_vector(ctaLayout.getOutDimNames()));
+    llvm::errs() << "ctaLayout after applying warp layout: " << ctaLayout
+                 << "\n";
+
+    return combineCtaCgaWithShape(ctaLayout, layout.getCTALayout(), blockShape);
+    ;
+#if 0
+    SmallVector<unsigned> tileShape({instrShapeMNK[0], instrShapeMNK[2]});
+    llvm::errs() << "tile shape for A = " << tileShape[0] << ", "
+                 << tileShape[1] << "\n";
+    auto order = getOrderForDotOperand(opIdx, rank, /*kContig*/ true);
+    auto repOrder = layout.getRepOrderForOperand(opIdx);
+
+    LinearLayout ctaLayout =
+        identityStandardND(kRegister, trivialShape, repOrder);
+    llvm::errs() << "ctaLayout: " << ctaLayout << "\n";
+
+    unsigned inner = order[0];
+    unsigned outer = order[1];
+
+
+    // kWidth of elements are packed into a single i32 register for TMM
+    // operations. At this point, each element is represented by a
+    // separate register. These registers are going to be packed on TMM
+    // lowering to LLVM.
+    ctaLayout = ctaLayout *
+                LinearLayout::identity1D(kWidth, kRegister, dimNames[inner]);
+    // Outer dimension is spread along all lanes.
+    ctaLayout = ctaLayout * LinearLayout::identity1D(tileShape[outer], kLane,
+                                                     dimNames[outer]);
+    // Now spread the rest of the inner dimension over registers.
+    ctaLayout =
+        ctaLayout * LinearLayout::identity1D(tileShape[inner] / kWidth,
+                                             kRegister, dimNames[inner]);
+
+    // Apply warp layout.
+    ctaLayout *=
+        broadcastedDotOperandLayout(ctx, layout.getWarpsPerCTA(), warpOrder,
+                                    rank - 1, kWarp)
+            .transposeOuts(llvm::to_vector(ctaLayout.getOutDimNames()));
+
+    return combineCtaCgaWithShape(ctaLayout, layout.getCTALayout(), shape);
+#endif
+  } else if (opIdx == 1) {
+    assert(false && "TODO");
+#if 0
+    SmallVector<unsigned> tileShape({instrShapeMNK[2], instrShapeMNK[1]});
+    auto order = getOrderForDotOperand(opIdx, rank, /*kContig*/ true);
+    auto repOrder = layout.getRepOrderForOperand(opIdx);
+
+    LinearLayout ctaLayout =
+        identityStandardND(kRegister, trivialShape, repOrder);
+
+    unsigned inner = order[0];
+    unsigned outer = order[1];
+
+    // Start with kWidth elements over the K dimension. These are values
+    // that later are going to be packed into a single i32 value.
+    ctaLayout = ctaLayout * LinearLayout::identity1D(kWidth, S("register"),
+                                                     dimNames[inner]);
+    // The rest if the inner dimension is spread among lanes.
+    ctaLayout = ctaLayout * LinearLayout::identity1D(tileShape[inner] / kWidth,
+                                                     kLane, dimNames[inner]);
+    // At this point, we are likely to have some of 32 lanes unassigned.
+    // Keep assigning lanes, now going in the outer dimension.
+    unsigned outerPerLane =
+        std::min(32 * kWidth / tileShape[inner], tileShape[outer]);
+    ctaLayout = ctaLayout *
+                LinearLayout::identity1D(outerPerLane, kLane, dimNames[outer]);
+    // Cover the rest of the outer dimension using additional registers.
+    ctaLayout =
+        ctaLayout * LinearLayout::identity1D(tileShape[outer] / outerPerLane,
+                                             kRegister, dimNames[outer]);
+    // Apply warp layout.
+    ctaLayout *=
+        broadcastedDotOperandLayout(ctx, layout.getWarpsPerCTA(), warpOrder,
+                                    rank - 2, kWarp)
+            .transposeOuts(llvm::to_vector(ctaLayout.getOutDimNames()));
+
+    return combineCtaCgaWithShape(ctaLayout, layout.getCTALayout(), shape);
+#endif
+  } else {
+    assert(false && "TODO");
+#if 0
+    assert(opIdx == 2);
+    SmallVector<unsigned> tileShape({instrShapeMNK[0], instrShapeMNK[1]});
+    auto order = getMatrixOrder(rank, /*rowMajor*/ true);
+    auto repOrder = layout.getRepOrder();
+
+    LinearLayout ctaLayout =
+        identityStandardND(kRegister, trivialShape, repOrder);
+
+    unsigned inner = order[0];
+    unsigned outer = order[1];
+
+    // Tile layout is similar to A.
+    ctaLayout = ctaLayout * LinearLayout::identity1D(kWidth, S("register"),
+                                                     dimNames[inner]);
+    ctaLayout = ctaLayout * LinearLayout::identity1D(tileShape[outer], kLane,
+                                                     dimNames[outer]);
+    ctaLayout =
+        ctaLayout * LinearLayout::identity1D(tileShape[inner] / kWidth,
+                                             kRegister, dimNames[inner]);
+    // Apply warp layout.
+    ctaLayout *=
+        identityStandardND(S("warp"), layout.getWarpsPerCTA(), warpOrder)
+            .transposeOuts(llvm::to_vector(ctaLayout.getOutDimNames()));
+
+    return combineCtaCgaWithShape(ctaLayout, layout.getCTALayout(), shape);
+#endif
+  }
+  llvm_unreachable("Unhandled Op Idx");
+  return LinearLayout::empty(); // Remove
+}
+
 } // namespace mlir::triton::gpu

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1987,6 +1987,20 @@ struct LoadOpConversion
     }
     Value elemSizeInBytes = b.i32_val(originalElemBits / 8);
 
+    LLVM_DEBUG({
+      const unsigned numLoads = numRepOuter * numLoadPerOutRepCluster *
+                                numRepInner / numOperandsInnerDimPerLoad;
+      llvm::dbgs() << "Preparing to dispatch " << numLoads << " loads\n";
+      llvm::dbgs() << "Outer loads: " << numRepOuter * numLoadPerOutRepCluster
+                   << " (" << numLoadPerOutRepCluster
+                   << " per out rep cluster)\n";
+      llvm::dbgs() << "Inner loads: "
+                   << numRepInner / numOperandsInnerDimPerLoad << "\n";
+      llvm::dbgs() << "Load dimension: " << tileHeight << ", "
+                   << tileWidth * vBlocks << " (" << elemSizeInBits
+                   << " bits)\n";
+    });
+
     ValueTable loadVals;
     for (int outer = 0; outer < numRepOuter; ++outer) {
       for (int rep = 0; rep < numLoadPerOutRepCluster; ++rep) {

--- a/unittest/Dialect/CMakeLists.txt
+++ b/unittest/Dialect/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(TritonGPU)
+add_subdirectory(TritonIntelGPU)

--- a/unittest/Dialect/TritonIntelGPU/CMakeLists.txt
+++ b/unittest/Dialect/TritonIntelGPU/CMakeLists.txt
@@ -1,5 +1,10 @@
 add_triton_ut(
 	NAME LinearLayoutConversionsIntel
 	SRCS LinearLayoutConversionsTest.cpp
-	LIBS TritonGPUIR TritonIntelGPUIR
+	LIBS
+		TritonGPUIR
+		TritonGPUTransforms
+		TritonIntelAnalysis
+		TritonIntelGPUTransforms
+		TritonNvidiaGPUTransforms
 )

--- a/unittest/Dialect/TritonIntelGPU/CMakeLists.txt
+++ b/unittest/Dialect/TritonIntelGPU/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_triton_ut(
+	NAME LinearLayoutConversionsIntel
+	SRCS LinearLayoutConversionsTest.cpp
+	LIBS TritonGPUIR TritonIntelGPUIR
+)

--- a/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
@@ -39,6 +39,7 @@ public:
     llvm::errs() << "\n";
     auto dpasRepsUnsigned = SmallVector<unsigned>{
         static_cast<unsigned>(dpasReps[1]), static_cast<unsigned>(dpasReps[2])};
+    // TODO: could put the getOrderForDotOperand in the builder?
     return Subgroup2DBlockEncodingAttr::get(
         &ctx, warpsPerCTA,
         CTALayoutAttr::get(&ctx, dpasLayout.getCTAsPerCGA(),

--- a/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
@@ -45,7 +45,6 @@ public:
         instrShape, numBlocks, dpasReps,
         getOrderForDotOperand(opIdx, /*rank*/ 2, /*kContig*/ true), kWidth,
         dpasLayout.getThreadsPerWarp());
-    llvm::errs() << "sdb layout: " << layout << "\n";
     return layout;
   }
 
@@ -104,7 +103,6 @@ TEST_F(LinearLayoutConversionsTest, FP16_32x32x1_M256_N32_K32_A) {
 }
 
 TEST_F(LinearLayoutConversionsTest, FP16_32x16x2_M256_N32_K32_A) {
-
   EXPECT_EQ(
       subgroup2DBlockToLinearLayout(
           /*blockShape*/ {256, 32},
@@ -121,16 +119,13 @@ TEST_F(LinearLayoutConversionsTest, FP16_32x16x2_M256_N32_K32_A) {
 }
 
 TEST_F(LinearLayoutConversionsTest, FP16_32x16x2_M256_N32_K32_B) {
-
-  auto layout = subgroup2DBlockToLinearLayout(
-      /*shape*/ {32, 256},
-      sdb(/*instrShape*/ {32, 16}, /*numBlocks*/ 2, /*kWidth*/ 2,
-          /*warpsPerCTA*/ {8, 4}, /*repCluster*/ {4, 2},
-          /*blockShape*/ {32, 256}, /*opsPerChannel*/ 2,
-          /*opIdx*/ 1),
-      /*kWidth*/ 2);
-  llvm::errs() << "layout from conversion: " << layout << "\n";
-  EXPECT_EQ(layout,
+  EXPECT_EQ(subgroup2DBlockToLinearLayout(
+                /*shape*/ {32, 256},
+                sdb(/*instrShape*/ {32, 16}, /*numBlocks*/ 2, /*kWidth*/ 2,
+                    /*warpsPerCTA*/ {8, 4}, /*repCluster*/ {4, 2},
+                    /*blockShape*/ {32, 256}, /*opsPerChannel*/ 2,
+                    /*opIdx*/ 1),
+                /*kWidth*/ 2),
             LinearLayout(
                 {{S("register"),
                   {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {16, 0}, {0, 16}, {0, 128}}},
@@ -141,17 +136,14 @@ TEST_F(LinearLayoutConversionsTest, FP16_32x16x2_M256_N32_K32_B) {
 }
 
 TEST_F(LinearLayoutConversionsTest, I8_16x32x1_M64_N128_K32_A) {
-
-  auto layout = subgroup2DBlockToLinearLayout(
-      /*shape*/ {64, 32},
-      sdb(/*instrShape*/ {16, 32}, /*numBlocks*/ 1, /*kWidth*/ 1,
-          /*warpsPerCTA*/ {4, 8}, /*repCluster*/ {2, 1},
-          /*blockShape*/ {64, 32}, /*opsPerChannel*/ 4,
-          /*opIdx*/ 0),
-      /*kWidth*/ 1);
-  llvm::errs() << "layout from conversion: " << layout << "\n";
   EXPECT_EQ(
-      layout,
+      subgroup2DBlockToLinearLayout(
+          /*shape*/ {64, 32},
+          sdb(/*instrShape*/ {16, 32}, /*numBlocks*/ 1, /*kWidth*/ 1,
+              /*warpsPerCTA*/ {4, 8}, /*repCluster*/ {2, 1},
+              /*blockShape*/ {64, 32}, /*opsPerChannel*/ 4,
+              /*opIdx*/ 0),
+          /*kWidth*/ 1),
       LinearLayout({{S("register"), {{0, 1}, {1, 0}, {2, 0}, {4, 0}, {8, 0}}},
                     {S("lane"), {{0, 2}, {0, 4}, {0, 8}, {0, 16}}},
                     {S("warp"), {{0, 0}, {0, 0}, {0, 0}, {16, 0}, {32, 0}}},
@@ -160,17 +152,14 @@ TEST_F(LinearLayoutConversionsTest, I8_16x32x1_M64_N128_K32_A) {
 }
 
 TEST_F(LinearLayoutConversionsTest, I8_32x32x1_M64_N128_K32_B) {
-
-  auto layout = subgroup2DBlockToLinearLayout(
-      /*shape*/ {32, 128},
-      sdb(/*instrShape*/ {32, 16}, /*numBlocks*/ 1, /*kWidth*/ 1,
-          /*warpsPerCTA*/ {4, 8}, /*repCluster*/ {2, 1},
-          /*blockShape*/ {32, 128}, /*opsPerChannel*/ 4,
-          /*opIdx*/ 1),
-      /*kWidth*/ 1);
-  llvm::errs() << "layout from conversion: " << layout << "\n";
   EXPECT_EQ(
-      layout,
+      subgroup2DBlockToLinearLayout(
+          /*shape*/ {32, 128},
+          sdb(/*instrShape*/ {32, 16}, /*numBlocks*/ 1, /*kWidth*/ 1,
+              /*warpsPerCTA*/ {4, 8}, /*repCluster*/ {2, 1},
+              /*blockShape*/ {32, 128}, /*opsPerChannel*/ 4,
+              /*opIdx*/ 1),
+          /*kWidth*/ 1),
       LinearLayout({{S("register"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {16, 0}}},
                     {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}}},
                     {S("warp"), {{0, 16}, {0, 32}, {0, 64}, {0, 0}, {0, 0}}},

--- a/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
@@ -1,0 +1,99 @@
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
+#include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
+#include "intel/include/Dialect/TritonIntelGPU/IR/LinearLayoutConversions.h"
+
+#include "mlir/IR/MLIRContext.h"
+#include "triton/Dialect/TritonGPU/IR/Attributes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Tools/StrUtil.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Signals.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace mlir::triton::gpu::intel {
+
+namespace {
+
+class LinearLayoutConversionsTest : public ::testing::Test {
+public:
+  void SetUp() { ctx.loadDialect<TritonGPUDialect, TritonIntelGPUDialect>(); }
+
+#if 0
+        Subgroup2DBlockEncodingAttr sdb(ArrayRef<unsigned> instrShape, unsigned kWidth, unsigned threadsPerWarp,
+                                ArrayRef<unsigned> warpsPerCTA,
+                                ArrayRef<unsigned> CTAsPerCGA,
+                                ArrayRef<unsigned> CTASplitNum,
+                                ArrayRef<unsigned> CTAOrder) {
+        return Subgroup2DBlockEncodingAttr::get(
+            &ctx, warpsPerCTA,
+            CTALayoutAttr::get(&ctx, CTAsPerCGA, CTASplitNum, CTAOrder), instrShape,
+            kWidth, threadsPerWarp);
+        }
+#endif
+
+  Subgroup2DBlockEncodingAttr sdb(ArrayRef<unsigned> instrShape,
+                                  unsigned kWidth,
+                                  ArrayRef<unsigned> warpsPerCTA,
+                                  unsigned opIdx) {
+    auto dpasLayout = DpasEncodingAttr::get(
+        &ctx, /*repeatCount=*/8, /*systolicDepth=*/8, /*executionSize=*/16,
+        /*opsPerChan=*/2, warpsPerCTA, /*repCluster=*/{4, 2},
+        /*threadsPerWarp=*/16);
+
+    // TODO: unsigned or int64_t?
+    auto instrShapeSigned = SmallVector<int64_t>{instrShape[0], instrShape[2]};
+    auto dpasReps = dpasLayout.getDPASRepetitions(instrShapeSigned, opIdx);
+    llvm::errs() << "dpas reps size = " << dpasReps.size() << "\n";
+    assert(dpasReps.size() == 3);
+    llvm::errs() << "dpas reps: ";
+    for (size_t i = 0; i < dpasReps.size(); i++) {
+      llvm::errs() << dpasReps[i] << " ";
+    }
+    llvm::errs() << "\n";
+    auto dpasRepsUnsigned = SmallVector<unsigned>{
+        static_cast<unsigned>(dpasReps[1]), static_cast<unsigned>(dpasReps[2])};
+    return Subgroup2DBlockEncodingAttr::get(
+        &ctx, warpsPerCTA,
+        CTALayoutAttr::get(&ctx, dpasLayout.getCTAsPerCGA(),
+                           dpasLayout.getCTASplitNum(),
+                           dpasLayout.getCTAOrder()),
+        instrShape, dpasRepsUnsigned, kWidth, dpasLayout.getThreadsPerWarp());
+  }
+
+  StringAttr S(StringRef str) { return StringAttr::get(&ctx, str); }
+
+protected:
+  MLIRContext ctx;
+};
+
+TEST_F(LinearLayoutConversionsTest, FP16_M256_N32_K16_A) {
+  // Layout for A operand, warpsPerCTA is (8, 4). We have one tile per warp.
+  // The load should be 32 by 16 with 2 blocks --> 32 by 32
+  // There is one load per warp.
+  // The warp stride is 32
+
+  auto layout = subgroup2DBlockToLinearLayout(
+      /*shape*/ {32, 32},
+      sdb(/*instrShape*/ {256, 256, 32}, /*kWidth*/ 2, /*warpsPerCTA*/ {8, 4},
+          /*opIdx*/ 0),
+      /*kWidth*/ 2, /*opIdx*/ 0);
+  llvm::errs() << "layout from conversion: " << layout << "\n";
+  EXPECT_EQ(
+      layout,
+      LinearLayout(
+          {{S("register"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {16, 0}, {0, 16}}},
+           {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}}},
+           {S("warp"), {{0, 0}, {0, 0}, {32, 0}, {64, 0}, {128, 0}}},
+           {S("block"), {}}},
+          {S("dim0"), S("dim1")}));
+}
+
+} // anonymous namespace
+} // namespace mlir::triton::gpu::intel
+
+int main(int argc, char *argv[]) {
+  llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
@@ -76,12 +76,12 @@ TEST_F(LinearLayoutConversionsTest, FP16_32x32x1_M256_N32_K32_A) {
           {S("dim0"), S("dim1")}));
 }
 
-TEST_F(LinearLayoutConversionsTest, FP16_32x32x1_M256_N32_K32_B) {
+TEST_F(LinearLayoutConversionsTest, FP16_32x16x2_M256_N32_K32_B) {
   // Layout for A operand, warpsPerCTA is (8, 4). We have one tile per warp.
   // The load should be 32 by 16 with 2 blocks --> 32 by 32
   // There are two loads per warp.
 
-  auto sdbEncoding = sdb(/*instrShape*/ {32, 32}, /*numBlocks*/ 1, /*kWidth*/ 2,
+  auto sdbEncoding = sdb(/*instrShape*/ {32, 16}, /*numBlocks*/ 2, /*kWidth*/ 2,
                          /*warpsPerCTA*/ {8, 4}, /*blockShape*/ {32, 256},
                          /*opIdx*/ 1);
   llvm::errs() << "sdp: " << sdbEncoding << "\n";
@@ -90,14 +90,14 @@ TEST_F(LinearLayoutConversionsTest, FP16_32x32x1_M256_N32_K32_B) {
       /*shape*/ {32, 256}, sdbEncoding,
       /*kWidth*/ 2, /*opIdx*/ 1);
   llvm::errs() << "layout from conversion: " << layout << "\n";
-  EXPECT_EQ(
-      layout,
-      LinearLayout(
-          {{S("register"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {16, 0}, {0, 16}}},
-           {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}}},
-           {S("warp"), {{0, 0}, {0, 0}, {32, 0}, {64, 0}, {128, 0}}},
-           {S("block"), {}}},
-          {S("dim0"), S("dim1")}));
+  EXPECT_EQ(layout,
+            LinearLayout(
+                {{S("register"),
+                  {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {16, 0}, {0, 16}, {0, 128}}},
+                 {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}}},
+                 {S("warp"), {{0, 32}, {0, 64}, {0, 0}, {0, 0}, {0, 0}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
 }
 
 } // anonymous namespace

--- a/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
@@ -55,6 +55,38 @@ protected:
   MLIRContext ctx;
 };
 
+TEST_F(LinearLayoutConversionsTest, FP32_32x8x2_M256_N128_K32_A) {
+  EXPECT_EQ(
+      subgroup2DBlockToLinearLayout(
+          /*blockShape*/ {256, 32},
+          sdb(/*instrShape*/ {32, 8}, /*numBlocks*/ 2, /*kWidth*/ 4,
+              /*warpsPerCTA*/ {8, 4}, /*repCluster*/ {4, 1},
+              /*blockShape*/ {256, 32}, /*opsPerChannel*/ 1, /*opIdx*/ 0),
+          /*kWidth*/ 4),
+      LinearLayout(
+          {{S("register"), {{2, 0}, {4, 0}, {8, 0}, {16, 0}, {0, 8}, {0, 16}}},
+           {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {1, 0}}},
+           {S("warp"), {{0, 0}, {0, 0}, {32, 0}, {64, 0}, {128, 0}}},
+           {S("block"), {}}},
+          {S("dim0"), S("dim1")}));
+}
+
+TEST_F(LinearLayoutConversionsTest, FP32_32x16x1_M256_N128_K32_B) {
+  EXPECT_EQ(
+      subgroup2DBlockToLinearLayout(
+          /*blockShape*/ {32, 128},
+          sdb(/*instrShape*/ {32, 16}, /*numBlocks*/ 1, /*kWidth*/ 4,
+              /*warpsPerCTA*/ {8, 4}, /*repCluster*/ {4, 1},
+              /*blockShape*/ {32, 128}, /*opsPerChannel*/ 1, /*opIdx*/ 1),
+          /*kWidth*/ 4),
+      LinearLayout(
+          {{S("register"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {16, 0}, {0, 64}}},
+           {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}}},
+           {S("warp"), {{0, 16}, {0, 32}, {0, 0}, {0, 0}, {0, 0}}},
+           {S("block"), {}}},
+          {S("dim0"), S("dim1")}));
+}
+
 TEST_F(LinearLayoutConversionsTest, FP16_32x32x1_M256_N32_K32_A) {
   EXPECT_EQ(
       subgroup2DBlockToLinearLayout(

--- a/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
@@ -29,21 +29,13 @@ public:
         opsPerChannel, warpsPerCTA, repCluster,
         /*threadsPerWarp=*/16);
 
-    auto dpasRepsRef =
-        llvm::to_vector(dpasLayout.getDPASRepetitions(blockShape, opIdx));
-    assert(dpasRepsRef.size() == 3);
-    auto dpasReps =
-        SmallVector<unsigned>{static_cast<unsigned>(dpasRepsRef[1]),
-                              static_cast<unsigned>(dpasRepsRef[2])};
-
     // TODO: could put the getOrderForDotOperand in the builder?
     auto layout = Subgroup2DBlockEncodingAttr::get(
         &ctx, warpsPerCTA,
         CTALayoutAttr::get(
             &ctx, dpasLayout.getCTAsPerCGA(), // TODO: add to DpasLayout?
             dpasLayout.getCTASplitNum(), dpasLayout.getCTAOrder()),
-        instrShape, numBlocks, dpasReps,
-        getOrderForDotOperand(opIdx, /*rank*/ 2, /*kContig*/ true), kWidth,
+        instrShape, numBlocks, getOrderForDotOperand(opIdx, /*rank*/ 2, /*kContig*/ true), kWidth,
         dpasLayout.getThreadsPerWarp());
     return layout;
   }

--- a/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
@@ -71,7 +71,6 @@ TEST_F(LinearLayoutConversionsTest, FP16_M256_N32_K16_A) {
   // Layout for A operand, warpsPerCTA is (8, 4). We have one tile per warp.
   // The load should be 32 by 16 with 2 blocks --> 32 by 32
   // There is one load per warp.
-  // The warp stride is 32
 
   auto layout = subgroup2DBlockToLinearLayout(
       /*shape*/ {32, 32},
@@ -88,6 +87,31 @@ TEST_F(LinearLayoutConversionsTest, FP16_M256_N32_K16_A) {
            {S("block"), {}}},
           {S("dim0"), S("dim1")}));
 }
+
+
+TEST_F(LinearLayoutConversionsTest, FP16_M256_N32_K16_B) {
+    // Layout for A operand, warpsPerCTA is (8, 4). We have one tile per warp.
+    // The load should be 32 by 16 with 2 blocks --> 32 by 32
+    // There are two loads per warp.
+  
+    auto sdbEncoding = sdb(/*instrShape*/ {256, 256, 32}, /*kWidth*/ 2, /*warpsPerCTA*/ {8, 4},
+        /*opIdx*/ 1);
+    llvm::errs() << "sdp: " << sdbEncoding << "\n";
+
+    auto layout = subgroup2DBlockToLinearLayout(
+        /*shape*/ {32, 32},
+        sdbEncoding,
+        /*kWidth*/ 2, /*opIdx*/ 1);
+    llvm::errs() << "layout from conversion: " << layout << "\n";
+    EXPECT_EQ(
+        layout,
+        LinearLayout(
+            {{S("register"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {16, 0}, {0, 16}}},
+             {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}}},
+             {S("warp"), {{0, 0}, {0, 0}, {32, 0}, {64, 0}, {128, 0}}},
+             {S("block"), {}}},
+            {S("dim0"), S("dim1")}));
+  }
 
 } // anonymous namespace
 } // namespace mlir::triton::gpu::intel

--- a/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
@@ -44,7 +44,8 @@ public:
         CTALayoutAttr::get(&ctx, dpasLayout.getCTAsPerCGA(),
                            dpasLayout.getCTASplitNum(),
                            dpasLayout.getCTAOrder()),
-        instrShape, numBlocks, dpasRepsUnsigned, kWidth,
+        instrShape, numBlocks, dpasRepsUnsigned,
+        getOrderForDotOperand(opIdx, /*rank*/ 2, /*kContig*/ true), kWidth,
         dpasLayout.getThreadsPerWarp());
   }
 
@@ -66,7 +67,7 @@ TEST_F(LinearLayoutConversionsTest, DISABLED_FP16_32x32x1_M256_N32_K32_A) {
       sdb(/*instrShape*/ {32, 32}, /*numBlocks*/ 1, /*kWidth*/ 2,
           /*warpsPerCTA*/ {8, 4},
           /*blockShape*/ {256, 32}, /*opIdx*/ 0),
-      /*kWidth*/ 2, /*opIdx*/ 0);
+      /*kWidth*/ 2);
   llvm::errs() << "layout from conversion: " << layout << "\n";
   EXPECT_EQ(
       layout,
@@ -89,7 +90,7 @@ TEST_F(LinearLayoutConversionsTest, FP16_32x16x2_M256_N32_K32_A) {
 
   auto layout = subgroup2DBlockToLinearLayout(
       /*blockShape*/ {256, 32}, sdbEncoding,
-      /*kWidth*/ 2, /*opIdx*/ 0);
+      /*kWidth*/ 2);
   llvm::errs() << "layout from conversion: " << layout << "\n";
   EXPECT_EQ(
       layout,
@@ -113,7 +114,7 @@ TEST_F(LinearLayoutConversionsTest, FP16_32x16x2_M256_N32_K32_B) {
 
   auto layout = subgroup2DBlockToLinearLayout(
       /*shape*/ {32, 256}, sdbEncoding,
-      /*kWidth*/ 2, /*opIdx*/ 1);
+      /*kWidth*/ 2);
   llvm::errs() << "layout from conversion: " << layout << "\n";
   EXPECT_EQ(layout,
             LinearLayout(

--- a/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
@@ -35,7 +35,8 @@ public:
         CTALayoutAttr::get(
             &ctx, dpasLayout.getCTAsPerCGA(), // TODO: add to DpasLayout?
             dpasLayout.getCTASplitNum(), dpasLayout.getCTAOrder()),
-        instrShape, numBlocks, getOrderForDotOperand(opIdx, /*rank*/ 2, /*kContig*/ true), kWidth,
+        instrShape, numBlocks,
+        getOrderForDotOperand(opIdx, /*rank*/ 2, /*kContig*/ true), kWidth,
         dpasLayout.getThreadsPerWarp());
     return layout;
   }

--- a/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonIntelGPU/LinearLayoutConversionsTest.cpp
@@ -19,6 +19,7 @@ class LinearLayoutConversionsTest : public ::testing::Test {
 public:
   void SetUp() { ctx.loadDialect<TritonGPUDialect, TritonIntelGPUDialect>(); }
 
+  // Create a Subgroup2DBlockEncoding layout based on a DPAS layout
   Subgroup2DBlockEncodingAttr sdb(ArrayRef<unsigned> instrShape,
                                   unsigned numBlocks, unsigned kWidth,
                                   ArrayRef<unsigned> warpsPerCTA,
@@ -29,25 +30,24 @@ public:
         /*opsPerChan=*/2, warpsPerCTA, /*repCluster=*/{4, 2},
         /*threadsPerWarp=*/16);
 
-    auto dpasReps = dpasLayout.getDPASRepetitions(blockShape, opIdx);
-    llvm::errs() << "dpas reps size = " << dpasReps.size() << "\n";
-    assert(dpasReps.size() == 3);
-    llvm::errs() << "dpas reps: ";
-    for (size_t i = 0; i < dpasReps.size(); i++) {
-      llvm::errs() << dpasReps[i] << " ";
-    }
-    llvm::errs() << "\n";
-    auto dpasRepsUnsigned = SmallVector<unsigned>{
-        static_cast<unsigned>(dpasReps[1]), static_cast<unsigned>(dpasReps[2])};
+    auto dpasRepsRef =
+        llvm::to_vector(dpasLayout.getDPASRepetitions(blockShape, opIdx));
+    assert(dpasRepsRef.size() == 3);
+    auto dpasReps =
+        SmallVector<unsigned>{static_cast<unsigned>(dpasRepsRef[1]),
+                              static_cast<unsigned>(dpasRepsRef[2])};
+
     // TODO: could put the getOrderForDotOperand in the builder?
-    return Subgroup2DBlockEncodingAttr::get(
+    auto layout = Subgroup2DBlockEncodingAttr::get(
         &ctx, warpsPerCTA,
-        CTALayoutAttr::get(&ctx, dpasLayout.getCTAsPerCGA(),
-                           dpasLayout.getCTASplitNum(),
-                           dpasLayout.getCTAOrder()),
-        instrShape, numBlocks, dpasRepsUnsigned,
+        CTALayoutAttr::get(
+            &ctx, dpasLayout.getCTAsPerCGA(), // TODO: add to DpasLayout?
+            dpasLayout.getCTASplitNum(), dpasLayout.getCTAOrder()),
+        instrShape, numBlocks, dpasReps,
         getOrderForDotOperand(opIdx, /*rank*/ 2, /*kContig*/ true), kWidth,
         dpasLayout.getThreadsPerWarp());
+    llvm::errs() << "sdb layout: " << layout << "\n";
+    return layout;
   }
 
   StringAttr S(StringRef str) { return StringAttr::get(&ctx, str); }
@@ -56,25 +56,17 @@ protected:
   MLIRContext ctx;
 };
 
-// TODO: is this valid, and how should this layout be created?
-TEST_F(LinearLayoutConversionsTest, DISABLED_FP16_32x32x1_M256_N32_K32_A) {
-
-  // Layout for A operand, warpsPerCTA is (8, 4). We have one tile per warp.
-  // The load should be 32 by 16 with 2 blocks --> 32 by 32
-  // There is one load per warp.
-
-  auto layout = subgroup2DBlockToLinearLayout(
-      /*blockShape*/ {256, 32},
-      sdb(/*instrShape*/ {32, 32}, /*numBlocks*/ 1, /*kWidth*/ 2,
-          /*warpsPerCTA*/ {8, 4},
-          /*blockShape*/ {256, 32}, /*opIdx*/ 0),
-      /*kWidth*/ 2);
-  llvm::errs() << "layout from conversion: " << layout << "\n";
+TEST_F(LinearLayoutConversionsTest, FP16_32x32x1_M256_N32_K32_A) {
   EXPECT_EQ(
-      layout,
+      subgroup2DBlockToLinearLayout(
+          /*blockShape*/ {256, 32},
+          sdb(/*instrShape*/ {32, 32}, /*numBlocks*/ 1, /*kWidth*/ 2,
+              /*warpsPerCTA*/ {8, 4},
+              /*blockShape*/ {256, 32}, /*opIdx*/ 0),
+          /*kWidth*/ 2),
       LinearLayout(
-          {{S("register"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {16, 0}, {0, 16}}},
-           {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}}},
+          {{S("register"), {{0, 1}, {1, 0}, {2, 0}, {4, 0}, {8, 0}, {16, 0}}},
+           {S("lane"), {{0, 2}, {0, 4}, {0, 8}, {0, 16}}},
            {S("warp"), {{0, 0}, {0, 0}, {32, 0}, {64, 0}, {128, 0}}},
            {S("block"), {}}},
           {S("dim0"), S("dim1")}));
@@ -84,17 +76,14 @@ TEST_F(LinearLayoutConversionsTest, FP16_32x16x2_M256_N32_K32_A) {
   // Layout for A operand, warpsPerCTA is (8, 4). We have one tile per warp.
   // The load should be 32 by 16 with 2 blocks --> 32 by 32
   // There is one load per warp.
-  auto sdbEncoding = sdb(/*instrShape*/ {32, 16}, /*numBlocks*/ 2, /*kWidth*/ 2,
-                         /*warpsPerCTA*/ {8, 4},
-                         /*blockShape*/ {256, 32}, /*opIdx*/ 0);
-  llvm::errs() << "sdp: " << sdbEncoding << "\n";
 
-  auto layout = subgroup2DBlockToLinearLayout(
-      /*blockShape*/ {256, 32}, sdbEncoding,
-      /*kWidth*/ 2);
-  llvm::errs() << "layout from conversion: " << layout << "\n";
   EXPECT_EQ(
-      layout,
+      subgroup2DBlockToLinearLayout(
+          /*blockShape*/ {256, 32},
+          sdb(/*instrShape*/ {32, 16}, /*numBlocks*/ 2, /*kWidth*/ 2,
+              /*warpsPerCTA*/ {8, 4},
+              /*blockShape*/ {256, 32}, /*opIdx*/ 0),
+          /*kWidth*/ 2),
       LinearLayout(
           {{S("register"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {16, 0}, {0, 16}}},
            {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}}},
@@ -108,13 +97,11 @@ TEST_F(LinearLayoutConversionsTest, FP16_32x16x2_M256_N32_K32_B) {
   // The load should be 32 by 16 with 2 blocks --> 32 by 32
   // There are two loads per warp.
 
-  auto sdbEncoding = sdb(/*instrShape*/ {32, 16}, /*numBlocks*/ 2, /*kWidth*/ 2,
-                         /*warpsPerCTA*/ {8, 4}, /*blockShape*/ {32, 256},
-                         /*opIdx*/ 1);
-  llvm::errs() << "sdp: " << sdbEncoding << "\n";
-
   auto layout = subgroup2DBlockToLinearLayout(
-      /*shape*/ {32, 256}, sdbEncoding,
+      /*shape*/ {32, 256},
+      sdb(/*instrShape*/ {32, 16}, /*numBlocks*/ 2, /*kWidth*/ 2,
+          /*warpsPerCTA*/ {8, 4}, /*blockShape*/ {32, 256},
+          /*opIdx*/ 1),
       /*kWidth*/ 2);
   llvm::errs() << "layout from conversion: " << layout << "\n";
   EXPECT_EQ(layout,


### PR DESCRIPTION
Add a new layout to describe the tensor layout with respect to the GPU compute hierarchy (register, lane, warp, block). This PR introduces the layout and adds its definition and basic functions to the Triton Intel GPU Dialect. The conversion to Linear Layout function has been added and unit tested through an Intel specific `LinearLayoutConversionsTest`. The layouts are unpacked - each register is assumed to be the size of the tensor type. However, the layout generation follows the convention described in https://github.khronos.org/SPIRV-Registry/extensions/INTEL/[SPV_INTEL_2d_block_io](https://github.khronos.org/SPIRV-Registry/extensions/INTEL/SPV_INTEL_2d_block_io.html).html. While there may be some bugs, the goal is for any valid operation described in the SPIRV extension to be represented correctly with this layout. 

Currently the layout is unused other than for linear layout conversion testing purposes. I plan to leave this PR in draft until I have replaced the `block_io` attribute on the load ops with this layout - and then I plan to replace the linear layout code I added to `LoadStoreOpToLLVM.cpp`. That second task might prove challenging since I think the DPAS layouts do sometimes incorporate register packing schemes into the layout - but looking at the upstream layouts for NVIDIA and AMD MMA, specific packing is an implementation detail and not represented as part of the high-level layout encoding. 

cc #4192 