### PR TITLE
Don't use PyTorch for getting active backend in `make_tensor_descriptor`

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -9,8 +9,6 @@ from triton.runtime import driver
 from .._C.libtriton import ir
 from . import core as tl
 
-import triton
-
 T = TypeVar('T')
 TensorTy = TypeVar('TensorTy')
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1921,8 +1921,8 @@ class TritonSemantic(Generic[TensorTy]):
             )
 
         last_stride = tl._unwrap_if_constexpr(strides[-1])
-        backend = triton.runtime.driver.active.get_current_target().backend
-        if backend != "xpu" and last_stride != 1:
+        backend = self.builder.options.backend_name
+        if backend != "intel" and last_stride != 1:
             raise ValueError(f"Tensor descriptor last dim must be 1 but got {last_stride}")
 
         shape = [self.make_scalar(x, tl.int32) for x in shape]


### PR DESCRIPTION
To fix the following error using @chengjunlu idea from https://github.com/intel/intel-xpu-backend-for-triton/issues/4837#issuecomment-3149572048:
```bash
FAILED [5.4279s] inductor/test_flex_attention.py::TestFlexAttentionXPU::test_strided_inputs_q_s0_k_s0_v_s0_do_s0_xpu_float16 - torch._inductor.exc.InductorError: SubprocException: An exception occurred in a subprocess:

Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/triton/language/core.py", line 43, in wrapper
    return fn(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/triton/language/core.py", line 2307, in make_tensor_descriptor
    return _semantic.make_tensor_descriptor(base, shape, strides, block_shape)
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/triton/language/semantic.py", line 1891, in make_tensor_descriptor
    backend = triton.runtime.driver.active.get_current_target().backend
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/triton/backends/intel/driver.py", line 807, in get_current_target
    device = self.get_current_device()
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/triton/backends/intel/driver.py", line 799, in get_current_device
    return self.utils.get_current_device()
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/triton/backends/intel/driver.py", line 793, in __getattr__
    self.utils = XPUUtils()
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/triton/backends/intel/driver.py", line 310, in __init__
    self.device_count = mod.init_devices(self.get_sycl_queue())
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/triton/backends/intel/driver.py", line 320, in get_sycl_queue
    return torch.xpu.current_stream().sycl_queue
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/torch/xpu/__init__.py", line 377, in current_stream
    _lazy_init()
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/torch/xpu/__init__.py", line 118, in _lazy_init
    raise RuntimeError(
RuntimeError: Cannot re-initialize XPU in forked subprocess. To use XPU with multiprocessing, you must use the 'spawn' start method

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/torch/_inductor/compile_worker/subproc_pool.py", line 377, in do_job
    result = job()
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/torch/_inductor/runtime/compile_tasks.py", line 62, in _worker_compile_triton
    kernel.precompile(warm_cache_only=True)
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/torch/_inductor/runtime/triton_heuristics.py", line 428, in precompile
    self._precompile_worker()
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/torch/_inductor/runtime/triton_heuristics.py", line 459, in _precompile_worker
    compile_results.append(self._precompile_config(c))
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/torch/_inductor/runtime/triton_heuristics.py", line 748, in _precompile_config
    binary = triton.compile(*compile_args, **compile_kwargs)
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/triton/compiler/compiler.py", line 306, in compile
    module = src.make_ir(options, codegen_fns, module_map, context)
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/triton/compiler/compiler.py", line 82, in make_ir
    return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
triton.compiler.errors.CompilationError: at 99:13:
    k_offset = off_zkv * stride_kz + off_hkv * stride_kh
    v_offset = off_zkv * stride_vz + off_hkv * stride_vh

    Q = Q + q_offset
    K = K + k_offset
    V = V + v_offset

    # Setting up the TMA descriptors for Q, K, V
    desc_q = None
    desc_k = None
    desc_v = None
    desc_q = tl.make_tensor_descriptor(
             ^
Cannot re-initialize XPU in forked subprocess. To use XPU with multiprocessing, you must use the 'spawn' start method


Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"


To execute this test, run the following from the base repo dir:
    python test/inductor/test_flex_attention.py TestFlexAttentionXPU.test_strided_inputs_q_s0_k_s0_v_s0_do_s0_xpu_float16
```