### PR TITLE
[LoadOpToBlockIOConversion] Add env var to allow more 2d block load generation

### DIFF
--- a/python/test/unit/intel/test_block_io.py
+++ b/python/test/unit/intel/test_block_io.py
@@ -199,4 +199,6 @@ def test_block_io(M, N, dtype_str, layout, load_block_ptr, store_block_ptr, devi
     assert torch.equal(a, x)
 
     if support_block_io:
+        if not load_block_ptr:
+            assert 'spirv_Subgroup2DBlockLoad' in kernel.asm['llir'] or 'GenISA.LSC2DBlockRead' in kernel.asm['llir']
         assert 'spirv_Subgroup2DBlockStoreINTEL' in kernel.asm['llir'] or 'GenISA.LSC2DBlockWrite' in kernel.asm['llir']


### PR DESCRIPTION
When `TRITON_INTEL_ENABLE_BLOCK_IO_ALL_LAYOUTS` is defined, it extends 2d block load generation for regular pointer for all layout.