### PR TITLE
Update and unpin ninja

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=70.2.0", "cmake>=3.20,<4.0", "ninja==1.11.1.4", "pybind11>=2.13.1"]
+requires = ["setuptools>=70.2.0", "cmake>=3.20,<4.0", "ninja>=1.13.1", "pybind11>=2.13.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.mypy]


### PR DESCRIPTION
Have to re-run when 1.13.1 is published

fixes https://github.com/intel/intel-xpu-backend-for-triton/issues/4876 
related to https://github.com/intel/intel-xpu-backend-for-triton/pull/4875
