### PR TITLE
Add custom timeout to detect stuck CI runs early

### DIFF
--- a/.github/workflows/spirvrunner-test.yml
+++ b/.github/workflows/spirvrunner-test.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on:
       - rolling
       - runner-0.0.22
+    timeout-minutes: 75 # equal to max + 3*std over the last 600 successful runs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
### Change Summary
Added custom timeout for `Tests` job of the `Test SPIRVRunner` workflow based on historical data that could lead to resource savings and faster CI for the project.

### More details
Over the last 586 successful runs, the `Tests` job has a maximum runtime of 56 minutes (mean=6, std=6).

However, there are failed runs that fail after reaching the threshold of 6 hours that GitHub imposes. In other words, these jobs seem to get stuck, possibly for external or random reasons. 

One such example is [this](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/13866541356/job/38806693439) job run, that failed after 6 hours. More stuck jobs have been observed over the last six months, the first one on 27-Feb-2025 and the last one one on 14-Mar-2025 (see below for full list of urls), while more recent occurences are also possible because our dataset has a cutoff date around late May. With the proposed changes, a total of **24 hours would have been saved** over the last six months retrospectively, clearing the queue for other workflows and **speeding up the CI** of the project, while also **saving resources** in general 🌱.

The idea is to set a timeout to stop jobs that run much longer than their historical maximum, because such jobs are probably stuck and will simply fail after GitHub's timeout of 6 hours.

Our PR proposes to set the timeout to `max + 3*std = 74 minutes` where `max` and `std` (standard deviation) are derived from the history of 586 successful runs. This will provide sufficient margin if the workflow gets naturally slower in the future, but if you would prefer lower/higher threshold we would be happy to do it.


<details>
  <summary>Click here to see all the recently timed-out runs.</summary>

  14-Mar-2025 => [timed-out run](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/13866541356/job/38806693439)
06-Mar-2025 => [timed-out run](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/13710216494/job/38344950860)
14-Mar-2025 => [timed-out run](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/13654072566/job/38761510916)
27-Feb-2025 => [timed-out run](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/13576280622/job/37953135686)
27-Feb-2025 => [timed-out run](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/13569722053/job/37931357725)

</details>

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Thanks for your time on this.

Feel free to let us know (here or in the email below) if you have any questions, and thanks for putting in the time to read this.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because the change is in the CI, adding a single line of code that is clearly documented [here](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) 

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
