### PR TITLE
Use `IntelGPUError` exception type in `extract_spill_size_from_zebin` (#6028)

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -80,8 +80,9 @@ def extract_spill_size_from_zebin(file):
         elf = ELFFile(f)
         zeinfo = elf.get_section_by_name(".ze_info")
         if zeinfo is None:
-            raise RuntimeError('Internal Triton ZEBIN codegen error:'
-                               'Section .ze_info not found in zebin')
+            from triton.runtime.errors import IntelGPUError
+            raise IntelGPUError('Internal Triton ZEBIN codegen error:'
+                                'Section .ze_info not found in zebin')
         text = zeinfo.data().decode('utf-8')
         match = SPILL_SIZE_RE.search(text)
         if match is not None:


### PR DESCRIPTION
(cherry picked from commit e2739bc8c43721ef45931e691c7b93558903b8c1)