### PR TITLE
[BENCHMARKS] Use `setuptools.find_packages` to include all python submodules

### DIFF
--- a/benchmarks/setup.py
+++ b/benchmarks/setup.py
@@ -7,7 +7,7 @@ import sys
 #  https://github.com/pypa/setuptools/discussions/2838
 from distutils import log  # pylint: disable=[deprecated-module]
 
-from setuptools import setup, Extension
+from setuptools import setup, Extension, find_packages
 from setuptools.command.build_ext import build_ext as _build_ext
 
 import torch
@@ -112,7 +112,7 @@ def get_git_commit_hash(length=8):
 setup(
     name="triton-kernels-benchmark",
     version="3.3.0" + get_git_commit_hash(),
-    packages=["triton_kernels_benchmark"],
+    packages=find_packages(),
     install_requires=[
         "torch>=2.6",
         "pandas",

--- a/benchmarks/triton_kernels_benchmark/benchmark_utils.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_utils.py
@@ -19,7 +19,7 @@ from triton_kernels_benchmark.benchmark_testing import (
     MarkArgs,
 )
 from triton_kernels_benchmark.benchmark_shapes_parser import ShapePatternParser
-from triton_kernels_benchmark.benchmark_config_templates import CONFIGS
+from triton_kernels_benchmark.configs.benchmark_config_templates import CONFIGS
 
 
 @dataclass


### PR DESCRIPTION
It's needed for example for `configs` submodule.