### PR TITLE
Remove `wheel` dependency as unused

### DIFF
--- a/.github/WINDOWS.md
+++ b/.github/WINDOWS.md
@@ -141,7 +141,7 @@ python -c 'import torch;print(torch.__version__)'
 Install build dependencies:
 
 ```
-pip install -U wheel pybind11 cmake
+pip install -U pybind11 cmake
 ```
 
 Build and install Triton:

--- a/.github/actions/setup-pytorch/action.yml
+++ b/.github/actions/setup-pytorch/action.yml
@@ -121,7 +121,6 @@ runs:
         export TORCH_XPU_ARCH_LIST="pvc,bmg,dg2,arl-h,mtl-h"
 
         cd pytorch
-        pip install wheel
         # FIXME: Compatibility with versions of CMake older than 3.5 has been removed, this brakes compilation of third_party/protobuf:
         # CMake Error at third_party/protobuf/cmake/CMakeLists.txt:2 (cmake_minimum_required)
         pip install 'cmake<4.0.0'

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -119,7 +119,7 @@ jobs:
           .venv\Scripts\activate.ps1
           Invoke-BatchFile "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
           cd ${{ env.NEW_WORKSPACE }}
-          pip install -U wheel pybind11 cmake
+          pip install -U pybind11 cmake
           pip install -v '.[build,tests,tutorials]'
 
       - name: Triton version

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -53,7 +53,7 @@ jobs:
           .venv\Scripts\activate.ps1
           Invoke-BatchFile "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
           cd ${{ env.NEW_WORKSPACE }}
-          pip install -U wheel pybind11 cmake
+          pip install -U pybind11 cmake
           pip install -v '.[build]'
 
       - name: Clean

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           # cmake 3.22.1 does not work with the recent torchaudio: https://github.com/intel/intel-xpu-backend-for-triton/issues/2079
           # cmake<4.0.0 is required as a workaround for CMake Error at third_party/double-conversion/CMakeLists.txt:1 (cmake_minimum_required)
-          pip install wheel 'cmake<4.0.0' build
+          pip install 'cmake<4.0.0' build
 
       - name: Setup PyTorch
         id: setup-pytorch

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -144,7 +144,7 @@ jobs:
           .venv\Scripts\activate.ps1
           Invoke-BatchFile "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
           cd ${{ env.NEW_WORKSPACE }}
-          pip install -U wheel pybind11 cmake
+          pip install -U pybind11 cmake
           pip install -v '.[build,tests,tutorials]'
 
       - name: Triton version

--- a/.github/workflows/inductor-tests-windows.yml
+++ b/.github/workflows/inductor-tests-windows.yml
@@ -122,7 +122,7 @@ jobs:
           .venv\Scripts\activate.ps1
           Invoke-BatchFile "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
           cd ${{ env.NEW_WORKSPACE }}
-          pip install -U wheel pybind11 cmake
+          pip install -U pybind11 cmake
           pip install -v '.[build,tests,tutorials]'
 
       - name: Triton version

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Python build dependencies
         run: |
           # cmake 3.22.1 does not work with the recent torchaudio: https://github.com/intel/intel-xpu-backend-for-triton/issues/2079
-          pip install wheel cmake build
+          pip install cmake build
 
       - name: Setup PyTorch
         id: setup-pytorch

--- a/.github/workflows/pip-test-windows.yml
+++ b/.github/workflows/pip-test-windows.yml
@@ -90,7 +90,7 @@ jobs:
           .venv\Scripts\activate.ps1
           Invoke-BatchFile "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
           cd ${{ env.NEW_WORKSPACE }}
-          pip install -U wheel pybind11 'cmake>=3.20,<4.0' intel-sycl-rt==2025.2.1 build
+          pip install -U pybind11 'cmake>=3.20,<4.0' intel-sycl-rt==2025.2.1 build
           # `build` can't determine that Ninja is already installed.
           # similar issue: https://github.com/pypa/build/issues/506
           python -m build --wheel --no-isolation --skip-dependency-check

--- a/.github/workflows/sglang-tests.yml
+++ b/.github/workflows/sglang-tests.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Install Python build dependencies
         run: |
-          pip install wheel cmake
+          pip install cmake
 
       - name: Create reports dir
         run: |

--- a/.github/workflows/third-party-benchmarks.yml
+++ b/.github/workflows/third-party-benchmarks.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install Python build dependencies
         run: |
-          pip install wheel cmake
+          pip install cmake
 
       - name: Setup PyTorch
         uses: ./.github/actions/setup-pytorch

--- a/.github/workflows/third-party-tests.yml
+++ b/.github/workflows/third-party-tests.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Install Python build dependencies
         run: |
-          pip install wheel cmake
+          pip install cmake
 
       - name: Setup PyTorch
         uses: ./.github/actions/setup-pytorch

--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Install Python build dependencies
         run: |
-          pip install wheel cmake
+          pip install cmake
 
       - name: Setup PyTorch
         uses: ./.github/actions/setup-pytorch

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,4 @@
 setuptools>=70.2.0
-wheel
 build
 cmake>=3.20,<4.0
 ninja<1.13.0

--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -74,7 +74,7 @@ if [ "$VENV" = true ]; then
   echo "**** Creating Python virtualenv ****"
   python3 -m venv .venv --prompt triton
   source .venv/bin/activate
-  pip install ninja cmake wheel pybind11
+  pip install ninja cmake pybind11
 fi
 
 if [ ! -d "$PACKAGES_DIR" ]; then


### PR DESCRIPTION
Ref: https://github.com/pypa/wheel?tab=readme-ov-file#historical-note: `"This project used to contain the implementation of the [setuptools](https://pypi.org/project/setuptools/) bdist_wheel command, but as of setuptools v70.1, it no longer needs wheel installed for that to work. Thus, you should install this only if you intend to use the wheel command line tool!"`