### PR TITLE
[DLE2025.2] Fix warning: `ext_oneapi_get_default_context is deprecated: use khr_get_default_context() instead` (#4973)

### DIFF
--- a/third_party/intel/backend/arch_parser.c
+++ b/third_party/intel/backend/arch_parser.c
@@ -43,7 +43,7 @@ extern "C" EXPORT_FUNC const char *parse_device_arch(uint64_t dev_arch) {
   case sycl::ext::oneapi::experimental::architecture::intel_gpu_pvc:
     arch = "pvc";
     break;
-#if SYCL_COMPILER_VERSION >= 20250000
+#if __SYCL_COMPILER_VERSION >= 20250000
   case sycl::ext::oneapi::experimental::architecture::intel_gpu_ptl_h:
     arch = "ptl_h";
     break;

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -169,10 +169,14 @@ sycl::context get_default_context(const sycl::device &sycl_device) {
 #ifdef WIN32
   sycl::context ctx;
   try {
+#if __SYCL_COMPILER_VERSION >= 20250604
+    ctx = platform.khr_get_default_context();
+#else
     ctx = platform.ext_oneapi_get_default_context();
+#endif
   } catch (const std::runtime_error &ex) {
     // This exception is thrown on Windows because
-    // ext_oneapi_get_default_context is not implemented. But it can be safely
+    // khr_get_default_context is not implemented. But it can be safely
     // ignored it seems.
 #if _DEBUG
     std::cout << "ERROR: " << ex.what() << std::endl;
@@ -180,7 +184,11 @@ sycl::context get_default_context(const sycl::device &sycl_device) {
   }
   return ctx;
 #else
+#if __SYCL_COMPILER_VERSION >= 20250604
+  return platform.khr_get_default_context();
+#else
   return platform.ext_oneapi_get_default_context();
+#endif
 #endif
 }
 

--- a/third_party/intel/tools/intel/compile.cpp
+++ b/third_party/intel/tools/intel/compile.cpp
@@ -32,7 +32,11 @@ unsigned char BIN_NAME[{bin_size}] = {{ {bin_data} }};
 // sycl globals
 const sycl::device sycl_device;
 const auto ctx =
+#if __SYCL_COMPILER_VERSION >= 20250604
+    sycl_device.get_platform().khr_get_default_context();
+#else
     sycl_device.get_platform().ext_oneapi_get_default_context();
+#endif
 const auto l0_device =
     sycl::get_native<sycl::backend::ext_oneapi_level_zero>(sycl_device);
 const auto l0_context =

--- a/utils/SPIRVRunner/SPIRVRunner.cpp
+++ b/utils/SPIRVRunner/SPIRVRunner.cpp
@@ -127,10 +127,14 @@ sycl::context get_default_context(const sycl::device &sycl_device) {
 #ifdef WIN32
   sycl::context ctx;
   try {
+#if __SYCL_COMPILER_VERSION >= 20250604
+    ctx = platform.khr_get_default_context();
+#else
     ctx = platform.ext_oneapi_get_default_context();
+#endif
   } catch (const std::runtime_error &ex) {
     // This exception is thrown on Windows because
-    // ext_oneapi_get_default_context is not implemented. But it can be safely
+    // khr_get_default_context is not implemented. But it can be safely
     // ignored it seems.
 #if _DEBUG
     std::cout << "ERROR: " << ex.what() << std::endl;
@@ -138,7 +142,11 @@ sycl::context get_default_context(const sycl::device &sycl_device) {
   }
   return ctx;
 #else
+#if __SYCL_COMPILER_VERSION >= 20250604
+  return platform.khr_get_default_context();
+#else
   return platform.ext_oneapi_get_default_context();
+#endif
 #endif
 }
 


### PR DESCRIPTION
Locally on subset tests - works. CI is still not successful for some
reason: https://github.com/intel/intel-xpu-backend-for-triton/pull/4963

~The implementation in PyTorch gives confidence in these changes
https://github.com/pytorch/pytorch/blob/06c7516994d6fdd4b1ac8b8aeae74cdcae0d34f4/c10/xpu/XPUFunctions.cpp#L138~

**UPD:** Pytorch approach doesn't suit us, they define the version
`SYCL_COMPILER_VERSION` in
https://github.com/pytorch/pytorch/blob/2a70d98abf8256d3d768eff028fca20198579824/cmake/Modules/FindSYCLToolkit.cmake#L60,
using `icpx --version`. Since `icpx` is not always available to us, we
will have to use the sycl version, which is defined directly in
`sycl/version.cpp` header (however, the version must be determined
carefully, since it does not match the version Pytorch uses).

For example:
2025.2.0
```cpp
// from sycl/version.hpp
#define __SYCL_COMPILER_VERSION 20250604
#define __LIBSYCL_MAJOR_VERSION 8
#define __LIBSYCL_MINOR_VERSION 0
#define __LIBSYCL_PATCH_VERSION 0
```
```bash
icpx --version
Intel(R) oneAPI DPC++/C++ Compiler 2025.2.0 (2025.2.0.20250605)
```

vs

2025.1.1
```cpp
// from sycl/version.hpp
#define __SYCL_COMPILER_VERSION 20250418
#define __LIBSYCL_MAJOR_VERSION 8
#define __LIBSYCL_MINOR_VERSION 0
#define __LIBSYCL_PATCH_VERSION 0
```
```bash
icpx --version
Intel(R) oneAPI DPC++/C++ Compiler 2025.1.1 (2025.1.1.20250418)
```

Candidate for cherry-pick.

---------

Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>
(cherry picked from commit https://github.com/intel/intel-xpu-backend-for-triton/commit/c60ab880ee858b7290f4a7894b20b9d70de1217a)