### PR TITLE
[DEBUG] Inductor tests on LTS2

### DIFF
--- a/.github/workflows/inductor-tests-reusable.yml
+++ b/.github/workflows/inductor-tests-reusable.yml
@@ -37,7 +37,7 @@ env:
 jobs:
   build:
     name: Test
-    runs-on: ${{ contains(inputs.runner_label, 'igc') && fromJSON(format('["linux","{0}"]', inputs.runner_label)) || fromJSON(format('["linux","rolling","{0}","{1}"]', inputs.runner_label || 'max1100', inputs.runner_version)) }}
+    runs-on: ${{ contains(inputs.runner_label, 'igc') && fromJSON(format('["linux","{0}"]', inputs.runner_label)) || fromJSON(format('["linux","lts","{0}","{1}"]', inputs.runner_label || 'max1100', inputs.runner_version)) }}
     timeout-minutes: 960
     defaults:
       run:


### PR DESCRIPTION
https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/21253350876/job/61160800140 (passed)
https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/21286164195 (inductor/test_torchinductor_opinfo.py; lts2; to check)