### PR TITLE
Use OCL builtin for precise divide and sqrt

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -202,10 +202,6 @@ class XPUBackend(BaseBackend):
         passes.common.add_symbol_dce(pm)
         passes.ttir.add_loop_unroll(pm)
         pm.run(mod, 'make_ttir')
-
-        if intel.has_precise_divide_sqrt(mod):
-            metadata["build_flags"] = "-cl-fp32-correctly-rounded-divide-sqrt"
-
         return mod
 
     @staticmethod

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -301,16 +301,6 @@ void init_triton_intel(py::module &&m) {
     return py::int_(ret);
   });
 
-  m.def("has_precise_divide_sqrt", [](mlir::ModuleOp &mod) -> bool {
-    using namespace mlir;
-    WalkResult result = mod.walk([&](Operation *op) {
-      if (isa<mlir::triton::PreciseDivFOp, mlir::triton::PreciseSqrtOp>(op))
-        return WalkResult::interrupt();
-      return WalkResult::advance();
-    });
-    return result.wasInterrupted();
-  });
-
   // FIXME: This is for internal experimentation. In the end we will need a
   // producer flag (e.g. PyTorch flag) to allow the Triton compiler to use the
   // fast math semantics on all arithmetic operations.


### PR DESCRIPTION
Note that they are not official interfaces.

Fixes #5419