### PR TITLE
Revert "Skip some tutorials for B60 (#6000)"

### DIFF
--- a/scripts/skiplist/xe2/tutorials.txt
+++ b/scripts/skiplist/xe2/tutorials.txt
@@ -1,3 +1,0 @@
-# [B60] Tutorials randomly UR_RESULT_ERROR_DEVICE_LOST https://github.com/intel/intel-xpu-backend-for-triton/issues/5999
-01-vector-add
-08-grouped-gemm


### PR DESCRIPTION
This reverts commit b6b0be334f31fae7bae913da3b3acb2dc44e0b72.

Let's recheck with agama 1222

B60: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/21955628373 (works)