### PR TITLE
Don't copy `compile_commands.json` in `compile-triton.sh`

### DIFF
--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -182,9 +182,6 @@ build_triton() {
 
   # Install triton and its dependencies.
   pip install -v -e '.[build,tests]'
-
-  # Copy compile_commands.json in the build directory (so that cland vscode plugin can find it).
-  cp $(find $TRITON_PROJ_BUILD -name compile_commands.json) $TRITON_PROJ/
 }
 
 build() {


### PR DESCRIPTION
No longer needed after https://github.com/triton-lang/triton/commit/3043f5e9645a49d08a0ee0ade814043f556550f7

Can potentially conflict and lead to:
`error: [Errno 20] Not a directory: PosixPath('.../intel-xpu-backend-for-triton/compile_commands.json') `