### PR TITLE
[Debug] Run E2E on B60 and release/3.6.x branch

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -57,10 +57,7 @@ env:
 jobs:
   run_tests:
     name: Test ${{ inputs.suite }} ${{ inputs.dtype }} ${{ inputs.mode }} ${{ inputs.test_mode }}
-    runs-on:
-      - linux
-      - rolling
-      - ${{ inputs.runner_label || 'max1550' }}
+    runs-on: ${{ fromJSON((inputs.runner_label == '' || startsWith(inputs.runner_label, 'max')) && format('["linux", "rolling", "{0}"]', inputs.runner_label || 'max1550') || format('["linux", "{0}"]', inputs.runner_label)) }}
     timeout-minutes: 720
     defaults:
       run:


### PR DESCRIPTION
(cherry picked from commit bbd7d6343fe75c012eaa0d9327cd5a206e11573b)
(cherry picked from commit 7ee0b58d8bbf522e57ea3173b2a5c17b7a548eab)

https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/21490591680 (to check)

