### PR TITLE
Fix Proton tests when PyTorch is installed with `pytorch_mode==wheels`

### DIFF
--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -284,7 +284,7 @@ jobs:
         if: matrix.suite == 'rest'
         run: |
           # `intel-pti` can be installed in "Setup PyTorch" step with `pytorch_mode==wheels`
-          pip uninstall intel-pti
+          pip uninstall intel-pti -y
           PTI_COMMIT_ID="$(<.github/pins/pti.txt)"
           git clone https://github.com/intel/pti-gpu.git
           cd pti-gpu


### PR DESCRIPTION
CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18781246886 (proton tests passed)

To fix https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18741946621/job/53461278673