### PR TITLE
Fix `load_binary` function for clang++ compiler (#4951)

### DIFF
--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -188,7 +188,7 @@ extern "C" EXPORT_FUNC PyObject *load_binary(PyObject *args) {
   const char *name, *build_flags_ptr;
   int shared;
   PyObject *py_bytes;
-  bool is_spv;
+  int is_spv;
   int devId;
 
   if (!PyArg_ParseTuple(args, "sSispi", &name, &py_bytes, &shared,


### PR DESCRIPTION
Looks like `p (bool) [int]`
(https://docs.python.org/3.13/library/functions.html#bool) was misinterpreted. There was no need to use the bool type directly. It also looks like it's a UB bug, as it worked for GCC but not for clang.


(cherry picked from commit 84fd6100092cb021609b5d5482c184cee51045a5)