### PR TITLE
Use github standard runners for a lightweight job: `pre-commit checks`

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -11,7 +11,7 @@ jobs:
   coverity:
     name: Coverity
 
-    runs-on: ubuntu-latest
+    runs-on: Linux
     defaults:
       run:
         shell: bash -noprofile --norc -eo pipefail {0}


### PR DESCRIPTION
~Coverity CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18464740038~ ~This turned out to be not as lightweight as I thought, so I will switch to python from pyenv there (in separate PR)~