### PR TITLE
Create `findOrCreateCastOp` utility

### DIFF
--- a/test/Triton/Intel/TensorDescToBlockPointer/loop.mlir
+++ b/test/Triton/Intel/TensorDescToBlockPointer/loop.mlir
@@ -75,10 +75,8 @@ module {
   // CHECK:          [[TENSOR_PTR_1:%.+]] = tt.advance [[VAR_arg1]], {{\[}}[[CST_8_i32]], [[IDX_CAST]]] : <tensor<16x32xf16>>
   // CHECK:          [[LOAD:%.+]] = tt.load [[TENSOR_PTR_1]] {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32} : !tt.ptr<tensor<16x32xf16>>
   // CHECK:          [[ADD:%.+]] = arith.addf [[VAR_arg2]], [[LOAD]] : tensor<16x32xf16>
-  // CHECK-DAG:      [[EXTSI_PARAM_1a:%.+]] = arith.extsi [[PARAM_1]] : i32 to i64
-  // CHECK-DAG:      [[EXTSI_PARAM_2a:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
-  // CHECK-DAG:      [[CST_0_i32_1:%.+]] = arith.constant 0 : i32
-  // CHECK:          [[TENSOR_PTR2:%.+]] = tt.make_tensor_ptr [[PARAM_0]], {{\[}}[[EXTSI_PARAM_2a]], [[EXTSI_PARAM_1a]]], {{\[}}[[CST_1_i64]], [[EXTSI_PARAM_2]]], {{\[}}[[CST_0_i32_1]], [[CST_0_i32_1]]] {{.*}} : <tensor<16x32xf16>>
+  // CHECK:          [[CST_0_i32_1:%.+]] = arith.constant 0 : i32
+  // CHECK:          [[TENSOR_PTR2:%.+]] = tt.make_tensor_ptr [[PARAM_0]], {{\[}}[[EXTSI_PARAM_2]], [[EXTSI_PARAM_1]]], {{\[}}[[CST_1_i64]], [[EXTSI_PARAM_2]]], {{\[}}[[CST_0_i32_1]], [[CST_0_i32_1]]] {{.*}} : <tensor<16x32xf16>>
   // CHECK:          [[CMP:%.+]] = arith.cmpi eq, [[IDX_CAST]], [[CST_8_i32]] : i32
   // CHECK:          [[TENSOR_PTR3:%.+]] = arith.select [[CMP]], [[VAR_arg1]], [[TENSOR_PTR:%.+]] : !tt.ptr<tensor<16x32xf16>>
   // CHECK:          scf.yield [[TENSOR_PTR3]], [[ADD]] : !tt.ptr<tensor<16x32xf16>>, tensor<16x32xf16>

--- a/third_party/intel/include/Utils/Utility.h
+++ b/third_party/intel/include/Utils/Utility.h
@@ -18,6 +18,8 @@ class LoopLikeOpInterface;
 
 namespace mlir::triton::intel {
 
+Value findOrCreateCastOp(Value val, Type targetType);
+
 // Lookup for a integer constant with the given value and bitwidth in the
 // current block (before the builder insertion point). Return it if found,
 // otherwise create a new one.

--- a/third_party/intel/lib/Dialect/Triton/Transforms/BlockPointerToTensorDesc.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/BlockPointerToTensorDesc.cpp
@@ -101,24 +101,6 @@ private:
     return true;
   }
 
-  arith::TruncIOp getOrCreateTruncI32Op(Value v) const {
-    assert(v.getType().isInteger(64) && "Expecting i64 value");
-    Location loc = v.getLoc();
-    OpBuilder builder(v.getContext());
-    Type targetType = builder.getIntegerType(32);
-
-    if (Operation *defOp = v.getDefiningOp()) {
-      if (auto nextOp = dyn_cast_or_null<arith::TruncIOp>(defOp->getNextNode()))
-        if (nextOp.getType() == targetType && nextOp.getIn() == v)
-          return nextOp;
-      builder.setInsertionPointAfter(defOp);
-    } else {
-      builder.setInsertionPointToStart(v.getParentBlock());
-    }
-
-    return arith::TruncIOp::create(builder, loc, targetType, v);
-  }
-
   tt::MakeTensorDescOp
   createMakeTensorDescOp(tt::MakeTensorPtrOp makeTensorPtrOp,
                          tt::PaddingOption padding) {
@@ -132,7 +114,8 @@ private:
     Value base = makeTensorPtrOp.getBase();
     SmallVector<Value> shape;
     for (Value s : makeTensorPtrOp.getShape())
-      shape.push_back(getOrCreateTruncI32Op(s));
+      shape.push_back(tt::intel::findOrCreateCastOp(
+          s, IntegerType::get(s.getContext(), 32)));
     SmallVector<Value> strides = makeTensorPtrOp.getStrides();
     return tt::MakeTensorDescOp::create(builder, loc, descTy, base, shape,
                                         strides, padding);

--- a/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp
@@ -32,31 +32,6 @@ bool hasATensorDescriptorType(mlir::TypeRange types) {
   });
 }
 
-Value findOrCreateCast(Location loc, Value val, Type tgtType,
-                       OpBuilder &builder) {
-  assert(isa<IntegerType>(tgtType) && isa<IntegerType>(val.getType()) &&
-         "Expecting integer types");
-  assert(val.getType().getIntOrFloatBitWidth() <=
-             tgtType.getIntOrFloatBitWidth() &&
-         "Expecting smaller type");
-
-  if (val.getType() == tgtType)
-    return val;
-
-  Block *block = builder.getInsertionBlock();
-  const Block::iterator insertPoint = builder.getInsertionPoint();
-
-  auto it = std::find_if(block->begin(), insertPoint, [&](Operation &op) {
-    if (auto castOp = dyn_cast<arith::ExtSIOp>(op))
-      return castOp.getIn() == val && castOp.getType() == tgtType;
-    return false;
-  });
-
-  return (it != insertPoint)
-             ? cast<arith::ExtSIOp>(*it)
-             : getValueOrCreateCastToIndexLike(builder, loc, tgtType, val);
-}
-
 struct TritonIntelTensorDescToBlockPointer
     : tt::intel::impl::TritonIntelTensorDescToBlockPointerBase<
           TritonIntelTensorDescToBlockPointer> {
@@ -209,12 +184,10 @@ private:
     for (const auto [shape, stride, size] :
          llvm::zip(op.getShape(), op.getStrides(),
                    tDescType.getBlockType().getShape())) {
-      shapes.push_back(findOrCreateCast(
-          loc, shape, builder.getIntegerType(shapeAndStridesBitwidth),
-          builder));
-      strides.push_back(findOrCreateCast(
-          loc, stride, builder.getIntegerType(shapeAndStridesBitwidth),
-          builder));
+      shapes.push_back(tt::intel::findOrCreateCastOp(
+          shape, builder.getIntegerType(shapeAndStridesBitwidth)));
+      strides.push_back(tt::intel::findOrCreateCastOp(
+          stride, builder.getIntegerType(shapeAndStridesBitwidth)));
       Value zero =
           tt::intel::findOrCreateIntConstant(loc, 0, offsetBitwidth, builder);
       offsets.push_back(zero);

--- a/third_party/intel/lib/Utils/Utility.cpp
+++ b/third_party/intel/lib/Utils/Utility.cpp
@@ -20,6 +20,49 @@ static std::optional<int64_t> getIntAttr(const OpFoldResult ofr) {
 
 namespace mlir::triton::intel {
 
+Value findOrCreateCastOp(Value val, Type targetType) {
+  Location loc = val.getLoc();
+  OpBuilder builder(val.getContext());
+
+  auto isMatchingCastOp = [&](CastOpInterface castOp) {
+    return castOp->getNumOperands() == 1 && castOp->getOperand(0) == val &&
+           castOp->getNumResults() == 1 &&
+           castOp->getResult(0).getType() == targetType;
+  };
+
+  if (Operation *defOp = val.getDefiningOp()) {
+    Operation *nextOp = defOp->getNextNode();
+    if (auto castOp = dyn_cast<CastOpInterface>(nextOp)) {
+      if (isMatchingCastOp(castOp))
+        return castOp->getResult(0);
+    }
+
+    builder.setInsertionPointAfter(defOp);
+  } else {
+    Value foundCast = nullptr;
+    val.getParentBlock()->walk([&](Operation *op) {
+      if (isa<arith::ConstantOp>(op))
+        return WalkResult::advance();
+
+      auto castOp = dyn_cast<CastOpInterface>(op);
+      if (!castOp)
+        return WalkResult::interrupt();
+
+      if (isMatchingCastOp(castOp)) {
+        foundCast = castOp->getResult(0);
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (foundCast)
+      return foundCast;
+
+    builder.setInsertionPointToStart(val.getParentBlock());
+  }
+
+  return getValueOrCreateCastToIndexLike(builder, loc, targetType, val);
+}
+
 Value findOrCreateIntConstant(Location loc, int val, unsigned bitWidth,
                               OpBuilder &builder) {
   Block *block = builder.getInsertionBlock();


### PR DESCRIPTION
This PR introduces a `findOrCreateCastOp` helper in the Intel Triton utilities and refactors existing passes to use it, reducing duplicated “reuse-or-insert cast” logic across transformations.