### PR TITLE
[BACKEND] hint to LLVM that we can bound threadIdx.x (#7249)

### DIFF
--- a/test/Conversion/reduce_to_llvm.mlir
+++ b/test/Conversion/reduce_to_llvm.mlir
@@ -25,7 +25,7 @@ tt.func private @reduce_linear_layout(%arg0: tensor<32x16xi32, #linear>) -> tens
   // is not needed.
 
   // Reduce within threads
-  // CHECK-NEXT: [[SUM0:%.*]] = add i32 [[SRC0]], [[SRC2]]
+  // CHECK: [[SUM0:%.*]] = add i32 [[SRC0]], [[SRC2]]
   // CHECK-NEXT: [[SUM1:%.*]] = add i32 [[SRC1]], [[SRC3]]
 
   // Reduce within warp.


### PR DESCRIPTION
877cf7a9751c21d01dfc523cbc852c94ffde6c04 relanded most of e7cef2e63f79d4802878016bc0dbf3666b912ece, but missed one change.