### PR TITLE
[NOT MERGE] just to see how `rel/3.4` branch for PyTorch looks like

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -90,11 +90,6 @@ jobs:
           # cmake<4.0.0 is required as a workaround for CMake Error at third_party/double-conversion/CMakeLists.txt:1 (cmake_minimum_required)
           pip install wheel 'cmake<4.0.0'
 
-      # https://github.com/pytorch/data/blob/e316c5ca1ab2a4f69dd6d48e8fc9c6f8d0c7c468/README.md?plain=1#L6-L15
-      - name: Install pinned torchdata
-        run: |
-          pip install torchdata==0.9.0
-
       - name: Setup PyTorch
         uses: ./.github/actions/setup-pytorch
         with:
@@ -105,7 +100,6 @@ jobs:
           cd pytorch
           echo "BENCHMARK_COMMIT_ID=$(<.github/ci_commit_pins/torchbench.txt)" | tee -a "$GITHUB_ENV"
           echo "TORCHVISION_COMMIT_ID=$(<.github/ci_commit_pins/vision.txt)" | tee -a "$GITHUB_ENV"
-          echo "TORCHTEXT_COMMIT_ID=$(<.github/ci_commit_pins/text.txt)" | tee -a "$GITHUB_ENV"
           echo "TORCHAUDIO_COMMIT_ID=$(<.github/ci_commit_pins/audio.txt)" | tee -a "$GITHUB_ENV"
           echo "TRANSFORMERS_VERSION=$(<.ci/docker/ci_commit_pins/huggingface.txt)" | tee -a "$GITHUB_ENV"
           echo "TIMM_COMMIT_ID=$(<.ci/docker/ci_commit_pins/timm.txt)" | tee -a "$GITHUB_ENV"
@@ -161,15 +155,6 @@ jobs:
           package: torchvision
           repository: pytorch/vision
           ref: ${{ env.TORCHVISION_COMMIT_ID }}
-          extra-cache-key: ${{ env.PYTORCH_VERSION }}
-
-      - name: Install torchtext package
-        if: ${{ inputs.suite == 'torchbench' }}
-        uses: ./.github/actions/install-dependency
-        with:
-          package: torchtext
-          repository: pytorch/text
-          ref: ${{ env.TORCHTEXT_COMMIT_ID }}
           extra-cache-key: ${{ env.PYTORCH_VERSION }}
 
       - name: Install torchaudio package
@@ -273,7 +258,6 @@ jobs:
           TRITON_REPO=$GITHUB_REPOSITORY
           TRITON_COMMIT_ID=$GITHUB_SHA
           TORCHVISION_COMMIT_ID=$TORCHVISION_COMMIT_ID
-          TORCHTEXT_COMMIT_ID=$TORCHTEXT_COMMIT_ID
           TORCHAUDIO_COMMIT_ID=$TORCHAUDIO_COMMIT_ID
           TRANSFORMERS_VERSION=$TRANSFORMERS_VERSION
           TIMM_COMMIT_ID=$TIMM_COMMIT_ID

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -204,7 +204,6 @@ jobs:
           cd c:/pytorch
           echo "BENCHMARK_COMMIT_ID=$(<.github/ci_commit_pins/torchbench.txt)" | tee -a "$GITHUB_ENV"
           echo "TORCHVISION_COMMIT_ID=$(<.github/ci_commit_pins/vision.txt)" | tee -a "$GITHUB_ENV"
-          echo "TORCHTEXT_COMMIT_ID=$(<.github/ci_commit_pins/text.txt)" | tee -a "$GITHUB_ENV"
           echo "TORCHAUDIO_COMMIT_ID=$(<.github/ci_commit_pins/audio.txt)" | tee -a "$GITHUB_ENV"
           echo "TRANSFORMERS_VERSION=$(<.ci/docker/ci_commit_pins/huggingface.txt)" | tee -a "$GITHUB_ENV"
           echo "TIMM_COMMIT_ID=$(<.ci/docker/ci_commit_pins/timm.txt)" | tee -a "$GITHUB_ENV"
@@ -237,7 +236,6 @@ jobs:
           TRITON_REPO=$GITHUB_REPOSITORY
           TRITON_COMMIT_ID=$GITHUB_SHA
           TORCHVISION_COMMIT_ID=$TORCHVISION_COMMIT_ID
-          TORCHTEXT_COMMIT_ID=$TORCHTEXT_COMMIT_ID
           TORCHAUDIO_COMMIT_ID=$TORCHAUDIO_COMMIT_ID
           TRANSFORMERS_VERSION=$TRANSFORMERS_VERSION
           TIMM_COMMIT_ID=$TIMM_COMMIT_ID

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -49,11 +49,6 @@ jobs:
           # cmake 3.22.1 does not work with the recent torchaudio: https://github.com/intel/intel-xpu-backend-for-triton/issues/2079
           pip install wheel cmake
 
-      # https://github.com/pytorch/data/blob/e316c5ca1ab2a4f69dd6d48e8fc9c6f8d0c7c468/README.md?plain=1#L6-L15
-      - name: Install pinned torchdata
-        run: |
-          pip install torchdata==0.9.0
-
       - name: Setup PyTorch
         uses: ./.github/actions/setup-pytorch
 
@@ -61,7 +56,6 @@ jobs:
         run: |
           cd pytorch
           echo "TORCHVISION_COMMIT_ID=$(<.github/ci_commit_pins/vision.txt)" | tee -a $GITHUB_ENV
-          echo "TORCHTEXT_COMMIT_ID=$(<.github/ci_commit_pins/text.txt)" | tee -a $GITHUB_ENV
           echo "TORCHAUDIO_COMMIT_ID=$(<.github/ci_commit_pins/audio.txt)" | tee -a $GITHUB_ENV
           echo "TRANSFORMERS_VERSION=$(<.ci/docker/ci_commit_pins/huggingface.txt)" | tee -a $GITHUB_ENV
           echo "TIMM_COMMIT_ID=$(<.ci/docker/ci_commit_pins/timm.txt)" | tee -a $GITHUB_ENV
@@ -83,14 +77,6 @@ jobs:
           package: torchvision
           repository: pytorch/vision
           ref: ${{ env.TORCHVISION_COMMIT_ID }}
-          extra-cache-key: ${{ env.PYTORCH_VERSION }}
-
-      - name: Install torchtext package
-        uses: ./.github/actions/install-dependency
-        with:
-          package: torchtext
-          repository: pytorch/text
-          ref: ${{ env.TORCHTEXT_COMMIT_ID }}
           extra-cache-key: ${{ env.PYTORCH_VERSION }}
 
       - name: Install torchaudio package
@@ -124,7 +110,6 @@ jobs:
           cp -L pytorch/dist/*.whl wheels/
           cp -L dist/*.whl wheels/
           cp -L torchvision*/dist/*.whl wheels/
-          cp -L torchtext*/dist/*.whl wheels/
           cp -L torchaudio*/dist/*.whl wheels/
           cp -L timm*/dist/*.whl wheels/
           cp -L transformers*/dist/*.whl wheels/
@@ -148,7 +133,6 @@ jobs:
           TRITON_REPO=intel/intel-xpu-backend-for-triton
           TRITON_COMMIT_ID=$TRITON_COMMIT_ID
           TORCHVISION_COMMIT_ID=$TORCHVISION_COMMIT_ID
-          TORCHTEXT_COMMIT_ID=$TORCHTEXT_COMMIT_ID
           TORCHAUDIO_COMMIT_ID=$TORCHAUDIO_COMMIT_ID
           EOF
 

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -30,6 +30,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
       fail-fast: false
       max-parallel: 2
     defaults:

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -10,6 +10,12 @@ on:
     paths:
       - .github/workflows/nightly-wheels.yml
       - .github/pins/pytorch.txt
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/nightly-wheels.yml
+      - .github/pins/pytorch.txt
 
 permissions: read-all
 
@@ -31,6 +37,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14.0-rc.1"
       fail-fast: false
       max-parallel: 2
     defaults:

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2447,7 +2447,12 @@ def test_reduce1d(op, dtype_str, shape, num_ctas, num_warps, threads_per_warp, d
     # input
     rs = RandomState(17)
     # limit the range of integers so that the sum does not overflow
-    x = numpy_random((shape, ), dtype_str=dtype_str, rs=rs)
+    if dtype_str in integral_dtypes:
+        low = 0 if dtype_str in uint_dtypes else -100
+        high = 100
+        x = numpy_random((shape, ), dtype_str=dtype_str, rs=rs, low=low, high=high)
+    else:
+        x = numpy_random((shape, ), dtype_str=dtype_str, rs=rs)
     numpy_op = {
         'sum': np.sum,
         'max': np.max,

--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -90,7 +90,7 @@ fi
 ############################################################################
 # Check installed torch pinned dependencies
 
-PINNED_TORCH_DEPENDENCIES_REGEX="^torchtext==|^torchaudio==|^torchvision=="
+PINNED_TORCH_DEPENDENCIES_REGEX="^torchaudio==|^torchvision=="
 INSTALLED_PINNED_TORCH_DEPENDENCIES=$(pip list --format=freeze | grep -iE "$PINNED_TORCH_DEPENDENCIES_REGEX" || true)
 
 if [ -n "$INSTALLED_PINNED_TORCH_DEPENDENCIES" ]; then
@@ -104,7 +104,7 @@ if [ -n "$INSTALLED_PINNED_TORCH_DEPENDENCIES" ]; then
     echo "**** INFO: PyTorch pinned dependencies build from source mode is not supported. ****"
     exit 1
   fi
-  pip uninstall -y torchtext torchaudio torchvision
+  pip uninstall -y torchaudio torchvision
 fi
 
 ############################################################################

--- a/scripts/patch-pytorch.sh
+++ b/scripts/patch-pytorch.sh
@@ -35,4 +35,4 @@ apply_patch() {
 echo "Applying PyTorch patches in $REPO_ROOT"
 
 # put your patch applies here
-apply_patch https://github.com/pytorch/pytorch/pull/143553.diff
+# apply_patch https://github.com/pytorch/pytorch/pull/143553.diff

--- a/setup.py
+++ b/setup.py
@@ -787,7 +787,7 @@ TRITON_VERSION = "3.4.0" + get_git_version_suffix() + os.environ.get("TRITON_WHE
 
 # Dynamically define supported Python versions and classifiers
 MIN_PYTHON = (3, 9)
-MAX_PYTHON = (3, 13)
+MAX_PYTHON = (3, 14)
 
 PYTHON_REQUIRES = f">={MIN_PYTHON[0]}.{MIN_PYTHON[1]},<{MAX_PYTHON[0]}.{MAX_PYTHON[1] + 1}"
 BASE_CLASSIFIERS = [


### PR DESCRIPTION
Request to build new branch based on current pin of Triton in Pytorch: https://github.com/intel/intel-xpu-backend-for-triton/pull/4864#issuecomment-3166867787.

Unfortunately, we have already managed to add a new commit to the release/3.4.x branch:  https://github.com/intel/intel-xpu-backend-for-triton/commit/7527cb85c74110f1ee10165c99e0ac589ea24c7a. That was the original plan. The only problem is that the commit hash changes for those who use this branch without pinning a commit from it. Otherwise there shouldn't be any problems, this commit just changes our yml files, adapts one test that stopped working and does not apply flex attn patch.


Automatic checks didn't start, so I started them manually:
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/16826709189 (Build and test - success)
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/16826721817 (Build on Windows - success)
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/16826741205 (Triton wheels - **PyTorch build for 3.14 failed**, the only way to fix it - update PyTorch version; on the other side - **Triton build successful according** https://github.com/pytorch/pytorch/pull/160183)