### PR TITLE
Create SimplifySignedArithmetic pass

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -106,6 +106,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::intel::registerTritonIntelRemoveMasks();
   mlir::triton::intel::registerTritonIntelStrideVersioning();
   mlir::triton::intel::registerTritonIntelBlockPointerToTensorDesc();
+  mlir::triton::intel::registerTritonIntelSimplifySignedArithmetic();
   mlir::triton::intel::registerTritonIntelTensorDescToBlockPointer();
   mlir::triton::registerRelayoutTritonGPUPass();
   mlir::triton::gpu::registerAllocateSharedMemoryPass();

--- a/test/Triton/Intel/SimplifySignedArithmetic/simplify-signed-arithmetic.mlir
+++ b/test/Triton/Intel/SimplifySignedArithmetic/simplify-signed-arithmetic.mlir
@@ -1,0 +1,431 @@
+// RUN: triton-opt %s -split-input-file -triton-intel-simplify-signed-arithmetic | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Positive Tests - Should convert signed to unsigned
+//===----------------------------------------------------------------------===//
+
+// Test 1: get_program_id is non-negative, constant divisor is positive -> convert remsi to remui
+module {
+tt.func public @remsi_from_program_id() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c128 = arith.constant 128 : i32
+  %rem = arith.remsi %pid, %c128 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @remsi_from_program_id
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[C128:.*]] = arith.constant 128
+// CHECK: %[[REM:.*]] = arith.remui %[[PID]], %[[C128]]
+// CHECK: tt.return %[[REM]]
+}
+
+// -----
+
+// Test 2: make_range with start=0 is non-negative -> convert
+module {
+tt.func public @remsi_from_make_range() -> tensor<128xi32> {
+  %range = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+  %c64 = arith.constant dense<64> : tensor<128xi32>
+  %rem = arith.remsi %range, %c64 : tensor<128xi32>
+  tt.return %rem : tensor<128xi32>
+}
+// CHECK-LABEL: @remsi_from_make_range
+// CHECK: %[[RANGE:.*]] = tt.make_range
+// CHECK: %[[C64:.*]] = arith.constant dense<64>
+// CHECK: %[[REM:.*]] = arith.remui %[[RANGE]], %[[C64]]
+// CHECK: tt.return %[[REM]]
+}
+
+// -----
+
+// Test 3: Non-negative constant dividend -> convert
+module {
+tt.func public @remsi_from_constant() -> i32 {
+  %c100 = arith.constant 100 : i32
+  %c7 = arith.constant 7 : i32
+  %rem = arith.remsi %c100, %c7 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @remsi_from_constant
+// CHECK: %[[C100:.*]] = arith.constant 100
+// CHECK: %[[C7:.*]] = arith.constant 7
+// CHECK: %[[REM:.*]] = arith.remui %[[C100]], %[[C7]]
+// CHECK: tt.return %[[REM]]
+}
+
+// -----
+
+// Test 4: addi of two non-negative values -> convert
+module {
+tt.func public @remsi_from_addi() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c10 = arith.constant 10 : i32
+  %sum = arith.addi %pid, %c10 : i32
+  %c128 = arith.constant 128 : i32
+  %rem = arith.remsi %sum, %c128 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @remsi_from_addi
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[C10:.*]] = arith.constant 10
+// CHECK: %[[SUM:.*]] = arith.addi %[[PID]], %[[C10]]
+// CHECK: %[[C128:.*]] = arith.constant 128
+// CHECK: %[[REM:.*]] = arith.remui %[[SUM]], %[[C128]]
+// CHECK: tt.return %[[REM]]
+}
+
+// -----
+
+// Test 5: muli of two non-negative values -> convert
+module {
+tt.func public @remsi_from_muli() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c4 = arith.constant 4 : i32
+  %prod = arith.muli %pid, %c4 : i32
+  %c256 = arith.constant 256 : i32
+  %rem = arith.remsi %prod, %c256 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @remsi_from_muli
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[C4:.*]] = arith.constant 4
+// CHECK: %[[PROD:.*]] = arith.muli %[[PID]], %[[C4]]
+// CHECK: %[[C256:.*]] = arith.constant 256
+// CHECK: %[[REM:.*]] = arith.remui %[[PROD]], %[[C256]]
+// CHECK: tt.return %[[REM]]
+}
+
+// -----
+
+// Test 6: get_num_programs is non-negative -> convert
+module {
+tt.func public @remsi_from_num_programs() -> i32 {
+  %np = tt.get_num_programs x : i32
+  %c32 = arith.constant 32 : i32
+  %rem = arith.remsi %np, %c32 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @remsi_from_num_programs
+// CHECK: %[[NP:.*]] = tt.get_num_programs x
+// CHECK: %[[C32:.*]] = arith.constant 32
+// CHECK: %[[REM:.*]] = arith.remui %[[NP]], %[[C32]]
+// CHECK: tt.return %[[REM]]
+}
+
+// -----
+
+// Test 7: splat of non-negative scalar -> convert
+module {
+tt.func public @remsi_from_splat() -> tensor<128xi32> {
+  %pid = tt.get_program_id x : i32
+  %splat = tt.splat %pid : i32 -> tensor<128xi32>
+  %c64 = arith.constant dense<64> : tensor<128xi32>
+  %rem = arith.remsi %splat, %c64 : tensor<128xi32>
+  tt.return %rem : tensor<128xi32>
+}
+// CHECK-LABEL: @remsi_from_splat
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[SPLAT:.*]] = tt.splat %[[PID]]
+// CHECK: %[[C64:.*]] = arith.constant dense<64>
+// CHECK: %[[REM:.*]] = arith.remui %[[SPLAT]], %[[C64]]
+// CHECK: tt.return %[[REM]]
+}
+
+// -----
+
+// Test 8: expand_dims preserves non-negativity -> convert
+module {
+tt.func public @remsi_from_expand_dims() -> tensor<1x128xi32> {
+  %range = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+  %expanded = tt.expand_dims %range {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+  %c32 = arith.constant dense<32> : tensor<1x128xi32>
+  %rem = arith.remsi %expanded, %c32 : tensor<1x128xi32>
+  tt.return %rem : tensor<1x128xi32>
+}
+// CHECK-LABEL: @remsi_from_expand_dims
+// CHECK: %[[RANGE:.*]] = tt.make_range
+// CHECK: %[[EXPANDED:.*]] = tt.expand_dims %[[RANGE]]
+// CHECK: %[[C32:.*]] = arith.constant dense<32>
+// CHECK: %[[REM:.*]] = arith.remui %[[EXPANDED]], %[[C32]]
+// CHECK: tt.return %[[REM]]
+}
+
+// -----
+
+// Test 9: broadcast preserves non-negativity -> convert
+module {
+tt.func public @remsi_from_broadcast() -> tensor<64x128xi32> {
+  %range = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+  %expanded = tt.expand_dims %range {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+  %broadcast = tt.broadcast %expanded : tensor<1x128xi32> -> tensor<64x128xi32>
+  %c16 = arith.constant dense<16> : tensor<64x128xi32>
+  %rem = arith.remsi %broadcast, %c16 : tensor<64x128xi32>
+  tt.return %rem : tensor<64x128xi32>
+}
+// CHECK-LABEL: @remsi_from_broadcast
+// CHECK: %[[RANGE:.*]] = tt.make_range
+// CHECK: %[[EXPANDED:.*]] = tt.expand_dims %[[RANGE]]
+// CHECK: %[[BROADCAST:.*]] = tt.broadcast %[[EXPANDED]]
+// CHECK: %[[C16:.*]] = arith.constant dense<16>
+// CHECK: %[[REM:.*]] = arith.remui %[[BROADCAST]], %[[C16]]
+// CHECK: tt.return %[[REM]]
+}
+
+// -----
+
+// Test 10: andi with non-negative mask -> convert
+module {
+tt.func public @remsi_from_andi(%arg0: i32) -> i32 {
+  %c0x7FFF = arith.constant 32767 : i32
+  %masked = arith.andi %arg0, %c0x7FFF : i32
+  %c128 = arith.constant 128 : i32
+  %rem = arith.remsi %masked, %c128 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @remsi_from_andi
+// CHECK: %[[MASK:.*]] = arith.constant 32767
+// CHECK: %[[MASKED:.*]] = arith.andi %arg0, %[[MASK]]
+// CHECK: %[[C128:.*]] = arith.constant 128
+// CHECK: %[[REM:.*]] = arith.remui %[[MASKED]], %[[C128]]
+// CHECK: tt.return %[[REM]]
+}
+
+// -----
+
+// Test 11: Typical Triton indexing pattern - pid * BLOCK_SIZE + make_range
+module {
+tt.func public @typical_triton_indexing() -> tensor<128xi32> {
+  %pid = tt.get_program_id x : i32
+  %c128 = arith.constant 128 : i32
+  %offset = arith.muli %pid, %c128 : i32
+  %range = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+  %offset_splat = tt.splat %offset : i32 -> tensor<128xi32>
+  %idx = arith.addi %offset_splat, %range : tensor<128xi32>
+  %c256 = arith.constant dense<256> : tensor<128xi32>
+  %rem = arith.remsi %idx, %c256 : tensor<128xi32>
+  tt.return %rem : tensor<128xi32>
+}
+// CHECK-LABEL: @typical_triton_indexing
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[C128:.*]] = arith.constant 128
+// CHECK: %[[OFFSET:.*]] = arith.muli %[[PID]], %[[C128]]
+// CHECK: %[[RANGE:.*]] = tt.make_range
+// CHECK: %[[SPLAT:.*]] = tt.splat %[[OFFSET]]
+// CHECK: %[[IDX:.*]] = arith.addi %[[SPLAT]], %[[RANGE]]
+// CHECK: %[[C256:.*]] = arith.constant dense<256>
+// CHECK: %[[REM:.*]] = arith.remui %[[IDX]], %[[C256]]
+// CHECK: tt.return %[[REM]]
+}
+
+// -----
+
+// Test 12: divsi with non-negative dividend and positive divisor -> convert to divui
+module {
+tt.func public @divsi_from_program_id() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c128 = arith.constant 128 : i32
+  %div = arith.divsi %pid, %c128 : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @divsi_from_program_id
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[C128:.*]] = arith.constant 128
+// CHECK: %[[DIV:.*]] = arith.divui %[[PID]], %[[C128]]
+// CHECK: tt.return %[[DIV]]
+}
+
+// -----
+
+// Test 13: Chained divsi/remsi pattern (y1 = idx / 128, y1_rem = y1 % 64)
+module {
+tt.func public @chained_div_rem() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c128 = arith.constant 128 : i32
+  %c64 = arith.constant 64 : i32
+  %y1 = arith.divsi %pid, %c128 : i32
+  %y1_rem = arith.remsi %y1, %c64 : i32
+  tt.return %y1_rem : i32
+}
+// CHECK-LABEL: @chained_div_rem
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[C128:.*]] = arith.constant 128
+// CHECK: %[[C64:.*]] = arith.constant 64
+// CHECK: %[[Y1:.*]] = arith.divui %[[PID]], %[[C128]]
+// CHECK: %[[Y1_REM:.*]] = arith.remui %[[Y1]], %[[C64]]
+// CHECK: tt.return %[[Y1_REM]]
+}
+
+// -----
+
+// Test 14: divsi with tensor types
+module {
+tt.func public @divsi_tensor() -> tensor<128xi32> {
+  %range = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+  %c32 = arith.constant dense<32> : tensor<128xi32>
+  %div = arith.divsi %range, %c32 : tensor<128xi32>
+  tt.return %div : tensor<128xi32>
+}
+// CHECK-LABEL: @divsi_tensor
+// CHECK: %[[RANGE:.*]] = tt.make_range
+// CHECK: %[[C32:.*]] = arith.constant dense<32>
+// CHECK: %[[DIV:.*]] = arith.divui %[[RANGE]], %[[C32]]
+// CHECK: tt.return %[[DIV]]
+}
+
+// -----
+
+// Test 15: Multiple chained divsi operations
+module {
+tt.func public @multiple_chained_divsi() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c128 = arith.constant 128 : i32
+  %c8192 = arith.constant 8192 : i32
+  %y1 = arith.divsi %pid, %c128 : i32
+  %y5 = arith.divsi %pid, %c8192 : i32
+  %sum = arith.addi %y1, %y5 : i32
+  tt.return %sum : i32
+}
+// CHECK-LABEL: @multiple_chained_divsi
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[C128:.*]] = arith.constant 128
+// CHECK: %[[C8192:.*]] = arith.constant 8192
+// CHECK: %[[Y1:.*]] = arith.divui %[[PID]], %[[C128]]
+// CHECK: %[[Y5:.*]] = arith.divui %[[PID]], %[[C8192]]
+// CHECK: %[[SUM:.*]] = arith.addi %[[Y1]], %[[Y5]]
+// CHECK: tt.return %[[SUM]]
+}
+
+//===----------------------------------------------------------------------===//
+// Negative Tests - Should NOT convert
+//===----------------------------------------------------------------------===//
+
+// -----
+
+// Negative Test 1: Function argument (unknown sign) -> do NOT convert
+module {
+tt.func public @no_convert_unknown_arg(%arg0: i32) -> i32 {
+  %c128 = arith.constant 128 : i32
+  %rem = arith.remsi %arg0, %c128 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @no_convert_unknown_arg
+// CHECK: arith.remsi
+// CHECK-NOT: arith.remui
+}
+
+// -----
+
+// Negative Test 2: Negative constant dividend -> do NOT convert
+module {
+tt.func public @no_convert_negative_dividend() -> i32 {
+  %cn10 = arith.constant -10 : i32
+  %c7 = arith.constant 7 : i32
+  %rem = arith.remsi %cn10, %c7 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @no_convert_negative_dividend
+// CHECK: arith.remsi
+// CHECK-NOT: arith.remui
+}
+
+// -----
+
+// Negative Test 3: Zero divisor -> do NOT convert (not positive)
+module {
+tt.func public @no_convert_zero_divisor() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c0 = arith.constant 0 : i32
+  %rem = arith.remsi %pid, %c0 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @no_convert_zero_divisor
+// CHECK: arith.remsi
+// CHECK-NOT: arith.remui
+}
+
+// -----
+
+// Negative Test 4: Negative constant divisor -> do NOT convert
+module {
+tt.func public @no_convert_negative_divisor() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %cn128 = arith.constant -128 : i32
+  %rem = arith.remsi %pid, %cn128 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @no_convert_negative_divisor
+// CHECK: arith.remsi
+// CHECK-NOT: arith.remui
+}
+
+// -----
+
+// Negative Test 5: make_range with negative start -> do NOT convert
+module {
+tt.func public @no_convert_negative_range() -> tensor<128xi32> {
+  %range = tt.make_range {start = -64 : i32, end = 64 : i32} : tensor<128xi32>
+  %c32 = arith.constant dense<32> : tensor<128xi32>
+  %rem = arith.remsi %range, %c32 : tensor<128xi32>
+  tt.return %rem : tensor<128xi32>
+}
+// CHECK-LABEL: @no_convert_negative_range
+// CHECK: arith.remsi
+// CHECK-NOT: arith.remui
+}
+
+// -----
+
+// Negative Test 6: Non-constant divisor -> do NOT convert
+module {
+tt.func public @no_convert_non_constant_divisor(%arg0: i32) -> i32 {
+  %pid = tt.get_program_id x : i32
+  %rem = arith.remsi %pid, %arg0 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @no_convert_non_constant_divisor
+// CHECK: arith.remsi
+// CHECK-NOT: arith.remui
+}
+
+// -----
+
+// Negative Test 7: divsi with unknown dividend -> do NOT convert
+module {
+tt.func public @no_convert_divsi_unknown_arg(%arg0: i32) -> i32 {
+  %c128 = arith.constant 128 : i32
+  %div = arith.divsi %arg0, %c128 : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @no_convert_divsi_unknown_arg
+// CHECK: arith.divsi
+// CHECK-NOT: arith.divui
+}
+
+// -----
+
+// Negative Test 8: divsi with negative divisor -> do NOT convert
+module {
+tt.func public @no_convert_divsi_negative_divisor() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %cn128 = arith.constant -128 : i32
+  %div = arith.divsi %pid, %cn128 : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @no_convert_divsi_negative_divisor
+// CHECK: arith.divsi
+// CHECK-NOT: arith.divui
+}
+
+// -----
+
+// Negative Test 9: divsi with non-constant divisor -> do NOT convert
+module {
+tt.func public @no_convert_divsi_non_constant_divisor(%arg0: i32) -> i32 {
+  %pid = tt.get_program_id x : i32
+  %div = arith.divsi %pid, %arg0 : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @no_convert_divsi_non_constant_divisor
+// CHECK: arith.divsi
+// CHECK-NOT: arith.divui
+}

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -271,6 +271,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         intel.passes.ttir.add_fuse_reshape(pm)
         passes.common.add_canonicalizer(pm)
         passes.ttir.add_combine(pm)
+        intel.passes.ttir.add_simplify_signed_arithmetic(pm)
         passes.ttir.add_reorder_broadcast(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)

--- a/third_party/intel/include/Dialect/Triton/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/Triton/Transforms/Passes.td
@@ -158,4 +158,32 @@ def TritonIntelStrideVersioning
   ];
 }
 
+def TritonIntelSimplifySignedArithmetic
+    : Pass<"triton-intel-simplify-signed-arithmetic", "mlir::ModuleOp"> {
+  let summary = "Simplify signed arithmetic ops by converting to unsigned when operands are non-negative";
+
+  let description = [{
+    Converts signed arithmetic operations (remsi, divsi) to their unsigned
+    equivalents when operands are provably non-negative. This enables simpler
+    code generation (e.g., power-of-2 remainder becomes bitwise AND, division
+    becomes logical shift right).
+
+    Conversions:
+    - arith.remsi -> arith.remui (when dividend >= 0, divisor > 0)
+    - arith.divsi -> arith.divui (when dividend >= 0, divisor > 0)
+
+    Sources of non-negative values:
+    - tt.get_program_id (always [0, 2^31-1])
+    - tt.get_num_programs (always [1, 2^31])
+    - tt.make_range(start, end) with start >= 0
+    - Non-negative integer constants
+    - arith.addi/muli of non-negative operands
+    - arith.divsi/divui/remui with non-negative dividend and positive divisor
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::TritonDialect"
+  ];
+}
+
 #endif // TRITON_DIALECT_TRITON_INTEL_TRANSFORMS_PASSES

--- a/third_party/intel/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_triton_library(TritonIntelTransforms
   RemoveMasks.cpp
   StrideVersioning.cpp
   BlockPointerToTensorDesc.cpp
+  SimplifySignedArithmetic.cpp
   TensorDescToBlockPointer.cpp
 
   DEPENDS

--- a/third_party/intel/lib/Dialect/Triton/Transforms/SimplifySignedArithmetic.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/SimplifySignedArithmetic.cpp
@@ -1,0 +1,201 @@
+#include "intel/include/Dialect/Triton/Transforms/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Verifier.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "triton-intel-simplify-signed-arithmetic"
+
+using namespace mlir;
+namespace tt = mlir::triton;
+
+namespace mlir::triton::intel {
+#define GEN_PASS_DEF_TRITONINTELSIMPLIFYSIGNEDARITHMETIC
+#include "intel/include/Dialect/Triton/Transforms/Passes.h.inc"
+} // namespace mlir::triton::intel
+
+namespace {
+
+class SignedArithmeticSimplifier {
+public:
+  void run(ModuleOp moduleOp) {
+    SmallVector<arith::RemSIOp> remOpsToConvert;
+    SmallVector<arith::DivSIOp> divOpsToConvert;
+
+    // Collect divsi operations first (order matters for tracking)
+    moduleOp.walk([&](arith::DivSIOp divOp) {
+      if (!isCandidate(divOp))
+        return WalkResult::skip();
+
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Converting divsi to divui: " << divOp << "\n");
+      divOpsToConvert.push_back(divOp);
+      return WalkResult::advance();
+    });
+
+    // Collect remsi operations
+    moduleOp.walk([&](arith::RemSIOp remOp) {
+      if (!isCandidate(remOp))
+        return WalkResult::skip();
+
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Converting remsi to remui: " << remOp << "\n");
+      remOpsToConvert.push_back(remOp);
+      return WalkResult::advance();
+    });
+
+    // Convert divsi to divui
+    for (arith::DivSIOp divOp : divOpsToConvert) {
+      OpBuilder builder(divOp);
+      auto newOp = arith::DivUIOp::create(builder, divOp.getLoc(),
+                                          divOp.getLhs(), divOp.getRhs());
+      divOp.replaceAllUsesWith(newOp.getResult());
+      divOp.erase();
+    }
+
+    // Convert remsi to remui
+    for (arith::RemSIOp remOp : remOpsToConvert) {
+      OpBuilder builder(remOp);
+      auto newOp = arith::RemUIOp::create(builder, remOp.getLoc(),
+                                          remOp.getLhs(), remOp.getRhs());
+      remOp.replaceAllUsesWith(newOp.getResult());
+      remOp.erase();
+    }
+
+    LLVM_DEBUG(llvm::dbgs()
+               << "Converted " << divOpsToConvert.size() << " divsi and "
+               << remOpsToConvert.size() << " remsi operations\n");
+  }
+
+private:
+  /// Returns true if a signed div/rem operation can be converted to unsigned:
+  /// - dividend must be provably non-negative
+  /// - divisor must be a positive constant
+  template <typename OpTy, typename = std::enable_if_t<llvm::is_one_of<
+                               OpTy, arith::DivSIOp, arith::RemSIOp>::value>>
+  bool isCandidate(OpTy op) const {
+    return isNonNegative(op.getLhs()) && isPositiveConstant(op.getRhs());
+  }
+
+  /// Returns true if value is provably non-negative (>= 0).
+  bool isNonNegative(Value value) const {
+    Operation *defOp = value.getDefiningOp();
+    if (!defOp)
+      return false;
+
+    // tt.get_program_id always returns [0, 2^31-1]
+    if (isa<tt::GetProgramIdOp>(defOp))
+      return true;
+
+    // tt.get_num_programs returns [1, 2^31]
+    if (isa<tt::GetNumProgramsOp>(defOp))
+      return true;
+
+    // tt.make_range with non-negative start
+    // Note: getStart() returns uint32_t, use getStartAttr().getInt() for signed
+    if (auto makeRange = dyn_cast<tt::MakeRangeOp>(defOp))
+      return makeRange.getStartAttr().getInt() >= 0;
+
+    // Non-negative constant (scalar or tensor)
+    if (auto constOp = dyn_cast<arith::ConstantOp>(defOp)) {
+      if (auto intAttr = dyn_cast<IntegerAttr>(constOp.getValue()))
+        return intAttr.getValue().isNonNegative();
+      if (auto denseAttr = dyn_cast<DenseElementsAttr>(constOp.getValue())) {
+        if (denseAttr.getElementType().isSignlessInteger()) {
+          return llvm::all_of(denseAttr.getValues<APInt>(),
+                              [](const APInt &v) { return v.isNonNegative(); });
+        }
+      }
+    }
+
+    // arith.addi of two non-negative values (assumes no overflow)
+    if (auto addOp = dyn_cast<arith::AddIOp>(defOp))
+      return isNonNegative(addOp.getLhs()) && isNonNegative(addOp.getRhs());
+
+    // arith.muli of two non-negative values (assumes no overflow)
+    if (auto mulOp = dyn_cast<arith::MulIOp>(defOp))
+      return isNonNegative(mulOp.getLhs()) && isNonNegative(mulOp.getRhs());
+
+    // arith.remui/divui always produce non-negative results
+    if (isa<arith::RemUIOp, arith::DivUIOp>(defOp))
+      return true;
+
+    // arith.divsi/remsi with non-negative dividend and positive divisor
+    if (auto divOp = dyn_cast<arith::DivSIOp>(defOp))
+      return isNonNegative(divOp.getLhs()) &&
+             isPositiveConstant(divOp.getRhs());
+    if (auto remOp = dyn_cast<arith::RemSIOp>(defOp))
+      return isNonNegative(remOp.getLhs()) &&
+             isPositiveConstant(remOp.getRhs());
+
+    // arith.andi with non-negative constant mask
+    if (auto andOp = dyn_cast<arith::AndIOp>(defOp)) {
+      if (isNonNegativeConstant(andOp.getLhs()) ||
+          isNonNegativeConstant(andOp.getRhs()))
+        return true;
+    }
+
+    // tt.splat preserves non-negativity
+    if (auto splatOp = dyn_cast<tt::SplatOp>(defOp))
+      return isNonNegative(splatOp.getSrc());
+
+    // tt.expand_dims preserves non-negativity
+    if (auto expandOp = dyn_cast<tt::ExpandDimsOp>(defOp))
+      return isNonNegative(expandOp.getSrc());
+
+    // tt.broadcast preserves non-negativity
+    if (auto broadcastOp = dyn_cast<tt::BroadcastOp>(defOp))
+      return isNonNegative(broadcastOp.getSrc());
+
+    return false;
+  }
+
+  /// Returns true if value is a non-negative constant.
+  bool isNonNegativeConstant(Value value) const {
+    auto constOp = value.getDefiningOp<arith::ConstantOp>();
+    if (!constOp)
+      return false;
+    if (auto intAttr = dyn_cast<IntegerAttr>(constOp.getValue()))
+      return intAttr.getValue().isNonNegative();
+    return false;
+  }
+
+  /// Returns true if value is a positive constant (> 0).
+  bool isPositiveConstant(Value value) const {
+    Operation *defOp = value.getDefiningOp();
+    if (!defOp)
+      return false;
+
+    if (auto constOp = dyn_cast<arith::ConstantOp>(defOp)) {
+      if (auto intAttr = dyn_cast<IntegerAttr>(constOp.getValue()))
+        return intAttr.getValue().isStrictlyPositive();
+      if (auto denseAttr = dyn_cast<DenseElementsAttr>(constOp.getValue())) {
+        if (denseAttr.getElementType().isSignlessInteger()) {
+          return llvm::all_of(denseAttr.getValues<APInt>(), [](const APInt &v) {
+            return v.isStrictlyPositive();
+          });
+        }
+      }
+    }
+
+    // Splat of positive constant
+    if (auto splatOp = dyn_cast<tt::SplatOp>(defOp))
+      return isPositiveConstant(splatOp.getSrc());
+
+    return false;
+  }
+};
+
+struct TritonIntelSimplifySignedArithmetic
+    : tt::intel::impl::TritonIntelSimplifySignedArithmeticBase<
+          TritonIntelSimplifySignedArithmetic> {
+public:
+  void runOnOperation() final {
+    ModuleOp moduleOp = getOperation();
+    SignedArithmeticSimplifier simplifier;
+    simplifier.run(moduleOp);
+    assert(succeeded(verify(moduleOp)) && "Module verification failed");
+  }
+};
+
+} // namespace

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -67,6 +67,8 @@ void init_triton_intel_passes_ttir(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_stride_versioning",
                      intel::createTritonIntelStrideVersioning);
   ADD_PASS_WRAPPER_0("add_fuse_reshape", intel::createTritonIntelFuseReshape);
+  ADD_PASS_WRAPPER_0("add_simplify_signed_arithmetic",
+                     intel::createTritonIntelSimplifySignedArithmetic);
 }
 
 void init_triton_intel_passes_ttgpuir(py::module &&m) {


### PR DESCRIPTION
Create SimplifySignedArithmetic pass to produce unsigned operations when possible

Adding a pass to change remsi->remui and divsi->divui when the operands are non-negative. It'll help to produce simplier and more performant code for the case from https://github.com/intel/intel-xpu-backend-for-triton/issues/5761 because unsigned operations don't have extra checks that create a more complicated control flow. 

Note that this implementation currently assumes that there can be no overflow in arith.addi and arith.muli.
Also it probably makes sense to refactor in into usage of IntegerRangeAnalysis when it's ready.

Perf impact on a "new" version from https://github.com/intel/intel-xpu-backend-for-triton/issues/5761 (without forcing single layout) on my BMG machine is 8%: 282.17GB/s->304.85GB/s

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`. (TBD)

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
