### PR TITLE
[Utility]: Early exit from updateLayout

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
@@ -198,9 +198,9 @@ LogicalResult getConvertBackwardSlice(
   auto updateLayout = [&](Value value, Attribute encoding) {
     assert(isTensorOrTensorPointerType(value.getType()));
 
-    RankedTensorType tensorType = getRankedTensorType(value.getType());
-    if (tensorType.getEncoding() == encoding)
-      return success();
+    if (RankedTensorType tensorType = getRankedTensorType(value.getType()))
+      if (tensorType.getEncoding() == encoding)
+        return success();
 
     slice.insert(value);
     Attribute &existing = layout[value];


### PR DESCRIPTION
This PR adds an early exit optimization to the updateLayout function to avoid unnecessary processing when a tensor already has the desired encoding.