### PR TITLE
Temporary disable building wheels for Python 3.13

### DIFF
--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -30,7 +30,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "3.13"
       fail-fast: false
       max-parallel: 2
     defaults:


### PR DESCRIPTION
Will fix the issue with torchdata and Python 3.13 later. 