### PR TITLE
Disable false positive warnings: `You are including <sycl/sycl.hpp> without -fsycl flag*` for compilers: g++ and clang++

### DIFF
--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -97,6 +97,8 @@ def _build(name: str, src: str, srcdir: str, library_dirs: list[str], include_di
                 ccflags += ["--std=c++17"]
             if os.environ.get("TRITON_SUPPRESS_GCC_HOST_CODE_DEPRECATION_WARNINGS", "1") == "1":
                 ccflags += ["-Wno-deprecated-declarations"]
+            if os.environ.get("TRITON_SUPPRESS_SYCL_DISABLE_FSYCL_SYCLHPP_WARNING", "1") == "1":
+                ccflags += ["-DSYCL_DISABLE_FSYCL_SYCLHPP_WARNING"]
         if os.name == "nt":
             library_dirs = library_dirs + [
                 os.path.abspath(os.path.join(sysconfig.get_paths(scheme=scheme)["stdlib"], "..", "libs"))


### PR DESCRIPTION
If we try to enable this flag, we will get the following problems:
* `g++` - `g++: error: unrecognized command-line option ‘-fsycl’`
* `clang++` - 
```bash
/opt/intel/oneapi/compiler/2025.3/include/sycl/group.hpp:374:5: error: unknown type name '__ocl_event_t'
  374 |     __ocl_event_t E = __spirv_GroupAsyncCopy(
      |     ^
/opt/intel/oneapi/compiler/2025.3/include/sycl/group.hpp:398:5: error: use of undeclared identifier '__ocl_event_t'; did you mean '__ocl_vec_t'?
  398 |     __ocl_event_t E = __spirv_GroupAsyncCopy(
      |     ^~~~~~~~~~~~~
      |     __ocl_vec_t
/opt/intel/oneapi/compiler/2025.3/include/sycl/__spirv/spirv_types.hpp:167:1: note: '__ocl_vec_t' declared here
  167 | using __ocl_vec_t = dataT __attribute__((ext_vector_type(dims)));
      | ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
```