### PR TITLE
Only use `sycl::opencl::has_extension` to query device extension

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -113,12 +113,6 @@ class XPUBackend(BaseBackend):
         dev_prop['max_num_sub_groups'] = tgt_prop.get('max_num_sub_groups', None)
         dev_prop['sub_group_sizes'] = tgt_prop.get('sub_group_sizes', None)
         dev_prop['has_fp64'] = tgt_prop.get('has_fp64', None)
-        dev_prop['has_subgroup_matrix_multiply_accumulate'] = tgt_prop.get('has_subgroup_matrix_multiply_accumulate',
-                                                                           False)
-        dev_prop['has_subgroup_matrix_multiply_accumulate_tensor_float32'] = tgt_prop.get(
-            'has_subgroup_matrix_multiply_accumulate_tensor_float32', False)
-        dev_prop['has_subgroup_2d_block_io'] = tgt_prop.get('has_subgroup_2d_block_io', False)
-        dev_prop['has_bfloat16_conversions'] = tgt_prop.get('has_bfloat16_conversions', True)
 
         return dev_prop
 

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -919,7 +919,7 @@ class XPUDriver(DriverBase):
 
         def update_advanced_features(device, dev_property):
             if knobs.intel.device_extensions:
-                # May be useful when using the `TRITON INTEL_DEVICE_ARCH` environment variable
+                # May be useful when using the `TRITON_INTEL_DEVICE_ARCH` environment variable
                 # to be able to flexibly turn on/off the advanced feature.
                 supported_extensions = set()
                 supported_extensions.update(knobs.intel.device_extensions.split(" "))


### PR DESCRIPTION
Benchmark CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18691111532