### PR TITLE
[E2E] Pin `numpy==1.26.4` as `torch-xpu-ops` does (#4938)

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Install python test dependencies
         run: |
-          pip install pyyaml pandas scipy numpy psutil pyre_extensions torchrec
+          pip install pyyaml pandas scipy 'numpy==1.26.4' psutil pyre_extensions torchrec
 
       - name: Install transformers package
         if: ${{ inputs.suite == 'huggingface' }}

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Install python test dependencies
         run: |
           .venv\Scripts\activate.ps1
-          pip install pyyaml pandas scipy numpy psutil pyre_extensions torchrec
+          pip install pyyaml pandas scipy 'numpy==1.26.4' psutil pyre_extensions torchrec
 
       - name: Install transformers package
         if: inputs.suite == 'all' || inputs.suite == 'huggingface'

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -468,7 +468,7 @@ run_inductor_tests() {
     git checkout $rev
   )
 
-  pip install pyyaml pandas scipy numpy psutil pyre_extensions torchrec
+  pip install pyyaml pandas scipy 'numpy==1.26.4' psutil pyre_extensions torchrec
 
   # TODO: Find the fastest Hugging Face model
   ZE_AFFINITY_MASK=0 python pytorch/benchmarks/dynamo/huggingface.py --accuracy --float32 -dxpu -n10 --no-skip --dashboard --inference --freezing --total-partitions 1 --partition-id 0 --only AlbertForMaskedLM --backend=inductor --timeout=4800 --output=$(pwd -P)/inductor_log.csv


### PR DESCRIPTION
Ref:
https://github.com/intel/torch-xpu-ops/blob/f2bcd8a4b87c8ff508640ebda24736abed92decd/.github/actions/inductor-xpu-e2e-test/action.yml#L94C9-L94C34

CI:
https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/17154375326 (`functorch_maml_omniglot` passed, it didn't work
[before](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/17060055766/job/48365105525#step:21:1567))


(cherry picked from commit ad0e8d974ae9424bd408e530960522d98a48a6e7)