### PR TITLE
[LoadStoreOpToLLVM] Enable predicated load and store

### DIFF
--- a/python/test/unit/tools/test_disasm.py
+++ b/python/test/unit/tools/test_disasm.py
@@ -34,4 +34,4 @@ def test_disam_spvbin():
     assert x[0] == 12
     dis = h.asm["spvdis"]
     # check that the spvdis has a store instruction.
-    assert "OpStore" in dis
+    assert "PredicatedStore" in dis

--- a/test/TritonIntelGPU/blockptr_load.mlir
+++ b/test/TritonIntelGPU/blockptr_load.mlir
@@ -1,5 +1,5 @@
-// RUN: env TRITON_INTEL_ONE_MATRIX_PER_LOAD_BT=0 triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm --check-prefixes=CHECK,LARGE-BLOCK-SIZE-TRANS-B
-// RUN: env TRITON_INTEL_ONE_MATRIX_PER_LOAD_BT=1 triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm --check-prefixes=CHECK,SMALL-BLOCK-SIZE-TRANS-B
+// RUN: env TRITON_INTEL_PREDICATED=1 TRITON_INTEL_ONE_MATRIX_PER_LOAD_BT=0 triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm --check-prefixes=CHECK,LARGE-BLOCK-SIZE-TRANS-B
+// RUN: env TRITON_INTEL_PREDICATED=1 TRITON_INTEL_ONE_MATRIX_PER_LOAD_BT=1 triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm --check-prefixes=CHECK,SMALL-BLOCK-SIZE-TRANS-B
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 4], order = [1, 0]}>
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
@@ -337,15 +337,15 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
       %45 = tt.load %21 : !tt.ptr<tensor<64x16xf16, #blocked>>
 
       // CHECK-COUNT-16: llvm.icmp "slt"
-      // CHECK-COUNT-32: llvm.load {{.*}} -> i16
+      // CHECK-COUNT-32: triton_gen.predicated_load {{.*}} -> i16
       %46 = tt.load %21 {boundaryCheck = array<i32: 0>} : !tt.ptr<tensor<64x16xf16, #blocked>>
 
       // CHECK-COUNT-16: llvm.icmp "slt"
-      // CHECK-COUNT-32: llvm.load {{.*}} -> i16
+      // CHECK-COUNT-32: triton_gen.predicated_load {{.*}} -> i16
       %47 = tt.load %21 {boundaryCheck = array<i32: 1>} : !tt.ptr<tensor<64x16xf16, #blocked>>
 
       // CHECK-COUNT-32: llvm.icmp "slt"
-      // CHECK-COUNT-32: llvm.load {{.*}} -> i16
+      // CHECK-COUNT-32: triton_gen.predicated_load {{.*}} -> i16
       %48 = tt.load %21 {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<64x16xf16, #blocked>>
       tt.return
   }

--- a/test/TritonIntelGPU/blockptr_store.mlir
+++ b/test/TritonIntelGPU/blockptr_store.mlir
@@ -1,5 +1,5 @@
-// RUN: triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm
-// RUN: env TRITON_INTEL_ENABLE_BLOCK_IO_ALL_LAYOUTS=1 triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm  --check-prefixes=ALL-LAYOUT
+// RUN: env TRITON_INTEL_PREDICATED=1 triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm
+// RUN: env TRITON_INTEL_PREDICATED=1 TRITON_INTEL_ENABLE_BLOCK_IO_ALL_LAYOUTS=1 triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=llvm.inline_asm  --check-prefixes=ALL-LAYOUT
 
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 1, threadsPerWarp = 16, warpsPerCTA = [4, 4], repCluster = [2, 2]}>
 #dot_a = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
@@ -526,7 +526,7 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
       // CHECK: %[[VAL_587:.*]] = llvm.mlir.constant(3 : i32) : i32
       // CHECK: %[[VAL_588:.*]] = llvm.and %[[VAL_586]], %[[VAL_587]] : i32
       // CHECK: %[[threadPred:.*]] = llvm.icmp "eq" %[[VAL_588]], {{.*}} : i32
-      // CHECK-COUNT-32: llvm.cond_br %[[threadPred]]
+      // CHECK-COUNT-32: triton_gen.predicated_store {{.*}} %[[threadPred]]
       tt.store %0, %cst : !tt.ptr<tensor<64x16xf16, #blocked>>
 
       // CHECK-COUNT-16: llvm.icmp "slt"

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -3320,7 +3320,10 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
       Value ret;
       // Create a predicated load operation.
       if (pred) {
-        if (triton::tools::getBoolEnv("TRITON_INTEL_PREDICATED"))
+        std::optional<bool> enablePredicated =
+            mlir::triton::tools::isEnvValueBool(
+                mlir::triton::tools::getStrEnv("TRITON_INTEL_PREDICATED"));
+        if (!enablePredicated.has_value() || enablePredicated.value())
           ret = rewriter.create<TritonGEN::PredicatedLoadOp>(
               loc, retTy, addrElem, b.i64_val(alignment), pred, other_);
         else {
@@ -3765,7 +3768,10 @@ struct StoreOpConversion
 
       if (maskVal) {
         // Create a predicated store operation.
-        if (triton::tools::getBoolEnv("TRITON_INTEL_PREDICATED")) {
+        std::optional<bool> enablePredicated =
+            mlir::triton::tools::isEnvValueBool(
+                mlir::triton::tools::getStrEnv("TRITON_INTEL_PREDICATED"));
+        if (!enablePredicated.has_value() || enablePredicated.value()) {
           unsigned numElems = valArgTy.getIntOrFloatBitWidth() * nWords /
                               valueElemTy.getIntOrFloatBitWidth();
           vecWord = b.bitcast(vecWord, vec_ty(valueElemTy, numElems));


### PR DESCRIPTION
This PR enables predicated load and store operations by changing the default behavior of the TRITON_INTEL_PREDICATED environment variable from false to true.

Benchmark CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18111223923 (no regression, potential gain)