### PR TITLE
[benchmarks] Add options to print SW efficiency

### DIFF
--- a/benchmarks/gpu_info.json
+++ b/benchmarks/gpu_info.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "GPU -> [BF16/FP16 DPAS TFLOPs , Memory bandwidth GB/s]",
+  "Intel(R) Data Center GPU Max 1100": [
+    355.53,
+    1228.80
+  ],
+  "Intel(R) Data Center GPU Max 1550": [
+    419.43,
+    3276.8
+  ],
+  "Intel(R) Arc(TM) B580 Graphics": [
+    116.74,
+    456.0
+  ],
+  "Intel(R) Arc(TM) B570 Graphics": [
+    103.22,
+    380.0
+  ]
+}

--- a/benchmarks/triton_kernels_benchmark/benchmark_testing.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_testing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+import re
 from typing import Callable, ClassVar, Dict, Optional, List, Tuple, Union, Set
 from collections.abc import Iterable
 from enum import Enum
@@ -13,8 +14,10 @@ import argparse
 import datetime
 import os
 import time
+from pathlib import Path
 
 import scipy.stats
+import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 
@@ -335,6 +338,30 @@ def filter_providers(
     return supported_providers
 
 
+def get_gpu_info():
+    device_name = torch.xpu.is_available() and torch.xpu.get_device_name()
+    if device_name is None:
+        print("Couldn't read device name.")
+        return None, None
+
+    # benchmarks/triton_kernels_benchmark/benchmark_testing.py -> benchmarks/gpu_info.json
+    current_dir = Path(__file__).parent.resolve()
+    gpu_info_path = current_dir.parent / "gpu_info.json"
+
+    if not gpu_info_path.exists():
+        print(f"Warning: '{gpu_info_path}' not found.")
+        return None, None
+
+    with open(gpu_info_path, "r", encoding="utf-8") as f:
+        gpu_info = json.load(f)
+
+    if device_name not in gpu_info:
+        print(f"Warning: Device '{device_name}' not found in {gpu_info_path}")
+        return None, None
+
+    return gpu_info[device_name]
+
+
 def perf_report(benchmarks):
     """
     Mark a function for benchmarking. The benchmark can then be executed by using the :code:`.run` method on the return value.
@@ -351,8 +378,7 @@ class MarkArgs:
     reports: str = ""
     n_runs: int = 1
     brief: bool = False
-    hw_gbps: float = None
-    hw_tflops: float = None
+    eff: bool = False
 
     @staticmethod
     def load_cli_args() -> MarkArgs:
@@ -377,29 +403,44 @@ class MarkArgs:
             help="Print only mean values without min, max, CV.",
         )
         parser.add_argument(
-            "--hw_gbps",
-            type=float,
-            help="Hardware bandwidth in GB/s to calculate efficiency.",
-        )
-        parser.add_argument(
-            "--hw_tflops",
-            type=float,
-            help="Hardware peak performance in TFLOPS to calculate efficiency.",
+            "--eff",
+            "-e",
+            action="store_true",
+            help="Print HW utilization, will use internal database from 'gpu_info.json'.",
         )
         args = parser.parse_args()
-        return MarkArgs(args.reports, args.n_runs, args.brief, args.hw_gbps, args.hw_tflops)
+        return MarkArgs(args.reports, args.n_runs, args.brief, args.eff)
 
 
-def enhance_df(df, mark_args: MarkArgs):
+def enhance_df(df, bench, mark_args: MarkArgs):
+    hw_tflops, hw_gbps = None, None
+    if mark_args.eff:
+        hw_tflops, hw_gbps = get_gpu_info()
+
     df = df.copy()
     if mark_args.brief:
         df = df[[c for c in df.columns if not any(map(c.endswith, ("min", "max", "CV")))]]
 
+    # Find and write down HW efficiency columns
+    tflops_labels = [l for l in bench.ylabel if l.lower().endswith("tflops")]
+    tflops_pattern = "-(" + "|".join(tflops_labels) + ")(-min|-max)?$"
+
+    gbps_labels = [l for l in bench.ylabel if l.lower().replace("/", "p").endswith("gbps")]
+    gbps_pattern = "-(" + "|".join(gbps_labels) + ")(-min|-max)?$"
+
     for col in df.columns:
-        if col.lower().replace("/", "p").endswith("gbps") and mark_args.hw_gbps:
-            df[col + "-eff"] = (df[col] / mark_args.hw_gbps).apply(lambda x: f"{x:.1%}")
-        elif col.lower().endswith("tflops") and mark_args.hw_tflops:
-            df[col + "-eff"] = (df[col] / mark_args.hw_tflops).apply(lambda x: f"{x:.1%}")
+        if re.search(tflops_pattern, col) and hw_tflops:
+            df[re.sub(tflops_pattern, "-ceff", col)] = df[col] / hw_tflops
+        if re.search(gbps_pattern, col) and hw_gbps:
+            df[re.sub(gbps_pattern, "-meff", col)] = df[col] / hw_gbps
+            # df[re.sub(gbps_pattern, "-meff", col)] = (df[col] / mark_args.hw_gbps).apply(lambda x: f"{x:.1%}")
+    # We will only keep resulting efficiency column, we are either compute or memory bound.
+    for provider in bench.line_names:
+        if f"{provider}-ceff" in df.columns and f"{provider}-meff" in df.columns:
+            df[f"{provider}-eff"] = np.maximum(df[f"{provider}-ceff"],
+                                               df[f"{provider}-meff"]).apply(lambda x: f"{x:.2%}")
+            del df[f"{provider}-ceff"]
+            del df[f"{provider}-meff"]
 
     return df
 
@@ -487,7 +528,7 @@ class Mark:
             col0, col1 = df.columns.tolist()
             df["Diff"] = df[col1] - df[col0]
 
-        df = enhance_df(df, mark_args)
+        df = enhance_df(df, bench, mark_args)
         if print_data:
             print(bench.plot_name + ":")
             print(df.to_string())


### PR DESCRIPTION
User provides hardware capability with a call like this:
`python benchmarks/triton_kernels_benchmark/gemm_tensor_desc_benchmark.py --hw_gbps 1229 --hw_tflops 356 --brief` and we can print software efficiency and save it to the report as well.

If this functionality is popular and required, we could save hardware capability to the file and read it automatically, maybe with a call to `scripts/capture-hw-details.sh` before the script or during the benchmark. Then user will not have to provide device properties.

We potentially could also just print one efficiency (max between compute and memory).

Example output:
```
python benchmarks/triton_kernels_benchmark/gemm_tensor_desc_benchmark.py --hw_gbps 1229 --hw_tflops 356 --brief
matmul-tensor-desc-performance:
         B        M         N        K  Triton-GB/s  OneDNN-GB/s  CUTLASS-GB/s  Triton-TFlops  OneDNN-TFlops  CUTLASS-TFlops Triton-GB/s-eff OneDNN-GB/s-eff CUTLASS-GB/s-eff Triton-TFlops-eff OneDNN-TFlops-eff CUTLASS-TFlops-eff
0      1.0      1.0    1024.0   4096.0   175.750946   425.577337    115.970394       0.175494       0.424955        0.115801           14.3%           34.6%             9.4%              0.0%              0.1%               0.0%
1      1.0      1.0    4096.0   4096.0   524.016979   521.413149    443.931886       0.523633       0.521032        0.443607           42.6%           42.4%            36.1%              0.1%              0.1%               0.1%
2      1.0      1.0    4096.0  14336.0   389.696066   469.416483    455.829798       0.389547       0.469236        0.455655           31.7%           38.2%            37.1%              0.1%              0.1%               0.1%
3      1.0      1.0    6144.0   4096.0   486.236889   489.735672    546.370370       0.485921       0.489417        0.546015           39.6%           39.8%            44.5%              0.1%              0.1%               0.2%
4      1.0      1.0   13824.0   5120.0   441.854767   458.802913    397.907679       0.441650       0.458591        0.397724           36.0%           37.3%            32.4%              0.1%              0.1%               0.1%
5      1.0      1.0   14336.0   4096.0   445.977144   453.376201    408.517751       0.445728       0.453123        0.408290           36.3%           36.9%            33.2%              0.1%              0.1%               0.1%
6      1.0      1.0   28672.0   4096.0   498.016222   529.741423    475.100868       0.497756       0.529464        0.474852           40.5%           43.1%            38.7%              0.1%              0.1%               0.1%
7      1.0      1.0  128256.0   4096.0   578.545692   640.628428    577.928586       0.578259       0.640311        0.577642           47.1%           52.1%            47.0%              0.2%              0.2%               0.2%
8      1.0      4.0   12288.0   4096.0   458.061690   466.060043    403.248084       1.828081       1.860002        1.609325           37.3%           37.9%            32.8%              0.5%              0.5%               0.5%
9      1.0      8.0    1024.0   4096.0   178.596631   420.144175     91.909371       1.412224       3.322221        0.726758           14.5%           34.2%             7.5%              0.4%              0.9%               0.2%
10     1.0      8.0    4096.0   4096.0   527.689799   513.870853    363.931855       4.196927       4.087019        2.894495           42.9%           41.8%            29.6%              1.2%              1.1%               0.8%
11     1.0      8.0    4096.0  14336.0   390.121087   472.716502    387.426715       3.111419       3.770161        3.089930           31.7%           38.5%            31.5%              0.9%              1.1%               0.9%
12     1.0      8.0    6144.0   4096.0   479.017137   495.920279    526.579822       3.812281       3.946806        4.190811           39.0%           40.4%            42.8%              1.1%              1.1%               1.2%
13     1.0      8.0   14336.0   4096.0   445.520030   453.850414    427.656637       3.548320       3.614666        3.406048           36.3%           36.9%            34.8%              1.0%              1.0%               1.0%
14     1.0      8.0   28672.0   4096.0   487.241924   529.412984    494.972012       3.881689       4.217652        3.943272           39.6%           43.1%            40.3%              1.1%              1.2%               1.1%
15     1.0      8.0  128256.0   4096.0   560.061839   638.153974    583.876454       4.462784       5.085051        4.652547           45.6%           51.9%            47.5%              1.3%              1.4%               1.3%
16     1.0    512.0    8192.0   8192.0   296.682089   377.936908    278.408932     127.916825     162.950481      120.038209           24.1%           30.8%            22.7%             35.9%             45.8%              33.7%
17     1.0    512.0    8192.0  32768.0   297.996733   414.006919    296.896851     139.496528     193.802553      138.981657           24.2%           33.7%            24.2%             39.2%             54.4%              39.0%
18     1.0    512.0   32768.0   8192.0   393.451786   399.217928    385.462203     176.611344     179.199631      173.025006           32.0%           32.5%            31.4%             49.6%             50.3%              48.6%
19     1.0   1024.0    1024.0   1024.0   344.359945   312.308600    231.729491      88.156146      79.951002       59.322750           28.0%           25.4%            18.9%             24.8%             22.5%              16.7%
20     1.0   1024.0    8192.0  16384.0   207.744225   252.478797    208.903088     170.184069     206.830630      171.133410           16.9%           20.5%            17.0%             47.8%             58.1%              48.1%
21     1.0   1024.0    8192.0  28672.0   191.088374   227.313312    198.575703     163.548831     194.553053      169.957091           15.5%           18.5%            16.2%             45.9%             54.6%              47.7%
22     1.0   2048.0    2048.0   2048.0   259.508372   341.138993    222.421005     132.868286     174.663164      113.879554           21.1%           27.8%            18.1%             37.3%             49.1%              32.0%
23     1.0   3072.0    3072.0   4096.0   190.148059   219.432945    187.540746     166.895668     192.599430      164.607192           15.5%           17.9%            15.3%             46.9%             54.1%              46.2%
24     1.0   4096.0    4096.0   4096.0   190.780275   222.339944    175.173214     195.359002     227.676103      179.377371           15.5%           18.1%            14.3%             54.9%             64.0%              50.4%
25     1.0   4096.0    8192.0  16384.0    91.940661    94.919261     83.223153     188.294473     194.394647      170.441018            7.5%            7.7%             6.8%             52.9%             54.6%              47.9%
26     1.0   8192.0    1024.0  16384.0   190.708685   186.268641    186.365886     156.228555     152.591271      152.670934           15.5%           15.2%            15.2%             43.9%             42.9%              42.9%
27     1.0   8192.0    4096.0   4096.0   190.876395   212.877970    175.153624     223.379919     249.128047      204.979784           15.5%           17.3%            14.3%             62.7%             70.0%              57.6%
28     1.0   8192.0    4096.0  16384.0    89.539968    86.694727     89.235761     183.377854     177.550800      182.754838            7.3%            7.1%             7.3%             51.5%             49.9%              51.3%
29     1.0   8192.0    8192.0   8192.0   103.311161   111.342884     70.806559     211.581257     228.030226      145.011832            8.4%            9.1%             5.8%             59.4%             64.1%              40.7%
30     1.0  16384.0    1024.0   8192.0   246.024283   275.092183    239.593021     191.945803     214.624301      186.928193           20.0%           22.4%            19.5%             53.9%             60.3%              52.5%
31     1.0  16384.0    4096.0   8192.0   116.857383   124.702125    113.550945     212.732374     227.013291      206.713186            9.5%           10.1%             9.2%             59.8%             63.8%              58.1%
32     1.0  16384.0    8192.0   1024.0   420.457559   506.532221    267.520700     196.822190     237.114969      125.230261           34.2%           41.2%            21.8%             55.3%             66.6%              35.2%
33     1.0  16384.0    8192.0   4096.0   138.795960   152.690504    131.224377     206.730274     227.425565      195.452745           11.3%           12.4%            10.7%             58.1%             63.9%              54.9%
34     4.0  32768.0     128.0   4096.0   557.546790   485.472400    378.755178      66.921953      58.270914       45.461720           45.4%           39.5%            30.8%             18.8%             16.4%              12.8%
35     4.0  32768.0    4096.0    128.0   814.060842  1513.905977    407.025866      51.199896      95.216259       25.599661           66.2%          123.2%            33.1%             14.4%             26.7%               7.2%
36    32.0   4096.0     128.0   4096.0   551.669541   538.095889    521.920722      64.561098      62.972593       61.079636           44.9%           43.8%            42.5%             18.1%             17.7%              17.2%
37  4096.0      8.0     128.0  16384.0   583.029627   561.039587    501.603018       4.385839       4.220419        3.773308           47.4%           45.7%            40.8%              1.2%              1.2%               1.1%
38  4096.0      8.0   16384.0    128.0   636.337183   669.579984    462.410021       4.523101       4.759392        3.286822           51.8%           54.5%            37.6%              1.3%              1.3%               0.9%
```
