### PR TITLE
Revert "[UT] Use pytest fixture in `test_divide.py` and `test_block_io.py`"

### DIFF
--- a/python/test/unit/intel/test_block_io.py
+++ b/python/test/unit/intel/test_block_io.py
@@ -1,3 +1,4 @@
+import os
 import itertools
 
 import numpy as np
@@ -8,11 +9,7 @@ import pathlib
 import triton
 from triton._internal_testing import is_xpu
 
-
-@pytest.fixture(autouse=True)
-def triton_block_io(monkeypatch):
-    monkeypatch.setenv("TRITON_INTEL_ENABLE_BLOCK_IO_ALL_LAYOUTS", "1")
-    yield
+os.environ["TRITON_INTEL_ENABLE_BLOCK_IO_ALL_LAYOUTS"] = "1"
 
 
 class DpasLayout:

--- a/third_party/intel/python/test/test_divide.py
+++ b/third_party/intel/python/test/test_divide.py
@@ -5,12 +5,9 @@ import pytest
 import triton
 import triton.language as tl
 
+import os
 
-@pytest.fixture(autouse=True)
-def triton_predicated_load(monkeypatch):
-    monkeypatch.setenv("TRITON_INTEL_PREDICATED_LOAD", "1")
-    yield
-
+os.environ["TRITON_INTEL_PREDICATED_LOAD"] = "1"
 
 aten = torch.ops.aten
 


### PR DESCRIPTION
Reverts intel/intel-xpu-backend-for-triton#5782

LTS started to fail: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/21068890723/job/60613696827, `TRITON_INTEL_ENABLE_BLOCK_IO_ALL_LAYOUTS` appears to not be setting correctly with pytest fixture.