### PR TITLE
Annotate loop containing chained dot operations

### DIFF
--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
@@ -62,6 +62,13 @@ def TritonIntelGPU_Dialect : Dialect {
     static constexpr llvm::StringRef getSupport16BitAtomicsAttrName() {
       return "ttig.support_16bit_atomics";
     }
+
+    /// FIXME: Remove once IGC can split large 2D block loads.
+    /// Get the name of the attribute used to indicate that a region (e.g. a loop)
+    /// contains chained dot operations.
+    static constexpr llvm::StringRef getContainsChainedDotAttrName() {
+      return "ttig.contains_chained_dot";
+    }
   }];
 
   let useDefaultAttributePrinterParser = 1;

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -987,6 +987,12 @@ struct LoadOpToBlockIOConversion
   LogicalResult
   rewriteTensorPointerLoad(triton::LoadOp op, OpAdaptor adaptor,
                            ConversionPatternRewriter &rewriter) const {
+    // FIXME: Remove once IGC can split large 2D block loads.
+    if (auto forOp = op->getParentOfType<scf::ForOp>())
+      oneMatrixPerLoadForBT |=
+          (op->hasAttr(triton::gpu::intel::TritonIntelGPUDialect::
+                           getContainsChainedDotAttrName()));
+
     Value ptr = op.getPtr();
     assert(isTensorPointerType(ptr.getType()) &&
            "Expecting tensor pointer type");
@@ -2466,7 +2472,7 @@ struct LoadOpToBlockIOConversion
   }
 
 private:
-  bool oneMatrixPerLoadForBT;
+  mutable bool oneMatrixPerLoadForBT;
   bool useTileLoadLinearLayout;
 };
 


### PR DESCRIPTION
When a loop contains chained dot operations (result of one dot operation is used by another) an attribute is added to the loop so that subsequent passes can query the attribute.
