### PR TITLE
Fix assertion and enable test 'test_tensor_descriptor_batched_gemm_2d'

### DIFF
--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -759,8 +759,6 @@ def batched_gemm_2d_tma_kernel(a_ptr, b_ptr, c_ptr,  #
 
 @pytest.mark.interpreter
 def test_tensor_descriptor_batched_gemm_2d_tma(device):
-    if is_xpu():
-        pytest.skip("FIXME: issue #4132")
     BLOCK_M, BLOCK_N, BLOCK_K = 128, 256, 64
 
     if is_hip():

--- a/scripts/skiplist/lts/language.txt
+++ b/scripts/skiplist/lts/language.txt
@@ -379,4 +379,5 @@ python/test/unit/language/test_tensor_descriptor.py::test_mxfp8_mxfp4_matmul_tma
 python/test/unit/language/test_tensor_descriptor.py::test_mxfp8_mxfp4_matmul_tma[3-128-256-256-1024-512-256]
 python/test/unit/language/test_tensor_descriptor.py::test_mxfp8_mxfp4_matmul_tma[3-128-256-256-128-256-256]
 python/test/unit/language/test_tensor_descriptor.py::test_mxfp8_mxfp4_matmul_tma[3-128-256-256-8192-8192-8192]
+python/test/unit/language/test_tensor_descriptor.py::test_tensor_descriptor_batched_gemm_2d_tma
 python/test/unit/language/test_tensor_descriptor.py::test_tensor_descriptor_batched_gemm_3d_tma

--- a/third_party/intel/lib/TritonIntelGPUTransforms/Coalesce.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Coalesce.cpp
@@ -395,11 +395,14 @@ private:
                "Expecting operand to have blocked pointer type");
         std::optional<tt::MakeTensorPtrOp> defOp =
             triton::intel::findDefiningMakeTensorPtrOp(operand);
-        assert(defOp && "Expecting a MakeTensorPtr operation");
-        LLVM_DEBUG({
-          llvm::dbgs() << "[" DEBUG_TYPE "]: Found definition: " << defOp
-                       << "\n";
-        });
+        if (!defOp) {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "[" DEBUG_TYPE
+                        "]: Could not find 'make_tensor_ptr' definition for "
+                     << operand << "\n");
+          return;
+        }
+
         IRRewriter rewriter(builder);
         changeAndPropagateLayout(*defOp, encoding, rewriter);
         newArgs.push_back(operand);


### PR DESCRIPTION
The coalescing pass attempts to find the `make_tensor_ptr` operation that created the block pointer used by candidate `tt.load` operations.  When the block pointer definition is yielded by a `scf.if` and also by the loop int arguments, an assertion is triggered. The assertion is fixed by enhancing the logic used to find the `make_tensor_ptr` definition. 
Fixes issue #4356 and allows tensor descriptor test `test_tensor_descriptor_batched_gemm_2d_tma` to pass.
