### PR TITLE
[TEST] Fix `block_load_helper.py`

### DIFF
--- a/python/test/unit/intel/block_load_helper.py
+++ b/python/test/unit/intel/block_load_helper.py
@@ -13,14 +13,14 @@ def run_load_ir(temp_file, elem_size, *args):
         tt.func @dyn_block(
             %iptr: i64, %base_width: i32, %base_height: i32, %base_pitch: i32,
             %x: i32, %y: i32) {{
-            %p0 = llvm.inttoptr %iptr : i64 to !llvm.ptr
+            %p0 = llvm.inttoptr %iptr : i64 to !llvm.ptr<1>
 
             %v = triton_gen.2Dblockload %p0, %base_width, %base_height,
                 %base_pitch, %x, %y
                 {{ elem_size_in_bits = {elem_size}, tile_width = 8, tile_height = 8,
                 v_blocks = 1, transpose = false,
                 vnni_transform = false, cache_control = Default }}
-                : (!llvm.ptr, i32, i32, i32, i32, i32)
+                : (!llvm.ptr<1>, i32, i32, i32, i32, i32)
                 -> vector<1x{out_type}>
 
             // To prevent gluon-inline from removing the unused 2Dblockload call.

--- a/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
@@ -489,13 +489,12 @@ llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_
 
 module attributes {"ttg.threads-per-warp" = 16 : i32} {
 llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
-  // CHECK:    %[[ELEM_BITS:.*]] = llvm.mlir.constant(16 : i32) : i32
-  // CHECK:    %[[TILE_WIDTH:.*]] = llvm.mlir.constant(8 : i32) : i32
-  // CHECK:    %[[TILE_HEIGHT:.*]] = llvm.mlir.constant(8 : i32) : i32
-  // CHECK:    %[[VBLOCKS:.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK:    %[[TRANSPOSE:.*]] = llvm.mlir.constant(false) : i1
-  // CHECK:    %[[VNNI:.*]] = llvm.mlir.constant(false) : i1
-  // CHECK:    llvm.call spir_funccc @llvm.genx.GenISA.LSC2DBlockRead.v4i16({{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[ELEM_BITS]], %[[TILE_WIDTH]], %[[TILE_HEIGHT]], %[[VBLOCKS]], %[[TRANSPOSE]], %[[VNNI]], {{.*}})
+  // CHECK:      llvm.mlir.constant(2 : i32) : i32
+  // CHECK:      [[ElemSize:%.*]] = llvm.mlir.constant(2 : i32) : i32
+  // CHECK-NEXT: [[TileWidth:%.*]] = llvm.mlir.constant(8 : i32) : i32
+  // CHECK-NEXT: [[TileHeight:%.*]] = llvm.mlir.constant(8 : i32) : i32
+  // CHECK-NEXT: [[VBlocks:%.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT: llvm.call spir_funccc @_Z32__spirv_Subgroup2DBlockLoadINTELiiiiPU3AS1viiiDv2_iPv([[ElemSize]], [[TileWidth]], [[TileHeight]], [[VBlocks]], {{.*}}, %arg2, %arg3, {{.*}}, [[DEST:%.*]]) {{.*}} : (i32, i32, i32, i32, !llvm.ptr<1>{{.*}}, i32, i32, i32, vector<2xi32>, !llvm.ptr{{.*}}) -> ()
   %0 = triton_gen.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=16, tile_width=8, tile_height=8, v_blocks=1, transpose=false, vnni_transform=false, cache_control=Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32) -> vector<4xi16>
   llvm.return
 }

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -148,11 +148,6 @@ static bool isSPVBuiltinAvailableImpl(TritonGEN::Matrix2DBlockLoadOp op) {
       op.getTileWidth() == 8 && op.getVBlocks() == 4 && !op.getVnniTransform())
     return false;
 
-  // intel_sub_group_2d_block_read_16b_8r8x1c
-  if (op.getElemSizeInBits() == 16 && op.getTileHeight() == 8 &&
-      op.getTileWidth() == 8 && op.getVBlocks() == 1 && !op.getVnniTransform())
-    return false;
-
   // intel_sub_group_2d_block_read_transpose_32b_32r4x1c
   if (op.getElemSizeInBits() == 32 && op.getTileHeight() == 32 &&
       op.getTileWidth() == 4 && op.getVBlocks() == 1 && op.getTranspose())


### PR DESCRIPTION
Fix `error: 'llvm.call' op operand type mismatch for operand 4: '!llvm.ptr' != '!llvm.ptr<1>'`