### PR TITLE
Speed up `test_mxfp_matmul` by reducing block sizes: 128->64

### DIFF
--- a/python/test/unit/intel/test_mxfp_matmul.py
+++ b/python/test/unit/intel/test_mxfp_matmul.py
@@ -97,7 +97,7 @@ def mxfp_matmul(  #
 
 
 @pytest.mark.parametrize("M, N, K", [(1024, 512, 512)])
-@pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 128, 128)])
+@pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(64, 64, 64)])
 @pytest.mark.parametrize("NUM_STAGES", [1, 3])
 @pytest.mark.parametrize("B_TRANS", [True, False])
 @pytest.mark.parametrize("PACK_B_ALONG_K", [True, False])


### PR DESCRIPTION
I ran the test twice, for 128 and 64 blocks, to see the impact of compilation and +- pure runtime, and got the following data:

128 blocks:
1. `192 passed, 96 xfailed in 1464.76s (0:24:24)`
2. `192 passed, 96 xfailed in 7.16s`

64 blocks:
1. `192 passed, 96 xfailed in 235.29s (0:03:55)`
3. `192 passed, 96 xfailed in 5.99s`

It can be reverted in the future when compilation works better.