### PR TITLE
Enable `xcit_large_24_p8_224` model

### DIFF
--- a/.github/models/accuracy/timm_models.txt
+++ b/.github/models/accuracy/timm_models.txt
@@ -4,3 +4,4 @@ gmixer_24_224
 mobilenetv3_large_100
 nfnet_l0
 tnt_s_patch16_224
+xcit_large_24_p8_224


### PR DESCRIPTION
Before this, we didn't launch it: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15184972314

https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15441126244/job/43458966815 (`torch._inductor.exc.InductorError: RuntimeError: Triton Error [ZE]: 0x70000004`)