### PR TITLE
[E2E] Align `torchbench` dependencies to match what `torch-xpu-ops` uses

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Install python test dependencies
         run: |
-          pip install pyyaml pandas scipy 'numpy==1.26.4' psutil
+          pip install pyyaml pandas scipy psutil
 
       - name: Install transformers package
         if: ${{ inputs.suite == 'huggingface' }}
@@ -207,6 +207,9 @@ jobs:
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
         run: |
           cd pytorch
+
+          # Some models are still not compatible with numpy>2.0
+          pip install 'numpy==1.26.4'
 
           export WORKSPACE=$GITHUB_WORKSPACE
 


### PR DESCRIPTION
Inspired by https://github.com/intel/torch-xpu-ops/commit/779f89911779b8c7296aaec3cf74945c18acc270

CI:
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18884486325 (to double check)
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18888410336 (passed)