### PR TITLE
Add declaration warnings suppression option

### DIFF
--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -96,6 +96,8 @@ def _build(name: str, src: str, srcdir: str, library_dirs: list[str], include_di
         else:
             if os.name != "nt":
                 extra_compile_args += ["--std=c++17"]
+            if os.environ.get("TRITON_SUPPRESS_HOST_CODE_DEPRECATION_WARNINGS"):
+                extra_compile_args += ["-Wno-deprecated-declarations"]
         if os.name == "nt":
             library_dirs = library_dirs + [
                 os.path.abspath(os.path.join(sysconfig.get_paths(scheme=scheme)["stdlib"], "..", "libs"))


### PR DESCRIPTION
After migrating to 2025.1 PyTorch is seeing excessive deprecated declarations warnings when our host code is compiled with gcc.
I was able to reproduce it with:
```bash
pip install transformers==4.44.2 pandas psutil scipy
pip install torch==2.8.0.dev20250515 --pre --index-url https://download.pytorch.org/whl/nightly/xpu
git clone https://github.com/pytorch/pytorch
cd pytorch
git checkout 46a5746426714a1b1d01c06795fa3a3c5426d9bc
rm -rf ~/.triton/ && rm -rf /tmp/torchinductor_* && rm -rf /tmp/tmp*
CXX=gcc python benchmarks/dynamo/huggingface.py --performance --float16 -d xpu -n10 --inference  --only AlbertForMaskedLM --backend=inductor
```
Though the problem is not specific to Triton, we can suppress those for the upcoming release.
