### PR TITLE
Fix crash when processing getMakeTensorPtr op through while loop

### DIFF
--- a/lib/Dialect/Triton/IR/Utility.cpp
+++ b/lib/Dialect/Triton/IR/Utility.cpp
@@ -89,6 +89,9 @@ tt::MakeTensorPtrOp tt::getMakeTensorPtrOp(Value v) {
                : condBr.getFalseDestOperands()[argNum]);
     return tt::getMakeTensorPtrOp(argOwner->getOperand(argNum));
   }
+  if (auto whileOp = dyn_cast<scf::WhileOp>(argOwner)) {
+    return tt::getMakeTensorPtrOp(whileOp.getOperand(argNum));
+  }
   llvm_unreachable("Unable to getMakeTensorPtr()");
 }
 


### PR DESCRIPTION
Properly handle while loop in `getMakeTensorPtr`. 

This is common code, but given upstream is deprecating the feature I don't think they want to take this change. The test for this is in #4463 but I think it is better to keep the commit logically separate and not have it squashed and merged with #4463. 