### PR TITLE
Use Python from pyenv for `Aggregate and check results` job in `e2e-accuracy.yml`

### DIFF
--- a/.github/workflows/e2e-accuracy.yml
+++ b/.github/workflows/e2e-accuracy.yml
@@ -146,8 +146,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Setup Python
-        uses: actions/setup-python@v6
+      - name: Install Python (from pyenv)
+        uses: ./.github/actions/setup-pyenv-python
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
To avoid: `Error: The version '3.10' with architecture 'x64' was not found for this operating system.` like in https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18435296612/job/52538158961