### PR TITLE
Add shader dump when compile triton

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -320,6 +320,8 @@ def compile(src, target=None, options=None):
         **options.__dict__,
         **env_vars,
     }
+
+    metadata["cache_dir"] = fn_cache_manager.cache_dir
     metadata["triton_version"] = __version__
     # run compilation pipeline  and populate metadata
     stages = dict()

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -489,6 +489,7 @@ class nvidia_knobs(base_knobs):
 class intel_knobs(base_knobs):
     spirv_dis: env_intel_tool = env_intel_tool("spirv-dis")
 
+    dump_shader_info: env_bool = env_bool("TRITON_INTEL_ENABLE_IGC_SHADER_DUMP", False)
     gen_native_code: env_bool = env_bool("TRITON_XPU_GEN_NATIVE_CODE", False)
     tile_load_ll: env_bool = env_bool("TRITON_XPU_ENABLE_TILE_LOAD_LINEAR_LAYOUT", True)
     advanced_path: env_bool = env_bool("TRITON_INTEL_ADVANCED_PATH", False)


### PR DESCRIPTION
Add dump information for debug  when autotune the Triton kernel:
1. Print the Triton cache director when dump the autotuner information with `TRITON_PRINT_AUTOTUNING`
2. Add a new knob `TRITON_INTEL_ENABLE_IGC_SHADER_DUMP` to dump the shader information in IGC when compiling the Triton kernel.