### PR TITLE
Remove structured binding usage in DPASAnalysis

### DIFF
--- a/third_party/intel/include/Analysis/DPAS.tpp
+++ b/third_party/intel/include/Analysis/DPAS.tpp
@@ -26,7 +26,7 @@ DPASAnalysis<DPASEngineType, Enable>::DPASAnalysis(Operation *root) {
 
   // Populate the maps.
   mod.walk([&](FunctionOpInterface funcOp) {
-    [[maybe_unused]] auto [it, inserted] = funcToDotMap.try_emplace(funcOp);
+    auto it = funcToDotMap.try_emplace(funcOp).first;
 
     funcOp.walk([&](Operation *op) {
       if (!isa<DotOp, DotScaledOp>(op))


### PR DESCRIPTION
#6105 introduces a usage of structured bindings which are subsequently captured within a lambda expression. Since capturing destructured names are a C++20 extension, the module will currently fail to compile with oneAPI 2025.2.0 and emit an error on `-std=c++17`.

```
In file included from /tmp/tmp.ieqchQuQo4/third_party/intel/include/Analysis/DPAS.h:217:
/tmp/tmp.ieqchQuQo4/third_party/intel/include/Analysis/DPAS.tpp:35:7: error: captured structured bindings are a C++20 extension [-Werror,-Wc++20-extensions]
   35 |       it->second.push_back(op);
      |       ^
/tmp/tmp.ieqchQuQo4/third_party/intel/include/Analysis/DPAS.tpp:31:36: note: while substituting into a lambda expression here
   31 |     funcOp.walk([&](Operation *op) {
      |                                    ^
/tmp/tmp.ieqchQuQo4/third_party/intel/include/Analysis/DPAS.tpp:28:44: note: while substituting into a lambda expression here
   28 |   mod.walk([&](FunctionOpInterface funcOp) {
      |                                            ^
/tmp/tmp.ieqchQuQo4/third_party/intel/include/Analysis/DPAS.h:127:14: note: in instantiation of member function 'mlir::triton::gpu::intel::DPASAnalysis<mlir::triton::gpu::intel::DPASEngineTypeXe2>::DPASAnalysis' requested here
  127 |       return DPASAnalysisV1(mod);
      |              ^
/tmp/tmp.ieqchQuQo4/third_party/intel/include/Analysis/DPAS.tpp:29:28: note: 'it' declared here
   29 |     [[maybe_unused]] auto [it, inserted] = funcToDotMap.try_emplace(funcOp);
      |                            ^
/tmp/tmp.ieqchQuQo4/third_party/intel/include/Analysis/DPAS.tpp:35:7: error: captured structured bindings are a C++20 extension [-Werror,-Wc++20-extensions]
   35 |       it->second.push_back(op);
      |       ^
/tmp/tmp.ieqchQuQo4/third_party/intel/include/Analysis/DPAS.tpp:31:36: note: while substituting into a lambda expression here
   31 |     funcOp.walk([&](Operation *op) {
      |                                    ^
/tmp/tmp.ieqchQuQo4/third_party/intel/include/Analysis/DPAS.tpp:28:44: note: while substituting into a lambda expression here
   28 |   mod.walk([&](FunctionOpInterface funcOp) {
      |                                            ^
/tmp/tmp.ieqchQuQo4/third_party/intel/include/Analysis/DPAS.h:128:12: note: in instantiation of member function 'mlir::triton::gpu::intel::DPASAnalysis<mlir::triton::gpu::intel::DPASEngineTypeXe3P>::DPASAnalysis' requested here
  128 |     return DPASAnalysisV2(mod);
      |            ^
/tmp/tmp.ieqchQuQo4/third_party/intel/include/Analysis/DPAS.tpp:29:28: note: 'it' declared here
   29 |     [[maybe_unused]] auto [it, inserted] = funcToDotMap.try_emplace(funcOp);
      |                            ^
2 errors generated.
```

If the intent is to switch to `-std=c++20` in the near future, feel free to close this. Though, given the discussion in #5952, this was likely just an oversight.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `this is a trivial fix`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
