### PR TITLE
Use DLE 2025.2 for SPIRVRunner test to unblock CI

### DIFF
--- a/.github/workflows/spirvrunner-test.yml
+++ b/.github/workflows/spirvrunner-test.yml
@@ -20,7 +20,7 @@ jobs:
     name: Tests
     runs-on:
       - rolling
-      - runner-0.0.22
+      - dle-2025.2
     timeout-minutes: 75 # equal to max + 3*std over the last 600 successful runs
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Workaround before #5458 is resolved
[![Test SPIRVRunner](https://github.com/intel/intel-xpu-backend-for-triton/actions/workflows/spirvrunner-test.yml/badge.svg)](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/19278644553/job/55124495138?pr=5459)