### PR TITLE
Make fuse reshape with load op deterministic

### DIFF
--- a/test/Triton/Intel/FuseReshape/fuse-reshape.mlir
+++ b/test/Triton/Intel/FuseReshape/fuse-reshape.mlir
@@ -185,12 +185,12 @@ tt.func public @fuseLoadWithReshape4(%arg0: i32, %arg1: !tt.ptr<f16>, %arg2: !tt
 // CHECK: [[ADD22:%.*]] = arith.addi [[MUL22]], %c1_i32 : i32
 // CHECK: [[PTR2:%.*]] = tt.make_tensor_ptr %arg2, [[[ADD12]], %c64_i64], [%c64_i64, %c1_i64], [[[ADD22]], %c2_i32] {order = array<i32: 1, 0>} : <tensor<32x64xf16>>
 // CHECK: scf.for
-// CHECK:   [[ADV:%.*]] = tt.advance [[PTR2]], {{.*}} : <tensor<32x64xf16>>
+// CHECK:   [[ADV:%.*]] = tt.advance [[PTR1]], {{.*}} : <tensor<32x64xf16>>
 // CHECK:   [[LOAD_B1:%.*]] = tt.load [[ADV]] : !tt.ptr<tensor<32x64xf16>>
 // CHECK:   tt.dot {{.*}}, [[LOAD_B1]], {{.*}}, inputPrecision = tf32 : tensor<64x32xf16> * tensor<32x64xf16> -> tensor<64x64xf32>
 // CHECK:   scf.yield
 // CHECK: scf.for
-// CHECK:   [[ADV:%.*]] = tt.advance [[PTR1]], {{.*}} : <tensor<32x64xf16>>
+// CHECK:   [[ADV:%.*]] = tt.advance [[PTR2]], {{.*}} : <tensor<32x64xf16>>
 // CHECK:   [[LOAD_B1:%.*]] = tt.load [[ADV]] : !tt.ptr<tensor<32x64xf16>>
 // CHECK:   tt.dot {{.*}}, [[LOAD_B1]], {{.*}}, inputPrecision = tf32 : tensor<64x32xf16> * tensor<32x64xf16> -> tensor<64x64xf32>
 // CHECK:   scf.yield

--- a/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
@@ -111,7 +111,7 @@ public:
 private:
   // Duplicate the root operation of the given chains.
   void duplicateRoot(DefUseChains &chains) const {
-    std::map<Operation *, DefUseChains> rootToChains;
+    std::unordered_map<Operation *, DefUseChains> rootToChains;
     for (const DefUseChain &chain : chains) {
       Operation *start = chain.getStart();
       if (!rootToChains[start].empty())


### PR DESCRIPTION
Similar to https://github.com/intel/intel-xpu-backend-for-triton/pull/4323. The main idea is to get rid of structures where pointers are sorted.