### PR TITLE
Add `TRITON_INTEL_DEVICE_ARCH` env var to redefine architecture if needed

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -506,6 +506,7 @@ class intel_knobs(base_knobs):
     # `ocloc query CL_DEVICE_EXTENSIONS`. If not set, a compiler calls `ocloc` in runtime to get
     # the actual device extensions.
     device_extensions: env_opt_str = env_opt_str("TRITON_INTEL_DEVICE_EXTENSIONS")
+    device_arch: env_opt_str = env_opt_str("TRITON_INTEL_DEVICE_ARCH")
 
 
 class amd_knobs(base_knobs):

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -118,7 +118,7 @@ class XPUBackend(BaseBackend):
             raise TypeError("target.arch is not a dict")
         dirname = os.path.dirname(os.path.realpath(__file__))
         mod = compile_module_from_src(Path(os.path.join(dirname, "arch_parser.c")).read_text(), "arch_utils")
-        self.device_arch = mod.parse_device_arch(target.arch.get('architecture', 0))
+        self.device_arch = knobs.intel.device_arch or mod.parse_device_arch(target.arch.get('architecture', 0))
         self.properties = self.parse_target(target.arch)
         self.binary_ext = "spv"
 


### PR DESCRIPTION
How to use:
`TRITON_INTEL_DEVICE_ARCH=arl-s TRITON_ALWAYS_COMPILE=1 pytest "python/test/unit/language/test_core.py::test_dot[1-64-64-64-4-False-False-none-tf32-float32-float32-1-None]" --device xpu -s
`

This is necessary for more flexible testing, but we need to be careful because in the current version it only affects the performance features and does not override the following properties:
```python
        dev_prop['gpu_eu_count'] = tgt_prop.get('gpu_eu_count', None)
        dev_prop['gpu_subslice_count'] = tgt_prop.get('gpu_subslice_count', None)
        dev_prop['max_work_group_size'] = tgt_prop.get('max_work_group_size', None)
        dev_prop['max_num_sub_groups'] = tgt_prop.get('max_num_sub_groups', None)
        dev_prop['sub_group_sizes'] = tgt_prop.get('sub_group_sizes', None)
        dev_prop['has_fp64'] = tgt_prop.get('has_fp64', None)
```