### PR TITLE
[Build][Clang][C++17] Don't capture structured bindings in lambdas

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1381,8 +1381,17 @@ struct LoadOpToBlockIOConversion
         oneMatrixPerLoadForBT.has_value() ? *oneMatrixPerLoadForBT : false);
     if (!sizeInfo.isValid())
       return failure();
-    auto [tileHeight, tileWidth, numPackedVals, vBlocks, rowDim, colDim,
-          isTransposeRequired, regPackedBases] = std::move(sizeInfo);
+    // Extract members to regular variables for C++17 compatibility
+    // (capturing structured bindings in lambdas requires C++20)
+    int tileHeight = sizeInfo.tileHeight;
+    int tileWidth = sizeInfo.tileWidth;
+    int numPackedVals = sizeInfo.numElemPerPackedVal;
+    int vBlocks = sizeInfo.vBlocks;
+    int rowDim = sizeInfo.rowDim;
+    int colDim = sizeInfo.colDim;
+    bool isTransposeRequired = sizeInfo.transpose;
+    std::optional<SetVector<unsigned>> regPackedBases =
+        std::move(sizeInfo.regPackedBases);
 
     unsigned packedElemSizeInBits = elemSizeInBits * numPackedVals;
     if (!check2DBlockAddressPayloadRestriction(packedElemSizeInBits, tileWidth))


### PR DESCRIPTION
Clang complains, feature supported since C++20

```
  FAILED: third_party/intel/lib/TritonIntelGPUToLLVM/CMakeFiles/TritonIntelGPUToLLVM.dir/LoadStoreOpToLLVM.cpp.o
  /usr/bin/clang++  (...)
  /home/jovyan/workspace/intel-xpu-backend-for-triton/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp:1548:13: error: captured structured bindings are a C++20 extension [-Werror,-Wc++20-extensions]
   1548 |         if (tileHeight >= shape[isTransposeRequired ? 1 : 0] &&
        |             ^
  /home/jovyan/workspace/intel-xpu-backend-for-triton/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp:1384:11: note: 'tileHeight' declared here
   1384 |     auto [tileHeight, tileWidth, numPackedVals, vBlocks, rowDim, colDim,
        |           ^
  /home/jovyan/workspace/intel-xpu-backend-for-triton/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp:1548:33: error: captured structured bindings are a C++20 extension [-Werror,-Wc++20-extensions]
   1548 |         if (tileHeight >= shape[isTransposeRequired ? 1 : 0] &&
        |                                 ^
  /home/jovyan/workspace/intel-xpu-backend-for-triton/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp:1385:11: note: 'isTransposeRequired' declared here
   1385 |           isTransposeRequired, regPackedBases] = std::move(sizeInfo);
        |           ^
  /home/jovyan/workspace/intel-xpu-backend-for-triton/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp:1549:14: error: captured structured bindings are a C++20 extension [-Werror,-Wc++20-extensions]
   1549 |             (tileWidth * numPackedVals * vBlocks) >=
        |              ^
  /home/jovyan/workspace/intel-xpu-backend-for-triton/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp:1384:23: note: 'tileWidth' declared here
   1384 |     auto [tileHeight, tileWidth, numPackedVals, vBlocks, rowDim, colDim,
        |                       ^
  /home/jovyan/workspace/intel-xpu-backend-for-triton/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp:1549:26: error: captured structured bindings are a C++20 extension [-Werror,-Wc++20-extensions]
   1549 |             (tileWidth * numPackedVals * vBlocks) >=
        |                          ^
  /home/jovyan/workspace/intel-xpu-backend-for-triton/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp:1384:34: note: 'numPackedVals' declared here
   1384 |     auto [tileHeight, tileWidth, numPackedVals, vBlocks, rowDim, colDim,
        |                                  ^
  /home/jovyan/workspace/intel-xpu-backend-for-triton/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp:1549:42: error: captured structured bindings are a C++20 extension [-Werror,-Wc++20-extensions]
   1549 |             (tileWidth * numPackedVals * vBlocks) >=
        |                                          ^
  /home/jovyan/workspace/intel-xpu-backend-for-triton/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp:1384:49: note: 'vBlocks' declared here
   1384 |     auto [tileHeight, tileWidth, numPackedVals, vBlocks, rowDim, colDim,
        |                                                 ^
  5 errors generated.

```