### PR TITLE
Downgrade `setuptools>=70.2.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==70.2.0", "cmake>=3.20,<4.0", "ninja>=1.11.1", "pybind11>=2.13.1"]
+requires = ["setuptools>=70.2.0", "cmake>=3.20,<4.0", "ninja>=1.11.1", "pybind11>=2.13.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.mypy]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-setuptools==70.2.0
+setuptools>=70.2.0
 wheel
 cmake>=3.20,<4.0
 ninja>=1.11.1

--- a/setup.py
+++ b/setup.py
@@ -817,7 +817,7 @@ setup(
     description="A language and compiler for custom Deep Learning operations",
     long_description="",
     install_requires=[
-        "setuptools==70.2.0",
+        "setuptools>=70.2.0",
         "importlib-metadata; python_version < '3.10'",
     ],
     packages=list(get_packages()),


### PR DESCRIPTION
The plan after the merge is to add this commit to the release branch after ae324eeac8e102a2b40370e341460f3791353398 commit so that PyTorch could update without full testing.