### PR TITLE
fix: compilation error with triton

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -410,7 +410,7 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
     return success();
 
   auto numPartitions = partitions.getNumPartitions();
-  auto defaultPartition = partitions.getPartition((int)0);
+  auto defaultPartition = partitions.getPartition((unsigned int)0);
   auto loopVarCategories = classifyLoopVars(loop, defaultPartition, partitions);
   auto [loopVarIndices, newResultIndices] =
       getLoopVarIndicesToKeep(loop, defaultPartition, loopVarCategories);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -458,7 +458,7 @@ static SmallVector<Value> Fp_to_Fp8_RTNE(Location loc,
                 (std::is_same_v<SrcTy, BFloat16Type>));
   static_assert((std::is_same_v<DstTy, Float8E4M3Type>) ||
                 (std::is_same_v<DstTy, Float8E5M2Type>));
-  constexpr int64_t SRC_MASK = (1L << (SrcBits - 1)) - 1;
+  constexpr int64_t SRC_MASK = (1ULL << (SrcBits - 1)) - 1;
   constexpr int64_t SRC_MMASK = (1L << SrcMBits) - 1;
   constexpr int64_t DST_NAN = 0x7F;
   constexpr int64_t DST_MAX =


### PR DESCRIPTION
# Fix mirror bugs in compilation

1. ```partitions.getPartition((int)0)```
  `getPartition` function has two type parameters(`unsigned` and `Operation *`)
  There are no candidates for `int`.

2. ```constexpr int64_t SRC_MASK = (1ULL << (SrcBits - 1)) - 1;```
  On Windows/MSVC, long is 32-bit (LLP64). When `SrcBits == 32`, this becomes `1L << 31`. Left-shifting a signed 32-bit long into the sign bit is **undefined behavior**. MSVC treats this as non–constant at compile time, causing: `constexpr variable must be initialized by a constant expression`
  Use an unsigned 64-bit base for bit shifts (and make masks unsigned), so the expression is well-defined and remains a constant expression across compilers

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
