### PR TITLE
Add sparse conditional copy propagation to Triton's `make_ttgir` transformation pipeline.

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -304,6 +304,7 @@ class XPUBackend(BaseBackend):
         passes.ttgpuir.add_reorder_instructions(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
+        passes.common.add_sccp(pm)
         passes.common.add_canonicalizer(pm)
         if knobs.intel.opt_reduction_locality:
             intel.passes.ttgpuir.add_optimize_reduction_locality(pm)


### PR DESCRIPTION
The SCCP pass is a dataflow transformation that propagates constants through the IR, therefore simplifying it.