### PR TITLE
[NFI] Create Intel specific `RewriteTensorDescriptorToPointer` pass

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -108,6 +108,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::intel::registerTritonIntelBlockPointerToTensorDesc();
   mlir::triton::intel::registerTritonIntelSimplifySignedArithmetic();
   mlir::triton::intel::registerTritonIntelTensorDescToBlockPointer();
+  mlir::triton::intel::registerTritonRewriteTensorDescriptorToPointer();
   mlir::triton::registerRelayoutTritonGPUPass();
   mlir::triton::gpu::registerAllocateSharedMemoryPass();
   mlir::triton::gpu::registerTritonGPUAllocateWarpGroups();

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -276,7 +276,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         passes.ttir.add_loop_unroll(pm)
         # FIXME: move add_rewrite_tensor_descriptor_to_pointer back to be consistent with other backends.
         intel.passes.ttir.add_convert_tdesc_to_block_pointer(pm)
-        passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)
+        intel.passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)
         pm.run(mod, 'make_ttir')
         return mod
 

--- a/third_party/intel/include/Dialect/Triton/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/Triton/Transforms/Passes.td
@@ -11,6 +11,17 @@
 
 include "mlir/Pass/PassBase.td"
 
+def TritonRewriteTensorDescriptorToPointer : Pass</*cli-arg*/"triton-intel-rewrite-tensor-descriptor-to-pointer", /*Op*/"mlir::ModuleOp"> {
+  let summary = "Rewrite load/stores of tensor descriptors into pointer load/stores";
+  let description = [{
+    This pass rewrites all load/store semantics initiated by a `tt.make_tensor_descriptor` into pointer semantics. After
+    this pass, `tt.make_tensor_descriptor`  will disappear, and it generates logics to compute the pointer/mask/other
+    for each load/store.
+  }];
+
+  let dependentDialects = ["mlir::triton::TritonDialect"];
+}
+
 def TritonIntelBlockPointerToTensorDesc
     : Pass<"triton-intel-block-pointer-to-tdesc", "mlir::ModuleOp"> {
   let summary = "Convert block pointers into tensor descriptors";

--- a/third_party/intel/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -1,10 +1,11 @@
 add_triton_library(TritonIntelTransforms
+  BlockPointerToTensorDesc.cpp
   FuseReshape.cpp
   RemoveBoundaryChecks.cpp
   RemoveMasks.cpp
-  StrideVersioning.cpp
-  BlockPointerToTensorDesc.cpp
+  RewriteTensorDescriptorToPointer.cpp
   SimplifySignedArithmetic.cpp
+  StrideVersioning.cpp
   TensorDescToBlockPointer.cpp
 
   DEPENDS

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
@@ -1,0 +1,609 @@
+#include "intel/include/Dialect/Triton/Transforms/Passes.h"
+
+#include "triton/Dialect/Triton/Transforms/ArithTypeConversion.h"
+#include "triton/Dialect/Triton/Transforms/FunctionTypeConversion.h"
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Transforms/Patterns.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/ValueRange.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/SmallVectorExtras.h"
+#include "llvm/Support/LogicalResult.h"
+#include "llvm/Support/raw_ostream.h"
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/Transforms/FuncConversions.h>
+#include <mlir/IR/Builders.h>
+#include <mlir/IR/Value.h>
+#include <mlir/Pass/Pass.h>
+#include <mlir/Transforms/DialectConversion.h>
+
+#include <iterator>
+
+namespace mlir::triton::intel {
+
+#define GEN_PASS_DEF_TRITONREWRITETENSORDESCRIPTORTOPOINTER
+#include "intel/include/Dialect/Triton/Transforms/Passes.h.inc"
+
+namespace {
+
+bool hasATensorDescriptorType(mlir::TypeRange types) {
+  return llvm::any_of(types, [](mlir::Type t) {
+    return llvm::isa<mlir::triton::TensorDescType>(t);
+  });
+}
+
+using namespace mlir;
+
+/**
+ * @brief Filter out operand segment sizes from the list of attributes since
+ * this attribute is operation specific and shouldn't be set arbitrarily.
+ */
+mlir::SmallVector<NamedAttribute>
+filterSegmentSizes(mlir::ArrayRef<NamedAttribute> attrs) {
+  mlir::SmallVector<NamedAttribute> ret;
+  llvm::copy_if(attrs, std::back_inserter(ret), [](const NamedAttribute &attr) {
+    auto attrName = attr.getName().getValue();
+    return attrName != "operandSegmentSizes";
+  });
+  return ret;
+}
+
+struct Descriptor {
+  Value base;
+  ValueRange shape;
+  ValueRange strides;
+  Value paddingOption;
+  Value roundF32ToTF32;
+};
+
+Descriptor unpackDescriptor(TensorDescType type, ValueRange pack) {
+  int rank = type.getBlockType().getRank();
+  assert(pack.size() == 1 + 2 * static_cast<size_t>(rank) + 2 &&
+         "Expected tensor descriptors to consist of a pointer, "
+         "followed by 'rank' shape values and 'rank' stride values, "
+         "followed by padding and TF32 rounding option values.");
+
+  Descriptor res;
+  res.base = pack[0];
+  res.shape = pack.slice(1, rank);
+  res.strides = pack.slice(1 + rank, rank);
+  res.paddingOption = pack[1 + 2 * rank];
+  res.roundF32ToTF32 = pack[2 + 2 * rank];
+  return res;
+}
+
+Value expandOffsets(OpBuilder &builder, Location loc,
+                    ArrayRef<int64_t> blockShape, Value offsets, unsigned dim) {
+  Value expandedResult = offsets;
+  for (size_t j = 0; j < blockShape.size(); ++j) {
+    if (j == dim) {
+      continue;
+    }
+    expandedResult =
+        triton::ExpandDimsOp::create(builder, loc, expandedResult, j);
+  }
+
+  return expandedResult;
+}
+
+Value getExpandedOffsetWithRange(OpBuilder &builder, const Location &loc,
+                                 ArrayRef<std::int64_t> blockShape,
+                                 Value offset, unsigned dim) {
+  // Add range
+  auto indexI32RowType =
+      RankedTensorType::get({blockShape[dim]}, builder.getI32Type());
+  auto indexRowType =
+      RankedTensorType::get({blockShape[dim]}, builder.getI64Type());
+  Value splatOffset =
+      triton::SplatOp::create(builder, loc, indexRowType, offset);
+  Value range = triton::MakeRangeOp::create(builder, loc, indexI32RowType, 0,
+                                            blockShape[dim]);
+  Value i64Range = arith::ExtSIOp::create(builder, loc, indexRowType, range);
+
+  Value offsets = arith::AddIOp::create(builder, loc, splatOffset, i64Range);
+  return expandOffsets(builder, loc, blockShape, offsets, dim);
+}
+
+Value generatePtrFromOffsetRanges(OpBuilder &builder, Location loc,
+                                  ArrayRef<int64_t> blockShape,
+                                  Descriptor &desc, ValueRange offsets) {
+  assert(blockShape.size() == desc.shape.size());
+  assert(blockShape.size() == offsets.size());
+  auto indexTensorType =
+      RankedTensorType::get(blockShape, builder.getI64Type());
+  auto ptrType = cast<triton::PointerType>(desc.base.getType());
+  auto ptrTensorType = RankedTensorType::get(blockShape, ptrType);
+
+  // Generate offsets per dimension
+  Value ptr = triton::SplatOp::create(builder, loc, ptrTensorType, desc.base);
+  for (unsigned i = 0; i < blockShape.size(); ++i) {
+    // We must splat strides into the expanded shape not a row for retaining
+    // the divisibility information given by strides
+    Value splatStride = triton::SplatOp::create(
+        builder, loc, offsets[i].getType(), desc.strides[i]);
+    Value offsetWithStride =
+        arith::MulIOp::create(builder, loc, offsets[i], splatStride);
+    Value broadcasted = triton::BroadcastOp::create(
+        builder, loc, indexTensorType, offsetWithStride);
+
+    // Add to the pointer
+    ptr =
+        triton::AddPtrOp::create(builder, loc, ptrTensorType, ptr, broadcasted);
+  }
+
+  return ptr;
+}
+
+Value generatePtr(OpBuilder &builder, const Location &loc,
+                  ArrayRef<std::int64_t> blockShape, Descriptor &desc,
+                  ValueRange offsets) {
+  assert(blockShape.size() == desc.shape.size());
+  assert(blockShape.size() == offsets.size());
+  SmallVector<Value> offsetRanges;
+  for (unsigned i = 0; i < blockShape.size(); ++i) {
+    auto offsetWithRange =
+        getExpandedOffsetWithRange(builder, loc, blockShape, offsets[i], i);
+    offsetRanges.push_back(offsetWithRange);
+  }
+
+  return generatePtrFromOffsetRanges(builder, loc, blockShape, desc,
+                                     offsetRanges);
+}
+
+Value generateMaskFromOffsetRanges(OpBuilder &builder, const Location &loc,
+                                   ArrayRef<std::int64_t> blockShape,
+                                   Descriptor &desc, ValueRange offsetRanges) {
+  assert(blockShape.size() == desc.shape.size());
+  assert(blockShape.size() == offsetRanges.size());
+
+  // Generate mask per dimension
+  auto maskTensorType = RankedTensorType::get(blockShape, builder.getI1Type());
+  Value mask;
+  for (std::size_t i = 0; i < blockShape.size(); ++i) {
+    auto offsetWithRange = offsetRanges[i];
+
+    // Compare with lower bound
+    Value lowerBound = mlir::arith::ConstantIntOp::create(
+        builder, loc, builder.getI64Type(), 0);
+    Value splatLowerBound = triton::SplatOp::create(
+        builder, loc, offsetWithRange.getType(), lowerBound);
+    Value cmpLower =
+        arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::sge,
+                              offsetWithRange, splatLowerBound);
+
+    // Compare with upper bound
+    Value splatUpperBound = triton::SplatOp::create(
+        builder, loc, offsetWithRange.getType(), desc.shape[i]);
+    Value cmpUpper =
+        arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::slt,
+                              offsetWithRange, splatUpperBound);
+
+    // And and broadcast
+    Value andResult = arith::AndIOp::create(builder, loc, cmpLower, cmpUpper);
+    Value broadcasted =
+        triton::BroadcastOp::create(builder, loc, maskTensorType, andResult);
+
+    // And up all results
+    if (!mask) {
+      mask = broadcasted;
+    } else {
+      mask = arith::AndIOp::create(builder, loc, mask, broadcasted);
+    }
+  }
+
+  return mask;
+}
+
+Value generateMask(OpBuilder &builder, const Location &loc,
+                   ArrayRef<std::int64_t> blockShape, Descriptor &desc,
+                   ValueRange offsets) {
+  assert(blockShape.size() == desc.shape.size());
+  assert(blockShape.size() == offsets.size());
+  SmallVector<Value> offsetRanges;
+  for (unsigned i = 0; i < blockShape.size(); ++i) {
+    auto offsetWithRange =
+        getExpandedOffsetWithRange(builder, loc, blockShape, offsets[i], i);
+    offsetRanges.push_back(offsetWithRange);
+  }
+
+  return generateMaskFromOffsetRanges(builder, loc, blockShape, desc,
+                                      offsetRanges);
+}
+
+Value generateOther(OpBuilder &builder, Location loc, Type scalarTy,
+                    ArrayRef<int64_t> blockShape,
+                    Value paddingOption = nullptr) {
+  auto blockTy = RankedTensorType::get(blockShape, scalarTy);
+  if (paddingOption && mlir::isa<FloatType>(scalarTy)) {
+    auto floatTy = mlir::cast<FloatType>(scalarTy);
+    auto nan = llvm::APFloat::getNaN(floatTy.getFloatSemantics());
+    auto nanValue = arith::ConstantOp::create(
+        builder, loc,
+        SplatElementsAttr::get(blockTy, builder.getFloatAttr(floatTy, nan)));
+    auto zeroValue = arith::ConstantOp::create(
+        builder, loc,
+        SplatElementsAttr::get(blockTy, builder.getZeroAttr(floatTy)));
+    return mlir::arith::SelectOp::create(builder, loc, paddingOption, nanValue,
+                                         zeroValue);
+  } else {
+    auto attr = builder.getZeroAttr(blockTy);
+    return arith::ConstantOp::create(builder, loc, attr);
+  }
+}
+
+Value generateOther(OpBuilder &builder, Location loc, TensorDescType descTy,
+                    Value paddingOption = nullptr) {
+  auto blockTy = descTy.getSignlessBlockType();
+  return generateOther(builder, loc, blockTy.getElementType(),
+                       blockTy.getShape(), paddingOption);
+}
+
+Type getI32TypeLike(OpBuilder &builder, Type ty) {
+  if (auto shapedTy = dyn_cast<ShapedType>(ty))
+    return shapedTy.clone(builder.getI32Type());
+  return builder.getI32Type();
+}
+
+Value getI32ConstLike(OpBuilder &builder, Location loc, Type likeType,
+                      int32_t value) {
+  auto i32Ty = getI32TypeLike(builder, likeType);
+  if (auto shapedTy = dyn_cast<ShapedType>(i32Ty)) {
+    auto attr =
+        DenseElementsAttr::get(shapedTy, builder.getI32IntegerAttr(value));
+    return arith::ConstantOp::create(builder, loc, shapedTy, attr);
+  }
+  return arith::ConstantOp::create(builder, loc, i32Ty,
+                                   builder.getI32IntegerAttr(value));
+}
+
+Value roundF32ToTF32(OpBuilder &builder, Location loc, Value value) {
+  auto valueTy = value.getType();
+  auto i32Ty = getI32TypeLike(builder, valueTy);
+  auto bits = triton::BitcastOp::create(builder, loc, i32Ty, value);
+
+  auto expMask = getI32ConstLike(builder, loc, i32Ty, 0x7F800000);
+  auto exp = arith::AndIOp::create(builder, loc, bits, expMask);
+  auto isSpecial = arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::eq,
+                                         exp, expMask);
+
+  auto shift = getI32ConstLike(builder, loc, i32Ty, 13);
+  auto lsb = arith::AndIOp::create(
+      builder, loc, arith::ShRUIOp::create(builder, loc, bits, shift),
+      getI32ConstLike(builder, loc, i32Ty, 1));
+  auto roundBias = arith::AddIOp::create(
+      builder, loc, lsb, getI32ConstLike(builder, loc, i32Ty, 0x00000FFF));
+  auto rounded = arith::AndIOp::create(
+      builder, loc, arith::AddIOp::create(builder, loc, bits, roundBias),
+      getI32ConstLike(builder, loc, i32Ty, 0xFFFFE000));
+  auto outBits =
+      arith::SelectOp::create(builder, loc, isSpecial, bits, rounded);
+  return triton::BitcastOp::create(builder, loc, valueTy, outBits);
+}
+
+SmallVector<mlir::Value> castToI64(OpBuilder &builder,
+                                   mlir::ValueRange values) {
+  auto i64Type = builder.getI64Type();
+  return llvm::map_to_vector(values, [&](mlir::Value v) {
+    return builder.createOrFold<arith::ExtSIOp>(v.getLoc(), i64Type, v);
+  });
+}
+
+struct RewriteMakeTensorDesc : OpConversionPattern<triton::MakeTensorDescOp> {
+  using OpConversionPattern<triton::MakeTensorDescOp>::OpConversionPattern;
+
+  llvm::LogicalResult
+  matchAndRewrite(triton::MakeTensorDescOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<mlir::Value> ptrShapeStridesPaddingOption;
+    llvm::append_values(ptrShapeStridesPaddingOption, adaptor.getBase());
+    llvm::append_range(ptrShapeStridesPaddingOption,
+                       castToI64(rewriter, adaptor.getShape()));
+    llvm::append_range(ptrShapeStridesPaddingOption, adaptor.getStrides());
+    auto paddingOption = mlir::arith::ConstantOp::create(
+        rewriter, op.getLoc(), rewriter.getI1Type(),
+        rewriter.getBoolAttr(adaptor.getPadding() ==
+                             triton::PaddingOption::PAD_NAN));
+    llvm::append_values(ptrShapeStridesPaddingOption, paddingOption);
+    auto roundF32ToTF32 = mlir::arith::ConstantOp::create(
+        rewriter, op.getLoc(), rewriter.getI1Type(),
+        rewriter.getBoolAttr(false));
+    llvm::append_values(ptrShapeStridesPaddingOption, roundF32ToTF32);
+    rewriter.replaceOpWithMultiple(op, {ptrShapeStridesPaddingOption});
+    return mlir::success();
+  }
+};
+
+struct RewriteLoadPattern : OpConversionPattern<triton::DescriptorLoadOp> {
+  using OpConversionPattern<triton::DescriptorLoadOp>::OpConversionPattern;
+
+  llvm::LogicalResult
+  matchAndRewrite(triton::DescriptorLoadOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    const auto blockShape = op.getDesc().getType().getBlockType().getShape();
+    auto descTy = op.getDesc().getType();
+    auto desc = unpackDescriptor(descTy, adaptor.getDesc());
+    auto offsets = castToI64(rewriter, op.getIndices());
+    auto other = generateOther(rewriter, loc, descTy, desc.paddingOption);
+    auto newLoad = triton::LoadOp::create(
+        rewriter, loc, generatePtr(rewriter, loc, blockShape, desc, offsets),
+        generateMask(rewriter, loc, blockShape, desc, offsets), other,
+        triton::CacheModifier::NONE, triton::EvictionPolicy::NORMAL, false);
+    newLoad->setAttrs(filterSegmentSizes(op->getAttrs()));
+
+    Value result = newLoad.getResult();
+    if (descTy.getBlockType().getElementType().isF32()) {
+
+      auto ifOp = scf::IfOp::create(rewriter, loc, result.getType(),
+                                    desc.roundF32ToTF32, /*withElse=*/true);
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(ifOp.thenBlock());
+      auto rounded = roundF32ToTF32(rewriter, loc, result);
+      scf::YieldOp::create(rewriter, loc, rounded);
+
+      rewriter.setInsertionPointToStart(ifOp.elseBlock());
+      scf::YieldOp::create(rewriter, loc, result);
+      result = ifOp.getResult(0);
+    }
+
+    rewriter.replaceOp(op, result);
+    return llvm::success();
+  }
+};
+
+struct RewriteStorePattern : OpConversionPattern<triton::DescriptorStoreOp> {
+  using OpConversionPattern<triton::DescriptorStoreOp>::OpConversionPattern;
+
+  llvm::LogicalResult
+  matchAndRewrite(triton::DescriptorStoreOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto descTy = op.getDesc().getType();
+    const auto blockShape = descTy.getBlockType().getShape();
+    auto desc = unpackDescriptor(descTy, adaptor.getDesc());
+    auto offsets = castToI64(rewriter, op.getIndices());
+
+    auto newStore = rewriter.replaceOpWithNewOp<triton::StoreOp>(
+        op, generatePtr(rewriter, loc, blockShape, desc, offsets), op.getSrc(),
+        generateMask(rewriter, loc, blockShape, desc, offsets),
+        triton::CacheModifier::NONE, triton::EvictionPolicy::NORMAL);
+    newStore->setAttrs(filterSegmentSizes(op->getAttrs()));
+
+    return llvm::success();
+  }
+};
+
+std::pair<Value, Value>
+generateGatherScatterPtrMask(OpBuilder &builder, Location loc,
+                             ArrayRef<int64_t> blockShape, Descriptor &desc,
+                             Value xOffsets, Value yOffset) {
+  Value xOffsetRange =
+      expandOffsets(builder, loc, blockShape, xOffsets, /*dim=*/0);
+  yOffset = castToI64(builder, {yOffset})[0];
+  auto xOffsetI64Ty = RankedTensorType::get(
+      cast<RankedTensorType>(xOffsetRange.getType()).getShape(),
+      yOffset.getType());
+  xOffsetRange =
+      arith::ExtSIOp::create(builder, loc, xOffsetI64Ty, xOffsetRange);
+  auto yOffsetRange =
+      getExpandedOffsetWithRange(builder, loc, blockShape, yOffset, /*dim=*/1);
+  auto ptr = generatePtrFromOffsetRanges(builder, loc, blockShape, desc,
+                                         {xOffsetRange, yOffsetRange});
+  auto mask = generateMaskFromOffsetRanges(builder, loc, blockShape, desc,
+                                           {xOffsetRange, yOffsetRange});
+  return {ptr, mask};
+}
+
+struct RewriteGatherPattern : OpConversionPattern<triton::DescriptorGatherOp> {
+  using OpConversionPattern<triton::DescriptorGatherOp>::OpConversionPattern;
+
+  llvm::LogicalResult
+  matchAndRewrite(triton::DescriptorGatherOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto descTy = op.getDesc().getType();
+    const auto blockShape = op.getResult().getType().getShape();
+    auto desc = unpackDescriptor(descTy, adaptor.getDesc());
+    auto [ptr, mask] = generateGatherScatterPtrMask(
+        rewriter, loc, blockShape, desc, op.getXOffsets(), op.getYOffset());
+    auto other = generateOther(rewriter, loc,
+                               descTy.getSignlessBlockType().getElementType(),
+                               blockShape, desc.paddingOption);
+    auto newLoad = triton::LoadOp::create(
+        rewriter, loc, ptr, mask, other, triton::CacheModifier::NONE,
+        triton::EvictionPolicy::NORMAL, false);
+    newLoad->setAttrs(filterSegmentSizes(op->getAttrs()));
+
+    Value result = newLoad.getResult();
+    if (descTy.getSignlessBlockType().getElementType().isF32()) {
+      auto rounded = roundF32ToTF32(rewriter, loc, result);
+      result = arith::SelectOp::create(rewriter, loc, desc.roundF32ToTF32,
+                                       rounded, result);
+    }
+
+    rewriter.replaceOp(op, result);
+    return llvm::success();
+  }
+};
+
+struct RewriteScatterPattern
+    : OpConversionPattern<triton::DescriptorScatterOp> {
+  using OpConversionPattern<triton::DescriptorScatterOp>::OpConversionPattern;
+
+  llvm::LogicalResult
+  matchAndRewrite(triton::DescriptorScatterOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto descTy = op.getDesc().getType();
+    const auto blockShape = op.getSrc().getType().getShape();
+    auto desc = unpackDescriptor(descTy, adaptor.getDesc());
+    auto [ptr, mask] = generateGatherScatterPtrMask(
+        rewriter, loc, blockShape, desc, op.getXOffsets(), op.getYOffset());
+    auto newStore = rewriter.replaceOpWithNewOp<triton::StoreOp>(
+        op, ptr, op.getSrc(), mask, triton::CacheModifier::NONE,
+        triton::EvictionPolicy::NORMAL);
+    newStore->setAttrs(filterSegmentSizes(op->getAttrs()));
+
+    return llvm::success();
+  }
+};
+
+std::optional<RMWOp> translateReduceKind(DescriptorReduceKind kind,
+                                         TensorDescType ty) {
+  auto scalarTy = ty.getBlockType().getElementType();
+  switch (kind) {
+  case DescriptorReduceKind::ADD:
+    return scalarTy.isInteger() ? RMWOp::ADD : RMWOp::FADD;
+  case DescriptorReduceKind::MIN:
+    if (scalarTy.isUnsignedInteger()) {
+      return RMWOp::UMIN;
+    } else if (scalarTy.isSignedInteger()) {
+      return RMWOp::MIN;
+    }
+    return {};
+  case DescriptorReduceKind::MAX:
+    if (scalarTy.isUnsignedInteger()) {
+      return RMWOp::UMAX;
+    } else if (scalarTy.isSignedInteger()) {
+      return RMWOp::MAX;
+    }
+    return {};
+  case DescriptorReduceKind::AND:
+    return RMWOp::AND;
+  case DescriptorReduceKind::OR:
+    return RMWOp::OR;
+  case DescriptorReduceKind::XOR:
+    return RMWOp::XOR;
+  default:
+    break;
+  }
+  return {};
+}
+
+struct RewriteReducePattern : OpConversionPattern<triton::DescriptorReduceOp> {
+  using OpConversionPattern<triton::DescriptorReduceOp>::OpConversionPattern;
+
+  llvm::LogicalResult
+  matchAndRewrite(triton::DescriptorReduceOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto descTy = op.getDesc().getType();
+    const auto blockShape = descTy.getBlockType().getShape();
+    auto desc = unpackDescriptor(descTy, adaptor.getDesc());
+    auto offsets = castToI64(rewriter, op.getIndices());
+    auto rmwOp = translateReduceKind(op.getKind(), descTy);
+    if (!rmwOp) {
+      std::string msgstring;
+      llvm::raw_string_ostream msg(msgstring);
+      msg << "Cannot fallback on descriptor atomic op, unsupported for type "
+          << descTy.getBlockType().getElementType();
+      return op->emitError(msgstring);
+    }
+
+    triton::AtomicRMWOp::create(
+        rewriter, loc, descTy.getSignlessBlockType(), *rmwOp,
+        generatePtr(rewriter, loc, blockShape, desc, offsets), op.getSrc(),
+        generateMask(rewriter, loc, blockShape, desc, offsets),
+        MemSemantic::RELEASE, MemSyncScope::GPU);
+    op.erase();
+    return success();
+  }
+};
+
+/**
+ * @brief This implements the pass for converting triton tensor descriptor
+ * loads/stores into indexed loads/stores.
+ *
+ * The key idea is that each tensor descriptor can be broken down into multiple
+ * values. Suppose we have a tensor pointer with rank r, we can cast that tensor
+ * descriptor value to and from 1+2r values: a tensor pointer value and two i32
+ * value for each dimension representing the dynamic shape and strides.
+ *
+ * As in normal conversion patterns, individual operations can be converted
+ * using casted tensor descriptors and offsets and casting the results back to
+ * tensor pointers.
+ *
+ * We have special handling for TMA loads/stores and the make tensor descriptor
+ * op.
+ *
+ * @note Why use the conversion pattern rewriter? In most cases the defining
+ * operation of a tensor descriptor will be a make tensor descriptor op.
+ * However, this isn't always true - for example, if the tensor descriptor is a
+ * function argument or is in a conditional statement, we need better tracking
+ * of the pointer, shape, and strides.
+ */
+class TritonRewriteTensorDescriptorToPointerPass
+    : public triton::intel::impl::TritonRewriteTensorDescriptorToPointerBase<
+          TritonRewriteTensorDescriptorToPointerPass> {
+  void runOnOperation() override {
+    auto op = getOperation();
+
+    mlir::ConversionTarget target(getContext());
+    target.addDynamicallyLegalDialect<mlir::arith::ArithDialect,
+                                      mlir::scf::SCFDialect,
+                                      mlir::triton::TritonDialect>(
+        [](mlir::Operation *op) {
+          return !hasATensorDescriptorType(op->getOperandTypes()) &&
+                 !hasATensorDescriptorType(op->getResultTypes());
+        });
+    target.addDynamicallyLegalOp<triton::FuncOp>([](triton::FuncOp funcOp) {
+      return !hasATensorDescriptorType(funcOp.getFunctionType().getInputs()) &&
+             !hasATensorDescriptorType(funcOp.getFunctionType().getResults());
+    });
+
+    mlir::TypeConverter converter;
+
+    converter.addConversion([](mlir::Type t) {
+      // Most types don't require any conversion
+      return t;
+    });
+    converter.addConversion([](mlir::triton::TensorDescType t,
+                               llvm::SmallVectorImpl<mlir::Type> &out) {
+      // We convert a tensor descriptor into an pointer, and a shape and stride
+      // for each dimension, and padding option. i.e., we create 1+2*rank+1
+      // values. Note that tensor descriptors may be signed/unsigned integers
+      // whereas pointers should always be signless.
+      auto tensorType = t.getSignlessBlockType();
+      out.push_back(triton::getPointerType(tensorType.getElementType()));
+      out.insert(out.end(), 2 * tensorType.getRank(),
+                 mlir::IntegerType::get(t.getContext(), 64));
+      out.push_back(mlir::IntegerType::get(t.getContext(), 1));
+      out.push_back(mlir::IntegerType::get(t.getContext(), 1));
+      return mlir::success();
+    });
+
+    mlir::RewritePatternSet patterns(op->getContext());
+
+    // Populate conversion patterns to handle loops, function calls, and arith
+    // ops.
+    triton::populateFunctionTypeConversions(converter, patterns);
+    mlir::scf::populateSCFStructuralTypeConversions(converter, patterns);
+    triton::populateArithTypeConversions(converter, patterns);
+
+    patterns
+        .add<RewriteMakeTensorDesc, RewriteLoadPattern, RewriteStorePattern,
+             RewriteGatherPattern, RewriteScatterPattern, RewriteReducePattern>(
+            converter, &getContext());
+
+    ConversionConfig config;
+    config.buildMaterializations = false;
+
+    if (mlir::failed(mlir::applyPartialConversion(
+            op, target, std::move(patterns), config))) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::triton::intel

--- a/third_party/intel/python/test/rewrite-tensor-descriptor-to-pointer.mlir
+++ b/third_party/intel/python/test/rewrite-tensor-descriptor-to-pointer.mlir
@@ -1,0 +1,153 @@
+// RUN: triton-opt %s --triton-intel-rewrite-tensor-descriptor-to-pointer --canonicalize --cse --split-input-file | FileCheck %s --implicit-check-not \!tt.tensordesc
+
+module {
+  tt.func public @load(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32) -> (tensor<128x128xf32>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c256_i64 = arith.constant 256 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c256_i32 = arith.constant 256 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c256_i32, %c256_i32], [%c1_i64, %c256_i64] {order = array<i32: 0>} : <f32>, <tensor<128x128xf32>>
+    %3 = tt.descriptor_load %0[%arg1, %arg2] : !tt.tensordesc<tensor<128x128xf32>> -> tensor<128x128xf32>
+    tt.return %3 : tensor<128x128xf32>
+  }
+}
+
+// CHECK-LABEL: @load
+// CHECK-SAME: %[[ARG0:[^:]*]]
+// CHECK-SAME: %[[ARG1:[^:]*]]
+// CHECK-SAME: %[[ARG2:[^:]*]]
+// CHECK-DAG: %[[CST:.*]] = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+// CHECK-DAG: %[[CST0:.*]] = arith.constant dense<0> : tensor<1x128xi64>
+// CHECK-DAG: %[[CST1:.*]] = arith.constant dense<256> : tensor<128x1xi64>
+// CHECK-DAG: %[[CST2:.*]] = arith.constant dense<0> : tensor<128x1xi64>
+// CHECK-DAG: %[[CST3:.*]] = arith.constant dense<256> : tensor<1x128xi64>
+
+// CHECK-DAG: %[[VAL0:.*]] = arith.extsi %[[ARG1]] : i32 to i64
+// CHECK-DAG: %[[VAL1:.*]] = arith.extsi %[[ARG2]] : i32 to i64
+// CHECK-DAG: %[[VAL2:.*]] = tt.splat %[[ARG0]] :
+// CHECK-DAG: %[[VAL3:.*]] = tt.splat %[[VAL0]] :
+// CHECK-DAG: %[[VAL4:.*]] = tt.make_range {end = 128 : i32, start = 0 : i32}
+// CHECK-DAG: %[[VAL5:.*]] = arith.extsi %[[VAL4]] :
+// CHECK-DAG: %[[VAL6:.*]] = arith.addi %[[VAL3]], %[[VAL5]] :
+// CHECK-DAG: %[[VAL7:.*]] = tt.expand_dims %[[VAL6]] {axis = 1 : i32}
+// CHECK-DAG: %[[VAL8:.*]] = tt.broadcast %[[VAL7]] : tensor<128x1xi64> -> tensor<128x128xi64>
+// CHECK-DAG: %[[VAL9:.*]] = tt.addptr %[[VAL2]], %[[VAL8]] :
+// CHECK-DAG: %[[VAL10:.*]] = tt.splat %[[VAL1]] :
+// CHECK-DAG: %[[VAL11:.*]] = arith.addi %[[VAL10]], %[[VAL5]] :
+// CHECK-DAG: %[[VAL12:.*]] = tt.expand_dims %[[VAL11]] {axis = 0 : i32}
+// CHECK-DAG: %[[VAL13:.*]] = arith.muli %[[VAL12]], %[[CST3]] :
+// CHECK-DAG: %[[VAL14:.*]] = tt.broadcast %[[VAL13]] : tensor<1x128xi64> -> tensor<128x128xi64>
+// CHECK-DAG: %[[VAL15:.*]] = tt.addptr %[[VAL9]], %[[VAL14]] :
+
+// CHECK-DAG: %[[VAL16:.*]] = arith.cmpi sge, %[[VAL7]], %[[CST2]]
+// CHECK-DAG: %[[VAL17:.*]] = arith.cmpi slt, %[[VAL7]], %[[CST1]]
+// CHECK-DAG: %[[VAL18:.*]] = arith.andi %[[VAL16]], %[[VAL17]]
+// CHECK-DAG: %[[VAL19:.*]] = tt.broadcast %[[VAL18]] : tensor<128x1xi1> -> tensor<128x128xi1>
+// CHECK-DAG: %[[VAL20:.*]] = arith.cmpi sge, %[[VAL12]], %[[CST0]]
+// CHECK-DAG: %[[VAL21:.*]] = arith.cmpi slt, %[[VAL12]], %[[CST3]]
+// CHECK-DAG: %[[VAL22:.*]] = arith.andi %[[VAL20]], %[[VAL21]]
+// CHECK-DAG: %[[VAL23:.*]] = tt.broadcast %[[VAL22]] : tensor<1x128xi1> -> tensor<128x128xi1>
+// CHECK-DAG: %[[VAL24:.*]] = arith.andi %[[VAL19]], %[[VAL23]]
+
+// CHECK-DAG: %[[VAL25:.*]] = tt.load %[[VAL15]], %[[VAL24]], %[[CST]]
+// CHECK: tt.return %[[VAL25]] :
+
+// -----
+
+module {
+  tt.func public @store(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32, %arg3: tensor<128x128xf32>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c256_i64 = arith.constant 256 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c256_i32 = arith.constant 256 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c256_i32, %c256_i32], [%c1_i64, %c256_i64] {order = array<i32: 0>} : <f32>, <tensor<128x128xf32>>
+    tt.descriptor_store %0[%arg1, %arg2], %arg3 : !tt.tensordesc<tensor<128x128xf32>>, tensor<128x128xf32>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: @store
+// CHECK-SAME: %[[ARG0:[^:]*]]
+// CHECK-SAME: %[[ARG1:[^:]*]]
+// CHECK-SAME: %[[ARG2:[^:]*]]
+// CHECK-SAME: %[[ARG3:[^:]*]]
+// CHECK-DAG: %[[CST:.*]] = arith.constant dense<0> : tensor<1x128xi64>
+// CHECK-DAG: %[[CST0:.*]] = arith.constant dense<256> : tensor<128x1xi64>
+// CHECK-DAG: %[[CST1:.*]] = arith.constant dense<0> : tensor<128x1xi64>
+// CHECK-DAG: %[[CST2:.*]] = arith.constant dense<256> : tensor<1x128xi64>
+
+// CHECK-DAG: %[[VAL0:.*]] = arith.extsi %[[ARG1]] : i32 to i64
+// CHECK-DAG: %[[VAL1:.*]] = arith.extsi %[[ARG2]] : i32 to i64
+// CHECK-DAG: %[[VAL2:.*]] = tt.splat %[[ARG0]] :
+// CHECK-DAG: %[[VAL3:.*]] = tt.splat %[[VAL0]] :
+// CHECK-DAG: %[[VAL4:.*]] = tt.make_range {end = 128 : i32, start = 0 : i32}
+// CHECK-DAG: %[[VAL5:.*]] = arith.extsi %[[VAL4]] :
+// CHECK-DAG: %[[VAL6:.*]] = arith.addi %[[VAL3]], %[[VAL5]] :
+// CHECK-DAG: %[[VAL7:.*]] = tt.expand_dims %[[VAL6]] {axis = 1 : i32}
+// CHECK-DAG: %[[VAL8:.*]] = tt.broadcast %[[VAL7]] : tensor<128x1xi64> -> tensor<128x128xi64>
+// CHECK-DAG: %[[VAL9:.*]] = tt.addptr %[[VAL2]], %[[VAL8]] :
+// CHECK-DAG: %[[VAL10:.*]] = tt.splat %[[VAL1]] :
+// CHECK-DAG: %[[VAL11:.*]] = arith.addi %[[VAL10]], %[[VAL5]] :
+// CHECK-DAG: %[[VAL12:.*]] = tt.expand_dims %[[VAL11]] {axis = 0 : i32}
+// CHECK-DAG: %[[VAL13:.*]] = arith.muli %[[VAL12]], %[[CST2]] :
+// CHECK-DAG: %[[VAL14:.*]] = tt.broadcast %[[VAL13]] : tensor<1x128xi64> -> tensor<128x128xi64>
+// CHECK-DAG: %[[VAL15:.*]] = tt.addptr %[[VAL9]], %[[VAL14]] :
+
+// CHECK-DAG: %[[VAL16:.*]] = arith.cmpi sge, %[[VAL7]], %[[CST1]]
+// CHECK-DAG: %[[VAL17:.*]] = arith.cmpi slt, %[[VAL7]], %[[CST0]]
+// CHECK-DAG: %[[VAL18:.*]] = arith.andi %[[VAL16]], %[[VAL17]]
+// CHECK-DAG: %[[VAL19:.*]] = tt.broadcast %[[VAL18]] : tensor<128x1xi1> -> tensor<128x128xi1>
+// CHECK-DAG: %[[VAL20:.*]] = arith.cmpi sge, %[[VAL12]], %[[CST]]
+// CHECK-DAG: %[[VAL21:.*]] = arith.cmpi slt, %[[VAL12]], %[[CST2]]
+// CHECK-DAG: %[[VAL22:.*]] = arith.andi %[[VAL20]], %[[VAL21]]
+// CHECK-DAG: %[[VAL23:.*]] = tt.broadcast %[[VAL22]] : tensor<1x128xi1> -> tensor<128x128xi1>
+// CHECK-DAG: %[[VAL24:.*]] = arith.andi %[[VAL19]], %[[VAL23]]
+
+// CHECK: tt.store %[[VAL15]], %[[ARG3]], %[[VAL24]]
+
+// -----
+
+module {
+  tt.func public @callee(%tensordesc: !tt.tensordesc<tensor<128x128xf32>>) -> !tt.tensordesc<tensor<128x128xf32>> {
+    tt.return %tensordesc : !tt.tensordesc<tensor<128x128xf32>>
+  }
+
+  tt.func public @caller(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+    %c1_i64 = arith.constant 1 : i64
+    %c256_i32 = arith.constant 256 : i32
+    %c256_i64 = arith.constant 256 : i64
+    %0 = tt.make_tensor_descriptor %arg0, [%c256_i32, %c256_i32], [%c256_i64, %c1_i64] {order = array<i32: 0>} : <f32>, <tensor<128x128xf32>>
+    %1 = tt.call @callee(%0) : (!tt.tensordesc<tensor<128x128xf32>>) -> !tt.tensordesc<tensor<128x128xf32>>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: @callee
+// CHECK-SAME: %[[PTR:[^:]*]]
+// CHECK-SAME: %[[SHAPE0:[^:]*]]
+// CHECK-SAME: %[[SHAPE1:[^:]*]]
+// CHECK-SAME: %[[STRIDE0:[^:]*]]
+// CHECK-SAME: %[[STRIDE1:[^:]*]]
+// CHECK-SAME: %[[PAD:[^:]*]]
+// CHECK-SAME: %[[ROUND:[^:]*]]
+// CHECK-NEXT: tt.return %[[PTR]], %[[SHAPE0]], %[[SHAPE1]], %[[STRIDE0]], %[[STRIDE1]], %[[PAD]], %[[ROUND]]
+
+// CHECK-LABEL: @caller
+// CHECK-SAME: %[[PTR:[^:]*]]
+// CHECK-DAG: %[[c1:.*]] = arith.constant 1 : i64
+// CHECK-DAG: %[[c256:.*]] = arith.constant 256 : i64
+// CHECK: %{{.*}}:7 = tt.call @callee(%[[PTR]], %[[c256]], %[[c256]], %[[c256]], %[[c1]], %false, %false)
+// CHECK-SAME -> (!tt.ptr<f32>, i64, i64, i64, i64, i1, i1)
+
+// -----
+
+module {
+  tt.func public @arg_attr(%arg0: !tt.tensordesc<tensor<128x128xf32>>, %arg1: i32 {tt.divisibility = 16 : i32}) {
+    tt.return
+  }
+}
+
+// CHECK-LABEL: @arg_attr
+// CHECK-SAME: %arg7: i32 {tt.divisibility = 16 : i32}) {

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -61,6 +61,8 @@ void init_triton_intel_passes_ttir(py::module &&m) {
                      intel::createTritonIntelBlockPointerToTensorDesc);
   ADD_PASS_WRAPPER_0("add_convert_tdesc_to_block_pointer",
                      intel::createTritonIntelTensorDescToBlockPointer);
+  ADD_PASS_WRAPPER_0("add_rewrite_tensor_descriptor_to_pointer",
+                     intel::createTritonRewriteTensorDescriptorToPointer);
   ADD_PASS_WRAPPER_0("add_remove_boundary_checks",
                      intel::createTritonIntelRemoveBoundaryChecks);
   ADD_PASS_WRAPPER_0("add_remove_masks", intel::createTritonIntelRemoveMasks);


### PR DESCRIPTION
It is currently identical to `lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp` in this PR.