### PR TITLE
Run E2E accuracy workload only on rolling driver

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -56,6 +56,7 @@ jobs:
     name: Test ${{ inputs.suite }} ${{ inputs.dtype }} ${{ inputs.mode }} ${{ inputs.test_mode }}
     runs-on:
       - linux
+      - rolling
       - ${{ inputs.runner_label || 'max1550' }}
     timeout-minutes: 720
     defaults:


### PR DESCRIPTION
To simplify the analysis of problems found during the run.