### PR TITLE
ci: fix run-benchmarks label not triggering benchmark workflows

### DIFF
--- a/.github/workflows/triton-benchmarks-bmg.yml
+++ b/.github/workflows/triton-benchmarks-bmg.yml
@@ -46,7 +46,7 @@ jobs:
           try:
               files = [f['filename'] for f in json.load(sys.stdin)]
               print('true' if any(
-                  f.startswith('to-be-reverted/.github/workflows/triton-benchmarks') or f.startswith('to-be-reverted/benchmarks/')
+                  f.startswith('.github/workflows/triton-benchmarks') or f.startswith('benchmarks/')
                   for f in files
               ) else 'false')
           except Exception:

--- a/.github/workflows/triton-benchmarks-pvc.yml
+++ b/.github/workflows/triton-benchmarks-pvc.yml
@@ -46,7 +46,7 @@ jobs:
           try:
               files = [f['filename'] for f in json.load(sys.stdin)]
               print('true' if any(
-                  f.startswith('to-be-reverted/.github/workflows/triton-benchmarks') or f.startswith('to-be-reverted/benchmarks/')
+                  f.startswith('.github/workflows/triton-benchmarks') or f.startswith('benchmarks/')
                   for f in files
               ) else 'false')
           except Exception:


### PR DESCRIPTION
## Summary

- Fixes the `run-benchmarks` PR label not actually triggering benchmark workflows
- The previous attempt in #6152 added `types: [labeled]` to the trigger but kept the `paths` filter, which is a global gate in GitHub Actions — it blocks the entire workflow before any job-level `if:` condition is evaluated
- Replaces the `paths` filter with a lightweight `guard` job that checks trigger conditions at the job level, where both label events and path-based filtering can be properly handled

### How the guard job works

| Event | Behavior |
|-------|----------|
| `labeled` with `run-benchmarks` | Benchmarks run |
| `labeled` with any other label | Benchmarks skipped |
| `opened` / `synchronize` / `reopened` | Queries GitHub API for changed files; runs benchmarks only if `benchmarks/` or `triton-benchmarks*.yml` files changed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)