### PR TITLE
[Coalescing]: Generalize implementation to reduce code duplication

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/Coalesce.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Coalesce.cpp
@@ -222,10 +222,11 @@ private:
       }
       if (auto yieldOp = dyn_cast<scf::YieldOp>(user)) {
         if (auto loopOp = yieldOp->getParentOfType<LoopLikeOpInterface>()) {
-          for (OpOperand &operand : yieldOp->getOpOperands())
-            if (operand.get() == val)
-              propagateLayoutToLoopResult(loopOp, operand.getOperandNumber(),
-                                          layout, rewriter);
+          for (OpOperand &operand : llvm::make_filter_range(
+                   yieldOp->getOpOperands(),
+                   [&val](OpOperand &operand) { return operand.get() == val; }))
+            propagateLayoutToLoopResult(loopOp, operand.getOperandNumber(),
+                                        layout, rewriter);
           continue;
         }
       }


### PR DESCRIPTION
This PR generalizes the coalescing implementation to reduce code duplication by unifying the handling of loop operations and value propagation.

- Replaces specific scf::ForOp and scf::WhileOp handling with generic LoopLikeOpInterface
- Merges separate methods for propagating layouts from operation results and block arguments into a single unified approach