### PR TITLE
[CI][E2E-accuracy] Fix bug with aggregation of 1 result

### DIFF
--- a/.github/workflows/e2e-accuracy.yml
+++ b/.github/workflows/e2e-accuracy.yml
@@ -165,13 +165,14 @@ jobs:
 
       - name: Upload aggregated results
         uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
         with:
           name: aggregated-results-${{ github.run_id }}
           path: aggregated-results
           include-hidden-files: true
 
       - name: Check results against reference
-        if: ${{ inputs.models == 'all' && inputs.only_one_model == '' }}
+        if: ${{ inputs.models == 'all' && inputs.only_one_model == ''  && !cancelled()}}
         run: |
           PYTORCH_XPU_OPS_REF="$(<.github/pins/e2e_reference_torch-xpu-ops.txt)"
           git clone https://github.com/intel/torch-xpu-ops.git

--- a/scripts/e2e_checks/compare_reference.sh
+++ b/scripts/e2e_checks/compare_reference.sh
@@ -80,7 +80,7 @@ for suite in "${suites[@]}"; do
         fi
 
         for dtype in "${dtypes[@]}"; do
-            CSV_FILE="$RESULT_DIR/logs-$suite-$dtype-$mode-accuracy/$suite/$dtype/inductor_${suite}_${dtype}_${mode}_xpu_accuracy.csv"
+            CSV_FILE="$RESULT_DIR/$suite/$dtype/inductor_${suite}_${dtype}_${mode}_xpu_accuracy.csv"
 
             # Check if CSV file exists
             if [ ! -f "$CSV_FILE" ]; then


### PR DESCRIPTION
Closes https://github.com/intel/intel-xpu-backend-for-triton/issues/5158

The issue appeared because [download artifact](https://github.com/actions/download-artifact?tab=readme-ov-file#v5---whats-new) will change it's behavior if only one artefact is available. In this case the we will loose the artifact name and extract it's content into selected folder. So it's `separate-reports/contentA` instead of `separate-reports/artifactA/contentA;separate-reports/artifactB/contentB`.

The change is that we now always merge artifacts and lose names like `artifactA`. So we have to change result parsing as well.