### PR TITLE
Hot fix for windows build; don't include `<dlfcn.h>` in `hipblas_instance.h`

### DIFF
--- a/third_party/amd/include/hipblas_instance.h
+++ b/third_party/amd/include/hipblas_instance.h
@@ -7,8 +7,9 @@
 #define NOMINMAX
 #include <windows.h>
 // tricky one
-// otherwise there may be a compilation error of llvm/TargetParser/TargetParser.h
-// due to a coincidence between the macro name and one of the values in the enum:
+// otherwise there may be a compilation error of
+// llvm/TargetParser/TargetParser.h due to a coincidence between the macro name
+// and one of the values in the enum:
 // https://github.com/llvm/llvm-project/blame/bb38b48910967041045997a0c1293ee2ba834196/llvm/include/llvm/TargetParser/TargetParser.h#L166-L170C3
 #ifdef NO_ERROR
 #undef NO_ERROR

--- a/third_party/amd/include/hipblas_instance.h
+++ b/third_party/amd/include/hipblas_instance.h
@@ -2,7 +2,13 @@
 #define TRITON_HIPBLAS_INSTANCE_H
 
 #include "hipblas_types.h"
+#ifdef WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#else
 #include <dlfcn.h>
+#endif
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -70,6 +76,9 @@ class HipblasLtInstance {
   hipblasLtMatmulPreference_t preference = NULL;
 
   void loadHipBlasDylib() {
+#ifdef WIN32
+    assert(0 && "Not implemented on Windows");
+#else
     if (dylibHandle == nullptr) {
       // First reuse the existing handle
       dylibHandle = dlopen(name, RTLD_NOLOAD);
@@ -116,9 +125,16 @@ class HipblasLtInstance {
                                std::string(name) +
                                "`: " + std::string(dlsym_error));
     }
+#endif
   }
 
-  void unloadHipBlasDylib() { dlclose(dylibHandle); }
+  void unloadHipBlasDylib() {
+#ifdef WIN32
+    assert(0 && "Not implemented on Windows");
+#else
+    dlclose(dylibHandle);
+#endif
+  }
 
   void successOrExit(hipblasStatus_t status, const std::string &context = "") {
     if (status != HIPBLAS_STATUS_SUCCESS) {

--- a/third_party/amd/include/hipblas_instance.h
+++ b/third_party/amd/include/hipblas_instance.h
@@ -6,6 +6,13 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <windows.h>
+// tricky one
+// otherwise there may be a compilation error of llvm/TargetParser/TargetParser.h
+// due to a coincidence between the macro name and one of the values in the enum:
+// https://github.com/llvm/llvm-project/blame/bb38b48910967041045997a0c1293ee2ba834196/llvm/include/llvm/TargetParser/TargetParser.h#L166-L170C3
+#ifdef NO_ERROR
+#undef NO_ERROR
+#endif
 #else
 #include <dlfcn.h>
 #endif


### PR DESCRIPTION
CI on bmg:
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18036971240 (failed)
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18038741503 (build passed)