### PR TITLE
[SoftwarePipeliner] Limit barrier scope to workgroup

### DIFF
--- a/benchmarks/triton_kernels_benchmark/flash_attention_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/flash_attention_benchmark.py
@@ -457,7 +457,7 @@ class _attention(torch.autograd.Function):
             N_CTX=q.shape[2],  #
             BLOCK_DMODEL=Lk,  #
             STAGE=stage,  #
-            split_barriers_scope='None',  # possible scope value: 'Subgroup','Workgroup'
+            use_barrier=False,  #
         )
 
         ctx.save_for_backward(q, k, v, o, M)

--- a/scripts/flash_attention.py
+++ b/scripts/flash_attention.py
@@ -29,8 +29,7 @@ def get_options():
     config.add_argument('-BLOCK-N', action='extend', nargs='+', type=int, help='Sizes of N')
     config.add_argument('-stages', action='extend', nargs='+', type=int, help='Numbers of stages')
     config.add_argument('-warps', action='extend', nargs='+', type=int, help='Numbers of warps')
-    config.add_argument('-split-barriers-scope', action='store', type=str,
-                        help='Split barrier scope. Should be either Subgroup or Workgroup.')
+    config.add_argument('-use-barrier', action='store', type=bool, help='Use barrier')
     return parser.parse_args()
 
 
@@ -40,14 +39,10 @@ def get_configs(options):
     bn_values = options.BLOCK_N if options.BLOCK_N else [32, 64]
     stages_values = options.stages if options.stages else [3, 4]
     warps_values = options.warps if options.warps else [8, 16, 32]
-    split_barriers_scope = options.split_barriers_scope if options.split_barriers_scope else 'None'
+    use_barrier = options.use_barrier if options.use_barrier is not None else False
     return [
-        triton.Config({'BLOCK_M': BM, 'BLOCK_N': BN, 'grf_mode': '256', 'split_barriers_scope': split_barriers_scope},
-                      num_stages=s, num_warps=w)
-        for BM in bm_values
-        for BN in bn_values
-        for s in stages_values
-        for w in warps_values
+        triton.Config({'BLOCK_M': BM, 'BLOCK_N': BN, 'grf_mode': '256', 'use_barrier': use_barrier}, num_stages=s,
+                      num_warps=w) for BM in bm_values for BN in bn_values for s in stages_values for w in warps_values
     ]
 
 

--- a/test/TritonIntelGPU/split-barrier.mlir
+++ b/test/TritonIntelGPU/split-barrier.mlir
@@ -1,5 +1,4 @@
-// RUN: triton-opt %s -split-input-file -tritonintelgpu-pipeline="num-stages=3 split-barriers-scope=workgroup" | FileCheck %s --check-prefixes=CHECK,WORKGROUP_SCOPE
-// RUN: triton-opt %s -split-input-file -tritonintelgpu-pipeline="num-stages=3 split-barriers-scope=subgroup" | FileCheck %s --check-prefixes=CHECK,SUBGROUP_SCOPE
+// RUN: triton-opt %s -split-input-file -tritonintelgpu-pipeline="num-stages=3 use-barrier" | FileCheck %s
 
 // CHECK: #[[$BLOCK:.+]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 16], warpsPerCTA = [8, 4], order = [1, 0]}>
 // CHECK: #[[$DPAS:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 8], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
@@ -23,13 +22,11 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
     // CHECK:      ttig.prefetch {{.*}} : !tt.ptr<tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DPAS]], kWidth = 1}>>>
     // CHECK:      ttig.prefetch {{.*}} : !tt.ptr<tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DPAS]], kWidth = 2}>>>
     // CHECK:      scf.for %[[IV:.*]] = {{.*}} to {{.*}} step {{.*}} iter_args({{.*}}) -> (tensor<128x256xf32, #mma>, !tt.ptr<tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>>, !tt.ptr<tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>>, !tt.ptr<tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>>, !tt.ptr<tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>>)
-    // WORKGROUP_SCOPE-NEXT: triton_gen.split_barrier_arrive {execution_scope = WorkGroup, memory_scope = WorkGroup}
-    // SUBGROUP_SCOPE-NEXT: triton_gen.split_barrier_arrive {execution_scope = SubGroup, memory_scope = SubGroup}
+    // CHECK-NEXT: triton_gen.split_barrier_arrive {execution_scope = WorkGroup, memory_scope = WorkGroup}
     // CHECK:        ttig.prefetch {{.*}} : !tt.ptr<tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DPAS]], kWidth = 1}>>>
     // CHECK:        ttig.prefetch {{.*}} : !tt.ptr<tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DPAS]], kWidth = 2}>>
     // CHECK:        tt.dot {{.*}} : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DPAS]], kWidth = 1}>> * tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DPAS]], kWidth = 2}>> -> tensor<128x256xf32, #[[$DPAS]]>
-    // WORKGROUP_SCOPE:   triton_gen.split_barrier_wait {execution_scope = WorkGroup, memory_scope = WorkGroup}
-    // SUBGROUP_SCOPE:   triton_gen.split_barrier_wait {execution_scope = SubGroup, memory_scope = SubGroup}
+    // CHECK:   triton_gen.split_barrier_wait {execution_scope = WorkGroup, memory_scope = WorkGroup}
     // CHECK-NEXT:   scf.yield
     %23:3 = scf.for %arg2 = %c0_i32 to %c64_i32 step %c64_i32 iter_args(%arg3 = %cst, %arg4 = %18, %arg5 = %22) -> (tensor<128x256xf32, #dpas>, !tt.ptr<tensor<128x64xf16, #dot0>>, !tt.ptr<tensor<64x256xf16, #dot1>>)  : i32 {
       %55:3 = scf.for %arg9 = %c0_i32 to %c64_i32 step %c64_i32 iter_args(%arg10 = %cst, %arg11 = %18, %arg12 = %22) -> (tensor<128x256xf32, #dpas>, !tt.ptr<tensor<128x64xf16, #dot0>>, !tt.ptr<tensor<64x256xf16, #dot1>>)  : i32 {
@@ -70,13 +67,11 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
     // CHECK:      ttig.prefetch {{.*}} : !tt.ptr<tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DPAS]], kWidth = 1}>>>
     // CHECK:      ttig.prefetch {{.*}} : !tt.ptr<tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DPAS]], kWidth = 2}>>>
     // CHECK:      scf.for %[[IV:.*]] = {{.*}} to {{.*}} step {{.*}} iter_args({{.*}}) -> (tensor<128x256xf32, #mma>, !tt.ptr<tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>>, !tt.ptr<tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>>, !tt.ptr<tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>>, !tt.ptr<tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>>)
-    // WORKGROUP_SCOPE-NEXT: triton_gen.split_barrier_arrive {execution_scope = WorkGroup, memory_scope = WorkGroup}
-    // SUBGROUP_SCOPE-NEXT: triton_gen.split_barrier_arrive {execution_scope = SubGroup, memory_scope = SubGroup}
+    // CHECK-NEXT: triton_gen.split_barrier_arrive {execution_scope = WorkGroup, memory_scope = WorkGroup}
     // CHECK:        ttig.prefetch {{.*}} : !tt.ptr<tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DPAS]], kWidth = 1}>>>
     // CHECK:        ttig.prefetch {{.*}} : !tt.ptr<tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DPAS]], kWidth = 2}>>
     // CHECK:        tt.dot {{.*}} : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DPAS]], kWidth = 1}>> * tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DPAS]], kWidth = 2}>> -> tensor<128x256xf32, #[[$DPAS]]>
-    // WORKGROUP_SCOPE:   triton_gen.split_barrier_wait {execution_scope = WorkGroup, memory_scope = WorkGroup}
-    // SUBGROUP_SCOPE:   triton_gen.split_barrier_wait {execution_scope = SubGroup, memory_scope = SubGroup}
+    // CHECK:   triton_gen.split_barrier_wait {execution_scope = WorkGroup, memory_scope = WorkGroup}
     // CHECK-NEXT:   scf.yield
     %23:3 = scf.for %arg9 = %c0_i32 to %c64_i32 step %c64_i32 iter_args(%arg10 = %cst, %arg11 = %18, %arg12 = %22) -> (tensor<128x256xf32, #dpas>, !tt.ptr<tensor<128x64xf16, #dot0>>, !tt.ptr<tensor<64x256xf16, #dot1>>)  : i32 {
       %56 = tt.load %arg11 {boundaryCheck = array<i32: 0, 1>, ttig.block_io = "row_major"} : !tt.ptr<tensor<128x64xf16, #dot0>>

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h
@@ -13,9 +13,6 @@
 
 namespace mlir::triton::gpu::intel {
 
-/// Split barrier scope
-enum SplitBarrierScope { None = 0, Workgroup = 1, Subgroup = 2 };
-
 #define GEN_PASS_DECL
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
 

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -75,13 +75,8 @@ def TritonIntelGPUPipeline : Pass<"tritonintelgpu-pipeline", "mlir::ModuleOp"> {
     Option<"numStages", "num-stages",
            "int32_t", /*default*/"3",
            "number of pipeline stages">,
-    Option<"splitBarrierScope", "split-barriers-scope",
-           "enum SplitBarrierScope", "SplitBarrierScope::None",
-           "insert split barriers in a loop",
-           "llvm::cl::values("
-           "clEnumValN(SplitBarrierScope::None, \"none\", \"No scope\"), "
-           "clEnumValN(SplitBarrierScope::Workgroup, \"workgroup\", \"Workgroup scope\"), "
-           "clEnumValN(SplitBarrierScope::Subgroup, \"subgroup\", \"Subgroup scope\"))">,
+    Option<"useBarrier", "use-barrier", "bool", /*default*/"false",
+           "generate barriers">,
   ];
 }
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Pipeliner/SoftwarePipeliner.cpp
@@ -38,9 +38,7 @@ static bool preCondition(scf::ForOp forOp) {
   return true;
 }
 
-static void pipelineLoop(
-    scf::ForOp forOp, int numStages,
-    std::optional<triton::TritonGEN::MemScope> barrierScope = std::nullopt) {
+static void pipelineLoop(scf::ForOp forOp, int numStages, bool useBarrier) {
   mlir::scf::PipeliningOption options;
   if (!preCondition(forOp))
     return;
@@ -59,19 +57,17 @@ static void pipelineLoop(
     return;
 
   scf::ForOp loop = (*newForOp);
-  if (barrierScope) {
-    assert((*barrierScope == triton::TritonGEN::MemScope::SUB_GROUP) ||
-           (*barrierScope == triton::TritonGEN::MemScope::WORK_GROUP) &&
-               "The barrier scope must be SubGroup or Workgroup");
+  if (useBarrier) {
+    auto barrierScope = triton::TritonGEN::MemScope::WORK_GROUP;
     OpBuilder b(loop);
     Location loc = loop.getLoc();
     b.setInsertionPointToStart(loop.getBody());
-    triton::TritonGEN::SplitBarrierArriveOp::create(b, loc, *barrierScope,
-                                                    *barrierScope);
+    triton::TritonGEN::SplitBarrierArriveOp::create(b, loc, barrierScope,
+                                                    barrierScope);
     auto yield = cast<scf::YieldOp>(loop.getBody()->getTerminator());
     b.setInsertionPoint(yield);
-    triton::TritonGEN::SplitBarrierWaitOp::create(b, loc, *barrierScope,
-                                                  *barrierScope);
+    triton::TritonGEN::SplitBarrierWaitOp::create(b, loc, barrierScope,
+                                                  barrierScope);
   }
 }
 
@@ -92,23 +88,11 @@ struct IntelGPUPipelinePass
     if (numStages <= 1)
       return;
 
-    std::optional<triton::TritonGEN::MemScope> barrierScope = std::nullopt;
-    switch (splitBarrierScope) {
-    case ttgi::SplitBarrierScope::None:
-      break;
-    case ttgi::SplitBarrierScope::Workgroup:
-      barrierScope = triton::TritonGEN::MemScope::WORK_GROUP;
-      break;
-    case ttgi::SplitBarrierScope::Subgroup:
-      barrierScope = triton::TritonGEN::MemScope::SUB_GROUP;
-      break;
-    }
-
     SmallVector<scf::ForOp> loops;
     getOperation()->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
 
     for (scf::ForOp forOp : loops)
-      pipelineLoop(forOp, numStages, barrierScope);
+      pipelineLoop(forOp, numStages, useBarrier);
   }
 };
 } // anonymous namespace

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -77,9 +77,8 @@ void init_triton_intel_passes_ttgpuir(py::module &&m) {
                      gpu::intel::createTritonIntelGPUAccelerateMatmul);
   ADD_PASS_WRAPPER_0("add_rewrite_stack_ptr",
                      gpu::intel::createTritonIntelGPURewriteStackPtr);
-  ADD_PASS_OPTION_WRAPPER_2("add_pipeline",
-                            gpu::intel::createTritonIntelGPUPipeline, int,
-                            enum gpu::intel::SplitBarrierScope);
+  ADD_PASS_OPTION_WRAPPER_2(
+      "add_pipeline", gpu::intel::createTritonIntelGPUPipeline, int, bool);
   ADD_PASS_WRAPPER_0("add_allocate_shared_memory",
                      gpu::intel::createIntelAllocateSharedMemory);
   ADD_PASS_WRAPPER_0("add_remove_layout_conversions",
@@ -153,12 +152,6 @@ void init_triton_intel(py::module &&m) {
   init_triton_intel_passes_ttir(passes.def_submodule("ttir"));
   init_triton_intel_passes_ttgpuir(passes.def_submodule("ttgpuir"));
   init_triton_intel_passes_arith(passes.def_submodule("arith"));
-
-  // Split barrier scope enum
-  py::enum_<gpu::intel::SplitBarrierScope>(m, "SplitBarrierScope")
-      .value("none", gpu::intel::SplitBarrierScope::None)
-      .value("Workgroup", gpu::intel::SplitBarrierScope::Workgroup)
-      .value("Subgroup", gpu::intel::SplitBarrierScope::Subgroup);
 
   m.def("optimize_module", [](llvm::Module *mod,
                               const llvm::OptimizationLevel &opt,


### PR DESCRIPTION
This PR removes the barrier scope control parameter to prepare for migrating to named barriers. Named barriers do not accept barrier scope as input, and the subgroup barrier scope was never utilized.