### PR TITLE
[LoadStoreOpToLLVM] Fix load with `base height == 1`

### DIFF
--- a/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
+++ b/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
@@ -263,27 +263,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 32 : i32, "ttg.th
     // CHECK: [[C1:%.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK: [[LOAD:%.*]] = triton_gen.2Dblockload %{{.*}}, %{{.*}}, [[C1]], %{{.*}}, %{{.*}}, %{{.*}} {elem_size_in_bits = 32, tile_width = 8, tile_height = 16, v_blocks = 2
 
-    // CHECK: [[C0_:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: [[OLDVAL:%.*]] = llvm.extractelement [[LOAD]][[[C0_]] : i32] : vector<16xi32>
+    // CHECK: [[VEC:%.*]] = llvm.mlir.undef : vector<2xi32>
+
+    // CHECK: [[C0:%.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: [[OLDVAL:%.*]] = llvm.extractelement [[LOAD]][[[C0]] : i32] : vector<16xi32>
     // CHECK: [[C0:%.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK: [[THREADID_i64:%.*]] = llvm.call spir_funccc @_Z12get_local_idj([[C0]])
     // CHECK: [[THREADID:%.*]] = llvm.trunc [[THREADID_i64]] : i64 to i32
     // CHECK: [[C8:%.*]] = llvm.mlir.constant(8 : i32) : i32
     // CHECK: [[REM:%.*]] = llvm.urem [[THREADID]], [[C8]] : i32
     // CHECK: [[NEWVAL:%.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij([[OLDVAL]], [[REM]])
-    // CHECK: [[LOAD1:%.*]] = llvm.insertelement [[NEWVAL]], [[LOAD]][[[C0_]] : i32] : vector<16xi32>
+    // CHECK: [[C0:%.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: [[VEC1:%.*]] = llvm.insertelement [[NEWVAL]], [[VEC]][[[C0]] : i32] : vector<2xi32>
 
-    // CHECK: [[C8_:%.*]] = llvm.mlir.constant(8 : i32) : i32
-    // CHECK: [[OLDVAL:%.*]] = llvm.extractelement [[LOAD1]][[[C8_]] : i32] : vector<16xi32>
+    // CHECK: [[C8:%.*]] = llvm.mlir.constant(8 : i32) : i32
+    // CHECK: [[OLDVAL:%.*]] = llvm.extractelement [[LOAD]][[[C8]] : i32] : vector<16xi32>
     // CHECK: [[C0:%.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK: [[THREADID_i64:%.*]] = llvm.call spir_funccc @_Z12get_local_idj([[C0]])
     // CHECK: [[THREADID:%.*]] = llvm.trunc [[THREADID_i64]] : i64 to i32
     // CHECK: [[C8:%.*]] = llvm.mlir.constant(8 : i32) : i32
     // CHECK: [[REM:%.*]] = llvm.urem [[THREADID]], [[C8]] : i32
     // CHECK: [[NEWVAL:%.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij([[OLDVAL]], [[REM]])
-    // CHECK: [[LOAD2:%.*]] = llvm.insertelement [[NEWVAL]], [[LOAD1]][[[C8_]] : i32] : vector<16xi32>
+    // CHECK: [[C1:%.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK: [[VEC2:%.*]] = llvm.insertelement [[NEWVAL]], [[VEC1]][[[C1]] : i32] : vector<2xi32>
 
-    // CHECK: llvm.shufflevector [[LOAD2]], [[LOAD2]] [0, 0, 0, 0, 0, 0, 0, 0, 8, 8, 8, 8, 8, 8, 8, 8]
+    // CHECK: llvm.shufflevector [[VEC2]], [[VEC2]] [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1]
     tt.return
   }
 }

--- a/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
+++ b/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
@@ -246,3 +246,44 @@ module attributes {ttig.support_sg_2d_block, "ttg.num-warps" = 8 : i32} {
     tt.return
   }
 }
+
+// -----
+
+// COM: Check codegen when base height is 1 and tile height is > 1.
+#mma = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 1, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [2, 1], A = [16, 8], B = [8, 16], C = [16, 16]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_sg_2d_block} {
+  // CHECK-LABEL: @baseheight1
+  tt.func public @baseheight1(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+    %18 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>}>>
+    %19 = tt.expand_dims %18 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>}>> -> tensor<1x32xi32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %20 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %21 = tt.addptr %20, %19 : tensor<1x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>, tensor<1x32xi32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %22 = tt.broadcast %21 : tensor<1x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> -> tensor<64x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %50 = tt.load %22 {ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    // CHECK: [[C1:%.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK: [[LOAD:%.*]] = triton_gen.2Dblockload %{{.*}}, %{{.*}}, [[C1]], %{{.*}}, %{{.*}}, %{{.*}} {elem_size_in_bits = 32, tile_width = 8, tile_height = 16, v_blocks = 2
+
+    // CHECK: [[C0_:%.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: [[OLDVAL:%.*]] = llvm.extractelement [[LOAD]][[[C0_]] : i32] : vector<16xi32>
+    // CHECK: [[C0:%.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: [[THREADID_i64:%.*]] = llvm.call spir_funccc @_Z12get_local_idj([[C0]])
+    // CHECK: [[THREADID:%.*]] = llvm.trunc [[THREADID_i64]] : i64 to i32
+    // CHECK: [[C8:%.*]] = llvm.mlir.constant(8 : i32) : i32
+    // CHECK: [[REM:%.*]] = llvm.urem [[THREADID]], [[C8]] : i32
+    // CHECK: [[NEWVAL:%.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij([[OLDVAL]], [[REM]])
+    // CHECK: [[LOAD1:%.*]] = llvm.insertelement [[NEWVAL]], [[LOAD]][[[C0_]] : i32] : vector<16xi32>
+
+    // CHECK: [[C8_:%.*]] = llvm.mlir.constant(8 : i32) : i32
+    // CHECK: [[OLDVAL:%.*]] = llvm.extractelement [[LOAD1]][[[C8_]] : i32] : vector<16xi32>
+    // CHECK: [[C0:%.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: [[THREADID_i64:%.*]] = llvm.call spir_funccc @_Z12get_local_idj([[C0]])
+    // CHECK: [[THREADID:%.*]] = llvm.trunc [[THREADID_i64]] : i64 to i32
+    // CHECK: [[C8:%.*]] = llvm.mlir.constant(8 : i32) : i32
+    // CHECK: [[REM:%.*]] = llvm.urem [[THREADID]], [[C8]] : i32
+    // CHECK: [[NEWVAL:%.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij([[OLDVAL]], [[REM]])
+    // CHECK: [[LOAD2:%.*]] = llvm.insertelement [[NEWVAL]], [[LOAD1]][[[C8_]] : i32] : vector<16xi32>
+
+    // CHECK: llvm.shufflevector [[LOAD2]], [[LOAD2]] [0, 0, 0, 0, 0, 0, 0, 0, 8, 8, 8, 8, 8, 8, 8, 8]
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1381,12 +1381,12 @@ struct LoadOpToBlockIOConversion
                 (usePackedType && opIdx == DpasEncodingAttr::OpIdx::OperandB &&
                  !isTransposeRequired && originalElemBits != 32));
 
-            // If base height is less than tile height, only the initial
-            // base height rows contain valid data. To ensure the entire tile
-            // is filled with valid data, we must replicate these valid rows
-            // throughout the tile.
-            if (baseHeightInt < tileHeight) {
-              assert(baseHeightInt == 1 && "TODO: support baseHeight > 1");
+            // When strides[0] is 0, we only want to load the first row, so we
+            // set the base height to be 1. If base height is less than tile
+            // height, only the first row contain valid data. To ensure the
+            // entire tile is filled with valid data, we must replicate the
+            // first row throughout the tile.
+            if (baseHeightInt < tileHeight && baseHeightInt == 1) {
               SmallVector<int32_t> shuffleIndices(numValuesPerLoad);
 
               // Variable to track the start index of the matrix.
@@ -1402,17 +1402,13 @@ struct LoadOpToBlockIOConversion
                   if (tileWidth < threadsPerWarp) {
                     assert(tileWidth * 2 == threadsPerWarp &&
                            "Expecting tileWidth to be 2x threadsPerWarp");
-                    // Since tile width is 2x threads per warp, we only need to
-                    // perform special handling when base height is 1.
-                    if (baseHeightInt == 1) {
-                      Value idx = b.i32_val(valueIndex);
-                      Value oldVal = b.extract_element(ret, idx);
-                      Value threadId = getThreadId(rewriter, loc);
-                      Value newVal = targetInfo.shuffleIdx(
-                          rewriter, loc, oldVal,
-                          b.urem(threadId, b.i32_val(tileWidth)));
-                      ret = b.insert_element(ret.getType(), ret, newVal, idx);
-                    }
+                    Value idx = b.i32_val(valueIndex);
+                    Value oldVal = b.extract_element(ret, idx);
+                    Value threadId = getThreadId(rewriter, loc);
+                    Value newVal = targetInfo.shuffleIdx(
+                        rewriter, loc, oldVal,
+                        b.urem(threadId, b.i32_val(tileWidth)));
+                    ret = b.insert_element(ret.getType(), ret, newVal, idx);
                   }
 
                   startIndex = valueIndex;


### PR DESCRIPTION
When `strides[0]` is 0, we only want to load the first row, so we set the base height to be 1. (<= done in another PR)
When base height is less than tile height and base height is 1, only the first row contain valid data. 
To ensure the entire tile is filled with valid data, we must replicate the first row throughout the tile.

Benchmark CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/16004699061 (no geomean regression)
Inductor CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/16041054719 (passes)

New changes:
Benchmark CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/16041041775

Fixes #4593