### PR TITLE
Exclude `tools/test_aot.py` tests that cause hangs on windows && A770

### DIFF
--- a/python/test/unit/tools/test_aot.py
+++ b/python/test/unit/tools/test_aot.py
@@ -465,7 +465,7 @@ def check_hasco_binary_str(tmp_dir: str, dtype: str):
 
 
 # Test edge case where the provided kernel signature has no specializations
-@pytest.mark.parametrize("generate_native_code", [False])
+@pytest.mark.parametrize("generate_native_code", [True, False])
 def test_compile_link_matmul_no_specialization(generate_native_code):
     np.random.seed(3)
 
@@ -501,7 +501,7 @@ def test_compile_link_matmul_no_specialization(generate_native_code):
         np.testing.assert_allclose(c_tri, c_ref * c_ref, atol=1e-4, rtol=0.0)
 
 
-@pytest.mark.parametrize("generate_native_code", [False])
+@pytest.mark.parametrize("generate_native_code", [True, False])
 def test_compile_link_matmul(generate_native_code):
     np.random.seed(3)
 
@@ -536,7 +536,7 @@ def test_compile_link_matmul(generate_native_code):
         np.testing.assert_allclose(c_tri, c_ref * c_ref, atol=1e-4, rtol=0.0)
 
 
-@pytest.mark.parametrize("generate_native_code", [False])
+@pytest.mark.parametrize("generate_native_code", [True, False])
 def test_launcher_has_no_available_kernel(generate_native_code):
     np.random.seed(3)
 
@@ -580,7 +580,7 @@ def test_launcher_has_no_available_kernel(generate_native_code):
 @pytest.mark.skipif(not is_cuda() and not is_xpu(), reason="Requires CUDA or XPU")
 def test_compile_link_autotune_matmul():
     # this test is pretty slow, so we only run with the native binary
-    generate_native_code = False
+    generate_native_code = True
 
     np.random.seed(3)
 

--- a/scripts/skiplist/a770/tools.txt
+++ b/scripts/skiplist/a770/tools.txt
@@ -1,0 +1,7 @@
+python/test/unit/tools/test_aot.py::test_launcher_has_no_available_kernel[True]
+python/test/unit/tools/test_aot.py::test_launcher_has_no_available_kernel[False]
+python/test/unit/tools/test_aot.py::test_compile_link_matmul_no_specialization[True]
+python/test/unit/tools/test_aot.py::test_compile_link_matmul_no_specialization[False]
+python/test/unit/tools/test_aot.py::test_compile_link_matmul[True]
+python/test/unit/tools/test_aot.py::test_compile_link_matmul[False]
+python/test/unit/tools/test_aot.py::test_compile_link_autotune_matmul


### PR DESCRIPTION
CI:
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/17377509783 (hangs)
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/17383427279/job/49345644046 (passed)

Relates to #4955