### PR TITLE
Drop old PyTorch cache

### DIFF
--- a/.github/actions/setup-pytorch/action.yml
+++ b/.github/actions/setup-pytorch/action.yml
@@ -82,7 +82,7 @@ runs:
       uses: ./.github/actions/load
       env:
         # Increase this value to reset cache
-        CACHE_NUMBER: 17
+        CACHE_NUMBER: 18
       with:
         path: pytorch
         key: pytorch-$PYTORCH_CACHE_KEY-$CACHE_NUMBER


### PR DESCRIPTION
Wheels CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18128550115 (passed)


It fixes the following error: `RuntimeError: operator torchvision::nms does not exist` from http://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18113254786/job/51543875210