### PR TITLE
[DLE2025.2] Fix warning: `ext_oneapi_get_default_context is deprecated: use khr_get_default_context() instead`

### DIFF
--- a/third_party/intel/backend/arch_parser.c
+++ b/third_party/intel/backend/arch_parser.c
@@ -43,7 +43,7 @@ extern "C" EXPORT_FUNC const char *parse_device_arch(uint64_t dev_arch) {
   case sycl::ext::oneapi::experimental::architecture::intel_gpu_pvc:
     arch = "pvc";
     break;
-#if SYCL_COMPILER_VERSION >= 20250000
+#if __SYCL_COMPILER_VERSION >= 20250000
   case sycl::ext::oneapi::experimental::architecture::intel_gpu_ptl_h:
     arch = "ptl_h";
     break;

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -169,7 +169,7 @@ sycl::context get_default_context(const sycl::device &sycl_device) {
 #ifdef WIN32
   sycl::context ctx;
   try {
-#if SYCL_COMPILER_VERSION >= 20250200
+#if __SYCL_COMPILER_VERSION >= 20250604
     ctx = platform.khr_get_default_context();
 #else
     ctx = platform.ext_oneapi_get_default_context();
@@ -184,7 +184,7 @@ sycl::context get_default_context(const sycl::device &sycl_device) {
   }
   return ctx;
 #else
-#if SYCL_COMPILER_VERSION >= 20250200
+#if __SYCL_COMPILER_VERSION >= 20250604
   return platform.khr_get_default_context();
 #else
   return platform.ext_oneapi_get_default_context();

--- a/third_party/intel/tools/intel/compile.cpp
+++ b/third_party/intel/tools/intel/compile.cpp
@@ -32,7 +32,7 @@ unsigned char BIN_NAME[{bin_size}] = {{ {bin_data} }};
 // sycl globals
 const sycl::device sycl_device;
 const auto ctx =
-#if SYCL_COMPILER_VERSION >= 20250200
+#if __SYCL_COMPILER_VERSION >= 20250604
     sycl_device.get_platform().khr_get_default_context();
 #else
     sycl_device.get_platform().ext_oneapi_get_default_context();

--- a/utils/SPIRVRunner/SPIRVRunner.cpp
+++ b/utils/SPIRVRunner/SPIRVRunner.cpp
@@ -127,7 +127,7 @@ sycl::context get_default_context(const sycl::device &sycl_device) {
 #ifdef WIN32
   sycl::context ctx;
   try {
-#if SYCL_COMPILER_VERSION >= 20250200
+#if __SYCL_COMPILER_VERSION >= 20250604
     ctx = platform.khr_get_default_context();
 #else
     ctx = platform.ext_oneapi_get_default_context();
@@ -142,7 +142,7 @@ sycl::context get_default_context(const sycl::device &sycl_device) {
   }
   return ctx;
 #else
-#if SYCL_COMPILER_VERSION >= 20250200
+#if __SYCL_COMPILER_VERSION >= 20250604
   return platform.khr_get_default_context();
 #else
   return platform.ext_oneapi_get_default_context();


### PR DESCRIPTION
Locally on subset tests - works. CI is still not successful for some reason: https://github.com/intel/intel-xpu-backend-for-triton/pull/4963

~The implementation in PyTorch gives confidence in these changes https://github.com/pytorch/pytorch/blob/06c7516994d6fdd4b1ac8b8aeae74cdcae0d34f4/c10/xpu/XPUFunctions.cpp#L138~

**UPD:** Pytorch approach doesn't suit us, they define the version `SYCL_COMPILER_VERSION` in https://github.com/pytorch/pytorch/blob/2a70d98abf8256d3d768eff028fca20198579824/cmake/Modules/FindSYCLToolkit.cmake#L60, using `icpx --version`. Since `icpx` is not always available to us, we will have to use the sycl version, which is defined directly in `sycl/version.cpp` header (however, the version must be determined carefully, since it does not match the version Pytorch uses).

For example:
2025.2.0
```cpp
// from sycl/version.hpp
#define __SYCL_COMPILER_VERSION 20250604
#define __LIBSYCL_MAJOR_VERSION 8
#define __LIBSYCL_MINOR_VERSION 0
#define __LIBSYCL_PATCH_VERSION 0
```
```bash
icpx --version
Intel(R) oneAPI DPC++/C++ Compiler 2025.2.0 (2025.2.0.20250605)
```

vs

2025.1.1
```cpp
// from sycl/version.hpp
#define __SYCL_COMPILER_VERSION 20250418
#define __LIBSYCL_MAJOR_VERSION 8
#define __LIBSYCL_MINOR_VERSION 0
#define __LIBSYCL_PATCH_VERSION 0
```
```bash
icpx --version
Intel(R) oneAPI DPC++/C++ Compiler 2025.1.1 (2025.1.1.20250418)
```

Candidate for cherry-pick.