### PR TITLE
Fix implementation of `test_tensor_descriptor_load_nd`

### DIFF
--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import triton
 import triton.language as tl
-from triton._internal_testing import is_blackwell, is_hopper, is_interpreter, numpy_random, to_triton, unwrap_tensor, tma_dtypes, to_numpy, uint_dtypes
+from triton._internal_testing import is_blackwell, is_hopper, is_interpreter, numpy_random, to_triton, unwrap_tensor, tma_dtypes, to_numpy
 from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 from typing import Optional
 from triton._internal_testing import is_cuda, is_hip, is_hip_cdna3, is_xpu


### PR DESCRIPTION
The `test_tensor_descriptor_load_nd` test case contains the following code:
```
  inp = to_triton(numpy_random(alloc_shape, dtype_str), device=device, dst_type=dtype_str)
  inp.data = inp.data[..., :INNER_BLOCK - 3]
```

The `inp.data` is updated (shallow update) to a tensor of 29 elements (when INNER_BLOCK == 32), however `inp.shape` becomes stale as it was created during construction of the `TensorWrapper` class during the call to `to_triton`.  

A better implementation is to slice the numpy array before translating it to a triton tensor.

