### PR TITLE
Update `inductor_xpu_test.sh`: don't add `--freezing` in reference mode; add new mode: `inference-with-freezing`

### DIFF
--- a/.github/workflows/e2e-accuracy.yml
+++ b/.github/workflows/e2e-accuracy.yml
@@ -18,12 +18,12 @@ on:
           - torchbench
         default: all
       mode:
-        description: Inference, inference-no-freezing, or training
+        description: Inference, inference-with-freezing, or training
         type: choice
         options:
           - all
           - inference
-          - inference-no-freezing
+          - inference-with-freezing
           - training
         default: all
       dtype:
@@ -86,7 +86,7 @@ jobs:
             suite='["${{ inputs.suite }}"]'
           fi
           if [[ -z "${{ inputs.mode }}" || "${{ inputs.mode }}" == "all" ]]; then
-            mode='["inference", "inference-no-freezing", "training"]'
+            mode='["inference", "inference-with-freezing", "training"]'
           else
             mode='["${{ inputs.mode }}"]'
           fi

--- a/.github/workflows/e2e-performance.yml
+++ b/.github/workflows/e2e-performance.yml
@@ -18,12 +18,12 @@ on:
           - torchbench
         default: all
       mode:
-        description: Inference, inference-no-freezing, or training
+        description: Inference, inference-with-freezing, or training
         type: choice
         options:
           - all
           - inference
-          - inference-no-freezing
+          - inference-with-freezing
           - training
         default: all
       dtype:
@@ -87,7 +87,7 @@ jobs:
             suite='["${{ inputs.suite }}"]'
           fi
           if [[ -z "${{ inputs.mode }}" || "${{ inputs.mode }}" == "all" ]]; then
-            mode='["inference", "inference-no-freezing", "training"]'
+            mode='["inference", "inference-with-freezing", "training"]'
           else
             mode='["${{ inputs.mode }}"]'
           fi

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -12,7 +12,7 @@ on:
         type: string
         default: all
       mode:
-        description: Inference, inference-no-freezing, or training
+        description: Inference, inference-with-freezing, or training
         type: string
         default: all
       test_mode:

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -14,12 +14,12 @@ on:
           - torchbench
         default: all
       mode:
-        description: Inference, inference-no-freezing, or training
+        description: Inference, inference-with-freezing, or training
         type: choice
         options:
           - all
           - inference
-          - inference-no-freezing
+          - inference-with-freezing
           - training
         default: all
       dtype:
@@ -90,7 +90,7 @@ jobs:
             suite='["${{ inputs.suite }}"]'
           fi
           if [[ -z "${{ inputs.mode }}" || "${{ inputs.mode }}" == "all" ]]; then
-            mode='["inference", "inference-no-freezing", "training"]'
+            mode='["inference", "inference-with-freezing", "training"]'
           else
             mode='["${{ inputs.mode }}"]'
           fi

--- a/scripts/check_inductor_report.py
+++ b/scripts/check_inductor_report.py
@@ -70,7 +70,7 @@ def main():
     argparser = argparse.ArgumentParser()
     argparser.add_argument("--suite", required=True)
     argparser.add_argument("--dtype", required=True)
-    argparser.add_argument("--mode", required=True, choices=("inference", "training", "inference-no-freezing"))
+    argparser.add_argument("--mode", required=True, choices=("inference", "training", "inference-with-freezing"))
     argparser.add_argument("--test_mode", required=True, choices=("performance", "accuracy"))
     argparser.add_argument("--device", help="i.e. xpu", required=True)
     argparser.add_argument("--models-file", help="Subset of models list", required=True)

--- a/scripts/inductor_xpu_test.sh
+++ b/scripts/inductor_xpu_test.sh
@@ -24,7 +24,9 @@ if [[ -n "$MODEL_ONLY" ]]; then
 fi
 
 if [[ $MODE == "inference" ]]; then
-    Mode_extra="--inference --freezing "
+    # For PT >= 2.1
+    # Remove --freezing cause feature not ready
+    Mode_extra="--inference"
 fi
 
 if [[ $MODE == "inference-no-freezing" ]]; then

--- a/scripts/inductor_xpu_test.sh
+++ b/scripts/inductor_xpu_test.sh
@@ -29,8 +29,8 @@ if [[ $MODE == "inference" ]]; then
     Mode_extra="--inference"
 fi
 
-if [[ $MODE == "inference-no-freezing" ]]; then
-    Mode_extra="--inference "
+if [[ $MODE == "inference-with-freezing" ]]; then
+    Mode_extra="--inference --freezing "
 fi
 
 if [[ $MODE == "training" ]]; then


### PR DESCRIPTION
I noticed because (although I'm not sure if that's root cause):
```bash
# works
python benchmarks/dynamo/torchbench.py --accuracy --float32 -d xpu -n10 --inference --only detectron2_maskrcnn_r_50_c4  --backend=inductor --cold-start-latency

# doesn't work
# run it from .scripts_cache/pytorch
../../scripts/inductor_xpu_test.sh torchbench float32 inference accuracy xpu 0 static 1 0 detectron2_maskrcnn_r_50_c4
```


`torch-xpu-ops` sources in main: https://github.com/intel/torch-xpu-ops/blob/5b4d7444484576f721d2295761cf8fafa924ef36/.github/scripts/inductor_xpu_test.sh#L30

in custom branch (on which they made a reproducer for us): https://github.com/intel/torch-xpu-ops/blob/6e05eb3f3cb84bceb818a9f0461da773c56ac3ef/.github/scripts/inductor_xpu_test.sh#L31