### PR TITLE
Report OS in E2E reports

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -286,6 +286,7 @@ jobs:
           LEVEL_ZERO_VERSION=$LEVEL_ZERO_VERSION
           GPU_DEVICE=$GPU_DEVICE
           AGAMA_VERSION=$AGAMA_VERSION
+          OS=${{ runner.os }}
           EOF
 
       - name: Copy reports

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -356,6 +356,7 @@ jobs:
           LEVEL_ZERO_VERSION=$LEVEL_ZERO_VERSION
           GPU_DEVICE=$GPU_DEVICE
           AGAMA_VERSION=$AGAMA_VERSION
+          OS=${{ runner.os }}
           EOF
 
       - name: Upload test logs


### PR DESCRIPTION
After #4518 we need to distinguish E2E runs on Linux and Windows. Setting `OS` to `Linux` or `Windows` in the dotenv file.