### PR TITLE
Use PyTorch cache key in `extra-cache-key` action field for dependency installation

### DIFF
--- a/.github/actions/setup-pytorch/action.yml
+++ b/.github/actions/setup-pytorch/action.yml
@@ -22,6 +22,10 @@ inputs:
   cache:
     description: Cache enabled or disabled
     default: enabled
+outputs:
+  pytorch_cache_key:
+    description: "PyTorch cache key"
+    value: ${{ steps.generate-pytorch-cache-key.outputs.pytorch_cache_key }}
 runs:
   using: "composite"
   steps:
@@ -70,22 +74,24 @@ runs:
         sudo ln -sfT ${{ inputs.oneapi }} /opt/intel/oneapi
 
     - name: Generate PyTorch cache key
+      id: generate-pytorch-cache-key
       shell: bash
+      env:
+        # Increase this value to reset cache
+        CACHE_NUMBER: 18
       run: |
         ONEAPI_LINK=$(readlink /opt/intel/oneapi || true)
         ONEAPI_KEY=$(sha256sum /opt/intel/installed.txt 2> /dev/null | cut -d\  -f1 || true)
         PYTORCH_CACHE_KEY=$(echo $PYTHON_VERSION $PYTORCH_COMMIT_ID ${{ hashFiles('scripts/patch-pytorch.sh') }} ${{ inputs.mode }}${ONEAPI_KEY}${ONEAPI_LINK} | sha256sum - | cut -d\  -f1)
         echo "PYTORCH_CACHE_KEY=$PYTORCH_CACHE_KEY" | tee -a "$GITHUB_ENV"
+        echo "pytorch_cache_key=pytorch-$PYTORCH_CACHE_KEY-$CACHE_NUMBER" >> "$GITHUB_OUTPUT"
 
     - name: Load PyTorch from a cache
       id: pytorch-cache
       uses: ./.github/actions/load
-      env:
-        # Increase this value to reset cache
-        CACHE_NUMBER: 18
       with:
         path: pytorch
-        key: pytorch-$PYTORCH_CACHE_KEY-$CACHE_NUMBER
+        key: ${{ steps.generate-pytorch-cache-key.outputs.pytorch_cache_key }}
         enabled: ${{ inputs.cache == 'enabled' }}
 
     - name: Clone PyTorch repository

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -92,6 +92,7 @@ jobs:
           pip install wheel 'cmake<4.0.0'
 
       - name: Setup PyTorch
+        id: setup-pytorch
         uses: ./.github/actions/setup-pytorch
         with:
           ref: ${{ inputs.pytorch_ref }}
@@ -151,7 +152,7 @@ jobs:
           package: torchvision
           repository: pytorch/vision
           ref: ${{ env.TORCHVISION_COMMIT_ID }}
-          extra-cache-key: ${{ env.PYTORCH_VERSION }}
+          extra-cache-key: ${{ steps.setup-pytorch.outputs.pytorch_cache_key }}
 
       - name: Install torchaudio package
         if: ${{ inputs.suite == 'torchbench' }}
@@ -160,7 +161,7 @@ jobs:
           package: torchaudio
           repository: pytorch/audio
           ref: ${{ env.TORCHAUDIO_COMMIT_ID }}
-          extra-cache-key: ${{ env.PYTORCH_VERSION }}
+          extra-cache-key: ${{ steps.setup-pytorch.outputs.pytorch_cache_key }}
 
       - name: Install timm package
         if: ${{ inputs.suite == 'timm_models' || inputs.suite == 'torchbench' }}
@@ -169,7 +170,7 @@ jobs:
           package: timm
           repository: huggingface/pytorch-image-models
           ref: ${{ env.TIMM_COMMIT_ID }}
-          extra-cache-key: ${{ env.PYTORCH_VERSION }}
+          extra-cache-key: ${{ steps.setup-pytorch.outputs.pytorch_cache_key }}
 
       - name: Clone pytorch benchmark
         if: ${{ inputs.suite == 'torchbench' }}

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -57,6 +57,7 @@ jobs:
           pip install wheel cmake
 
       - name: Setup PyTorch
+        id: setup-pytorch
         uses: ./.github/actions/setup-pytorch
 
       - name: Identify pinned versions
@@ -83,7 +84,7 @@ jobs:
           package: torchvision
           repository: pytorch/vision
           ref: ${{ env.TORCHVISION_COMMIT_ID }}
-          extra-cache-key: ${{ env.PYTORCH_VERSION }}
+          extra-cache-key: ${{ steps.setup-pytorch.outputs.pytorch_cache_key }}
 
       - name: Install torchaudio package
         uses: ./.github/actions/install-dependency
@@ -91,7 +92,7 @@ jobs:
           package: torchaudio
           repository: pytorch/audio
           ref: ${{ env.TORCHAUDIO_COMMIT_ID }}
-          extra-cache-key: ${{ env.PYTORCH_VERSION }}
+          extra-cache-key: ${{ steps.setup-pytorch.outputs.pytorch_cache_key }}
 
       - name: Install timm package
         uses: ./.github/actions/install-dependency
@@ -99,7 +100,7 @@ jobs:
           package: timm
           repository: huggingface/pytorch-image-models
           ref: ${{ env.TIMM_COMMIT_ID }}
-          extra-cache-key: ${{ env.PYTORCH_VERSION }}
+          extra-cache-key: ${{ steps.setup-pytorch.outputs.pytorch_cache_key }}
 
       - name: Install transformers package
         run: |


### PR DESCRIPTION
Now the PyTorch dependency cache depends on the PyTorch cache itself, not just its version, which should fix the situation when an old/incompatible cache is used.

This should fix `RuntimeError: operator torchvision::nms does not exist` error.

E2E accuracy CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18529650669 (`Install torchvision package` step works now)