### PR TITLE
Only create predicated block when load with mask

### DIFF
--- a/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
+++ b/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
@@ -145,6 +145,7 @@ module attributes {ttig.support_sg_2d_block, "ttg.num-warps" = 8 : i32} {
                                            %arg1: tensor<256x64x!tt.ptr<f16>, #mma_1>,
                                            %arg2: tensor<128x64x!tt.ptr<f16>, #mma_2>,
                                            %arg3: tensor<256x64x!tt.ptr<f16>, #mma_2>) {
+    // CHECK-NOT: llvm.cond_br
     // CHECK-COUNT-4: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 16, v_blocks = 2
     %0 = tt.load %arg0 {ttig.block_io = "row_major"} : tensor<256x64x!tt.ptr<f16>, #mma>
 


### PR DESCRIPTION
CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15744389236
16% improvement on GEMM tensor of pointer.
![Screenshot 2025-06-18 204424](https://github.com/user-attachments/assets/84a50381-d447-4464-aea1-50d3db6f78b4)
