### PR TITLE
Revert "Fix E2E performance workload (#3528)"

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -210,7 +210,7 @@ jobs:
         if: ${{ inputs.suite == 'torchbench' }}
         run: |
           cd benchmark
-          pip install -r requirements.txt
+          python install.py
           pip install -e .
 
       - name: Run e2e ${{ inputs.test_mode }} tests


### PR DESCRIPTION
No more problems when installing this way. Moreover, `install.py` also downloads datasets, I'm not sure why I didn't see this problem in the logs last time. Maybe the datasets were cached.

This reverts commit 03e93233878040d82a5438f93d0bdfaad91efa23.

https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15442076981 (installation passed)