### PR TITLE
Use only one process for pytest and triton kernels test suite on BMG

### DIFF
--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -666,7 +666,7 @@ run_triton_kernels_tests() {
   if [[ -f "$gpu_file" ]] && grep -q "B580" "$gpu_file"; then
     # Using any other number of processes results in an error on the BMG due to insufficient resources.
     # FIXME: reconsider in the future
-    max_procs=${PYTEST_MAX_PROCESSES:-1}
+    max_procs=1
   else
     max_procs=${PYTEST_MAX_PROCESSES:-4}
   fi


### PR DESCRIPTION
To fix problem on Windows: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/17937351515/job/51085592650