### PR TITLE
Don't use `packaging` python lib in `capture-hw-details.sh`

### DIFF
--- a/scripts/capture-hw-details.sh
+++ b/scripts/capture-hw-details.sh
@@ -98,7 +98,7 @@ export AGAMA_VERSION="$(agama_version)"
 export GPU_DEVICE="$(gpu_device)"
 
 if python -c "import torch" &> /dev/null; then
-    export TORCH_VERSION=$(python -c "import torch; from packaging.version import Version; print(Version(torch.__version__).base_version)")
+    export TORCH_VERSION=$(python -c "import torch; print(torch.__version__)")
 else
     export TORCH_VERSION="Not installed"
 fi


### PR DESCRIPTION
To fix:
```bash
OS=Linux
/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/torch/_subclasses/functional_tensor.py:279: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at /runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/pytorch/torch/csrc/utils/tensor_numpy.cpp:84.)
  cpu = _conversion_method_template(device=torch.device("cpu"))
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'packaging'
LIBIGC1_VERSION=2.11.12-1146
LEVEL_ZERO_VERSION=1.21.9.0-1136
```
Seems not a big deal
```python
>>> import torch; from packaging.version import Version; print(Version(torch.__version__).base_version)
2.9.0
>>> import torch; print((torch.__version__))))
2.9.0a0+git54cc63b
```