### PR TITLE
Report tutorial 09

### DIFF
--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -365,7 +365,7 @@ run_tutorial_tests() {
   run_tutorial_test "06-fused-attention"
   run_tutorial_test "07-extern-functions"
   run_tutorial_test "08-grouped-gemm"
-  TRITON_TEST_REPORTS=false run_tutorial_test "09-persistent-matmul"
+  run_tutorial_test "09-persistent-matmul"
   run_tutorial_test "10-experimental-block-pointer"
   run_tutorial_test "10i-experimental-block-pointer"
 


### PR DESCRIPTION
The tutorial 09 uses Proton, so it previously was excluded from reporting. Enabling reporting for this tutorial so it will be available in the pass rate. This brings the total number of tutorials to 12.
