### PR TITLE
Use `use_pyenv_python=true` by default in `build-test-gpu.yml`

### DIFF
--- a/.github/workflows/build-test-gpu.yml
+++ b/.github/workflows/build-test-gpu.yml
@@ -42,7 +42,7 @@ on:
       use_pyenv_python:
         description: Use Python built with pyenv
         type: boolean
-        default: false
+        default: true
 
 permissions: read-all
 
@@ -64,4 +64,4 @@ jobs:
       skip_list: ${{ inputs.skip_list }}
       run_name: ${{ inputs.run_name || format('Build and test {0}', inputs.runner_label) }}
       enable_unskip: ${{ inputs.enable_unskip }}
-      use_pyenv_python: ${{ inputs.use_pyenv_python || false }}
+      use_pyenv_python: ${{ inputs.use_pyenv_python || true }}


### PR DESCRIPTION
To fix: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18741945464

```bash
The version '3.10' with architecture 'x64' was not found for this operating system.
```