### PR TITLE
[OptimizeDotOperands] Keep original attributes

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
@@ -449,6 +449,7 @@ private:
               : nullptr;
       assert(newAttr && "Expecting a valid blockIO attribute");
 
+      newLoadOp->setAttrs(loadOp->getAttrs());
       newLoadOp->setAttr(blockIOAttrName, newAttr);
       LLVM_DEBUG(llvm::dbgs().indent(2) << "newLoadOp: " << newLoadOp << "\n");
       cleanUp.insert(loadOp);


### PR DESCRIPTION
`AccelerateMatmul` pass adds `one_matrix_per_load` attribute to chain dot's B operand load. 
We would like to keep the attribute when fusing with `tt.trans` in `OptimizeDotOperands` pass.