### PR TITLE
Remove `__builtin_unreachable` macros for Windows as unused

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -33,10 +33,6 @@
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Utility.h"
 #include "llvm/Support/ErrorHandling.h"
 
-#if defined(_MSC_VER) && !defined(__clang__)
-#define __builtin_unreachable() __assume(0)
-#endif
-
 using namespace mlir::triton::gpu;
 
 namespace mlir {


### PR DESCRIPTION
`__builtin_unreachable` was removed in https://github.com/triton-lang/triton/commit/084d620d87810f1dcb625852efb82d674a191e68