### PR TITLE
[AccelerateMatmul] Fix `getWarpsPerTile` with `rank > 2`

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
@@ -63,7 +63,9 @@ getWarpsPerTile(tt::DotOp dotOp, ttgi::DpasEncodingAttr::DPASCapability dpasCap,
         setAttrOnBOperand(dotOp, attrName, UnitAttr::get(ctx));
         setAttrOnBOperand(cast<tt::DotOp>(op), attrName, UnitAttr::get(ctx));
       }
-      return {numWarps, 1};
+      SmallVector<unsigned> ret(shape.size(), 1);
+      ret[0] = numWarps;
+      return ret;
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/helion/issues/772, #5246