### PR TITLE
Revert "Ignore markdown files to save CI time"

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,16 +48,10 @@ on:
     branches:
       - main
       - release/**
-    paths-ignore:
-      - '**/*.md'
-      - '.github/ISSUE_TEMPLATE/**'
   push:
     branches:
       - main
       - release/**
-    paths-ignore:
-      - '**/*.md'
-      - '.github/ISSUE_TEMPLATE/**'
 
 # Cancels in-progress PR runs when the PR is updated. Manual runs are never cancelled.
 concurrency:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -7,16 +7,10 @@ on:
     branches:
       - main
       - release/**
-    paths-ignore:
-      - '**/*.md'
-      - '.github/ISSUE_TEMPLATE/**'
   push:
     branches:
       - main
       - release/**
-    paths-ignore:
-      - '**/*.md'
-      - '.github/ISSUE_TEMPLATE/**'
 
 permissions: read-all
 

--- a/.github/workflows/spirvrunner-test.yml
+++ b/.github/workflows/spirvrunner-test.yml
@@ -6,15 +6,9 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - '**/*.md'
-      - '.github/ISSUE_TEMPLATE/**'
   push:
     branches:
       - main
-    paths-ignore:
-      - '**/*.md'
-      - '.github/ISSUE_TEMPLATE/**'
 
 permissions: read-all
 


### PR DESCRIPTION
Reverts intel/intel-xpu-backend-for-triton#5526

Blocks CI as no jobs to run