### PR TITLE
[FlexAttn] Empty cache to fix `UR_RESULT_ERROR_DEVICE_LOST`

### DIFF
--- a/benchmarks/triton_kernels_benchmark/flex_attention_benchmark_causal_mask.py
+++ b/benchmarks/triton_kernels_benchmark/flex_attention_benchmark_causal_mask.py
@@ -129,6 +129,7 @@ if 'B580' in torch.xpu.get_device_name():
         args={},
     ))
 def benchmark(Z, H_q, H_kv, N_CTX_q, N_CTX_kv, D_HEAD_qk, D_HEAD_v, MODE, provider):
+    torch.xpu.empty_cache()
     # Maximum across torch=200, triton=600
     do_bench = benchmark_suite.get_do_bench(n_warmup=600, n_repeat=10, quantiles=[0.5, 0.0, 1.0])
     if MODE not in ('fwd', 'bwd'):


### PR DESCRIPTION
Fixes #5827

CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/21050359703