### PR TITLE
[TritonGENToLLVM] Do not adjust zero base width

### DIFF
--- a/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
@@ -31,30 +31,11 @@ llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_
 
 // -----
 
+// COM: If base width and base height are zeros, then we want to ensure that they continue to be zeros.
 llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_pitch : i32, %x : i32, %y : i32) {
-  // CHECK:     llvm.func @triton_gen.2Dblockload(%arg0: !llvm.ptr<1>, %arg1: i32, %arg2: i32, %arg3: i32) {
-  // CHECK:       [[BaseWidth:%.*]] = llvm.mlir.constant(0 : i32) : i32
-  // CHECK-NEXT:  [[BaseHeight:%.*]] = llvm.mlir.constant(0 : i32) : i32
-  // CHECK-NEXT:  [[EIGHT:%.*]] = llvm.mlir.constant(8 : i32) : i32
-  // CHECK-NEXT:  [[DEST:%.*]] = llvm.alloca [[EIGHT]] x i16 : (i32) -> !llvm.ptr
-  // CHECK-NEXT:  [[PTRTOINT:%.*]] = llvm.ptrtoint %arg0 : !llvm.ptr<1> to i64
-  // CHECK-NEXT:  [[CL:%.*]] = llvm.mlir.constant(63 : i64) : i64
-  // CHECK-NEXT:  [[AND:%.*]] = llvm.and [[PTRTOINT]], [[CL]] : i64
-  // CHECK-NEXT:  [[TRUNC:%.*]] = llvm.trunc [[AND]] : i64 to i32
-  // CHECK-DAG:   [[ONE:%.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK-NEXT:  [[DIV:%.*]] = llvm.udiv [[TRUNC]], [[ONE]] : i32
-  // CHECK-NEXT:  [[ADD_1:%.*]] = llvm.add %arg2, [[DIV]] : i32
-  // CHECK-DAG:   [[ZERO_1:%.*]] = llvm.mlir.constant(0 : i32) : i32
-  // CHECK-DAG:   [[ONE:%.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK-DAG:   [[UNDEF:%.*]] = llvm.mlir.undef : vector<2xi32>
-  // CHECK-NEXT:  [[COORD0:%.*]] = llvm.insertelement [[ADD_1]], [[UNDEF]][[[ZERO_1]] : i32] : vector<2xi32>
-  // CHECK-NEXT:  [[COORD1:%.*]] = llvm.insertelement %arg3, [[COORD0]][[[ONE]] : i32] : vector<2xi32>
-  // CHECK-DAG:   [[ElemSize:%.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK-DAG:   [[TileWidth:%.*]] = llvm.mlir.constant(32 : i32) : i32
-  // CHECK-DAG:   [[TileHeight:%.*]] = llvm.mlir.constant(8 : i32) : i32
-  // CHECK-DAG:   [[VBlocks:%.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK-NEXT:  llvm.call spir_funccc @_Z32__spirv_Subgroup2DBlockLoadINTELiiiiPU3AS1viiiDv2_iPv([[ElemSize]], [[TileWidth]], [[TileHeight]], [[VBlocks]], %arg0, [[BaseWidth]], [[BaseHeight]], %arg1, [[COORD1]], [[DEST]]) {{.*}} : (i32, i32, i32, i32, !llvm.ptr<1>{{.*}}, i32, i32, i32, vector<2xi32>, !llvm.ptr{{.*}}) -> ()
-  // CHECK-NEXT:  llvm.load [[DEST]] : !llvm.ptr -> vector<8xi16>
+  // CHECK-DAG: [[BaseWidth:%.*]] = llvm.mlir.constant(0 : i32) : i32
+  // CHECK-DAG: [[BaseHeight:%.*]] = llvm.mlir.constant(0 : i32) : i32
+  // CHECK:     llvm.call spir_funccc @_Z32__spirv_Subgroup2DBlockLoadINTELiiiiPU3AS1viiiDv2_iPv({{.*}}, [[BaseWidth]], [[BaseHeight]], {{.*}})
   %base_width = llvm.mlir.constant(0 : i32) : i32
   %base_height = llvm.mlir.constant(0 : i32) : i32
   %0 = triton_gen.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=8, tile_width=32, tile_height=8, v_blocks=1, transpose=false, vnni_transform=false, cache_control=Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32) -> vector<8xi16>

--- a/test/TritonGEN/tritongen-2Dblockprefetch-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockprefetch-to-llvm.mlir
@@ -30,6 +30,19 @@ llvm.func @triton_gen.2Dblockprefetch(%ptr : !llvm.ptr<1>, %base_width : i32, %b
 
 // -----
 
+// COM: If base width and base height are zeros, then we want to ensure that they continue to be zeros.
+llvm.func @triton_gen.2Dblockprefetch(%ptr : !llvm.ptr<1>, %base_pitch : i32, %x : i32, %y : i32) {
+  // CHECK-DAG: [[BaseWidth:%.*]] = llvm.mlir.constant(0 : i32) : i32
+  // CHECK-DAG: [[BaseHeight:%.*]] = llvm.mlir.constant(0 : i32) : i32
+  // CHECK:     llvm.call spir_funccc @_Z36__spirv_Subgroup2DBlockPrefetchINTELiiiiPU3AS1viiiDv2_i({{.*}}, [[BaseWidth]], [[BaseHeight]], {{.*}})
+  %base_width = llvm.mlir.constant(0 : i32) : i32
+  %base_height = llvm.mlir.constant(0 : i32) : i32
+  triton_gen.2Dblockprefetch %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=8, tile_width=32, tile_height=8, v_blocks=1, cache_control=L1UC_L3UC} : (!llvm.ptr<1>, i32, i32, i32, i32, i32)
+  llvm.return
+}
+
+// -----
+
 llvm.func @triton_gen.2Dblockprefetch(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
   // CHECK-COUNT-2: llvm.mlir.constant(1 : i32) : i32
   // CHECK:         [[ElemSize:%.*]] = llvm.mlir.constant(1 : i32) : i32

--- a/test/TritonGEN/tritongen-2Dblockstore-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockstore-to-llvm.mlir
@@ -33,6 +33,19 @@ llvm.func @triton_gen.2Dblockstore(%ptr : !llvm.ptr<1>, %base_width : i32, %base
 
 // -----
 
+// COM: If base width and base height are zeros, then we want to ensure that they continue to be zeros.
+llvm.func @triton_gen.2Dblockstore(%ptr : !llvm.ptr<1>, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<8xi8>) {
+  // CHECK-DAG: [[BaseWidth:%.*]] = llvm.mlir.constant(0 : i32) : i32
+  // CHECK-DAG: [[BaseHeight:%.*]] = llvm.mlir.constant(0 : i32) : i32
+  // CHECK:     llvm.call spir_funccc @_Z33__spirv_Subgroup2DBlockStoreINTELiiiiPvPU3AS1viiiDv2_i({{.*}}, [[BaseWidth]], [[BaseHeight]], {{.*}})
+  %base_width = llvm.mlir.constant(0 : i32) : i32
+  %base_height = llvm.mlir.constant(0 : i32) : i32
+  triton_gen.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=8, tile_width=16, tile_height=8, v_blocks=1, cache_control=L1UC_L3UC} : (!llvm.ptr<1>, i32, i32, i32, i32, i32, vector<8xi8>)
+  llvm.return
+}
+
+// -----
+
 llvm.func @triton_gen.2Dblockstore(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<8xi16>) {
   // CHECK-COUNT-2: llvm.mlir.constant(1 : i32) : i32
   // CHECK:         [[ElemSize:%.*]] = llvm.mlir.constant(1 : i32) : i32

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -158,6 +158,7 @@ computeAlignedBaseWidthAndOffset(OpTy op, ConversionPatternRewriter &rewriter) {
   Value offsetInBytes =
       b.trunc(i32_ty, b.and_(baseAddr, b.i64_val(ALIGNMENT_MASK)));
   // Adjust the base width to account for the byte offset.
+  // If base width is zero, then we want to keep it as zero.
   Value adjustedBaseWidth = op.getBaseWidth();
   llvm::APInt baseWidthVal;
   if (!matchPattern(op.getBaseWidth(), m_ConstantInt(&baseWidthVal)) ||

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -158,7 +158,11 @@ computeAlignedBaseWidthAndOffset(OpTy op, ConversionPatternRewriter &rewriter) {
   Value offsetInBytes =
       b.trunc(i32_ty, b.and_(baseAddr, b.i64_val(ALIGNMENT_MASK)));
   // Adjust the base width to account for the byte offset.
-  Value adjustedBaseWidth = b.add(op.getBaseWidth(), offsetInBytes);
+  Value adjustedBaseWidth = op.getBaseWidth();
+  llvm::APInt baseWidthVal;
+  if (!matchPattern(op.getBaseWidth(), m_ConstantInt(&baseWidthVal)) ||
+      !baseWidthVal.isZero())
+    adjustedBaseWidth = b.add(op.getBaseWidth(), offsetInBytes);
   // Adjust the x-coordinate offset based on the number of scalar elements.
   Value elemSizeInBytes = b.i32_val(op.getElemSizeInBits() / 8);
   Value adjustedXOffset =


### PR DESCRIPTION
When base shape to a 2d block io builtins is zero, the HW doesn't perform an out-of-bound check in 2D block IO instructions (because it doesn't know the actual size of the memory accessed).
Because the ptr operand may not be 64-bytes aligned, we compensate by adjusting the base width and the offset X passed to the builtin. However, this causes the base width to no longer be zero, and so the HW assumes that the updated base width is the full memory width, and consequently it ends up loading nothing.
Note: zero base width is used in our raise block pointer pass.