### PR TITLE
Revert "Workaround -Wno-error for GCC 14 (upstream Pytorch) (#2895)"

### DIFF
--- a/.github/actions/setup-pytorch/action.yml
+++ b/.github/actions/setup-pytorch/action.yml
@@ -126,7 +126,7 @@ runs:
         # CMake Error at third_party/protobuf/cmake/CMakeLists.txt:2 (cmake_minimum_required)
         pip install 'cmake<4.0.0'
         pip install -r requirements.txt
-        USE_XCCL=1 USE_STATIC_MKL=1 CFLAGS="-Wno-error=maybe-uninitialized" python setup.py bdist_wheel 2>&1 | grep -v \
+        USE_XCCL=1 USE_STATIC_MKL=1 python setup.py bdist_wheel 2>&1 | grep -v \
           "Double arithmetic operation is not supported on this platform with FP64 conversion emulation mode (poison FP64 kernels is enabled)." | grep -v '^$'
 
     - name: Install PyTorch (built from source)


### PR DESCRIPTION
This reverts commit 3fcbdc83497a0ca37bfa32c1f00d05fb01043982.

Closes https://github.com/intel/intel-xpu-backend-for-triton/issues/2897