### PR TITLE
[VLLM] Enable TILE_SIZE in `unified_attention` kernel

### DIFF
--- a/benchmarks/third_party/vllm/unified_attention_benchmark.py
+++ b/benchmarks/third_party/vllm/unified_attention_benchmark.py
@@ -914,7 +914,7 @@ def unified_attention_td(
     #     or max_seqlen_q > 1
     #     or num_seqs > seq_threshold_3D
     # ):
-    TILE_SIZE_PREFILL = TILE_SIZE_DECODE = block_size
+    TILE_SIZE_PREFILL = TILE_SIZE_DECODE = 16
     assert TILE_SIZE_PREFILL <= block_size, "TILE_SIZE_PREFILL must be <= block_size"
     assert TILE_SIZE_DECODE <= block_size, "TILE_SIZE_DECODE must be <= block_size"
     assert block_size % TILE_SIZE_PREFILL == 0, "block_size must be multiple of TILE_SIZE_PREFILL"


### PR DESCRIPTION
This PR reenables TILE_SIZE that was missing from https://github.com/intel/intel-xpu-backend-for-triton/pull/5789

It is a partial implementation that allows only `BLOCK_SIZE % TILE_SIZE == 0 && BLOCK_SIZE >= TILE_SIZE`, but it improves performance in cases with `BLOCK_SIZE = 64`, which was the case for default vllm run.

Basically it specifically improves performance of block_size 64 cases. Before that the size was too large and perfomance was much worse than block_size 16 cases, but now 64 case is processed with the same tiles as block_size 16 case, and performance is better.

I also enable block_size 64 in our benchmarks and increate error tolerance a little.

<details><summary>With TILE_SIZE==BLOCK_SIZE (before this PR)</summary>
<p>

```
    q_heads  k_heads  head_size           dtype qdtype                                                                           seq_lens sliding_window  soft_cap  num_blocks  block_size  triton-GB/s  triton-td-GB/s  pytorch-GB/s  triton-TFlops  triton-td-TFlops  pytorch-TFlops triton-eff triton-td-eff pytorch-eff
0        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None       NaN       32768          16    15.965698       85.930070     23.718860       4.087219         21.998098        6.072028      1.30%         6.99%       1.93%
1        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None       NaN       32768          64    16.731456       49.799391     24.679655       4.283253         12.748644        6.317992      1.36%         4.05%       2.01%
2        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None       NaN        2048          16    15.898822       79.649976     23.020667       4.070098         20.390394        5.893291      1.29%         6.48%       1.87%
3        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None       NaN        2048          64    16.828842       49.865068     25.675556       4.308184         12.765458        6.572942      1.37%         4.06%       2.09%
4        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None      50.0       32768          16    15.018562       60.941044     19.991867       3.844752         15.600907        5.117918      1.22%         4.96%       1.63%
5        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None      50.0       32768          64    15.193819       30.351981     21.111135       3.889618          7.770107        5.404451      1.24%         2.47%       1.72%
6        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None      50.0        2048          16    15.038321       60.854277     21.419560       3.849810         15.578695        5.483407      1.22%         4.95%       1.74%
7        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None      50.0        2048          64    15.195697       30.462966     18.187771       3.890099          7.798519        4.656069      1.24%         2.48%       1.48%
8        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256       NaN       32768          16    15.668056       86.121407     22.229200       3.342519         18.372567        4.742229      1.28%         7.01%       1.81%
9        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256       NaN       32768          64    16.261754       47.294697     20.190592       3.469174         10.089535        4.307326      1.32%         3.85%       1.64%
10       32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256       NaN        2048          16    15.772540       86.129272     21.918140       3.364808         18.374245        4.675870      1.28%         7.01%       1.78%
11       32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256       NaN        2048          64    16.292918       48.124346     21.074081       3.475823         10.266527        4.495804      1.33%         3.92%       1.72%
12       32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256      50.0       32768          16    14.564903       64.664819     18.549931       3.107179         13.795161        3.957319      1.19%         5.26%       1.51%
13       32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256      50.0       32768          64    14.823191       30.116109     17.466725       3.162281          6.424770        3.726235      1.21%         2.45%       1.42%
14       32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256      50.0        2048          16    14.624944       61.907526     16.357448       3.119988         13.206939        3.489589      1.19%         5.04%       1.33%
15       32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256      50.0        2048          64    15.053970       29.581794     16.257413       3.211514          6.310783        3.468248      1.23%         2.41%       1.32%
16       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None       NaN       32768          16     6.097277       50.033824     15.415865       0.634854          5.209567        1.605114      0.50%         4.07%       1.25%
17       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None       NaN       32768          64     6.183803       28.346896     17.533491       0.643863          2.951504        1.825603      0.50%         2.31%       1.43%
18       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None       NaN        2048          16     6.121640       51.210902     15.725523       0.637391          5.332125        1.637356      0.50%         4.17%       1.28%
19       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None       NaN        2048          64     6.190408       27.315194     14.316649       0.644551          2.844083        1.490662      0.50%         2.22%       1.17%
20       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None      50.0       32768          16     5.804058       31.232566     12.858675       0.604324          3.251963        1.338857      0.47%         2.54%       1.05%
21       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None      50.0       32768          64     5.749605       16.534635     15.260843       0.598654          1.721601        1.588973      0.47%         1.35%       1.24%
22       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None      50.0        2048          16     5.718508       31.878284     14.951833       0.595416          3.319196        1.556798      0.47%         2.59%       1.22%
23       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None      50.0        2048          64     5.725041       16.384837     13.617777       0.596096          1.706004        1.417895      0.47%         1.33%       1.11%
24       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256       NaN       32768          16     8.503531       56.756275      5.968244       1.060796          7.080213        0.744524      0.69%         4.62%       0.49%
25       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256       NaN       32768          64     8.637603       26.607091      6.132251       1.077521          3.319172        0.764984      0.70%         2.17%       0.50%
26       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256       NaN        2048          16     8.593906       60.202195      6.588377       1.072070          7.510083        0.821885      0.70%         4.90%       0.54%
27       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256       NaN        2048          64     8.738526       27.127507      6.658645       1.090111          3.384093        0.830650      0.71%         2.21%       0.54%
28       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256      50.0       32768          16     7.918193       47.186910      5.232786       0.987776          5.886457        0.652778      0.64%         3.84%       0.43%
29       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256      50.0       32768          64     8.036969       16.669404      6.088464       1.002593          2.079469        0.759522      0.65%         1.36%       0.50%
30       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256      50.0        2048          16     8.050255       47.721255      5.651622       1.004251          5.953115        0.705027      0.66%         3.88%       0.46%
31       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256      50.0        2048          64     8.125778       16.467723      5.151475       1.013672          2.054310        0.642634      0.66%         1.34%       0.42%
32       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None       NaN       32768          16    60.945221      218.318947     18.975017       0.242539          0.868827        0.075513      4.96%        17.77%       1.54%
33       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None       NaN       32768          64    62.703654      170.156530     22.563990       0.249537          0.677159        0.089796      5.10%        13.85%       1.84%
34       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None       NaN        2048          16    62.526904      221.095311     22.723604       0.248834          0.879876        0.090431      5.09%        17.99%       1.85%
35       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None       NaN        2048          64    61.805992      162.854894     20.657240       0.245965          0.648101        0.082208      5.03%        13.25%       1.68%
36       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None      50.0       32768          16    55.702196      185.115628     18.630179       0.221674          0.736691        0.074141      4.53%        15.06%       1.52%
37       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None      50.0       32768          64    58.238813      133.932292     18.360191       0.231769          0.533000        0.073067      4.74%        10.90%       1.49%
38       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None      50.0        2048          16    57.527885      173.976146     19.698429       0.228939          0.692360        0.078392      4.68%        14.16%       1.60%
39       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None      50.0        2048          64    56.363513      128.745478     19.676586       0.224306          0.512359        0.078305      4.59%        10.48%       1.60%
40       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256       NaN       32768          16    15.163891      125.142189      4.594438       0.059411          0.490301        0.018001      1.23%        10.18%       0.37%
41       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256       NaN       32768          64    15.202855       67.817450      3.853106       0.059564          0.265705        0.015096      1.24%         5.52%       0.31%
42       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256       NaN        2048          16    15.833483      122.409202      3.794822       0.062035          0.479593        0.014868      1.29%         9.96%       0.31%
43       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256       NaN        2048          64    15.139458       71.891987      4.061839       0.059316          0.281669        0.015914      1.23%         5.85%       0.33%
44       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256      50.0       32768          16    14.129760       88.722029      3.729722       0.055360          0.347608        0.014613      1.15%         7.22%       0.30%
45       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256      50.0       32768          64    14.243781       52.869107      4.027709       0.055806          0.207138        0.015780      1.16%         4.30%       0.33%
46       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256      50.0        2048          16    14.443400       88.256358      3.906987       0.056589          0.345784        0.015307      1.18%         7.18%       0.32%
47       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256      50.0        2048          64    14.354495       50.640041      3.902406       0.056240          0.198405        0.015289      1.17%         4.12%       0.32%
48       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None       NaN       32768          16    16.016656       74.964922     29.450214       4.555849         21.323356        8.376950      1.30%         6.10%       2.40%
49       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None       NaN       32768          64    16.521835       55.366944     31.086997       4.699544         15.748820        8.842524      1.34%         4.51%       2.53%
50       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None       NaN        2048          16    16.041921       75.104925     30.909968       4.563035         21.363179        8.792169      1.31%         6.11%       2.52%
51       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None       NaN        2048          64    16.573520       54.923551     31.002032       4.714246         15.622699        8.818356      1.35%         4.47%       2.52%
52       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None      50.0       32768          16    14.915512       56.668435     24.802148       4.242634         16.119022        7.054833      1.21%         4.61%       2.02%
53       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None      50.0       32768          64    15.264859       32.979310     24.338362       4.342004          9.380781        6.922912      1.24%         2.68%       1.98%
54       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None      50.0        2048          16    14.864890       56.297029     24.009118       4.228235         16.013377        6.829260      1.21%         4.58%       1.95%
55       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None      50.0        2048          64    15.230960       32.660342     24.796933       4.332362          9.290053        7.053350      1.24%         2.66%       2.02%
56       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256       NaN       32768          16    16.050377       71.909828     24.094790       3.735360         16.735378        5.607515      1.31%         5.85%       1.96%
57       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256       NaN       32768          64    16.455369       56.774638     28.377545       3.829613         13.213007        6.604229      1.34%         4.62%       2.31%
58       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256       NaN        2048          16    16.351483       74.447091     28.215340       3.805436         17.325868        6.566479      1.33%         6.06%       2.30%
59       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256       NaN        2048          64    16.495374       57.174268     27.470336       3.838923         13.306011        6.393096      1.34%         4.65%       2.24%
60       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256      50.0       32768          16    14.886600       56.920332     22.994935       3.464518         13.246914        5.351549      1.21%         4.63%       1.87%
61       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256      50.0       32768          64    15.387184       33.948479     22.431470       3.581017          7.900737        5.220415      1.25%         2.76%       1.83%
62       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256      50.0        2048          16    14.983548       56.879164     21.842301       3.487080         13.237333        5.083299      1.22%         4.63%       1.78%
63       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256      50.0        2048          64    15.331009       33.871386     23.486098       3.567944          7.882795        5.465855      1.25%         2.76%       1.91%
64       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None       NaN       32768          16     7.228500       43.071067     17.068882       1.223916          7.292711        2.890071      0.59%         3.51%       1.39%
65       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None       NaN       32768          64     7.332869       28.906938     16.190542       1.241587          4.894468        2.741352      0.60%         2.35%       1.32%
66       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None       NaN        2048          16     7.248958       43.396453     17.092304       1.227380          7.347805        2.894037      0.59%         3.53%       1.39%
67       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None       NaN        2048          64     7.389928       28.959287     17.049455       1.251249          4.903332        2.886781      0.60%         2.36%       1.39%
68       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None      50.0       32768          16     6.838423       29.016096     15.343271       1.157869          4.912950        2.597893      0.56%         2.36%       1.25%
69       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None      50.0       32768          64     6.877452       17.846567     14.576674       1.164477          3.021747        2.468095      0.56%         1.45%       1.19%
70       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None      50.0        2048          16     6.861739       28.460589     15.407799       1.161817          4.818893        2.608819      0.56%         2.32%       1.25%
71       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None      50.0        2048          64     6.782607       17.478573     14.413682       1.148418          2.959439        2.440497      0.55%         1.42%       1.17%
72       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256       NaN       32768          16     9.758730       47.511241      8.206680       1.618131          7.878013        1.360780      0.79%         3.87%       0.67%
73       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256       NaN       32768          64    10.092993       30.095656      7.537588       1.673556          4.990271        1.249835      0.82%         2.45%       0.61%
74       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256       NaN        2048          16     9.828252       46.936367      7.437026       1.629658          7.782691        1.233161      0.80%         3.82%       0.61%
75       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256       NaN        2048          64     9.931566       31.159327      7.067367       1.646789          5.166642        1.171866      0.81%         2.54%       0.58%
76       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256      50.0       32768          16     9.164967       35.469880      6.890507       1.519677          5.881391        1.142540      0.75%         2.89%       0.56%
77       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256      50.0       32768          64     9.312246       17.193930      7.219241       1.544098          2.850989        1.197049      0.76%         1.40%       0.59%
78       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256      50.0        2048          16     9.073667       35.680988      6.982656       1.504538          5.916395        1.157820      0.74%         2.90%       0.57%
79       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256      50.0        2048          64     9.345503       17.076389      7.045846       1.549612          2.831499        1.168298      0.76%         1.39%       0.57%
80       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None       NaN       32768          16    62.620205      177.624626     17.673487       0.495884          1.406593        0.139955      5.10%        14.46%       1.44%
81       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None       NaN       32768          64    62.411659      169.055720     16.832184       0.494232          1.338737        0.133293      5.08%        13.76%       1.37%
82       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None       NaN        2048          16    63.668500      200.949078     17.900031       0.504185          1.591298        0.141749      5.18%        16.35%       1.46%
83       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None       NaN        2048          64    62.756959      164.622185     16.907782       0.496967          1.303628        0.133891      5.11%        13.40%       1.38%
84       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None      50.0       32768          16    57.694515      172.253538     16.480471       0.456878          1.364060        0.130507      4.70%        14.02%       1.34%
85       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None      50.0       32768          64    58.924913      123.896448     17.088430       0.466621          0.981125        0.135322      4.80%        10.08%       1.39%
86       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None      50.0        2048          16    57.761520      158.469028     10.890332       0.457408          1.254902        0.086240      4.70%        12.90%       0.89%
87       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None      50.0        2048          64    57.697093      115.745368     10.792307       0.456898          0.916577        0.085463      4.70%         9.42%       0.88%
88       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256       NaN       32768          16    14.897268       88.214723      2.427232       0.114387          0.677347        0.018637      1.21%         7.18%       0.20%
89       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256       NaN       32768          64    14.988351       66.552684      2.406602       0.115086          0.511018        0.018479      1.22%         5.42%       0.20%
90       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256       NaN        2048          16    15.227050       88.718803      2.422489       0.116919          0.681218        0.018601      1.24%         7.22%       0.20%
91       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256       NaN        2048          64    15.037432       66.579867      2.418841       0.115463          0.511226        0.018573      1.22%         5.42%       0.20%
92       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256      50.0       32768          16    14.743674       66.757088      2.221552       0.113208          0.512587        0.017058      1.20%         5.43%       0.18%
93       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256      50.0       32768          64    14.860602       49.603166      2.207929       0.114106          0.380873        0.016953      1.21%         4.04%       0.18%
94       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256      50.0        2048          16    15.097315       67.266683      2.224925       0.115923          0.516500        0.017084      1.23%         5.47%       0.18%
95       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256      50.0        2048          64    14.853154       49.671174      2.206532       0.114048          0.381395        0.016943      1.21%         4.04%       0.18%
```


</p>
</details> 

<details><summary>With TILE_SIZE=16</summary>
<p>


```
    q_heads  k_heads  head_size           dtype qdtype                                                                           seq_lens sliding_window  soft_cap  num_blocks  block_size  triton-GB/s  triton-td-GB/s  pytorch-GB/s  triton-TFlops  triton-td-TFlops  pytorch-TFlops triton-eff triton-td-eff pytorch-eff
0        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None       NaN       32768          16    16.086928       81.926828     22.107677       4.118254         20.973268        5.659565      1.31%         6.67%       1.80%
1        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None       NaN       32768          64    16.751413       83.570520     25.626360       4.288362         21.394053        6.560348      1.36%         6.80%       2.09%
2        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None       NaN        2048          16    15.975298       81.824537     23.890928       4.089676         20.947082        6.116078      1.30%         6.66%       1.94%
3        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None       NaN        2048          64    16.868405       84.504429     24.938860       4.318312         21.633134        6.384348      1.37%         6.88%       2.03%
4        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None      50.0       32768          16    14.895447       58.776679     18.407783       3.813235         15.046830        4.712393      1.21%         4.78%       1.50%
5        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None      50.0       32768          64    15.284770       60.335114     19.914511       3.912901         15.445789        5.098115      1.24%         4.91%       1.62%
6        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None      50.0        2048          16    14.956638       60.963723     20.224663       3.828899         15.606713        5.177514      1.22%         4.96%       1.65%
7        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None      50.0        2048          64    15.183726       60.095366     17.841987       3.887034         15.384414        4.567549      1.24%         4.89%       1.45%
8        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256       NaN       32768          16    15.743334       86.231580     21.334924       3.358578         18.396070        4.551451      1.28%         7.02%       1.74%
9        32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256       NaN       32768          64    16.238251       83.655562     21.503126       3.464160         17.846520        4.587333      1.32%         6.81%       1.75%
10       32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256       NaN        2048          16    15.935537       81.749691     19.489656       3.399581         17.439934        4.157793      1.30%         6.65%       1.59%
11       32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256       NaN        2048          64    16.360140       83.662977     20.599358       3.490163         17.848102        4.394530      1.33%         6.81%       1.68%
12       32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256      50.0       32768          16    14.567827       64.523345     17.447832       3.107803         13.764980        3.722204      1.19%         5.25%       1.42%
13       32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256      50.0       32768          64    14.856559       61.153343     17.088298       3.169399         13.046047        3.645504      1.21%         4.98%       1.39%
14       32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256      50.0        2048          16    14.719840       64.580745     19.109027       3.140233         13.777226        4.076592      1.20%         5.26%       1.56%
15       32        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256      50.0        2048          64    14.972053       63.851043     19.032529       3.194038         13.621556        4.060273      1.22%         5.20%       1.55%
16       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None       NaN       32768          16     6.066446       49.867856     15.362697       0.631644          5.192286        1.599578      0.49%         4.06%       1.25%
17       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None       NaN       32768          64     6.166603       51.325636     14.205886       0.642072          5.344072        1.479130      0.50%         4.18%       1.16%
18       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None       NaN        2048          16     6.033955       51.895920     13.687713       0.628261          5.403450        1.425177      0.49%         4.22%       1.11%
19       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None       NaN        2048          64     6.166840       50.682177     16.555120       0.642097          5.277074        1.723734      0.50%         4.12%       1.35%
20       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None      50.0       32768          16     5.770779       31.882512     15.319646       0.600859          3.319636        1.595095      0.47%         2.59%       1.25%
21       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None      50.0       32768          64     5.723542       33.308538     15.162481       0.595940          3.468115        1.578731      0.47%         2.71%       1.23%
22       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None      50.0        2048          16     5.738974       31.848739     15.526818       0.597547          3.316119        1.616666      0.47%         2.59%       1.26%
23       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None      50.0        2048          64     5.730224       33.084052     14.473433       0.596636          3.444741        1.506987      0.47%         2.69%       1.18%
24       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256       NaN       32768          16     8.490024       63.042581      6.273037       1.059111          7.864415        0.782547      0.69%         5.13%       0.51%
25       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256       NaN       32768          64     8.636923       61.142862      5.176849       1.077436          7.627429        0.645800      0.70%         4.98%       0.42%
26       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256       NaN        2048          16     8.362693       63.480880      6.717121       1.043226          7.919091        0.837945      0.68%         5.17%       0.55%
27       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256       NaN        2048          64     8.658764       60.921875      5.619520       1.080161          7.599862        0.701022      0.70%         4.96%       0.46%
28       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256      50.0       32768          16     7.922774       44.530786      4.558069       0.988348          5.555111        0.568608      0.64%         3.62%       0.37%
29       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256      50.0       32768          64     7.923060       45.844354      4.087710       0.988383          5.718976        0.509932      0.64%         3.73%       0.33%
30       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256      50.0        2048          16     7.966844       47.627904      4.798511       0.993845          5.941470        0.598603      0.65%         3.88%       0.39%
31       32        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256      50.0        2048          64     8.049664       46.654458      4.097072       1.004177          5.820035        0.511100      0.66%         3.80%       0.33%
32       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None       NaN       32768          16    60.248833      207.475189     18.242388       0.239768          0.825673        0.072598      4.90%        16.88%       1.48%
33       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None       NaN       32768          64    61.531094      196.540432     17.047106       0.244871          0.782157        0.067841      5.01%        15.99%       1.39%
34       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None       NaN        2048          16    62.890631      216.263833     17.219137       0.250281          0.860649        0.068526      5.12%        17.60%       1.40%
35       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None       NaN        2048          64    62.068388      203.891236     17.966494       0.247009          0.811411        0.071500      5.05%        16.59%       1.46%
36       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None      50.0       32768          16    57.556195      189.953300     18.018579       0.229052          0.755943        0.071707      4.68%        15.46%       1.47%
37       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None      50.0       32768          64    57.911128      186.999063     19.813402       0.230465          0.744186        0.078850      4.71%        15.22%       1.61%
38       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None      50.0        2048          16    57.820032      194.696378     20.277932       0.230102          0.774818        0.080699      4.71%        15.84%       1.65%
39       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None      50.0        2048          64    58.466419      191.708175     19.781567       0.232674          0.762927        0.078723      4.76%        15.60%       1.61%
40       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256       NaN       32768          16    15.447636      126.229947      4.291800       0.060523          0.494562        0.016815      1.26%        10.27%       0.35%
41       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256       NaN       32768          64    15.596953      122.175146      4.153807       0.061108          0.478676        0.016274      1.27%         9.94%       0.34%
42       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256       NaN        2048          16    15.762395      123.928628      4.394517       0.061756          0.485546        0.017217      1.28%        10.09%       0.36%
43       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256       NaN        2048          64    15.534767      122.128441      4.226423       0.060864          0.478493        0.016559      1.26%         9.94%       0.34%
44       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256      50.0       32768          16    14.322962       88.231979      4.245462       0.056117          0.345688        0.016634      1.17%         7.18%       0.35%
45       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256      50.0       32768          64    14.275603       86.254862      3.904909       0.055931          0.337942        0.015299      1.16%         7.02%       0.32%
46       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256      50.0        2048          16    14.368052       87.220318      3.819548       0.056293          0.341725        0.014965      1.17%         7.10%       0.31%
47       32        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256      50.0        2048          64    14.179300       81.878015      4.033252       0.055554          0.320794        0.015802      1.15%         6.66%       0.33%
48       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None       NaN       32768          16    15.951392       75.022130     31.215877       4.537285         21.339628        8.879183      1.30%         6.11%       2.54%
49       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None       NaN       32768          64    16.385213       74.394452     31.456163       4.660683         21.161088        8.947531      1.33%         6.05%       2.56%
50       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None       NaN        2048          16    16.245163       74.857096     31.258892       4.620846         21.292685        8.891418      1.32%         6.09%       2.54%
51       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None       NaN        2048          64    16.592482       74.504080     29.849140       4.719639         21.192272        8.490422      1.35%         6.06%       2.43%
52       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None      50.0       32768          16    14.699176       56.881572     24.923018       4.181099         16.179647        7.089214      1.20%         4.63%       2.03%
53       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None      50.0       32768          64    15.354268       57.461582     25.392618       4.367436         16.344628        7.222789      1.25%         4.68%       2.07%
54       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None      50.0        2048          16    14.874888       55.972926     24.802496       4.231079         15.921188        7.054932      1.21%         4.56%       2.02%
55       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]           None      50.0        2048          64    15.271183       57.452258     25.470289       4.343803         16.341976        7.244882      1.24%         4.68%       2.07%
56       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256       NaN       32768          16    16.138107       72.273294     27.750339       3.755778         16.819967        6.458261      1.31%         5.88%       2.26%
57       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256       NaN       32768          64    16.445983       73.042190     28.656261       3.827429         16.998910        6.669093      1.34%         5.94%       2.33%
58       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256       NaN        2048          16    16.321712       72.360951     28.600837       3.798507         16.840367        6.656195      1.33%         5.89%       2.33%
59       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256       NaN        2048          64    16.459438       73.097744     28.686195       3.830560         17.011839        6.676060      1.34%         5.95%       2.33%
60       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256      50.0       32768          16    14.887753       56.909100     23.463165       3.464786         13.244300        5.460518      1.21%         4.63%       1.91%
61       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256      50.0       32768          64    15.325578       57.373342     23.364151       3.566680         13.352341        5.437475      1.25%         4.67%       1.90%
62       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256      50.0        2048          16    14.916763       56.924077     23.343974       3.471537         13.247785        5.432779      1.21%         4.63%       1.90%
63       64        8        128  torch.bfloat16   None                                               [(320, 320), (320, 320), (320, 320)]            256      50.0        2048          64    15.357136       57.729405     23.092688       3.574024         13.435207        5.374298      1.25%         4.70%       1.88%
64       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None       NaN       32768          16     7.265515       45.373251     17.132146       1.230183          7.682513        2.900783      0.59%         3.69%       1.39%
65       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None       NaN       32768          64     7.408156       44.085178     17.214641       1.254335          7.464419        2.914750      0.60%         3.59%       1.40%
66       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None       NaN        2048          16     7.336324       43.934594     17.249773       1.242172          7.438922        2.920699      0.60%         3.58%       1.40%
67       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None       NaN        2048          64     7.344794       44.677731     17.125947       1.243607          7.564749        2.899733      0.60%         3.64%       1.39%
68       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None      50.0       32768          16     6.761447       28.314855     15.202139       1.144835          4.794218        2.573997      0.55%         2.30%       1.24%
69       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None      50.0       32768          64     6.820450       29.236902     14.148963       1.154826          4.950337        2.395676      0.56%         2.38%       1.15%
70       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None      50.0        2048          16     6.832421       29.161970     14.151163       1.156853          4.937650        2.396048      0.56%         2.37%       1.15%
71       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]           None      50.0        2048          64     6.906352       29.534629     15.164733       1.169370          5.000747        2.567664      0.56%         2.40%       1.23%
72       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256       NaN       32768          16     9.812457       48.072314      8.018873       1.627039          7.971046        1.329639      0.80%         3.91%       0.65%
73       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256       NaN       32768          64     9.969403       45.580317      7.439795       1.653063          7.557839        1.233620      0.81%         3.71%       0.61%
74       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256       NaN        2048          16     9.863532       45.561420      7.938080       1.635508          7.554706        1.316242      0.80%         3.71%       0.65%
75       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256       NaN        2048          64    10.064035       47.245733      8.214859       1.668755          7.833988        1.362136      0.82%         3.84%       0.67%
76       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256      50.0       32768          16     9.126661       35.565526      6.899302       1.513325          5.897250        1.143999      0.74%         2.89%       0.56%
77       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256      50.0       32768          64     9.338091       36.373745      7.466582       1.548383          6.031264        1.238061      0.76%         2.96%       0.61%
78       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256      50.0        2048          16     9.182067       35.427957      7.019074       1.522512          5.874439        1.163858      0.75%         2.88%       0.57%
79       64        8        128  torch.bfloat16   None                                                   [(1, 1328), (5, 18), (129, 463)]            256      50.0        2048          64     9.410314       36.385785      7.552608       1.560359          6.033260        1.252326      0.77%         2.96%       0.61%
80       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None       NaN       32768          16    61.261479      197.420928     17.954087       0.485124          1.563359        0.142177      4.99%        16.07%       1.46%
81       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None       NaN       32768          64    63.053793      195.599334     18.397268       0.499317          1.548934        0.145686      5.13%        15.92%       1.50%
82       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None       NaN        2048          16    63.929757      200.481724     16.335774       0.506254          1.587597        0.129362      5.20%        16.32%       1.33%
83       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None       NaN        2048          64    63.152334      177.210792     18.208930       0.500098          1.403316        0.144195      5.14%        14.42%       1.48%
84       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None      50.0       32768          16    57.270350      170.819974     16.639844       0.453519          1.352708        0.131769      4.66%        13.90%       1.35%
85       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None      50.0       32768          64    57.968671      175.526972     16.969912       0.459049          1.389982        0.134383      4.72%        14.28%       1.38%
86       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None      50.0        2048          16    58.287453      161.416455     17.475249       0.461573          1.278242        0.138385      4.74%        13.14%       1.42%
87       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]           None      50.0        2048          64    58.815031      176.485218     16.241392       0.465751          1.397571        0.128614      4.79%        14.36%       1.32%
88       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256       NaN       32768          16    15.528009       99.463578      3.826622       0.119230          0.763720        0.029382      1.26%         8.09%       0.31%
89       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256       NaN       32768          64    15.477883       92.625455      3.878493       0.118845          0.711215        0.029781      1.26%         7.54%       0.32%
90       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256       NaN        2048          16    15.776715       99.737413      3.915287       0.121140          0.765823        0.030063      1.28%         8.12%       0.32%
91       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256       NaN        2048          64    15.570277       96.949632      3.868644       0.119555          0.744417        0.029705      1.27%         7.89%       0.31%
92       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256      50.0       32768          16    15.309273       72.293038      3.488363       0.117551          0.555094        0.026785      1.25%         5.88%       0.28%
93       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256      50.0       32768          64    15.290606       74.540831      3.661537       0.117407          0.572354        0.028115      1.24%         6.07%       0.30%
94       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256      50.0        2048          16    15.491119       67.045364      3.653598       0.118947          0.514801        0.028054      1.26%         5.46%       0.30%
95       64        8        128  torch.bfloat16   None  [(1, 1513), (1, 245), (1, 102), (1, 123), (1, 3454), (1, 434), (1, 345), (1, 34)]            256      50.0        2048          64    15.348190       74.883232      3.410709       0.117849          0.574983        0.026189      1.25%         6.09%       0.28%

```

</p>
</details> 
