### PR TITLE
Fix running tutorials without --select-from-file

### DIFF
--- a/scripts/pytest-utils.sh
+++ b/scripts/pytest-utils.sh
@@ -59,7 +59,7 @@ pytest() {
 }
 
 run_tutorial_test() {
-    if [[ -v TRITON_TEST_SELECTFILE ]] && ! grep -qF "$1" "$TRITON_TEST_SELECTFILE"; then
+    if [[ -f $TRITON_TEST_SELECTFILE ]] && ! grep -qF "$1" "$TRITON_TEST_SELECTFILE"; then
         return
     fi
 


### PR DESCRIPTION
If `--select-from-file` not specified then the script should run all tutorials.