### PR TITLE
[PROTON] Enable back `test_api.py::test_state`

### DIFF
--- a/third_party/proton/test/test_api.py
+++ b/third_party/proton/test/test_api.py
@@ -333,8 +333,6 @@ def test_scope_vector_metrics(tmp_path: pathlib.Path):
 
 
 def test_state(tmp_path: pathlib.Path):
-    if is_xpu():
-        pytest.skip("https://github.com/intel/intel-xpu-backend-for-triton/issues/5447")
     temp_file = tmp_path / "test_state.hatchet"
     proton.start(str(temp_file.with_suffix("")))
     proton.enter_scope("test0")


### PR DESCRIPTION
Closes #5447

I ran this test multiple times to catch the intermittent error, but it didn't reproduce. Since a lot has changed since then, including the Proton itself, the driver, and the PTI, it's entirely possible this issue no longer exists. I suggest merging it and monitoring.