### PR TITLE
Install python from pyenv for coverity check and pre-commit checks

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -78,8 +78,8 @@ jobs:
           path: $HOME/.cache/pip
           key: pip-3.10-${{ hashFiles('.pre-commit-config.yaml') }}-${{ env.CACHE_NUMBER }}
 
-      - name: Install Python 3.10
-        uses: actions/setup-python@v6
+      - name: Install Python (from pyenv)
+        uses: ./.github/actions/setup-pyenv-python
         with:
           python-version: '3.10'
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -24,8 +24,8 @@ jobs:
         run: |
           sudo apt install -y file
 
-      - name: Install Python 3.10
-        uses: actions/setup-python@v6
+      - name: Install Python (from pyenv)
+        uses: ./.github/actions/setup-pyenv-python
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
The last known places where there may be a potential problem with the Python installation on self-hosted runners on 25.04.

Failure example: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18435296612/job/52538158961
`The version '3.10' with architecture 'x64' was not found for this operating system.`