### PR TITLE
Use Python 3.10 in CI

### DIFF
--- a/.github/workflows/auto-update-translator-cid.yml
+++ b/.github/workflows/auto-update-translator-cid.yml
@@ -44,13 +44,13 @@ jobs:
           CACHE_NUMBER: 1
         with:
           path: $HOME/.cache/pip
-          key: pip-3.9-${{ hashFiles('pyproject.toml', 'setup.py') }}-${{ env.CACHE_NUMBER }}
+          key: pip-3.10-${{ hashFiles('pyproject.toml', 'setup.py') }}-${{ env.CACHE_NUMBER }}
 
-      - name: Install Python 3.9
+      - name: Install Python 3.10
         if: ${{ env.TARGET_PRID == null }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Setup PyTorch
         if: ${{ env.TARGET_PRID == null }}

--- a/.github/workflows/build-test-gpu.yml
+++ b/.github/workflows/build-test-gpu.yml
@@ -51,7 +51,7 @@ jobs:
     name: Integration tests matrix
     strategy:
       matrix:
-        python: ["3.9"]
+        python: ["3.10"]
     uses: ./.github/workflows/build-test-reusable.yml
     with:
       device: ${{ inputs.runner_label }}

--- a/.github/workflows/build-test-spirv.yml
+++ b/.github/workflows/build-test-spirv.yml
@@ -10,7 +10,7 @@ jobs:
     name: Integration tests matrix
     uses: ./.github/workflows/build-test-reusable.yml
     with:
-      python_version: "3.9"
+      python_version: "3.10"
       skip_list: default
       build_llvm: true
       use_spirv_backend: true

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Clean up old workspaces
         shell: bash

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -108,7 +108,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.9"
+          - "3.10"
         driver: ${{ fromJson((inputs.runner_label || '') == '' && '["rolling", "lts"]' || '["rolling"]') }}
 
     uses: ./.github/workflows/build-test-reusable.yml

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Clean up old workspaces
         shell: bash

--- a/.github/workflows/inductor-tests-reusable.yml
+++ b/.github/workflows/inductor-tests-reusable.yml
@@ -18,7 +18,7 @@ on:
       python_version:
         description: Python version
         type: string
-        default: "3.9"
+        default: "3.10"
       pytorch_repo:
         description: PyTorch repo (e.g. user/repo)
         type: string

--- a/.github/workflows/inductor-tests-windows.yml
+++ b/.github/workflows/inductor-tests-windows.yml
@@ -27,7 +27,7 @@ on:
       python_version:
         description: Python version
         type: string
-        default: "3.9"
+        default: "3.10"
       run_name:
         description: Custom run name
         type: string
@@ -37,7 +37,7 @@ permissions: read-all
 
 env:
   PYTHONIOENCODING: utf-8
-  PYTHON_VERSION: "${{ inputs.python_version || '3.9' }}"
+  PYTHON_VERSION: "${{ inputs.python_version || '3.10' }}"
   NEW_WORKSPACE: C:\gh${{ github.run_id }}
 
 jobs:

--- a/.github/workflows/inductor-tests.yml
+++ b/.github/workflows/inductor-tests.yml
@@ -23,7 +23,7 @@ on:
       python_version:
         description: Python version
         type: string
-        default: "3.9"
+        default: "3.10"
       run_name:
         description: Custom run name
         type: string
@@ -74,7 +74,7 @@ jobs:
     uses: ./.github/workflows/inductor-tests-reusable.yml
     with:
       pytorch_repo: ${{ inputs.pytorch_repo || 'pytorch/pytorch' }}
-      python_version: ${{ inputs.python_version || '3.9' }}
+      python_version: ${{ inputs.python_version || '3.10' }}
       runner_label: ${{ inputs.runner_label || '' }}
       suite: ${{ needs.compute-params.outputs.suite }}
       pytorch_ref: ${{ inputs.pytorch_ref || '' }}

--- a/.github/workflows/pip-test-windows.yml
+++ b/.github/workflows/pip-test-windows.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Clean up old workspaces
         shell: bash

--- a/.github/workflows/pip-test.yml
+++ b/.github/workflows/pip-test.yml
@@ -25,7 +25,7 @@ on:
 permissions: read-all
 
 env:
-  PYTHON_VERSION: '3.9'
+  PYTHON_VERSION: '3.10'
   TRITON_TEST_CMD: scripts/test-triton.sh --skip-pytorch-install
 
 jobs:

--- a/.github/workflows/spirvrunner-test.yml
+++ b/.github/workflows/spirvrunner-test.yml
@@ -13,7 +13,7 @@ on:
 permissions: read-all
 
 env:
-  PYTHON_VERSION: '3.9'
+  PYTHON_VERSION: '3.10'
 
 jobs:
   tests:


### PR DESCRIPTION
We have new test time dependencies that do not exist for Python 3.9 (#4424).

Note 1: we will continue building the wheels for 3.9 and will test with Python 3.9 with ["Build and test Python"](https://github.com/intel/intel-xpu-backend-for-triton/actions/workflows/build-test-python.yml) (going to skip tests that reuire the new dependency, will do in a separate PR).

Note 2: we need to update branch protection rules before merging this PR.