### PR TITLE
Fix `Cannot find '/usr/bin/file' command` issue for "Coverity" workflow

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -20,6 +20,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install /usr/bin/file
+        run: |
+          sudo apt install -y file
+
       - name: Install Python 3.10
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/17464021984/job/49595193292 - working