### PR TITLE
Use direct conversion from BF16 to F32 without intermediate F16.

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1043,6 +1043,14 @@ struct FpToFpOpConversion
       return outVals;
     }
 
+    if (srcElementType.isBF16() && dstElementType.isF32()) {
+      SmallVector<Value> outVals;
+      for (Value v : operands[0]) {
+        outVals.push_back(intel::convertBf16ToFp32(loc, rewriter, v));
+      }
+      return outVals;
+    }
+
     bool useFP16IntermediateSrc = srcElementType.isF32();
     bool isDstFP32 = dstElementType.isF32();
     Type srcType = useFP16IntermediateSrc ? f16_ty : srcElementType;


### PR DESCRIPTION
Fixes #4522.

This also fixes the 'L0 error 0x78000011' failure of test_mxfp8_mxfp4_matmul.
