### PR TITLE
[tritonintelgpu-remove-layout-conversions]: Failure to find `make_tensor_ptr` operation for `tt.store` within while loop.

### DIFF
--- a/third_party/intel/include/Utils/Utility.h
+++ b/third_party/intel/include/Utils/Utility.h
@@ -4,6 +4,9 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Value.h"
 
+namespace mlir::triton {
+class MakeTensorPtrOp;
+}
 namespace mlir::triton::intel {
 
 // Lookup for a integer constant with the given value and bitwidth in the
@@ -11,6 +14,10 @@ namespace mlir::triton::intel {
 // otherwise create a new one.
 Value findOrCreateIntConstant(Location loc, int val, unsigned bitWidth,
                               OpBuilder &builder);
+
+// Find the defining makeTensorPtrOp operation of the given value.
+std::optional<mlir::triton::MakeTensorPtrOp>
+findDefiningMakeTensorPtrOp(Value val);
 
 // This function folds the `op` operation and returns the constant value if it
 // has successfully folded to a constant. Otherwise, it returns `std::nullopt`.

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -735,9 +735,10 @@ bool LayoutPropagation::rewriteStoreOp(StoreOp storeOp) {
   // Locate the operation that created the block pointer.
   std::optional<triton::MakeTensorPtrOp> defOp =
       triton::intel::findDefiningMakeTensorPtrOp(ptr);
-  assert(defOp &&
-         "MakeTensorPtrOp should be the only op that creates a tensor pointer");
-  auto makeTensorPtrOp = *defOp;
+  if (!defOp)
+    return false;
+
+  triton::MakeTensorPtrOp makeTensorPtrOp = *defOp;
 
   // DPAS encoding have to be propagated if conversion from a DPAS layout to
   // another layout has been done before.


### PR DESCRIPTION
This PR introduces a centralized helper to trace back to the defining MakeTensorPtrOp for a tensor pointer, and updates two GPU transformation passes to use it. It fixes issue #4336.