### PR TITLE
Improved performance of the fp4tofp conversion

### DIFF
--- a/test/TritonIntelGPU/fp4tofp.mlir
+++ b/test/TritonIntelGPU/fp4tofp.mlir
@@ -1,0 +1,108 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm  -canonicalize | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [16], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [32], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {triton_intel_gpu.support_bf16_conversion, triton_intel_gpu.support_dpas, triton_intel_gpu.support_sg_2d_block, triton_intel_gpu.target_arch = "spir16", ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 16384 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @fp4_to_bf16_kernel(%arg0: !tt.ptr<i8>, %arg1: !tt.ptr<bf16>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i32 = arith.constant 16 : i32
+    %c16_i64 = arith.constant 16 : i64
+    %c32_i32 = arith.constant 32 : i32
+    %c32_i64 = arith.constant 32 : i64
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c16_i32 : i32
+    %2 = tt.make_tensor_ptr %arg0, [%c16_i64], [%c1_i64], [%1] {order = array<i32: 0>, tt.divisibility = dense<16> : tensor<1xi32>} : <tensor<16xi8, #blocked>>
+    %3 = tt.load %2 : !tt.ptr<tensor<16xi8, #blocked>>
+    %4 = ttg.fp4_to_fp %3 {axis = 0 : i32} : tensor<16xi8, #blocked> -> tensor<32xbf16, #blocked1>
+    %5 = arith.muli %0, %c32_i32 : i32
+    %6 = tt.make_tensor_ptr %arg1, [%c32_i64], [%c1_i64], [%5] {order = array<i32: 0>, tt.divisibility = dense<16> : tensor<1xi32>} : <tensor<32xbf16, #blocked1>>
+    tt.store %6, %4 : !tt.ptr<tensor<32xbf16, #blocked1>>
+    tt.return
+  }
+}
+// CHECK-DAG: [[C4V:%.+]] = llvm.mlir.constant(dense<4> : vector<4xi32>) : vector<4xi32>
+// CHECK-DAG: [[C15V:%.+]] = llvm.mlir.constant(dense<252645135> : vector<4xi32>) : vector<4xi32>
+// CHECK-DAG: [[TABLE:%.+]] = llvm.mlir.constant(dense<[0.000000e+00, 5.000000e-01, 1.000000e+00, 1.500000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 6.000000e+00, -0.000000e+00, -5.000000e-01, -1.000000e+00, -1.500000e+00, -2.000000e+00, -3.000000e+00, -4.000000e+00, -6.000000e+00]> : vector<16xbf16>) : vector<16xbf16>
+// CHECK-DAG: [[C3:%.+]] = llvm.mlir.constant(3 : i32) : i32
+// CHECK: [[I32V:%.+]] = llvm.load {{.+}} : !llvm.ptr<1> -> vector<4xi32>
+// CHECK: [[IDXV0I32:%.+]] = llvm.and [[I32V]], [[C15V]] : vector<4xi32>
+// CHECK: [[LSHR:%.+]] = llvm.lshr [[I32V]], [[C4V]] : vector<4xi32>
+// CHECK: [[IDXV1I32:%.+]] = llvm.and [[LSHR]], [[C15V]] : vector<4xi32>
+// CHECK: [[IDX0I32:%.+]] = llvm.extractelement [[IDXV0I32]][[[C3]] : i32] : vector<4xi32>
+// CHECK: [[IDX1I32:%.+]] = llvm.extractelement [[IDXV1I32]][[[C3]] : i32] : vector<4xi32>
+// CHECK: [[IDXV0I8:%.+]] = llvm.bitcast [[IDX0I32]] : i32 to vector<4xi8>
+// CHECK: [[IDXV1I8:%.+]] = llvm.bitcast [[IDX1I32]] : i32 to vector<4xi8>
+// CHECK: [[IDX0I8:%.+]] = llvm.extractelement [[IDXV0I8]][[[C3]] : i32] : vector<4xi8>
+// CHECK: [[V0:%.+]] = llvm.extractelement [[TABLE]][[[IDX0I8]] : i8] : vector<16xbf16>
+// CHECK: [[IDX1I8:%.+]] = llvm.extractelement [[IDXV1I8]][[[C3]] : i32] : vector<4xi8>
+// CHECK: [[V1:%.+]] = llvm.extractelement [[TABLE]][[[IDX1I8]] : i8] : vector<16xbf16>
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [16], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [32], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {triton_intel_gpu.support_bf16_conversion, triton_intel_gpu.support_dpas, triton_intel_gpu.support_sg_2d_block, triton_intel_gpu.target_arch = "spir16", ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 16384 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @fp4_to_bf16_kernel(%arg0: !tt.ptr<i8>, %arg1: !tt.ptr<bf16>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i32 = arith.constant 16 : i32
+    %c16_i64 = arith.constant 16 : i64
+    %c32_i32 = arith.constant 32 : i32
+    %c32_i64 = arith.constant 32 : i64
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c16_i32 : i32
+    %2 = tt.make_tensor_ptr %arg0, [%c16_i64], [%c1_i64], [%1] {order = array<i32: 0>, tt.divisibility = dense<4> : tensor<1xi32>} : <tensor<16xi8, #blocked>>
+    %3 = tt.load %2 : !tt.ptr<tensor<16xi8, #blocked>>
+    %4 = ttg.fp4_to_fp %3 {axis = 0 : i32} : tensor<16xi8, #blocked> -> tensor<32xbf16, #blocked1>
+    %5 = arith.muli %0, %c32_i32 : i32
+    %6 = tt.make_tensor_ptr %arg1, [%c32_i64], [%c1_i64], [%5] {order = array<i32: 0>, tt.divisibility = dense<4> : tensor<1xi32>} : <tensor<32xbf16, #blocked1>>
+    tt.store %6, %4 : !tt.ptr<tensor<32xbf16, #blocked1>>
+    tt.return
+  }
+}
+// CHECK-DAG: [[C4V:%.+]] = llvm.mlir.constant(dense<4> : vector<4xi8>) : vector<4xi8>
+// CHECK-DAG: [[C15V:%.+]] = llvm.mlir.constant(dense<15> : vector<4xi8>) : vector<4xi8>
+// CHECK-DAG: [[TABLE:%.+]] = llvm.mlir.constant(dense<[0.000000e+00, 5.000000e-01, 1.000000e+00, 1.500000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 6.000000e+00, -0.000000e+00, -5.000000e-01, -1.000000e+00, -1.500000e+00, -2.000000e+00, -3.000000e+00, -4.000000e+00, -6.000000e+00]> : vector<16xbf16>) : vector<16xbf16>
+// CHECK-DAG: [[C3:%.+]] = llvm.mlir.constant(3 : i32) : i32
+// CHECK: [[I32:%.+]] = llvm.load {{.+}} {alignment = 4 : i64} : !llvm.ptr<1> -> i32
+// CHECK: [[IDXVI8:%.+]] = llvm.bitcast [[I32]] : i32 to vector<4xi8>
+// CHECK: [[IDXV0I8:%.+]] = llvm.and [[IDXVI8]], [[C15V]] : vector<4xi8>
+// CHECK: [[IDXV1I8:%.+]] = llvm.lshr [[IDXVI8]], [[C4V]] : vector<4xi8>
+// CHECK: [[IDX0I8:%.+]] = llvm.extractelement [[IDXV0I8]][[[C3]] : i32] : vector<4xi8>
+// CHECK: [[V0:%.+]] = llvm.extractelement [[TABLE]][[[IDX0I8]] : i8] : vector<16xbf16>
+// CHECK: [[IDX1I8:%.+]] = llvm.extractelement [[IDXV1I8]][[[C3]] : i32] : vector<4xi8>
+// CHECK: [[V1:%.+]] = llvm.extractelement [[TABLE]][[[IDX1I8]] : i8] : vector<16xbf16>
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [16], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [32], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {triton_intel_gpu.support_bf16_conversion, triton_intel_gpu.support_dpas, triton_intel_gpu.support_sg_2d_block, triton_intel_gpu.target_arch = "spir16", ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 16384 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @fp4_to_bf16_kernel(%arg0: !tt.ptr<i8>, %arg1: !tt.ptr<bf16>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i32 = arith.constant 16 : i32
+    %c16_i64 = arith.constant 16 : i64
+    %c32_i32 = arith.constant 32 : i32
+    %c32_i64 = arith.constant 32 : i64
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c16_i32 : i32
+    %2 = tt.make_tensor_ptr %arg0, [%c16_i64], [%c1_i64], [%1] {order = array<i32: 0>, tt.divisibility = dense<1> : tensor<1xi32>} : <tensor<16xi8, #blocked>>
+    %3 = tt.load %2 : !tt.ptr<tensor<16xi8, #blocked>>
+    %4 = ttg.fp4_to_fp %3 {axis = 0 : i32} : tensor<16xi8, #blocked> -> tensor<32xbf16, #blocked1>
+    %5 = arith.muli %0, %c32_i32 : i32
+    %6 = tt.make_tensor_ptr %arg1, [%c32_i64], [%c1_i64], [%5] {order = array<i32: 0>, tt.divisibility = dense<1> : tensor<1xi32>} : <tensor<32xbf16, #blocked1>>
+    tt.store %6, %4 : !tt.ptr<tensor<32xbf16, #blocked1>>
+    tt.return
+  }
+}
+// CHECK-DAG: [[C4:%.+]] = llvm.mlir.constant(4 : i8) : i8
+// CHECK-DAG: [[C15:%.+]] = llvm.mlir.constant(15 : i8) : i8
+// CHECK-DAG: [[TABLE:%.+]] = llvm.mlir.constant(dense<[0.000000e+00, 5.000000e-01, 1.000000e+00, 1.500000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 6.000000e+00, -0.000000e+00, -5.000000e-01, -1.000000e+00, -1.500000e+00, -2.000000e+00, -3.000000e+00, -4.000000e+00, -6.000000e+00]> : vector<16xbf16>) : vector<16xbf16>
+// CHECK-DAG: [[C3:%.+]] = llvm.mlir.constant(3 : i32) : i32
+// CHECK-DAG: [[C0:%.+]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-COUNT-16: [[I8:%.+]] = llvm.load {{.+}} {alignment = 1 : i64} : !llvm.ptr<1> -> i8
+// CHECK: [[I8V:%.+]] = llvm.bitcast [[I8]] : i8 to vector<1xi8>
+// CHECK: [[I8:%.+]] = llvm.extractelement [[I8V]][[[C0]] : i32] : vector<1xi8>
+// CHECK: [[IDX0I8:%.+]] = llvm.and [[I8]], [[C15]] : i8
+// CHECK: [[IDX1I8:%.+]] = llvm.lshr [[I8]], [[C4]] : i8
+// CHECK: [[V0:%.+]] = llvm.extractelement [[TABLE]][[[IDX0I8]] : i8] : vector<16xbf16>
+// CHECK: [[V1:%.+]] = llvm.extractelement [[TABLE]][[[IDX1I8]] : i8] : vector<16xbf16>

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Fp4ToFpOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Fp4ToFpOpToLLVM.cpp
@@ -13,6 +13,38 @@ using namespace mlir::triton::gpu;
 using namespace mlir::triton::gpu::intel;
 
 namespace {
+struct CachingBuilder : TritonLLVMOpBuilder {
+  CachingBuilder(Location loc, OpBuilder &builder)
+      : TritonLLVMOpBuilder(loc, builder) {}
+
+  Value dense_val(const ShapedType &type, ArrayRef<Attribute> values) {
+    auto attr = DenseElementsAttr::get(type, values);
+    return getOrCreateConstant(type, attr);
+  }
+
+  Value i8_val(int64_t val) { return int_val(8, val); }
+  Value i32_val(int64_t val) { return int_val(32, val); }
+
+  Value int_val(short bitwidth, int64_t val) {
+    Type ty = builder->getIntegerType(bitwidth);
+    Attribute attr = builder->getIntegerAttr(ty, val);
+    return getOrCreateConstant(ty, attr);
+  }
+
+private:
+  DenseMap<std::pair<Type, Attribute>, Value> constCache;
+
+  Value getOrCreateConstant(Type type, Attribute attr) {
+    auto key = std::make_pair(type, attr);
+    auto it = constCache.find(key);
+    if (it != constCache.end())
+      return it->second;
+    auto cst = builder->create<LLVM::ConstantOp>(loc, type, attr);
+    constCache[key] = cst;
+    return cst;
+  }
+};
+
 class Fp4ToFpOpPattern : public ConvertOpToLLVMPattern<Fp4ToFpOp> {
 public:
   Fp4ToFpOpPattern(LLVMTypeConverter &typeConverter, PatternBenefit benefit)
@@ -22,50 +54,234 @@ public:
   matchAndRewrite(Fp4ToFpOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
-    Type elemType = op.getType().getElementType();
-    assert(elemType == f16_ty || elemType == bf16_ty);
-
     SmallVector<Value> results;
+
     {
-      SmallVector<Value> xVals =
-          unpackLLElements(loc, adaptor.getSrc(), rewriter);
-      convertMxfp4x2ToFloat(rewriter, loc, xVals, results,
-                            elemType == f16_ty ? f16_ty : bf16_ty);
+      CachingBuilder b(loc, rewriter);
+      // Create a constant vector containing all the possible values
+      Value table;
+      {
+        auto elemTy = dyn_cast<FloatType>(op.getType().getElementType());
+        assert(elemTy == f16_ty || elemTy == bf16_ty);
+        SmallVector<Attribute, 16> values;
+        for (double v : {0., 0.5, 1., 1.5, 2., 3., 4., 6., -0., -0.5, -1., -1.5,
+                         -2., -3., -4., -6.})
+          values.push_back(b.builder->getFloatAttr(elemTy, v));
+        table = b.dense_val(VectorType::get({16}, elemTy), values);
+      }
+
+      SmallVector<Value> values;
+      Value src = adaptor.getSrc();
+      auto i8Ty = b.builder->getI8Type();
+      collectValues(b, src, values);
+
+      for (auto value : values) {
+        if (auto vecTy = dyn_cast_or_null<VectorType>(value.getType());
+            !vecTy) {
+          assert(value.getType() == i8Ty);
+          Value idx1 = b.and_(value, b.i8_val(15));
+          Value idx2 = b.lshr(value, b.i8_val(4));
+          results.push_back(b.extract_element(table, idx1));
+          results.push_back(b.extract_element(table, idx2));
+        } else if (vecTy.getElementType() == b.builder->getI32Type()) {
+          ShapedType i8VecTy = VectorType::get(4, i8Ty);
+          auto andVect =
+              b.dense_val(vecTy, b.builder->getI32IntegerAttr(0x0F0F0F0F));
+          auto shVec = b.dense_val(vecTy, b.builder->getI32IntegerAttr(4));
+          Value i32IdxVec1 = b.and_(value, andVect);
+          Value i32IdxVec2 = b.and_(b.lshr(value, shVec), andVect);
+          // Extract each value from i32 vectors and cast to i8 vectors
+          for (int32_t i = 0, n = vecTy.getNumElements(); i < n; ++i) {
+            auto idx = b.i32_val(i);
+            Value i1 = b.extract_element(i32IdxVec1, idx);
+            Value i2 = b.extract_element(i32IdxVec2, idx);
+            Value idxVec1 = b.bitcast(i1, i8VecTy);
+            Value idxVec2 = b.bitcast(i2, i8VecTy);
+            extractFloats(b, idxVec1, idxVec2, vecTy.getNumElements(), results,
+                          table);
+          }
+        } else {
+          assert(vecTy.getElementType() == i8Ty);
+          auto andVect = b.dense_val(vecTy, b.builder->getI8IntegerAttr(0x0F));
+          auto shVec = b.dense_val(vecTy, b.builder->getI8IntegerAttr(4));
+          Value idxVec1 = b.and_(value, andVect);
+          Value idxVec2 = b.lshr(value, shVec);
+          extractFloats(b, idxVec1, idxVec2, vecTy.getNumElements(), results,
+                        table);
+        }
+      }
     }
+
     rewriter.replaceOp(op, packLLElements(loc, getTypeConverter(), results,
                                           rewriter, op.getType()));
     return success();
   }
 
 private:
-  static void convertMxfp4x2ToFloat(RewriterBase &rewriter, Location loc,
-                                    SmallVector<Value> &values,
-                                    SmallVector<Value> &results,
-                                    FloatType floatTy) {
-    assert(results.empty() && !values.empty());
-
-    Value table;
-    { // Create a constant vector containing all the possible values
-      auto vecTy = VectorType::get({16}, floatTy);
-      SmallVector<Attribute, 16> values;
-      for (double v : {0., 0.5, 1., 1.5, 2., 3., 4., 6., -0., -0.5, -1., -1.5,
-                       -2., -3., -4., -6.})
-        values.push_back(rewriter.getFloatAttr(floatTy, v));
-      table = rewriter.create<LLVM::ConstantOp>(
-          loc, vecTy, DenseElementsAttr::get(vecTy, values));
+  static void collectValues(CachingBuilder &b, Value src,
+                            SmallVector<Value> &values) {
+    auto structTy = dyn_cast_or_null<LLVM::LLVMStructType>(src.getType());
+    if (!structTy) {
+      values.emplace_back(src);
+      return;
     }
 
-    TritonLLVMOpBuilder b(loc, rewriter);
-    Value i8_4 = b.i8_val(4);
-    Value i8_15 = b.i8_val(15);
-    results.reserve(values.size() * 2);
-    for (Value v : values) {
-      // The first and last 4 bits are the values indices in the table
-      Value idx1 = b.and_(v, i8_15);
-      Value idx2 = b.lshr(v, i8_4);
-      results.push_back(b.extract_element(table, idx1));
-      results.push_back(b.extract_element(table, idx2));
+    // If the entire struct consists of subsequent insertvalue:
+    // %str = llvm.mlir.undef : !llvm.struct<(i8, i8)>
+    // %str0 = llvm.insertvalue %v0, %str[0] : !llvm.struct<(i8, i8)>
+    // %str1 = llvm.insertvalue %v1, %str0[1] : !llvm.struct<(i8, i8)>
+    // use the inserted values (%v0 and %v1) instead of adding the
+    // extractvalue operations.
+    auto i8Ty = b.builder->getI8Type();
+    auto remaining = structTy.getBody().size();
+    values.resize(remaining);
+    for (auto ins = src.getDefiningOp<LLVM::InsertValueOp>();
+         ins && ins.getPosition()[0] == remaining - 1;
+         ins = ins.getContainer().getDefiningOp<LLVM::InsertValueOp>()) {
+      values[--remaining] = ins.getValue();
+      assert(values[remaining].getType() == i8Ty);
     }
+
+    // Add the remaining values, if any.
+    if (remaining) {
+      for (auto [i, type] : llvm::enumerate(
+               llvm::make_range(structTy.getBody().begin(),
+                                structTy.getBody().begin() + remaining))) {
+        assert(type == i8Ty);
+        values[i] = b.extract_val(type, src, i);
+      }
+    }
+
+    // Detect subsequent extractions of all vallues from an i8 vector:
+    // %c0 = llvm.mlir.constant(0 : i32) : i32
+    // %e0 = llvm.extractelement %i8vec[%c0 : i32] : vector<2xi8>
+    // %c1 = llvm.mlir.constant(1 : i32) : i32
+    // %e1 = llvm.extractelement %i8vec[%c1 : i32] : vector<2xi8>
+    // If values[i] == e0 and values[i + 1] == e1, replace them with i8vec.
+    if (replaceVectorExtracts(b, src, values)) {
+      // Detect subsequent extractions from i32 vector and casts to i8 vector:
+      // %c0 = llvm.mlir.constant(0 : i32) : i32
+      // %i0 = llvm.extractelement %i32vec[%c0 : i32] : vector<2xi32>
+      // %i8vec0 = llvm.bitcast %i0 : i32 to vector<4xi8>
+      // %c1 = llvm.mlir.constant(1 : i32) : i32
+      // %i1 = llvm.extractelement %i32vec[%c1 : i32] : vector<2xi32>
+      // %i8vec1 = llvm.bitcast %i1 : i32 to vector<4xi8>
+      // If values[i] == i8vec0 and values[i + 1] == i8vec1, replace them with
+      // i32vec.
+      replaceVectorCastExtracts(b, src, values);
+    }
+  }
+
+  // Extract floats from the lookup table by indices.
+  static void extractFloats(CachingBuilder &b, Value idxVec1, Value idxVec2,
+                            int32_t size, SmallVector<Value> &results,
+                            Value table) {
+    auto off = results.size();
+    results.resize(off + size * 2);
+    for (int32_t i = 0; i < size; ++i) {
+      Value idx = b.extract_element(idxVec1, b.i32_val(i));
+      results[off + 2 * i] = b.extract_element(table, idx);
+    }
+    for (int32_t i = 0; i < size; ++i) {
+      Value idx = b.extract_element(idxVec2, b.i32_val(i));
+      results[off + 2 * i + 1] = b.extract_element(table, idx);
+    }
+  }
+
+  // Detect the subsequent extractions of all vallues from an i8 vector and
+  // replace them with the vector.
+  static bool replaceVectorExtracts(CachingBuilder &b, Value src,
+                                    SmallVector<Value> &values) {
+    bool replaced = false;
+    for (unsigned i = 0; i < values.size(); i++) {
+      // If the value is an extractelement from a vector and the index is 0
+      // and the subsequent values are the extraction of all values from the
+      // same vector, replace all these values with the original vector.
+      if (auto vec = isVectorExtract(values[i], 0);
+          vec && replaceValues(
+                     values, i,
+                     dyn_cast<VectorType>(vec.getType()).getNumElements() - 1,
+                     vec, isVectorExtract)) {
+        assert(dyn_cast<VectorType>(vec.getType()).getElementType() ==
+               b.builder->getI8Type());
+        replaced = true;
+      }
+    }
+    return replaced;
+  }
+
+  // If a value is a bitcast of a value extracted from an i32 vector and the
+  // subsequent values are also extracts from the same vector, replace all
+  // them with the original vector.
+  static void replaceVectorCastExtracts(CachingBuilder &b, Value src,
+                                        SmallVector<Value> &values) {
+    auto isCastExtract = [i8Ty = b.builder->getI8Type(),
+                          i32Ty = b.builder->getI32Type()](Value &value,
+                                                           unsigned pos) {
+      if (auto bitcast = value.getDefiningOp<LLVM::BitcastOp>()) {
+        if (auto vecTy = dyn_cast_or_null<VectorType>(bitcast.getType());
+            vecTy && vecTy.getElementType() == i8Ty &&
+            vecTy.getNumElements() == 4) {
+          auto operand = bitcast.getOperand();
+          if (auto vec = isVectorExtract(operand, pos)) {
+            if (auto elType =
+                    dyn_cast<VectorType>(vec.getType()).getElementType();
+                elType == i32Ty) {
+              return vec;
+            }
+          }
+        }
+      }
+      return Value();
+    };
+
+    for (unsigned i = 0; i < values.size(); i++) {
+      if (auto vec = isCastExtract(values[i], 0)) {
+        replaceValues(values, i,
+                      dyn_cast<VectorType>(vec.getType()).getNumElements() - 1,
+                      vec, isCastExtract);
+      }
+    }
+  }
+
+  // Check if the value is an extraction from a vector at the specified
+  // position and the vector size is > 1, return the vector.
+  static Value isVectorExtract(Value value, unsigned pos) {
+    if (auto extract = value.getDefiningOp<LLVM::ExtractElementOp>()) {
+      auto operand = extract.getOperand(0);
+      if (auto vecTy = dyn_cast_or_null<VectorType>(operand.getType());
+          vecTy && vecTy.getNumElements() > 1) {
+        if (auto idx =
+                extract.getPosition().getDefiningOp<LLVM::ConstantOp>()) {
+          if (auto attr = dyn_cast_or_null<IntegerAttr>(idx.getValue());
+              attr && attr.getInt() == pos) {
+            return operand;
+          }
+        }
+      }
+    }
+    return Value();
+  }
+
+  // Replace the value at the `position` with the `replacement` and erase the
+  // `count` values after it, if the `map` function returns the `replacement`
+  // for all these values.
+  static bool
+  replaceValues(SmallVector<Value> &values, unsigned position, unsigned count,
+                Value replacement,
+                const std::function<Value(Value &, unsigned)> &map) {
+    if (position + count + 1 > values.size())
+      return false;
+    for (auto [i, v] : llvm::enumerate(
+             llvm::make_range(values.begin() + position + 1,
+                              values.begin() + position + 1 + count))) {
+      if (map(v, i + 1) != replacement)
+        return false;
+    }
+    values[position] = replacement;
+    values.erase(values.begin() + position + 1,
+                 values.begin() + position + 1 + count);
+    return true;
   }
 };
 } // anonymous namespace


### PR DESCRIPTION
Use a simple lookup table instead of explicit conversion.
Use bitwise operations on vectors to build the indices.

Fixes #4298

------------
This is another (and perhaps overcomplicated) version of #4299, that uses bitwise operations on vectors (not per element) to build the indices. The resulting llir is the following:
```MLIR
%idx_vec0 = lshr <16 x i8> %i8vec, splat (i8 4)
%idx_vec1 = and <16 x i8> %i8vec, splat (i8 15)
%idx0 = extractelement <16 x i8> %idx_vec0, i64 0
%bf0 = extractelement <16 x bfloat> <bfloat 0xR0000, bfloat 0xR3F00, bfloat 0xR3F80, bfloat 0xR3FC0, bfloat 0xR4000, bfloat 0xR4040, bfloat 0xR4080, bfloat 0xR40C0, bfloat 0xR8000, bfloat 0xRBF00, bfloat 0xRBF80, bfloat 0xRBFC0, bfloat 0xRC000, bfloat 0xRC040, bfloat 0xRC080, bfloat 0xRC0C0>, i8 %idx0
%idx1 = extractelement <16 x i8> %idx_vec1, i64 0
%bf1 = extractelement <16 x bfloat> <bfloat 0xR0000, bfloat 0xR3F00, bfloat 0xR3F80, bfloat 0xR3FC0, bfloat 0xR4000, bfloat 0xR4040, bfloat 0xR4080, bfloat 0xR40C0, bfloat 0xR8000, bfloat 0xRBF00, bfloat 0xRBF80, bfloat 0xRBFC0, bfloat 0xRC000, bfloat 0xRC040, bfloat 0xRC080, bfloat 0xRC0C0>, i8 %idx1
...
 
```
