### PR TITLE
Don't call `os.remove` on Windows in `intel/backend/compiler.py`

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -435,13 +435,17 @@ class XPUBackend(BaseBackend):
                                 ocloc_cmd[-1] = metadata["build_flags"] + shader_dump_opt
                                 subprocess.run(ocloc_cmd, check=True, close_fds=False, stdout=flog,
                                                stderr=subprocess.STDOUT)
-                        os.remove(flog.name)
-                    if os.path.exists(fsrc.name):
+                        if os.name != "nt":
+                            # Skip deleting on Windows to avoid
+                            # PermissionError: [WinError 32] The process cannot access the file because
+                            # it is being used by another process
+                            os.remove(flog.name)
+                    if os.path.exists(fsrc.name) and os.name != "nt":
                         os.remove(fsrc.name)
                 except subprocess.CalledProcessError as e:
                     with open(flog.name) as log_file:
                         log = log_file.read()
-                    if os.path.exists(flog.name):
+                    if os.path.exists(flog.name) and os.name != "nt":
                         os.remove(flog.name)
 
                     if e.returncode == 255:
@@ -457,7 +461,7 @@ class XPUBackend(BaseBackend):
 
                 with open(fbin, 'rb') as f:
                     zebin = f.read()
-                if os.path.exists(fbin):
+                if os.path.exists(fbin) and os.name != "nt":
                     os.remove(fbin)
             return zebin
         return spirv


### PR DESCRIPTION
For example:
```bash
FAILED intel\test_driver.py::test_auto_grf - assert 2 == 0
 +  where 2 = CompletedProcess(args=['C:\\ar\\_work\\intel-xpu-backend-for-triton\\intel-xpu-backend-for-triton\\.venv\\Scripts\\python.exe', 'C:\\Users\\vagrant\\AppData\\Local\\Temp\\tmppk9es5bh.py'], returncode=2, stdout=b'', stderr=b"c:\\hostedtoolcache\\Python\\3.10.11\\x64\\python.exe: can't open file 'C:\\\\Users\\\\vagrant\\\\AppData\\\\Local\\\\Temp\\\\tmppk9es5bh.py': [Errno 13] Permission denied\r\n").returncode
FAILED intel\test_native_code_generation.py::test_empty_kernel - PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\vagrant\\AppData\\Local\\Temp\\tmpp44er6rp.log'
```