### PR TITLE
[E2E] Run E2E models only on rolling driver

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -56,6 +56,7 @@ jobs:
     name: Test ${{ inputs.suite }} ${{ inputs.dtype }} ${{ inputs.mode }} ${{ inputs.test_mode }}
     runs-on:
       - linux
+      - rolling
       - ${{ inputs.runner_label || 'max1550' }}
     timeout-minutes: 720
     defaults:


### PR DESCRIPTION
CI:
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/17215497140 (functorch_maml_omniglot to check)
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/17215519185 (moondream to check)