### PR TITLE
Hot fix after #4811; don't create vector with only one element

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM/DPAS.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM/DPAS.cpp
@@ -351,19 +351,17 @@ private:
           for (int repOuter = 0; repOuter < repClusterOuter; ++repOuter) {
             for (int repInner = 0; repInner < repClusterInner; ++repInner) {
               Value matVal = rewriter.create<LLVM::UndefOp>(loc, dotOpTy);
-              for (int k = 0; k < numElemsPerOperand; ++k) {
-                matVal = tb.insert_element(dotOpTy, matVal, elems[offset++],
-                                           tb.i32_val(k));
-              }
-              if (isFToTF32Enabled) {
-                auto t32Val = rewriter.create<TritonGEN::FToTf32Op>(loc, matVal)
-                                  .getResult();
-                vals[{b, i * repClusterOuter + repOuter,
-                      j * repClusterInner + repInner}] = t32Val;
-              } else {
-                vals[{b, i * repClusterOuter + repOuter,
-                      j * repClusterInner + repInner}] = matVal;
-              }
+              if (numElemsPerOperand != 1)
+                for (int k = 0; k < numElemsPerOperand; ++k)
+                  matVal = tb.insert_element(dotOpTy, matVal, elems[offset++],
+                                             tb.i32_val(k));
+              else
+                matVal = elems[offset++];
+              if (isFToTF32Enabled)
+                matVal = rewriter.create<TritonGEN::FToTf32Op>(loc, matVal)
+                             .getResult();
+              vals[{b, i * repClusterOuter + repOuter,
+                    j * repClusterInner + repInner}] = matVal;
             }
           }
         }


### PR DESCRIPTION
To avoid:
```bash
inductor/test_flex_decoding.py::TestFlexDecodingXPU::test_builtin_score_mods_different_block_size_float32_score_mod1_BLOCK_SIZE2_xpu_float32 L0 build module failed. Log: 
error: undefined reference to `_Z25__spirv_RoundFToTF32INTELDv1_f'
in function: '__spirv_RoundFToTF32INTEL(float vector[1])' called by kernel: 'triton_tem_fused_0'

error: backend compiler failed build.

Error during Intel loadBinary: ZE_RESULT_ERROR_MODULE_BUILD_FAILURE
```

CI Flex attn: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/16691809088 (4h38m, no more these issues)
Flex decoding: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/16691844598 (2h58m, no more these issues)