### PR TITLE
Add `09-persistent-matmul` into A770 skiplist

### DIFF
--- a/scripts/skiplist/a770/tutorials.txt
+++ b/scripts/skiplist/a770/tutorials.txt
@@ -1,5 +1,6 @@
 03i-matrix-multiplication
 06-fused-attention
 08-grouped-gemm
+09-persistent-matmul
 10-experimental-block-pointer
 10i-experimental-block-pointer


### PR DESCRIPTION
```bash
    return self.shared_library.load_binary(args)
RuntimeError: Triton Error [ZE]: 0x78000011
```

https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15451596487