### PR TITLE
[NFC] Enhance the `if match` to `if match is not None`.

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -82,7 +82,7 @@ def extract_spill_size_from_zebin(file):
                                'Section .ze_info not found in zebin')
         text = zeinfo.data().decode('utf-8')
         match = SPILL_SIZE_RE.search(text)
-        if match:
+        if match is not None:
             return int(match.group(1))
     return 0
 


### PR DESCRIPTION
Improve code clarity by replacing an implicit truthiness check with an explicit None comparison when checking regex match results.