### PR TITLE
Add 03i-matrix-multiplication

### DIFF
--- a/python/tutorials/03i-matrix-multiplication.py
+++ b/python/tutorials/03i-matrix-multiplication.py
@@ -1,0 +1,13 @@
+"""
+Matrix Multiplication
+=====================
+Runs Matrix Multiplication tutorial with TRITON_INTEL_RAISE_BLOCK_POINTER=1.
+"""
+
+import os.path
+import runpy
+
+if __name__ == '__main__':
+    os.environ['TRITON_INTEL_RAISE_BLOCK_POINTER'] = '1'
+    dirname = os.path.dirname(__file__)
+    runpy.run_path(f'{dirname}/03-matrix-multiplication.py')

--- a/scripts/skiplist/lts/tutorials.txt
+++ b/scripts/skiplist/lts/tutorials.txt
@@ -1,4 +1,5 @@
 03-matrix-multiplication
+03i-matrix-multiplication
 06-fused-attention
 08-grouped-gemm
 09-persistent-matmul

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -373,8 +373,7 @@ run_tutorial_tests() {
   echo "Running with TRITON_INTEL_RAISE_BLOCK_POINTER      "
   echo "***************************************************"
 
-  TRITON_TEST_REPORTS=false TRITON_INTEL_RAISE_BLOCK_POINTER=1 \
-    run_tutorial_test "03-matrix-multiplication"
+  run_tutorial_test "03i-matrix-multiplication"
 }
 
 run_microbench_tests() {


### PR DESCRIPTION
Runs Matrix Multiplication tutorial with
TRITON_INTEL_RAISE_BLOCK_POINTER=1.

The unique name for this tutorial allows adding it to skip list if necessary, and reporting it in the pass rate report as an independent tutorial (the total number of tutorials increases to 11).
