### PR TITLE
Revert "[RemoveLayoutConversions]: Add support for backward rematerialization across scf.for loop. (#5186)"

### DIFF
--- a/test/TritonIntelGPU/combine.mlir
+++ b/test/TritonIntelGPU/combine.mlir
@@ -349,14 +349,15 @@ tt.func @loop(%arg0: !tt.ptr<f32>, %arg1: i32, %arg2: !tt.ptr<f32>, %arg3: i32, 
 // CHECK-LABEL: loop_if
 // CHECK-NOT: ttg.convert_layout
 //     CHECK: scf.for
-// CHECK-NOT:   ttg.convert_layout
+// CHECK-NOT: ttg.convert_layout
 //     CHECK:   scf.if
-//     CHECK:     ttg.convert_layout
+// CHECK-NOT: ttg.convert_layout
 //     CHECK:     scf.yield
-// CHECK-NEXT:  else
-// CHECK-NEXT:    scf.yield
-// CHECK-NOT:     ttg.convert_layout
+//     CHECK:   else
+//     CHECK:     scf.yield
+// CHECK-NOT: ttg.convert_layout
 //     CHECK:   scf.yield
+//     CHECK: ttg.convert_layout
 // CHECK-NOT: ttg.convert_layout
 //     CHECK: tt.store
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
@@ -2059,7 +2060,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
-// Check that if, conversions over ext and broadcast ops can be backward propagated across an scf.for loop.
+// Minimal repro for https://github.com/pytorch/pytorch/issues/154933
+//
+// Check that if, during hoisting conversions over ext and broadcast ops,
+// we see multiple different layouts assigned to the same value, then we
+// skip propagation of that layout.
 
 // CHECK-LABEL: @hoist_on_ext_broadcast_mismatch
 #blockedX = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
@@ -2076,14 +2081,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %3 = tt.addptr %1, %cast0 : tensor<4x!tt.ptr<i32>, #ttg.slice<{dim = 1, parent = #blockedX}>>, tensor<4xi64, #ttg.slice<{dim = 1, parent = #blockedX}>>
     %4 = tt.load %3 : tensor<4x!tt.ptr<i32>, #ttg.slice<{dim = 1, parent = #blockedX}>>
     %5 = tt.reshape %4 : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blockedX}>> -> tensor<4x1xi32, #blockedX>
+    // CHECK: arith.extsi
     %6 = arith.extsi %5 : tensor<4x1xi32, #blockedX> to tensor<4x1xi64, #blockedX>
     %7 = arith.addi %2, %6 : tensor<4x1xi64, #blockedX>
-    // CHECK: ttg.convert_layout
-    // CHECK-NOT: scf.for
-    // CHECK: arith.extsi
+    // for loop prevents fully hoisting the conversion.
     %8 = scf.for %arg2 = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%arg3 = %5) -> (tensor<4x1xi32, #blockedX>) : i32 {
       scf.yield %5 : tensor<4x1xi32, #blockedX>
     }
+    // CHECK: ttg.convert_layout
     %9 = arith.extsi %8 : tensor<4x1xi32, #blockedX> to tensor<4x1xi64, #blockedX>
     %10 = arith.addi %7, %9 : tensor<4x1xi64, #blockedX>
     %11 = ttg.convert_layout %10 : tensor<4x1xi64, #blockedX> -> tensor<4x1xi64, #blockedY>
@@ -3451,39 +3456,5 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 32 : i32, "ttg.th
     %59 = ttg.convert_layout %58 : tensor<256x256xf16, #blocked> -> tensor<256x256xf16, #blocked1>
     tt.store %50, %59, %57 : tensor<256x256x!tt.ptr<f16>, #blocked1>
     tt.return
-  }
-}
-
-// -----
-
-// COM: Test that the the layout conversion is hoisted above the loop.
-#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
-  // CHECK: hoist_layout_conversion
-  tt.func public @hoist_layout_conversion(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}) -> (tensor<4x1xi64, #blocked>, i32) {
-    %c1_i32 = arith.constant 1 : i32
-    %c4_i32 = arith.constant 4 : i32
-    %c0_i32 = arith.constant 0 : i32
-    %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blocked1}>>
-    %1 = arith.extsi %0 : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> to tensor<4xi64, #ttg.slice<{dim = 1, parent = #blocked1}>>
-    %2 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>, #ttg.slice<{dim = 1, parent = #blocked1}>>
-    // CHECK: ttg.convert_layout
-    %3 = tt.expand_dims %1 {axis = 1 : i32} : tensor<4xi64, #ttg.slice<{dim = 1, parent = #blocked1}>> -> tensor<4x1xi64, #blocked1>
-    %4 = tt.addptr %2, %1 : tensor<4x!tt.ptr<i32>, #ttg.slice<{dim = 1, parent = #blocked1}>>, tensor<4xi64, #ttg.slice<{dim = 1, parent = #blocked1}>>
-    %5 = tt.load %4 : tensor<4x!tt.ptr<i32>, #ttg.slice<{dim = 1, parent = #blocked1}>>
-    %6 = tt.reshape %5 : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> -> tensor<4x1xi32, #blocked1>
-    %7 = arith.extsi %6 : tensor<4x1xi32, #blocked1> to tensor<4x1xi64, #blocked1>
-    %8 = arith.addi %3, %7 : tensor<4x1xi64, #blocked1>
-    // CHECK: scf.for
-    // CHECK-NOT: ttg.convert_layout
-    %9:2 = scf.for %arg2 = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%arg3 = %6, %arg4 = %c1_i32) -> (tensor<4x1xi32, #blocked1>, i32)  : i32 {
-      %13 = arith.addi %arg2, %arg4 : i32
-      scf.yield %6, %13 : tensor<4x1xi32, #blocked1>, i32
-    }
-    %10 = arith.extsi %9#0 : tensor<4x1xi32, #blocked1> to tensor<4x1xi64, #blocked1>
-    %11 = arith.addi %8, %10 : tensor<4x1xi64, #blocked1>
-    %12 = ttg.convert_layout %11 : tensor<4x1xi64, #blocked1> -> tensor<4x1xi64, #blocked>
-    tt.return %12, %9#1 : tensor<4x1xi64, #blocked>, i32
   }
 }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -1126,12 +1126,6 @@ void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
         opsToRewrite.insert(ifOp.elseYield().getOperation());
         yieldOperandsMap[ifOp.elseYield()].push_back(operandIdx);
       }
-      if (auto forOp = v.getDefiningOp<scf::ForOp>()) {
-        unsigned operandIdx = cast<OpResult>(v).getResultNumber();
-        auto yieldOp = forOp.getBody()->getTerminator();
-        yieldOperandsMap[yieldOp].push_back(operandIdx);
-        opsToRewrite.insert(yieldOp);
-      }
     } else {
       BlockArgument blockArg = cast<BlockArgument>(v);
       Operation *parentOp = blockArg.getOwner()->getParentOp();
@@ -1155,21 +1149,9 @@ void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
   IRRewriter builder(slice.begin()->getContext());
   for (Operation *op : opsToRewrite) {
     if (auto forOp = dyn_cast<scf::ForOp>(op)) {
-      // Construct the new initialization argument by adding yielded operands
-      // that have been remapped.
-      auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
-      auto yieldOperands = llvm::to_vector(yieldOp.getOperands());
-      SmallVector<int> operandsToRewrite = yieldOperandsMap[yieldOp];
-      std::sort(operandsToRewrite.begin(), operandsToRewrite.end());
-      SmallVector<Value> newOperands;
-      for (int operandIdx : operandsToRewrite) {
-        Value yieldOperand = yieldOp.getOperand(operandIdx);
-        if (mapping.contains(yieldOperand))
-          newOperands.push_back(mapping.lookup(yieldOperand));
-      }
-
       // Keep a mapping of the operands index to the new operands index.
       SmallVector<std::pair<size_t, size_t>> argMapping;
+      SmallVector<Value> newOperands;
       for (auto arg : forOp.getRegionIterArgs()) {
         if (slice.count(arg)) {
           OpOperand &initVal = *forOp.getTiedLoopInit(arg);
@@ -1182,20 +1164,6 @@ void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
       // Create a new for loop with the new operands.
       scf::ForOp newForOp = replaceForOpWithNewSignature(
           builder, forOp, newOperands, replacements);
-
-      // Add rematerializations for loop results in the slice.
-      unsigned oldIdx = 0;
-      unsigned newIdx = forOp.getNumResults();
-      for (auto res : forOp.getResults()) {
-        if (slice.count(res)) {
-          mapping.map(forOp.getResult(oldIdx), newForOp.getResult(newIdx));
-          addRematValue(forOp.getResult(oldIdx), layout[res],
-                        newForOp.getResult(newIdx));
-          ++newIdx;
-        }
-        ++oldIdx;
-      }
-
       deadOps.push_back(forOp.getOperation());
       Block &loopBody = *newForOp.getBody();
       for (auto m : argMapping) {

--- a/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
@@ -216,7 +216,10 @@ LogicalResult getConvertBackwardSlice(
     queue.pop_back();
     if (!isTensorOrTensorPointerType(currentValue.getType()))
       continue;
-
+    // Skip propagating through for op results for now.
+    // TODO: enable this based on needs.
+    if (currentValue.getDefiningOp<scf::ForOp>())
+      return failure();
     if (failed(updateLayout(currentValue, encoding)))
       return failure();
 
@@ -227,20 +230,7 @@ LogicalResult getConvertBackwardSlice(
         return failure();
       currentValue = existing;
     }
-    if (auto forOp = currentValue.getDefiningOp<scf::ForOp>()) {
-      if (stopPropagation && stopPropagation(forOp))
-        continue;
 
-      auto loopRes = cast<OpResult>(currentValue);
-      OpOperand *initOperand = forOp.getTiedLoopInit(loopRes);
-      BlockArgument blockArg = forOp.getTiedLoopRegionIterArg(loopRes);
-      OpOperand *yieldOperand = forOp.getTiedLoopYieldedValue(blockArg);
-
-      enqueue(*initOperand, encoding);
-      enqueue(*yieldOperand, encoding);
-
-      continue;
-    }
     if (auto ifOp = currentValue.getDefiningOp<scf::IfOp>()) {
       if (stopPropagation && stopPropagation(ifOp))
         continue;


### PR DESCRIPTION
This reverts commit d81518e5e5f5d43c512bdc3e6eeb9ac08af454d3.

Flex Attn: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18371846182 (passed)
Core: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18372973983 (passed)