### PR TITLE
Add DescriptorLoadOp and DescriptorStoreOp lowering in `LoadStoreOpToLLVM` pass

### DIFF
--- a/python/test/unit/intel/test_block_tdesc.py
+++ b/python/test/unit/intel/test_block_tdesc.py
@@ -1,0 +1,132 @@
+import pytest
+import torch
+import pathlib
+
+import triton
+from triton._internal_testing import is_xpu
+
+
+@pytest.fixture(autouse=True, params=[False, True], ids=["branch-io", "predicated-io"])
+def predicated_io(request, monkeypatch):
+    if request.param:
+        monkeypatch.setenv("TRITON_INTEL_PREDICATED_LOAD", "1")
+        monkeypatch.setenv("TRITON_INTEL_PREDICATED_STORE", "1")
+    yield
+
+
+@pytest.mark.parametrize("M, N",
+                         [[256, 64], [256, 32], [128, 32], [128, 16], [64, 64], [64, 32], [32, 32], [16, 64], [16, 16]])
+@pytest.mark.parametrize("dtype_str", ["float32", "float16", "int8"])
+@pytest.mark.skipif(not is_xpu(), reason="Tensor descriptor tests are specific to the XPU backend")
+def test_tdesc_load_store(M, N, dtype_str, device, tmp_path: pathlib.Path):
+    num_warps = 4
+    threads_per_warp = 32
+
+    ty = {"float32": "f32", "float16": "f16", "int8": "i8"}[dtype_str]
+
+    ir = f"""
+    #blocked = #ttg.blocked<{{sizePerThread = [1, 1], threadsPerWarp = [1, {threads_per_warp}], warpsPerCTA = [1, {num_warps}], order = [1, 0]}}>
+    module attributes {{ttg.target = "xpu", "ttg.num-warps" = {num_warps} : i32, "ttg.threads-per-warp" = {threads_per_warp} : i32}} {{
+        tt.func public @descriptor_load_store(%arg0: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}) {{
+            %stride_i64 = arith.constant {N} : i64
+            %c1_i64 = arith.constant 1 : i64
+            %cM_i32 = arith.constant {M} : i32
+            %cN_i32 = arith.constant {N} : i32
+            %c0_i32 = arith.constant 0 : i32
+
+            %src_desc = tt.make_tensor_descriptor %arg0, [%cM_i32, %cN_i32], [%stride_i64, %c1_i64]
+                        : !tt.ptr<{ty}>, !tt.tensordesc<tensor<{M}x{N}x{ty}, #blocked>>
+
+            %data = tt.descriptor_load %src_desc [%c0_i32, %c0_i32]
+                    : !tt.tensordesc<tensor<{M}x{N}x{ty}, #blocked>> -> tensor<{M}x{N}x{ty}, #blocked>
+
+            %dst_desc = tt.make_tensor_descriptor %arg1, [%cM_i32, %cN_i32], [%stride_i64, %c1_i64]
+                        : !tt.ptr<{ty}>, !tt.tensordesc<tensor<{M}x{N}x{ty}, #blocked>>
+
+            tt.descriptor_store %dst_desc [%c0_i32, %c0_i32], %data
+                                : !tt.tensordesc<tensor<{M}x{N}x{ty}, #blocked>>, tensor<{M}x{N}x{ty}, #blocked>
+
+            tt.return
+        }}
+    }}
+    """
+    torch.manual_seed(42)
+
+    torch_dtype = getattr(torch, dtype_str)
+    if torch_dtype.is_floating_point:
+        a = torch.randn((M, N), dtype=torch_dtype, device=device)
+    else:
+        a = torch.randint(low=-127, high=128, size=(M, N), dtype=torch_dtype, device=device)
+
+    x = torch.empty_like(a)
+
+    temp_file = tmp_path / "test_tdesc_load_store.ttgir"
+    temp_file.write_text(ir)
+    kernel = triton.compile(str(temp_file))
+
+    kernel[(1, 1, 1)](a, x)
+    assert torch.equal(a, x)
+
+
+@pytest.mark.parametrize("M, N",
+                         [[256, 64], [256, 32], [128, 32], [128, 16], [64, 64], [64, 32], [32, 32], [16, 64], [16, 16]])
+@pytest.mark.parametrize("dtype_str", ["float32", "float16", "int8"])
+@pytest.mark.skipif(not is_xpu(), reason="Tensor descriptor tests are specific to the XPU backend")
+def test_tdesc_load_zero_padding(M, N, dtype_str, device, tmp_path: pathlib.Path):
+    """Load a MxN block through a descriptor whose shape is (M-1)x(N-1).
+
+    The last row and last column are out of bounds and must be zero-padded.
+    Input is filled with ones so any zero in the output indicates padding.
+    """
+    num_warps = 4
+    threads_per_warp = 32
+
+    ty = {"float32": "f32", "float16": "f16", "int8": "i8"}[dtype_str]
+
+    ir = f"""
+    #blocked = #ttg.blocked<{{sizePerThread = [1, 1], threadsPerWarp = [1, {threads_per_warp}], warpsPerCTA = [1, {num_warps}], order = [1, 0]}}>
+    module attributes {{ttg.target = "xpu", "ttg.num-warps" = {num_warps} : i32, "ttg.threads-per-warp" = {threads_per_warp} : i32}} {{
+        tt.func public @descriptor_load_store_pad(%arg0: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}) {{
+            %stride_i64 = arith.constant {N} : i64
+            %c1_i64 = arith.constant 1 : i64
+            %cM_minus1 = arith.constant {M - 1} : i32
+            %cN_minus1 = arith.constant {N - 1} : i32
+            %cM_i32 = arith.constant {M} : i32
+            %cN_i32 = arith.constant {N} : i32
+            %c0_i32 = arith.constant 0 : i32
+
+            // Source descriptor with shape (M-1)x(N-1) — last row/col out of bounds
+            %src_desc = tt.make_tensor_descriptor %arg0, [%cM_minus1, %cN_minus1], [%stride_i64, %c1_i64]
+                        : !tt.ptr<{ty}>, !tt.tensordesc<tensor<{M}x{N}x{ty}, #blocked>>
+
+            %data = tt.descriptor_load %src_desc [%c0_i32, %c0_i32]
+                    : !tt.tensordesc<tensor<{M}x{N}x{ty}, #blocked>> -> tensor<{M}x{N}x{ty}, #blocked>
+
+            // Destination descriptor with full shape so we can store everything
+            %dst_desc = tt.make_tensor_descriptor %arg1, [%cM_i32, %cN_i32], [%stride_i64, %c1_i64]
+                        : !tt.ptr<{ty}>, !tt.tensordesc<tensor<{M}x{N}x{ty}, #blocked>>
+
+            tt.descriptor_store %dst_desc [%c0_i32, %c0_i32], %data
+                                : !tt.tensordesc<tensor<{M}x{N}x{ty}, #blocked>>, tensor<{M}x{N}x{ty}, #blocked>
+
+            tt.return
+        }}
+    }}
+    """
+
+    torch_dtype = getattr(torch, dtype_str)
+    a = torch.ones((M, N), dtype=torch_dtype, device=device)
+    x = torch.empty_like(a)
+
+    temp_file = tmp_path / "test_tdesc_load_zero_padding.ttgir"
+    temp_file.write_text(ir)
+    kernel = triton.compile(str(temp_file))
+
+    kernel[(1, 1, 1)](a, x)
+
+    # Build expected: ones everywhere except last row and last column are zero-padded
+    expected = torch.ones((M, N), dtype=torch_dtype, device=device)
+    expected[M - 1, :] = 0
+    expected[:, N - 1] = 0
+
+    assert torch.equal(x, expected)

--- a/test/TritonIntelGPU/descriptor_load_store_to_llvm.mlir
+++ b/test/TritonIntelGPU/descriptor_load_store_to_llvm.mlir
@@ -1,0 +1,266 @@
+// RUN: TRITON_INTEL_PREDICATED_LOAD=1 TRITON_INTEL_PREDICATED_STORE=1 triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s
+
+// Test that tt.descriptor_load and tt.descriptor_store are converted to LLVM
+// gather loads/stores when going through the Intel GPU to LLVM conversion.
+// This is the native tensor descriptor path (without rewrite-tensor-descriptor-to-pointer).
+// These tests mirror the tests in test/Triton/rewrite-tensor-descriptor-to-pointer.mlir
+// but verify the LLVM lowering path instead.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @load
+  tt.func public @load(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32) -> (tensor<4x4xf32, #blocked>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c4_i32, %c4_i32], [%c1_i64, %c4_i64] {order = array<i32: 0>} : <f32>, <tensor<4x4xf32>>
+
+    // Verify the tensor descriptor is constructed as an LLVM struct with:
+    //   [0]: shape0 (i64), [1]: shape1 (i64), [2]: stride0 (i64), [3]: stride1 (i64), [4]: base_ptr (ptr<1>)
+    // CHECK: %[[DESC:.*]] = llvm.insertvalue %{{.*}}, %{{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+
+    // Verify extraction of descriptor fields:
+    // CHECK-DAG: %[[SHAPE0:.*]] = llvm.extractvalue %[[DESC]][0] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[SHAPE1:.*]] = llvm.extractvalue %[[DESC]][1] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[STRIDE0:.*]] = llvm.extractvalue %[[DESC]][2] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[STRIDE1:.*]] = llvm.extractvalue %[[DESC]][3] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[BASE_PTR:.*]] = llvm.extractvalue %[[DESC]][4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+
+    // Verify pointer arithmetic uses the base pointer from the descriptor
+    // CHECK: llvm.getelementptr %[[BASE_PTR]][%{{.*}}] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, f32
+
+    // Verify boundary checking: index0 >= 0 AND index0 < shape0
+    // CHECK: %[[ZERO0:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[IDX0_GE_ZERO:.*]] = llvm.icmp "sge" %{{.*}}, %[[ZERO0]] : i32
+    // CHECK: %[[SHAPE0_I32:.*]] = llvm.trunc %[[SHAPE0]] : i64 to i32
+    // CHECK: %[[IDX0_LT_SHAPE0:.*]] = llvm.icmp "slt" %{{.*}}, %[[SHAPE0_I32]] : i32
+    // CHECK: %[[DIM0_INBOUNDS:.*]] = llvm.and %[[IDX0_LT_SHAPE0]], %{{.*}} : i1
+    // CHECK: %[[DIM0_PRED:.*]] = llvm.and %[[DIM0_INBOUNDS]], %[[IDX0_GE_ZERO]] : i1
+
+    // Verify boundary checking: index1 >= 0 AND index1 < shape1
+    // CHECK: %[[ZERO1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[IDX1_GE_ZERO:.*]] = llvm.icmp "sge" %{{.*}}, %[[ZERO1]] : i32
+    // CHECK: %[[SHAPE1_I32:.*]] = llvm.trunc %[[SHAPE1]] : i64 to i32
+    // CHECK: %[[IDX1_LT_SHAPE1:.*]] = llvm.icmp "slt" %{{.*}}, %[[SHAPE1_I32]] : i32
+
+    // CHECK: %[[DIM1_INBOUNDS:.*]] = llvm.and %[[IDX1_LT_SHAPE1]], %[[DIM0_PRED]] : i1
+    // CHECK: %[[PRED:.*]] = llvm.and %[[DIM1_INBOUNDS]], %[[IDX1_GE_ZERO]] : i1
+
+    // Verify predicated load: conditional branch based on bounds check
+    // If in-bounds, go to load block; otherwise skip with default value
+    // CHECK: llvm.cond_br %[[PRED]], ^[[BB_LOAD:bb[0-9]+]], ^[[BB_MERGE:bb[0-9]+]](%{{.*}} : i32)
+    // CHECK: ^[[BB_LOAD]]:
+    // CHECK: %[[LOADED:.*]] = llvm.load %{{.*}} : !llvm.ptr<1> -> i32
+    // CHECK: llvm.br ^[[BB_MERGE]](%[[LOADED]] : i32)
+    // CHECK: ^[[BB_MERGE]](%{{.*}}: i32):
+
+    // CHECK: llvm.return
+    %3 = tt.descriptor_load %0[%arg1, %arg2] : !tt.tensordesc<tensor<4x4xf32>> -> tensor<4x4xf32, #blocked>
+    tt.return %3 : tensor<4x4xf32, #blocked>
+  }
+}
+
+// -----
+
+// Test predicated load with ttig.support_predicated_io attribute.
+// When the module has this attribute, the lowering uses triton_gen.predicated_load
+// instead of branching.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_predicated_io"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @predicated_load
+  tt.func public @predicated_load(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32) -> (tensor<4x4xf32, #blocked>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c4_i32, %c4_i32], [%c1_i64, %c4_i64] {order = array<i32: 0>} : <f32>, <tensor<4x4xf32>>
+
+    // Verify the tensor descriptor is constructed as an LLVM struct with:
+    //   [0]: shape0 (i64), [1]: shape1 (i64), [2]: stride0 (i64), [3]: stride1 (i64), [4]: base_ptr (ptr<1>)
+    // CHECK: %[[DESC:.*]] = llvm.insertvalue %{{.*}}, %{{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+
+    // Verify extraction of descriptor fields:
+    // CHECK-DAG: %[[SHAPE0:.*]] = llvm.extractvalue %[[DESC]][0] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[SHAPE1:.*]] = llvm.extractvalue %[[DESC]][1] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[STRIDE0:.*]] = llvm.extractvalue %[[DESC]][2] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[STRIDE1:.*]] = llvm.extractvalue %[[DESC]][3] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[BASE_PTR:.*]] = llvm.extractvalue %[[DESC]][4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+
+    // Verify pointer arithmetic uses the base pointer from the descriptor
+    // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[BASE_PTR]][%{{.*}}] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, f32
+
+    // Verify boundary checking: index0 >= 0 AND index0 < shape0
+    // CHECK: %[[ZERO0:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[IDX0_GE_ZERO:.*]] = llvm.icmp "sge" %{{.*}}, %[[ZERO0]] : i32
+    // CHECK: %[[SHAPE0_I32:.*]] = llvm.trunc %[[SHAPE0]] : i64 to i32
+    // CHECK: %[[IDX0_LT_SHAPE0:.*]] = llvm.icmp "slt" %{{.*}}, %[[SHAPE0_I32]] : i32
+    // CHECK: %[[DIM0_INBOUNDS:.*]] = llvm.and %[[IDX0_LT_SHAPE0]], %{{.*}} : i1
+    // CHECK: %[[DIM0_PRED:.*]] = llvm.and %[[DIM0_INBOUNDS]], %[[IDX0_GE_ZERO]] : i1
+
+    // Verify boundary checking: index1 >= 0 AND index1 < shape1
+    // CHECK: %[[ZERO1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[IDX1_GE_ZERO:.*]] = llvm.icmp "sge" %{{.*}}, %[[ZERO1]] : i32
+    // CHECK: %[[SHAPE1_I32:.*]] = llvm.trunc %[[SHAPE1]] : i64 to i32
+    // CHECK: %[[IDX1_LT_SHAPE1:.*]] = llvm.icmp "slt" %{{.*}}, %[[SHAPE1_I32]] : i32
+
+    // CHECK: %[[DIM1_INBOUNDS:.*]] = llvm.and %[[IDX1_LT_SHAPE1]], %[[DIM0_PRED]] : i1
+    // CHECK: %[[PRED:.*]] = llvm.and %[[DIM1_INBOUNDS]], %[[IDX1_GE_ZERO]] : i1
+
+    // Verify predicated load: uses triton_gen.predicated_load intrinsic
+    // with bounds predicate instead of branching.
+    // The GEP-computed pointer is bitcast and passed to the predicated load.
+    // CHECK: %[[LOAD_PTR:.*]] = llvm.bitcast %[[GEP]] : !llvm.ptr<1> to !llvm.ptr<1>
+    // CHECK: triton_gen.predicated_load %[[LOAD_PTR]], %{{.*}}, %[[PRED]], %{{.*}} {cache_control = Default} : (!llvm.ptr<1>, i64, i1, i32) -> i32
+
+    // CHECK: llvm.return
+    %3 = tt.descriptor_load %0[%arg1, %arg2] : !tt.tensordesc<tensor<4x4xf32>> -> tensor<4x4xf32, #blocked>
+    tt.return %3 : tensor<4x4xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @store
+  tt.func public @store(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32, %arg3: tensor<4x4xf32, #blocked>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c4_i32, %c4_i32], [%c1_i64, %c4_i64] {order = array<i32: 0>} : <f32>, <tensor<4x4xf32>>
+    // Verify the tensor descriptor is constructed as an LLVM struct
+    // CHECK: %[[DESC:.*]] = llvm.insertvalue %{{.*}}, %{{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+
+    // Verify extraction of all descriptor fields
+    // CHECK-DAG: %[[SHAPE0:.*]] = llvm.extractvalue %[[DESC]][0] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[SHAPE1:.*]] = llvm.extractvalue %[[DESC]][1] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[STRIDE0:.*]] = llvm.extractvalue %[[DESC]][2] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[STRIDE1:.*]] = llvm.extractvalue %[[DESC]][3] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[BASE_PTR:.*]] = llvm.extractvalue %[[DESC]][4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+
+    // Verify pointer arithmetic uses the base pointer
+    // CHECK: llvm.getelementptr %[[BASE_PTR]][%{{.*}}] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, f32
+
+    // Verify boundary checking: index0 >= 0 AND index0 < shape0
+    // CHECK: %[[S_ZERO0:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[S_IDX0_GE_ZERO:.*]] = llvm.icmp "sge" %{{.*}}, %[[S_ZERO0]] : i32
+    // CHECK: %[[S_SHAPE0_I32:.*]] = llvm.trunc %[[SHAPE0]] : i64 to i32
+    // CHECK: %[[S_IDX0_LT_SHAPE0:.*]] = llvm.icmp "slt" %{{.*}}, %[[S_SHAPE0_I32]] : i32
+    // CHECK: %[[S_DIM0_INBOUNDS:.*]] = llvm.and %[[S_IDX0_LT_SHAPE0]], %{{.*}} : i1
+    // CHECK: %[[S_DIM0_PRED:.*]] = llvm.and %[[S_DIM0_INBOUNDS]], %[[S_IDX0_GE_ZERO]] : i1
+
+    // Verify boundary checking: index1 >= 0 AND index1 < shape1
+    // CHECK: %[[S_ZERO1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[S_IDX1_GE_ZERO:.*]] = llvm.icmp "sge" %{{.*}}, %[[S_ZERO1]] : i32
+    // CHECK: %[[S_SHAPE1_I32:.*]] = llvm.trunc %[[SHAPE1]] : i64 to i32
+    // CHECK: %[[S_IDX1_LT_SHAPE1:.*]] = llvm.icmp "slt" %{{.*}}, %[[S_SHAPE1_I32]] : i32
+
+    // CHECK: %[[S_DIM1_INBOUNDS:.*]] = llvm.and %[[S_IDX1_LT_SHAPE1]], %[[S_DIM0_PRED]] : i1
+    // CHECK: %[[S_PRED:.*]] = llvm.and %[[S_DIM1_INBOUNDS]], %[[S_IDX1_GE_ZERO]] : i1
+
+    // Verify the thread redundancy predicate is combined with boundary mask.
+    // The thread predicate (from redundant-thread elimination) is AND'd with
+    // the boundary mask (S_PRED) to form the final store predicate.
+    // Note: we match STORE_PRED directly anchored on S_PRED to skip over
+    // element 1's interleaved boundary checks.
+    // CHECK: %[[STORE_PRED:.*]] = llvm.and %{{.*}}, %[[S_PRED]] : i1
+
+    // Verify predicated store: conditional branch based on combined predicate
+    // (thread redundancy AND boundary mask)
+    // CHECK: llvm.cond_br %[[STORE_PRED]], ^[[BB_STORE:bb[0-9]+]], ^[[BB_MERGE:bb[0-9]+]]
+    // CHECK: ^[[BB_STORE]]:
+    // CHECK: llvm.store %{{.*}}, %{{.*}} : i32, !llvm.ptr<1>
+    // CHECK: llvm.br ^[[BB_MERGE]]
+    // CHECK: ^[[BB_MERGE]]:
+
+    // CHECK: llvm.return
+    tt.descriptor_store %0[%arg1, %arg2], %arg3 : !tt.tensordesc<tensor<4x4xf32>>, tensor<4x4xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Test predicated store with ttig.support_predicated_io attribute.
+// When the module has this attribute, the lowering uses triton_gen.predicated_store
+// instead of branching.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_predicated_io"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @predicated_store
+  tt.func public @predicated_store(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32, %arg3: tensor<4x4xf32, #blocked>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c4_i32, %c4_i32], [%c1_i64, %c4_i64] {order = array<i32: 0>} : <f32>, <tensor<4x4xf32>>
+    // Verify the tensor descriptor is constructed as an LLVM struct
+    // CHECK: %[[DESC:.*]] = llvm.insertvalue %{{.*}}, %{{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+
+    // Verify extraction of all descriptor fields
+    // CHECK-DAG: %[[SHAPE0:.*]] = llvm.extractvalue %[[DESC]][0] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[SHAPE1:.*]] = llvm.extractvalue %[[DESC]][1] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[STRIDE0:.*]] = llvm.extractvalue %[[DESC]][2] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[STRIDE1:.*]] = llvm.extractvalue %[[DESC]][3] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[BASE_PTR:.*]] = llvm.extractvalue %[[DESC]][4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+
+    // Verify pointer arithmetic uses the base pointer
+    // CHECK: %[[S_GEP:.*]] = llvm.getelementptr %[[BASE_PTR]][%{{.*}}] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, f32
+
+    // Verify boundary checking: index0 >= 0 AND index0 < shape0
+    // CHECK: %[[S_ZERO0:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[S_IDX0_GE_ZERO:.*]] = llvm.icmp "sge" %{{.*}}, %[[S_ZERO0]] : i32
+    // CHECK: %[[S_SHAPE0_I32:.*]] = llvm.trunc %[[SHAPE0]] : i64 to i32
+    // CHECK: %[[S_IDX0_LT_SHAPE0:.*]] = llvm.icmp "slt" %{{.*}}, %[[S_SHAPE0_I32]] : i32
+    // CHECK: %[[S_DIM0_INBOUNDS:.*]] = llvm.and %[[S_IDX0_LT_SHAPE0]], %{{.*}} : i1
+    // CHECK: %[[S_DIM0_PRED:.*]] = llvm.and %[[S_DIM0_INBOUNDS]], %[[S_IDX0_GE_ZERO]] : i1
+
+    // Verify boundary checking: index1 >= 0 AND index1 < shape1
+    // CHECK: %[[S_ZERO1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[S_IDX1_GE_ZERO:.*]] = llvm.icmp "sge" %{{.*}}, %[[S_ZERO1]] : i32
+    // CHECK: %[[S_SHAPE1_I32:.*]] = llvm.trunc %[[SHAPE1]] : i64 to i32
+    // CHECK: %[[S_IDX1_LT_SHAPE1:.*]] = llvm.icmp "slt" %{{.*}}, %[[S_SHAPE1_I32]] : i32
+
+    // CHECK: %[[S_DIM1_INBOUNDS:.*]] = llvm.and %[[S_IDX1_LT_SHAPE1]], %[[S_DIM0_PRED]] : i1
+    // CHECK: %[[S_PRED:.*]] = llvm.and %[[S_DIM1_INBOUNDS]], %[[S_IDX1_GE_ZERO]] : i1
+
+    // Verify the thread redundancy predicate is combined with boundary mask.
+    // The thread predicate (from redundant-thread elimination) is AND'd with
+    // the boundary mask (S_PRED) to form the final store predicate.
+    // Note: we match STORE_PRED directly anchored on S_PRED to skip over
+    // element 1's interleaved boundary checks.
+    // CHECK: %[[STORE_PRED:.*]] = llvm.and %{{.*}}, %[[S_PRED]] : i1
+
+    // Verify predicated store: uses triton_gen.predicated_store intrinsic
+    // with combined predicate (thread redundancy AND boundary mask).
+    // The GEP-computed pointer is bitcast and passed to the predicated store.
+    // CHECK: %[[STORE_PTR:.*]] = llvm.bitcast %[[S_GEP]] : !llvm.ptr<1> to !llvm.ptr<1>
+    // CHECK: triton_gen.predicated_store %[[STORE_PTR]], %{{.*}}, %{{.*}}, %[[STORE_PRED]] {cache_control = Default} : (!llvm.ptr<1>, i32, i64, i1)
+
+    // CHECK: llvm.return
+    tt.descriptor_store %0[%arg1, %arg2], %arg3 : !tt.tensordesc<tensor<4x4xf32>>, tensor<4x4xf32, #blocked>
+    tt.return
+  }
+}
+
+
+
+// -----
+
+// Test that tensor descriptor function arguments are properly converted to LLVM struct types.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @arg_attr
+  // Verify tensordesc argument is converted to LLVM struct type with the correct layout:
+  //   {shape0: i64, shape1: i64, stride0: i64, stride1: i64, base_ptr: ptr<1>}
+  // CHECK-SAME: %{{.*}}: !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+  // CHECK-SAME: %{{.*}}: i32
+  tt.func public @arg_attr(%arg0: !tt.tensordesc<tensor<4x4xf32>>, %arg1: i32 {tt.divisibility = 16 : i32}) {
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/CMakeLists.txt
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/CMakeLists.txt
@@ -13,6 +13,7 @@ add_triton_library(TritonIntelGPUToLLVM
     SPMDOpToLLVM.cpp
     SPIRVTargetInfo.cpp
     TargetInfo.cpp
+    TensorDescOpsToLLVM.cpp
     TensorPtrOpsToLLVM.cpp
     TritonGPUToLLVM.cpp
     TypeConverter.cpp

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -189,27 +189,14 @@ struct LoadStoreConversionBase {
   }
 
   std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
-  convertBlockPtrToTensorOfPtr(
-      Location loc, Value blockPointerStruct, RankedTensorType tensorType,
-      Type valueElemTy, ConversionPatternRewriter &rewriter,
-      ArrayRef<int32_t> boundaryCheck = {},
+  computeGatherScatterOperands(
+      Location loc, Value base, ArrayRef<Value> offsets, ArrayRef<Value> shapes,
+      ArrayRef<Value> strides, RankedTensorType tensorType, Type valueElemTy,
+      ConversionPatternRewriter &rewriter, ArrayRef<int32_t> boundaryCheck = {},
       std::optional<PaddingOption> padding = std::nullopt) const {
 
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     size_t rank = tensorType.getRank();
-    // The block pointer struct is expected to have the following layout:
-    //    Struct {
-    //      Value offset[rank];
-    //      Value shape[rank];
-    //      Value stride[rank];
-    //      Value base;
-    //    }
-    // All the values are decomposed by `unpackLLElements` into a vector.
-    // Defines the indices for the block pointer struct.
-    const unsigned blockOffset = 0, blockShape = 1 * rank,
-                   blockStride = 2 * rank, blockBase = 3 * rank;
-    const SmallVector<Value> &blockPtr =
-        unpackLLElements(loc, blockPointerStruct, rewriter);
     const unsigned numElems = getTotalElemsPerThread(tensorType);
 
     // Get the LLVM values for indices in block
@@ -237,28 +224,24 @@ struct LoadStoreConversionBase {
       SmallVector<Value> index = indices[i];
       SmallVector<Value> indicesInTensor(rank);
       for (unsigned j = 0; j < rank; ++j)
-        indicesInTensor[j] = b.add(index[j], blockPtr[blockOffset + j]);
+        indicesInTensor[j] = b.add(index[j], offsets[j]);
 
       // Get the LLVM values for pointers
       Value offset = linearize(
-          indicesInTensor,
-          {blockPtr.begin() + blockStride, blockPtr.begin() + blockBase},
-          b.i32_val(0),
+          indicesInTensor, strides, b.i32_val(0),
           [&](const Value &index, const Value &stride, const Value &off) {
             // off = off + index * stride
             return b.add(b.mul(index, b.trunc(i32_ty, stride)), off);
           });
 
       ptrElems[i] = b.gep(ptr_ty(rewriter.getContext(), 1 /*global*/),
-                          valueElemTy, blockPtr[blockBase], offset);
+                          valueElemTy, base, offset);
 
       if (boundaryProtect.size() > 0) {
         // Get the LLVM values for mask
         unsigned dim = 0;
         maskElems.push_back(linearize(
-            indicesInTensor,
-            {blockPtr.begin() + blockShape, blockPtr.begin() + blockStride},
-            b.int_val(1, 1),
+            indicesInTensor, shapes, b.int_val(1, 1),
             [&](const Value &index, const Value &shape, const Value &mask) {
               if (boundaryProtect.contains(dim++)) {
                 // mask = mask && (index < shape) && idx >= 0
@@ -324,6 +307,7 @@ struct LoadStoreConversionBase {
                    blockStride = 2 * rank, blockBase = 3 * rank;
     const SmallVector<Value> &blockPtr =
         unpackLLElements(loc, blockPointerStruct, rewriter);
+
     const unsigned numElems = getTotalElemsPerThread(tensorType);
 
     // Get the LLVM values for indices in block
@@ -379,10 +363,67 @@ struct LoadStoreConversionBase {
     return maskElems;
   }
 
+  /// Convenience overload that unpacks a block pointer struct and delegates
+  /// to computeGatherScatterOperands.
+  /// Block pointer struct layout:
+  ///   { offset[rank], shape[rank], stride[rank], base }
+  std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
+  convertBlockPtrToTensorOfPtr(
+      Location loc, Value blockPointerStruct, RankedTensorType tensorType,
+      Type valueElemTy, ConversionPatternRewriter &rewriter,
+      ArrayRef<int32_t> boundaryCheck = {},
+      std::optional<PaddingOption> padding = std::nullopt) const {
+
+    size_t rank = tensorType.getRank();
+    const unsigned blockOffset = 0, blockShape = 1 * rank,
+                   blockStride = 2 * rank, blockBase = 3 * rank;
+    const SmallVector<Value> &blockPtr =
+        unpackLLElements(loc, blockPointerStruct, rewriter);
+
+    Value base = blockPtr[blockBase];
+    ArrayRef<Value> offsets(&blockPtr[blockOffset], rank);
+    ArrayRef<Value> shapes(&blockPtr[blockShape], rank);
+    ArrayRef<Value> strides(&blockPtr[blockStride], rank);
+
+    return computeGatherScatterOperands(loc, base, offsets, shapes, strides,
+                                        tensorType, valueElemTy, rewriter,
+                                        boundaryCheck, padding);
+  }
+
+  /// Convenience overload that unpacks a tensor descriptor struct and
+  /// delegates to computeGatherScatterOperands.
+  /// TensorDescType struct layout:
+  ///   { shape[rank], stride[rank], base }
+  /// Offsets are provided externally via the indices operand of the
+  /// DescriptorLoadOp/DescriptorStoreOp (not stored in the struct).
+  std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
+  convertTensorDescriptorToTensorOfPtr(
+      Location loc, Value descriptorStruct, ValueRange indices,
+      RankedTensorType tensorType, Type valueElemTy,
+      ConversionPatternRewriter &rewriter, ArrayRef<int32_t> boundaryCheck = {},
+      std::optional<PaddingOption> padding = std::nullopt) const {
+
+    size_t rank = tensorType.getRank();
+    const unsigned descShape = 0, descStride = rank, descBase = 2 * rank;
+    const SmallVector<Value> &descElems =
+        unpackLLElements(loc, descriptorStruct, rewriter);
+
+    Value base = descElems[descBase];
+    SmallVector<Value> offsets(indices.begin(), indices.end());
+    ArrayRef<Value> shapes(&descElems[descShape], rank);
+    ArrayRef<Value> strides(&descElems[descStride], rank);
+
+    return computeGatherScatterOperands(loc, base, offsets, shapes, strides,
+                                        tensorType, valueElemTy, rewriter,
+                                        boundaryCheck, padding);
+  }
+
   // Ensure the operation doesn't have attributes that the IGC predicated
   // instruction cannot handle.
-  template <typename OpType, typename = std::enable_if_t<llvm::is_one_of<
-                                 OpType, LoadOp, StoreOp>::value>>
+  template <
+      typename OpType,
+      typename = std::enable_if_t<llvm::is_one_of<
+          OpType, LoadOp, StoreOp, DescriptorLoadOp, DescriptorStoreOp>::value>>
   bool canUsePredicatedInstructions(OpType op) const {
     if (!mlir::LLVM::intel::hasModuleAttr(
             op, TritonIntelGPUDialect::getSupportPredicatedIOAttrName()))
@@ -401,14 +442,18 @@ struct LoadStoreConversionBase {
       return canUsePredicatedLoad && !op.getIsVolatile();
     } else if constexpr (std::is_same_v<OpType, StoreOp>) {
       return !usePredicatedStore.has_value() || usePredicatedStore.value();
+    } else if constexpr (std::is_same_v<OpType, DescriptorLoadOp>) {
+      return canUsePredicatedLoad;
+    } else if constexpr (std::is_same_v<OpType, DescriptorStoreOp>) {
+      return !usePredicatedStore.has_value() || usePredicatedStore.value();
     }
 
     llvm_unreachable("unsupported operation type for predicated instruction");
   }
 
   // Convert Triton cache modifier to Intel GEN load cache control enum.
-  template <typename OpType,
-            typename = std::enable_if_t<std::is_same_v<OpType, LoadOp>>>
+  template <typename OpType, typename = std::enable_if_t<llvm::is_one_of<
+                                 OpType, LoadOp, DescriptorLoadOp>::value>>
   TritonGEN::LoadCacheControl tritonToIntelCacheModifier(OpType &op) const {
     CacheModifier cacheModifier = op.getCache();
 
@@ -2430,6 +2475,346 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
   }
 };
 
+struct DescriptorLoadOpConversion
+    : public ConvertOpToLLVMPattern<triton::DescriptorLoadOp>,
+      public LoadStoreConversionBase {
+  using ConvertOpToLLVMPattern<
+      triton::DescriptorLoadOp>::ConvertOpToLLVMPattern;
+
+  DescriptorLoadOpConversion(
+      LLVMTypeConverter &converter, const triton::intel::TargetInfo &targetInfo,
+      const triton::intel::ModuleAxisInfoAnalysis &axisAnalysisPass,
+      PatternBenefit benefit)
+      : ConvertOpToLLVMPattern<triton::DescriptorLoadOp>(converter, benefit),
+        LoadStoreConversionBase(targetInfo, axisAnalysisPass) {}
+
+  LogicalResult
+  matchAndRewrite(triton::DescriptorLoadOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op->getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto typeConverter = getTypeConverter();
+    MLIRContext *ctx = rewriter.getContext();
+
+    // Get the descriptor and indices
+    Value llDesc = adaptor.getDesc();
+    auto indices = adaptor.getIndices(); // These are the offsets (i32 values)
+
+    // Get result type information
+    auto resultType = cast<RankedTensorType>(op.getType());
+    Type valueElemTy = typeConverter->convertType(resultType.getElementType());
+    unsigned numElems = getTotalElemsPerThread(resultType);
+    size_t rank = resultType.getRank();
+
+    // Try to get the padding option from the defining MakeTensorDescOp.
+    // NOTE: This method only works when the descriptor is defined locally
+    // (i.e., not passed through block arguments, function arguments, or
+    // control flow). For descriptors that flow through control flow, we would
+    // need an analysis pass to propagate tensor descriptor information.
+    // TODO: Implement an analysis pass to propagate MakeTensorDescOp info
+    // through control flow for non-local descriptor definitions.
+    PaddingOption padding = PaddingOption::PAD_ZERO;
+    if (auto makeDescOp =
+            triton::intel::findDefiningOpOfType<triton::MakeTensorDescOp>(
+                op.getDesc())) {
+      padding = makeDescOp->getPadding();
+    }
+
+    // Boundary check all dimensions — tensor descriptors always encode shape
+    // bounds and don't have a user-facing boundaryCheck attribute.
+    SmallVector<int32_t> allDims(rank);
+    for (size_t i = 0; i < rank; ++i)
+      allDims[i] = static_cast<int32_t>(i);
+
+    // Reuse the shared gather/scatter operand computation.
+    SmallVector<Value> ptrElems, maskElems, otherElems;
+    std::tie(ptrElems, maskElems, otherElems) =
+        convertTensorDescriptorToTensorOfPtr(loc, llDesc, indices, resultType,
+                                             valueElemTy, rewriter, allDims,
+                                             padding);
+
+    // Determine vectorization
+    // NOTE: LoadOp uses getVectorSize(ptr) which relies on axis info analysis.
+    // DescriptorLoadOp doesn't have a ptr operand in the same way.
+    // For now, use vec=1 (scalar loads). This could be optimized later.
+    // TODO: Add axis info analysis support for DescriptorLoadOp to enable
+    // vectorization.
+    unsigned vec = 1;
+
+    // vectorized iteration through all pointer elements
+    const int valueElemNBits =
+        std::max(8u, valueElemTy.getIntOrFloatBitWidth());
+    const int numVecs = numElems / vec;
+
+    // Load redundantly in all dims except reg
+    llvm::MapVector<StringAttr, int> freeVarMasks =
+        getFreeVariableMasks(resultType);
+    uint32_t regMask = freeVarMasks[str_attr("register")];
+
+    SmallVector<Value> loadedVals;
+    for (size_t vecStart = 0; vecStart < numElems; vecStart += vec) {
+      if (unsigned canonicalVecStart = getCanonicalIndex(vecStart, regMask);
+          vecStart != canonicalVecStart) {
+        // For redundant registers, refer back to the canonical load
+        for (unsigned iVec = 0; iVec < vec; ++iVec)
+          loadedVals.push_back(loadedVals[canonicalVecStart + iVec]);
+        continue;
+      }
+
+      const size_t maxWordWidth = std::max<size_t>(32, valueElemNBits);
+      const size_t totalWidth = valueElemNBits * vec;
+      const size_t width = std::min(totalWidth, maxWordWidth);
+      const size_t nWords = std::max<size_t>(1, totalWidth / width);
+      assert((width / valueElemNBits) * nWords * numVecs == numElems);
+
+      // Get the predicate mask for this element (always present for
+      // DescriptorLoadOp since we always do boundary checking)
+      Value pred = maskElems[vecStart];
+
+      SmallVector<Type> retTys(nWords, IntegerType::get(ctx, width));
+      Type retTy = retTys.size() > 1
+                       ? vec_ty(IntegerType::get(ctx, width), nWords)
+                       : retTys[0];
+
+      // Build the "other" value for out-of-bounds (same pattern as LoadOp)
+      Value other_ = b.undef(retTy);
+      for (size_t ii = 0; ii < nWords; ++ii) {
+        size_t size = width / valueElemNBits;
+        VectorType vecTy = vec_ty(valueElemTy, size);
+        Value v = b.undef(vecTy);
+        for (size_t s = 0; s < size; ++s) {
+          Value falseVal = otherElems[vecStart + ii * size + s];
+          Value sVal = createIndexAttrConstant(
+              rewriter, loc, typeConverter->getIndexType(), s);
+          v = b.insert_element(vecTy, v, falseVal, sVal);
+        }
+        v = b.bitcast(v, IntegerType::get(ctx, width));
+        other_ = (nWords > 1)
+                     ? b.insert_element(retTy, other_, v,
+                                        createIndexAttrConstant(
+                                            rewriter, loc,
+                                            typeConverter->getIndexType(), ii))
+                     : v;
+      }
+      assert(other_ && "Expecting a valid value");
+
+      Value addrElem = b.bitcast(ptrElems[vecStart], ptr_ty(ctx, 1 /*global*/));
+      uint32_t alignment = nWords * width / 8;
+
+      auto createLoadWithAttrs = [&]() {
+        return SmallVector<Value>{b.load(retTy, addrElem, alignment,
+                                         /*isVolatile=*/false,
+                                         /*isNonTemporal=*/false)};
+      };
+
+      Value ret;
+      // NOTE: For DescriptorLoadOp, pred is always present since we always
+      // perform boundary checking for the gather fallback.
+      if (canUsePredicatedInstructions(op)) {
+        auto cacheModifier = tritonToIntelCacheModifier(op);
+        ret = TritonGEN::PredicatedLoadOp::create(
+            rewriter, loc, retTy, addrElem, b.i64_val(alignment), pred, other_,
+            cacheModifier);
+      } else {
+        Block &endBlock = LLVM::intel::createPredicatedBlock(
+            rewriter, loc, pred, SmallVector<Value, 1>{other_},
+            createLoadWithAttrs);
+        ret = *endBlock.args_begin();
+      }
+      assert(ret && "Expecting a valid value");
+
+      // Extract and store return values
+      SmallVector<Value> rets;
+      for (unsigned int ii = 0; ii < nWords; ++ii) {
+        Value curr = isa<VectorType>(retTy)
+                         ? b.extract_element(IntegerType::get(ctx, width), ret,
+                                             b.i32_val(ii))
+                         : ret;
+        unsigned numElem = width / valueElemNBits;
+        if (numElem == 1)
+          curr = b.bitcast(curr, valueElemTy);
+        else
+          curr = b.bitcast(curr, LLVM::getVectorType(valueElemTy, numElem));
+        rets.push_back(curr);
+      }
+
+      int tmp = width / valueElemNBits;
+      for (size_t ii = 0; ii < vec; ++ii) {
+        Value loaded = rets[ii / tmp];
+        if (isa<VectorType>(loaded.getType()))
+          loaded = b.extract_element(valueElemTy, loaded, b.i32_val(ii % tmp));
+        loadedVals.push_back(loaded);
+      }
+    } // end vec
+
+    Type llvmResultStructTy = typeConverter->convertType(op.getType());
+    Value resultStruct = packLLElements(loc, typeConverter, loadedVals,
+                                        rewriter, llvmResultStructTy);
+    rewriter.replaceOp(op, {resultStruct});
+    return success();
+  }
+};
+
+struct DescriptorStoreOpConversion
+    : public ConvertOpToLLVMPattern<triton::DescriptorStoreOp>,
+      public LoadStoreConversionBase {
+  using ConvertOpToLLVMPattern<
+      triton::DescriptorStoreOp>::ConvertOpToLLVMPattern;
+
+  DescriptorStoreOpConversion(
+      LLVMTypeConverter &converter, const triton::intel::TargetInfo &targetInfo,
+      const triton::intel::ModuleAxisInfoAnalysis &axisAnalysisPass,
+      PatternBenefit benefit)
+      : ConvertOpToLLVMPattern<triton::DescriptorStoreOp>(converter, benefit),
+        LoadStoreConversionBase(targetInfo, axisAnalysisPass) {}
+
+  LogicalResult
+  matchAndRewrite(triton::DescriptorStoreOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op->getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto *typeConverter = getTypeConverter();
+    MLIRContext *ctx = rewriter.getContext();
+
+    // Get the descriptor, value, and indices
+    Value llDesc = adaptor.getDesc();
+    Value llValue = adaptor.getSrc();
+    auto indices = adaptor.getIndices(); // These are the offsets (i32 values)
+
+    // Get value type information
+    auto valueTy = cast<RankedTensorType>(op.getSrc().getType());
+    Type valueElemTy = typeConverter->convertType(valueTy.getElementType());
+    unsigned numElems = getTotalElemsPerThread(valueTy);
+    size_t rank = valueTy.getRank();
+
+    // Boundary check all dimensions — tensor descriptors always encode shape
+    // bounds and don't have a user-facing boundaryCheck attribute.
+    SmallVector<int32_t> allDims(rank);
+    for (size_t i = 0; i < rank; ++i)
+      allDims[i] = static_cast<int32_t>(i);
+
+    // Reuse the shared gather/scatter operand computation.
+    SmallVector<Value> ptrElems, maskElems, dummyOther;
+    std::tie(ptrElems, maskElems, dummyOther) =
+        convertTensorDescriptorToTensorOfPtr(loc, llDesc, indices, valueTy,
+                                             valueElemTy, rewriter, allDims);
+
+    // Unpack the value elements
+    auto valueElems = unpackLLElements(loc, llValue, rewriter);
+    assert(ptrElems.size() == valueElems.size());
+
+    // NOTE: DescriptorStoreOp does not have a mask operand.
+    // Unlike StoreOp which has an optional mask.
+    // We use the redundant thread predicate for deduplication across
+    // warps/blocks.
+    auto freeVarMasks = getFreeVariableMasks(valueTy);
+    Value threadPred =
+        emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
+    uint32_t regMask = freeVarMasks[str_attr("register")];
+
+    // Determine vectorization
+    // NOTE: StoreOp uses getVectorSize(ptr) which relies on axis info analysis.
+    // DescriptorStoreOp doesn't have a ptr operand in the same way.
+    // For now, use vec=1 (scalar stores). This could be optimized later.
+    // TODO: Add axis info analysis support for DescriptorStoreOp to enable
+    // vectorization.
+    unsigned vec = 1;
+
+    const size_t dtsize =
+        std::max<int>(1, valueElemTy.getIntOrFloatBitWidth() / 8);
+    const size_t valueElemNBits = dtsize * 8;
+
+    unsigned elemsPerThread = numElems;
+    const int numVecs = elemsPerThread / vec;
+
+    for (size_t vecStart = 0; vecStart < elemsPerThread; vecStart += vec) {
+      if (!isCanonicalIndex(vecStart, regMask)) {
+        // Don't emit store ops for redundant elements within a thread
+        continue;
+      }
+
+      const size_t maxWordWidth = std::max<size_t>(32, valueElemNBits);
+      const size_t totalWidth = valueElemNBits * vec;
+      const size_t width = std::min(totalWidth, maxWordWidth);
+      const size_t nWords = std::max<size_t>(1, totalWidth / width);
+      const size_t wordNElems = width / valueElemNBits;
+      assert(wordNElems * nWords * numVecs == elemsPerThread);
+
+      Type valArgTy = IntegerType::get(ctx, width);
+      auto wordTy = vec_ty(valueElemTy, wordNElems);
+
+      SmallVector<std::pair<Value, std::string>> asmArgs;
+      for (size_t wordIdx = 0; wordIdx < nWords; ++wordIdx) {
+        // llWord is a width-len composition
+        Value llWord = b.undef(wordTy);
+        // Insert each value element to the composition
+        for (size_t elemIdx = 0; elemIdx < wordNElems; ++elemIdx) {
+          const size_t elemOffset = vecStart + wordIdx * wordNElems + elemIdx;
+          assert(elemOffset < valueElems.size());
+          Value elem = valueElems[elemOffset];
+          if (elem.getType().isInteger(1))
+            elem = b.sext(i8_ty, elem);
+          elem = b.bitcast(elem, valueElemTy);
+
+          llWord = b.insert_element(wordTy, llWord, elem, b.i32_val(elemIdx));
+        }
+        llWord = b.bitcast(llWord, valArgTy);
+        std::string constraint =
+            (width == 64) ? "l" : ((width == 32) ? "r" : "c");
+        asmArgs.emplace_back(llWord, constraint);
+      }
+
+      // Combine the thread redundancy predicate with the per-element boundary
+      // mask (always present for DescriptorStoreOp since we check all dims).
+      Value maskVal = threadPred;
+      if (maskElems.size() > 0) {
+        auto mask = maskElems[vecStart];
+        maskVal = maybeAnd(rewriter, loc, threadPred, mask);
+      }
+
+      auto vecTy = vec_ty(valArgTy, nWords);
+      Value vecWord = b.undef(vecTy);
+      for (size_t index = 0; index < asmArgs.size(); ++index) {
+        auto llWord = asmArgs[index].first;
+        if (nWords == 1)
+          vecWord = llWord;
+        else
+          vecWord = b.insert_element(vecTy, vecWord, llWord, b.i32_val(index));
+      }
+
+      Value addrElem = b.bitcast(ptrElems[vecStart], ptr_ty(ctx, 1 /*global*/));
+      uint32_t alignment = nWords * width / 8;
+
+      // NOTE: DescriptorStoreOp does not have isVolatile or cache attributes.
+      // StoreOp has these and uses getNonTemporalFlag.
+      // For now, generate a simple store without non-temporal hints.
+      // TODO: Consider adding cache hint support if needed.
+      auto createStoreWithAttrs = [&]() {
+        bool isVolatile = false;
+        bool isNonTemporal = false;
+        b.store(vecWord, addrElem, alignment, isVolatile, isNonTemporal);
+        return ArrayRef<Value>();
+      };
+
+      if (!maskVal) {
+        (void)createStoreWithAttrs();
+      } else if (canUsePredicatedInstructions(op)) {
+        // DescriptorStoreOp does not have a cache attribute, so use DEFAULT.
+        auto cacheModifier = TritonGEN::StoreCacheControl::DEFAULT;
+        TritonGEN::PredicatedStoreOp::create(rewriter, loc, addrElem, vecWord,
+                                             b.i64_val(alignment), maskVal,
+                                             cacheModifier);
+      } else {
+        LLVM::intel::createPredicatedBlock(rewriter, loc, maskVal,
+                                           createStoreWithAttrs);
+      }
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct StoreOpToBlockIOConversion
     : public ConvertTritonGPUOpToLLVMPattern<triton::StoreOp>,
       public BlockIOConversionBase {
@@ -3324,7 +3709,8 @@ void mlir::triton::intel::populateLoadStoreOpToLLVMPatterns(
     const intel::ModuleAxisInfoAnalysis &axisInfoAnalysis,
     PatternBenefit benefit) {
   patterns.add<AtomicCASOpConversion, AtomicRMWOpConversion, LoadOpConversion,
-               StoreOpConversion, PrefetchOpConversion>(
+               DescriptorLoadOpConversion, StoreOpConversion,
+               DescriptorStoreOpConversion, PrefetchOpConversion>(
       typeConverter, targetInfo, axisInfoAnalysis, benefit);
   // BlockIO is more efficient than gather load or scatter store.
   patterns.add<LoadOpToBlockIOConversion, StoreOpToBlockIOConversion>(

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -66,6 +66,10 @@ void populateTensorPtrOpsToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                         RewritePatternSet &patterns,
                                         PatternBenefit benefit);
 
+void populateTensorDescOpsToLLVMPatterns(LLVMTypeConverter &typeConverter,
+                                         RewritePatternSet &patterns,
+                                         PatternBenefit benefit);
+
 /* Third party patterns end */
 
 } // namespace mlir::triton::intel

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PipelineManager.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PipelineManager.h
@@ -225,6 +225,8 @@ public:
                                                benefit);
 
     intel::populateTensorPtrOpsToLLVMPatterns(typeConverter, patterns, benefit);
+    intel::populateTensorDescOpsToLLVMPatterns(typeConverter, patterns,
+                                               benefit);
     intel::populateHistogramOpToLLVMPatterns(typeConverter, patterns,
                                              targetInfo, benefit);
     intel::populatePrintOpToLLVMPattern(typeConverter, patterns, targetInfo,

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TensorDescOpsToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TensorDescOpsToLLVM.cpp
@@ -1,0 +1,50 @@
+#include "PatternTritonGPUOpToLLVM.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace {
+struct MakeTensorDescOpConversion
+    : public ConvertTritonGPUOpToLLVMPattern<triton::MakeTensorDescOp> {
+  using ConvertTritonGPUOpToLLVMPattern<
+      triton::MakeTensorDescOp>::ConvertTritonGPUOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::MakeTensorDescOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // The converted TensorDescType struct layout is:
+    // struct { shape0, shape1, ..., stride0, stride1, ..., base_ptr }
+    auto loc = op.getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+    auto shapes = adaptor.getShape();
+    auto strides = adaptor.getStrides();
+    auto base = adaptor.getBase();
+    auto result = op.getResult();
+
+    SmallVector<Value> elems;
+
+    // Shapes: extend from i32 to i64
+    for (auto shape : shapes)
+      elems.push_back(b.sext(i64_ty, shape));
+
+    // Strides: already i64
+    for (auto stride : strides)
+      elems.push_back(stride);
+
+    // Base pointer
+    elems.push_back(base);
+
+    auto newValue = packLLElements(op.getLoc(), getTypeConverter(), elems,
+                                   rewriter, result.getType());
+    rewriter.replaceOp(op, newValue);
+    return success();
+  }
+};
+} // namespace
+
+void mlir::triton::intel::populateTensorDescOpsToLLVMPatterns(
+    LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    PatternBenefit benefit) {
+  patterns.add<MakeTensorDescOpConversion>(typeConverter, benefit);
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TypeConverter.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TypeConverter.cpp
@@ -32,11 +32,29 @@ static Type convertTritonPointerType(triton::PointerType type) {
   return LLVM::LLVMPointerType::get(ctx, type.getAddressSpace());
 }
 
+static Type convertTritonDescType(triton::TensorDescType type) {
+  auto ctx = type.getContext();
+  auto blockType = type.getBlockType();
+  // struct { shape0, shape1, ..., stride0, stride1, ..., base_ptr }
+  auto shape = blockType.getShape();
+  SmallVector<Type, 4> types;
+  // shapes, strides
+  for (size_t i = 0; i < 2 * shape.size(); ++i)
+    types.push_back(IntegerType::get(ctx, 64));
+  // base_ptr (global address space = 1 on Intel GPUs)
+  types.push_back(LLVM::LLVMPointerType::get(ctx, 1));
+
+  return LLVM::LLVMStructType::getLiteral(ctx, types);
+}
+
 TritonIntelGPUToLLVMTypeConverter::TritonIntelGPUToLLVMTypeConverter(
     MLIRContext *ctx, LowerToLLVMOptions &option,
     const TargetInfoBase &targetInfo, const DataLayoutAnalysis *analysis)
     : TritonGPUToLLVMTypeConverter(ctx, option, targetInfo, analysis) {
   addConversion([&](triton::PointerType type) -> std::optional<Type> {
     return convertTritonPointerType(type);
+  });
+  addConversion([&](triton::TensorDescType type) -> std::optional<Type> {
+    return convertTritonDescType(type);
   });
 }


### PR DESCRIPTION
Add load/store for DescriptorLoadOp and DescriptorStoreOp.

Lowering is for gather load/store only, and is analgous to the
existing LoadOp/StoreOp lowering, but adjusted for TensorDescriptor.

Some common pathways have been refactored, notably, the logic of
`convertBlockPtrToTensorOfPtr` to work with both block ptr input
and tensor descriptor input.

There are a couple spots that will need to be amended later on:

1. Right now, padding information is attached to the `MakeTensorDescOp` and does not propagate to the type or through function calls. We need to flow this information to the `DescriptorLoadOp` through function invocations (not sure if its worth an analysis pass or if there is a simpler way to accomplish this).

2. We need axis analysis for TensorDescriptor ops to perform the vectorization.