### PR TITLE
GitHub workflow to build PyTorch wheels

### DIFF
--- a/.github/workflows/wheels-pytorch.yml
+++ b/.github/workflows/wheels-pytorch.yml
@@ -57,6 +57,7 @@ jobs:
           git checkout $pytorch_commit
           git submodule update --init --recursive
           bash -c '../scripts/patch-pytorch.sh'
+          echo "PyTorch commit: $pytorch_commit"
 
       - name: Create venv
         run: |
@@ -77,6 +78,15 @@ jobs:
           cd pytorch/.github/scripts
           python -c 'from generate_binary_build_matrix import PYTORCH_EXTRA_INSTALL_REQUIREMENTS; print(PYTORCH_EXTRA_INSTALL_REQUIREMENTS["xpu"])' | Tee-Object -Variable PYTORCH_EXTRA_INSTALL_REQUIREMENTS
           echo "PYTORCH_EXTRA_INSTALL_REQUIREMENTS=$PYTORCH_EXTRA_INSTALL_REQUIREMENTS" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Set PyTorch version
+        run: |
+          cd ${{ env.NEW_WORKSPACE }}
+          cd pytorch
+          $pytorch_version = Get-Content version.txt
+          $pytorch_version = "$pytorch_version.post${{ env.GITHUB_RUN_NUMBER }}"
+          echo "$pytorch_version" > version.txt
+          echo "PyTorch version: $pytorch_version"
 
       - name: Build PyTorch wheels
         run: |

--- a/.github/workflows/wheels-pytorch.yml
+++ b/.github/workflows/wheels-pytorch.yml
@@ -1,0 +1,130 @@
+name: PyTorch wheels
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/wheels-pytorch.yml
+      - .github/pins/pytorch.txt
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/wheels-pytorch.yml
+      - .github/pins/pytorch.txt
+
+permissions: read-all
+
+env:
+  NEW_WORKSPACE: C:\gh${{ github.run_id }}
+
+jobs:
+  windows:
+    runs-on:
+      - windows
+      - b580
+    strategy:
+      matrix:
+        python:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+      fail-fast: false
+      max-parallel: 2
+    steps:
+      - name: Checkout Triton repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Clean up old workspaces
+        shell: bash
+        run: |
+          rm -rf /c/gh*
+
+      # Copy workspace to a temporary location with a shorter name.
+      - name: Copy workspace
+        run: |
+          Copy-Item -Path ${{ github.workspace }} -Destination ${{ env.NEW_WORKSPACE }} -Recurse
+
+      - name: Checkout PyTorch repository
+        run: |
+          cd ${{ env.NEW_WORKSPACE }}
+          $pytorch_commit = Get-Content .github/pins/pytorch.txt
+          git clone --single-branch -b main --recurse-submodules -j8 https://github.com/pytorch/pytorch.git
+          cd pytorch
+          git checkout $pytorch_commit
+          git submodule update --init --recursive
+          bash -c '../scripts/patch-pytorch.sh'
+
+      - name: Create venv
+        run: |
+          cd ${{ env.NEW_WORKSPACE }}
+          python -m venv .venv
+
+      - name: Install build dependencies
+        run: |
+          cd ${{ env.NEW_WORKSPACE }}
+          .venv\Scripts\activate.ps1
+          cd pytorch
+          pip install cibuildwheel
+
+      - name: Identify runtime dependencies
+        run: |
+          cd ${{ env.NEW_WORKSPACE }}
+          .venv\Scripts\activate.ps1
+          cd pytorch/.github/scripts
+          python -c 'from generate_binary_build_matrix import PYTORCH_EXTRA_INSTALL_REQUIREMENTS; print(PYTORCH_EXTRA_INSTALL_REQUIREMENTS["xpu"])' | Tee-Object -Variable PYTORCH_EXTRA_INSTALL_REQUIREMENTS
+          echo "PYTORCH_EXTRA_INSTALL_REQUIREMENTS=$PYTORCH_EXTRA_INSTALL_REQUIREMENTS" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Build PyTorch wheels
+        run: |
+          cd ${{ env.NEW_WORKSPACE }}
+          .venv\Scripts\activate.ps1
+          Invoke-BatchFile "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+
+          cd pytorch
+
+          # Required to build on Windows
+          $env:CMAKE_SHARED_LINKER_FLAGS = "/FORCE:MULTIPLE"
+          $env:CMAKE_MODULE_LINKER_FLAGS = "/FORCE:MULTIPLE"
+          $env:CMAKE_EXE_LINKER_FLAGS = "/FORCE:MULTIPLE"
+          $env:TORCH_XPU_ARCH_LIST = "bmg,dg2,arl-h,mtl-h"
+
+          $env:CIBW_BUILD_VERBOSITY = "1"
+          $env:CIBW_SKIP = "cp{35,36,37}-*"
+          $env:CIBW_BUILD = "cp" + "${{ matrix.python}}".replace(".", "") + "*-win_amd64"
+          $env:CIBW_CACHE_PATH = "${{ env.NEW_WORKSPACE }}/cibw"
+          $env:USE_XCCL = "1"
+          $env:CIBW_BEFORE_BUILD = "pip install -r requirements.txt"
+
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Artifact name
+        run: |
+          (Get-ChildItem -Path "${{ env.NEW_WORKSPACE }}\pytorch\wheelhouse\*.whl").Name | Tee-Object -Variable WHEELS_NAME
+          echo "WHEELS_NAME=$WHEELS_NAME" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.WHEELS_NAME }}
+          path: ${{ env.NEW_WORKSPACE }}\pytorch\wheelhouse\*.whl
+
+      - name: Clean up workspace
+        if: ${{ always() }}
+        run: |
+          Remove-Item -LiteralPath ${{ env.NEW_WORKSPACE }} -Force -Recurse -ErrorAction Ignore
+
+      - name: Clean up temporary files
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          rm -rf rm -rf /tmp/triton-* /tmp/tmp*

--- a/.github/workflows/wheels-pytorch.yml
+++ b/.github/workflows/wheels-pytorch.yml
@@ -2,12 +2,6 @@ name: PyTorch wheels
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - .github/workflows/wheels-pytorch.yml
-      - .github/pins/pytorch.txt
   push:
     branches:
       - main

--- a/.github/workflows/wheels-pytorch.yml
+++ b/.github/workflows/wheels-pytorch.yml
@@ -2,6 +2,12 @@ name: PyTorch wheels
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/wheels-pytorch.yml
+      - .github/pins/pytorch.txt
   push:
     branches:
       - main

--- a/.github/workflows/wheels-pytorch.yml
+++ b/.github/workflows/wheels-pytorch.yml
@@ -90,7 +90,7 @@ jobs:
           cd ${{ env.NEW_WORKSPACE }}
           cd pytorch
           $pytorch_version = Get-Content version.txt
-          $pytorch_version = "$pytorch_version.post${{ env.GITHUB_RUN_NUMBER }}"
+          $pytorch_version = "$pytorch_version.post$env:GITHUB_RUN_NUMBER"
           echo "$pytorch_version" > version.txt
           echo "PyTorch version: $pytorch_version"
 


### PR DESCRIPTION
New workflow to build PyTorch wheels.
This workflow can be triggered manually and also triggered by PyTorch pin update. The wheels have correct runtime dependencies, so DLE is not required (#4195). Currently only wheels for Windows are supported to enable E2E on Windows (#3591).