### PR TITLE
Fix missed `Py_INCREF(Py_None)` in `driver.c`

### DIFF
--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -360,8 +360,7 @@ extern "C" EXPORT_FUNC PyObject *wait_on_sycl_queue(PyObject *cap) {
     return NULL;
   sycl::queue *sycl_queue = static_cast<sycl::queue *>(queue);
   sycl_queue->wait();
-
-  return Py_None;
+  Py_RETURN_NONE;
 }
 
 extern "C" EXPORT_FUNC PyObject *has_opencl_extension(int device_id,


### PR DESCRIPTION
From: https://docs.python.org/3.10/c-api/none.html#c.Py_RETURN_NONE

`Properly handle returning [Py_None](https://docs.python.org/3.10/c-api/none.html#c.Py_None) from within a C function (that is, increment the reference count of None and return it.)`