### PR TITLE
Build wheels for python 3.14

### DIFF
--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -36,7 +36,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-          - "3.14.0-rc.1"
+          - "3.14"
       fail-fast: false
       max-parallel: 2
     defaults:

--- a/.github/workflows/wheels-pytorch.yml
+++ b/.github/workflows/wheels-pytorch.yml
@@ -25,6 +25,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
       fail-fast: false
       max-parallel: 2
     steps:

--- a/.github/workflows/wheels-triton.yml
+++ b/.github/workflows/wheels-triton.yml
@@ -20,6 +20,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
       fail-fast: false
       max-parallel: 2
     steps:


### PR DESCRIPTION
https://github.com/actions/python-versions/releases/tag/3.14.0-18313368925 is released