### PR TITLE
Use `SmallPtrSet` instead of `std::set` to make lit test `loop-invariant-masks.mlir` deterministic

### DIFF
--- a/test/Triton/Intel/RemoveMasks/loop-invariant-masks.mlir
+++ b/test/Triton/Intel/RemoveMasks/loop-invariant-masks.mlir
@@ -38,7 +38,7 @@ module {
   // CHECK-DAG:       [[VAR_8:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_1023]] : i32
   // CHECK-DAG:       [[CST_511:%.+]] = arith.constant 511 : i32
   // CHECK-DAG:       [[VAR_9:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_511]] : i32
-  // CHECK:           [[VAR_10:%.+]] = arith.andi [[VAR_8]], [[VAR_9]] : i1 | [[VAR_10:%.+]] = arith.andi [[VAR_9]], [[VAR_8]] : i1
+  // CHECK:           [[VAR_10:%.+]] = arith.andi [[VAR_8]], [[VAR_9]] : i1
   // CHECK:           scf.if [[VAR_10]] {
   // CHECK:             scf.for {{.+}} = {{.+}} to {{.+}} step {{.+}} : i32 {
   // CHECK-NOT:           tt.load {{.*}}, {{.*}}, {{.*}}

--- a/test/Triton/Intel/RemoveMasks/loop-invariant-masks.mlir
+++ b/test/Triton/Intel/RemoveMasks/loop-invariant-masks.mlir
@@ -35,9 +35,9 @@ module {
   // CHECK:           [[VAR_6:%.+]] = tt.splat [[PARAM_3]] : i32 -> tensor<512xi32>
   // CHECK-DAG:       [[VAR_7:%.+]] = arith.cmpi slt, [[VAR_5]], [[VAR_6]] : tensor<512xi32>
   // CHECK-DAG:       [[CST_1023:%.+]] = arith.constant 1023 : i32
-  // CHECK:       [[VAR_8:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_1023]] : i32
-  // CHECK:       [[CST_511:%.+]] = arith.constant 511 : i32
-  // CHECK:       [[VAR_9:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_511]] : i32
+  // CHECK:           [[VAR_8:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_1023]] : i32
+  // CHECK:           [[CST_511:%.+]] = arith.constant 511 : i32
+  // CHECK:           [[VAR_9:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_511]] : i32
   // CHECK:           [[VAR_10:%.+]] = arith.andi [[VAR_8]], [[VAR_9]] : i1
   // CHECK:           scf.if [[VAR_10]] {
   // CHECK:             scf.for {{.+}} = {{.+}} to {{.+}} step {{.+}} : i32 {

--- a/test/Triton/Intel/RemoveMasks/loop-invariant-masks.mlir
+++ b/test/Triton/Intel/RemoveMasks/loop-invariant-masks.mlir
@@ -38,7 +38,7 @@ module {
   // CHECK-DAG:       [[VAR_8:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_1023]] : i32
   // CHECK-DAG:       [[CST_511:%.+]] = arith.constant 511 : i32
   // CHECK-DAG:       [[VAR_9:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_511]] : i32
-  // CHECK:           [[VAR_10:%.+]] = arith.andi [[VAR_8]], [[VAR_9]] : i1
+  // CHECK:           [[VAR_10:%.+]] = arith.andi [[VAR_8]], [[VAR_9]] : i1 | [[VAR_10:%.+]] = arith.andi [[VAR_9]], [[VAR_8]] : i1
   // CHECK:           scf.if [[VAR_10]] {
   // CHECK:             scf.for {{.+}} = {{.+}} to {{.+}} step {{.+}} : i32 {
   // CHECK-NOT:           tt.load {{.*}}, {{.*}}, {{.*}}

--- a/test/Triton/Intel/RemoveMasks/loop-invariant-masks.mlir
+++ b/test/Triton/Intel/RemoveMasks/loop-invariant-masks.mlir
@@ -35,9 +35,9 @@ module {
   // CHECK:           [[VAR_6:%.+]] = tt.splat [[PARAM_3]] : i32 -> tensor<512xi32>
   // CHECK-DAG:       [[VAR_7:%.+]] = arith.cmpi slt, [[VAR_5]], [[VAR_6]] : tensor<512xi32>
   // CHECK-DAG:       [[CST_1023:%.+]] = arith.constant 1023 : i32
-  // CHECK-DAG:       [[VAR_8:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_1023]] : i32
-  // CHECK-DAG:       [[CST_511:%.+]] = arith.constant 511 : i32
-  // CHECK-DAG:       [[VAR_9:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_511]] : i32
+  // CHECK:       [[VAR_8:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_1023]] : i32
+  // CHECK:       [[CST_511:%.+]] = arith.constant 511 : i32
+  // CHECK:       [[VAR_9:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_511]] : i32
   // CHECK:           [[VAR_10:%.+]] = arith.andi [[VAR_8]], [[VAR_9]] : i1
   // CHECK:           scf.if [[VAR_10]] {
   // CHECK:             scf.for {{.+}} = {{.+}} to {{.+}} step {{.+}} : i32 {

--- a/test/Triton/Intel/RemoveMasks/loop-invariant-masks.mlir
+++ b/test/Triton/Intel/RemoveMasks/loop-invariant-masks.mlir
@@ -36,7 +36,7 @@ module {
   // CHECK-DAG:       [[VAR_7:%.+]] = arith.cmpi slt, [[VAR_5]], [[VAR_6]] : tensor<512xi32>
   // CHECK-DAG:       [[CST_1023:%.+]] = arith.constant 1023 : i32
   // CHECK:           [[VAR_8:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_1023]] : i32
-  // CHECK:           [[CST_511:%.+]] = arith.constant 511 : i32
+  // CHECK-DAG:       [[CST_511:%.+]] = arith.constant 511 : i32
   // CHECK:           [[VAR_9:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_511]] : i32
   // CHECK:           [[VAR_10:%.+]] = arith.andi [[VAR_8]], [[VAR_9]] : i1
   // CHECK:           scf.if [[VAR_10]] {

--- a/test/Triton/Intel/RemoveMasks/loop-invariant-masks.mlir
+++ b/test/Triton/Intel/RemoveMasks/loop-invariant-masks.mlir
@@ -35,9 +35,9 @@ module {
   // CHECK:           [[VAR_6:%.+]] = tt.splat [[PARAM_3]] : i32 -> tensor<512xi32>
   // CHECK-DAG:       [[VAR_7:%.+]] = arith.cmpi slt, [[VAR_5]], [[VAR_6]] : tensor<512xi32>
   // CHECK-DAG:       [[CST_1023:%.+]] = arith.constant 1023 : i32
-  // CHECK:           [[VAR_8:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_1023]] : i32
+  // CHECK-DAG:       [[VAR_8:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_1023]] : i32
   // CHECK-DAG:       [[CST_511:%.+]] = arith.constant 511 : i32
-  // CHECK:           [[VAR_9:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_511]] : i32
+  // CHECK-DAG:       [[VAR_9:%.+]] = arith.cmpi sgt, [[PARAM_3]], [[CST_511]] : i32
   // CHECK:           [[VAR_10:%.+]] = arith.andi [[VAR_8]], [[VAR_9]] : i1
   // CHECK:           scf.if [[VAR_10]] {
   // CHECK:             scf.for {{.+}} = {{.+}} to {{.+}} step {{.+}} : i32 {

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RemoveMasks.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RemoveMasks.cpp
@@ -444,7 +444,7 @@ public:
            "Expecting a non-empty collection of masked operations");
 
     // Collect the (loop invariant) mask conditions.
-    std::set<Operation *> maskConds;
+    SmallPtrSet<Operation *, 8> maskConds;
     for (Operation *maskedOp : collector.getMaskedOps()) {
       if (auto loadOp = dyn_cast<tt::LoadOp>(maskedOp))
         maskConds.insert(loadOp.getMask().getDefiningOp());


### PR DESCRIPTION
CI:
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15275698269 (failed)
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15276240735
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15279775918 (passed)