### PR TITLE
[E2E] Add `accelerate` dependency for some huggingface models

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -144,6 +144,7 @@ jobs:
         run: |
           cd pytorch
           pip install -r .ci/docker/ci_commit_pins/huggingface-requirements.txt
+          pip install accelerate
 
       - name: Install torchvision package
         if: ${{ inputs.suite == 'timm_models' || inputs.suite == 'torchbench' }}


### PR DESCRIPTION
For example, it's needed for `openai/gpt-oss-20b`: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18659825836/job/53197489734#step:21:682

Inspired by https://github.com/intel/torch-xpu-ops/pull/2054.

CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18691554241 (now it's OOM error; I'll try to fix it separately)