### PR TITLE
Revert "[CI] Pin `pytest-rerunfailures<16` (#4994)"

### DIFF
--- a/.github/workflows/auto-update-translator-cid.yml
+++ b/.github/workflows/auto-update-translator-cid.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install test dependencies
         if: ${{ env.TARGET_PRID == null }}
         run: |
-          pip install pytest pytest-xdist 'pytest-rerunfailures<16' pytest-skip pytest-timeout expecttest
+          pip install pytest pytest-xdist pytest-rerunfailures pytest-skip pytest-timeout expecttest
           pip install git+https://github.com/kwasd/pytest-capturewarnings-ng.git@v1.2.0
 
       - name: Get commit ID from Triton's spirv-llvm-translator.conf

--- a/scripts/docs-triton.sh
+++ b/scripts/docs-triton.sh
@@ -36,7 +36,7 @@ export TRITON_PROJ=$BASE/intel-xpu-backend-for-triton
 export TRITON_PROJ_BUILD=$TRITON_PROJ/python/build
 export SCRIPTS_DIR=$(cd $(dirname "$0") && pwd)
 
-python3 -m pip install lit pytest pytest-xdist 'pytest-rerunfailures<16' pytest-skip
+python3 -m pip install lit pytest pytest-xdist pytest-rerunfailures pytest-skip
 
 source $SCRIPTS_DIR/pytest-utils.sh
 $SCRIPTS_DIR/install-pytorch.sh $([ $VENV = true ] && echo "--venv")

--- a/scripts/requirements-test.txt
+++ b/scripts/requirements-test.txt
@@ -13,7 +13,7 @@ tabulate
 # Used by test-triton.sh
 pytest-xdist
 pytest-forked
-pytest-rerunfailures<16
+pytest-rerunfailures
 pytest-skip
 pytest-timeout
 


### PR DESCRIPTION
This reverts commit a57ac88cffa32a3619b073422743a907f97e90e8.


https://pypi.org/project/pytest-rerunfailures/16.0.1/ is out.