### PR TITLE
Merge OpenAI Triton commit `e22060c`

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -381,6 +381,8 @@ def SharedLinearEncodingAttr
 
     SmallVector<unsigned> getOrder() const;
 
+    unsigned getRank() const { return getLinearLayout().getNumOutDims(); }
+
     LinearLayout toLinearLayout(ArrayRef<int64_t> shape) const;
 
     int32_t getAlignment() const { return static_cast<int32_t>(getLayoutAlignment()); }
@@ -698,6 +700,8 @@ def LinearEncodingAttr : DistributedEncoding<"LinearEncoding", "linear_encoding"
                                       bool skipBroadcast = true) const;
     SmallVector<unsigned> getThreadsPerWarp() const;
     SmallVector<unsigned> getWarpsPerCTA() const;
+
+    unsigned getRank() const { return getLinearLayout().getNumOutDims(); }
 
     // [FIXME LL] Supports legacy behaviour. We should remove these functions
     SmallVector<unsigned> getSizePerThread() const;

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1553,7 +1553,7 @@ void SliceEncodingAttr::print(mlir::AsmPrinter &printer) const {
 LogicalResult
 SliceEncodingAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                           unsigned dim, DistributedEncodingTrait parent) {
-  unsigned rank = ::getCGALayout(parent).getRank();
+  unsigned rank = cast<LayoutEncodingTrait>(parent).getRank();
   if (rank <= 1)
     return emitError() << "parent layout must have at least rank >= 2";
   if (dim >= rank) {

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1070,7 +1070,9 @@ LinearLayout tensorMemoryToLinearLayout(ArrayRef<int64_t> shape,
     // https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-data-path-layout-bny
     if (isM64TwoCTA) {
       auto bases = ret.getBases();
-      std::swap(bases[kRow].back(), bases[kCol].back());
+      auto basisCTA1 =
+          llvm::Log2_32(encoding.getBlockN() * encoding.getColStride()) - 1;
+      std::swap(bases[kRow].back(), bases[kCol][basisCTA1]);
       ret =
           LinearLayout(std::move(bases), ret.getOutDims(), ret.isSurjective());
     }

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -150,13 +150,48 @@ static std::optional<LinearLayout> getDistributedLayoutForTmemLdSt(
         LinearLayout::identity1D(cgaShape[0], rowColDims[1], dims[0]) *
         LinearLayout::identity1D(cgaShape[1], rowColDims[1], dims[1]);
     auto quot = divideRight(ll, ctaCol);
-    assert(quot.has_value());
+    bool isM64TwoCTA = !quot.has_value();
+    if (isM64TwoCTA) {
+      auto bases = ll.getBases();
+      auto logNCols = ll.getInDimSizeLog2(rowColDims[1]);
+      auto numCTAs = ctaCol.getTotalOutDimSize();
+      auto basisCTA1 = logNCols - 1 - llvm::Log2_32(numCTAs * numWarps / 4);
+      // Swap the (soon to be) warp=2 and block=1 bases
+      std::swap(bases[rowColDims[0]].back(), bases[rowColDims[1]][basisCTA1]);
+      auto transposedLL =
+          LinearLayout(std::move(bases), ll.getOutDims(), ll.isSurjective());
+      auto ctaCol =
+          LinearLayout::identity1D(cgaShape[0] / 2, rowColDims[1], dims[0]) *
+          LinearLayout::identity1D(cgaShape[1], rowColDims[1], dims[1]);
+      quot = divideRight(transposedLL, ctaCol);
+      assert(quot.has_value());
+    }
     auto maybeRet =
         getDistributedLayoutForTmemLdSt(*quot, atom, numWarps, bitwidth);
     if (!maybeRet)
       return maybeRet;
     // Add the full block layout (with broadcasting)
-    return *maybeRet * cgaLayout->getLinearLayout();
+    if (isM64TwoCTA) {
+      auto bases = maybeRet->getBases();
+      // Last reg has block[0] basis
+      // This is correct as we don't currently support emitting
+      // more than 1 tcgen05.mma instruction per N dimension
+      auto kReg = StringAttr::get(ctx, "register");
+      bases[kBlock].push_back(bases[kReg].back());
+      bases[kReg].pop_back();
+      auto kWarp = StringAttr::get(ctx, "warp");
+      std::swap(bases[kWarp][1], bases[kBlock][0]);
+      auto ret = LinearLayout(std::move(bases), maybeRet->getOutDims(),
+                              maybeRet->isSurjective());
+      // Remove first block basis as it's already in the layout
+      auto cta1 = LinearLayout::identity1D(2, kBlock, dims[0]);
+      auto smallCgaLayout = divideLeft(cgaLayout->getLinearLayout(), cta1);
+      assert(smallCgaLayout.has_value());
+      ret *= smallCgaLayout.value();
+      return ret;
+    } else {
+      return *maybeRet * cgaLayout->getLinearLayout();
+    }
   }
   // This code is dual to the one in lowerTMemLdSt
   if (bitwidth != 32) {

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -19,6 +19,7 @@ from triton._internal_testing import (
     is_hopper,
     is_xpu,
 )
+from triton.compiler import max_shared_mem
 from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
@@ -408,7 +409,7 @@ def test_device_tma_store():
 
 @gluon.jit
 def mma_kernel(a, b, out, M: ttgl.constexpr, N: ttgl.constexpr, K: ttgl.constexpr, block_layout_a: ttgl.constexpr,
-               block_layout_b: ttgl.constexpr, block_layout_c: ttgl.constexpr, acc_layout: ttgl.constexpr,
+               block_layout_b: ttgl.constexpr, cga_layout_c: ttgl.constexpr, acc_layout: ttgl.constexpr,
                shared_layout_a: ttgl.constexpr, shared_layout_b: ttgl.constexpr, acc_dtype: ttgl.constexpr,
                ASYNC: ttgl.constexpr, USE_TCGEN05: ttgl.constexpr):
     a_offs_m = ttgl.arange(0, M)[:, None]
@@ -446,7 +447,7 @@ def mma_kernel(a, b, out, M: ttgl.constexpr, N: ttgl.constexpr, K: ttgl.constexp
             (M, N),
             acc_layout,
             num_warps=ttgl.num_warps(),
-            cga_layout=block_layout_c.cga_layout,
+            cga_layout=cga_layout_c,
         )
         acc = acc_tmem.load(tmem_reg_layout)
     else:
@@ -716,18 +717,20 @@ def test_tma_mma_shared_inputs(warps, reps, ctas_per_cga, two_ctas, multicast):
                           if bitwidth == 16 or (acc_dtype == torch.float32 and not transpose_a and transpose_b)])
 @pytest.mark.parametrize("warps", ([8, 1], [4, 2], [4, 1]))
 @pytest.mark.parametrize("swizzling_a, swizzling_b", product([0, 32, 64, 128], repeat=2))
+@pytest.mark.parametrize("instr_m", [64, 128] if is_blackwell() else [64])
 @pytest.mark.parametrize("shape_m, shape_n, shape_k", [(1, 1, 1), (2, 4, 1), (2, 2, 4)])
 @pytest.mark.parametrize("ctas_per_cga", [[1, 1], [2, 1], [4, 4]])
 @pytest.mark.parametrize("two_ctas", [False, True] if is_blackwell() else [False])
-def test_mma_shared_inputs(bitwidth, transpose_a, transpose_b, acc_dtype, warps, swizzling_a, swizzling_b, shape_m,
-                           shape_n, shape_k, ctas_per_cga, two_ctas):
+def test_mma_shared_inputs(bitwidth, transpose_a, transpose_b, acc_dtype, warps, swizzling_a, swizzling_b, instr_m,
+                           shape_m, shape_n, shape_k, ctas_per_cga, two_ctas):
     # FIXME: Workaround for a bug in PTXAS when the shared layout is transposed and the swizzling is 0
     # This is fixed in PTXAS 13.0.88. Remove once we upgrade
     if bitwidth == 16 and ((transpose_a and swizzling_a == 0 and shape_m > 1) or
                            (not transpose_b and swizzling_b == 0 and shape_n > 1)):
         pytest.skip("Skipped due to a bug in PTXAS when the shared layout is transposed and the swizzling is 0")
     if ctas_per_cga[0] == 1 and two_ctas:
-        pytest.skip("Need at least 2 CTAs along M for 2CTA mode")
+        pytest.skip("Need at least 2 CTAs for 2CTA mode")
+
     use_tcgen05 = is_blackwell()
 
     torch_dtype_map = {
@@ -741,7 +744,8 @@ def test_mma_shared_inputs(bitwidth, transpose_a, transpose_b, acc_dtype, warps,
     }
 
     # We'll choose a larger instr shape along N, but sure
-    instr_shape = [16, 32, 256 // bitwidth]
+    # instr_m is the instruction per warp group so we divide by 4
+    instr_shape = [instr_m // 4, 32, 256 // bitwidth]
     M = instr_shape[0] * warps[0]
     N = instr_shape[1] * warps[1]
     K = instr_shape[2]
@@ -781,6 +785,12 @@ def test_mma_shared_inputs(bitwidth, transpose_a, transpose_b, acc_dtype, warps,
         MAX_ROWS = 512
         if M * N // 128 // num_ctas > MAX_ROWS:
             N //= (M * N // 128 // num_ctas // MAX_ROWS)
+
+    total_shmem = (M + N) * K * bitwidth // 8
+    device = triton.runtime.driver.active.get_current_device()
+    MAX_SHMEM = max_shared_mem(device)
+    if total_shmem > MAX_SHMEM:
+        pytest.skip(f"Total shared memory {total_shmem} bytes exceeds the maximum allowed {MAX_SHMEM} bytes")
 
     if two_ctas and N // ctas_per_cga[1] == 512:
         # grep for [Note: numRepN > 1 and two_ctas]
@@ -850,11 +860,13 @@ def test_mma_shared_inputs(bitwidth, transpose_a, transpose_b, acc_dtype, warps,
 
         cga_layout_a = make_2cta_cga_layout(ctas_per_cga, cta_split_a, cta_order, 0)
         cga_layout_b = make_2cta_cga_layout(ctas_per_cga_b, cta_split_b, cta_order, 1)
+        # The TMEM layout for instr_m == 128 splits along M, the one for instr_m == 64 splits along N
         cga_layout_c = make_2cta_cga_layout(ctas_per_cga, ctas_per_cga, cta_order, 0)
     else:
         cga_layout_a = make_cga_layout(ctas_per_cga, cta_split_a, cta_order)
         cga_layout_b = make_cga_layout(ctas_per_cga_b, cta_split_b, cta_order)
         cga_layout_c = make_cga_layout(ctas_per_cga, ctas_per_cga, cta_order)
+    cga_layout_c = tuple(tuple(basis) for basis in cga_layout_c)
 
     block_layout_a = ttgl.BlockedLayout([1, 8], [1, THREADS_PER_WARP], warps_per_cta=warps, order=[0, 1],
                                         cga_layout=cga_layout_a)
@@ -871,15 +883,13 @@ def test_mma_shared_inputs(bitwidth, transpose_a, transpose_b, acc_dtype, warps,
         shared_layout_b = ttgl.NVMMASharedLayout(swizzle_byte_width=swizzling_b, element_bitwidth=bitwidth, rank=2,
                                                  transposed=transpose_b, cga_layout=cga_layout_b)
     if use_tcgen05:
-        tmem_shape = (min(M // ctas_per_cga[0], 128), min(N // ctas_per_cga[1], 256))
+        tmem_shape = (instr_m, min(N // ctas_per_cga[1], 256))
         acc_layout = TensorMemoryLayout(tmem_shape, col_stride=32 // torch.finfo(acc_dtype).bits,
                                         cta_split_num=tuple(ctas_per_cga), two_ctas=two_ctas)
     else:
         acc_layout = ttgl.NVMMADistributedLayout(version=[3, 0], warps_per_cta=warps, instr_shape=instr_shape,
                                                  cga_layout=cga_layout_c)
 
-    block_layout_c = ttgl.BlockedLayout([1, 8], [1, THREADS_PER_WARP], warps_per_cta=warps, order=[1, 0],
-                                        cga_layout=cga_layout_c)
     torch.manual_seed(0)
 
     def cast(x, dtype):
@@ -894,7 +904,6 @@ def test_mma_shared_inputs(bitwidth, transpose_a, transpose_b, acc_dtype, warps,
         return x.view(dtype)
 
     # Sample bf16 as tf32 does not use the full range
-    device = triton.runtime.driver.active.get_current_device()
     a = cast(torch.randn((M, K), device=device, dtype=torch.float32), torch_dtype)
     b = cast(torch.randn((K, N), device=device, dtype=torch.float32), torch_dtype)
     out = torch.zeros((M, N), device=device, dtype=out_dtype)
@@ -908,7 +917,7 @@ def test_mma_shared_inputs(bitwidth, transpose_a, transpose_b, acc_dtype, warps,
         K,
         block_layout_a,
         block_layout_b,
-        block_layout_c,
+        cga_layout_c,
         acc_layout,
         shared_layout_a,
         shared_layout_b,

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -44,6 +44,7 @@ __all__ = [
     "JITFunction",
     "KernelInterface",
     "language",
+    "max_shared_mem",
     "MockTensor",
     "must_use_result",
     "next_power_of_2",

--- a/python/triton/compiler/__init__.py
+++ b/python/triton/compiler/__init__.py
@@ -1,7 +1,7 @@
-from .compiler import CompiledKernel, ASTSource, IRSource, compile, make_backend, LazyDict, get_cache_key
+from .compiler import CompiledKernel, ASTSource, IRSource, compile, make_backend, LazyDict, get_cache_key, max_shared_mem
 from .errors import CompilationError
 
 __all__ = [
     "compile", "make_backend", "ASTSource", "IRSource", "CompiledKernel", "CompilationError", "LazyDict",
-    "get_cache_key"
+    "get_cache_key", "max_shared_mem"
 ]


### PR DESCRIPTION
This PR changes the Triton base from https://github.com/intel/intel-xpu-backend-for-triton/commit/5ad4f2ed56937c2a1e4e4db3a999baeeac5b6c59 to e22060c (Jan 19).

Pass rate: 97.84%