### PR TITLE
Remove `torchdata==0.9.0` pin and `torchtext` as deprecated (#4849)

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -90,11 +90,6 @@ jobs:
           # cmake<4.0.0 is required as a workaround for CMake Error at third_party/double-conversion/CMakeLists.txt:1 (cmake_minimum_required)
           pip install wheel 'cmake<4.0.0'
 
-      # https://github.com/pytorch/data/blob/e316c5ca1ab2a4f69dd6d48e8fc9c6f8d0c7c468/README.md?plain=1#L6-L15
-      - name: Install pinned torchdata
-        run: |
-          pip install torchdata==0.9.0
-
       - name: Setup PyTorch
         uses: ./.github/actions/setup-pytorch
         with:
@@ -105,7 +100,6 @@ jobs:
           cd pytorch
           echo "BENCHMARK_COMMIT_ID=$(<.github/ci_commit_pins/torchbench.txt)" | tee -a "$GITHUB_ENV"
           echo "TORCHVISION_COMMIT_ID=$(<.github/ci_commit_pins/vision.txt)" | tee -a "$GITHUB_ENV"
-          echo "TORCHTEXT_COMMIT_ID=$(<.github/ci_commit_pins/text.txt)" | tee -a "$GITHUB_ENV"
           echo "TORCHAUDIO_COMMIT_ID=$(<.github/ci_commit_pins/audio.txt)" | tee -a "$GITHUB_ENV"
           echo "TRANSFORMERS_VERSION=$(<.ci/docker/ci_commit_pins/huggingface.txt)" | tee -a "$GITHUB_ENV"
           echo "TIMM_COMMIT_ID=$(<.ci/docker/ci_commit_pins/timm.txt)" | tee -a "$GITHUB_ENV"
@@ -161,15 +155,6 @@ jobs:
           package: torchvision
           repository: pytorch/vision
           ref: ${{ env.TORCHVISION_COMMIT_ID }}
-          extra-cache-key: ${{ env.PYTORCH_VERSION }}
-
-      - name: Install torchtext package
-        if: ${{ inputs.suite == 'torchbench' }}
-        uses: ./.github/actions/install-dependency
-        with:
-          package: torchtext
-          repository: pytorch/text
-          ref: ${{ env.TORCHTEXT_COMMIT_ID }}
           extra-cache-key: ${{ env.PYTORCH_VERSION }}
 
       - name: Install torchaudio package
@@ -273,7 +258,6 @@ jobs:
           TRITON_REPO=$GITHUB_REPOSITORY
           TRITON_COMMIT_ID=$GITHUB_SHA
           TORCHVISION_COMMIT_ID=$TORCHVISION_COMMIT_ID
-          TORCHTEXT_COMMIT_ID=$TORCHTEXT_COMMIT_ID
           TORCHAUDIO_COMMIT_ID=$TORCHAUDIO_COMMIT_ID
           TRANSFORMERS_VERSION=$TRANSFORMERS_VERSION
           TIMM_COMMIT_ID=$TIMM_COMMIT_ID

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -204,7 +204,6 @@ jobs:
           cd c:/pytorch
           echo "BENCHMARK_COMMIT_ID=$(<.github/ci_commit_pins/torchbench.txt)" | tee -a "$GITHUB_ENV"
           echo "TORCHVISION_COMMIT_ID=$(<.github/ci_commit_pins/vision.txt)" | tee -a "$GITHUB_ENV"
-          echo "TORCHTEXT_COMMIT_ID=$(<.github/ci_commit_pins/text.txt)" | tee -a "$GITHUB_ENV"
           echo "TORCHAUDIO_COMMIT_ID=$(<.github/ci_commit_pins/audio.txt)" | tee -a "$GITHUB_ENV"
           echo "TRANSFORMERS_VERSION=$(<.ci/docker/ci_commit_pins/huggingface.txt)" | tee -a "$GITHUB_ENV"
           echo "TIMM_COMMIT_ID=$(<.ci/docker/ci_commit_pins/timm.txt)" | tee -a "$GITHUB_ENV"
@@ -237,7 +236,6 @@ jobs:
           TRITON_REPO=$GITHUB_REPOSITORY
           TRITON_COMMIT_ID=$GITHUB_SHA
           TORCHVISION_COMMIT_ID=$TORCHVISION_COMMIT_ID
-          TORCHTEXT_COMMIT_ID=$TORCHTEXT_COMMIT_ID
           TORCHAUDIO_COMMIT_ID=$TORCHAUDIO_COMMIT_ID
           TRANSFORMERS_VERSION=$TRANSFORMERS_VERSION
           TIMM_COMMIT_ID=$TIMM_COMMIT_ID

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -49,11 +49,6 @@ jobs:
           # cmake 3.22.1 does not work with the recent torchaudio: https://github.com/intel/intel-xpu-backend-for-triton/issues/2079
           pip install wheel cmake
 
-      # https://github.com/pytorch/data/blob/e316c5ca1ab2a4f69dd6d48e8fc9c6f8d0c7c468/README.md?plain=1#L6-L15
-      - name: Install pinned torchdata
-        run: |
-          pip install torchdata==0.9.0
-
       - name: Setup PyTorch
         uses: ./.github/actions/setup-pytorch
 
@@ -61,7 +56,6 @@ jobs:
         run: |
           cd pytorch
           echo "TORCHVISION_COMMIT_ID=$(<.github/ci_commit_pins/vision.txt)" | tee -a $GITHUB_ENV
-          echo "TORCHTEXT_COMMIT_ID=$(<.github/ci_commit_pins/text.txt)" | tee -a $GITHUB_ENV
           echo "TORCHAUDIO_COMMIT_ID=$(<.github/ci_commit_pins/audio.txt)" | tee -a $GITHUB_ENV
           echo "TRANSFORMERS_VERSION=$(<.ci/docker/ci_commit_pins/huggingface.txt)" | tee -a $GITHUB_ENV
           echo "TIMM_COMMIT_ID=$(<.ci/docker/ci_commit_pins/timm.txt)" | tee -a $GITHUB_ENV
@@ -83,14 +77,6 @@ jobs:
           package: torchvision
           repository: pytorch/vision
           ref: ${{ env.TORCHVISION_COMMIT_ID }}
-          extra-cache-key: ${{ env.PYTORCH_VERSION }}
-
-      - name: Install torchtext package
-        uses: ./.github/actions/install-dependency
-        with:
-          package: torchtext
-          repository: pytorch/text
-          ref: ${{ env.TORCHTEXT_COMMIT_ID }}
           extra-cache-key: ${{ env.PYTORCH_VERSION }}
 
       - name: Install torchaudio package
@@ -124,7 +110,6 @@ jobs:
           cp -L pytorch/dist/*.whl wheels/
           cp -L dist/*.whl wheels/
           cp -L torchvision*/dist/*.whl wheels/
-          cp -L torchtext*/dist/*.whl wheels/
           cp -L torchaudio*/dist/*.whl wheels/
           cp -L timm*/dist/*.whl wheels/
           cp -L transformers*/dist/*.whl wheels/
@@ -148,7 +133,6 @@ jobs:
           TRITON_REPO=intel/intel-xpu-backend-for-triton
           TRITON_COMMIT_ID=$TRITON_COMMIT_ID
           TORCHVISION_COMMIT_ID=$TORCHVISION_COMMIT_ID
-          TORCHTEXT_COMMIT_ID=$TORCHTEXT_COMMIT_ID
           TORCHAUDIO_COMMIT_ID=$TORCHAUDIO_COMMIT_ID
           EOF
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2447,7 +2447,12 @@ def test_reduce1d(op, dtype_str, shape, num_ctas, num_warps, threads_per_warp, d
     # input
     rs = RandomState(17)
     # limit the range of integers so that the sum does not overflow
-    x = numpy_random((shape, ), dtype_str=dtype_str, rs=rs)
+    if dtype_str in integral_dtypes:
+        low = 0 if dtype_str in uint_dtypes else -100
+        high = 100
+        x = numpy_random((shape, ), dtype_str=dtype_str, rs=rs, low=low, high=high)
+    else:
+        x = numpy_random((shape, ), dtype_str=dtype_str, rs=rs)
     numpy_op = {
         'sum': np.sum,
         'max': np.max,

--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -90,7 +90,7 @@ fi
 ############################################################################
 # Check installed torch pinned dependencies
 
-PINNED_TORCH_DEPENDENCIES_REGEX="^torchtext==|^torchaudio==|^torchvision=="
+PINNED_TORCH_DEPENDENCIES_REGEX="^torchaudio==|^torchvision=="
 INSTALLED_PINNED_TORCH_DEPENDENCIES=$(pip list --format=freeze | grep -iE "$PINNED_TORCH_DEPENDENCIES_REGEX" || true)
 
 if [ -n "$INSTALLED_PINNED_TORCH_DEPENDENCIES" ]; then
@@ -104,7 +104,7 @@ if [ -n "$INSTALLED_PINNED_TORCH_DEPENDENCIES" ]; then
     echo "**** INFO: PyTorch pinned dependencies build from source mode is not supported. ****"
     exit 1
   fi
-  pip uninstall -y torchtext torchaudio torchvision
+  pip uninstall -y torchaudio torchvision
 fi
 
 ############################################################################

--- a/scripts/patch-pytorch.sh
+++ b/scripts/patch-pytorch.sh
@@ -35,5 +35,5 @@ apply_patch() {
 echo "Applying PyTorch patches in $REPO_ROOT"
 
 # put your patch applies here
-apply_patch https://github.com/pytorch/pytorch/pull/143553.diff
+# apply_patch https://github.com/pytorch/pytorch/pull/143553.diff
 apply_patch pytorch_fp64.patch


### PR DESCRIPTION
This is a prerequisite for adding the next commits to enable python3.13 and 3.14 wheel builds:
* https://github.com/intel/intel-xpu-backend-for-triton/commit/74f98d237b94b2a05ed7a6ae2b3e9349a6ae611c 3.13
* https://github.com/intel/intel-xpu-backend-for-triton/commit/83341cfc12e18d34bb65210923f6261a4e297224 3.14 lin
* https://github.com/intel/intel-xpu-backend-for-triton/pull/4858 3.14 win