### PR TITLE
Revert "Temporary disable building wheels for Python 3.13 (#4215)" (#4850)

### DIFF
--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -30,6 +30,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
       fail-fast: false
       max-parallel: 2
     defaults:


### PR DESCRIPTION
This reverts commit 1f4e845febde31e7564c30e7593f3a77fef8c4f7.

(cherry picked from commit 74f98d237b94b2a05ed7a6ae2b3e9349a6ae611c)
