### PR TITLE
[GEMM] Allow 2D block io when `M == 1`

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -186,9 +186,8 @@ private:
       }
 
       // Value -1 is used to represent the unknown stride.
-      if (axisInfo->getStride(otherDim) <= 0) {
-        LDBG("Found unknown or non positive stride: "
-             << axisInfo->getStride(otherDim));
+      if (axisInfo->getStride(otherDim) < 0) {
+        LDBG("Found unknown stride: " << axisInfo->getStride(otherDim));
         return false;
       }
 


### PR DESCRIPTION
When M is 1, `offs_am` is 0, and `a_ptrs` has stride `[0, 1]`.
```
offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
```

This PR changes MaterializeBlockPointer pass to allow stride to be 0.

Further improved GEMM tensor of pointer performance by 8%.
![Screenshot 2025-06-19 102705](https://github.com/user-attachments/assets/d5197a85-a188-4e1f-8db6-9549bc566564)


CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/15748650337