### PR TITLE
add icx-cl support for Windows.

### DIFF
--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -22,7 +22,7 @@ def is_xpu():
 
 
 def _cc_cmd(cc, src, out, include_dirs, library_dirs, libraries):
-    if "cl.EXE" in cc or "clang-cl" in cc:
+    if "cl.EXE" in cc or "clang-cl" in cc or "icx-cl" in cc:
         cc_cmd = [cc, "/Zc:__cplusplus", "/std:c++17", src, "/nologo", "/O2", "/LD", "/wd4996", "/MD", "/EHsc"]
         cc_cmd += [f"/I{dir}" for dir in include_dirs]
         cc_cmd += [f"/Fo{os.path.join(os.path.dirname(out), 'main.obj')}"]


### PR DESCRIPTION
This code add `CC` check and dispatch rule for Intel compiler `icx-cl` enabling.

I have local test pass for it on `sd3` module.

![image](https://github.com/user-attachments/assets/e53b6ced-3510-4e7c-aeed-ee59e5f9d879)


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `Tested in local pytorch environment.`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
