### PR TITLE
[PROTON][XPU] Always build XpuPti profiler

### DIFF
--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -118,10 +118,6 @@ jobs:
           ref: ${{ inputs.pytorch_ref }}
           mode: ${{ inputs.pytorch_mode }}
 
-      - name: Build Proton with XPU support
-        run: |
-          echo TRITON_BUILD_PROTON_XPU=1 | tee -a $GITHUB_ENV
-
       - name: Build Triton
         uses: ./.github/actions/setup-triton
         with:

--- a/setup.py
+++ b/setup.py
@@ -519,7 +519,6 @@ class CMakeBuild(build_ext):
         # environment variables we will pass through to cmake
         passthrough_args = [
             "TRITON_BUILD_PROTON",
-            "TRITON_BUILD_PROTON_XPU",
             "TRITON_BUILD_WITH_CCACHE",
             "TRITON_PARALLEL_LINK_JOBS",
         ]

--- a/third_party/proton/CMakeLists.txt
+++ b/third_party/proton/CMakeLists.txt
@@ -3,11 +3,6 @@ project(Proton LANGUAGES CXX)
 set(PROTON_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/csrc")
 set(PROTON_COMMON_DIR "${CMAKE_CURRENT_SOURCE_DIR}/common")
 
-option(TRITON_BUILD_PROTON_XPU "Build Proton with XPU support" OFF)
-if(TRITON_BUILD_PROTON_XPU)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTRITON_BUILD_PROTON_XPU")
-endif()
-
 # ============ Check for includes =============
 if(NOT CUPTI_INCLUDE_DIR)
   message(FATAL_ERROR "CUPTI include directory not defined")

--- a/third_party/proton/csrc/lib/Driver/CMakeLists.txt
+++ b/third_party/proton/csrc/lib/Driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SOURCE_FILES
+add_proton_library(ProtonDriver
 	Device.cpp
 	GPU/CudaApi.cpp
 	GPU/CuptiApi.cpp
@@ -6,11 +6,6 @@ set(SOURCE_FILES
 	GPU/HsaApi.cpp
 	GPU/RoctracerApi.cpp
 	GPU/NvtxApi.cpp
+	GPU/XpuApi.cpp
+	GPU/XpuptiApi.cpp
 )
-
-if(TRITON_BUILD_PROTON_XPU)
-    list(APPEND SOURCE_FILES GPU/XpuApi.cpp)
-	list(APPEND SOURCE_FILES GPU/XpuptiApi.cpp)
-endif()
-
-add_proton_library(ProtonDriver ${SOURCE_FILES})

--- a/third_party/proton/csrc/lib/Driver/Device.cpp
+++ b/third_party/proton/csrc/lib/Driver/Device.cpp
@@ -1,9 +1,7 @@
 #include "Device.h"
 #include "Driver/GPU/CudaApi.h"
 #include "Driver/GPU/HipApi.h"
-#ifdef TRITON_BUILD_PROTON_XPU
 #include "Driver/GPU/XpuApi.h"
-#endif
 
 #include "Utility/Errors.h"
 
@@ -16,11 +14,9 @@ Device getDevice(DeviceType type, uint64_t index) {
   if (type == DeviceType::HIP) {
     return hip::getDevice(index);
   }
-#ifdef TRITON_BUILD_PROTON_XPU
   if (type == DeviceType::XPU) {
     return xpu::getDevice(index);
   }
-#endif
   throw std::runtime_error("DeviceType not supported");
 }
 

--- a/third_party/proton/csrc/lib/Profiler/CMakeLists.txt
+++ b/third_party/proton/csrc/lib/Profiler/CMakeLists.txt
@@ -1,15 +1,10 @@
-set(SOURCE_FILES
-    Cupti/CuptiPCSampling.cpp
-    Cupti/CuptiProfiler.cpp
-    RocTracer/RoctracerProfiler.cpp
-	  Instrumentation/InstrumentationProfiler.cpp
-	  Instrumentation/CudaRuntime.cpp
-	  Instrumentation/HipRuntime.cpp
-	  Instrumentation/Metadata.cpp
+add_proton_library(ProtonProfiler
+	Cupti/CuptiPCSampling.cpp
+	Cupti/CuptiProfiler.cpp
+	RocTracer/RoctracerProfiler.cpp
+	Xpupti/XpuptiProfiler.cpp
+	Instrumentation/InstrumentationProfiler.cpp
+	Instrumentation/CudaRuntime.cpp
+	Instrumentation/HipRuntime.cpp
+	Instrumentation/Metadata.cpp
 )
-
-if(TRITON_BUILD_PROTON_XPU)
-    list(APPEND SOURCE_FILES Xpupti/XpuptiProfiler.cpp)
-endif()
-
-add_proton_library(ProtonProfiler ${SOURCE_FILES})

--- a/third_party/proton/csrc/lib/Session/Session.cpp
+++ b/third_party/proton/csrc/lib/Session/Session.cpp
@@ -3,13 +3,11 @@
 #include "Context/Shadow.h"
 #include "Data/TraceData.h"
 #include "Data/TreeData.h"
+#include "Driver/GPU/XpuApi.h"
 #include "Profiler/Cupti/CuptiProfiler.h"
 #include "Profiler/Instrumentation/InstrumentationProfiler.h"
 #include "Profiler/Roctracer/RoctracerProfiler.h"
-#ifdef TRITON_BUILD_PROTON_XPU
-#include "Driver/GPU/XpuApi.h"
 #include "Profiler/Xpupti/XpuptiProfiler.h"
-#endif
 #include "Utility/String.h"
 
 namespace proton {
@@ -24,13 +22,10 @@ Profiler *makeProfiler(const std::string &name, void *sycl_queue = nullptr,
     return &RoctracerProfiler::instance();
   } else if (proton::toLower(name) == "instrumentation") {
     return &InstrumentationProfiler::instance();
-  }
-#ifdef TRITON_BUILD_PROTON_XPU
-  if (proton::toLower(name) == "xpupti") {
+  } else if (proton::toLower(name) == "xpupti") {
     xpu::PROTON_UTILS = utils_cache_path;
     return &XpuptiProfiler::instance().setSyclQueue(sycl_queue);
   }
-#endif
   throw std::runtime_error("Unknown profiler: " + name);
 }
 


### PR DESCRIPTION
~Blocked  on #5369~
Part of #1145

Test with PIP: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18748307720 (build works)

The profiler now depends only on PTI headers (which are included in the Triton source code) at build time, so it should be safe enough to build at all times and in any environment.