### PR TITLE
Use OneDNN instead of cuBLAS for XPU backend in `08-grouped-gemm.py`

### DIFF
--- a/python/tutorials/08-grouped-gemm.py
+++ b/python/tutorials/08-grouped-gemm.py
@@ -511,9 +511,9 @@ def benchmark_square_matrices(N, provider):
         line_arg='provider',
         # argument name whose value corresponds to a different line in the plot
         # possible values for `line_arg``
-        line_vals=['cublas', 'triton'] + (['triton-tma'] if supports_tma() else []),
+        line_vals=[ref_lib.lower(), 'triton'] + (['triton-tma'] if supports_tma() else []),
         # label name for the lines
-        line_names=["cuBLAS", "Triton"] + (['Triton + TMA'] if supports_tma() else []),
+        line_names=[ref_lib, "Triton"] + (['Triton + TMA'] if supports_tma() else []),
         # line styles
         styles=[('green', '-'), ('blue', '-')] + ([('red', '-')] if supports_tma() else []),
         ylabel="runtime(ms)",  # label name for the y-axis
@@ -562,7 +562,7 @@ def benchmark_batches(M, provider):
     d_g_t_lds = torch.tensor(g_T_lds, dtype=torch.int32, device=DEVICE)
 
     quantiles = [0.5, 0.2, 0.8]
-    if provider == 'cublas':
+    if provider == ref_lib.lower():
         ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch_perf_fn(group_A, group_B), quantiles=quantiles)
     if provider == 'triton':
         ms, min_ms, max_ms = triton.testing.do_bench(


### PR DESCRIPTION
Now, it looks like:
```bash
group-gemm-performance:
        N  oneDNN (runtime(ms))  Triton (runtime(ms))  Triton + TMA (runtime(ms))
0   128.0               0.02792               0.04272                     0.75296
1   256.0               0.03392               0.06616                     0.74968
2   512.0               0.04912               0.21576                     0.81220
3  1024.0               0.12032               1.52900                     2.76720
Report file: group-gemm-performance.csv
group-gemm-performance-m-8192-k-8192:
        M  oneDNN (runtime(ms))  Triton (runtime(ms))  Triton + TMA (runtime(ms))
0   128.0               1.18120              12.64552                    24.60344
1   256.0               1.21836              25.10040                    35.67600
2   512.0               1.71708              50.06304                    59.05880
3  1024.0               2.91984             100.01904                   117.36344
```
