### PR TITLE
Don't use XPU specific `threads_per_warp` term in `python/triton/compiler/compiler.py`

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -479,10 +479,7 @@ class CompiledKernel:
         self.module, self.function, self.n_regs, self.n_spills, self.n_max_threads = driver.active.utils.load_binary(
             self.name, self.kernel, self.metadata.shared, self.metadata.build_flags,
             not self.metadata.generate_native_code, device)
-        if hasattr(self.metadata, "threads_per_warp"):
-            warp_size = self.metadata.threads_per_warp
-        else:
-            warp_size = driver.active.get_current_target().warp_size
+        warp_size = driver.active.get_current_target().warp_size
         if self.metadata.num_warps * warp_size > self.n_max_threads:
             raise_(OutOfResources(self.metadata.num_warps * warp_size, self.n_max_threads, "threads"))
         if knobs.runtime.kernel_load_end_hook is not None:


### PR DESCRIPTION
~Should be fine to use `warp_size` after https://github.com/intel/intel-xpu-backend-for-triton/pull/5122~ I read the code incorrectly.