### PR TITLE
[CLN][BENCH] Fix `softmax.h: non-void function does not return a value in all control paths` warning

### DIFF
--- a/benchmarks/onednn_kernel/softmax/softmax.h
+++ b/benchmarks/onednn_kernel/softmax/softmax.h
@@ -80,6 +80,7 @@ dnnl::stream softmax_example(const int M, const int N, const int axis,
     std::cerr << "oneDNN error caught: " << std::endl
               << "\tStatus: " << dnnl_status2str(e.status) << std::endl
               << "\tMessage: " << e.what() << std::endl;
+    throw;
   }
 }
 #endif // TRITONBENCHMARK_ONEDNN_SOFTMAX_H

--- a/benchmarks/xetla_kernel/softmax/softmax.h
+++ b/benchmarks/xetla_kernel/softmax/softmax.h
@@ -99,6 +99,7 @@ sycl::event softmax_forward(void *input, void *output, sycl::queue &queue) {
     return e_softmax_fwd;
   } catch (cl::sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << '\n';
+    throw;
   }
 }
 


### PR DESCRIPTION
In case of an exception, the benchmarks are not expected to continue running - so we just show this to the compiler explicitly.