### PR TITLE
[intel] Enable `sanitize_overflow`

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -38,7 +38,7 @@ class XPUOptions:
     extern_libs: dict = None
     debug: bool = False
     backend_name: str = 'intel'
-    sanitize_overflow: bool = False
+    sanitize_overflow: bool = True
     generate_native_code: bool = False
     advanced_path: bool = False
     enable_tile_load_linear_layout: bool = True


### PR DESCRIPTION
The feature was added in c54f9882aff504bf2ab62d0ba037fb042204dc90. It is enabled on all other backends.