### PR TITLE
Address post review comment #4344

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -295,9 +295,7 @@ private:
     // operation.
     std::optional<tt::MakeTensorPtrOp> defOp =
         tt::intel::findDefiningMakeTensorPtrOp(ptr);
-    if (!defOp)
-      return false;
-
+    assert(defOp && "Expected a make tensor ptr op.");
     tt::MakeTensorPtrOp makeTensorPtrOp = *defOp;
     Operation::operand_range shape = makeTensorPtrOp.getShape();
     if (shape.size() == 1)


### PR DESCRIPTION
In the scope of `satisfies2DBlockReadAlignment`, it expects make tensor pointer op to be found. 