### PR TITLE
[microbenchmarks] Add brief mode argument

### DIFF
--- a/benchmarks/triton_kernels_benchmark/benchmark_testing.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_testing.py
@@ -266,7 +266,7 @@ class MarkArgs:
     brief: bool = False
 
     @staticmethod
-    def load_cli_args() -> "MarkArgs":
+    def load_cli_args() -> MarkArgs:
         """Parses arguments via CLI, allows save_path overloading to `reports`."""
         parser = argparse.ArgumentParser()
         parser.add_argument(


### PR DESCRIPTION
Sometimes I want to analyze results and I don't want to overload the screen with min, max CV values. Also minor refactoring of result parsing. There's no point in 2 staticmethods here.

Output example for some benchmark:
Default:
```
     B       M       N       K  Triton-GB/s  Triton-GB/s-min  Triton-GB/s-max  Triton-TFlops  Triton-TFlops-min  Triton-TFlops-max  Triton-CV
0  1.0     1.0  1024.0  4096.0    10.125465         9.987750        10.146010       0.010111           0.009973           0.010131   0.001770
1  1.0   256.0  5120.0  8192.0    20.286079        20.262999        20.291196       4.668077           4.662766           4.669255   0.000165
2  1.0  1024.0  1024.0  1024.0    14.454144        14.447175        14.459128       3.700261           3.698477           3.701537   0.000244
```
With `python benchmark.py --brief`:

```
matmul-performance:
     B       M       N       K  Triton-GB/s  Triton-TFlops
0  1.0     1.0  1024.0  4096.0    10.101845       0.010087
1  1.0   256.0  5120.0  8192.0    20.286518       4.668179
2  1.0  1024.0  1024.0  1024.0    14.452154       3.699751
(triton) (base) jovyan@jupyter-ekrivov:~/triton/intel-xpu-backend-for-triton
```