### PR TITLE
Always run inductor tests on Rolling driver

### DIFF
--- a/.github/workflows/inductor-tests-reusable.yml
+++ b/.github/workflows/inductor-tests-reusable.yml
@@ -35,7 +35,8 @@ jobs:
     name: Test
     runs-on:
       - linux
-      - ${{ inputs.runner_label || 'rolling' }}
+      - rolling
+      - ${{ inputs.runner_label || 'max1100' }}
     timeout-minutes: 960
     defaults:
       run:


### PR DESCRIPTION
This is the main case, more than once I encounter the situation that the lts driver is used (like in https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/16772057438/job/47489337478) when I manually specify `max1100` label.