### PR TITLE
[DEBUG] Revert "Enable `SPV_INTEL_fp_fast_math_mode` (#4058)"

### DIFF
--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -292,7 +292,7 @@ void init_triton_intel(py::module &&m) {
       for (Instruction &inst : instructions(func)) {
         if (auto *op = dyn_cast<FPMathOperator>(&inst)) {
           FastMathFlags FMF;
-          // Default to allow contract when default fp fusion is not disabled.
+          // Allow contract when default fp fusion is enabled.
           if ((enableFpFusion.has_value() && enableFpFusion.value()) &&
               !fastMath.has_value()) {
             if (op->getOpcode() == Instruction::FAdd ||

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -293,7 +293,7 @@ void init_triton_intel(py::module &&m) {
         if (auto *op = dyn_cast<FPMathOperator>(&inst)) {
           FastMathFlags FMF;
           // Default to allow contract when default fp fusion is not disabled.
-          if ((!enableFpFusion.has_value() || enableFpFusion.value()) &&
+          if ((enableFpFusion.has_value() && enableFpFusion.value()) &&
               !fastMath.has_value()) {
             if (op->getOpcode() == Instruction::FAdd ||
                 op->getOpcode() == Instruction::FMul)


### PR DESCRIPTION
This reverts commit 353d6ff62fad536a7e60e5866bf28ef50a3d7126.

New CI link:
* E2E before rebase on main: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15567222381
* Inductor after rebase: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15630616934 (failed, but there is a regression on main)
* New run: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15638597833 (passed)


Before rebasing on main: there was one failure: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15617981986/job/43995909816?pr=4473

