### PR TITLE
[intel] Enable more debug information in compiler.py

### DIFF
--- a/python/test/unit/test_debuginfo.py
+++ b/python/test/unit/test_debuginfo.py
@@ -15,14 +15,15 @@ def test_triton_debuginfo_on():
     diLocalVarKey = "LLVM_EXTRACT_DI_LOCAL_VARIABLES"
 
     isEnvSet = lambda env, str: env.get(str, None) is not None
-    hasOrigLineInfo = (not isEnvSet(os.environ, lineInfoKey)
-                       or os.environ[lineInfoKey].lower() not in ["on", "true", "1"])
+    hasOrigLineInfo = (  # noqa: F841
+        not isEnvSet(os.environ, lineInfoKey) or os.environ[lineInfoKey].lower() not in ["on", "true", "1"])
     envs = [
         # expect no dbginfo if unset
         {lineInfoKey: None, diLocalVarKey: None, "hasDbgInfo": False},
         # expect dbginfo based on parent proccess' TRITON_DISABLE_LINE_INFO
-        {lineInfoKey: None, diLocalVarKey: "1", "hasDbgInfo": hasOrigLineInfo},
-        {lineInfoKey: "0", diLocalVarKey: "1", "hasDbgInfo": True},
+        # FIXME: enable after https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/3372 is fixed
+        # {lineInfoKey: None, diLocalVarKey: "1", "hasDbgInfo": hasOrigLineInfo},
+        # {lineInfoKey: "0", diLocalVarKey: "1", "hasDbgInfo": True},
         {lineInfoKey: "1", diLocalVarKey: "1", "hasDbgInfo": False},
         {lineInfoKey: "0", diLocalVarKey: "0", "hasDbgInfo": False},
         {lineInfoKey: "1", diLocalVarKey: "0", "hasDbgInfo": False},

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -359,7 +359,7 @@ run_minicore_tests() {
     run_pytest_command -k "not test_within_2gb" --verbose --device xpu runtime/ --ignore=runtime/test_cublas.py
 
   TRITON_TEST_SUITE=debug \
-    run_pytest_command --verbose -n ${PYTEST_MAX_PROCESSES:-8} test_debug.py test_debug_dump.py --forked --device xpu
+    run_pytest_command --verbose -n ${PYTEST_MAX_PROCESSES:-8} test_debug.py test_debuginfo.py test_debug_dump.py --forked --device xpu
 
   TRITON_TEST_SUITE=warnings \
     run_pytest_command --verbose -n ${PYTEST_MAX_PROCESSES:-8} test_perf_warning.py --device xpu

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -307,11 +307,32 @@ class XPUBackend(BaseBackend):
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
-        if not knobs.compilation.disable_line_info:
+
+        if not knobs.compilation.disable_line_info and not knobs.compilation.dump_ir_extract_di_local_variables:
             passes.llvmir.add_di_scope(pm)
+
         if XPUBackend.instrumentation:
             XPUBackend.instrumentation.patch("llvmir_to_llvm", pm, mod.context)
         pm.run(mod, 'make_llir')
+
+        if knobs.compilation.dump_ir_extract_di_local_variables:
+            # comments below on why separate it
+            if not knobs.compilation.disable_line_info:
+                pm = ir.pass_manager(mod.context)
+                pm.enable_debug()
+                passes.llvmir.add_di_scope(pm)
+                pm.run(mod, 'make_llir.disable_line_info')
+
+            # insert dbg intrinsic with several DI Attribute including source
+            # var name and type info note: unknown reason for now, but this
+            # pass and add_di_scope has to be run separately, otherwise if we
+            # put them into previous pipline, it trigger a segmentfault without
+            # any error message; could be due to a bug in mlir or pybind11
+            pm = ir.pass_manager(mod.context)
+            pm.enable_debug()
+            passes.llvmir.add_di_local_variable(pm)
+            pm.run(mod, 'make_llir.dump_ir_extract_di_local_variables')
+
         # LLVM-IR (MLIR) -> LLVM-IR (LLVM)
         llvm.init_targets()
         context = llvm.context()


### PR DESCRIPTION
I disabled some test cases due to https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/3372


how it looks like:

```bash
LLVM ERROR: unsupported opcode found in DIExpression
Fatal Python error: Aborted

Thread 0x00007faef837f640 (most recent call first):
  File "/home/jovyan/.conda/envs/xpu/lib/python3.10/socket.py", line 293 in accept
  File "/home/jovyan/.conda/envs/xpu/lib/python3.10/site-packages/pytest_rerunfailures.py", line 438 in run_server
  File "/home/jovyan/.conda/envs/xpu/lib/python3.10/threading.py", line 953 in run
  File "/home/jovyan/.conda/envs/xpu/lib/python3.10/threading.py", line 1016 in _bootstrap_inner
  File "/home/jovyan/.conda/envs/xpu/lib/python3.10/threading.py", line 973 in _bootstrap

Current thread 0x00007faefadfe740 (most recent call first):
  File "/home/jovyan/intel-xpu-backend-for-triton/python/triton/backends/intel/compiler.py", line 366 in make_spv
  File "/home/jovyan/intel-xpu-backend-for-triton/python/triton/backends/intel/compiler.py", line 438 in <lambda>
  File "/home/jovyan/intel-xpu-backend-for-triton/python/triton/compiler/compiler.py", line 324 in compile
```

Refs: https://llvm.org/docs/SourceLevelDebugging.html#diexpression