### PR TITLE
[BACKEND] Enhance the 2D Block io lowering for tt.store.

### DIFF
--- a/python/test/unit/intel/test_block_store.py
+++ b/python/test/unit/intel/test_block_store.py
@@ -120,7 +120,3 @@ def test_tensor_pointer_block_store(M, N, dtype_str, layout, device, tmp_path: p
 
     kernel[(1, 1, 1)](a, x, a, y)
     assert torch.equal(a, x) and torch.equal(a, y)
-
-    if support_block_io:
-        # assert '2d block io' in kernel.asm['llir']
-        pass

--- a/python/test/unit/intel/test_block_store.py
+++ b/python/test/unit/intel/test_block_store.py
@@ -1,0 +1,126 @@
+import itertools
+
+import numpy as np
+import pytest
+import torch
+import pathlib
+
+import triton
+from triton._internal_testing import is_xpu
+
+
+class DpasLayout:
+
+    def __init__(self, repeatCount, systolic_depth, execution_size, ops_per_chan, threads_per_warp, warps_per_cta,
+                 rep_cluster):
+        self.repeatCount = repeatCount
+        self.systolic_depth = systolic_depth
+        self.execution_size = execution_size
+        self.ops_per_chan = ops_per_chan
+        self.threads_per_warp = threads_per_warp
+        self.warps_per_cta = warps_per_cta
+        self.rep_cluster = rep_cluster
+
+    def __str__(self):
+        return f"#ttig.dpas<{{repeatCount={self.repeatCount}, systolicDepth={self.systolic_depth}, executionSize = {self.execution_size}, opsPerChan = {self.ops_per_chan}, threadsPerWarp = {self.threads_per_warp}, warpsPerCTA={self.warps_per_cta}, repCluster={self.rep_cluster}}}>"
+
+
+def warps_per_cta(layout):
+    return layout.warps_per_cta
+
+
+layouts = [
+    # Layout for Xe
+    DpasLayout(repeatCount=8, systolic_depth=8, execution_size=16, ops_per_chan=4, threads_per_warp=16,
+               warps_per_cta=[1, 4], rep_cluster=[1, 2]),
+    DpasLayout(repeatCount=8, systolic_depth=8, execution_size=16, ops_per_chan=2, threads_per_warp=16,
+               warps_per_cta=[8, 4], rep_cluster=[4, 2]),
+    DpasLayout(repeatCount=8, systolic_depth=8, execution_size=16, ops_per_chan=1, threads_per_warp=16,
+               warps_per_cta=[8, 4], rep_cluster=[1, 1]),
+]
+
+
+@pytest.mark.parametrize("M, N", [[M, N] for M, N in itertools.product([32, 64, 128, 256], [32, 64, 128, 256])])
+@pytest.mark.parametrize("dtype_str", ["float32", "float16", "int8"])
+@pytest.mark.parametrize("layout", layouts)
+@pytest.mark.skipif(not is_xpu(), reason="Block load tests are specific to the XPU backend")
+def test_tensor_pointer_block_store(M, N, dtype_str, layout, device, tmp_path: pathlib.Path):
+
+    warps = warps_per_cta(layout)
+    num_warps = int(np.prod(warps))
+    threads_per_warp = layout.threads_per_warp
+    ops_per_chan = layout.ops_per_chan
+    A_width = 1 if ops_per_chan == 1 else ops_per_chan // 2
+    B_width = ops_per_chan
+
+    ty = {"float32": "f32", "float16": "f16", "bfloat16": "i16", "int8": "i8"}[dtype_str]
+
+    support_block_io = torch.xpu.get_device_capability()['has_subgroup_2d_block_io']
+
+    ir = f"""
+    #mma = {layout}
+    #dot_a = #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>
+    #dot_b = #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>
+    module attributes {{{"ttig.support_sg_2d_block," if support_block_io else ""} "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = {num_warps} : i32, ttg.target = "xpu", "ttg.threads-per-warp" = {threads_per_warp} : i32}} {{
+        tt.func public @tensor_pointer_block_load(%arg0: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}, %arg2: !tt.ptr<{ty}> {{tt.divisibility = 16: i32}}, %arg3: !tt.ptr<{ty}> {{tt.divisibility = 16: i32}}) {{
+
+            // A matrix
+            %stride_a = arith.constant dense<{N}> : tensor<{M}x1xi32, #dot_a>
+            %1 = tt.make_range {{end = {M} : i32, start = 0 : i32}} : tensor<{M}xi32, #ttg.slice<{{dim = 1, parent = #dot_a}}>>
+            %2 = tt.expand_dims %1 {{axis = 1 : i32}} : tensor<{M}xi32, #ttg.slice<{{dim = 1, parent = #dot_a}}>> -> tensor<{M}x1xi32, #dot_a>
+            %4 = arith.muli %2, %stride_a : tensor<{M}x1xi32, #dot_a>
+            %5 = tt.make_range {{end = {N} : i32, start = 0 : i32}} : tensor<{N}xi32, #ttg.slice<{{dim = 0, parent = #dot_a}}>>
+            %6 = tt.expand_dims %5 {{axis = 0 : i32}} : tensor<{N}xi32, #ttg.slice<{{dim = 0, parent = #dot_a}}>> -> tensor<1x{N}xi32, #dot_a>
+            %7 = tt.broadcast %4 : tensor<{M}x1xi32, #dot_a> -> tensor<{M}x{N}xi32, #dot_a>
+            %8 = tt.broadcast %6 : tensor<1x{N}xi32, #dot_a> -> tensor<{M}x{N}xi32, #dot_a>
+            %9 = arith.addi %7, %8 : tensor<{M}x{N}xi32, #dot_a>
+
+            %10 = tt.splat %arg0 : !tt.ptr<{ty}> -> tensor<{M}x{N}x!tt.ptr<{ty}>, #dot_a>
+            %11 = tt.addptr %10, %9 : tensor<{M}x{N}x!tt.ptr<{ty}>, #dot_a>, tensor<{M}x{N}xi32, #dot_a>
+            %12 = tt.load %11 : tensor<{M}x{N}x!tt.ptr<{ty}>, #dot_a>
+            %13 = tt.splat %arg1 : !tt.ptr<{ty}> -> tensor<{M}x{N}x!tt.ptr<{ty}>, #dot_a>
+            %14 = tt.addptr %13, %9 : tensor<{M}x{N}x!tt.ptr<{ty}>, #dot_a>, tensor<{M}x{N}xi32, #dot_a>
+            tt.store %14, %12 {{ttig.block_io = "row_major"}} : tensor<{M}x{N}x!tt.ptr<{ty}>, #dot_a>
+
+            // B matrix
+            %stride_b = arith.constant dense<{N}> : tensor<{M}x1xi32, #dot_b>
+            %22 = tt.make_range {{end = {N} : i32, start = 0 : i32}} : tensor<{N}xi32, #ttg.slice<{{dim = 0, parent = #dot_b}}>>
+            %44 = tt.make_range {{end = {M} : i32, start = 0 : i32}} : tensor<{M}xi32, #ttg.slice<{{dim = 1, parent = #dot_b}}>>
+            %46 = tt.expand_dims %44 {{axis = 1 : i32}} : tensor<{M}xi32, #ttg.slice<{{dim = 1, parent = #dot_b}}>> -> tensor<{M}x1xi32, #dot_b>
+            %49 = arith.muli %46, %stride_b : tensor<{M}x1xi32, #dot_b>
+            %50 = tt.expand_dims %22 {{axis = 0 : i32}} : tensor<{N}xi32, #ttg.slice<{{dim = 0, parent = #dot_b}}>> -> tensor<1x{N}xi32, #dot_b>
+            %51 = tt.broadcast %49 : tensor<{M}x1xi32, #dot_b> -> tensor<{M}x{N}xi32, #dot_b>
+            %52 = tt.broadcast %50 : tensor<1x{N}xi32, #dot_b> -> tensor<{M}x{N}xi32, #dot_b>
+            %53 = arith.addi %51, %52 : tensor<{M}x{N}xi32, #dot_b>
+
+            %54 = tt.splat %arg2 : !tt.ptr<{ty}> -> tensor<{M}x{N}x!tt.ptr<{ty}>, #dot_b>
+            %55 = tt.addptr %54, %53 : tensor<{M}x{N}x!tt.ptr<{ty}>, #dot_b>, tensor<{M}x{N}xi32, #dot_b>
+            %56 = tt.load %55 : tensor<{M}x{N}x!tt.ptr<{ty}>, #dot_b>
+            %57 = tt.splat %arg3 : !tt.ptr<{ty}> -> tensor<{M}x{N}x!tt.ptr<{ty}>, #dot_b>
+            %58 = tt.addptr %57, %53 : tensor<{M}x{N}x!tt.ptr<{ty}>, #dot_b>, tensor<{M}x{N}xi32, #dot_b>
+            tt.store %58, %56 {{ttig.block_io = "row_major"}} : tensor<{M}x{N}x!tt.ptr<{ty}>, #dot_b>
+
+            tt.return
+        }}
+    }}
+    """
+
+    torch_dtype = getattr(torch, dtype_str)
+    if torch_dtype.is_floating_point:
+        a = torch.randn((M, N), dtype=torch_dtype, device=device)
+    else:
+        a = torch.randint(low=-127, high=128, size=(M, N), dtype=torch_dtype, device=device)
+
+    x = torch.empty_like(a)
+    y = torch.empty_like(a)
+
+    temp_file = tmp_path / "test_tensor_pointer_block_store.ttgir"
+    temp_file.write_text(ir)
+    kernel = triton.compile(str(temp_file))
+
+    kernel[(1, 1, 1)](a, x, a, y)
+    assert torch.equal(a, x) and torch.equal(a, y)
+
+    if support_block_io:
+        # assert '2d block io' in kernel.asm['llir']
+        pass

--- a/python/test/unit/intel/test_block_store.py
+++ b/python/test/unit/intel/test_block_store.py
@@ -120,3 +120,5 @@ def test_tensor_pointer_block_store(M, N, dtype_str, layout, device, tmp_path: p
 
     kernel[(1, 1, 1)](a, x, a, y)
     assert torch.equal(a, x) and torch.equal(a, y)
+
+    temp_file.unlink()

--- a/scripts/skiplist/lts/intel.txt
+++ b/scripts/skiplist/lts/intel.txt
@@ -1,1 +1,2 @@
 python/test/unit/intel/test_block_load.py::test_block_load_dpas_layout
+python/test/unit/intel/test_block_store.py::test_tensor_pointer_block_store

--- a/test/TritonIntelGPU/blockptr_store.mlir
+++ b/test/TritonIntelGPU/blockptr_store.mlir
@@ -1,54 +1,48 @@
 // RUN: triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm
 
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
-#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth=1}>
-#dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth=2}>
-module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_sg_2d_block"} {
   tt.func public @matmul_no_scf_with_advance_kernel(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>, %arg3: i64, %arg4: i64, %arg5: i64, %arg6: i64, %arg7: i64) {
-    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #dpas>
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf16, #dpas>
     %c32_i32 = arith.constant 32 : i32
     %c-64_i32 = arith.constant -64 : i32
     %c-32_i32 = arith.constant -32 : i32
     %c64_i32 = arith.constant 64 : i32
     %c0_i32 = arith.constant 0 : i32
     %c1_i64 = arith.constant 1 : i64
-    %3 = tt.make_tensor_ptr %arg0, [%arg3, %arg5], [%arg6, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<64x32xf16, #dot0>>
-    %6 = tt.make_tensor_ptr %arg1, [%arg3, %arg4], [%arg7, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<32x64xf16, #dot1>>
-    %7 = tt.advance %3, [%c64_i32, %c-32_i32] : <tensor<64x32xf16, #dot0>>
-    %8 = tt.advance %7, [%c-64_i32, %c32_i32] : <tensor<64x32xf16, #dot0>>
-    %9 = tt.load %8 {boundaryCheck = array<i32: 1>, padding = 1 : i32, ttig.block_io = "row_major"} : !tt.ptr<tensor<64x32xf16, #dot0>>
-    %10 = tt.load %6 {boundaryCheck = array<i32: 0>, padding = 1 : i32, ttig.block_io = "row_major"} : !tt.ptr<tensor<32x64xf16, #dot1>>
-    %11 = tt.dot %9, %10, %cst, inputPrecision = tf32 : tensor<64x32xf16, #dot0> * tensor<32x64xf16, #dot1> -> tensor<64x64xf32, #dpas>
-    %12 = arith.truncf %11#0 : tensor<64x64xf32, #dpas> to tensor<64x64xf16, #dpas>
     %13 = tt.make_tensor_ptr %arg2, [%arg3, %arg5], [%arg6, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<64x64xf16, #dpas>>
-    // The next two lines is used to start checking constant related to the BlockStore.
-    // CHECK-COUNT-3: llvm.call spir_funccc @_Z16get_sub_group_id
-    // CHECK-COUNT-39: llvm.extractvalue
-    // Next constant must be equal to warpsPerCTA[0]
-    // CHECK: %[[CST_4:.*]] = llvm.mlir.constant(4 : i32) : i32
-    // CHECK: %[[VAL_0:.*]] = llvm.urem %{{[0-9]+}}, %[[CST_4]] : i32
-    // Next constant must be equal to warpsPerCTA[1]
-    // CHECK: %[[CST_2:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK: %[[VAL_1:.*]] = llvm.urem %{{[0-9]+}}, %[[CST_2]] : i32
-    // Next constant must is elemsPerInstr[0]
-    // CHECK: %[[CST_8:.*]] = llvm.mlir.constant(8 : i32) : i32
-    // CHECK: llvm.mul %[[VAL_0]], %[[CST_8]] : i32
-    // Next constant must is elemsPerInstr[1]
-    // CHECK: %[[CST_16:.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK: llvm.mul %[[VAL_1]], %[[CST_16]] : i32
+    // CHECK: %[[offsetBaseY:.*]] = llvm.extractvalue {{.*}}[0] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[offsetBaseX:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[baseHeight:.*]] = llvm.extractvalue {{.*}}[2] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[baseWidth:.*]] = llvm.extractvalue {{.*}}[3] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[rowStride:.*]] = llvm.extractvalue {{.*}}[4] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[colStride:.*]] = llvm.extractvalue {{.*}}[5] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[base:.*]] = llvm.extractvalue {{.*}}[6] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[offsetBaseY_0:.*]] = llvm.trunc %[[offsetBaseY]] : i32 to i32
+    // CHECK-COUNT-32: llvm.extractvalue {{.*}} : !llvm.struct<(f16, f16, {{.*}})>
+    // CHECK-COUNT-1: llvm.call spir_funccc @_Z12get_local_idj
+    // CHECK: %[[WARP_ID:.*]] = llvm.call spir_funccc @_Z16get_sub_group_id() {no_unwind, will_return} : () -> i32
     // CHECK: llvm.mlir.undef : vector<8xf16>
     // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK: triton_gen.2Dblockstore {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+    // COM: Skip the register, lane, warp and block to the offset computation which should be covered by the LL tests.
+    // CHECK: %[[OFFSET_X:.*]] = llvm.add %[[offsetBaseY_0]], {{.*}} : i32
+    // CHECK: triton_gen.2Dblockstore {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[OFFSET_X]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+
     // CHECK: llvm.mlir.undef : vector<8xf16>
     // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK: triton_gen.2Dblockstore {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+    // CHECK: %[[OFFSET_X:.*]] = llvm.add %[[offsetBaseY_0]], {{.*}} : i32
+    // CHECK: triton_gen.2Dblockstore {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[OFFSET_X]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+
     // CHECK: llvm.mlir.undef : vector<8xf16>
     // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK: triton_gen.2Dblockstore {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+    // CHECK: %[[OFFSET_X:.*]] = llvm.add %[[offsetBaseY_0]], {{.*}} : i32
+    // CHECK: triton_gen.2Dblockstore {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[OFFSET_X]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+
     // CHECK: llvm.mlir.undef : vector<8xf16>
     // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK: triton_gen.2Dblockstore {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
-    tt.store %13, %12 {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<64x64xf16, #dpas>>
+    // CHECK: %[[OFFSET_X:.*]] = llvm.add %[[offsetBaseY_0]], {{.*}} : i32
+    // CHECK: triton_gen.2Dblockstore {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[OFFSET_X]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+    tt.store %13, %cst {boundaryCheck = array<i32: 0, 1>, ttig.block_io = "row_major"} : !tt.ptr<tensor<64x64xf16, #dpas>>
     tt.return
   }
 }
@@ -56,10 +50,10 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
 // -----
 
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 1], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>
-module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_sg_2d_block"} {
 // CHECK-LABEL:   llvm.func spir_kernelcc @dpas_layout_2d_store_rep_cluster_4_2(
 // CHECK-SAME:      %[[base:.*]]: !llvm.ptr<1>,
-// CHECK-SAME:      %[[width:.*]]: i64, %[[height:.*]]: i64, %[[rowStride:.*]]: i64, %[[PTR_1:.*]]: !llvm.ptr<1>) attributes {intel_reqd_sub_group_size = 16 : i32, triton_gen.max_work_group_size = array<i32: 128, 1, 1>} {
+// CHECK-SAME:      %[[width:.*]]: i64, %[[height:.*]]: i64, %[[rowStride:.*]]: i64, %[[PTR_1:.*]]: !llvm.ptr<1>) attributes {intel_reqd_sub_group_size = 16 : i32, triton_gen.max_work_group_size = array<i32: 16, 1, 1>} {
   tt.func public @dpas_layout_2d_store_rep_cluster_4_2(%base: !tt.ptr<f16>, %width: i64, %height: i64, %rowStride: i64) {
     %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf16, #dpas>
     %c0_i32 = arith.constant 0 : i32
@@ -80,107 +74,22 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK:           %[[VAL_79:.*]] = llvm.insertvalue %[[rowStride]], %[[VAL_78]][4] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
     // CHECK:           %[[VAL_80:.*]] = llvm.insertvalue %[[CST_1]], %[[VAL_79]][5] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
     // CHECK:           %[[BLOCK_PTR:.*]] = llvm.insertvalue %[[base]], %[[VAL_80]][6] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
-    // CHECK:           %[[CST_2:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK:           %[[SUB_GROUP_ID_RAW:.*]] = llvm.call spir_funccc @_Z16get_sub_group_id()
-    // CHECK:           %[[SUB_GROUP_ID_EXT:.*]] = llvm.zext %[[SUB_GROUP_ID_RAW]] : i32 to i64
-    // CHECK:           %[[SUB_GROUP_ID:.*]] = llvm.trunc %[[SUB_GROUP_ID_EXT]] : i64 to i32
-    // CHECK:           %[[CST_1:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:           %[[SUB_GROUP_ID_N:.*]] = llvm.urem %[[SUB_GROUP_ID]], %[[CST_1]]  : i32
-    // CHECK:           %[[SUB_GROUP_ID_M_:.*]] = llvm.udiv %[[SUB_GROUP_ID]], %[[CST_1]]  : i32
-    // CHECK:           %[[CST_1:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:           %[[SUB_GROUP_ID_M:.*]] = llvm.urem %[[SUB_GROUP_ID_M_]], %[[CST_1]]  : i32
-    // CHECK:           %[[OFFSET_0:.*]] = llvm.extractvalue %[[BLOCK_PTR]][0] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
-    // CHECK:           %[[OFFSET_1:.*]] = llvm.extractvalue %[[BLOCK_PTR]][1] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
-    // CHECK:           %[[WIDTH_i64:.*]] = llvm.extractvalue %[[BLOCK_PTR]][2] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
-    // CHECK:           %[[HEIGHT_i64:.*]] = llvm.extractvalue %[[BLOCK_PTR]][3] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK:           %[[SCALAR_BYTES:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK:           %[[OFF_0:.*]] = llvm.extractvalue %[[BLOCK_PTR]][0] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK:           %[[OFF_1:.*]] = llvm.extractvalue %[[BLOCK_PTR]][1] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK:           %[[HEIGHT_i64:.*]] = llvm.extractvalue %[[BLOCK_PTR]][2] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK:           %[[WIDTH_i64:.*]] = llvm.extractvalue %[[BLOCK_PTR]][3] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
     // CHECK:           %[[ROW_STRIDE_i64:.*]] = llvm.extractvalue %[[BLOCK_PTR]][4] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
     // CHECK:           %[[COL_STRIDE_i64:.*]] = llvm.extractvalue %[[BLOCK_PTR]][5] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
     // CHECK:           %[[BASE_PTR:.*]] = llvm.extractvalue %[[BLOCK_PTR]][6] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK:           %[[HEIGHT:.*]] = llvm.trunc %[[HEIGHT_i64]] : i64 to i32
+    // CHECK:           %[[WIDTH:.*]] = llvm.trunc %[[WIDTH_i64]] : i64 to i32
+    // CHECK:           %[[WIDTH_IN_BYTES:.*]] = llvm.mul %[[WIDTH]], %[[SCALAR_BYTES]] : i32
+    // CHECK:           %[[ROW_STRIDE:.*]] = llvm.trunc %[[ROW_STRIDE_i64]] : i64 to i32
+    // CHECK:           %[[ROW_STRIDE_IN_BYTES:.*]] = llvm.mul %[[ROW_STRIDE]], %[[SCALAR_BYTES]] : i32
+    // CHECK:           %[[OFFSET_1:.*]] = llvm.trunc %[[OFF_1]] : i32 to i32
+    // CHECK:           %[[OFFSET_0:.*]] = llvm.trunc %[[OFF_0]] : i32 to i32
     %13 = tt.make_tensor_ptr %base, [%width, %height], [%rowStride, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<32x32xf16, #dpas>>
-
-    // COM: The decomposed values of the tensor with DPAS layout.
-    // CHECK:           %[[VAL_97:.*]] = llvm.extractvalue %[[VAL_71]][0]
-    // CHECK:           %[[VAL_98:.*]] = llvm.extractvalue %[[VAL_71]][1]
-    // CHECK:           %[[VAL_99:.*]] = llvm.extractvalue %[[VAL_71]][2]
-    // CHECK:           %[[VAL_100:.*]] = llvm.extractvalue %[[VAL_71]][3]
-    // CHECK:           %[[VAL_101:.*]] = llvm.extractvalue %[[VAL_71]][4]
-    // CHECK:           %[[VAL_102:.*]] = llvm.extractvalue %[[VAL_71]][5]
-    // CHECK:           %[[VAL_103:.*]] = llvm.extractvalue %[[VAL_71]][6]
-    // CHECK:           %[[VAL_104:.*]] = llvm.extractvalue %[[VAL_71]][7]
-    // CHECK:           %[[VAL_105:.*]] = llvm.extractvalue %[[VAL_71]][8]
-    // CHECK:           %[[VAL_106:.*]] = llvm.extractvalue %[[VAL_71]][9]
-    // CHECK:           %[[VAL_107:.*]] = llvm.extractvalue %[[VAL_71]][10]
-    // CHECK:           %[[VAL_108:.*]] = llvm.extractvalue %[[VAL_71]][11]
-    // CHECK:           %[[VAL_109:.*]] = llvm.extractvalue %[[VAL_71]][12]
-    // CHECK:           %[[VAL_110:.*]] = llvm.extractvalue %[[VAL_71]][13]
-    // CHECK:           %[[VAL_111:.*]] = llvm.extractvalue %[[VAL_71]][14]
-    // CHECK:           %[[VAL_112:.*]] = llvm.extractvalue %[[VAL_71]][15]
-    // CHECK:           %[[VAL_113:.*]] = llvm.extractvalue %[[VAL_71]][16]
-    // CHECK:           %[[VAL_114:.*]] = llvm.extractvalue %[[VAL_71]][17]
-    // CHECK:           %[[VAL_115:.*]] = llvm.extractvalue %[[VAL_71]][18]
-    // CHECK:           %[[VAL_116:.*]] = llvm.extractvalue %[[VAL_71]][19]
-    // CHECK:           %[[VAL_117:.*]] = llvm.extractvalue %[[VAL_71]][20]
-    // CHECK:           %[[VAL_118:.*]] = llvm.extractvalue %[[VAL_71]][21]
-    // CHECK:           %[[VAL_119:.*]] = llvm.extractvalue %[[VAL_71]][22]
-    // CHECK:           %[[VAL_120:.*]] = llvm.extractvalue %[[VAL_71]][23]
-    // CHECK:           %[[VAL_121:.*]] = llvm.extractvalue %[[VAL_71]][24]
-    // CHECK:           %[[VAL_122:.*]] = llvm.extractvalue %[[VAL_71]][25]
-    // CHECK:           %[[VAL_123:.*]] = llvm.extractvalue %[[VAL_71]][26]
-    // CHECK:           %[[VAL_124:.*]] = llvm.extractvalue %[[VAL_71]][27]
-    // CHECK:           %[[VAL_125:.*]] = llvm.extractvalue %[[VAL_71]][28]
-    // CHECK:           %[[VAL_126:.*]] = llvm.extractvalue %[[VAL_71]][29]
-    // CHECK:           %[[VAL_127:.*]] = llvm.extractvalue %[[VAL_71]][30]
-    // CHECK:           %[[VAL_128:.*]] = llvm.extractvalue %[[VAL_71]][31]
-    // CHECK:           %[[VAL_129:.*]] = llvm.extractvalue %[[VAL_71]][32]
-    // CHECK:           %[[VAL_130:.*]] = llvm.extractvalue %[[VAL_71]][33]
-    // CHECK:           %[[VAL_131:.*]] = llvm.extractvalue %[[VAL_71]][34]
-    // CHECK:           %[[VAL_132:.*]] = llvm.extractvalue %[[VAL_71]][35]
-    // CHECK:           %[[VAL_133:.*]] = llvm.extractvalue %[[VAL_71]][36]
-    // CHECK:           %[[VAL_134:.*]] = llvm.extractvalue %[[VAL_71]][37]
-    // CHECK:           %[[VAL_135:.*]] = llvm.extractvalue %[[VAL_71]][38]
-    // CHECK:           %[[VAL_136:.*]] = llvm.extractvalue %[[VAL_71]][39]
-    // CHECK:           %[[VAL_137:.*]] = llvm.extractvalue %[[VAL_71]][40]
-    // CHECK:           %[[VAL_138:.*]] = llvm.extractvalue %[[VAL_71]][41]
-    // CHECK:           %[[VAL_139:.*]] = llvm.extractvalue %[[VAL_71]][42]
-    // CHECK:           %[[VAL_140:.*]] = llvm.extractvalue %[[VAL_71]][43]
-    // CHECK:           %[[VAL_141:.*]] = llvm.extractvalue %[[VAL_71]][44]
-    // CHECK:           %[[VAL_142:.*]] = llvm.extractvalue %[[VAL_71]][45]
-    // CHECK:           %[[VAL_143:.*]] = llvm.extractvalue %[[VAL_71]][46]
-    // CHECK:           %[[VAL_144:.*]] = llvm.extractvalue %[[VAL_71]][47]
-    // CHECK:           %[[VAL_145:.*]] = llvm.extractvalue %[[VAL_71]][48]
-    // CHECK:           %[[VAL_146:.*]] = llvm.extractvalue %[[VAL_71]][49]
-    // CHECK:           %[[VAL_147:.*]] = llvm.extractvalue %[[VAL_71]][50]
-    // CHECK:           %[[VAL_148:.*]] = llvm.extractvalue %[[VAL_71]][51]
-    // CHECK:           %[[VAL_149:.*]] = llvm.extractvalue %[[VAL_71]][52]
-    // CHECK:           %[[VAL_150:.*]] = llvm.extractvalue %[[VAL_71]][53]
-    // CHECK:           %[[VAL_151:.*]] = llvm.extractvalue %[[VAL_71]][54]
-    // CHECK:           %[[VAL_152:.*]] = llvm.extractvalue %[[VAL_71]][55]
-    // CHECK:           %[[VAL_153:.*]] = llvm.extractvalue %[[VAL_71]][56]
-    // CHECK:           %[[VAL_154:.*]] = llvm.extractvalue %[[VAL_71]][57]
-    // CHECK:           %[[VAL_155:.*]] = llvm.extractvalue %[[VAL_71]][58]
-    // CHECK:           %[[VAL_156:.*]] = llvm.extractvalue %[[VAL_71]][59]
-    // CHECK:           %[[VAL_157:.*]] = llvm.extractvalue %[[VAL_71]][60]
-    // CHECK:           %[[VAL_158:.*]] = llvm.extractvalue %[[VAL_71]][61]
-    // CHECK:           %[[VAL_159:.*]] = llvm.extractvalue %[[VAL_71]][62]
-    // CHECK:           %[[VAL_160:.*]] = llvm.extractvalue %[[VAL_71]][63]
-
-    // CHECK:           %[[HEIGHT_i32:.*]] = llvm.trunc %[[HEIGHT_i64]] : i64 to i32
-    // CHECK:           %[[baseHeight:.*]] = llvm.trunc %[[WIDTH_i64]] : i64 to i32
-    // CHECK:           %[[ROW_STRIDE_i32:.*]] = llvm.trunc %[[ROW_STRIDE_i64]] : i64 to i32
-    // CHECK:           %[[baseWidth:.*]] = llvm.mul %[[HEIGHT_i32]], %[[CST_2]] : i32
-    // CHECK:           %[[basePitch:.*]] = llvm.mul %[[ROW_STRIDE_i32]], %[[CST_2]] : i32
-    // CHECK:           %[[VAL_166:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:           %[[outerDimWarpId:.*]] = llvm.urem %[[SUB_GROUP_ID_M]], %[[VAL_166]]  : i32
-    // CHECK:           %[[VAL_168:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:           %[[innerDimWarpId:.*]] = llvm.urem %[[SUB_GROUP_ID_N]], %[[VAL_168]]  : i32
-    // CHECK:           %[[VAL_170:.*]] = llvm.mlir.constant(32 : i32) : i32
-    // CHECK:           %[[dimWarpId0:.*]] = llvm.mul %[[outerDimWarpId]], %[[VAL_170]] : i32
-    // CHECK:           %[[VAL_172:.*]] = llvm.mlir.constant(32 : i32) : i32
-    // CHECK:           %[[dimWarpId1:.*]] = llvm.mul %[[innerDimWarpId]], %[[VAL_172]] : i32
-    // CHECK:           %[[warpId0Offset:.*]] = llvm.add %[[dimWarpId0]], %[[OFFSET_0]] : i32
-    // CHECK:           %[[warpId1Offset:.*]] = llvm.add %[[dimWarpId1]], %[[OFFSET_1]] : i32
-    // CHECK:           %[[VAL_176:.*]] = llvm.mlir.constant(0 : i32) : i32
-
 
     // COM: The shape of DPAS layout replica is [4, 2]
     // COM: The replica order are [0, 1]
@@ -189,177 +98,239 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     // COM:                       [6, 7]
 
     // COM: replica [0, 0]
-    // CHECK:           %[[offsetY:.*]] = llvm.add %[[warpId0Offset]], %[[VAL_176]] : i32
-    // CHECK:           %[[VAL_178:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:           %[[offsetX:.*]] = llvm.add %[[warpId1Offset]], %[[VAL_178]] : i32
-    // CHECK:           %[[VAL_180:.*]] = llvm.mlir.undef : vector<8xf16>
-    // CHECK:           %[[VAL_182:.*]] = llvm.insertelement %[[VAL_97]], %[[VAL_180]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_184:.*]] = llvm.insertelement %[[VAL_98]], %[[VAL_182]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_186:.*]] = llvm.insertelement %[[VAL_99]], %[[VAL_184]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_188:.*]] = llvm.insertelement %[[VAL_100]], %[[VAL_186]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_190:.*]] = llvm.insertelement %[[VAL_101]], %[[VAL_188]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_192:.*]] = llvm.insertelement %[[VAL_102]], %[[VAL_190]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_194:.*]] = llvm.insertelement %[[VAL_103]], %[[VAL_192]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_196:.*]] = llvm.insertelement %[[VAL_104]], %[[VAL_194]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_197:.*]] = llvm.bitcast %[[VAL_196]] : vector<8xf16> to vector<8xi16>
-    // CHECK:           %[[VAL_198:.*]] = llvm.trunc %[[offsetY]] : i32 to i32
-    // CHECK:           %[[VAL_199:.*]] = llvm.trunc %[[offsetX]] : i32 to i32
-    // CHECK:           triton_gen.2Dblockstore %[[BASE_PTR]], %[[baseWidth]], %[[baseHeight]], %[[basePitch]], %[[VAL_199]], %[[VAL_198]], %[[VAL_197]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+    // CHECK: llvm.mlir.undef : vector<8xf16>
+    // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
+    // CHECK:           %[[VAL_183:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_184:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_185:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_186:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[OFFSET_X:.*]] = llvm.add %[[OFFSET_1]], %[[VAL_186]] : i32
+    // CHECK:           %[[OFFSET_Y:.*]] = llvm.add %[[OFFSET_0]], %[[VAL_186]] : i32
+    // CHECK:           triton_gen.2Dblockstore %[[BASE_PTR]], %[[WIDTH_IN_BYTES]], %[[HEIGHT]], %[[ROW_STRIDE_IN_BYTES]], %[[OFFSET_X]], %[[OFFSET_Y]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32, vector<8xi16>)
 
     // COM: replica [0, 1]
-    // CHECK:           %[[VAL_207:.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK:           %[[VAL_208:.*]] = llvm.add %[[warpId1Offset]], %[[VAL_207]] : i32
-    // CHECK:           %[[VAL_209:.*]] = llvm.mlir.undef : vector<8xf16>
-    // CHECK:           %[[VAL_211:.*]] = llvm.insertelement %[[VAL_105]], %[[VAL_209]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_213:.*]] = llvm.insertelement %[[VAL_106]], %[[VAL_211]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_215:.*]] = llvm.insertelement %[[VAL_107]], %[[VAL_213]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_217:.*]] = llvm.insertelement %[[VAL_108]], %[[VAL_215]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_219:.*]] = llvm.insertelement %[[VAL_109]], %[[VAL_217]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_221:.*]] = llvm.insertelement %[[VAL_110]], %[[VAL_219]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_223:.*]] = llvm.insertelement %[[VAL_111]], %[[VAL_221]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_225:.*]] = llvm.insertelement %[[VAL_112]], %[[VAL_223]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_226:.*]] = llvm.bitcast %[[VAL_225]] : vector<8xf16> to vector<8xi16>
-    // CHECK:           triton_gen.2Dblockstore %[[BASE_PTR]], %[[baseWidth]], %[[baseHeight]], %[[basePitch]], {{.*}}, %[[VAL_226]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+    // CHECK: llvm.mlir.undef : vector<8xf16>
+    // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
+    // CHECK:           %[[VAL_207:.*]] = llvm.mlir.constant(8 : i32) : i32
+    // CHECK:           %[[VAL_208:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_209:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_210:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_211:.*]] = llvm.mlir.constant(16 : i32) : i32
+    // CHECK:           %[[OFFSET_X:.*]] = llvm.add %[[OFFSET_1]], %[[VAL_211]] : i32
+    // CHECK:           %[[OFFSET_Y:.*]] = llvm.add %[[OFFSET_0]], %[[VAL_210]] : i32
+    // CHECK:           triton_gen.2Dblockstore %[[BASE_PTR]], %[[WIDTH_IN_BYTES]], %[[HEIGHT]], %[[ROW_STRIDE_IN_BYTES]], %[[OFFSET_X]], %[[OFFSET_Y]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32, vector<8xi16>)
 
     // COM: replica [1, 0]
+    // CHECK: llvm.mlir.undef : vector<8xf16>
+    // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
+    // CHECK:           %[[VAL_232:.*]] = llvm.mlir.constant(16 : i32) : i32
+    // CHECK:           %[[VAL_233:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_234:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_235:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK:           %[[VAL_236:.*]] = llvm.mlir.constant(8 : i32) : i32
-    // CHECK:           %[[VAL_237:.*]] = llvm.add %[[warpId0Offset]], %[[VAL_236]] : i32
-    // CHECK:           %[[VAL_238:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:           %[[VAL_239:.*]] = llvm.add %[[warpId1Offset]], %[[VAL_238]] : i32
-    // CHECK:           %[[VAL_240:.*]] = llvm.mlir.undef : vector<8xf16>
-    // CHECK:           %[[VAL_242:.*]] = llvm.insertelement %[[VAL_113]], %[[VAL_240]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_244:.*]] = llvm.insertelement %[[VAL_114]], %[[VAL_242]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_246:.*]] = llvm.insertelement %[[VAL_115]], %[[VAL_244]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_248:.*]] = llvm.insertelement %[[VAL_116]], %[[VAL_246]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_250:.*]] = llvm.insertelement %[[VAL_117]], %[[VAL_248]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_252:.*]] = llvm.insertelement %[[VAL_118]], %[[VAL_250]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_254:.*]] = llvm.insertelement %[[VAL_119]], %[[VAL_252]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_256:.*]] = llvm.insertelement %[[VAL_120]], %[[VAL_254]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_257:.*]] = llvm.bitcast %[[VAL_256]] : vector<8xf16> to vector<8xi16>
-    // CHECK:           triton_gen.2Dblockstore %[[BASE_PTR]], %[[baseWidth]], %[[baseHeight]], %[[basePitch]], {{.*}}, %[[VAL_257]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+    // CHECK:           %[[OFFSET_X:.*]] = llvm.add %[[OFFSET_1]], %[[VAL_235]] : i32
+    // CHECK:           %[[OFFSET_Y:.*]] = llvm.add %[[OFFSET_0]], %[[VAL_236]] : i32
+    // CHECK:           triton_gen.2Dblockstore %[[BASE_PTR]], %[[WIDTH_IN_BYTES]], %[[HEIGHT]], %[[ROW_STRIDE_IN_BYTES]], %[[OFFSET_X]], %[[OFFSET_Y]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32, vector<8xi16>)
+
 
     // COM: replica [1, 1]
-    // CHECK:           %[[VAL_267:.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK:           %[[VAL_268:.*]] = llvm.add %[[warpId1Offset]], %[[VAL_267]] : i32
-    // CHECK:           %[[VAL_269:.*]] = llvm.mlir.undef : vector<8xf16>
-    // CHECK:           %[[VAL_271:.*]] = llvm.insertelement %[[VAL_121]], %[[VAL_269]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_273:.*]] = llvm.insertelement %[[VAL_122]], %[[VAL_271]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_275:.*]] = llvm.insertelement %[[VAL_123]], %[[VAL_273]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_277:.*]] = llvm.insertelement %[[VAL_124]], %[[VAL_275]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_279:.*]] = llvm.insertelement %[[VAL_125]], %[[VAL_277]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_281:.*]] = llvm.insertelement %[[VAL_126]], %[[VAL_279]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_283:.*]] = llvm.insertelement %[[VAL_127]], %[[VAL_281]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_285:.*]] = llvm.insertelement %[[VAL_128]], %[[VAL_283]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_286:.*]] = llvm.bitcast %[[VAL_285]] : vector<8xf16> to vector<8xi16>
-    // CHECK:           triton_gen.2Dblockstore %[[BASE_PTR]], %[[baseWidth]], %[[baseHeight]], %[[basePitch]], {{.*}}, %[[VAL_286]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+    // CHECK: llvm.mlir.undef : vector<8xf16>
+    // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
+    // CHECK:           %[[VAL_257:.*]] = llvm.mlir.constant(24 : i32) : i32
+    // CHECK:           %[[VAL_258:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_259:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_260:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_261:.*]] = llvm.mlir.constant(8 : i32) : i32
+    // CHECK:           %[[VAL_262:.*]] = llvm.mlir.constant(16 : i32) : i32
+    // CHECK:           %[[OFFSET_X:.*]] = llvm.add %[[OFFSET_1]], %[[VAL_262]] : i32
+    // CHECK:           %[[OFFSET_Y:.*]] = llvm.add %[[OFFSET_0]], %[[VAL_261]] : i32
+    // CHECK:           triton_gen.2Dblockstore %[[BASE_PTR]], %[[WIDTH_IN_BYTES]], %[[HEIGHT]], %[[ROW_STRIDE_IN_BYTES]], %[[OFFSET_X]], %[[OFFSET_Y]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32, vector<8xi16>)
 
     // COM: replica [2, 0]
-    // CHECK:           %[[VAL_296:.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK:           %[[VAL_297:.*]] = llvm.add %[[warpId0Offset]], %[[VAL_296]] : i32
-    // CHECK:           %[[VAL_298:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:           %[[VAL_299:.*]] = llvm.add %[[warpId1Offset]], %[[VAL_298]] : i32
-    // CHECK:           %[[VAL_300:.*]] = llvm.mlir.undef : vector<8xf16>
-    // CHECK:           %[[VAL_302:.*]] = llvm.insertelement %[[VAL_129]], %[[VAL_300]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_304:.*]] = llvm.insertelement %[[VAL_130]], %[[VAL_302]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_306:.*]] = llvm.insertelement %[[VAL_131]], %[[VAL_304]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_308:.*]] = llvm.insertelement %[[VAL_132]], %[[VAL_306]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_310:.*]] = llvm.insertelement %[[VAL_133]], %[[VAL_308]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_312:.*]] = llvm.insertelement %[[VAL_134]], %[[VAL_310]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_314:.*]] = llvm.insertelement %[[VAL_135]], %[[VAL_312]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_316:.*]] = llvm.insertelement %[[VAL_136]], %[[VAL_314]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_317:.*]] = llvm.bitcast %[[VAL_316]] : vector<8xf16> to vector<8xi16>
-    // CHECK:           triton_gen.2Dblockstore %[[BASE_PTR]], %[[baseWidth]], %[[baseHeight]], %[[basePitch]], {{.*}}, %[[VAL_317]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+    // CHECK: llvm.mlir.undef : vector<8xf16>
+    // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
+    // CHECK:           %[[VAL_283:.*]] = llvm.mlir.constant(32 : i32) : i32
+    // CHECK:           %[[VAL_284:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_285:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_286:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_287:.*]] = llvm.mlir.constant(16 : i32) : i32
+    // CHECK:           %[[OFFSET_X:.*]] = llvm.add %[[OFFSET_1]], %[[VAL_286]] : i32
+    // CHECK:           %[[OFFSET_Y:.*]] = llvm.add %[[OFFSET_0]], %[[VAL_287]] : i32
+    // CHECK:           triton_gen.2Dblockstore %[[BASE_PTR]], %[[WIDTH_IN_BYTES]], %[[HEIGHT]], %[[ROW_STRIDE_IN_BYTES]], %[[OFFSET_X]], %[[OFFSET_Y]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32, vector<8xi16>)
+
 
     // COM: replica [2, 1]
-    // CHECK:           %[[VAL_327:.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK:           %[[VAL_328:.*]] = llvm.add %[[warpId1Offset]], %[[VAL_327]] : i32
-    // CHECK:           %[[VAL_329:.*]] = llvm.mlir.undef : vector<8xf16>
-    // CHECK:           %[[VAL_331:.*]] = llvm.insertelement %[[VAL_137]], %[[VAL_329]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_333:.*]] = llvm.insertelement %[[VAL_138]], %[[VAL_331]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_335:.*]] = llvm.insertelement %[[VAL_139]], %[[VAL_333]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_337:.*]] = llvm.insertelement %[[VAL_140]], %[[VAL_335]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_339:.*]] = llvm.insertelement %[[VAL_141]], %[[VAL_337]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_341:.*]] = llvm.insertelement %[[VAL_142]], %[[VAL_339]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_343:.*]] = llvm.insertelement %[[VAL_143]], %[[VAL_341]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_345:.*]] = llvm.insertelement %[[VAL_144]], %[[VAL_343]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_346:.*]] = llvm.bitcast %[[VAL_345]] : vector<8xf16> to vector<8xi16>
-    // CHECK:           triton_gen.2Dblockstore %[[BASE_PTR]], %[[baseWidth]], %[[baseHeight]], %[[basePitch]], {{.*}}, %[[VAL_346]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+    // CHECK: llvm.mlir.undef : vector<8xf16>
+    // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
+    // CHECK:           %[[VAL_308:.*]] = llvm.mlir.constant(40 : i32) : i32
+    // CHECK:           %[[VAL_309:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_310:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_311:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_312:.*]] = llvm.mlir.constant(16 : i32) : i32
+    // CHECK:           %[[VAL_313:.*]] = llvm.mlir.constant(16 : i32) : i32
+    // CHECK:           %[[OFFSET_X:.*]] = llvm.add %[[OFFSET_1]], %[[VAL_313]] : i32
+    // CHECK:           %[[OFFSET_Y:.*]] = llvm.add %[[OFFSET_0]], %[[VAL_312]] : i32
+    // CHECK:           triton_gen.2Dblockstore %[[BASE_PTR]], %[[WIDTH_IN_BYTES]], %[[HEIGHT]], %[[ROW_STRIDE_IN_BYTES]], %[[OFFSET_X]], %[[OFFSET_Y]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32, vector<8xi16>)
+
 
     // COM: replica [3, 0]
-    // CHECK:           %[[VAL_356:.*]] = llvm.mlir.constant(24 : i32) : i32
-    // CHECK:           %[[VAL_357:.*]] = llvm.add %[[warpId0Offset]], %[[VAL_356]] : i32
-    // CHECK:           %[[VAL_358:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:           %[[VAL_359:.*]] = llvm.add %[[warpId1Offset]], %[[VAL_358]] : i32
-    // CHECK:           %[[VAL_360:.*]] = llvm.mlir.undef : vector<8xf16>
-    // CHECK:           %[[VAL_362:.*]] = llvm.insertelement %[[VAL_145]], %[[VAL_360]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_364:.*]] = llvm.insertelement %[[VAL_146]], %[[VAL_362]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_366:.*]] = llvm.insertelement %[[VAL_147]], %[[VAL_364]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_368:.*]] = llvm.insertelement %[[VAL_148]], %[[VAL_366]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_370:.*]] = llvm.insertelement %[[VAL_149]], %[[VAL_368]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_372:.*]] = llvm.insertelement %[[VAL_150]], %[[VAL_370]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_374:.*]] = llvm.insertelement %[[VAL_151]], %[[VAL_372]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_376:.*]] = llvm.insertelement %[[VAL_152]], %[[VAL_374]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_377:.*]] = llvm.bitcast %[[VAL_376]] : vector<8xf16> to vector<8xi16>
-    // CHECK:           triton_gen.2Dblockstore %[[BASE_PTR]], %[[baseWidth]], %[[baseHeight]], %[[basePitch]], {{.*}}, %[[VAL_377]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+    // CHECK: llvm.mlir.undef : vector<8xf16>
+    // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
+    // CHECK:           %[[VAL_334:.*]] = llvm.mlir.constant(48 : i32) : i32
+    // CHECK:           %[[VAL_335:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_336:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_337:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_338:.*]] = llvm.mlir.constant(24 : i32) : i32
+    // CHECK:           %[[OFFSET_X:.*]] = llvm.add %[[OFFSET_1]], %[[VAL_337]] : i32
+    // CHECK:           %[[OFFSET_Y:.*]] = llvm.add %[[OFFSET_0]], %[[VAL_338]] : i32
+    // CHECK:           triton_gen.2Dblockstore %[[BASE_PTR]], %[[WIDTH_IN_BYTES]], %[[HEIGHT]], %[[ROW_STRIDE_IN_BYTES]], %[[OFFSET_X]], %[[OFFSET_Y]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32, vector<8xi16>)
+
 
     // COM: replica [3, 1]
-    // CHECK:           %[[VAL_387:.*]] = llvm.mlir.constant(16 : i32) : i32
-    // CHECK:           %[[VAL_388:.*]] = llvm.add %[[warpId1Offset]], %[[VAL_387]] : i32
-    // CHECK:           %[[VAL_389:.*]] = llvm.mlir.undef : vector<8xf16>
-    // CHECK:           %[[VAL_391:.*]] = llvm.insertelement %[[VAL_153]], %[[VAL_389]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_393:.*]] = llvm.insertelement %[[VAL_154]], %[[VAL_391]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_395:.*]] = llvm.insertelement %[[VAL_155]], %[[VAL_393]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_397:.*]] = llvm.insertelement %[[VAL_156]], %[[VAL_395]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_399:.*]] = llvm.insertelement %[[VAL_157]], %[[VAL_397]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_401:.*]] = llvm.insertelement %[[VAL_158]], %[[VAL_399]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_403:.*]] = llvm.insertelement %[[VAL_159]], %[[VAL_401]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_405:.*]] = llvm.insertelement %[[VAL_160]], %[[VAL_403]]{{\[}}{{.*}} : i32] : vector<8xf16>
-    // CHECK:           %[[VAL_406:.*]] = llvm.bitcast %[[VAL_405]] : vector<8xf16> to vector<8xi16>
-    // CHECK:           triton_gen.2Dblockstore %[[BASE_PTR]], %[[baseWidth]], %[[baseHeight]], %[[basePitch]], {{.*}}, %[[VAL_406]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+    // CHECK: llvm.mlir.undef : vector<8xf16>
+    // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
+    // CHECK:           %[[VAL_359:.*]] = llvm.mlir.constant(56 : i32) : i32
+    // CHECK:           %[[VAL_360:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_361:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_362:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[VAL_363:.*]] = llvm.mlir.constant(24 : i32) : i32
+    // CHECK:           %[[VAL_364:.*]] = llvm.mlir.constant(16 : i32) : i32
+    // CHECK:           %[[OFFSET_X:.*]] = llvm.add %[[OFFSET_1]], %[[VAL_364]] : i32
+    // CHECK:           %[[OFFSET_Y:.*]] = llvm.add %[[OFFSET_0]], %[[VAL_363]] : i32
+    // CHECK:           triton_gen.2Dblockstore %[[BASE_PTR]], %[[WIDTH_IN_BYTES]], %[[HEIGHT]], %[[ROW_STRIDE_IN_BYTES]], %[[OFFSET_X]], %[[OFFSET_Y]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32, vector<8xi16>)
 
-    tt.store %13, %cst {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<32x32xf16, #dpas>>
+
+    tt.store %13, %cst {boundaryCheck = array<i32: 0, 1>, ttig.block_io = "row_major"} : !tt.ptr<tensor<32x32xf16, #dpas>>
     tt.return
   }
 }
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 4], order = [1, 0]}>
-module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  // CHECK-LABEL:   llvm.func spir_kernelcc @boundary_check
-  tt.func public @boundary_check(%arg0: !tt.ptr<f16>, %col_stride: i64) {
-      %cst = arith.constant dense<0.000000e+00> : tensor<64x16xf16, #blocked>
-      %c64_i64 = arith.constant 64 : i64
-      %c1_i64 = arith.constant 1 : i64
-      %c0_i32 = arith.constant 0 : i32
-      %0 = tt.make_tensor_ptr %arg0, [%c64_i64, %c64_i64], [%c1_i64, %col_stride], [%c0_i32, %c0_i32] {order = array<i32: 0, 1>} : <tensor<64x16xf16, #blocked>>
-      // CHECK: llvm.call spir_funccc @_Z12get_local_idj
-      // CHECK-NOT: llvm.icmp "slt"
-      // CHECK: %[[threadID:.*]] = llvm.call spir_funccc @_Z12get_local_idj
-      // CHECK: %[[VAL_583:.*]] = llvm.trunc %[[threadID]] : i64 to i32
-      // CHECK: %[[VAL_584:.*]] = llvm.mlir.constant(16 : i32) : i32
-      // CHECK: %[[VAL_586:.*]] = llvm.udiv %[[VAL_583]], %[[VAL_584]] : i32
-      // CHECK: %[[VAL_587:.*]] = llvm.mlir.constant(3 : i32) : i32
-      // CHECK: %[[VAL_588:.*]] = llvm.and %[[VAL_586]], %[[VAL_587]] : i32
-      // CHECK: %[[threadPred:.*]] = llvm.icmp "eq" %[[VAL_588]], {{.*}} : i32
-      // CHECK-COUNT-32: llvm.cond_br %[[threadPred]]
-      tt.store %0, %cst : !tt.ptr<tensor<64x16xf16, #blocked>>
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_sg_2d_block"} {
+  tt.func public @block_store_no_boundary_check(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>, %arg3: i64, %arg4: i64, %arg5: i64, %arg6: i64, %arg7: i64) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf16, #dpas>
+    %c32_i32 = arith.constant 32 : i32
+    %c-64_i32 = arith.constant -64 : i32
+    %c-32_i32 = arith.constant -32 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %13 = tt.make_tensor_ptr %arg2, [%arg3, %arg5], [%arg6, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<64x64xf16, #dpas>>
+    // CHECK: %[[OFF_0:.*]] = llvm.extractvalue {{.*}}[0] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[OFF_1:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[HEIGHT_i64:.*]] = llvm.extractvalue {{.*}}[2] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[WIDTH_i64:.*]] = llvm.extractvalue {{.*}}[3] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[ROW_STRIDE_i64:.*]] = llvm.extractvalue {{.*}}[4] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[colStride:.*]] = llvm.extractvalue {{.*}}[5] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[base:.*]] = llvm.extractvalue {{.*}}[6] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
 
-      // CHECK-COUNT-16: llvm.icmp "slt"
-      // CHECK: %[[threadPred_0:.*]] = llvm.icmp "eq"
-      // CHECK-COUNT-32: llvm.and %[[threadPred_0]], {{.*}} : i1
-      tt.store %0, %cst {boundaryCheck = array<i32: 0>} : !tt.ptr<tensor<64x16xf16, #blocked>>
+    // CHECK:           %[[HEIGHT:.*]] = llvm.mlir.constant(8 : i32) : i32
+    // CHECK:           %[[WIDTH:.*]] = llvm.trunc %[[WIDTH_i64]] : i64 to i32
+    // CHECK:           %[[WIDTH_IN_BYTES:.*]] = llvm.mul %[[WIDTH]], {{.*}} : i32
+    // CHECK:           %[[ROW_STRIDE:.*]] = llvm.trunc %[[ROW_STRIDE_i64]] : i64 to i32
+    // CHECK:           %[[ROW_STRIDE_IN_BYTES:.*]] = llvm.mul %[[ROW_STRIDE]], {{.*}} : i32
+    // CHECK:           %[[OFFSET_1:.*]] = llvm.trunc %[[OFF_1]] : i32 to i32
+    // CHECK:           %[[OFFSET_0:.*]] = llvm.trunc %[[OFF_0]] : i32 to i32
 
-      // CHECK-COUNT-16: llvm.icmp "slt"
-      // CHECK: %[[threadPred_1:.*]] = llvm.icmp "eq"
-      // CHECK-COUNT-32: llvm.and %[[threadPred_1]], {{.*}} : i1
-      tt.store %0, %cst {boundaryCheck = array<i32: 1>} : !tt.ptr<tensor<64x16xf16, #blocked>>
+    // CHECK-COUNT-32: llvm.extractvalue {{.*}} : !llvm.struct<(f16, f16, {{.*}})>
+    // CHECK-COUNT-1: llvm.call spir_funccc @_Z12get_local_idj
+    // CHECK: %[[WARP_ID:.*]] = llvm.call spir_funccc @_Z16get_sub_group_id() {no_unwind, will_return} : () -> i32
+    // CHECK: llvm.mlir.undef : vector<8xf16>
+    // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
+    // COM: Skip the register, lane, warp and block to the offset computation which should be covered by the LL tests.
+    // CHECK:           %[[OFFSET_X:.*]] = llvm.add %[[OFFSET_1]], {{.*}} : i32
+    // CHECK:           %[[OFFSET_Y:.*]] = llvm.add %[[OFFSET_0]], {{.*}} : i32
+    // CHECK:           %[[STRIDE:.*]] = llvm.mul %[[OFFSET_Y]], %[[ROW_STRIDE_IN_BYTES]] : i32
+    // CHECK:           %[[BASE_WITH_OFF:.*]] = llvm.getelementptr %[[base]]{{\[}}%[[STRIDE]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, i16
+    // CHECK:           %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: triton_gen.2Dblockstore %[[BASE_WITH_OFF]], %[[WIDTH_IN_BYTES]], %[[HEIGHT]], {{.*}}, %[[OFFSET_X]], %[[CST_0]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
 
-      // CHECK-COUNT-32: llvm.icmp "slt"
-      // CHECK: %[[threadPred_2:.*]] = llvm.icmp "eq"
-      // CHECK-COUNT-32: llvm.and %[[threadPred_2]], {{.*}} : i1
-      tt.store %0, %cst {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<64x16xf16, #blocked>>
+    // CHECK: llvm.mlir.undef : vector<8xf16>
+    // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
+    // CHECK:           %[[OFFSET_X:.*]] = llvm.add %[[OFFSET_1]], {{.*}} : i32
+    // CHECK:           %[[OFFSET_Y:.*]] = llvm.add %[[OFFSET_0]], {{.*}} : i32
+    // CHECK:           %[[STRIDE:.*]] = llvm.mul %[[OFFSET_Y]], %[[ROW_STRIDE_IN_BYTES]] : i32
+    // CHECK:           %[[BASE_WITH_OFF:.*]] = llvm.getelementptr %[[base]]{{\[}}%[[STRIDE]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, i16
+    // CHECK:           %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: triton_gen.2Dblockstore %[[BASE_WITH_OFF]], %[[WIDTH_IN_BYTES]], %[[HEIGHT]], {{.*}}, %[[OFFSET_X]], %[[CST_0]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
 
-      tt.return
+    // CHECK: llvm.mlir.undef : vector<8xf16>
+    // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
+    // CHECK:           %[[OFFSET_X:.*]] = llvm.add %[[OFFSET_1]], {{.*}} : i32
+    // CHECK:           %[[OFFSET_Y:.*]] = llvm.add %[[OFFSET_0]], {{.*}} : i32
+    // CHECK:           %[[STRIDE:.*]] = llvm.mul %[[OFFSET_Y]], %[[ROW_STRIDE_IN_BYTES]] : i32
+    // CHECK:           %[[BASE_WITH_OFF:.*]] = llvm.getelementptr %[[base]]{{\[}}%[[STRIDE]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, i16
+    // CHECK:           %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: triton_gen.2Dblockstore %[[BASE_WITH_OFF]], %[[WIDTH_IN_BYTES]], %[[HEIGHT]], {{.*}}, %[[OFFSET_X]], %[[CST_0]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+
+    // CHECK: llvm.mlir.undef : vector<8xf16>
+    // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
+    // CHECK:           %[[OFFSET_X:.*]] = llvm.add %[[OFFSET_1]], {{.*}} : i32
+    // CHECK:           %[[OFFSET_Y:.*]] = llvm.add %[[OFFSET_0]], {{.*}} : i32
+    // CHECK:           %[[STRIDE:.*]] = llvm.mul %[[OFFSET_Y]], %[[ROW_STRIDE_IN_BYTES]] : i32
+    // CHECK:           %[[BASE_WITH_OFF:.*]] = llvm.getelementptr %[[base]]{{\[}}%[[STRIDE]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, i16
+    // CHECK:           %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: triton_gen.2Dblockstore %[[BASE_WITH_OFF]], %[[WIDTH_IN_BYTES]], %[[HEIGHT]], {{.*}}, %[[OFFSET_X]], %[[CST_0]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+    tt.store %13, %cst {boundaryCheck = array<i32: 1>, ttig.block_io = "row_major"} : !tt.ptr<tensor<64x64xf16, #dpas>>
+    tt.return
+  }
+}
+
+// -----
+
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_sg_2d_block"} {
+  tt.func public @block_store_deduplicate_no_boundary_check(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>, %arg3: i64, %arg4: i64, %arg5: i64, %arg6: i64, %arg7: i64) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x16xf16, #dpas>
+    %c32_i32 = arith.constant 32 : i32
+    %c-64_i32 = arith.constant -64 : i32
+    %c-32_i32 = arith.constant -32 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %13 = tt.make_tensor_ptr %arg2, [%arg3, %arg5], [%arg6, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<64x16xf16, #dpas>>
+    // CHECK: %[[OFF_0:.*]] = llvm.extractvalue {{.*}}[0] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[OFF_1:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[HEIGHT_i64:.*]] = llvm.extractvalue {{.*}}[2] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[WIDTH_i64:.*]] = llvm.extractvalue {{.*}}[3] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[ROW_STRIDE_i64:.*]] = llvm.extractvalue {{.*}}[4] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[colStride:.*]] = llvm.extractvalue {{.*}}[5] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+    // CHECK: %[[base:.*]] = llvm.extractvalue {{.*}}[6] : !llvm.struct<(i32, i32, i64, i64, i64, i64, ptr<1>)>
+
+    // CHECK:           %[[HEIGHT:.*]] = llvm.mlir.constant(8 : i32) : i32
+    // CHECK:           %[[WIDTH:.*]] = llvm.trunc %[[WIDTH_i64]] : i64 to i32
+    // CHECK:           %[[WIDTH_IN_BYTES:.*]] = llvm.mul %[[WIDTH]], {{.*}} : i32
+    // CHECK:           %[[ROW_STRIDE:.*]] = llvm.trunc %[[ROW_STRIDE_i64]] : i64 to i32
+    // CHECK:           %[[ROW_STRIDE_IN_BYTES:.*]] = llvm.mul %[[ROW_STRIDE]], {{.*}} : i32
+    // CHECK:           %[[OFFSET_1:.*]] = llvm.trunc %[[OFF_1]] : i32 to i32
+    // CHECK:           %[[OFFSET_0:.*]] = llvm.trunc %[[OFF_0]] : i32 to i32
+
+    // CHECK-COUNT-16: llvm.extractvalue {{.*}} : !llvm.struct<(f16, f16, {{.*}})>
+    // CHECK-COUNT-1: llvm.call spir_funccc @_Z12get_local_idj
+    // CHECK: %[[WARP_ID:.*]] = llvm.call spir_funccc @_Z16get_sub_group_id() {no_unwind, will_return} : () -> i32
+    // CHECK: llvm.mlir.undef : vector<8xf16>
+    // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
+    // COM: Skip the register, lane, warp and block to the offset computation which should be covered by the LL tests.
+    // CHECK:           %[[OFFSET_X:.*]] = llvm.add %[[OFFSET_1]], {{.*}} : i32
+    // CHECK:           %[[OFFSET_Y:.*]] = llvm.add %[[OFFSET_0]], {{.*}} : i32
+    // CHECK:           %[[STRIDE:.*]] = llvm.mul %[[OFFSET_Y]], %[[ROW_STRIDE_IN_BYTES]] : i32
+    // CHECK:           %[[BASE_WITH_OFF:.*]] = llvm.getelementptr %[[base]]{{\[}}%[[STRIDE]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, i16
+    // CHECK:           %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[OFFSET_Y:.*]] = llvm.select {{.*}}, %[[CST_0]], %[[HEIGHT]] : i1, i32
+    // CHECK: triton_gen.2Dblockstore %[[BASE_WITH_OFF]], %[[WIDTH_IN_BYTES]], %[[HEIGHT]], {{.*}}, %[[OFFSET_X]], %[[OFFSET_Y]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+
+    // CHECK: llvm.mlir.undef : vector<8xf16>
+    // CHECK-COUNT-8: llvm.insertelement %{{[0-9]+}}, %{{[0-9]+}}{{\[}}{{.*}} : i32] : vector<8xf16>
+    // CHECK:           %[[OFFSET_X:.*]] = llvm.add %[[OFFSET_1]], {{.*}} : i32
+    // CHECK:           %[[OFFSET_Y:.*]] = llvm.add %[[OFFSET_0]], {{.*}} : i32
+    // CHECK:           %[[STRIDE:.*]] = llvm.mul %[[OFFSET_Y]], %[[ROW_STRIDE_IN_BYTES]] : i32
+    // CHECK:           %[[BASE_WITH_OFF:.*]] = llvm.getelementptr %[[base]]{{\[}}%[[STRIDE]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, i16
+    // CHECK:           %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:           %[[OFFSET_Y:.*]] = llvm.select {{.*}}, %[[CST_0]], %[[HEIGHT]] : i1, i32
+    // CHECK: triton_gen.2Dblockstore %[[BASE_WITH_OFF]], %[[WIDTH_IN_BYTES]], %[[HEIGHT]], {{.*}}, %[[OFFSET_X]], %[[OFFSET_Y]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+    tt.store %13, %cst {boundaryCheck = array<i32: 1>, ttig.block_io = "row_major"} : !tt.ptr<tensor<64x16xf16, #dpas>>
+    tt.return
   }
 }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -308,7 +308,7 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
   template <
       typename OpTy,
       std::enable_if_t<llvm::is_one_of<OpTy, triton::gpu::intel::PrefetchOp,
-                                       triton::LoadOp>::value,
+                                       triton::LoadOp, triton::StoreOp>::value,
                        bool> = true>
   static bool isMemoryRowMajor(OpTy op) {
     Attribute blockIOAttr =
@@ -374,6 +374,142 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
                         b.ptrtoint(i64_ty, ptrs.at({0, 0})));
     pitch = targetInfo.shuffleIdx(rewriter, loc, pitch, 0);
     return b.umax(b.trunc(i32_ty, pitch), baseWidth);
+  }
+
+  // Return the tileHeight, tileWidth, vBlocks, row Dim and column Dim.
+  static std::tuple<int, int, int, int, int>
+  getBlockIOTileSize(const LinearLayout &ll) {
+
+    size_t rank = ll.getOutDims().size();
+    std::vector<unsigned> tileShape(rank, 1);
+
+    auto &bases = ll.getBases();
+    auto getBase = [&](std::string inDim) -> auto & {
+      for (auto &base : bases) {
+        if (base.first.getValue().compare(inDim) == 0) {
+          return base.second;
+        }
+      }
+      llvm_unreachable(("Could not find the input dim:" + inDim +
+                        ", on the ll:" + ll.toString())
+                           .c_str());
+    };
+    const auto &basesOfLane = getBase("lane");
+
+    int fastChangeDim = -1;
+    for (auto &base : basesOfLane) {
+      size_t i;
+      for (i = 0; i < rank; i++) {
+        if (base[i]) {
+          if (fastChangeDim < 0)
+            fastChangeDim = i;
+
+          if (tileShape[i] == base[i]) {
+            tileShape[i] <<= 1;
+          } else {
+            break;
+          }
+        }
+      }
+      if (i != rank)
+        break;
+    }
+
+    unsigned numLanes = 1 << basesOfLane.size();
+    // The slice of a single name is not in dense.
+    if (mlir::product<unsigned>(tileShape) != numLanes)
+      return std::make_tuple(-1, -1, -1, -1, -1);
+
+    unsigned sliceRank = 0;
+    int rowDim = -1;
+    for (size_t i = 0; i < rank; i++) {
+      if (tileShape[i] > 1) {
+        sliceRank++;
+        if (i != fastChangeDim)
+          rowDim = i;
+      }
+    }
+
+    // The block IO only supports 2D shape.
+    if (sliceRank > 2)
+      return std::make_tuple(-1, -1, -1, -1, -1);
+
+    // Note: we only walk thru the register bases of the incremental order of
+    // the naming. e.g: a0, a1, a2 ... It doesn't support to get the large tile
+    // shape for the DotOp B layout. e.g: Using for name in order a0, a2, a1, a3
+    // to make a large block io tile size.
+    // clang-format off
+    // ┌────┬────┬
+    // │A0  │A1  │
+    // │    │    │
+    // ├────┼────┼
+    // │A2  │A3  │
+    // │    │    │
+    // └────┴────┴
+    // clang-format on
+    // TODO: need to improve this.
+    const auto &basesOfRegister = getBase("register");
+    unsigned numNamesPerTile = 0;
+    // Increase the tile shape along the row dimension. (Increase the
+    // tileHeight.)
+    unsigned baseIter = 0;
+    for (; baseIter < basesOfRegister.size(); baseIter++) {
+      auto &base = basesOfRegister[baseIter];
+      size_t i;
+      for (i = 0; i < rank; i++) {
+        if (base[i]) {
+          if (rowDim < 0 && i != fastChangeDim) {
+            rowDim = i;
+          }
+          if (i != rowDim)
+            break;
+          if (tileShape[i] == base[i]) {
+            tileShape[i] <<= 1;
+            numNamesPerTile++;
+          } else {
+            break;
+          }
+        }
+      }
+
+      if (i != rank)
+        break;
+    }
+
+    if (rowDim < 0) {
+      if (fastChangeDim) {
+        // choose the first dimension as the row dimension.
+        rowDim = 0;
+      } else {
+        // choose the second dimension as the row dimension.
+        rowDim = 1;
+      }
+    }
+
+    unsigned vBlocks = 1;
+    // Increase the tile shape along the column dimension. (Increase the
+    // vBlocks.)
+    for (; baseIter < basesOfRegister.size(); baseIter++) {
+      auto &base = basesOfRegister[baseIter];
+      size_t i;
+      for (i = 0; i < rank; i++) {
+        if (base[i]) {
+          if (i != fastChangeDim)
+            break;
+          if ((tileShape[i] * vBlocks) == base[i]) {
+            vBlocks <<= 1;
+          } else {
+            break;
+          }
+        }
+      }
+
+      if (i != rank)
+        break;
+    }
+
+    return std::make_tuple(tileShape[rowDim], tileShape[fastChangeDim], vBlocks,
+                           rowDim, fastChangeDim);
   }
 };
 
@@ -778,6 +914,10 @@ struct LoadOpToBlockIOConversion
   LogicalResult
   matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
+    ModuleOp mod = op->getParentOfType<ModuleOp>();
+    if (!mod->hasAttr(triton::gpu::intel::TritonIntelGPUDialect::
+                          getSupportSG2DBlockAttrName()))
+      return failure();
     if (!isLoadCandidate(op))
       return failure();
 
@@ -1096,6 +1236,8 @@ struct LoadOpToBlockIOConversion
     // PVC 2D load supports 64 bytes per row at most. Load multiple dot operands
     // by enlarging the vBlocks.
     unsigned totalBytesPerRowPerDPASOp = tileWidth * elemSizeInBits / 8;
+    if (totalBytesPerRowPerDPASOp > 64)
+      return failure();
     numOperandsPer2DLoadN =
         std::min(numOperandsPer2DLoadN, 64 / totalBytesPerRowPerDPASOp);
 
@@ -2402,6 +2544,299 @@ private:
   bool useTileLoadLinearLayout;
 };
 
+struct StoreOpToBlockIOConversion
+    : public ConvertTritonGPUOpToLLVMPattern<triton::StoreOp>,
+      public BlockIOConversionBase {
+  using ConvertTritonGPUOpToLLVMPattern<
+      triton::StoreOp>::ConvertTritonGPUOpToLLVMPattern;
+
+  StoreOpToBlockIOConversion(
+      LLVMTypeConverter &converter, const triton::intel::TargetInfo &targetInfo,
+      const triton::intel::ModuleAxisInfoAnalysis &axisAnalysisPass,
+      PatternBenefit benefit)
+      : ConvertTritonGPUOpToLLVMPattern<triton::StoreOp>(converter, benefit),
+        BlockIOConversionBase(targetInfo, axisAnalysisPass) {}
+
+  LogicalResult
+  matchAndRewrite(triton::StoreOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    ModuleOp mod = op->getParentOfType<ModuleOp>();
+    if (!mod->hasAttr(TritonIntelGPUDialect::getSupportSG2DBlockAttrName()))
+      return failure();
+    Attribute blockIOAttr =
+        op->getAttr(TritonIntelGPUDialect::getBlockIOAttrName());
+    if (!blockIOAttr)
+      return failure();
+
+    Value value = op.getValue();
+    RankedTensorType tensorType = cast<RankedTensorType>(value.getType());
+    // Get the max tile shape supported by the layout.
+    Attribute encoding = tensorType.getEncoding();
+    std::optional<LinearLayout> llEncoding =
+        cast<DistributedEncodingTrait>(encoding).toLinearLayout(
+            tensorType.getShape());
+    assert(llEncoding.has_value() &&
+           "unexpected failure when getting linear layout");
+
+    int tileHeight, tileWidth, vBlocks, rowDim, colDim;
+    std::tie(tileHeight, tileWidth, vBlocks, rowDim, colDim) =
+        getBlockIOTileSize(*llEncoding);
+    // no valid tile shape for 2D block IO.
+    if (colDim < 0)
+      return failure();
+
+    Type eltTy = tensorType.getElementType();
+    unsigned elemSizeInBits = eltTy.getIntOrFloatBitWidth();
+    // 2D block store supports 64 bytes per row at most.
+    unsigned totalBytesPerRowPerDPASOp = tileWidth * elemSizeInBits / 8;
+    if (totalBytesPerRowPerDPASOp > 64)
+      return failure();
+
+    // TODO: use the axis info to general the handling for both regular pointer
+    // and block pointer.
+    const bool memoryRowMajor = isMemoryRowMajor(op);
+    unsigned contiguousDim = memoryRowMajor ? 1 : 0;
+    if (contiguousDim != colDim) {
+      // 2D Block store doesn't support transpose.
+      return failure();
+    }
+
+    // 2D block store only supports vBlocks = 1.
+    vBlocks = 1;
+    // 2D block store supports 8 rows at most.
+    tileHeight = std::min(8, tileHeight);
+
+    Location loc = op.getLoc();
+    MLIRContext *ctx = op.getContext();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    unsigned maskConstancyHor = 1, maskConstancyVer = 1;
+    unsigned numElems = getTotalElemsPerThread(tensorType);
+
+    Value llPtr = adaptor.getPtr();
+    Value llMask = adaptor.getMask();
+    Value llValue = adaptor.getValue();
+
+    SmallVector<Value> ptrElems, maskElems, valElems;
+    Value baseWidth, baseHeight, pitch, offsetBaseX, offsetBaseY;
+    Value elemSizeInBytes = b.i32_val(elemSizeInBits / 8);
+    auto boundaryCheck = op.getBoundaryCheck();
+    SetVector<unsigned> boundaryProtect(boundaryCheck.begin(),
+                                        boundaryCheck.end());
+    Value ptr = op.getPtr();
+    bool isBlockPointer = isTensorPointerType(ptr.getType());
+    if (isBlockPointer) {
+      auto [base, width, height, rowStride, colStride, offsetX, offsetY] =
+          getValuesFromBlockPointerStruct(llPtr, rewriter);
+
+      ptrElems = SmallVector<Value>(numElems, base);
+
+      assert(!llMask && "The masks is expected to be used with regular tensor "
+                        "pointer type, but got a block pointer type.");
+
+      if (boundaryProtect.contains(rowDim)) {
+        baseHeight = b.trunc(i32_ty, height);
+      } else {
+        // if the colDim is not boundary protected, then add the offsets into
+        // the base and use the tile height as the baseHeight here.
+        baseHeight = b.i32_val(tileHeight);
+      }
+
+      width = b.trunc(i32_ty, width);
+      if (boundaryProtect.contains(colDim)) {
+        // encoded as bytes.
+        baseWidth = b.mul(width, elemSizeInBytes);
+      } else {
+        // if the colDim is not boundary protected, then add the offsets into
+        // the base and use the tile width as the baseWidth here.
+        baseWidth = b.i32_val(
+            std::max(64u, vBlocks * tileWidth * (elemSizeInBits / 8)));
+      }
+
+      // encoded as bytes.
+      rowStride = b.trunc(i32_ty, rowStride);
+      pitch = b.mul(rowStride, elemSizeInBytes);
+      offsetBaseX = b.trunc(i32_ty, offsetX);
+      offsetBaseY = b.trunc(i32_ty, offsetY);
+    } else {
+      // Get the LLVM values for pointers
+      ptrElems = unpackLLElements(loc, llPtr, rewriter);
+      assert(ptrElems.size() == numElems &&
+             "the number of pointer values is not matched with the number of "
+             "elements");
+
+      // Get the LLVM values for mask
+      if (llMask) {
+        Value mask = op.getMask();
+        maskElems = unpackLLElements(loc, llMask, rewriter);
+        assert(maskElems.size() == numElems &&
+               "the number of mask values is not matched with the number of "
+               "elements");
+        auto axisInfo = const_cast<triton::intel::ModuleAxisInfoAnalysis &>(
+                            axisAnalysisPass)
+                            .getAxisInfo(mask);
+        if (axisInfo) {
+          maskConstancyHor = axisInfo->getConstancy(colDim);
+          maskConstancyVer = axisInfo->getConstancy(rowDim);
+        } else {
+          maskConstancyHor = 1;
+          maskConstancyVer = 1;
+        }
+      } else {
+        // no mask
+        maskConstancyHor = std::numeric_limits<unsigned>::max();
+        maskConstancyVer = std::numeric_limits<unsigned>::max();
+      }
+
+      // Check the constancy of the mask support to load the memory in 2D block.
+      if (!(maskConstancyHor >= tileWidth && maskConstancyVer >= tileHeight))
+        return failure();
+
+      baseWidth =
+          b.i32_val(std::max(64u, vBlocks * tileWidth * (elemSizeInBits / 8)));
+      baseHeight = b.i32_val(tileHeight);
+
+      // TODO: need to enhance the getPitch to take an Dim as input.
+      std::map<SmallVector<unsigned>, Value> ptrs;
+      // re-arrange the ptrs and masks to for large 2D block IO.
+      // Layout is unrelated to the scalar type.
+      SmallVector<SmallVector<unsigned>> offsets =
+          mlir::emitOffsetForLayout(encoding, tensorType);
+      for (size_t i = 0; i < ptrElems.size(); ++i) {
+        SmallVector<unsigned> offset = offsets[i];
+        ptrs[offset] = ptrElems[i];
+      }
+
+      pitch = getPitch(rewriter, ptr, ptrs, baseWidth, elemSizeInBits);
+      if (!pitch)
+        return failure();
+    }
+
+    // Get the LLVM values for store values
+    valElems = unpackLLElements(loc, llValue, rewriter);
+    assert(valElems.size() == numElems &&
+           "the number of store values is not matched with the number of "
+           "elements");
+
+    // Although the getBlockTileShape make sure there is no duplication within
+    // warp, still need to deduplicate the value in across warps and blocks;
+    auto freeVarMasks = getFreeVariableMasks(tensorType);
+    Value threadPred =
+        emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
+
+    unsigned threadsPerWarp =
+        TritonGPUDialect::getThreadsPerWarp(op->getParentOfType<ModuleOp>());
+
+    int64_t elemsPerLane = tileHeight * tileWidth / threadsPerWarp;
+    Type opequaType = IntegerType::get(ctx, elemSizeInBits);
+    Type store2DGenXType =
+        LLVM::getVectorType(opequaType,
+                            elemsPerLane); // make it opaque type.
+
+    StringAttr kRegister = str_attr("register");
+    StringAttr kLane = str_attr("lane");
+    StringAttr kWarp = str_attr("warp");
+    StringAttr kBlock = str_attr("block");
+
+    Value warpId = rewriter.create<arith::IndexCastOp>(
+        loc, i32_ty,
+        rewriter.create<mlir::gpu::SubgroupIdOp>(loc, /*upperBound=*/nullptr));
+
+    // Right now only support to stack the values into a vector in sequential
+    // order.
+    for (size_t valIter = 0; valIter < numElems; valIter += elemsPerLane) {
+      // Compose the matrix by stacking the name into vector.
+      Value storeVal = rewriter.create<LLVM::UndefOp>(
+          loc,
+          LLVM::getVectorType(typeConverter->convertType(eltTy), elemsPerLane));
+      for (size_t i = 0; i < elemsPerLane; ++i) {
+        storeVal =
+            b.insert_element(storeVal, valElems[valIter + i], b.i32_val(i));
+      }
+
+      // TODO: the threadPred has to be the uniform value. Maybe just add an
+      // attribute to notify IGC about this information.
+      Value pred = threadPred;
+      Value addrElem = ptrElems[valIter];
+      Value offsetX, offsetY;
+      if (isBlockPointer) {
+        // Need to apply the linear layout to get the offsets to the base of the
+        // block pointer.
+        // TODO: add annotation uniform to the offsets. Make sure the IGC detect
+        // the offsets as uniform.
+        auto offsets = applyLinearLayout(loc, rewriter, *llEncoding,
+                                         {{kRegister, b.i32_val(valIter)},
+                                          {kLane, b.i32_val(0)},
+                                          {kWarp, warpId},
+                                          {kBlock, b.i32_val(0)}});
+        // TODO: To support rank > 2 tensor, we need to add the offsets of other
+        // dim to the base.
+        assert(offsets.size() == 2 && "only support 2D tensor for now.");
+        offsetX = b.add(offsetBaseX, offsets[colDim].second);
+        if (!boundaryProtect.contains(colDim)) {
+          Value off = b.mul(offsetX, elemSizeInBytes);
+          addrElem =
+              b.gep(ptr_ty(ctx, 1 /*global*/), opequaType, addrElem, off);
+          offsetX = b.i32_val(0);
+        }
+
+        offsetY = b.add(offsetBaseY, offsets[rowDim].second);
+        if (!boundaryProtect.contains(rowDim)) {
+          Value off = b.mul(offsetY, pitch);
+          addrElem =
+              b.gep(ptr_ty(ctx, 1 /*global*/), opequaType, addrElem, off);
+          offsetY = b.i32_val(0);
+        }
+      } else {
+        addrElem = targetInfo.shuffleIdx(rewriter, loc, addrElem, 0);
+
+        offsetX = b.i32_val(0);
+        offsetY = b.i32_val(0);
+        // Use the top-left address and mask of the block to store the data.
+        // (The first value refer by the valIter.)
+        if (llMask) {
+          assert(maskElems.size() == valElems.size() &&
+                 "Invalid size of the masks.");
+          auto mask = maskElems[valIter];
+          pred = maybeAnd(rewriter, loc, pred, mask);
+          pred = targetInfo.shuffleIdx(rewriter, loc, pred, 0);
+        }
+      }
+
+      if (pred) {
+        // We leverage the GPU block I/O hardware out-of-bound protection
+        // feature by setting the offset to an invalid value when 'pred'
+        // is false (the HW will not read out-of-bounds values).
+        offsetY = b.select(pred, offsetY, baseHeight);
+      }
+
+      auto newOp = rewriter.create<TritonGEN::Matrix2DBlockStoreOp>(
+          loc,
+          /*ptr*/ addrElem,
+          /*base_width*/ baseWidth,
+          /*base_height*/ baseHeight,
+          /*base_pitch*/ pitch,
+          /*x*/ offsetX,
+          /*y*/ offsetY,
+          /*elem_size_in_bits*/ elemSizeInBits,
+          /*tile_width*/ tileWidth,
+          /*tile_height*/ tileHeight,
+          /*v_blocks*/ vBlocks,
+          /*stored_val*/ b.bitcast(storeVal, store2DGenXType));
+
+      if (failed(newOp.verify())) {
+        // delete the op so that the verifier will not abort the pass
+        // pipeline later, as we can fail this path and try a different
+        // approach.
+        rewriter.eraseOp(newOp);
+        return failure();
+      }
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct StoreOpConversion
     : public ConvertTritonGPUOpToLLVMPattern<triton::StoreOp>,
       public LoadStoreConversionBase {
@@ -2416,146 +2851,8 @@ struct StoreOpConversion
         LoadStoreConversionBase(targetInfo, axisAnalysisPass) {}
 
   LogicalResult
-  rewriteTensorPointerStore(triton::StoreOp op, OpAdaptor adaptor,
-                            ConversionPatternRewriter &rewriter) const {
-    Location loc = op.getLoc();
-    auto b = TritonLLVMOpBuilder(loc, rewriter);
-    Type resultType = op.getValue().getType();
-    auto tensorType = cast<RankedTensorType>(resultType);
-
-    // Only lower StoreOp with dpas layout encoding.
-    if (!hasDpasEncoding(tensorType))
-      return failure();
-
-    auto dpasLayout = cast<DpasEncodingAttr>(tensorType.getEncoding());
-    LLVMTypeConverter *typeConverter = getTypeConverter();
-    MLIRContext *ctx = rewriter.getContext();
-
-    Type eltTy = tensorType.getElementType();
-    unsigned elemSizeInBits = eltTy.getIntOrFloatBitWidth();
-    Value elemSizeInBytes = b.i32_val(elemSizeInBits / 8);
-    const ArrayRef<int64_t> tensorShape = tensorType.getShape();
-    size_t rank = tensorShape.size();
-    unsigned numElems = getTotalElemsPerThread(tensorType);
-    SmallVector<unsigned> elemsPerInstr = dpasLayout.getDPASInstShapeC();
-    auto warpsPerCTA = dpasLayout.getWarpsPerCTA();
-    SmallVector<int64_t> numReps =
-        dpasLayout.getDPASRepetitions(tensorShape, 2);
-    SmallVector<unsigned> dpasWarpsOrder =
-        getMatrixOrder(warpsPerCTA.size(), /*rowMajor*/ true);
-    unsigned threadsPerWarp =
-        product<unsigned>(getThreadsPerWarp(dpasLayout, tensorShape));
-
-    Value warpId = rewriter.create<arith::IndexCastOp>(
-        loc, i32_ty,
-        rewriter.create<mlir::gpu::SubgroupIdOp>(loc,
-                                                 /*upperBound=*/nullptr));
-    SmallVector<Value> multiDimWarpId = mlir::LLVM::delinearize(
-        rewriter, loc, warpId, warpsPerCTA, dpasWarpsOrder);
-
-    int64_t elemsPerLane = product<unsigned>(elemsPerInstr) / threadsPerWarp;
-    Type store2DGenXType =
-        LLVM::getVectorType(IntegerType::get(ctx, elemSizeInBits),
-                            elemsPerLane); // make it opaque type.
-
-    Value blockPtr = adaptor.getPtr();
-    auto [base, width, height, rowStride, colStride, offsetBaseX, offsetBaseY] =
-        getValuesFromBlockPointerStruct(blockPtr, rewriter);
-
-    auto vals = unpackLLElements(loc, adaptor.getValue(), rewriter);
-    assert(vals.size() == numElems);
-
-    width = b.trunc(i32_ty, width);
-    height = b.trunc(i32_ty, height);
-    rowStride = b.trunc(i32_ty, rowStride);
-    // encoded as bytes.
-    Value baseWidth = b.mul(width, elemSizeInBytes);
-    // encoded as bytes.
-    Value basePitch = b.mul(rowStride, elemSizeInBytes);
-
-    // A warp stride for the replicates.
-    SmallVector<unsigned> repClusterShape = dpasLayout.getShapeC();
-    unsigned outerDimWarpNum = std::min<unsigned>(
-        warpsPerCTA[rank - 2],
-        mlir::ceil<unsigned>(tensorShape[rank - 2], repClusterShape[rank - 2]));
-    unsigned innerDimWarpNum = std::min<unsigned>(
-        warpsPerCTA[rank - 1],
-        mlir::ceil<unsigned>(tensorShape[rank - 1], repClusterShape[rank - 1]));
-    Value outerDimWarpId =
-        b.urem(multiDimWarpId[rank - 2], b.i32_val(outerDimWarpNum));
-    Value innerDimWarpId =
-        b.urem(multiDimWarpId[rank - 1], b.i32_val(innerDimWarpNum));
-    int64_t numRepOuter = numReps[1];
-    int64_t numRepInner = numReps[2];
-
-    std::array<unsigned, 2> replicaStride = {
-        outerDimWarpNum * repClusterShape[rank - 2],
-        innerDimWarpNum * repClusterShape[rank - 1]};
-    std::array<unsigned, 2> warpStride = {repClusterShape[rank - 2],
-                                          repClusterShape[rank - 1]};
-
-    Value dimWarpId0 = b.mul(outerDimWarpId, b.i32_val(warpStride[0]));
-    Value dimWarpId1 = b.mul(innerDimWarpId, b.i32_val(warpStride[1]));
-    Value warpId0Offset = b.add(dimWarpId0, offsetBaseY);
-    Value warpId1Offset = b.add(dimWarpId1, offsetBaseX);
-
-    ArrayRef<unsigned> repCluster = dpasLayout.getRepCluster();
-    unsigned valOffset = 0;
-    for (int m = 0; m < numRepOuter; ++m) {
-      for (int n = 0; n < numRepInner; ++n) {
-        for (int repM = 0; repM < repCluster[0]; ++repM) {
-          Value offsetY =
-              b.add(warpId0Offset,
-                    b.i32_val(m * replicaStride[0] + repM * elemsPerInstr[0]));
-          for (int repN = 0; repN < repCluster[1]; ++repN) {
-            Value offsetX =
-                b.add(warpId1Offset, b.i32_val(n * replicaStride[1] +
-                                               repN * elemsPerInstr[1]));
-            Value storeVal = rewriter.create<LLVM::UndefOp>(
-                loc, LLVM::getVectorType(typeConverter->convertType(eltTy),
-                                         elemsPerLane));
-            for (size_t i = 0; i < elemsPerLane; ++i) {
-              storeVal =
-                  b.insert_element(storeVal, vals[valOffset], b.i32_val(i));
-              ++valOffset;
-            }
-
-            auto newOp = rewriter.create<TritonGEN::Matrix2DBlockStoreOp>(
-                loc,
-                /*ptr*/ base,
-                /*base_width*/ baseWidth,
-                /*base_height*/ height,
-                /*base_pitch*/ basePitch,
-                /*x*/ b.trunc(i32_ty, offsetX),
-                /*y*/ b.trunc(i32_ty, offsetY),
-                /*elem_size_in_bits*/ elemSizeInBits,
-                /*tile_width*/ elemsPerInstr[1],
-                /*tile_height*/ elemsPerInstr[0],
-                /*v_blocks*/ 1,
-                /*stored_val*/ b.bitcast(storeVal, store2DGenXType));
-
-            if (failed(newOp.verify())) {
-              // delete the op so that the verifier will not abort the pass
-              // pipeline later, as we can fail this path and try a different
-              // approach.
-              rewriter.eraseOp(newOp);
-              return failure();
-            }
-          }
-        }
-      }
-    }
-    rewriter.eraseOp(op);
-    return success();
-  }
-
-  LogicalResult
   matchAndRewrite(triton::StoreOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (isTensorPointerType(op.getPtr().getType()))
-      if (rewriteTensorPointerStore(op, adaptor, rewriter).succeeded())
-        return success();
-
     Location loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     auto *typeConverter = getTypeConverter();
@@ -3088,7 +3385,7 @@ void mlir::triton::intel::populateLoadStoreOpToLLVMPatterns(
                PrefetchOpConversion>(typeConverter, targetInfo,
                                      axisInfoAnalysis, benefit);
   // BlockIO is more efficient than gather load.
-  patterns.add<LoadOpToBlockIOConversion>(
+  patterns.add<LoadOpToBlockIOConversion, StoreOpToBlockIOConversion>(
       typeConverter, targetInfo, axisInfoAnalysis, benefit.getBenefit() + 2);
   patterns.add<LoadOpConversion>(typeConverter, targetInfo, axisInfoAnalysis,
                                  benefit, oneMatrixPerLoadForBT,

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -388,7 +388,7 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
     auto getBase = [&](const std::string &inDim) {
       for (const auto &base : bases) {
         StringAttr attr = base.first;
-        if (attr.getValue().compare(inDim) == 0) 
+        if (attr.getValue().compare(inDim) == 0)
           return base.second;
       }
       llvm_unreachable(("Could not find the input dim:" + inDim +
@@ -396,7 +396,7 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
                            .c_str());
     };
 
-    using BaseType = LinearLayout::BasesT::value_type::second_type;    
+    using BaseType = LinearLayout::BasesT::value_type::second_type;
     const BaseType &basesOfLane = getBase("lane");
 
     int fastChangeDim = -1;
@@ -461,7 +461,7 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
         int elem = base[i];
         if (elem == 0)
           continue;
-        if (rowDim < 0 && i != fastChangeDim) 
+        if (rowDim < 0 && i != fastChangeDim)
           rowDim = i;
         if (i != rowDim || tileShape[i] != elem)
           break;
@@ -477,7 +477,7 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
 
     // Increase the tile shape along the column dimension. (Increase the
     // vBlocks.)
-    unsigned vBlocks = 1;    
+    unsigned vBlocks = 1;
     for (; baseIter < basesOfRegister.size(); baseIter++) {
       const std::vector<int> &base = basesOfRegister[baseIter];
       size_t i = 0;


### PR DESCRIPTION
Refactor the 2D block IO store lowering.
1. Use one 2D block IO store lowering pattern with higher priority for the `tt.store` with either regular pointer or block pointer.
2. Use the linear layout utils to get the block IO tile shape. To support more variant of layouts in addition to the DPAS layout.
3. Fix the flaky that not checking the memory contiguous on store pointer.
4. Add boundary protection support for block pointer.
