### PR TITLE
Fix Flex Attn UT failures

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2239,8 +2239,6 @@ struct LoadOpToBlockIOConversion
       break;
     }
 
-    assert(memoryRowMajor || !getPitch(rewriter, ptr, elemSizeInBits, 0) &&
-                                 "Ensure column major was never supported");
     Value pitch =
         getPitch(rewriter, ptr, elemSizeInBits, memoryRowMajor ? 0 : 1);
     if (!pitch)


### PR DESCRIPTION
Before 92eb442262f4bbc8acf37c3831c644395e178b2f, `getStride(ptr, 0)` would be 1 for column major, i.e, pitch would be smaller than 64 bytes (HW restriction), so `getPitch` would return `nullptr`, and 2d block load would not be generated. This PR goes back to the original behavior and early return for column major.

Flex Attn UT: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/17833144533/job/50703282622 (GOOD)
Flex Attn benchmark: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/17836148975/job/50713713366 (GOOD)

Fixes #5129