### PR TITLE
Merge OpenAI Triton commit `81d413e` and drop python 3.9 support

### DIFF
--- a/.github/WINDOWS.md
+++ b/.github/WINDOWS.md
@@ -56,7 +56,7 @@ If you do not have a system Python installed at this step, you can install one w
 For example:
 
 ```
-choco install python --version=3.9.13
+choco install python --version=3.10.11
 ```
 
 ### Git

--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -58,9 +58,9 @@ jobs:
         id: matrix
         run: |
           if [[ -n "${{ inputs.runner_label }}" ]]; then
-            matrix='{"python": ["3.9", "3.10", "3.11", "3.12", "3.13"]}'
+            matrix='{"python": ["3.10", "3.11", "3.12", "3.13"]}'
           else
-            matrix='{"python": ["3.9", "3.10", "3.11", "3.12", "3.13"], "driver": ["rolling", "lts"]}'
+            matrix='{"python": ["3.10", "3.11", "3.12", "3.13"], "driver": ["rolling", "lts"]}'
           fi
           echo "matrix=$matrix" | tee -a $GITHUB_OUTPUT
 

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -32,7 +32,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/try-latest-pytorch.yml
+++ b/.github/workflows/try-latest-pytorch.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Matrix
         id: matrix
         run: |
-          integration_matrix='{"python": ["3.9", "3.10", "3.11", "3.12"], "driver": ["rolling", "lts"]}'
+          integration_matrix='{"python": ["3.10", "3.11", "3.12"], "driver": ["rolling", "lts"]}'
 
           echo "integration_matrix=$integration_matrix" | tee -a $GITHUB_OUTPUT
           e2e_matrix='{
@@ -97,7 +97,7 @@ jobs:
         inductor/test_max_autotune.py
         inductor/test_compile_subprocess.py
       runner_label: ${{ inputs.runner_label }}
-      python_version: "3.9"
+      python_version: "3.10"
 
   integration-tests:
     name: Integration tests

--- a/.github/workflows/wheels-pytorch.yml
+++ b/.github/workflows/wheels-pytorch.yml
@@ -21,7 +21,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/wheels-triton.yml
+++ b/.github/workflows/wheels-triton.yml
@@ -16,7 +16,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can install the latest stable release of Triton from pip:
 pip install triton
 ```
 
-Binary wheels are available for CPython 3.9-3.13.
+Binary wheels are available for CPython 3.10-3.13.
 
 # Install from source
 

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -14,7 +14,7 @@ You can install the latest stable release of Triton from pip:
 
       pip install triton
 
-Binary wheels are available for CPython 3.9-3.13.
+Binary wheels are available for CPython 3.10-3.13.
 
 -----------
 From Source

--- a/setup.py
+++ b/setup.py
@@ -798,7 +798,7 @@ def get_git_version_suffix():
 TRITON_VERSION = "3.5.0" + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", "")
 
 # Dynamically define supported Python versions and classifiers
-MIN_PYTHON = (3, 9)
+MIN_PYTHON = (3, 10)
 MAX_PYTHON = (3, 14)
 
 PYTHON_REQUIRES = f">={MIN_PYTHON[0]}.{MIN_PYTHON[1]},<{MAX_PYTHON[0]}.{MAX_PYTHON[1] + 1}"

--- a/third_party/proton/proton/context.py
+++ b/third_party/proton/proton/context.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from triton._C.libproton import proton as libproton
-from .flags import get_profiling_on
+from .flags import flags
 
 
 def depth(session: Optional[int] = 0) -> Optional[int]:
@@ -13,6 +13,6 @@ def depth(session: Optional[int] = 0) -> Optional[int]:
     Returns:
         depth (int or None): The depth of the context. If profiling is off, returns None.
     """
-    if not get_profiling_on():
+    if not flags.profiling_on:
         return None
     return libproton.get_context_depth(session)

--- a/third_party/proton/proton/flags.py
+++ b/third_party/proton/proton/flags.py
@@ -1,49 +1,28 @@
 """
-This file contains the global flags used in the proton package.
+Centralized, process-local flags with a minimal interface (no environment variables).
+
+Usage:
+    from triton.profiler.flags import flags
+
+    # Toggle
+    flags.profiling_on = True
+    flags.instrumentation_on = False
+
+    # Check
+    if flags.command_line:
+            ...
 """
-
-# Whether to enable profiling. Default is False.
-profiling_on = False
-# Whether instrumentation is enabled. Default is False.
-instrumentation_on = False
-# Whether the script is run from the command line. Default is False.
-command_line = False
+from dataclasses import dataclass
 
 
-def set_profiling_on():
-    global profiling_on
-    profiling_on = True
+@dataclass
+class ProfilerFlags:
+    # Whether to enable profiling. Default is False.
+    profiling_on: bool = False
+    # Whether instrumentation is enabled. Default is False.
+    instrumentation_on: bool = False
+    # Whether the script is run from the command line. Default is False.
+    command_line: bool = False
 
 
-def set_profiling_off():
-    global profiling_on
-    profiling_on = False
-
-
-def get_profiling_on():
-    global profiling_on
-    return profiling_on
-
-
-def set_command_line():
-    global command_line
-    command_line = True
-
-
-def is_command_line():
-    global command_line
-    return command_line
-
-
-def get_instrumentation_on():
-    return instrumentation_on
-
-
-def set_instrumentation_on():
-    global instrumentation_on
-    instrumentation_on = True
-
-
-def set_instrumentation_off():
-    global instrumentation_on
-    instrumentation_on = False
+flags = ProfilerFlags()

--- a/third_party/proton/proton/hooks/instrumentation.py
+++ b/third_party/proton/proton/hooks/instrumentation.py
@@ -14,7 +14,7 @@ from triton.runtime._allocation import set_profile_allocator, NullAllocator
 from triton.backends import backends
 
 from .hook import Hook
-from ..flags import set_instrumentation_on, set_instrumentation_off
+from ..flags import flags
 from .. import mode
 
 # TODO(fywkevin): add support for major.minor
@@ -153,7 +153,7 @@ class InstrumentationHook(Hook):
 
         InstrumentationHook.active_count += 1
 
-        set_instrumentation_on()
+        flags.instrumentation_on = True
 
         device = triton.runtime.driver.active.get_current_device()
         max_shared_mem = triton.runtime.driver.active.utils.get_device_properties(device)["max_shared_mem"]
@@ -218,7 +218,7 @@ class InstrumentationHook(Hook):
         backends[backend_name].compiler.instrumentation = {}
 
         # No runtime instrumentation hook is active anymore
-        set_instrumentation_off()
+        flags.instrumentation_on = False
 
         # Restore original JIT function run method
         if hasattr(JITFunction.run, "__wrapped__"):

--- a/third_party/proton/proton/language.py
+++ b/third_party/proton/proton/language.py
@@ -4,7 +4,7 @@ from triton._C.libtriton import proton as triton_proton
 from triton.language.semantic import TritonSemantic
 from triton.experimental.gluon.language._semantic import GluonSemantic
 
-from .flags import get_instrumentation_on
+from .flags import flags
 
 _ALL_SEMANTICS = {
     "triton": TritonSemantic,
@@ -34,7 +34,7 @@ def disable_semantic(semantic_name: str):
 
 
 def record(is_start: tl.constexpr, scope_name: tl.constexpr, semantic):
-    if not get_instrumentation_on():
+    if not flags.instrumentation_on:
         return
     _check_supported_semantic(semantic)
     is_start = tl._unwrap_if_constexpr(is_start)

--- a/third_party/proton/proton/profile.py
+++ b/third_party/proton/proton/profile.py
@@ -5,7 +5,7 @@ import pathlib
 
 from triton import knobs
 from triton._C.libproton import proton as libproton
-from .flags import set_profiling_off, set_profiling_on, is_command_line
+from .flags import flags
 from .hooks import HookManager, LaunchHook, InstrumentationHook
 from .mode import BaseMode
 from typing import Optional, Union
@@ -104,11 +104,11 @@ def start(
     Returns:
         session (int): The session ID of the profiling session.
     """
-    if is_command_line():
+    if flags.command_line:
         # Ignore the start() call if the script is run from the command line.
         return
 
-    set_profiling_on()
+    flags.profiling_on = True
 
     name = DEFAULT_PROFILE_NAME if name is None else name
     backend = _select_backend() if backend is None else backend
@@ -145,7 +145,7 @@ def activate(session: Optional[int] = None) -> None:
     Returns:
         None
     """
-    if is_command_line() and session != 0:
+    if flags.command_line and session != 0:
         raise ValueError("Only one session can be activated when running from the command line.")
 
     HookManager.activate(session)
@@ -167,7 +167,7 @@ def deactivate(session: Optional[int] = None) -> None:
     Returns:
         None
     """
-    if is_command_line() and session != 0:
+    if flags.command_line and session != 0:
         raise ValueError("Only one session can be deactivated when running from the command line.")
 
     HookManager.deactivate(session)
@@ -194,10 +194,10 @@ def finalize(session: Optional[int] = None, output_format: Optional[str] = "") -
     HookManager.unregister(session)
 
     if session is None:
-        set_profiling_off()
+        flags.profiling_on = False
         libproton.finalize_all(output_format)
     else:
-        if is_command_line() and session != 0:
+        if flags.command_line and session != 0:
             raise ValueError("Only one session can be finalized when running from the command line.")
         libproton.finalize(session, output_format)
 

--- a/third_party/proton/proton/proton.py
+++ b/third_party/proton/proton/proton.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 import os
 from .profile import start, finalize, _select_backend
-from .flags import set_command_line
+from .flags import flags
 
 
 def parse_arguments():
@@ -58,7 +58,7 @@ def execute_as_main(script, args):
 
 def do_setup_and_execute(target_args):
     # Set the command line mode to avoid any `start` calls in the script.
-    set_command_line()
+    flags.command_line = True
 
     script = target_args[0]
     script_args = target_args[1:] if len(target_args) > 1 else []

--- a/third_party/proton/proton/state.py
+++ b/third_party/proton/proton/state.py
@@ -1,5 +1,5 @@
 from triton._C.libproton import proton as libproton
-from .flags import get_profiling_on
+from .flags import flags
 from functools import wraps
 
 
@@ -29,13 +29,13 @@ class state:
         self.name = name
 
     def __enter__(self):
-        if not get_profiling_on():
+        if not flags.profiling_on:
             return self
         libproton.enter_state(self.name)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
-        if not get_profiling_on():
+        if not flags.profiling_on:
             return
         libproton.exit_state()
 
@@ -43,10 +43,10 @@ class state:
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if get_profiling_on():
+            if flags.profiling_on:
                 libproton.enter_state(self.name)
             ret = func(*args, **kwargs)
-            if get_profiling_on():
+            if flags.profiling_on:
                 libproton.exit_state()
             return ret
 


### PR DESCRIPTION
This PR change the Triton base from https://github.com/intel/intel-xpu-backend-for-triton/commit/22188cc405a290433384de4cc147d06d853a7eb5 to https://github.com/intel/intel-xpu-backend-for-triton/pull/5139/commits/81d413e7dd7dc926c590c9565993f623dc04b043 (Sep 13).
Pass rate: 98.8%

Please do not squash and merge this PR.