### PR TITLE
[CI] Update `build-test-python.yml` - don't run on LTS driver by default

### DIFF
--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -60,7 +60,7 @@ jobs:
           if [[ -n "${{ inputs.runner_label }}" ]]; then
             matrix='{"python": ["3.10", "3.11", "3.12", "3.13"]}'
           else
-            matrix='{"python": ["3.10", "3.11", "3.12", "3.13"], "driver": ["rolling", "lts"]}'
+            matrix='{"python": ["3.10", "3.11", "3.12", "3.13"], "driver": ["rolling"]}'
           fi
           echo "matrix=$matrix" | tee -a $GITHUB_OUTPUT
 


### PR DESCRIPTION
Since there is no LTS driver-specific code for different python versions, there is no need to run tests in this combination. We can save CI time here.