### PR TITLE
[REFACTOR] Use only absolute paths in benchmarks

### DIFF
--- a/benchmarks/micro_benchmarks/conversion/float_conversion/__init__.py
+++ b/benchmarks/micro_benchmarks/conversion/float_conversion/__init__.py
@@ -1,1 +1,1 @@
-from .float_conversion import get_benchmarks, run_benchmarks  # type: ignore # noqa: F401
+from conversion.float_conversion.float_conversion import get_benchmarks, run_benchmarks  # type: ignore # noqa: F401

--- a/benchmarks/triton_kernels_benchmark/__init__.py
+++ b/benchmarks/triton_kernels_benchmark/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-from .benchmark_testing import (
+from triton_kernels_benchmark.benchmark_testing import (
     assert_close,
     do_bench,
     filter_providers,
@@ -12,7 +12,7 @@ from .benchmark_testing import (
     get_do_bench,
 )
 
-from .benchmark_shapes_parser import ShapePatternParser
+from triton_kernels_benchmark.benchmark_shapes_parser import ShapePatternParser
 
 if BENCHMARKING_METHOD == "UPSTREAM_PYTORCH_PROFILER":
     os.environ["INJECT_PYTORCH"] = "True"

--- a/benchmarks/triton_kernels_benchmark/benchmark_testing.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_testing.py
@@ -224,7 +224,7 @@ def get_do_bench(n_warmup: int, n_repeat: int, quantiles: list):
 
 try:
     # The easiest way to overwrite that eliminates merge conflicts
-    from .benchmark_testing_rewrite import get_do_bench  # noqa: F401
+    from triton_kernels_benchmark.benchmark_testing_rewrite import get_do_bench  # noqa: F401
 except ImportError:
     pass
 


### PR DESCRIPTION
This is a more explicit way, it is better to use it wherever possible.