### PR TITLE
Limit supported cmake versions to be the same everywhere (#6903)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.20)
 
 if(POLICY CMP0116)
 # Introduced in cmake 3.20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=78.1.0", "cmake>=3.18", "ninja>=1.11.1", "pybind11>=2.13.1"]
+requires = ["setuptools>=78.1.0", "cmake>=3.20,<4.0", "ninja>=1.11.1", "pybind11>=2.13.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.mypy]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,6 @@
 setuptools>=78.1.0
 wheel
-cmake>=3.18,<4.0
+cmake>=3.20,<4.0
 ninja>=1.11.1
 pybind11>=2.13.1
 lit

--- a/setup.py
+++ b/setup.py
@@ -415,8 +415,8 @@ class CMakeBuild(build_ext):
 
         match = re.search(r"version\s*(?P<major>\d+)\.(?P<minor>\d+)([\d.]+)?", out.decode())
         cmake_major, cmake_minor = int(match.group("major")), int(match.group("minor"))
-        if (cmake_major, cmake_minor) < (3, 18):
-            raise RuntimeError("CMake >= 3.18.0 is required")
+        if (cmake_major, cmake_minor) < (3, 20):
+            raise RuntimeError("CMake >= 3.20 is required")
 
         for ext in self.extensions:
             self.build_extension(ext)
@@ -832,7 +832,7 @@ setup(
     test_suite="tests",
     extras_require={
         "build": [
-            "cmake>=3.20",
+            "cmake>=3.20,<4.0",
             "lit",
         ],
         "tests": [


### PR DESCRIPTION
From https://github.com/triton-lang/triton/commit/1cbcf9fe8446a2aa5a8d3f1ffa90965a1e728980. Most likely this commit will be needed for PyTorch CI.