### PR TITLE
[TEST] Update `triton_kernels` skiplist

### DIFF
--- a/scripts/skiplist/default/triton_kernels.txt
+++ b/scripts/skiplist/default/triton_kernels.txt
@@ -37,6 +37,7 @@ tests/test_matmul.py::test_op[False-True-False-True-False-None-128-1000-704-800-
 tests/test_matmul.py::test_op[False-True-False-True-False-None-16-1000-400-400-ragged-float8_e4m3fn-float8_e4m3fn-3-1-1-False-None-False-False-False-True]
 tests/test_matmul.py::test_op[False-True-False-True-False-None-16-1000-704-800-ragged-mxfloat8_e4m3fn-mxfloat4_e2m1-8-2-9-False-None-False-False-False-True]
 tests/test_matmul.py::test_op[False-True-False-True-False-None-16-1000-704-800-ragged-mxfloat8_e4m3fn-mxfloat4_e2m1-8-2-9-True-None-False-False-False-True]
+tests/test_matmul.py::test_op[False-True-True-False-False-None-128-1000-700-700-ragged-float16-float16-8-2-9-False-None-False-False-False-True]
 tests/test_matmul.py::test_op[False-True-True-False-False-None-128-1000-704-800-ragged-mxfloat8_e4m3fn-mxfloat4_e2m1-8-2-9-False-None-False-False-False-False]
 tests/test_matmul.py::test_op[False-True-True-False-False-None-128-1000-704-800-ragged-mxfloat8_e4m3fn-mxfloat4_e2m1-8-2-9-False-None-False-False-False-True]
 tests/test_matmul.py::test_op[False-True-True-False-False-None-128-1000-704-800-ragged-mxfloat8_e4m3fn-mxfloat4_e2m1-8-2-9-True-None-False-False-False-True]


### PR DESCRIPTION
Added `tests/test_matmul.py::test_op[False-True-True-False-False-None-128-1000-700-700-ragged-float16-float16-8-2-9-False-None-False-False-False-True]`, as it fails intermediately.