### PR TITLE
[BENCHMARK] Limit custom mask flex attention shapes for B580 and enable paged runs

### DIFF
--- a/benchmarks/triton_kernels_benchmark/flex_attention_benchmark_custom_masks.py
+++ b/benchmarks/triton_kernels_benchmark/flex_attention_benchmark_custom_masks.py
@@ -128,13 +128,13 @@ fa_kernel_mode = os.getenv('FA_KERNEL_MODE', 'fwd')
     benchmark_suite.Benchmark(
         x_names=['Z', 'H', 'N_CTX', 'D_HEAD', 'MASK', 'MODE'],
         x_vals=[[z, h, 16384 // z, dhead, mask, mode]
-                for z in ([4, 8, 16, 32] if not IS_B580 else [16, 32])
+                for z in [8, 16, 32]
                 for (h, dhead) in [(16, 128), (32, 64)]
                 for mask in MASKS
                 for mode in [fa_kernel_mode]]  #
         + [[4, 48, 1024, 64, mask, mode] for mask in MASKS for mode in [fa_kernel_mode]]  #
         + [[z, h, 1024, dhead, mask, mode]
-           for z in ([1, 2, 4, 8, 16, 32, 64] if not IS_B580 else [1, 2, 4, 8, 16])
+           for z in [1, 2, 4, 8, 16, 32]
            for (h, dhead) in [(8, 128), (32, 96), (4, 128)]
            for mask in MASKS
            for mode in [fa_kernel_mode]],


### PR DESCRIPTION
Reduces the batch configs for some custom mask shapes for B580.