### PR TITLE
[XPU] Get `mem_clock_rate` and `sm_clock_rate` in KHz instead of MHz to align with other backends

### DIFF
--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -53,7 +53,8 @@ extern "C" EXPORT_FUNC PyObject *get_device_properties(int device_id) {
 
   int multiprocessor_count =
       device_properties.numSlices * device_properties.numSubslicesPerSlice;
-  int sm_clock_rate = device_properties.coreClockRate;
+  // To align with other backends - convert MHz to KHz
+  int sm_clock_rate = device_properties.coreClockRate * 1000;
 
   ze_device_compute_properties_t compute_properties = {};
   compute_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_COMPUTE_PROPERTIES;

--- a/third_party/intel/backend/proton_utils.cpp
+++ b/third_party/intel/backend/proton_utils.cpp
@@ -81,7 +81,8 @@ extern "C" void getDeviceProperties(uint64_t index, uint32_t *clockRate,
   device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
   check(zeDeviceGetProperties(phDevice, &device_properties),
         "zeDeviceGetProperties");
-  *clockRate = device_properties.coreClockRate;
+  // To align with other backends - convert MHz to KHz
+  *clockRate = device_properties.coreClockRate * 1000;
   *numSms =
       device_properties.numSlices * device_properties.numSubslicesPerSlice;
   // create a struct to hold device memory properties


### PR DESCRIPTION
* [CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE](https://docs.nvidia.com/cuda/archive/12.0.1/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES_1gge12b8a782bebe21b1ac0091bf9f4e2a3f8c3b95eea20e23ae90c80661a38f8f0): Peak memory clock frequency in kilohertz
* [int hipDeviceProp_t::clockRate](https://rocm.docs.amd.com/projects/HIP/en/develop/doxygen/html/structhip_device_prop__t.html#a1dd15bee43692b8649dfbdc1adbaaf96): Max clock frequency of the multiProcessors in khz.
