### PR TITLE
Run `02-fused-softmax` on A770

### DIFF
--- a/scripts/skiplist/a770/tutorials.txt
+++ b/scripts/skiplist/a770/tutorials.txt
@@ -1,4 +1,3 @@
-02-fused-softmax
 03i-matrix-multiplication
 06-fused-attention
 08-grouped-gemm


### PR DESCRIPTION
I don't know exactly why me disabled this test on A770. However, after this change https://github.com/intel/intel-xpu-backend-for-triton/pull/4383 , it should run more stably.

* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15451596487 (`02-fused-softmax` passed)