### PR TITLE
Speedup 'rewrite stack ptr' pass by moving it after canonicalizer

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -320,8 +320,8 @@ class XPUBackend(BaseBackend):
         intel.passes.ttgpuir.add_to_llvmir(pm, options.advanced_path, options.one_matrix_per_load_for_bt,
                                            options.enable_tile_load_linear_layout)
         intel.passes.ttgpuir.add_gen_to_llvm(pm)
-        intel.passes.ttgpuir.add_rewrite_stack_ptr(pm)
         passes.common.add_canonicalizer(pm)
+        intel.passes.ttgpuir.add_rewrite_stack_ptr(pm)
         passes.common.add_cse(pm)
         passes.convert.add_arith_to_llvmir(pm)
         passes.common.add_canonicalizer(pm)


### PR DESCRIPTION
`0.6506 (  4.4%)    0.6506 (  6.9%)  TritonIntelGPURewriteStackPtr`
vs
`0.2397 (  1.9%)    0.2397 (  3.1%)  TritonIntelGPURewriteStackPtr`


Canonicalizer reduces 300k IR to 100k IR which speeds things up a lot. This data for one of the big Flex Attn kernels.