### PR TITLE
Require `filecheck` >= v1.0.0

### DIFF
--- a/scripts/requirements-test.txt
+++ b/scripts/requirements-test.txt
@@ -1,5 +1,5 @@
 # Keep in sync with extra_require.tests from setup.py
-filecheck
+filecheck>=1.0.0
 lit
 numpy
 pytest


### PR DESCRIPTION
Fixes `ModuleNotFoundError: No module named 'filecheck.options'`