### PR TITLE
Build PyTorch wheels

### DIFF
--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -199,13 +199,13 @@ function build_pytorch {
   pip install 'cmake<4.0.0'
   pip install -r requirements.txt
   pip install cmake ninja
-  USE_XCCL=1 USE_STATIC_MKL=1 python setup.py develop
+  USE_XCCL=1 USE_STATIC_MKL=1 python setup.py bdist_wheel
 }
 
 function install_pytorch {
   echo "****** Installing PyTorch ******"
   cd "$PYTORCH_PROJ"
-  # pip install dist/*.whl
+  pip install dist/*.whl
 }
 
 if [ "$CHECK_WHEEL" = false ] || ! pytorch_wheel_exists; then


### PR DESCRIPTION
This reverts accidental change from 19c32a78adc7c9a7fca955fae4fc9f576102ff52.

We need to use PyTorch wheels to cache them, for example, on Windows runners.
