### PR TITLE
Revert "Fix Python 3.9 typing error in tools/compile (#4946)"

### DIFF
--- a/python/triton/tools/compile.py
+++ b/python/triton/tools/compile.py
@@ -5,7 +5,7 @@ import sys
 from argparse import ArgumentParser
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import triton
 from triton._internal_testing import is_xpu
@@ -23,12 +23,12 @@ class CompileArgs:
     grid: str = ''
     grf_mode: str = ''
     generate_native_code: bool = False
-    target: Optional[str] = None
+    target: str | None = None
     num_warps: int = 1
     threads_per_warp: int = 32
     num_stages: int = 3
-    out_name: Optional[str] = None
-    out_path: Optional[Path] = None
+    out_name: str | None = None
+    out_path: Path | None = None
 
 
 desc = """


### PR DESCRIPTION
This reverts commit 6db18fbe78de0610e2f6c209d29b5c295501bce1.

Since we no longer support python 3.9, we can move to the new style of type hints.