### PR TITLE
[LoadOpToBlockIOConversion] Limit `vBlocks` of 2d block load

### DIFF
--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -115,6 +115,11 @@ loadCacheControlToCacheControls(Builder &builder,
 static bool isSPVBuiltinAvailable(TritonGEN::Matrix2DBlockLoadOp op) {
   // FIXME: The following signatures are not valid in SPV interface.
 
+  // intel_sub_group_2d_block_read_8b_1r16x4c
+  if (op.getElemSizeInBits() == 8 && op.getTileHeight() == 1 &&
+      op.getTileWidth() == 16 && op.getVBlocks() == 1 && !op.getVnniTransform())
+    return false;
+
   // intel_sub_group_2d_block_read_8b_8r8x1c
   if (op.getElemSizeInBits() == 8 && op.getTileHeight() == 8 &&
       op.getTileWidth() == 8 && op.getVBlocks() == 1 && !op.getVnniTransform())

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2500,6 +2500,10 @@ struct LoadOpToBlockIOConversion
                        static_cast<int>(MAX_WIDTH / totalBytesPerRowPerMatrix));
     // vBlocks has HW limitation of 4.
     vBlocks = std::min(vBlocks, 4);
+    // Limit vBlocks to 1 if block size is smaller than GRF size.
+    const unsigned GRF_SIZE = 64;
+    if (tileHeight * tileWidth * packedElemSizeInBits / 8 < GRF_SIZE)
+      vBlocks = 1;
 
     // TODO: use the axis info to general the handling for both regular pointer
     // and block pointer.


### PR DESCRIPTION
Fixes #5308

Flex Attn UT CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18510656080 (GOOD)