### PR TITLE
[TEST] xfail shape unsupported by block IO in `test_block_load_dpas_layout`

### DIFF
--- a/python/test/unit/intel/test_block_load.py
+++ b/python/test/unit/intel/test_block_load.py
@@ -16,6 +16,9 @@ from triton._internal_testing import is_xpu
 @pytest.mark.xfail(not torch.xpu.get_device_capability()['has_subgroup_2d_block_io'],
                    reason="Block loads not supported on this architecture")
 def test_block_load_dpas_layout(M, N, dtype_str, transpose, device, tmp_path: pathlib.Path):
+    if transpose and N == 8:
+        pytest.xfail("Pitch = 8 is not allowed by block IO")
+
     # modify the layouts to ensure the correct OCL/SPIRV intrinsic is called for each datatype
     if dtype_str == "int8":
         A_width = 2

--- a/scripts/skiplist/xe2/intel.txt
+++ b/scripts/skiplist/xe2/intel.txt
@@ -1,2 +1,0 @@
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/3935
-python/test/unit/intel/test_block_load.py::test_block_load_dpas_layout[True-int8-128-8]


### PR DESCRIPTION
There is HW restriction that pitch must be equal or greater than 64B.
There is no easy way to check that in runtime without affecting performance. 
The plan is to add runtime checks to ensure the HW restrictions are satisfied.

Fixes #3935 