### PR TITLE
capture-hw-details.sh: get igc64.dll version from the currenlty loaded graphics driver

### DIFF
--- a/scripts/capture-hw-details.sh
+++ b/scripts/capture-hw-details.sh
@@ -26,7 +26,7 @@ function libigc_version {
                 Write-Host "MULTIPLE"
             }
             elseif ($igc.Count -eq 1) {
-                Write-Host $igc[0]
+                Write-Host $igc
             }
             else {
                 Write-Host "Not Found"


### PR DESCRIPTION
When there are multiple libigc versions in a Windows driver store, Windows CI breaks:

```
LIBIGC1_VERSION=32.0.101.6737
32.0.101.8247
LEVEL_ZERO_VERSION=1.24.2
AGAMA_VERSION=32.0.101.6737
GPU_DEVICE=Intel(R) Arc(TM) 140V GPU (16GB)
TORCH_VERSION=Not installed
COMPILER_VERSION=2025.2.0
Error: Unable to process file command 'env' successfully.
Error: Invalid format '32.0.101.8247'
```

To fix this, we will get igc64.dll version from the currenlty loaded graphics driver.

Test run: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/19313141656/job/55238243773#step:9:41

resolves https://github.com/intel/intel-xpu-backend-for-triton/issues/5440