### PR TITLE
Enable environment reports for all parallelized jobs

### DIFF
--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -257,7 +257,7 @@ jobs:
           fi
 
           mkdir -p reports
-          cat <<EOF | tee "${reports_file}"
+          cat <<EOF | tee "$reports_file"
           TIMESTAMP=$(date '+%Y%m%d%H%M%S')
           GITHUB_RUN_ID=$GITHUB_RUN_ID
           GITHUB_RUN_NUMBER=$GITHUB_RUN_NUMBER


### PR DESCRIPTION
For better debugging and observability.