### PR TITLE
[E2E] Fix `secrets.HUGGING_FACE_HUB_TOKEN` usage

### DIFF
--- a/.github/workflows/e2e-accuracy.yml
+++ b/.github/workflows/e2e-accuracy.yml
@@ -125,6 +125,8 @@ jobs:
         dtype: ${{ fromJson(needs.setup.outputs.dtype) }}
       fail-fast: false
     uses: ./.github/workflows/e2e-reusable.yml
+    secrets:
+      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
     with:
       pytorch_ref: ${{ inputs.pytorch_ref || '' }}
       suite: ${{ matrix.suite }}

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -2,6 +2,9 @@ name: E2E reusable workflow
 
 on:
   workflow_call:
+    secrets:
+      HUGGING_FACE_HUB_TOKEN:
+        required: true
     inputs:
       pytorch_ref:
         description: PyTorch ref, keep empty for default


### PR DESCRIPTION
CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/18885865269 (passed)

Secrets must be explicitly passed into the subworkflow (where `workflow_call` is defined), otherwise empty strings are implicitly used instead.