### PR TITLE
[TDESC] [TEST] Test to verify tdesc support in annotate module pass

### DIFF
--- a/test/TritonIntelGPU/triton_annotate_module.mlir
+++ b/test/TritonIntelGPU/triton_annotate_module.mlir
@@ -27,3 +27,54 @@ module {
     tt.return
   }
 }
+
+// -----
+
+module {
+  // COM: Ensure that the 'threads-per-warp' attribute is overwritten when the kernel contains a 'tt.dot'
+  //      operation that can be lowered to DPAS instructions and uses tensor pointers.
+  // CHECK-NO-BDPAS: module attributes {"ttg.threads-per-warp" = 16 : i32, ttig.min_sg_size = 16 : i32, ttig.support_2d_block_io, ttig.support_subgroup_matrix_multiply_accumulate, ttig.target_arch = "spir64"}
+  // CHECK-BDPAS: module attributes {"ttg.threads-per-warp" = 16 : i32, ttig.min_sg_size = 16 : i32, ttig.support_2d_block_io, ttig.support_subgroup_matrix_multiply_accumulate, ttig.support_subgroup_scaled_matrix_multiply_accumulate, ttig.target_arch = "spir64"}
+
+  tt.func @kernel(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f32>) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %a_ptr = tt.make_tensor_ptr %arg0, [%c128_i64, %c32_i64], [%c32_i64, %c1_i64], [%c0_i32, %c1_i32] {order = array<i32: 0, 1>} : <tensor<128x32xf16>>
+    %b_ptr = tt.make_tensor_ptr %arg1, [%c32_i64, %c128_i64], [%c128_i64, %c1_i64], [%c0_i32, %c1_i32] {order = array<i32: 0, 1>} : <tensor<32x128xf16>>
+    %c_ptr = tt.make_tensor_ptr %arg2, [%c128_i64, %c128_i64], [%c128_i64, %c1_i64], [%c0_i32, %c1_i32] {order = array<i32: 0, 1>} : <tensor<128x128xf32>>
+    %a = tt.load %a_ptr : !tt.ptr<tensor<128x32xf16>>
+    %b = tt.load %b_ptr : !tt.ptr<tensor<32x128xf16>>
+    %c = tt.load %c_ptr : !tt.ptr<tensor<128x128xf32>>
+    %d = tt.dot %a, %b, %c : tensor<128x32xf16> * tensor<32x128xf16> -> tensor<128x128xf32>
+    tt.return
+  }
+}
+
+// -----
+
+module {
+  // COM: Ensure that the 'threads-per-warp' attribute is overwritten when the kernel contains a 'tt.dot'
+  //      operation that can be lowered to DPAS instructions and uses tensor descriptors.
+  // CHECK-NO-BDPAS: module attributes {"ttg.threads-per-warp" = 16 : i32, ttig.min_sg_size = 16 : i32, ttig.support_2d_block_io, ttig.support_subgroup_matrix_multiply_accumulate, ttig.target_arch = "spir64"}
+  // CHECK-BDPAS: module attributes {"ttg.threads-per-warp" = 16 : i32, ttig.min_sg_size = 16 : i32, ttig.support_2d_block_io, ttig.support_subgroup_matrix_multiply_accumulate, ttig.support_subgroup_scaled_matrix_multiply_accumulate, ttig.target_arch = "spir64"}
+
+  tt.func @kernel(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f32>) {
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %a_desc = tt.make_tensor_descriptor %arg0, [%c128_i32, %c32_i32], [%c32_i64, %c1_i64] : <f16>, <tensor<128x32xf16>>
+    %b_desc = tt.make_tensor_descriptor %arg1, [%c32_i32, %c128_i32], [%c128_i64, %c1_i64] : <f16>, <tensor<32x128xf16>>
+    %c_desc = tt.make_tensor_descriptor %arg2, [%c128_i32, %c128_i32], [%c128_i64, %c1_i64] : <f32>, <tensor<128x128xf32>>
+    %a = tt.descriptor_load %a_desc[%c0_i32]  : !tt.tensordesc<tensor<128x32xf16>> -> tensor<128x32xf16>
+    %b = tt.descriptor_load %b_desc[%c0_i32]  : !tt.tensordesc<tensor<32x128xf16>> -> tensor<32x128xf16>
+    %c = tt.descriptor_load %c_desc[%c0_i32]  : !tt.tensordesc<tensor<128x128xf32>> -> tensor<128x128xf32>
+    %d = tt.dot %a, %b, %c : tensor<128x32xf16> * tensor<32x128xf16> -> tensor<128x128xf32>
+    tt.return
+  }
+}


### PR DESCRIPTION
Closes #5680.

The annotate module pass does not need any enhancements to support kernels that use tensor descriptors because it does not care about block pointers or tensor descriptors.

This commit adds 2 test cases that verify tensor pointer and tensor descriptor support in the annotate module pass.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
