### PR TITLE
[PATCH] Skip PyTorch Page Attention UT

### DIFF
--- a/scripts/patch-pytorch.sh
+++ b/scripts/patch-pytorch.sh
@@ -37,3 +37,4 @@ echo "Applying PyTorch patches in $REPO_ROOT"
 # put your patch applies here
 apply_patch ./patch/170010.patch
 apply_patch ./patch/revert_170842.patch
+apply_patch ./patch/skip_page_attention_ut.patch

--- a/scripts/patch/skip_page_attention_ut.patch
+++ b/scripts/patch/skip_page_attention_ut.patch
@@ -1,0 +1,14 @@
+diff --git a/test/inductor/test_flex_attention.py b/test/inductor/test_flex_attention.py
+index 59cc752414..e9c08daeec 100644
+--- a/test/inductor/test_flex_attention.py
++++ b/test/inductor/test_flex_attention.py
+@@ -3326,6 +3326,9 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
+     def test_flex_attention_stride_ordering(self, device, mode, permute_order, shape):
+         from torch._inductor.ir import get_stride_order
+ 
++        if torch.version.xpu and mode == "paged_attention" and permute_order == (2, 0, 1, 3):
++            raise self.skipTest("OOB - negative kv indices")
++
+         if torch.version.hip and mode == "paged_attention":
+             raise self.skipTest(
+                 "TODO: figure out why mode_paged_attention_permute_order3_shape0 on MI200 caused mem fault"


### PR DESCRIPTION
The failure manifests as a segfault caused by OOB memory access. 
```
Segmentation fault from GPU at 0xff000000001fe000, ctx_id: 1 (CCS), type: 0 (NotPresent), level: 1 (PDE), access: 0 (Read), banned: 1, aborting.
```

After a quick investigation, we found that PagedAttention generates kv_indices < 0 for some tiles. Due to these negative indices, the kernel attempts to access memory below the base address, resulting in the OOB access.
The issue needs further investigation on the PagedAttention side to understand why negative kv_indices are generated and whether such values are expected or valid.

FlexAttn CI:  https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/21097250951