### PR TITLE
[TensorDescToBlockPointer] Find encoding from users

### DIFF
--- a/test/Triton/Intel/TensorDescToBlockPointer/basic.mlir
+++ b/test/Triton/Intel/TensorDescToBlockPointer/basic.mlir
@@ -28,11 +28,11 @@ module {
 
 // -----
 
-// CHECK-DAG: #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-// CHECK-DAG: #blocked1 = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 1], threadsPerWarp = [1, 1, 1, 1, 32], warpsPerCTA = [1, 1, 1, 1, 4], order = [4, 3, 2, 1, 0]}>
-// CHECK-DAG: [[CUSTOM:#.+]] = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-#custom = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+// CHECK-DAG: #blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+// CHECK-DAG: [[DEFAULT:#.+]] = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 1], threadsPerWarp = [1, 1, 1, 1, 32], warpsPerCTA = [1, 1, 1, 1, 4], order = [4, 3, 2, 1, 0]}>
+// CHECK-DAG: [[DEFAULT2:#.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#default = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @test_load(%arg0: !tt.ptr<f32>, %arg1: i32, %arg2: i32) {
     %c1_i64 = arith.constant 1 : i64
@@ -88,9 +88,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %c1_i64 = arith.constant 1 : i64
     %c1_i32 = arith.constant 1 : i32
     %0 = tt.make_tensor_descriptor %arg1, [%c1_i32, %c1_i32, %c1_i32, %arg2, %arg3], [%arg4, %arg5, %arg6, %arg7, %c1_i64] : <i8>, <tensor<1x1x1x8x128xui8>>
-    %1 = tt.descriptor_load %0[%c1_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] : !tt.tensordesc<tensor<1x1x1x8x128xui8>> -> tensor<8x128xi8, #blocked>
-    %2 = tt.splat %arg0 : !tt.ptr<i8> -> tensor<8x128x!tt.ptr<i8>, #blocked>
-    tt.store %2, %1 : tensor<8x128x!tt.ptr<i8>, #blocked>
+    %1 = tt.descriptor_load %0[%c1_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] : !tt.tensordesc<tensor<1x1x1x8x128xui8>> -> tensor<8x128xi8, #default>
+    %2 = tt.splat %arg0 : !tt.ptr<i8> -> tensor<8x128x!tt.ptr<i8>, #default>
+    tt.store %2, %1 : tensor<8x128x!tt.ptr<i8>, #default>
     tt.return
   }
   // CHECK:       tt.func public @test_load_res_type_contracted([[PARAM_0:%.+]]: !tt.ptr<i8>, [[PARAM_1:%.+]]: !tt.ptr<i8>
@@ -98,10 +98,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   // CHECK-NOT:     tt.descriptor_load
   // CHECK:         [[CST_0:%.+]] = arith.constant 0 : i32
   // CHECK:         [[CST_1:%.+]] = arith.constant 1 : i32
-  // CHECK:         [[TENSOR_PTR:%.+]] = tt.make_tensor_ptr [[PARAM_1]], {{.*}} : <tensor<1x1x1x8x128xi8, #blocked1>>
-  // CHECK:         [[TENSOR_PTR1:%.+]] = tt.advance [[TENSOR_PTR]], {{\[}}[[CST_1]], [[CST_0]], [[CST_0]], [[CST_0]], [[CST_0]]{{\]}} : <tensor<1x1x1x8x128xi8, #blocked1>>
-  // CHECK:         [[LOAD:%.+]] = tt.load [[TENSOR_PTR1]] {boundaryCheck = array<i32: 0, 1, 2, 3, 4>, padding = 1 : i32} : !tt.ptr<tensor<1x1x1x8x128xi8, #blocked1>>
-  // CHECK:         [[RESHAPE:%.+]] = tt.reshape [[LOAD]] : tensor<1x1x1x8x128xi8, #blocked1> -> tensor<8x128xi8, #blocked>
+  // CHECK:         [[TENSOR_PTR:%.+]] = tt.make_tensor_ptr [[PARAM_1]], {{.*}} : <tensor<1x1x1x8x128xi8, [[DEFAULT]]>>
+  // CHECK:         [[TENSOR_PTR1:%.+]] = tt.advance [[TENSOR_PTR]], {{\[}}[[CST_1]], [[CST_0]], [[CST_0]], [[CST_0]], [[CST_0]]{{\]}} : <tensor<1x1x1x8x128xi8, [[DEFAULT]]>>
+  // CHECK:         [[LOAD:%.+]] = tt.load [[TENSOR_PTR1]] {boundaryCheck = array<i32: 0, 1, 2, 3, 4>, padding = 1 : i32} : !tt.ptr<tensor<1x1x1x8x128xi8, [[DEFAULT]]>>
+  // CHECK:         [[RESHAPE:%.+]] = tt.reshape [[LOAD]] : tensor<1x1x1x8x128xi8, #blocked1> -> tensor<8x128xi8, [[DEFAULT2]]>
   // CHECK:         tt.return
   // CHECK:       }
 
@@ -109,10 +109,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %c1_i64 = arith.constant 1 : i64
     %c64_i32 = arith.constant 64 : i32
     %c8_i32 = arith.constant 8 : i32
-    %cst = arith.constant dense<1.000000e+00> : tensor<16x128xf32, #custom>
+    %cst = arith.constant dense<1.000000e+00> : tensor<16x128xf32, #blocked>
     %0 = arith.extsi %arg2 : i32 to i64
     %desc1 = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%0, %c1_i64] : <f32>, <tensor<16x128xf32>>
-    tt.descriptor_store %desc1[%c8_i32, %c64_i32], %cst : !tt.tensordesc<tensor<16x128xf32>>, tensor<16x128xf32, #custom>
+    tt.descriptor_store %desc1[%c8_i32, %c64_i32], %cst : !tt.tensordesc<tensor<16x128xf32>>, tensor<16x128xf32, #blocked>
     tt.return
   }
   // CHECK:      tt.func public @test_store([[PARAM_0:%.+]]: !tt.ptr<f32>, [[PARAM_1:%.+]]: i32, [[PARAM_2:%.+]]: i32) {
@@ -122,12 +122,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   // CHECK-DAG:    [[CST_1_i64:%.+]] = arith.constant 1 : i64
   // CHECK-DAG:    [[CST_64_i32:%.+]] = arith.constant 64 : i32
   // CHECK-DAG:    [[CST_8_i32:%.+]] = arith.constant 8 : i32
-  // CHECK-DAG:    [[CST:%.+]] = arith.constant dense<1.000000e+00> : tensor<16x128xf32, [[CUSTOM]]>
+  // CHECK-DAG:    [[CST:%.+]] = arith.constant dense<1.000000e+00> : tensor<16x128xf32, #blocked>
   // CHECK-DAG:    [[EXTSI_PARAM_1:%.+]] = arith.extsi [[PARAM_1]] : i32 to i64
   // CHECK-DAG:    [[EXTSI_PARAM_2:%.+]] = arith.extsi [[PARAM_2]] : i32 to i64
-  // CHECK:        [[TENSOR_PTR:%.+]] = tt.make_tensor_ptr [[PARAM_0]], {{\[}}[[EXTSI_PARAM_1]], [[EXTSI_PARAM_2]]], {{\[}}[[EXTSI_PARAM_2]], [[CST_1_i64]]], {{\[}}[[CST_0_i32]], [[CST_0_i32]]] {{.*}} : <tensor<16x128xf32, [[CUSTOM]]>>
-  // CHECK:        [[TENSOR_PTR1:%.+]] = tt.advance [[TENSOR_PTR]], {{\[}}[[CST_8_i32]], [[CST_64_i32]]] : <tensor<16x128xf32, [[CUSTOM]]>>
-  // CHECK:        tt.store [[TENSOR_PTR1]], [[CST]]  {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<16x128xf32, [[CUSTOM]]>>
+  // CHECK:        [[TENSOR_PTR:%.+]] = tt.make_tensor_ptr [[PARAM_0]], {{\[}}[[EXTSI_PARAM_1]], [[EXTSI_PARAM_2]]], {{\[}}[[EXTSI_PARAM_2]], [[CST_1_i64]]], {{\[}}[[CST_0_i32]], [[CST_0_i32]]] {{.*}} : <tensor<16x128xf32, #blocked>>
+  // CHECK:        [[TENSOR_PTR1:%.+]] = tt.advance [[TENSOR_PTR]], {{\[}}[[CST_8_i32]], [[CST_64_i32]]] : <tensor<16x128xf32, #blocked>>
+  // CHECK:        tt.store [[TENSOR_PTR1]], [[CST]]  {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<16x128xf32, #blocked>>
   // CHECK:        tt.return
   // CHECK:      }
 }

--- a/test/Triton/Intel/TensorDescToBlockPointer/loop.mlir
+++ b/test/Triton/Intel/TensorDescToBlockPointer/loop.mlir
@@ -1,7 +1,6 @@
 // RUN: triton-opt %s -triton-intel-tdesc-to-block-pointer  | FileCheck %s
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // COM: Loop containing a tensor descriptor load operation using a loop invariant tensor descriptor.
   tt.func public @load_in_loop1(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32) {
@@ -219,7 +218,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
       scf.condition(%6) %arg3 : !tt.tensordesc<tensor<8x128xf32>>
     } do {
     ^bb0(%arg3: !tt.tensordesc<tensor<8x128xf32>>):
-      %12 = tt.descriptor_load %arg3[%0, %c0_i32] : !tt.tensordesc<tensor<8x128xf32>> -> tensor<8x128xf32, #blocked1>
+      %12 = tt.descriptor_load %arg3[%0, %c0_i32] : !tt.tensordesc<tensor<8x128xf32>> -> tensor<8x128xf32, #blocked>
       scf.yield %arg3 : !tt.tensordesc<tensor<8x128xf32>>
     }
     tt.return
@@ -227,14 +226,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   // CHECK: tt.func public @load_in_while_loop({{.*}}) {
   // CHECK-NOT:    tt.make_tensor_descriptor
   // CHECK-NOT:    tt.descriptor_load
-  // CHECK:        [[TENSOR_PTR:%.*]] = tt.make_tensor_ptr {{.*}} : <tensor<8x128xf32, #blocked1>>
-  // CHECK:        scf.while ([[ARG3:%.*]] = [[TENSOR_PTR]]) : (!tt.ptr<tensor<8x128xf32, #blocked1>>) -> !tt.ptr<tensor<8x128xf32, #blocked1>> {
-  // CHECK:          scf.condition({{.*}}) [[ARG3]] : !tt.ptr<tensor<8x128xf32, #blocked1>>
+  // CHECK:        [[TENSOR_PTR:%.*]] = tt.make_tensor_ptr {{.*}} : <tensor<8x128xf32, #blocked>>
+  // CHECK:        scf.while ([[ARG3:%.*]] = [[TENSOR_PTR]]) : (!tt.ptr<tensor<8x128xf32, #blocked>>) -> !tt.ptr<tensor<8x128xf32, #blocked>> {
+  // CHECK:          scf.condition({{.*}}) [[ARG3]] : !tt.ptr<tensor<8x128xf32, #blocked>>
   // CHECK:        } do {
-  // CHECK:        ^bb0([[ARG4:%.*]]: !tt.ptr<tensor<8x128xf32, #blocked1>>):
-  // CHECK:          [[PTR1:%.*]] = tt.advance [[ARG4]], {{.*}} : <tensor<8x128xf32, #blocked1>>
-  // CHECK:          tt.load [[PTR1]] {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32} : !tt.ptr<tensor<8x128xf32, #blocked1>>
-  // CHECK:          scf.yield [[ARG4]] : !tt.ptr<tensor<8x128xf32, #blocked1>>
+  // CHECK:        ^bb0([[ARG4:%.*]]: !tt.ptr<tensor<8x128xf32, #blocked>>):
+  // CHECK:          [[PTR1:%.*]] = tt.advance [[ARG4]], {{.*}} : <tensor<8x128xf32, #blocked>>
+  // CHECK:          tt.load [[PTR1]] {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32} : !tt.ptr<tensor<8x128xf32, #blocked>>
+  // CHECK:          scf.yield [[ARG4]] : !tt.ptr<tensor<8x128xf32, #blocked>>
   // CHECK:        }
 
   // COM: For loop yields a tensor descriptor used by a while loop.
@@ -254,7 +253,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
       scf.condition(%6) %arg3 : !tt.tensordesc<tensor<8x128xf32>>
     } do {
     ^bb0(%arg3: !tt.tensordesc<tensor<8x128xf32>>):
-      %12 = tt.descriptor_load %arg3[%c8_i32, %c8_i32] : !tt.tensordesc<tensor<8x128xf32>> -> tensor<8x128xf32, #blocked1>
+      %12 = tt.descriptor_load %arg3[%c8_i32, %c8_i32] : !tt.tensordesc<tensor<8x128xf32>> -> tensor<8x128xf32, #blocked>
       scf.yield %arg3 : !tt.tensordesc<tensor<8x128xf32>>
     }
     tt.return
@@ -262,17 +261,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   // CHECK:      tt.func public @while_uses_tdesc_yielded_by_for_loop({{.*}}) {
   // CHECK-NOT:    tt.make_tensor_descriptor
   // CHECK-NOT:    tt.descriptor_load
-  // CHECK:        [[TENSOR_PTR:%.*]] = tt.make_tensor_ptr {{.*}} : <tensor<8x128xf32, #blocked1>>
-  // CHECK:        [[FOR_RES:%.+]] = scf.for [[IV:%.+]] = {{.*}} iter_args([[ARG3:%.*]] = [[TENSOR_PTR]]) -> (!tt.ptr<tensor<8x128xf32, #blocked1>>) : i32 {
-  // CHECK:          scf.yield {{.*}} : !tt.ptr<tensor<8x128xf32, #blocked1>>
+  // CHECK:        [[TENSOR_PTR:%.*]] = tt.make_tensor_ptr {{.*}} : <tensor<8x128xf32, #blocked>>
+  // CHECK:        [[FOR_RES:%.+]] = scf.for [[IV:%.+]] = {{.*}} iter_args([[ARG3:%.*]] = [[TENSOR_PTR]]) -> (!tt.ptr<tensor<8x128xf32, #blocked>>) : i32 {
+  // CHECK:          scf.yield {{.*}} : !tt.ptr<tensor<8x128xf32, #blocked>>
   // CHECK:        }
-  // CHECK:        scf.while ([[ARG3:%.*]] = [[FOR_RES]]) : (!tt.ptr<tensor<8x128xf32, #blocked1>>) -> !tt.ptr<tensor<8x128xf32, #blocked1>> {
-  // CHECK:          scf.condition({{.*}}) [[ARG3]] : !tt.ptr<tensor<8x128xf32, #blocked1>>
+  // CHECK:        scf.while ([[ARG3:%.*]] = [[FOR_RES]]) : (!tt.ptr<tensor<8x128xf32, #blocked>>) -> !tt.ptr<tensor<8x128xf32, #blocked>> {
+  // CHECK:          scf.condition({{.*}}) [[ARG3]] : !tt.ptr<tensor<8x128xf32, #blocked>>
   // CHECK:        } do {
-  // CHECK:        ^bb0([[ARG4:%.*]]: !tt.ptr<tensor<8x128xf32, #blocked1>>):
-  // CHECK:          [[TENSOR_PTR1:%.*]] = tt.advance [[ARG4]], {{.*}} : <tensor<8x128xf32, #blocked1>
-  // CHECK:          tt.load [[TENSOR_PTR1]] {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32} : !tt.ptr<tensor<8x128xf32, #blocked1>>
-  // CHECK:          scf.yield [[ARG4]] : !tt.ptr<tensor<8x128xf32, #blocked1>>
+  // CHECK:        ^bb0([[ARG4:%.*]]: !tt.ptr<tensor<8x128xf32, #blocked>>):
+  // CHECK:          [[TENSOR_PTR1:%.*]] = tt.advance [[ARG4]], {{.*}} : <tensor<8x128xf32, #blocked>
+  // CHECK:          tt.load [[TENSOR_PTR1]] {boundaryCheck = array<i32: 0, 1>, padding = 1 : i32} : !tt.ptr<tensor<8x128xf32, #blocked>>
+  // CHECK:          scf.yield [[ARG4]] : !tt.ptr<tensor<8x128xf32, #blocked>>
   // CHECK:        }
 
 }

--- a/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/TensorDescToBlockPointer.cpp
@@ -63,12 +63,15 @@ void collectEncodingsFromUsers(Value value, SmallPtrSetImpl<Value> &visited,
   for (Operation *user : value.getUsers()) {
     // Direct load/store user.
     if (auto loadOp = dyn_cast<tt::DescriptorLoadOp>(user)) {
-      encodings.insert(cast<RankedTensorType>(loadOp.getType()).getEncoding());
+      if (auto encoding =
+              cast<RankedTensorType>(loadOp.getType()).getEncoding())
+        encodings.insert(encoding);
       continue;
     }
     if (auto storeOp = dyn_cast<tt::DescriptorStoreOp>(user)) {
-      encodings.insert(
-          cast<RankedTensorType>(storeOp.getSrc().getType()).getEncoding());
+      if (auto encoding =
+              cast<RankedTensorType>(storeOp.getSrc().getType()).getEncoding())
+        encodings.insert(encoding);
       continue;
     }
 
@@ -124,6 +127,13 @@ void collectEncodingsFromUsers(Value value, SmallPtrSetImpl<Value> &visited,
             collectEncodingsFromUsers(result, visited, encodings);
             collectEncodingsFromUsers(beforeArg, visited, encodings);
           }
+        }
+      } else if (auto ifOp = dyn_cast<scf::IfOp>(yieldOp->getParentOp())) {
+        // Yield in if's then/else region goes to the if's results.
+        for (auto [yieldedVal, result] :
+             llvm::zip(yieldOp.getOperands(), ifOp.getResults())) {
+          if (yieldedVal == value)
+            collectEncodingsFromUsers(result, visited, encodings);
         }
       }
       continue;


### PR DESCRIPTION
This PR enhances the TensorDescToBlockPointer pass to find and use tensor encodings from the users of MakeTensorDescOp operations, rather than always using the default blocked encoding. This allows custom encodings specified in DescriptorLoadOp/DescriptorStoreOp operations to be propagated to the generated block pointers.