### PR TITLE
Add tensor descriptor implementation for Flex Decoding (#4961)

### DIFF
--- a/scripts/patch-pytorch.sh
+++ b/scripts/patch-pytorch.sh
@@ -36,3 +36,4 @@ echo "Applying PyTorch patches in $REPO_ROOT"
 
 # put your patch applies here
 apply_patch ./patch/flex_attn_143553.patch
+apply_patch ./patch/flex_decoding_tensor_desc.patch

--- a/scripts/patch/flex_decoding_tensor_desc.patch
+++ b/scripts/patch/flex_decoding_tensor_desc.patch
@@ -1,0 +1,80 @@
+diff --git a/torch/_inductor/kernel/flex/flex_decoding.py b/torch/_inductor/kernel/flex/flex_decoding.py
+index 679caa9f09..08fb95b03b 100644
+--- a/torch/_inductor/kernel/flex/flex_decoding.py
++++ b/torch/_inductor/kernel/flex/flex_decoding.py
+@@ -326,6 +326,10 @@ def create_flex_decoding_kernel(*args, **kwargs):
+         # Set default to False
+         cur_kernel_options.setdefault("USE_TMA", False)
+ 
++        # Change to True if block pointer implementation is removed.
++        if torch.xpu.is_available() and can_use_tma(query, key, value):
++            cur_kernel_options["USE_TMA"] = False
++
+         # Add ROCm-specific parameters if they exist in the config
+         for attrib in ["kpack", "matrix_instr_nonkdim", "waves_per_eu"]:
+             if hasattr(conf, attrib):
+diff --git a/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja b/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
+index f4596070c8..01a9b0dffa 100644
+--- a/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
++++ b/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
+@@ -143,11 +143,28 @@
+         block_shape=(BLOCK_N, V_HEAD_DIM_ROUNDED),
+         order=(1, 0)
+     )
++    desc_k = None
++    desc_v = None
++    {%- if USE_TMA %}
++    desc_k = tl.make_tensor_descriptor(
++        base=K,
++        shape=[KV_LEN, QK_HEAD_DIM],
++        strides=[stride_kn, 1],
++        block_shape=[BLOCK_N, QK_HEAD_DIM_ROUNDED],
++    )
++
++    desc_v = tl.make_tensor_descriptor(
++        base=V,
++        shape=[KV_LEN, V_HEAD_DIM],
++        strides=[stride_vn, 1],
++        block_shape=[BLOCK_N, V_HEAD_DIM_ROUNDED],
++    )
++    {%- endif %}
+     offs_n = tl.arange(0, BLOCK_N) + off_n
+ 
+     acc, l_i, m_i = forward_inner(
+         {{gen_argdefs()}},
+-        q, K_block_ptr, V_block_ptr, None, None, Q_LEN, KV_LEN,
++        q, K_block_ptr, V_block_ptr, desc_k, desc_v, Q_LEN, KV_LEN,
+         # accumulatd values
+         acc, l_i, m_i,
+         #offsets
+@@ -193,11 +210,29 @@
+             block_shape=(BLOCK_N, V_HEAD_DIM_ROUNDED),
+             order=(1, 0)
+         )
++        desc_k = None
++        desc_v = None
++        {%- if USE_TMA %}
++        desc_k = tl.make_tensor_descriptor(
++            base=K,
++            shape=[KV_LEN, QK_HEAD_DIM],
++            strides=[stride_kn, 1],
++            block_shape=[BLOCK_N, QK_HEAD_DIM_ROUNDED],
++        )
++
++        desc_v = tl.make_tensor_descriptor(
++            base=V,
++            shape=[KV_LEN, V_HEAD_DIM],
++            strides=[stride_vn, 1],
++            block_shape=[BLOCK_N, V_HEAD_DIM_ROUNDED],
++        )
++        {%- endif %}
++
+         offs_n = tl.arange(0, BLOCK_N) + off_n
+ 
+         acc, l_i, m_i = forward_inner(
+             {{gen_argdefs()}},
+-            q, K_block_ptr, V_block_ptr, None, None, Q_LEN, KV_LEN,
++            q, K_block_ptr, V_block_ptr, desc_k, desc_v, Q_LEN, KV_LEN,
+             # accumulatd values
+             acc, l_i, m_i,
+             #offsets


### PR DESCRIPTION
https://github.com/pytorch/pytorch/commit/fc69c2bc67672c3b2d0c62c1821895f09288f1c0 removes block pointer implementation. In order to get good performance on Intel, structural pointer representation (e.g., tensor descriptor) implementation is required.
This PR adds a tensor descriptor implementation for Flex Decoding under `USE_TMA`.

---------


(cherry picked from commit d6079517b054ac7c94b582aac06c6b2a2f6aaabf)