### PR TITLE
Separate TTGPU to LLVM and TritonGEN to LLVM Lowering

### DIFF
--- a/test/Conversion/intel/sub-group-transpose.mlir
+++ b/test/Conversion/intel/sub-group-transpose.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-intel-gpu-to-llvm --convert-tritongen-to-llvm | FileCheck %s
 
 // Basic 16x16 transpose test
 

--- a/test/Conversion/intel/tritongpu_to_gen_dot.mlir
+++ b/test/Conversion/intel/tritongpu_to_gen_dot.mlir
@@ -1,5 +1,5 @@
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory  --convert-triton-intel-gpu-to-llvm --cse -canonicalize | FileCheck %s --implicit-check-not=llvm.inline_asm --check-prefixes=CHECK,NO-AGGRESSIVE-REUSE
-// RUN: env TRITON_INTEL_AGGRESSIVE_DPAS_REUSE=1 triton-opt %s -split-input-file --allocate-shared-memory  --convert-triton-intel-gpu-to-llvm --cse -canonicalize | FileCheck %s --implicit-check-not=llvm.inline_asm  --check-prefixes=CHECK,AGGRESSIVE-REUSE
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-intel-gpu-to-llvm --convert-tritongen-to-llvm --cse -canonicalize | FileCheck %s --implicit-check-not=llvm.inline_asm --check-prefixes=CHECK,NO-AGGRESSIVE-REUSE
+// RUN: env TRITON_INTEL_AGGRESSIVE_DPAS_REUSE=1 triton-opt %s -split-input-file --allocate-shared-memory  --convert-triton-intel-gpu-to-llvm --convert-tritongen-to-llvm --cse -canonicalize | FileCheck %s --implicit-check-not=llvm.inline_asm  --check-prefixes=CHECK,AGGRESSIVE-REUSE
 
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 1], repCluster = [1, 1]}>
 #dot_operand_a = #ttg.dot_op<{opIdx=0, parent=#dpas, kWidth=1}>

--- a/test/Conversion/intel/tritongpu_to_llvm_intel_advanced_path.mlir
+++ b/test/Conversion/intel/tritongpu_to_llvm_intel_advanced_path.mlir
@@ -1,4 +1,4 @@
-// RUN: env TRITON_INTEL_ADVANCED_PATH=1 triton-opt %s --convert-triton-intel-gpu-to-llvm --split-input-file | FileCheck %s
+// RUN: env TRITON_INTEL_ADVANCED_PATH=1 triton-opt %s --convert-triton-intel-gpu-to-llvm --convert-tritongen-to-llvm --split-input-file | FileCheck %s
 
 module attributes {"ttig.support_sg_2d_block", "ttig.support_dpas", "ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 1 : i32} {
   // CHECK-DAG: llvm.func spir_funccc @_Z45__spirv_SubgroupMatrixMultiplyAccumulateINTELiDv8_sDv8_iDv8_fi(i32, vector<8xi16>, vector<8xi32>, vector<8xf32>, i32) -> vector<8xf32> attributes {convergent, memory_effects = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none>, no_unwind, will_return}

--- a/test/TritonIntelGPU/blockptr_load.mlir
+++ b/test/TritonIntelGPU/blockptr_load.mlir
@@ -1,5 +1,5 @@
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm --check-prefixes=CHECK,LARGE-BLOCK-SIZE-TRANS-B
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-intel-gpu-to-llvm=one_matrix_per_load_for_bt=1 | FileCheck %s --implicit-check-not=llvm.inline_asm --check-prefixes=CHECK,SMALL-BLOCK-SIZE-TRANS-B
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-intel-gpu-to-llvm --convert-tritongen-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm --check-prefixes=CHECK,LARGE-BLOCK-SIZE-TRANS-B
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-intel-gpu-to-llvm=one_matrix_per_load_for_bt=1 --convert-tritongen-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm --check-prefixes=CHECK,SMALL-BLOCK-SIZE-TRANS-B
 
 // CHECK-DAG: llvm.func spir_funccc @_Z45__spirv_SubgroupMatrixMultiplyAccumulateINTELiDv8_sDv8_iDv8_fi(i32, vector<8xi16>, vector<8xi32>, vector<8xf32>, i32) -> vector<8xf32> attributes {convergent, memory_effects = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none>, no_unwind, will_return}
 // CHECK-DAG: llvm.func spir_funccc @_Z32__spirv_Subgroup2DBlockLoadINTELiiiiPU3AS1viiiDv2_iPv(i32, i32, i32, i32, !llvm.ptr<1> {llvm.nonnull, llvm.readonly}, i32, i32, i32, vector<2xi32>, !llvm.ptr {llvm.nonnull, llvm.writeonly}) attributes {no_unwind, will_return}

--- a/test/TritonIntelGPU/blockptr_store.mlir
+++ b/test/TritonIntelGPU/blockptr_store.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm
+// RUN: triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm --convert-tritongen-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm
 
 // CHECK: llvm.func spir_funccc @_Z33__spirv_Subgroup2DBlockStoreINTELiiiiPvPU3AS1viiiDv2_i(i32, i32, i32, i32, !llvm.ptr {llvm.nonnull, llvm.readonly}, !llvm.ptr<1> {llvm.nonnull, llvm.writeonly}, i32, i32, i32, vector<2xi32>) attributes {no_unwind, will_return}
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>

--- a/test/TritonIntelGPU/prefetch-to-llvm.mlir
+++ b/test/TritonIntelGPU/prefetch-to-llvm.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm --cse -canonicalize | FileCheck %s
+// RUN: triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm --convert-tritongen-to-llvm --cse -canonicalize | FileCheck %s
 
 // CHECK: llvm.func spir_funccc @_Z36__spirv_Subgroup2DBlockPrefetchINTELiiiiPU3AS1viiiDv2_i(i32, i32, i32, i32, !llvm.ptr<1> {llvm.nonnull}, i32, i32, i32, vector<2xi32>) attributes {memory_effects = #llvm.memory_effects<other = none, argMem = read, inaccessibleMem = none>, no_unwind}
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {

--- a/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
+++ b/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
@@ -1,4 +1,6 @@
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-intel-gpu-to-llvm --cse | FileCheck %s --implicit-check-not=llvm.inline_asm
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-intel-gpu-to-llvm --convert-tritongen-to-llvm --cse  | FileCheck %s --implicit-check-not=llvm.inline_asm
+// XFAIL: * 
+// COM: Failing validation due to 0 stride returned from axis info 
 
 // CHECK:   llvm.func spir_funccc @_Z32__spirv_Subgroup2DBlockLoadINTELiiiiPU3AS1viiiDv2_iPv
 #mma = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [2, 4], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>

--- a/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
+++ b/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
@@ -1,6 +1,6 @@
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-intel-gpu-to-llvm --convert-tritongen-to-llvm --cse  | FileCheck %s --implicit-check-not=llvm.inline_asm
-// XFAIL: * 
-// COM: Failing validation due to 0 stride returned from axis info 
+// XFAIL: *
+// COM: Failing validation due to 0 stride returned from axis info
 
 // CHECK:   llvm.func spir_funccc @_Z32__spirv_Subgroup2DBlockLoadINTELiiiiPU3AS1viiiDv2_iPv
 #mma = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [2, 4], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>

--- a/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
+++ b/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
@@ -1,6 +1,4 @@
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-intel-gpu-to-llvm --convert-tritongen-to-llvm --cse  | FileCheck %s --implicit-check-not=llvm.inline_asm
-// XFAIL: *
-// COM: Failing validation due to 0 stride returned from axis info
 
 // CHECK:   llvm.func spir_funccc @_Z32__spirv_Subgroup2DBlockLoadINTELiiiiPU3AS1viiiDv2_iPv
 #mma = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [2, 4], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -327,6 +327,7 @@ class XPUBackend(BaseBackend):
         passes.ttgpuir.add_allocate_global_scratch_memory(pm)
         intel.passes.ttgpuir.add_to_llvmir(pm, options.advanced_path, options.one_matrix_per_load_for_bt,
                                            options.enable_tile_load_linear_layout)
+        intel.passes.ttgpuir.add_gen_to_llvm(pm)
         intel.passes.ttgpuir.add_rewrite_stack_ptr(pm)
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
@@ -16,6 +16,7 @@ def TritonIntelGPU_Dialect : Dialect {
     "triton::TritonDialect",
     "triton::gpu::TritonGPUDialect",
     "mlir::gpu::GPUDialect",
+    "mlir::triton::TritonGEN::TritonGENDialect",
   ];
 
   let extraClassDeclaration = [{

--- a/third_party/intel/include/TritonGENToLLVM/Passes.td
+++ b/third_party/intel/include/TritonGENToLLVM/Passes.td
@@ -16,7 +16,7 @@ def ConvertTritonGENToLLVM : Pass<"convert-tritongen-to-llvm", "mlir::ModuleOp">
   let description = [{
     This pass converts the TritonGEN dialect operations to LLVM dialect operations.
   }];
-  // TODO: do we need this?
+
   let constructor = "mlir::triton::createConvertTritonGENToLLVM()";
 
   let dependentDialects = ["mlir::LLVM::LLVMDialect"];

--- a/third_party/intel/include/TritonGENToLLVM/Passes.td
+++ b/third_party/intel/include/TritonGENToLLVM/Passes.td
@@ -11,11 +11,14 @@
 
 include "mlir/Pass/PassBase.td"
 
-def ConvertTritonGENToLLVM : Pass<"convert-tritongen-to-llvm"> {
+def ConvertTritonGENToLLVM : Pass<"convert-tritongen-to-llvm", "mlir::ModuleOp"> {
   let summary = "Convert the Triton GEN dialect to the LLVM dialect";
   let description = [{
     This pass converts the TritonGEN dialect operations to LLVM dialect operations.
   }];
+  // TODO: do we need this? 
+  let constructor = "mlir::triton::createConvertTritonGENToLLVM()";
+
   let dependentDialects = ["mlir::LLVM::LLVMDialect"];
 }
 

--- a/third_party/intel/include/TritonGENToLLVM/Passes.td
+++ b/third_party/intel/include/TritonGENToLLVM/Passes.td
@@ -17,8 +17,6 @@ def ConvertTritonGENToLLVM : Pass<"convert-tritongen-to-llvm", "mlir::ModuleOp">
     This pass converts the TritonGEN dialect operations to LLVM dialect operations.
   }];
 
-  let constructor = "mlir::triton::createConvertTritonGENToLLVM()";
-
   let dependentDialects = ["mlir::LLVM::LLVMDialect"];
 }
 

--- a/third_party/intel/include/TritonGENToLLVM/Passes.td
+++ b/third_party/intel/include/TritonGENToLLVM/Passes.td
@@ -16,7 +16,7 @@ def ConvertTritonGENToLLVM : Pass<"convert-tritongen-to-llvm", "mlir::ModuleOp">
   let description = [{
     This pass converts the TritonGEN dialect operations to LLVM dialect operations.
   }];
-  // TODO: do we need this? 
+  // TODO: do we need this?
   let constructor = "mlir::triton::createConvertTritonGENToLLVM()";
 
   let dependentDialects = ["mlir::LLVM::LLVMDialect"];

--- a/third_party/intel/include/TritonGENToLLVM/TritonGENToLLVMPass.h
+++ b/third_party/intel/include/TritonGENToLLVM/TritonGENToLLVMPass.h
@@ -26,6 +26,8 @@ void populateTritonGENToLLVMConversionPatterns(LLVMTypeConverter &converter,
 
 void registerConvertTritonGENToLLVMInterface(DialectRegistry &registry);
 
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTritonGENToLLVM();
+
 } // namespace triton
 } // namespace mlir
 

--- a/third_party/intel/include/TritonGENToLLVM/TritonGENToLLVMPass.h
+++ b/third_party/intel/include/TritonGENToLLVM/TritonGENToLLVMPass.h
@@ -26,8 +26,6 @@ void populateTritonGENToLLVMConversionPatterns(LLVMTypeConverter &converter,
 
 void registerConvertTritonGENToLLVMInterface(DialectRegistry &registry);
 
-std::unique_ptr<OperationPass<ModuleOp>> createConvertTritonGENToLLVM();
-
 } // namespace triton
 } // namespace mlir
 

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -882,13 +882,3 @@ void registerConvertTritonTritonGENToLLVMInterface(DialectRegistry &registry) {
         dialect->addInterfaces<TritonGENToLLVMDialectInterface>();
       });
 }
-
-namespace mlir {
-namespace triton {
-
-std::unique_ptr<OperationPass<ModuleOp>> createConvertTritonGENToLLVM() {
-  return std::make_unique<::ConvertTritonGENToLLVM>();
-}
-
-} // namespace triton
-} // namespace mlir

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -876,3 +876,13 @@ void registerConvertTritonTritonGENToLLVMInterface(DialectRegistry &registry) {
         dialect->addInterfaces<TritonGENToLLVMDialectInterface>();
       });
 }
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTritonGENToLLVM() {
+  return std::make_unique<::ConvertTritonGENToLLVM>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -557,8 +557,8 @@ struct PrefetchOpConversion
             /*v_blocks*/ vBlocks,
             /*cache_opt*/ TritonGEN::LoadCacheControl::L1C_L3C);
         if (failed(newOp.verify())) {
-          // delete the op so that the verifier will not abort the pass pipeline
-          // later. fail this path and retry with gather load.
+          // delete the op so that the verifier will not abort the pass
+          // pipeline later, as we can fail this path and retry.
           rewriter.eraseOp(newOp);
           return failure();
         }
@@ -759,7 +759,7 @@ struct PrefetchOpConversion
                 /*cache_opt*/ TritonGEN::LoadCacheControl::L1C_L3C);
             if (failed(newOp.verify())) {
               // delete the op so that the verifier will not abort the pass
-              // pipeline later. fail this path and retry with gather load.
+              // pipeline later, as we can fail this path and retry.
               rewriter.eraseOp(newOp);
               return failure();
             }
@@ -1576,7 +1576,7 @@ struct LoadOpConversion
                   /*vnni_transform*/ false);
               if (failed(load2dOp.verify())) {
                 // delete the op so that the verifier will not abort the pass
-                // pipeline later. fail this path and retry with gather load.
+                // pipeline later, as we can fail this path and retry.
                 rewriter.eraseOp(load2dOp);
                 return failure();
               }
@@ -2090,7 +2090,7 @@ struct LoadOpConversion
                originalElemBits != 32));
           if (failed(load2dOp.verify())) {
             // delete the op so that the verifier will not abort the pass
-            // pipeline later. fail this path and retry with gather load.
+            // pipeline later, as we can fail this path and retry.
             rewriter.eraseOp(load2dOp);
             return failure();
           }
@@ -2525,7 +2525,7 @@ struct StoreOpConversion
 
             if (failed(newOp.verify())) {
               // delete the op so that the verifier will not abort the pass
-              // pipeline later. fail this path and retry with gather load.
+              // pipeline later, as we can fail this path and retry.
               rewriter.eraseOp(newOp);
               return failure();
             }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -558,7 +558,8 @@ struct PrefetchOpConversion
             /*cache_opt*/ TritonGEN::LoadCacheControl::L1C_L3C);
         if (failed(newOp.verify())) {
           // delete the op so that the verifier will not abort the pass
-          // pipeline later, as we can fail this path and retry.
+          // pipeline later, as we can fail this path and try a different
+          // approach.
           rewriter.eraseOp(newOp);
           return failure();
         }
@@ -759,7 +760,8 @@ struct PrefetchOpConversion
                 /*cache_opt*/ TritonGEN::LoadCacheControl::L1C_L3C);
             if (failed(newOp.verify())) {
               // delete the op so that the verifier will not abort the pass
-              // pipeline later, as we can fail this path and retry.
+              // pipeline later, as we can fail this path and try a different
+              // approach.
               rewriter.eraseOp(newOp);
               return failure();
             }
@@ -1576,7 +1578,8 @@ struct LoadOpConversion
                   /*vnni_transform*/ false);
               if (failed(load2dOp.verify())) {
                 // delete the op so that the verifier will not abort the pass
-                // pipeline later, as we can fail this path and retry.
+                // pipeline later, as we can fail this path and try a different
+                // approach.
                 rewriter.eraseOp(load2dOp);
                 return failure();
               }
@@ -2090,7 +2093,8 @@ struct LoadOpConversion
                originalElemBits != 32));
           if (failed(load2dOp.verify())) {
             // delete the op so that the verifier will not abort the pass
-            // pipeline later, as we can fail this path and retry.
+            // pipeline later, as we can fail this path and try a different
+            // approach.
             rewriter.eraseOp(load2dOp);
             return failure();
           }
@@ -2525,7 +2529,8 @@ struct StoreOpConversion
 
             if (failed(newOp.verify())) {
               // delete the op so that the verifier will not abort the pass
-              // pipeline later, as we can fail this path and retry.
+              // pipeline later, as we can fail this path and try a different
+              // approach.
               rewriter.eraseOp(newOp);
               return failure();
             }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -557,8 +557,9 @@ struct PrefetchOpConversion
             /*v_blocks*/ vBlocks,
             /*cache_opt*/ TritonGEN::LoadCacheControl::L1C_L3C);
         if (failed(newOp.verify())) {
-          // Explicitly invoke verifier because `triton_gen` ops are immediately
-          // lowered further to a builtin call.
+          // delete the op so that the verifier will not abort the pass pipeline
+          // later. fail this path and retry with gather load.
+          rewriter.eraseOp(newOp);
           return failure();
         }
       }
@@ -757,8 +758,9 @@ struct PrefetchOpConversion
                 /*v_blocks*/ vBlocks,
                 /*cache_opt*/ TritonGEN::LoadCacheControl::L1C_L3C);
             if (failed(newOp.verify())) {
-              // Explicitly invoke verifier because `triton_gen` ops are
-              // immediately lowered further to a builtin call.
+              // delete the op so that the verifier will not abort the pass
+              // pipeline later. fail this path and retry with gather load.
+              rewriter.eraseOp(newOp);
               return failure();
             }
           }
@@ -1573,8 +1575,9 @@ struct LoadOpConversion
                   /*transpose*/ false,
                   /*vnni_transform*/ false);
               if (failed(load2dOp.verify())) {
-                // Explicitly invoke verifier because `triton_gen` ops are
-                // immediately lowered further to a builtin call.
+                // delete the op so that the verifier will not abort the pass
+                // pipeline later. fail this path and retry with gather load.
+                rewriter.eraseOp(load2dOp);
                 return failure();
               }
 
@@ -2086,8 +2089,9 @@ struct LoadOpConversion
               (usePackedType && !isOperandA && !isTransposeRequired &&
                originalElemBits != 32));
           if (failed(load2dOp.verify())) {
-            // Explicitly invoke verifier because `triton_gen` ops are
-            // immediately lowered further to a builtin call.
+            // delete the op so that the verifier will not abort the pass
+            // pipeline later. fail this path and retry with gather load.
+            rewriter.eraseOp(load2dOp);
             return failure();
           }
           LLVM_DEBUG(llvm::dbgs() << "Generated load op: " << load2dOp << "\n");
@@ -2520,8 +2524,9 @@ struct StoreOpConversion
                 /*stored_val*/ b.bitcast(storeVal, store2DGenXType));
 
             if (failed(newOp.verify())) {
-              // Explicitly invoke verifier because `triton_gen` ops are
-              // immediately lowered further to a builtin call.
+              // delete the op so that the verifier will not abort the pass
+              // pipeline later. fail this path and retry with gather load.
+              rewriter.eraseOp(newOp);
               return failure();
             }
           }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PipelineManager.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PipelineManager.h
@@ -254,10 +254,8 @@ public:
     // to help convert scalar expression to LLVM.
     arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
     populateMathToLLVMConversionPatterns(typeConverter, patterns);
-    triton::populateTritonGENToLLVMConversionPatterns(typeConverter, patterns);
     triton::populateGPUToTritonGENConversionPatterns(typeConverter, patterns);
     cf::populateControlFlowToLLVMConversionPatterns(typeConverter, patterns);
-    populateTritonGENToSPIRVConversionPatterns(patterns);
     populateGpuToLLVMSPVConversionPatterns(typeConverter, patterns);
     populateSPIRVToLLVMConversionPatterns(typeConverter, patterns,
                                           spirv::ClientAPI::OpenCL);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVM.cpp
@@ -76,7 +76,8 @@ struct ConvertTritonGPUToLLVM
   }
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<LLVM::LLVMDialect, spirv::SPIRVDialect>();
+    registry.insert<LLVM::LLVMDialect, TritonGEN::TritonGENDialect,
+                    spirv::SPIRVDialect>();
   }
 
   void runOnOperation() override {

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVM.cpp
@@ -51,7 +51,7 @@ public:
   explicit TritonLLVMConversionTarget(MLIRContext &ctx)
       : ConversionTarget(ctx) {
     addLegalDialect<LLVM::LLVMDialect>();
-    addIllegalDialect<triton::TritonGEN::TritonGENDialect>();
+    addLegalDialect<triton::TritonGEN::TritonGENDialect>();
     addIllegalDialect<triton::TritonDialect>();
     addIllegalDialect<triton::gpu::TritonGPUDialect>();
     addIllegalDialect<triton::gpu::intel::TritonIntelGPUDialect>();
@@ -76,8 +76,7 @@ struct ConvertTritonGPUToLLVM
   }
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<LLVM::LLVMDialect, TritonGEN::TritonGENDialect,
-                    spirv::SPIRVDialect>();
+    registry.insert<LLVM::LLVMDialect, spirv::SPIRVDialect>();
   }
 
   void runOnOperation() override {

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -16,6 +16,7 @@
 #include "intel/include/Target/LLVMIR/Dialect/TritonGEN/TritonGENToLLVMIRTranslation.h"
 #include "intel/include/Target/LLVMIR/PostProcess.h"
 #include "intel/include/TritonAnnotateModule/Passes.h"
+#include "intel/include/TritonGENToLLVM/Passes.h"
 #include "intel/include/TritonIntelGPUToLLVM/Passes.h"
 #include "intel/include/TritonRaiseBlockPointer/Passes.h"
 #include "intel/include/TritonToTritonGPUWarp/Passes.h"
@@ -67,6 +68,7 @@ void init_triton_intel_passes_ttgpuir(py::module &&m) {
   ADD_PASS_OPTION_WRAPPER_3("add_to_llvmir",
                             gpu::intel::createConvertTritonIntelGPUToLLVM, bool,
                             bool, bool);
+  ADD_PASS_WRAPPER_0("add_gen_to_llvm", gpu::intel::createConvertTritonGENToLLVM);
   ADD_PASS_WRAPPER_0("add_accelerate_matmul",
                      gpu::intel::createTritonIntelGPUAccelerateMatmul);
   ADD_PASS_WRAPPER_0("add_rewrite_stack_ptr",

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -68,7 +68,7 @@ void init_triton_intel_passes_ttgpuir(py::module &&m) {
   ADD_PASS_OPTION_WRAPPER_3("add_to_llvmir",
                             gpu::intel::createConvertTritonIntelGPUToLLVM, bool,
                             bool, bool);
-  ADD_PASS_WRAPPER_0("add_gen_to_llvm", gpu::intel::createConvertTritonGENToLLVM);
+  ADD_PASS_WRAPPER_0("add_gen_to_llvm", createConvertTritonGENToLLVM);
   ADD_PASS_WRAPPER_0("add_accelerate_matmul",
                      gpu::intel::createTritonIntelGPUAccelerateMatmul);
   ADD_PASS_WRAPPER_0("add_rewrite_stack_ptr",


### PR DESCRIPTION
Changes the Intel lowering pipeline during `make_llir` to first convert TritonIntelGPU to LLVM Dialect, then convert TritonGEN to LLVM Dialect. This is analogous to the NVIDIA backend, allows us to run the GEN verifier on all GEN ops, and allows us to write lit tests against TTGPUIR looking for specific gen ops - e.g. 2d block loads with specific tile sizes. 

To lower GEN to LLVM Dialect we need to add the GEN To SPIRV and SPIRV to LLVM patterns to the lowering step. I chose to do that in the existing TritonGENToLLVM pass, but we could introduce a new pass too (`TritonGENToLLVMViaSPIRV`?). 

Finally, I had to disable the tensor of pointer -> 2d block io lit test. The test is failing Gen validation because the pitch passed to the TritonGEN op is 0. This likely wouldn't work in practice, but it is now being caught during lit testing because we are running the verifier. I have opened a separate issue to fix this: https://github.com/intel/intel-xpu-backend-for-triton/issues/4275

I also discovered several places where the DPAS layout was using the incorrect `opsPerChannel` parameter for the data type - I had initially opened https://github.com/intel/intel-xpu-backend-for-triton/issues/4270 to track this, but fixed the issue in this PR. However, we should consider layout validation to ensure DPAS type-specific parameters match the data type.

close #4269