### PR TITLE
[TritonGEN] Reduce `GenISA` usage

### DIFF
--- a/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
@@ -338,7 +338,13 @@ llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_
 // -----
 
 llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
-  // CHECK:      llvm.call spir_funccc @llvm.genx.GenISA.LSC2DBlockRead.v32i16({{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %arg5, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}) -> vector<32xi16>
+  // CHECK:      llvm.mlir.constant(2 : i32) : i32
+  // CHECK:      [[ElemSize:%.*]] = llvm.mlir.constant(2 : i32) : i32
+  // CHECK-NEXT: [[TileWidth:%.*]] = llvm.mlir.constant(16 : i32) : i32
+  // CHECK-NEXT: [[TileHeight:%.*]] = llvm.mlir.constant(16 : i32) : i32
+  // CHECK-NEXT: [[VBlocks:%.*]] = llvm.mlir.constant(2 : i32) : i32
+  // CHECK-NEXT: llvm.call spir_funccc @_Z32__spirv_Subgroup2DBlockLoadINTELiiiiPU3AS1viiiDv2_iPv([[ElemSize]], [[TileWidth]], [[TileHeight]], [[VBlocks]], %arg0, [[ADD_0]], %arg2, %arg3, {{.*}}, [[DEST:%.*]]) {{.*}} : (i32, i32, i32, i32, !llvm.ptr<1>{{.*}}, i32, i32, i32, vector<2xi32>, !llvm.ptr{{.*}}) -> ()
+  // CHECK-NEXT: llvm.load [[DEST]] : !llvm.ptr -> vector<32xi16>
   %0 = triton_gen.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=16, tile_width=16, tile_height=16, v_blocks=2, transpose=false, vnni_transform=false, cache_control=Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32) -> vector<32xi16>
   llvm.return
 }
@@ -469,7 +475,13 @@ llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_
 // -----
 
 llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
-  // CHECK:      llvm.call spir_funccc @llvm.genx.GenISA.LSC2DBlockRead.v16i32({{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %arg5, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}) -> vector<16xi32>
+  // CHECK:      llvm.mlir.constant(2 : i32) : i32
+  // CHECK:      [[ElemSize:%.*]] = llvm.mlir.constant(2 : i32) : i32
+  // CHECK-NEXT: [[TileWidth:%.*]] = llvm.mlir.constant(16 : i32) : i32
+  // CHECK-NEXT: [[TileHeight:%.*]] = llvm.mlir.constant(16 : i32) : i32
+  // CHECK-NEXT: [[VBlocks:%.*]] = llvm.mlir.constant(2 : i32) : i32
+  // CHECK-NEXT: llvm.call spir_funccc @_Z41__spirv_Subgroup2DBlockLoadTransformINTELiiiiPU3AS1viiiDv2_iPv([[ElemSize]], [[TileWidth]], [[TileHeight]], [[VBlocks]], %arg0, [[ADD_0]], %arg2, %arg3, {{.*}}, [[DEST:%.*]]) {{.*}} : (i32, i32, i32, i32, !llvm.ptr<1>{{.*}}, i32, i32, i32, vector<2xi32>, !llvm.ptr{{.*}}) -> ()
+  // CHECK-NEXT: llvm.load [[DEST]] : !llvm.ptr -> vector<16xi32>
   %0 = triton_gen.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=16, tile_width=16, tile_height=16, v_blocks=2, transpose=false, vnni_transform=true, cache_control=Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32) -> vector<16xi32>
   llvm.return
 }

--- a/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
+++ b/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
@@ -158,7 +158,14 @@ module attributes {ttig.support_sg_2d_block, "ttg.num-warps" = 8 : i32} {
     // CHECK: [[C8:%.*]] = llvm.mlir.constant(8 : i32) : i32
     // CHECK: [[C16:%.*]] = llvm.mlir.constant(16 : i32) : i32
 
-    // CHECK-COUNT-4: llvm.call spir_funccc @llvm.genx.GenISA.LSC2DBlockRead.v32f16
+    // CHECK: [[C2:%.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK: llvm.call spir_funccc @_Z32__spirv_Subgroup2DBlockLoadINTELiiiiPU3AS1viiiDv2_iPv([[C2]], [[C16]], [[C16]], [[C2]], {{.*}})
+    // CHECK: [[C2:%.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK: llvm.call spir_funccc @_Z32__spirv_Subgroup2DBlockLoadINTELiiiiPU3AS1viiiDv2_iPv([[C2]], [[C16]], [[C16]], [[C2]], {{.*}})
+    // CHECK: [[C2:%.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK: llvm.call spir_funccc @_Z32__spirv_Subgroup2DBlockLoadINTELiiiiPU3AS1viiiDv2_iPv([[C2]], [[C16]], [[C16]], [[C2]], {{.*}})
+    // CHECK: [[C2:%.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK: llvm.call spir_funccc @_Z32__spirv_Subgroup2DBlockLoadINTELiiiiPU3AS1viiiDv2_iPv([[C2]], [[C16]], [[C16]], [[C2]], {{.*}})
     %0 = tt.load %arg0 {ttig.block_io = "row_major"} : tensor<256x64x!tt.ptr<f16>, #mma>
 
     // CHECK: [[C2:%.*]] = llvm.mlir.constant(2 : i32) : i32

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -111,13 +111,6 @@ loadCacheControlToCacheControls(Builder &builder,
 }
 
 static bool isOCLBuiltinAvailable(TritonGEN::Matrix2DBlockLoadOp op) {
-  // The following signature is not valid in OCL interface.
-  // _Z42intel_sub_group_2d_block_read_16b_16r16x2cPU3AS1viiiDv2_iPDh
-  if (op.getElemSizeInBits() == 16 && op.getTileHeight() == 16 &&
-      op.getTileWidth() == 16 && op.getVBlocks() == 2) {
-    return false;
-  }
-
   if (op.getElemSizeInBits() == 8 && op.getTileWidth() == 16 &&
       op.getVBlocks() != 4 && !op.getVnniTransform()) {
     // TODO: add ocl builtin/spirv intrinsics for 8b 16 column 1 vBlock & 2

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -110,11 +110,28 @@ loadCacheControlToCacheControls(Builder &builder,
   return builder.getAttr<TritonGEN::DecorationCacheControlAttr>(decorations);
 }
 
-static bool isOCLBuiltinAvailable(TritonGEN::Matrix2DBlockLoadOp op) {
-  if (op.getElemSizeInBits() == 8 && op.getTileWidth() == 16 &&
-      op.getVBlocks() != 4 && !op.getVnniTransform()) {
-    // TODO: add ocl builtin/spirv intrinsics for 8b 16 column 1 vBlock & 2
-    // vBlock reads
+static bool isSPVBuiltinAvailable(TritonGEN::Matrix2DBlockLoadOp op) {
+  // FIXME: The following signatures are not valid in SPV interface.
+  // intel_sub_group_2d_block_read_8b_32r16x1c
+  // intel_sub_group_2d_block_read_8b_32r16x2c
+  // intel_sub_group_2d_block_read_8b_16r16x2c
+  // intel_sub_group_2d_block_read_8b_8r16x1c
+  // intel_sub_group_2d_block_read_8b_8r16x2c
+  if ((op.getElemSizeInBits() == 8 && op.getTileHeight() == 32 &&
+       op.getTileWidth() == 16 && op.getVBlocks() == 1 &&
+       !op.getVnniTransform()) ||
+      (op.getElemSizeInBits() == 8 && op.getTileHeight() == 32 &&
+       op.getTileWidth() == 16 && op.getVBlocks() == 2 &&
+       !op.getVnniTransform()) ||
+      (op.getElemSizeInBits() == 8 && op.getTileHeight() == 16 &&
+       op.getTileWidth() == 16 && op.getVBlocks() == 2 &&
+       !op.getVnniTransform()) ||
+      (op.getElemSizeInBits() == 8 && op.getTileHeight() == 8 &&
+       op.getTileWidth() == 16 && op.getVBlocks() == 1 &&
+       !op.getVnniTransform()) ||
+      (op.getElemSizeInBits() == 8 && op.getTileHeight() == 8 &&
+       op.getTileWidth() == 16 && op.getVBlocks() == 2 &&
+       !op.getVnniTransform())) {
     return false;
   }
 
@@ -483,7 +500,7 @@ struct TritonMatrix2DBlockLoadLowering
   LogicalResult
   matchAndRewrite(TritonGEN::Matrix2DBlockLoadOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (!isOCLBuiltinAvailable(op)) {
+    if (!isSPVBuiltinAvailable(op)) {
       // Fallback to GenISA interface.
       rewriter.replaceOp(op, createGenISA2DBlockRead(op, rewriter));
       return success();


### PR DESCRIPTION
SPV variant `16b_16r16x2c` is available, no need to use `GenISA`.

Benchmark CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15216714545 (no geomean regression)
Flex Decoding CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15218710307 (no regression)