### PR TITLE
Fix performance regression (#5559)

### DIFF
--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -1224,10 +1224,8 @@ def test_mxfp8_mxfp4_matmul(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, B_TR
             pytest.xfail("None scale has not been tested on XPU backend")
         if not (A_DATA_TYPE == "float8e5" and B_DATA_TYPE == "float4"):
             pytest.xfail(f"(A: {A_DATA_TYPE}, B: {B_DATA_TYPE}) has not been tested on XPU backend")
-        if (BLOCK_M, BLOCK_N,
-                BLOCK_K) == (128, 256,
-                             256) and CONST_SCALE and triton.runtime.driver.active.utils.get_device_properties(
-                                 triton.runtime.driver.active.get_current_device())["max_shared_mem"] < 196608:
+        if ((BLOCK_M, BLOCK_N, BLOCK_K) == (128, 256, 256) and triton.runtime.driver.active.utils.get_device_properties(
+                triton.runtime.driver.active.get_current_device())["max_shared_mem"] < 196608):
             pytest.xfail("XPU: Not enough shared memory")
     if not PACK_B_ALONG_K and B_DATA_TYPE != "float4":
         pytest.xfail("Pack along K can only be False for float4")

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -1646,7 +1646,11 @@ void LayoutRematerialization::hoistConvertDotOperand() {
 void LayoutRematerialization::hoistConvertDotOperand(
     ConvertLayoutOp convertOp) {
   auto targetType = convertOp.getType();
-  // The pass is targeted to MMA dot operands
+
+  // The pass is targeted to NVidia.
+  auto dotEnc = dyn_cast<DotOperandEncodingAttr>(targetType.getEncoding());
+  if (!(dotEnc && isa<NvidiaMmaEncodingAttr>(dotEnc.getParent())))
+    return;
 
   auto canBePipelined = [&](ConvertLayoutOp convertOp) {
     // FIXME: Check that the parent is a for loop


### PR DESCRIPTION
Fixes issue #5553 and
https://github.com/intel/intel-xpu-backend-for-triton/issues/5518

---------


(cherry picked from commit 96b9f835ee24dc1168a5f8c870a41ab02ef5f28f)


Inductor core: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/19742918284 (to check)
Flex Attn: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/19742963501 (passed)
Flex decoding: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/19742982142 (passed)