### PR TITLE
[BENCHMARK] Update cutlass's gemm configuration file

### DIFF
--- a/benchmarks/cutlass_kernel/gemm/input_gemm.in
+++ b/benchmarks/cutlass_kernel/gemm/input_gemm.in
@@ -1,10 +1,12 @@
+# OLD SHAPES : `cutlass-sycl/benchmarks/device/pvc/input_files/input_gemm.in`
+
 PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=1 --k=5120 --n=13824
 PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=4 --k=4096 --n=12288
 PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=512 --k=8192 --n=8192
 PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=512 --k=32768 --n=8192
 PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=512 --k=8192 --n=32768
+PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=1024 --k=28672 --n=8192
 PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=1024 --k=16384 --n=8192
-PvcGemmBF16BF16FP32_RRR_2 --bm_name=bf16_bf16_fp32 --l=1 --m=1024 --k=28672 --n=8192
 PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=3072 --k=4096 --n=3072
 PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=4096 --k=4096 --n=4096
 PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=4096 --k=16384 --n=8192
@@ -17,5 +19,23 @@ PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=16384 --k=1024 --n=
 PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=16384 --k=4096 --n=8192
 PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=4 --m=32768 --k=4096 --n=128
 PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=4 --m=32768 --k=128 --n=4096
-PvcGemmBF16BF16FP32_RRR_3 --bm_name=bf16_bf16_fp32 --l=32 --m=4096 --k=4096 --n=128
-PvcGemmBF16BF16FP32_RRR_5 --bm_name=bf16_bf16_fp32 --l=4096 --m=8 --k=16384 --n=128
+PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=32 --m=4096 --k=4096 --n=128
+PvcGemmBF16BF16FP32_RRR_3 --bm_name=bf16_bf16_fp32 --l=4096 --m=8 --k=16384 --n=128
+PvcGemmBF16BF16FP32_RRR_2 --bm_name=bf16_bf16_fp32 --l=4096 --m=8 --k=128 --n=16384
+
+# NEW SHAPES : `cutlass-sycl/benchmarks/device/pvc/input_files/input_pytorch_2.in`
+
+PvcGemmBF16BF16FP32_RCR_16 --bm_name=bf16_bf16_fp32 --l=1 --m=1 --k=4096 --n=1024
+PvcGemmBF16BF16FP32_RRR_5 --bm_name=bf16_bf16_fp32 --l=1 --m=1 --k=4096 --n=4096
+PvcGemmBF16BF16FP32_RRR_5 --bm_name=bf16_bf16_fp32 --l=1 --m=1 --k=14336 --n=4096
+PvcGemmBF16BF16FP32_RRR_5 --bm_name=bf16_bf16_fp32 --l=1 --m=1 --k=4096 --n=6144
+PvcGemmBF16BF16FP32_RRR_2 --bm_name=bf16_bf16_fp32 --l=1 --m=1 --k=4096 --n=14336
+PvcGemmBF16BF16FP32_RRR_2 --bm_name=bf16_bf16_fp32 --l=1 --m=1 --k=4096 --n=28672
+PvcGemmBF16BF16FP32_RRR_2 --bm_name=bf16_bf16_fp32 --l=1 --m=1 --k=4096 --n=128256
+PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=8 --k=4096 --n=1024
+PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=8 --k=4096 --n=4096
+PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=8 --k=14336 --n=4096
+PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=8 --k=4096 --n=6144
+PvcGemmBF16BF16FP32_RRR_2 --bm_name=bf16_bf16_fp32 --l=1 --m=8 --k=4096 --n=14336
+PvcGemmBF16BF16FP32_RRR_2 --bm_name=bf16_bf16_fp32 --l=1 --m=8 --k=4096 --n=28672
+PvcGemmBF16BF16FP32_RRR_2 --bm_name=bf16_bf16_fp32 --l=1 --m=8 --k=4096 --n=128256

--- a/benchmarks/triton_kernels_benchmark/gemm_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_benchmark.py
@@ -430,6 +430,13 @@ def get_benchmark(
             name = 'gemm'
             func = getattr(cutlass_kernel, name)
 
+            # Special case where the b matrix needs to be transposed (see: `./cutlass_kernel/gemm/input_gemm.in`)
+            if (B, M, N, K) == (1, 1, 1024, 4096):
+                _, b_shape = get_shapes(B, M, N, K, transpose_a=False, transpose_b=True)
+                b = torch.reshape(b, b_shape)
+                torch_b = b
+                torch_b = torch.transpose(torch_b, -2, -1)
+
             def cutlass_invoker():
                 if B == 1:
                     c = torch.zeros((M, N), device='xpu', dtype=torch.float32)


### PR DESCRIPTION
# Description

Following on the PR [#4720](https://github.com/intel/intel-xpu-backend-for-triton/pull/4720), this PR updates the GEMM configuration file used by the CUTLASS provider to improve performance.

As mentioned in this [comment](https://github.com/intel/intel-xpu-backend-for-triton/pull/4720#issuecomment-3131169074), this updated configuration is not the official CUTLASS one and does not deliver the best known performance for GEMM in CUTLASS.

**Note:** Work to integrate the best known performance configuration is already being tracked in the issue [#4775](https://github.com/intel/intel-xpu-backend-for-triton/issues/4775).

