### PR TITLE
Allow to run Inductor tests on IGC dev driver

### DIFF
--- a/.github/workflows/inductor-tests-reusable.yml
+++ b/.github/workflows/inductor-tests-reusable.yml
@@ -33,10 +33,7 @@ env:
 jobs:
   build:
     name: Test
-    runs-on:
-      - linux
-      - rolling
-      - ${{ inputs.runner_label || 'max1100' }}
+    runs-on: ${{ startsWith(inputs.runner_label, 'igc') && fromJSON(format('["linux","{0}"]', inputs.runner_label)) || fromJSON(format('["linux","rolling","{0}"]', inputs.runner_label || 'max1100')) }}
     timeout-minutes: 960
     defaults:
       run:


### PR DESCRIPTION
CI:
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/17262760115 (dev-igc, correct selected)
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/17262693515 (rolling, correct selected)