### PR TITLE
[CI] Don't run LTS checks by default on PRs; it's still possible with `lts` label

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -110,7 +110,19 @@ jobs:
       matrix:
         python:
           - "3.10"
-        driver: ${{ fromJson((inputs.runner_label || '') == '' && '["rolling", "lts"]' || '["rolling"]') }}
+        driver: >-
+          ${{
+            fromJson(
+              (inputs.runner_label || '') == '' &&
+              (
+                github.event_name == 'push' ||
+                github.event_name == 'workflow_dispatch' ||
+                contains(github.event.pull_request.labels.*.name, 'lts')
+              ) &&
+              '["rolling", "lts"]' ||
+              '["rolling"]'
+            )
+          }}
 
     uses: ./.github/workflows/build-test-reusable.yml
     with:


### PR DESCRIPTION
The decision to fix LTS bugs post-factum is made on the basis that such situations are extremely rare, but at the same time, the committer needs to be attentive to the results of the check on the main branch and fix any issues ASAP.