### PR TITLE
Limit the minimum repeatCount value to make sure the number elements of DPAS operand A is enough to be shared to each logical lane.

### DIFF
--- a/test/TritonIntelGPU/tritonintelgpu-invalid.mlir
+++ b/test/TritonIntelGPU/tritonintelgpu-invalid.mlir
@@ -214,3 +214,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return
   }
 }
+
+// -----
+
+#dpas = #ttig.dpas<{repeatCount = 1, systolicDepth = 8, executionSize = 16, opsPerChan = 1, threadsPerWarp = 16, warpsPerCTA = [2, 2], repCluster = [1, 1]}>
+// expected-error @below {{The DPAS encoding implies an invalid layout for A operand. The non-uniform matrix A could not be referred in kernel}}
+#dot_a = #ttg.dot_op<{opIdx=0, parent=#dpas, kWidth=1}>
+
+// -----
+
+// expected-error @below {{threadsPerWarp could not be smaller than the execution size}}
+#dpas = #ttig.dpas<{repeatCount = 1, systolicDepth = 8, executionSize = 16, opsPerChan = 1, threadsPerWarp = 8, warpsPerCTA = [2, 2], repCluster = [1, 1]}>

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
@@ -291,7 +291,7 @@ LogicalResult DpasEncodingAttr::verify(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
     unsigned repeatCount, unsigned systolicDepth, unsigned executionSize,
     unsigned opsPerChan, ::llvm::ArrayRef<unsigned> warpsPerCTA,
-    ::llvm::ArrayRef<unsigned> repCluster, unsigned sugGroupSize) {
+    ::llvm::ArrayRef<unsigned> repCluster, unsigned subGroupSize) {
   if (repeatCount > 8 || repeatCount < 1) {
     return emitError() << "repeatCount must be in the range [1, 8], but was:"
                        << repeatCount;
@@ -309,6 +309,12 @@ LogicalResult DpasEncodingAttr::verify(
   if (!(repCluster.size() == 2 || repCluster.size() == 3)) {
     return emitError() << "expected rank 2 or 3 of repCluster, but the rank is:"
                        << repCluster.size();
+  }
+
+  if (subGroupSize < executionSize) {
+    return emitError() << "threadsPerWarp could not be smaller than the "
+                          "execution size. got subGroupSize:"
+                       << subGroupSize << ", executionSize:" << executionSize;
   }
 
   return success();


### PR DESCRIPTION
The number of elements of the matrix for dot operands A maybe less than the sub-group-size. 
E.G for the case: repCount = 1, systolic depth = 8, ops per channel = 1 and threads_per_warp = 16.

It is not supported by the IGC scalar backend. We have to limit the minimal number of repCount=2 for that case with paddings.