### PR TITLE
Enable store block IO for all layout by default

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2683,9 +2683,11 @@ struct StoreOpToBlockIOConversion
   LogicalResult
   matchAndRewrite(triton::StoreOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    static const bool enableBlockIOForAllLayout =
-        triton::tools::getBoolEnv("TRITON_INTEL_ENABLE_BLOCK_IO_ALL_LAYOUTS");
-    if (!isBlockIOCandidate(op, enableBlockIOForAllLayout))
+    std::optional<bool> enableBlockIOForAllLayout =
+        mlir::triton::tools::isEnvValueBool(mlir::triton::tools::getStrEnv(
+            "TRITON_INTEL_ENABLE_BLOCK_IO_ALL_LAYOUTS"));
+    if (!isBlockIOCandidate(op, !enableBlockIOForAllLayout.has_value() ||
+                                    enableBlockIOForAllLayout.value()))
       return failure();
 
     Location loc = op.getLoc();


### PR DESCRIPTION
This PR enables block IO lowering for store op for all layout encoding by default, but it can still be disabled by `TRITON_INTEL_ENABLE_BLOCK_IO_ALL_LAYOUTS=0`.
Will remove the env var `TRITON_INTEL_ENABLE_BLOCK_IO_ALL_LAYOUTS` in another PR when no regressions identified. 

Benchmark CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/17305242559