### PR TITLE
Hot fix of #4197

### DIFF
--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -304,7 +304,8 @@ void init_triton_intel(py::module &&m) {
           // Default to allow contract when default fp fusion is not disabled.
           if ((!enableFpFusion.has_value() || enableFpFusion.value()) &&
               !fastMath.has_value()) {
-            if (isa<AddOperator>(op) || isa<MulOperator>(op))
+            if (op->getOpcode() == Instruction::FAdd ||
+                op->getOpcode() == Instruction::FMul)
               FMF.setAllowContract(true);
           } else if (fastMath.has_value() && fastMath.value())
             FMF.setFast(true);


### PR DESCRIPTION
We should use `TRITON_DEFAULT_FP_FUSION` to disallow `mul+add->fma` fusion. 