### PR TITLE
Changes to improve `one-matrix-per-load` attribute passing

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
@@ -449,6 +449,7 @@ private:
               : nullptr;
       assert(newAttr && "Expecting a valid blockIO attribute");
 
+      newLoadOp->setAttrs(loadOp->getAttrs());
       newLoadOp->setAttr(blockIOAttrName, newAttr);
       LLVM_DEBUG(llvm::dbgs().indent(2) << "newLoadOp: " << newLoadOp << "\n");
       cleanUp.insert(loadOp);


### PR DESCRIPTION
Please do not squash and merge this PR.