### PR TITLE
Make sure `arch_parser.c` work with DLE 2025.0

### DIFF
--- a/third_party/intel/backend/arch_parser.c
+++ b/third_party/intel/backend/arch_parser.c
@@ -43,9 +43,11 @@ extern "C" EXPORT_FUNC const char *parse_device_arch(uint64_t dev_arch) {
   case sycl::ext::oneapi::experimental::architecture::intel_gpu_pvc:
     arch = "pvc";
     break;
+#if SYCL_COMPILER_VERSION >= 20250000
   case sycl::ext::oneapi::experimental::architecture::intel_gpu_ptl_h:
     arch = "ptl_h";
     break;
+#endif
   default:
     std::cerr << "sycl_arch not recognized: " << (uint64_t)sycl_arch
               << std::endl;


### PR DESCRIPTION
`#if SYCL_COMPILER_VERSION >= 20250000` should be enough:
```bash
icpx --version
Intel(R) oneAPI DPC++/C++ Compiler 2025.0.4 (2025.0.4.20241205)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/intel/oneapi/compiler/2025.0/bin/compiler
Configuration file: /opt/intel/oneapi/compiler/2025.0/bin/compiler/../icpx.cfg
(triton-3.11) jovyan@jupyter:~/intel-xpu-backend-for-triton$ grep SYCL_COMPILER_VERSION /opt/intel/oneapi/compiler/2025.0/include/ -r
/opt/intel/oneapi/compiler/2025.0/include/syclcompat/device.hpp:#if (defined(__SYCL_COMPILER_VERSION) && __SYCL_COMPILER_VERSION >= 20221105)
/opt/intel/oneapi/compiler/2025.0/include/syclcompat/device.hpp:#if (__SYCL_COMPILER_VERSION && __SYCL_COMPILER_VERSION < 20220902)
/opt/intel/oneapi/compiler/2025.0/include/sycl/version.hpp:#define __SYCL_COMPILER_VERSION 20241205
```