### PR TITLE
Support NAN padding tdesc to block pointer.

### DIFF
--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -384,8 +384,6 @@ def test_tensor_descriptor_store_nd(dtype_str, num_ctas, ndim, INNER_BLOCK, devi
 
 @pytest.mark.interpreter
 def test_tensor_descriptor_padding(device):
-    if is_xpu():
-        pytest.skip("FIXME: issue #5400")
 
     @triton.jit
     def device_tma_load(in_ptr, out_ptr, IM, IN, YM, YN, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr,

--- a/test/Triton/Intel/TensorDescToBlockPointer/basic.mlir
+++ b/test/Triton/Intel/TensorDescToBlockPointer/basic.mlir
@@ -21,7 +21,31 @@ module {
   // CHECK-DAG:    [[EXTSI_PARAM_2:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
   // CHECK:        [[TENSOR_PTR:%.+]] = tt.make_tensor_ptr [[PARAM_0]], {{\[}}[[EXTSI_PARAM_1]], [[EXTSI_PARAM_2]]], {{\[}}[[EXTSI_PARAM_2]], [[CST_1_i64]]], {{\[}}[[CST_0_i32]], [[CST_0_i32]]] {{.*}} : <tensor<16x128xf32>>
   // CHECK:        [[TENSOR_PTR1:%.+]] = tt.advance [[TENSOR_PTR]], {{\[}}[[CST_8_i32]], [[CST_64_i32]]] : <tensor<16x128xf32>>
-  // CHECK:        [[LOAD1:%.+]] = tt.load [[TENSOR_PTR1]] {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<16x128xf32>>
+  // CHECK:        [[LOAD1:%.+]] = tt.load [[TENSOR_PTR1]] {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32} : !tt.ptr<tensor<16x128xf32>>
+  // CHECK:        tt.return
+  // CHECK:      }
+
+  tt.func public @test_load_padding_nan(%arg0: !tt.ptr<f32>, %arg1: i32, %arg2: i32) {
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i32 = arith.constant 64 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %0 = arith.extsi %arg2 : i32 to i64
+    %desc1 = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%0, %c1_i64] {padding = 2 : i32} : <f32>, <tensor<16x128xf32>>
+    %load1 = tt.descriptor_load %desc1[%c8_i32, %c64_i32] : !tt.tensordesc<tensor<16x128xf32>> -> tensor<16x128xf32>
+    tt.return
+  }
+  // CHECK:      tt.func public @test_load_padding_nan([[PARAM_0:%.+]]: !tt.ptr<f32>, [[PARAM_1:%.+]]: i32, [[PARAM_2:%.+]]: i32) {
+  // CHECK-NOT:    tt.make_tensor_descriptor
+  // CHECK-NOT:    tt.descriptor_load
+  // CHECK-DAG:    [[CST_0_i32:%.+]] = arith.constant 0 : i32
+  // CHECK-DAG:    [[CST_1_i64:%.+]] = arith.constant 1 : i64
+  // CHECK-DAG:    [[CST_64_i32:%.+]] = arith.constant 64 : i32
+  // CHECK-DAG:    [[CST_8_i32:%.+]] = arith.constant 8 : i32
+  // CHECK-DAG:    [[EXTSI_PARAM_1:%.+]] = arith.extsi [[PARAM_1]] : i32 to i64
+  // CHECK-DAG:    [[EXTSI_PARAM_2:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
+  // CHECK:        [[TENSOR_PTR:%.+]] = tt.make_tensor_ptr [[PARAM_0]], {{\[}}[[EXTSI_PARAM_1]], [[EXTSI_PARAM_2]]], {{\[}}[[EXTSI_PARAM_2]], [[CST_1_i64]]], {{\[}}[[CST_0_i32]], [[CST_0_i32]]] {{.*}} : <tensor<16x128xf32>>
+  // CHECK:        [[TENSOR_PTR1:%.+]] = tt.advance [[TENSOR_PTR]], {{\[}}[[CST_8_i32]], [[CST_64_i32]]] : <tensor<16x128xf32>>
+  // CHECK:        [[LOAD1:%.+]] = tt.load [[TENSOR_PTR1]] {boundaryCheck = array<i32: 0, 1>, padding = 2 : i32} : !tt.ptr<tensor<16x128xf32>>
   // CHECK:        tt.return
   // CHECK:      }
 

--- a/test/Triton/Intel/TensorDescToBlockPointer/invalid.mlir
+++ b/test/Triton/Intel/TensorDescToBlockPointer/invalid.mlir
@@ -21,3 +21,24 @@ tt.func public @test_host_descriptor(%desc: !tt.tensordesc<tensor<2x16xf16>>) {
   tt.descriptor_store %desc[%c2_i32, %c32_i32], %0 : !tt.tensordesc<tensor<2x16xf16>>, tensor<2x16xf16>
   tt.return
 }
+
+// COM: if a statement yielding a tensor descriptor, then the padding option is not retrievable.
+tt.func public @while_loop_with_if_stmt(%arg0: !tt.ptr<f32>, %arg1: i32, %arg2: i32) {
+  // CHECK: tt.func public @while_loop_with_if_stmt({{.*}}) {
+  // CHECK: tt.make_tensor_descriptor
+  // CHECK: tt.descriptor_load
+  %c1_i64 = arith.constant 1 : i64
+  %c128_i32 = arith.constant 128 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tt.get_program_id x : i32
+  %7 = arith.cmpi eq, %0, %c0_i32 : i32
+  %11 = scf.if %7 -> (!tt.tensordesc<tensor<8x128xf32>>) {
+    %16 = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%c1_i64, %c1_i64] : <f32>, <tensor<8x128xf32>>
+    scf.yield %16 : !tt.tensordesc<tensor<8x128xf32>>
+  } else {
+    %17 = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%c1_i64, %c1_i64] : <f32>, <tensor<8x128xf32>>
+    scf.yield %17 : !tt.tensordesc<tensor<8x128xf32>>
+  }
+  %12 = tt.descriptor_load %11[%c128_i32, %c128_i32] : !tt.tensordesc<tensor<8x128xf32>> -> tensor<8x128xf32>
+  tt.return
+}

--- a/test/Triton/Intel/TensorDescToBlockPointer/loop.mlir
+++ b/test/Triton/Intel/TensorDescToBlockPointer/loop.mlir
@@ -32,7 +32,7 @@ module {
   // CHECK:        [[FOR_RES:%.+]]:2 = scf.for [[IV:%.+]] = {{.*}} iter_args([[VAR_arg1:%.+]] = [[TENSOR_PTR]], [[VAR_arg2:%.+]] = [[CST]]) -> (!tt.ptr<tensor<16x32xf16>>, tensor<16x32xf16>) {
   // CHECK:          [[IDX_CAST:%.+]] = arith.index_cast [[IV]] : index to i32
   // CHECK:          [[TENSOR_PTR_1:%.+]] = tt.advance [[VAR_arg1]], {{\[}}[[CST_8_i32]], [[IDX_CAST]]] : <tensor<16x32xf16>>
-  // CHECK:          [[LOAD:%.+]] = tt.load [[TENSOR_PTR_1]] {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<16x32xf16>>
+  // CHECK:          [[LOAD:%.+]] = tt.load [[TENSOR_PTR_1]] {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32} : !tt.ptr<tensor<16x32xf16>>
   // CHECK:          [[ADD:%.+]] = arith.addf [[VAR_arg2]], [[LOAD]] : tensor<16x32xf16>
   // CHECK:          scf.yield [[VAR_arg1]], [[ADD]] : !tt.ptr<tensor<16x32xf16>>, tensor<16x32xf16>
   // CHECK:        }
@@ -73,7 +73,7 @@ module {
   // CHECK:        [[FOR_RES:%.+]]:2 = scf.for [[IV:%.+]] = {{.*}} iter_args([[VAR_arg1:%.+]] = [[TENSOR_PTR]], [[VAR_arg2:%.+]] = [[CST]]) -> (!tt.ptr<tensor<16x32xf16>>, tensor<16x32xf16>) {
   // CHECK:          [[IDX_CAST:%.+]] = arith.index_cast [[IV]] : index to i32
   // CHECK:          [[TENSOR_PTR_1:%.+]] = tt.advance [[VAR_arg1]], {{\[}}[[CST_8_i32]], [[IDX_CAST]]] : <tensor<16x32xf16>>
-  // CHECK:          [[LOAD:%.+]] = tt.load [[TENSOR_PTR_1]] {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<16x32xf16>>
+  // CHECK:          [[LOAD:%.+]] = tt.load [[TENSOR_PTR_1]] {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32} : !tt.ptr<tensor<16x32xf16>>
   // CHECK:          [[ADD:%.+]] = arith.addf [[VAR_arg2]], [[LOAD]] : tensor<16x32xf16>
   // CHECK-DAG:      [[EXTSI_PARAM_1a:%.+]] = arith.extsi [[PARAM_1]] : i32 to i64
   // CHECK-DAG:      [[EXTSI_PARAM_2a:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
@@ -108,7 +108,7 @@ module {
   // CHECK:        [[TENSOR_PTR:%.+]] = tt.make_tensor_ptr {{.*}} : <tensor<16x32xf16>>
   // CHECK:        [[FOR_RES:%.+]] = scf.for [[IV:%.+]] = {{.*}} iter_args([[VAR_arg1:%.+]] = [[TENSOR_PTR]]) -> (!tt.ptr<tensor<16x32xf16>>)
   // CHECK:        [[TENSOR_PTR1:%.+]] = tt.advance [[FOR_RES]], {{.*}} : <tensor<16x32xf16>>
-  // CHECK:        tt.load [[TENSOR_PTR1]] {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<16x32xf16>>
+  // CHECK:        tt.load [[TENSOR_PTR1]] {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32} : !tt.ptr<tensor<16x32xf16>>
   // CHECK:        tt.return
   // CHECK:      }
 
@@ -233,7 +233,7 @@ module {
   // CHECK:        } do {
   // CHECK:        ^bb0([[ARG4:%.*]]: !tt.ptr<tensor<8x128xf32>>):
   // CHECK:          [[PTR1:%.*]] = tt.advance [[ARG4]], {{.*}} : <tensor<8x128xf32>
-  // CHECK:          tt.load [[PTR1]] {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<8x128xf32>>
+  // CHECK:          tt.load [[PTR1]] {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32} : !tt.ptr<tensor<8x128xf32>>
   // CHECK:          scf.yield [[ARG4]] : !tt.ptr<tensor<8x128xf32>>
   // CHECK:        }
 
@@ -271,52 +271,8 @@ module {
   // CHECK:        } do {
   // CHECK:        ^bb0([[ARG4:%.*]]: !tt.ptr<tensor<8x128xf32>>):
   // CHECK:          [[TENSOR_PTR1:%.*]] = tt.advance [[ARG4]], {{.*}} : <tensor<8x128xf32>
-  // CHECK:          tt.load [[TENSOR_PTR1]] {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<8x128xf32>>
+  // CHECK:          tt.load [[TENSOR_PTR1]] {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32} : !tt.ptr<tensor<8x128xf32>>
   // CHECK:          scf.yield [[ARG4]] : !tt.ptr<tensor<8x128xf32>>
-  // CHECK:        }
-
-  // COM: While loop containing a if statement yielding a tensor descriptor used by a load operation.
-  tt.func public @while_loop_with_if_stmt(%arg0: !tt.ptr<f32>, %arg1: i32, %arg2: i32) {
-    %c1_i64 = arith.constant 1 : i64
-    %c128_i32 = arith.constant 128 : i32
-    %c0_i32 = arith.constant 0 : i32
-    %0 = tt.get_program_id x : i32
-    %3 = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%c1_i64, %c1_i64] : <f32>, <tensor<8x128xf32>>
-    %5 = scf.while (%arg3 = %3) : (!tt.tensordesc<tensor<8x128xf32>>) -> (!tt.tensordesc<tensor<8x128xf32>>) {
-      %6 = arith.cmpi slt, %0, %c128_i32 : i32
-      scf.condition(%6) %arg3 : !tt.tensordesc<tensor<8x128xf32>>
-    } do {
-    ^bb0(%arg3: !tt.tensordesc<tensor<8x128xf32>>):
-      %7 = arith.cmpi eq, %0, %c0_i32 : i32
-      %10 = arith.select %7, %c1_i64, %c1_i64 : i64
-      %11 = scf.if %7 -> (!tt.tensordesc<tensor<8x128xf32>>) {
-        %16 = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%c1_i64, %c1_i64] : <f32>, <tensor<8x128xf32>>
-        scf.yield %16 : !tt.tensordesc<tensor<8x128xf32>>
-      } else {
-        scf.yield %arg3 : !tt.tensordesc<tensor<8x128xf32>>
-      }
-      %12 = tt.descriptor_load %11[%c128_i32, %c128_i32] : !tt.tensordesc<tensor<8x128xf32>> -> tensor<8x128xf32>
-      scf.yield %11 : !tt.tensordesc<tensor<8x128xf32>>
-    }
-    tt.return
-  }
-  // CHECK:      tt.func public @while_loop_with_if_stmt({{.*}}) {
-  // CHECK-NOT:    tt.make_tensor_descriptor
-  // CHECK-NOT:    tt.descriptor_load
-  // CHECK:        [[TENSOR_PTR:%.*]] = tt.make_tensor_ptr {{.*}} : <tensor<8x128xf32>
-  // CHECK:        scf.while ([[ARG3:%.*]] = [[TENSOR_PTR]]) : (!tt.ptr<tensor<8x128xf32>>) -> !tt.ptr<tensor<8x128xf32>> {
-  // CHECK:          scf.condition({{.*}}) [[ARG3]] : !tt.ptr<tensor<8x128xf32>>
-  // CHECK:        } do {
-  // CHECK:        ^bb0([[ARG4:%.*]]: !tt.ptr<tensor<8x128xf32>>):
-  // CHECK:          [[IF_RES:%.*]] = scf.if {{.*}} -> (!tt.ptr<tensor<8x128xf32>>) {
-  // CHECK:            [[TENSOR_PTR1:%.*]] = tt.make_tensor_ptr {{.*}} : <tensor<8x128xf32>
-  // CHECK:            scf.yield [[TENSOR_PTR1]] : !tt.ptr<tensor<8x128xf32>>
-  // CHECK:          } else {
-  // CHECK:            scf.yield [[ARG4]] : !tt.ptr<tensor<8x128xf32>>
-  // CHECK:          }
-  // CHECK:          [[TENSOR_PTR2:%.*]] = tt.advance [[IF_RES]], {{.*}} : <tensor<8x128xf32>
-  // CHECK:          tt.load [[TENSOR_PTR2]] {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<8x128xf32>>
-  // CHECK:          scf.yield [[IF_RES]] : !tt.ptr<tensor<8x128xf32>>
   // CHECK:        }
 
 }

--- a/third_party/intel/include/Utils/Utility.h
+++ b/third_party/intel/include/Utils/Utility.h
@@ -16,8 +16,8 @@ Value findOrCreateIntConstant(Location loc, int val, unsigned bitWidth,
                               OpBuilder &builder);
 
 // Find the defining makeTensorPtrOp operation of the given value.
-std::optional<mlir::triton::MakeTensorPtrOp>
-findDefiningMakeTensorPtrOp(Value val);
+template <class OpTy>
+std::optional<OpTy> findDefiningMakeTensorPtrOp(Value val);
 
 // This function folds the `v` value and returns the constant value if it
 // has successfully folded to a constant. Otherwise, it returns `std::nullopt`.

--- a/third_party/intel/lib/Dialect/Triton/Transforms/FuseReshape.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/FuseReshape.cpp
@@ -48,7 +48,8 @@ public:
       if (isCandidate(reshapeOp)) {
         auto loadOp = cast<tt::LoadOp>(reshapeOp.getSrc().getDefiningOp());
         tt::MakeTensorPtrOp makeTensorPtrOp =
-            *triton::intel::findDefiningMakeTensorPtrOp(loadOp.getPtr());
+            *triton::intel::findDefiningMakeTensorPtrOp<tt::MakeTensorPtrOp>(
+                loadOp.getPtr());
         manager.createChains(makeTensorPtrOp, reshapeOp);
       }
     });
@@ -249,7 +250,8 @@ private:
       return false;
 
     std::optional<tt::MakeTensorPtrOp> makeTensorPtrOp =
-        triton::intel::findDefiningMakeTensorPtrOp(loadOp.getPtr());
+        triton::intel::findDefiningMakeTensorPtrOp<tt::MakeTensorPtrOp>(
+            loadOp.getPtr());
     if (!makeTensorPtrOp)
       return false;
 

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RemoveBoundaryChecks.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RemoveBoundaryChecks.cpp
@@ -33,7 +33,8 @@ public:
         return WalkResult::skip();
 
       tt::MakeTensorPtrOp makeTensorPtrOp =
-          *tt::intel::findDefiningMakeTensorPtrOp(loadOp.getPtr());
+          *tt::intel::findDefiningMakeTensorPtrOp<tt::MakeTensorPtrOp>(
+              loadOp.getPtr());
       LLVM_DEBUG(llvm::dbgs()
                  << "Analyzing boundaryCheck for: " << loadOp << "\n");
 
@@ -163,7 +164,8 @@ private:
       return false;
 
     std::optional<tt::MakeTensorPtrOp> makeTensorPtrOp =
-        tt::intel::findDefiningMakeTensorPtrOp(loadOp.getPtr());
+        tt::intel::findDefiningMakeTensorPtrOp<tt::MakeTensorPtrOp>(
+            loadOp.getPtr());
     if (!makeTensorPtrOp)
       return false;
 

--- a/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp
@@ -61,12 +61,25 @@ public:
   void runOnOperation() final {
     ModuleOp moduleOp = getOperation();
 
-    WalkResult res = moduleOp->walk<WalkOrder::PreOrder>([](Operation *op) {
+    WalkResult res = moduleOp->walk<WalkOrder::PreOrder>([=](Operation *op) {
       if (isa<tt::DescriptorGatherOp>(op) || isa<tt::DescriptorScatterOp>(op) ||
           isa<tt::DescriptorReduceOp>(op)) {
         op->emitRemark(
             "TritonIntelTensorDescToBlockPointer: Failed to rewrite");
         return WalkResult::interrupt();
+      }
+      if (auto loadOp = dyn_cast_or_null<tt::DescriptorLoadOp>(op)) {
+        // Retrieve the padding option from the MakeTensorDescOp.
+        std::optional<tt::MakeTensorDescOp> makeTensorDescOp =
+            triton::intel::findDefiningMakeTensorPtrOp<tt::MakeTensorDescOp>(
+                loadOp.getDesc());
+        if (!makeTensorDescOp) {
+          op->emitRemark("TritonIntelTensorDescToBlockPointer: Failed to "
+                         "retrieve the padding option.");
+          return WalkResult::interrupt();
+        }
+
+        this->paddingInfo[loadOp] = makeTensorDescOp->getPadding();
       }
       return WalkResult::advance();
     });
@@ -257,9 +270,16 @@ private:
 
     constexpr bool isLoad = std::is_same_v<OpTy, tt::DescriptorLoadOp>;
     if constexpr (isLoad) {
+      // Default to PAD_ZERO as this is the expected padding behavior for
+      // descriptor loads. It should be specified in the tt.make_tensor_desc if
+      // it is retrieved.
+      triton::PaddingOption padding = triton::PaddingOption::PAD_ZERO;
+      if (paddingInfo.contains(op)) {
+        padding = paddingInfo[op];
+      }
       auto loadOp = builder.createOrFold<tt::LoadOp>(
           loc, ptr, boundaryCheck,
-          /*padding*/ std::nullopt, op.getCache(), op.getEvict(),
+          /*padding*/ padding, op.getCache(), op.getEvict(),
           /*volatile*/ false);
       LLVM_DEBUG(llvm::dbgs().indent(2) << loadOp << "\n");
       op.replaceAllUsesWith(loadOp);
@@ -277,6 +297,7 @@ private:
 
 private:
   SmallPtrSet<Operation *, 8> cleanUp;
+  llvm::SmallDenseMap<Operation *, triton::PaddingOption, 8> paddingInfo;
 };
 
 } // namespace

--- a/third_party/intel/lib/TritonIntelGPUTransforms/Coalesce.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Coalesce.cpp
@@ -345,7 +345,8 @@ private:
         assert(tt::isTensorPointerType(operand.getType()) &&
                "Expecting operand to have blocked pointer type");
         std::optional<tt::MakeTensorPtrOp> defOp =
-            triton::intel::findDefiningMakeTensorPtrOp(operand);
+            triton::intel::findDefiningMakeTensorPtrOp<tt::MakeTensorPtrOp>(
+                operand);
         if (!defOp) {
           LLVM_DEBUG(llvm::dbgs()
                      << "[" DEBUG_TYPE

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -62,7 +62,7 @@ private:
 
     // Find the make tensor ptr operation that created the base ptr.
     std::optional<tt::MakeTensorPtrOp> defOp =
-        tt::intel::findDefiningMakeTensorPtrOp(ptr);
+        tt::intel::findDefiningMakeTensorPtrOp<tt::MakeTensorPtrOp>(ptr);
     if (!defOp) {
       LDBG("Could not find make tensor ptr op for: " << *op);
       return;
@@ -301,7 +301,7 @@ private:
     // Find the make tensor ptr operation that created the base ptr for the load
     // operation.
     std::optional<tt::MakeTensorPtrOp> defOp =
-        tt::intel::findDefiningMakeTensorPtrOp(ptr);
+        tt::intel::findDefiningMakeTensorPtrOp<tt::MakeTensorPtrOp>(ptr);
     assert(defOp && "Expected a make tensor ptr op.");
     tt::MakeTensorPtrOp makeTensorPtrOp = *defOp;
     Operation::operand_range shape = makeTensorPtrOp.getShape();

--- a/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
@@ -62,7 +62,8 @@ public:
       if (isCandidate(transOp)) {
         auto loadOp = cast<tt::LoadOp>(transOp.getSrc().getDefiningOp());
         tt::MakeTensorPtrOp makeTensorPtrOp =
-            *triton::intel::findDefiningMakeTensorPtrOp(loadOp.getPtr());
+            *triton::intel::findDefiningMakeTensorPtrOp<tt::MakeTensorPtrOp>(
+                loadOp.getPtr());
         manager.createChains(makeTensorPtrOp, transOp);
       }
     });
@@ -188,7 +189,8 @@ private:
       return false;
 
     std::optional<tt::MakeTensorPtrOp> makeTensorPtrOp =
-        triton::intel::findDefiningMakeTensorPtrOp(loadOp.getPtr());
+        triton::intel::findDefiningMakeTensorPtrOp<tt::MakeTensorPtrOp>(
+            loadOp.getPtr());
 
     return makeTensorPtrOp.has_value();
   }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -807,7 +807,7 @@ bool LayoutPropagation::rewriteTensorPtrStoreOp(StoreOp storeOp) {
 
   // Locate the operation that created the block pointer.
   std::optional<triton::MakeTensorPtrOp> defOp =
-      triton::intel::findDefiningMakeTensorPtrOp(ptr);
+      triton::intel::findDefiningMakeTensorPtrOp<triton::MakeTensorPtrOp>(ptr);
   if (!defOp)
     return false;
 


### PR DESCRIPTION
This PR adds support for propagating NAN padding options from make_tensor_descriptor operations to tt.load operations during the tensor descriptor to block pointer transformation pass. Previously, padding information was not being preserved during this transformation.