### PR TITLE
[Inductor][UT] Make sure `pytest-skip` is not in use

### DIFF
--- a/.github/workflows/inductor-tests-reusable.yml
+++ b/.github/workflows/inductor-tests-reusable.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Install python test dependencies
         run: |
           pip install pandas scipy tqdm
+          pip uninstall pytest-skip
 
       - name: Run inductor tests
         run: |


### PR DESCRIPTION
Tp avoid: `argparse.ArgumentError: argument --shard-id: conflicting option string: --shard-id` like in https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/19388256931/job/55478197241#step:8:1827


https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/19394181771/job/55491874461?pr=5485 (There are no more problems with `--shard-id` option)