### PR TITLE
Eliminate wrapper facades for the Triton hooks API

### DIFF
--- a/python/triton/_utils.py
+++ b/python/triton/_utils.py
@@ -35,26 +35,3 @@ def find_paths_if(iterable: Union[IterableType, Any], pred: Callable[[ObjPath, A
     _impl((), iterable)
 
     return list(ret.keys())
-
-
-class ClassPropertyDescriptor:
-
-    def __init__(self, fget, fset=None):
-        self.fget = fget
-        self.fset = fset
-
-    def __get__(self, obj, cls):
-        return self.fget(cls)
-
-    def __set__(self, obj, value):
-        if self.fset is None:
-            raise AttributeError("can't set attribute")
-        self.fset(obj.__class__, value)
-
-    def setter(self, fset):
-        self.fset = fset
-        return self
-
-
-def classproperty(func):
-    return ClassPropertyDescriptor(func)

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -9,7 +9,6 @@ from ..runtime.autotuner import OutOfResources
 from ..runtime.cache import get_cache_manager, get_dump_manager, get_override_manager
 from ..runtime.driver import driver
 from ..tools.disasm import get_sass, get_spvdis
-from .._utils import classproperty
 # TODO: this shouldn't be here
 from .code_generator import ast_to_ttir
 from pathlib import Path
@@ -431,24 +430,6 @@ class AsmDict(dict):
 
 
 class CompiledKernel:
-
-    # FIXME: remove launch_enter_hook/launch_exit_hook properties
-    # when pytorch has a compatible layer for the new API.
-    @classproperty
-    def launch_enter_hook(cls):
-        return knobs.runtime.launch_enter_hook
-
-    @launch_enter_hook.setter
-    def launch_enter_hook(cls, value):
-        knobs.runtime.launch_enter_hook = value
-
-    @classproperty
-    def launch_exit_hook(cls):
-        return knobs.runtime.launch_exit_hook
-
-    @launch_exit_hook.setter
-    def launch_exit_hook(cls, value):
-        knobs.runtime.launch_exit_hook = value
 
     def __init__(self, src, metadata_group, hash):
         from collections import namedtuple

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -14,7 +14,7 @@ from triton.tools.tensor_descriptor import TensorDescriptor
 from types import ModuleType
 from .. import knobs
 from ..runtime.driver import driver
-from .._utils import find_paths_if, get_iterable_path, classproperty
+from .._utils import find_paths_if, get_iterable_path
 
 TRITON_MODULE = __name__[:-len(".runtime.jit")]
 
@@ -493,24 +493,6 @@ class JitFunctionInfo:
 
 
 class JITFunction(KernelInterface[T]):
-
-    # FIXME: remove cache_hook/compiled_hook properties
-    # when pytorch has a compatible layer for the new API.
-    @classproperty
-    def cache_hook(cls):
-        return knobs.runtime.jit_cache_hook
-
-    @cache_hook.setter
-    def cache_hook(cls, value):
-        knobs.runtime.jit_cache_hook = value
-
-    @classproperty
-    def compiled_hook(cls):
-        return knobs.runtime.jit_post_compile_hook
-
-    @compiled_hook.setter
-    def compiled_hook(cls, value):
-        knobs.runtime.jit_post_compile_hook = value
 
     def _call_hook(
         self,


### PR DESCRIPTION
PyTorch CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15138366239 (passed)