### PR TITLE
[E2E] Update `runs-on:` condition to easily test LTS and B60 platforms (#5940)

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -57,10 +57,7 @@ env:
 jobs:
   run_tests:
     name: Test ${{ inputs.suite }} ${{ inputs.dtype }} ${{ inputs.mode }} ${{ inputs.test_mode }}
-    runs-on:
-      - linux
-      - rolling
-      - ${{ inputs.runner_label || 'max1550' }}
+    runs-on: ${{ fromJSON((inputs.runner_label == '' || startsWith(inputs.runner_label, 'max')) && format('["linux", "rolling", "{0}"]', inputs.runner_label || 'max1550') || format('["linux", "{0}"]', inputs.runner_label)) }}
     timeout-minutes: 720
     defaults:
       run:


### PR DESCRIPTION
(cherry picked from commit bbd7d6343fe75c012eaa0d9327cd5a206e11573b)