### PR TITLE
Skip `09-persistent-matmul` on ARL-S

### DIFF
--- a/scripts/skiplist/arl-s/tutorials.txt
+++ b/scripts/skiplist/arl-s/tutorials.txt
@@ -1,5 +1,6 @@
 03-matrix-multiplication
 06-fused-attention
 08-grouped-gemm
+09-persistent-matmul
 10-experimental-block-pointer
 10i-experimental-block-pointer


### PR DESCRIPTION
https://github.com/intel/intel-xpu-backend-for-triton/issues/4487#issuecomment-2963712873