### PR TITLE
Remove `torchdata==0.9.0` pin and `torchtext` as deprecated

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -100,7 +100,6 @@ jobs:
           cd pytorch
           echo "BENCHMARK_COMMIT_ID=$(<.github/ci_commit_pins/torchbench.txt)" | tee -a "$GITHUB_ENV"
           echo "TORCHVISION_COMMIT_ID=$(<.github/ci_commit_pins/vision.txt)" | tee -a "$GITHUB_ENV"
-          echo "TORCHTEXT_COMMIT_ID=$(<.github/ci_commit_pins/text.txt)" | tee -a "$GITHUB_ENV"
           echo "TORCHAUDIO_COMMIT_ID=$(<.github/ci_commit_pins/audio.txt)" | tee -a "$GITHUB_ENV"
           echo "TRANSFORMERS_VERSION=$(<.ci/docker/ci_commit_pins/huggingface.txt)" | tee -a "$GITHUB_ENV"
           echo "TIMM_COMMIT_ID=$(<.ci/docker/ci_commit_pins/timm.txt)" | tee -a "$GITHUB_ENV"
@@ -156,15 +155,6 @@ jobs:
           package: torchvision
           repository: pytorch/vision
           ref: ${{ env.TORCHVISION_COMMIT_ID }}
-          extra-cache-key: ${{ env.PYTORCH_VERSION }}
-
-      - name: Install torchtext package
-        if: ${{ inputs.suite == 'torchbench' }}
-        uses: ./.github/actions/install-dependency
-        with:
-          package: torchtext
-          repository: pytorch/text
-          ref: ${{ env.TORCHTEXT_COMMIT_ID }}
           extra-cache-key: ${{ env.PYTORCH_VERSION }}
 
       - name: Install torchaudio package
@@ -273,7 +263,6 @@ jobs:
           TRITON_REPO=$GITHUB_REPOSITORY
           TRITON_COMMIT_ID=$GITHUB_SHA
           TORCHVISION_COMMIT_ID=$TORCHVISION_COMMIT_ID
-          TORCHTEXT_COMMIT_ID=$TORCHTEXT_COMMIT_ID
           TORCHAUDIO_COMMIT_ID=$TORCHAUDIO_COMMIT_ID
           TRANSFORMERS_VERSION=$TRANSFORMERS_VERSION
           TIMM_COMMIT_ID=$TIMM_COMMIT_ID

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -159,7 +159,6 @@ jobs:
           cd /c/pytorch
           echo "BENCHMARK_COMMIT_ID=$(<.github/ci_commit_pins/torchbench.txt)" | tee -a "$GITHUB_ENV"
           echo "TORCHVISION_COMMIT_ID=$(<.github/ci_commit_pins/vision.txt)" | tee -a "$GITHUB_ENV"
-          echo "TORCHTEXT_COMMIT_ID=$(<.github/ci_commit_pins/text.txt)" | tee -a "$GITHUB_ENV"
           echo "TORCHAUDIO_COMMIT_ID=$(<.github/ci_commit_pins/audio.txt)" | tee -a "$GITHUB_ENV"
           echo "TRANSFORMERS_VERSION=$(<.ci/docker/ci_commit_pins/huggingface.txt)" | tee -a "$GITHUB_ENV"
           echo "TIMM_COMMIT_ID=$(<.ci/docker/ci_commit_pins/timm.txt)" | tee -a "$GITHUB_ENV"
@@ -189,16 +188,6 @@ jobs:
           package: torchvision
           repository: pytorch/vision
           ref: ${{ env.TORCHVISION_COMMIT_ID }}
-          extra-cache-key: ${{ env.PYTORCH_VERSION }}
-          workspace: /c/gh${{ github.run_id }}
-
-      - name: Install torchtext package
-        if: inputs.suite == 'all' || inputs.suite == 'torchbench'
-        uses: ./.github/actions/install-dependency
-        with:
-          package: torchtext
-          repository: pytorch/text
-          ref: ${{ env.TORCHTEXT_COMMIT_ID }}
           extra-cache-key: ${{ env.PYTORCH_VERSION }}
           workspace: /c/gh${{ github.run_id }}
 
@@ -346,7 +335,6 @@ jobs:
           TRITON_REPO=$GITHUB_REPOSITORY
           TRITON_COMMIT_ID=$GITHUB_SHA
           TORCHVISION_COMMIT_ID=$TORCHVISION_COMMIT_ID
-          TORCHTEXT_COMMIT_ID=$TORCHTEXT_COMMIT_ID
           TORCHAUDIO_COMMIT_ID=$TORCHAUDIO_COMMIT_ID
           TRANSFORMERS_VERSION=$TRANSFORMERS_VERSION
           TIMM_COMMIT_ID=$TIMM_COMMIT_ID

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -56,7 +56,6 @@ jobs:
         run: |
           cd pytorch
           echo "TORCHVISION_COMMIT_ID=$(<.github/ci_commit_pins/vision.txt)" | tee -a $GITHUB_ENV
-          echo "TORCHTEXT_COMMIT_ID=$(<.github/ci_commit_pins/text.txt)" | tee -a $GITHUB_ENV
           echo "TORCHAUDIO_COMMIT_ID=$(<.github/ci_commit_pins/audio.txt)" | tee -a $GITHUB_ENV
           echo "TRANSFORMERS_VERSION=$(<.ci/docker/ci_commit_pins/huggingface.txt)" | tee -a $GITHUB_ENV
           echo "TIMM_COMMIT_ID=$(<.ci/docker/ci_commit_pins/timm.txt)" | tee -a $GITHUB_ENV
@@ -78,14 +77,6 @@ jobs:
           package: torchvision
           repository: pytorch/vision
           ref: ${{ env.TORCHVISION_COMMIT_ID }}
-          extra-cache-key: ${{ env.PYTORCH_VERSION }}
-
-      - name: Install torchtext package
-        uses: ./.github/actions/install-dependency
-        with:
-          package: torchtext
-          repository: pytorch/text
-          ref: ${{ env.TORCHTEXT_COMMIT_ID }}
           extra-cache-key: ${{ env.PYTORCH_VERSION }}
 
       - name: Install torchaudio package
@@ -119,7 +110,6 @@ jobs:
           cp -L pytorch/dist/*.whl wheels/
           cp -L dist/*.whl wheels/
           cp -L torchvision*/dist/*.whl wheels/
-          cp -L torchtext*/dist/*.whl wheels/
           cp -L torchaudio*/dist/*.whl wheels/
           cp -L timm*/dist/*.whl wheels/
           cp -L transformers*/dist/*.whl wheels/
@@ -143,7 +133,6 @@ jobs:
           TRITON_REPO=intel/intel-xpu-backend-for-triton
           TRITON_COMMIT_ID=$TRITON_COMMIT_ID
           TORCHVISION_COMMIT_ID=$TORCHVISION_COMMIT_ID
-          TORCHTEXT_COMMIT_ID=$TORCHTEXT_COMMIT_ID
           TORCHAUDIO_COMMIT_ID=$TORCHAUDIO_COMMIT_ID
           EOF
 

--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -129,7 +129,7 @@ fi
 ############################################################################
 # Check installed torch pinned dependencies
 
-PINNED_TORCH_DEPENDENCIES_REGEX="^torchtext==|^torchaudio==|^torchvision=="
+PINNED_TORCH_DEPENDENCIES_REGEX="^torchaudio==|^torchvision=="
 INSTALLED_PINNED_TORCH_DEPENDENCIES=$(pip list --format=freeze | grep -iE "$PINNED_TORCH_DEPENDENCIES_REGEX" || true)
 
 if [ -n "$INSTALLED_PINNED_TORCH_DEPENDENCIES" ]; then
@@ -143,7 +143,7 @@ if [ -n "$INSTALLED_PINNED_TORCH_DEPENDENCIES" ]; then
     echo "**** INFO: PyTorch pinned dependencies build from source mode is not supported. ****"
     exit 1
   fi
-  pip uninstall -y torchtext torchaudio torchvision
+  pip uninstall -y torchaudio torchvision
 fi
 
 ############################################################################


### PR DESCRIPTION
* Nightly wheels: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/16774870347/job/47498431732 (passed)
* E2E performance, torchbench: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/16775280352 (network connection error)
* E2E accuracy, torchbench: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/16777572980 (seems fine)

TorchText development is stopped: https://github.com/pytorch/text/releases/tag/v0.18.0 and it is not used in https://github.com/intel/torch-xpu-ops/blame/main/.github/workflows/nightly_ondemand_whl.yml

Motivation - to enable build wheels for python 3.13 and 3.14 (will try to enable it separately).