### PR TITLE
Remove `02-fused-softmax` from ARL skiplists

### DIFF
--- a/scripts/skiplist/arl-h/tutorials.txt
+++ b/scripts/skiplist/arl-h/tutorials.txt
@@ -1,4 +1,3 @@
-02-fused-softmax
 03-matrix-multiplication
 03i-matrix-multiplication
 06-fused-attention

--- a/scripts/skiplist/arl-s/tutorials.txt
+++ b/scripts/skiplist/arl-s/tutorials.txt
@@ -1,4 +1,3 @@
-02-fused-softmax
 03-matrix-multiplication
 03i-matrix-multiplication
 06-fused-attention


### PR DESCRIPTION
Should be more stable after https://github.com/intel/intel-xpu-backend-for-triton/commit/a2f22851e5d50c93ff902d3c09e57cf10db04479