### PR TITLE
[PROTON][XPU] Fix utility function: `enumDeviceUUIDs`

### DIFF
--- a/third_party/intel/backend/proton_utils.cpp
+++ b/third_party/intel/backend/proton_utils.cpp
@@ -9,9 +9,10 @@ extern "C" void waitOnSyclQueue(void *syclQueue) {
 
 // FIXME: Should it be in DeviceInfo class?
 // Inspired by Kineto: `XpuptiActivityProfiler.cpp`
-extern "C" void
-enumDeviceUUIDs(std::vector<std::array<uint8_t, 16>> deviceUUIDs_) {
-  if (!deviceUUIDs_.empty()) {
+extern "C" void enumDeviceUUIDs(void *deviceUUIDsPtr) {
+  auto *deviceUUIDs_ =
+      reinterpret_cast<std::vector<std::array<uint8_t, 16>> *>(deviceUUIDsPtr);
+  if (!deviceUUIDs_->empty()) {
     return;
   }
   auto platform_list = sycl::platform::get_platforms();
@@ -24,13 +25,13 @@ enumDeviceUUIDs(std::vector<std::array<uint8_t, 16>> deviceUUIDs_) {
     for (const auto &device : device_list) {
       if (device.is_gpu()) {
         if (device.has(sycl::aspect::ext_intel_device_info_uuid)) {
-          deviceUUIDs_.push_back(
+          deviceUUIDs_->push_back(
               device.get_info<sycl::ext::intel::info::device::uuid>());
         } else {
           std::cerr << "Warnings: UUID is not supported for this XPU device. "
                        "The device index of records will be 0."
                     << std::endl;
-          deviceUUIDs_.push_back(std::array<uint8_t, 16>{});
+          deviceUUIDs_->push_back(std::array<uint8_t, 16>{});
         }
       }
     }

--- a/third_party/proton/csrc/lib/Profiler/Xpupti/XpuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Xpupti/XpuptiProfiler.cpp
@@ -275,7 +275,7 @@ void CallbackCommon(pti_callback_domain domain,
   std::cout << std::endl;
 }
 
-typedef void (*EnumDeviceUUIDsFunc)(std::vector<std::array<uint8_t, 16>>);
+typedef void (*EnumDeviceUUIDsFunc)(void *);
 
 int callEnumDeviceUUIDs(const std::string &utils_cache_path) {
   void *handle = dlopen(xpu::PROTON_UTILS.data(), RTLD_LAZY);
@@ -294,7 +294,7 @@ int callEnumDeviceUUIDs(const std::string &utils_cache_path) {
     return 1;
   }
 
-  enumDeviceUUIDs(deviceUUIDs_);
+  enumDeviceUUIDs(&deviceUUIDs_);
 
   dlclose(handle);
   return 0;


### PR DESCRIPTION
To avoid: `Warnings: Can't find the legal XPU device from the given UUID.` like in https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18820590361/job/53695741968?pr=5383#step:13:322