### PR TITLE
[DLE2025.2] Add workaround for `test_subprocess.py/test_print`

### DIFF
--- a/python/test/unit/language/test_subprocess.py
+++ b/python/test/unit/language/test_subprocess.py
@@ -53,6 +53,9 @@ def test_print(func_type: str, data_type: str, device: str):
         return
 
     outs = [line for line in proc.stdout.decode("UTF-8").splitlines() if line]
+    # FIXME: workaround for DLE 2025.2, namely PTI 0.13.1
+    # https://github.com/intel/intel-xpu-backend-for-triton/issues/4998
+    outs = filter(lambda elem: "Another subscriber already subscribed to Sycl runtime events" not in elem, outs)
     # The total number of elements in the 1-D tensor to print.
     N = 128
 


### PR DESCRIPTION
Relates to #4998

Tested in https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/17329962452/job/49203454420?pr=4963