### PR TITLE
ci: trigger benchmark workflows on 'run-benchmarks' PR label

### DIFF
--- a/.github/workflows/triton-benchmarks-bmg.yml
+++ b/.github/workflows/triton-benchmarks-bmg.yml
@@ -6,12 +6,14 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - .github/workflows/triton-benchmarks*.yml
       - benchmarks/**
 
 jobs:
   benchmarks:
+    if: github.event.action != 'labeled' || github.event.label.name == 'run-benchmarks'
     uses: ./.github/workflows/triton-benchmarks.yml
     with:
       runner_label: b580

--- a/.github/workflows/triton-benchmarks-pvc.yml
+++ b/.github/workflows/triton-benchmarks-pvc.yml
@@ -6,12 +6,14 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - .github/workflows/triton-benchmarks*.yml
       - benchmarks/**
 
 jobs:
   benchmarks:
+    if: github.event.action != 'labeled' || github.event.label.name == 'run-benchmarks'
     uses: ./.github/workflows/triton-benchmarks.yml
     with:
       runner_label: max1550


### PR DESCRIPTION
## Summary

- Add `labeled` event type to the `pull_request` trigger in both `triton-benchmarks-pvc.yml` and `triton-benchmarks-bmg.yml`
- Add a job-level `if` condition so benchmarks only run when the label event carries the `run-benchmarks` label (path-based triggers are unaffected)

## Motivation

Previously benchmark CI only ran automatically when files under `benchmarks/**` or `.github/workflows/triton-benchmarks*.yml` were modified. This change allows contributors to trigger benchmark runs on any PR by applying the `run-benchmarks` label through the GitHub UI, without requiring benchmark file changes.

## How it works

When a PR is labeled with `run-benchmarks`, both the PVC (`max1550`) and BMG (`b580`) benchmark workflows are triggered. The job-level condition:
```
if: github.event.action != 'labeled' || github.event.label.name == 'run-benchmarks'
```
ensures that:
1. Path-triggered runs (opened/synchronize/reopened) are unaffected
2. Label-triggered runs only fire for the `run-benchmarks` label, not any other label

🤖 Generated with [Claude Code](https://claude.com/claude-code)