### PR TITLE
Temporary enable `TRITON_SUPPRESS_GCC_HOST_CODE_DEPRECATION_WARNINGS` by default

### DIFF
--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -96,7 +96,7 @@ def _build(name: str, src: str, srcdir: str, library_dirs: list[str], include_di
         else:
             if os.name != "nt":
                 extra_compile_args += ["--std=c++17"]
-            if os.environ.get("TRITON_SUPPRESS_GCC_HOST_CODE_DEPRECATION_WARNINGS"):
+            if os.environ.get("TRITON_SUPPRESS_GCC_HOST_CODE_DEPRECATION_WARNINGS", "True"):
                 extra_compile_args += ["-Wno-deprecated-declarations"]
         if os.name == "nt":
             library_dirs = library_dirs + [

--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -96,7 +96,7 @@ def _build(name: str, src: str, srcdir: str, library_dirs: list[str], include_di
         else:
             if os.name != "nt":
                 extra_compile_args += ["--std=c++17"]
-            if os.environ.get("TRITON_SUPPRESS_GCC_HOST_CODE_DEPRECATION_WARNINGS", "True"):
+            if os.environ.get("TRITON_SUPPRESS_GCC_HOST_CODE_DEPRECATION_WARNINGS", "1") == "1":
                 extra_compile_args += ["-Wno-deprecated-declarations"]
         if os.name == "nt":
             library_dirs = library_dirs + [


### PR DESCRIPTION
CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15568618894