### PR TITLE
Fix Windows CI failure (ninja regression)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=70.2.0", "cmake>=3.20,<4.0", "ninja>=1.11.1", "pybind11>=2.13.1"]
+requires = ["setuptools>=70.2.0", "cmake>=3.20,<4.0", "ninja==1.11.1.4", "pybind11>=2.13.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.mypy]


### PR DESCRIPTION
Ninja 1.13.0 with MSVC link.exe fails, apparently due to RSP line limit of 16,383 characters
https://github.com/ninja-build/ninja/issues/2616