### PR TITLE
Skip for xe2: tests/test_roofline.py::test_get_memset_tbps

### DIFF
--- a/scripts/skiplist/xe2/triton_kernels.txt
+++ b/scripts/skiplist/xe2/triton_kernels.txt
@@ -1,0 +1,2 @@
+# https://github.com/intel/intel-xpu-backend-for-triton/issues/5977
+tests/test_roofline.py::test_get_memset_tbps


### PR DESCRIPTION
#5977