### PR TITLE
[tritonintelgpu-materialize-block-pointer]: Failure to retrieve `make_tensor_ptr` operation for load fed by `tt.advance` in a `scf.for` loop.loop.

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -55,7 +55,8 @@ public:
              "Expected 'loadOp' to load a tensor value.");
 
       // Find the make tensor ptr operation that created the base ptr.
-      std::optional<tt::MakeTensorPtrOp> defOp = tt::intel::findDefiningMakeTensorPtrOp(ptr);
+      std::optional<tt::MakeTensorPtrOp> defOp =
+          tt::intel::findDefiningMakeTensorPtrOp(ptr);
       if (!defOp) {
         LDBG("Could not find make tensor ptr op for: " << loadOp);
         return;

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -55,11 +55,13 @@ public:
              "Expected 'loadOp' to load a tensor value.");
 
       // Find the make tensor ptr operation that created the base ptr.
-      tt::MakeTensorPtrOp makeTensorPtrOp = tt::getMakeTensorPtrOp(ptr);
-      if (!makeTensorPtrOp) {
+      std::optional<tt::MakeTensorPtrOp> defOp = tt::intel::findDefiningMakeTensorPtrOp(ptr);
+      if (!defOp) {
         LDBG("Could not find make tensor ptr op for: " << loadOp);
         return;
       }
+
+      tt::MakeTensorPtrOp makeTensorPtrOp = *defOp;
       LDBG("Make tensor ptr op: " << makeTensorPtrOp);
 
       Operation::operand_range shape = makeTensorPtrOp.getShape();
@@ -290,9 +292,12 @@ private:
 
     // Find the make tensor ptr operation that created the base ptr for the load
     // operation.
-    tt::MakeTensorPtrOp makeTensorPtrOp = tt::getMakeTensorPtrOp(ptr);
-    assert(makeTensorPtrOp && "Expected a make tensor ptr op.");
+    std::optional<tt::MakeTensorPtrOp> defOp =
+        tt::intel::findDefiningMakeTensorPtrOp(ptr);
+    if (!defOp)
+      return false;
 
+    tt::MakeTensorPtrOp makeTensorPtrOp = *defOp;
     Operation::operand_range shape = makeTensorPtrOp.getShape();
     if (shape.size() == 1)
       return false;


### PR DESCRIPTION
The materialize block ptr transformation trips on an assertion because it cannot locate the `make_tensor_ptr` operation that crated the block ptr used by a `tt.load` via a `tt.select` -> `tt.advance` -> `tt.load` use-def chain. 

Fixes issue #4342.