### PR TITLE
Enable block IO store on regular pointer by default

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2756,9 +2756,10 @@ struct StoreOpToBlockIOConversion
       offsetBaseX = offsetX;
       offsetBaseY = offsetY;
     } else {
-      static const bool enableBlockStore = triton::tools::getBoolEnv(
-          "TRITON_INTEL_ENABLE_BLOCK_IO_STORE_ON_REGULAR_PTR");
-      if (!enableBlockStore)
+      std::optional<bool> enableBlockStore =
+          mlir::triton::tools::isEnvValueBool(mlir::triton::tools::getStrEnv(
+              "TRITON_INTEL_ENABLE_BLOCK_IO_STORE_ON_REGULAR_PTR"));
+      if (enableBlockStore.has_value() && !enableBlockStore.value())
         return failure();
       // Get the LLVM values for pointers
       ptrElems = unpackLLElements(loc, llPtr, rewriter);


### PR DESCRIPTION
Benchmark CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/16389219960 (no geomean regression)
Inductor UT CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/16389222996 (passes)
Flex Decoding CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/16390730800 (passes)
Flex Attention CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/16417773290 (no regression)

This PR changes the default behavior. Plan to remove the env var after merging a while and no unexpected regression.