### PR TITLE
Temp add code for aggressively remove convert layout for Intel GPU. 

### DIFF
--- a/test/TritonIntelGPU/remove_layout_conversions_5763.mlir
+++ b/test/TritonIntelGPU/remove_layout_conversions_5763.mlir
@@ -1,0 +1,36 @@
+// RUN: triton-opt %s -tritonintelgpu-remove-layout-conversions 2>&1 | FileCheck %s
+
+// CHECK-NOT: ttg.convert_layout
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 16], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 8], order = [1, 0]}>
+module attributes {"ttg.num-warps" = 16 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @remove_layout(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    %cst = arith.constant dense<15> : tensor<2x2048xi64, #blocked>
+    %cst_0 = arith.constant dense<32> : tensor<2x2048xi64, #blocked>
+    %cst_1 = arith.constant dense<true> : tensor<1x2048xi1, #blocked>
+    %cst_2 = arith.constant dense<0> : tensor<2x2048xi64, #blocked>
+    %cst_3 = arith.constant dense<2048> : tensor<1x2048xi32, #blocked>
+    %0 = tt.make_range {end = 2048 : i32, start = 0 : i32} : tensor<2048xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<2048xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x2048xi32, #blocked>
+    %2 = arith.cmpi slt, %1, %cst_3 : tensor<1x2048xi32, #blocked>
+    %3 = tt.broadcast %1 : tensor<1x2048xi32, #blocked> -> tensor<2x2048xi32, #blocked>
+    %4 = arith.extsi %3 : tensor<2x2048xi32, #blocked> to tensor<2x2048xi64, #blocked>
+    %5 = arith.cmpi slt, %4, %cst : tensor<2x2048xi64, #blocked>
+    %6 = arith.select %5, %4, %cst : tensor<2x2048xi1, #blocked>, tensor<2x2048xi64, #blocked>
+    %7 = arith.cmpi sge, %6, %cst_2 : tensor<2x2048xi64, #blocked>
+    %8 = arith.cmpi slt, %6, %cst_0 : tensor<2x2048xi64, #blocked>
+    %9 = arith.andi %7, %8 : tensor<2x2048xi1, #blocked>
+    %10 = arith.xori %2, %cst_1 : tensor<1x2048xi1, #blocked>
+    %11 = tt.broadcast %10 : tensor<1x2048xi1, #blocked> -> tensor<2x2048xi1, #blocked>
+    %12 = arith.ori %9, %11 : tensor<2x2048xi1, #blocked>
+    tt.assert %7, "index out of bounds: 0 <= tmp28 < 32" : tensor<2x2048xi1, #blocked>
+    %13 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<2x2048x!tt.ptr<f16>, #blocked>
+    %14 = tt.addptr %13, %6 : tensor<2x2048x!tt.ptr<f16>, #blocked>, tensor<2x2048xi64, #blocked>
+
+    // COM: the following conversion layout should be backward to tt.assert.
+    %15 = ttg.convert_layout %14 : tensor<2x2048x!tt.ptr<f16>, #blocked> -> tensor<2x2048x!tt.ptr<f16>, #blocked1>
+    %16 = tt.load %15 evictionPolicy = evict_last : tensor<2x2048x!tt.ptr<f16>, #blocked1>
+    tt.print " " {hex = false, isSigned = array<i32: 0>} : %16 : tensor<2x2048xf16, #blocked1>
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -167,6 +167,75 @@ public:
       std::function<bool(Operation *)> stopPropagation = nullptr);
 
 private:
+  // Forward propagate the remat value to simplify the IR.
+
+  /*
+  If the value is used by multiple user and one of its users is the convert
+  layout op.
+  1. Original IR
+   ┌─┐
+   └┬┘
+    │
+   ┌┴┐
+   └┬┘
+    │
+    ├───────┐
+    │       │
+    │      ┌┴┐ // cvt_layout
+    │      └┬┘
+    │       │
+   ┌┴┐     ┌┴┐
+   └─┘     └─┘
+
+  After the backward propagate convert layout op, there are going to be
+  duplicated expression with different layout.
+  2. After backward propagate convert layout op.
+
+  ┌─┐         ┌─┐  // duplicate expression with different layout.
+  └┬┘         └┬┘
+   │           │
+  ┌┴┐         ┌┴┐
+  └┬┘         └┬┘
+   │           │
+   ├───────┐   │
+   │       │   │
+   │      ┌┴┐  │
+   │      └─┘  │
+   │       ┌───┘
+  ┌┴┐     ┌┴┐
+  └─┘     └─┘
+
+  Need to forward propagate the remat value to clean up the IR as what we did in
+  forward layout propagation.
+  3. After forward propagate remet values while the mapping information is still
+  valid in rematMapping.
+
+  ┌─┐         ┌─┐ // The expression with old layout could be removed later.
+  └┬┘         └┬┘
+   │           │
+  ┌┴┐         ┌┴┐
+  └┬┘         └┬┘
+   │           │
+   └───────┐   │
+           │   │
+          ┌┴┐  │
+          └─┘  │
+   ┌───────┬───┘
+  ┌┴┐     ┌┴┐
+  └─┘     └─┘
+  */
+  void setEncoding(DenseMap<Value, Attribute> &values, ValueRange ops,
+                   Attribute &layout, SmallVector<Value> &changed,
+                   Operation *op);
+  SmallVector<Value> propagateToUsers(DenseMap<Value, Attribute> &values,
+                                      Value value, Attribute &layout);
+  void propagateLayout(DenseMap<Value, Attribute> &values);
+  Value getValueAs(Value value, Attribute encoding);
+  Operation *cloneElementwise(OpBuilder &rewriter, Operation *op,
+                              Attribute encoding);
+  Operation *rewriteOp(Operation *op, Attribute encoding);
+  void forwardPropagateRemat(DenseMap<Value, Attribute> &values);
+
   void updateRematMapping(SmallVector<std::tuple<Value, Value>> &values);
   void reduceLoopCarriedValues();
   // Existing tuples of (value, layout) that needs to be updated when recreating
@@ -196,7 +265,8 @@ void LayoutRematerialization::addRematValue(Value old, Attribute encoding,
 // Remove unneeded values now that we are done with the rematMapping.
 void LayoutRematerialization::cleanup() {
   for (Operation *op : llvm::reverse(opToDelete))
-    op->erase();
+    if (op->getUsers().empty())
+      op->erase();
 }
 
 // Return true if the op is an op with a layout we don't want to change. We will
@@ -1356,6 +1426,180 @@ void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
   rewriteSlice(slice, layout, convertOp, mapping);
 }
 
+void LayoutRematerialization::setEncoding(DenseMap<Value, Attribute> &values,
+                                          ValueRange ops, Attribute &layout,
+                                          SmallVector<Value> &changed,
+                                          Operation *op) {
+  for (Value value : ops) {
+    if (!isa<RankedTensorType>(value.getType()))
+      continue;
+    Attribute dstEncoding;
+    if (isa<tt::StoreOp, ttg::ConvertLayoutOp>(op)) {
+      // Try to remove the convert by making the dst encoding match the source
+      // encoding.
+      dstEncoding = layout;
+    } else {
+      dstEncoding = inferDstEncoding(op, layout);
+    }
+    if (!values.contains(value)) {
+      values[value] = dstEncoding;
+      changed.push_back(value);
+    }
+  }
+}
+
+SmallVector<Value>
+LayoutRematerialization::propagateToUsers(DenseMap<Value, Attribute> &values,
+                                          Value value, Attribute &layout) {
+  SmallVector<Value> changed;
+  for (OpOperand &use : value.getUses()) {
+    Operation *user = use.getOwner();
+    if (user->hasTrait<OpTrait::SameOperandsAndResultEncoding>() ||
+        user->hasTrait<OpTrait::Elementwise>()) {
+      setEncoding(values, user->getResults(), layout, changed, user);
+    }
+  }
+  return changed;
+}
+
+void LayoutRematerialization::propagateLayout(
+    DenseMap<Value, Attribute> &values) {
+  SmallVector<Value> queue;
+  for (auto it : values) {
+    queue.push_back(it.first);
+  }
+  while (!queue.empty()) {
+    Value currentValue = queue.back();
+    Attribute layout = values[currentValue];
+    queue.pop_back();
+    SmallVector<Value> changed = propagateToUsers(values, currentValue, layout);
+
+    LLVM_DEBUG({
+      DBGS() << "propagateLayout considering " << currentValue
+             << ", which has layout:\n";
+      DBGS() << "  " << layout << "\n";
+      DBGS() << "changed: " << changed.size() << "\n";
+    });
+
+    queue.insert(queue.end(), changed.begin(), changed.end());
+  }
+}
+
+Value LayoutRematerialization::getValueAs(Value value, Attribute encoding) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(value.getType())) {
+    Value rewrittenValue = getRematValue(value, encoding);
+    if (rewrittenValue)
+      return rewrittenValue;
+    OpBuilder rewriter(value.getContext());
+    rewriter.setInsertionPointAfterValue(value);
+    auto tmpType = tensorType.cloneWithEncoding(encoding);
+    Value converted =
+        ttg::ConvertLayoutOp::create(rewriter, value.getLoc(), tmpType, value);
+    // Add to map for future use.
+    addRematValue(value, encoding, converted);
+    return converted;
+  }
+  return value;
+};
+
+Operation *LayoutRematerialization::cloneElementwise(OpBuilder &rewriter,
+                                                     Operation *op,
+                                                     Attribute encoding) {
+  Operation *newOp = rewriter.clone(*op);
+
+  Attribute operandEnc = ttgi::inferSrcEncoding(op, encoding);
+  assert(operandEnc);
+
+  for (OpOperand &operand : op->getOpOperands()) {
+    newOp->setOperand(operand.getOperandNumber(),
+                      getValueAs(operand.get(), operandEnc));
+  }
+
+  for (unsigned i = 0, e = op->getNumResults(); i < e; ++i) {
+    auto origType = dyn_cast<RankedTensorType>(op->getResult(i).getType());
+    if (!origType)
+      continue;
+    auto newType = origType.cloneWithEncoding(encoding);
+    newOp->getResult(i).setType(newType);
+  }
+  return newOp;
+};
+
+Operation *LayoutRematerialization::rewriteOp(Operation *op,
+                                              Attribute encoding) {
+  opToDelete.insert(op);
+  OpBuilder rewriter(op);
+  if (op->hasTrait<OpTrait::SameOperandsAndResultEncoding>() ||
+      op->hasTrait<OpTrait::Elementwise>()) {
+    Operation *newOp = cloneElementwise(rewriter, op, encoding);
+    for (auto [oldResult, newResult] :
+         llvm::zip(op->getResults(), newOp->getResults())) {
+      if (oldResult.getType() == newResult.getType()) {
+        oldResult.replaceAllUsesWith(newResult);
+        continue;
+      }
+      addRematValue(oldResult, encoding, newResult);
+    }
+    return newOp;
+  }
+  llvm::report_fatal_error("unexpected op in rewrite");
+  return (mlir::Operation *)nullptr;
+};
+
+void LayoutRematerialization::forwardPropagateRemat(
+    DenseMap<Value, Attribute> &valuesToPropagate) {
+
+  if (valuesToPropagate.empty())
+    return;
+
+  propagateLayout(valuesToPropagate);
+
+  LLVM_DEBUG({
+    DBGS() << "forwardPropagateRemat remat the value with new layout:\n";
+    for (auto &kv : valuesToPropagate) {
+      DBGS().indent(2) << "value: " << kv.first << "\n";
+      DBGS().indent(2) << "to layout:" << kv.second << "\n";
+    }
+  });
+
+  std::deque<Region *> regQueue = {&funcOp->getRegion(0)};
+  while (!regQueue.empty()) {
+    Region *currentRegion = regQueue.front();
+    regQueue.pop_front();
+    for (Operation &op : currentRegion->getOps()) {
+      bool needRewrite = false;
+      SmallVector<Value> results = op.getResults();
+      for (Value result : results) {
+        // Only care about value in the given set.
+        if (!valuesToPropagate.contains(result))
+          continue;
+        auto layout = valuesToPropagate[result];
+        auto remtValue = getRematValue(result, layout);
+        // If the value is already rematerialized, skip.
+        if (remtValue)
+          continue;
+        auto encoding = cast<RankedTensorType>(result.getType()).getEncoding();
+        // If the encoding is already what we want skip.
+        if (encoding == layout)
+          continue;
+        needRewrite = true;
+      }
+      if (needRewrite) {
+        // Create the op with the new layout.
+        rewriteOp(&op, valuesToPropagate[op.getResult(0)]);
+      } else if (auto assertOp = dyn_cast<tt::AssertOp>(&op)) {
+        // Only need to deal with the first operand which is the condition
+        // tensor.
+        Value operand = assertOp->getOperand(0);
+        if (!valuesToPropagate.contains(operand))
+          continue;
+        Value newOperand = getRematValue(operand, valuesToPropagate[operand]);
+        assertOp->setOperand(0, newOperand);
+      }
+    }
+  }
+}
+
 LogicalResult LayoutRematerialization::getConvertBackwardSlice(
     OpOperand &root, Attribute rootEncoding, SetVector<Value> &slice,
     DenseMap<Value, Attribute> &layout,
@@ -1591,9 +1835,21 @@ void LayoutRematerialization::backwardRematerialization(
   int64_t convertLayoutCost = 32 * convertLayoutBytes * 3;
   int64_t rematerialisationCost = 0;
 
+  DenseMap<Value, Attribute> forwardPropagateCandidates;
   // Evaluate single-use status for every operation in slice
   for (Operation *op : sliceOps) {
     auto dialect = op->getDialect();
+    if (!isOpSingleUse(op)) {
+      for (Value result : op->getResults()) {
+        for (Operation *user : result.getUsers()) {
+          if (user == convertOp) {
+            continue;
+          }
+          forwardPropagateCandidates[result] = layout[result];
+          break;
+        }
+      }
+    }
     if (isOpSingleUse(op)) {
       // when we rematerialise, this operation does not get duplicated
       // so it does not contribute to our cost model:
@@ -1650,6 +1906,9 @@ void LayoutRematerialization::backwardRematerialization(
 
   // 3. Rewrite the slice.
   rewriteSlice(slice, layout, convertOp);
+
+  // 4. Forward propagate rematerial values created during backward slice.
+  forwardPropagateRemat(forwardPropagateCandidates);
 }
 
 void LayoutRematerialization::hoistConvertDotOperand() {


### PR DESCRIPTION
TODO: 
1. Investigate the cost model for propagating the layout.
2. Measure the overhead in SLM access and barrier on Intel GPU.