### PR TITLE
Use `ocloc` for querying OpenCL extensions if OpenCL backend isn't available and `ocloc` is in PATH

### DIFF
--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -28,7 +28,7 @@ static std::vector<std::pair<sycl::device, ze_device_handle_t>>
 
 static std::vector<sycl::device> sycl_opencl_device_list;
 
-static bool has_opencl;
+static bool has_opencl = false;
 
 template <typename T>
 static inline T checkSyclErrors(const std::tuple<T, ze_result_t> tuple) {


### PR DESCRIPTION
This solution should be easy to maintain, since we only start trying to use `ocloc` when the OpenCL backend is not available, which is when the code previously didn't work at all.