### PR TITLE
Run CI for `stacked/**` branches

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,10 +48,12 @@ on:
     branches:
       - main
       - release/**
+      - stacked/**
   push:
     branches:
       - main
       - release/**
+      - stacked/**
 
 # Cancels in-progress PR runs when the PR is updated. Manual runs are never cancelled.
 concurrency:


### PR DESCRIPTION
Perhaps for the `push` event it is excessive, let's see how it goes, then tune as necessary.