### PR TITLE
[AxisInfo] Fix `getStride` of mul and div

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -513,7 +513,8 @@ private:
   std::optional<int64_t> getConstantValue(OpTy op, const AxisInfo &lhs,
                                           const AxisInfo &rhs) override {
     if (lhs.getConstantValue().has_value() &&
-        rhs.getConstantValue().has_value())
+        rhs.getConstantValue().has_value() &&
+        rhs.getConstantValue().value() != 0)
       return {lhs.getConstantValue().value() / rhs.getConstantValue().value()};
     return {};
   }
@@ -582,7 +583,8 @@ private:
   std::optional<int64_t> getConstantValue(OpTy op, const AxisInfo &lhs,
                                           const AxisInfo &rhs) override {
     if (lhs.getConstantValue().has_value() &&
-        rhs.getConstantValue().has_value())
+        rhs.getConstantValue().has_value() &&
+        rhs.getConstantValue().value() != 0)
       return {lhs.getConstantValue().value() % rhs.getConstantValue().value()};
     else if (rhs.getConstantValue().has_value() &&
              rhs.getConstantValue().value() == 1)

--- a/test/Analysis/intel/test-axis-info.mlir
+++ b/test/Analysis/intel/test-axis-info.mlir
@@ -137,10 +137,15 @@ tt.func @mul(%arg0: i64 {tt.divisibility = 16 : i32}) {
 tt.func @mul_stride() {
   // CHECK: stride = [1]
   %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
-  // CHECK-NEXT: stride = [0], {{.*}}constant_value = -1
-  %neg1 = arith.constant dense<-1> : tensor<128xi32>
+  // CHECK-NEXT: stride = [0], {{.*}}constant_value = 2
+  %pos1 = arith.constant dense<2> : tensor<128xi32>
+  // CHECK-NEXT: stride = [2]
+  %1 = arith.muli %0, %pos1 : tensor<128xi32>
+
+  // CHECK-NEXT: stride = [0], {{.*}}constant_value = -2
+  %neg1 = arith.constant dense<-2> : tensor<128xi32>
   // CHECK-NEXT: stride = [-1]
-  %1 = arith.muli %0, %neg1 : tensor<128xi32>
+  %2 = arith.muli %0, %neg1 : tensor<128xi32>
   tt.return
 }
 
@@ -182,17 +187,26 @@ tt.func @div() {
 tt.func @div_stride() {
   // CHECK: stride = [1]
   %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  // CHECK-NEXT: stride = [0], {{.*}}constant_value = 4
+  %c4 = arith.constant dense<4> : tensor<128xi32>
+  // CHECK-NEXT: stride = [4]
+  %1 = arith.muli %0, %c4 : tensor<128xi32>
+  // CHECK-NEXT: stride = [0], {{.*}}constant_value = 2
+  %c2 = arith.constant dense<2> : tensor<128xi32>
+  // CHECK-NEXT: stride = [2]
+  %2 = arith.divsi %1, %c2 : tensor<128xi32>
+
   // CHECK-NEXT: stride = [0], {{.*}}constant_value = -2
   %neg1 = arith.constant dense<-2> : tensor<128xi32>
   // CHECK-NEXT: stride = [-1]
-  %2 = arith.divsi %0, %neg1 : tensor<128xi32>
+  %3 = arith.divsi %0, %neg1 : tensor<128xi32>
 
   // CHECK: stride = [0]
   %cst = arith.constant dense<4> : tensor<128xi32>
   // CHECK-NEXT: stride = [0], {{.*}}constant_value = 0
   %zero = arith.constant dense<0> : tensor<128xi32>
   // CHECK-NEXT: stride = [-1]
-  %1 = arith.divsi %cst, %zero : tensor<128xi32>
+  %4 = arith.divsi %cst, %zero : tensor<128xi32>
   tt.return
 }
 

--- a/third_party/intel/lib/Analysis/AxisInfo.cpp
+++ b/third_party/intel/lib/Analysis/AxisInfo.cpp
@@ -285,7 +285,7 @@ public:
     if (intAttr || boolAttr) {
       int64_t value{};
       if (intAttr)
-        value = intAttr.getValue().getZExtValue();
+        value = intAttr.getValue().getSExtValue();
       else
         value = boolAttr.getValue() ? 1 : 0;
       return AxisInfo(/*stride=*/{0}, /*contiguity=*/{1},
@@ -296,7 +296,12 @@ public:
     // TODO: generalize to dense attr
     auto splatAttr = dyn_cast<SplatElementsAttr>(op.getValue());
     if (splatAttr && splatAttr.getElementType().isIntOrIndex()) {
-      int64_t value = splatAttr.template getSplatValue<APInt>().getZExtValue();
+      APInt apValue = splatAttr.template getSplatValue<APInt>();
+      // Use getZExtValue for 1-bit integers (booleans) to avoid sign extension
+      // turning true into -1, use getSExtValue for wider integers to properly
+      // handle negative values.
+      int64_t value = apValue.getBitWidth() == 1 ? apValue.getZExtValue()
+                                                 : apValue.getSExtValue();
       TensorType ty = cast<TensorType>(splatAttr.getType());
       return AxisInfo(
           /*stride=*/AxisInfo::DimVectorT(ty.getRank(), 0),
@@ -566,7 +571,8 @@ private:
   std::optional<int64_t> getConstantValue(OpTy op, const AxisInfo &lhs,
                                           const AxisInfo &rhs) override {
     if (lhs.getConstantValue().has_value() &&
-        rhs.getConstantValue().has_value())
+        rhs.getConstantValue().has_value() &&
+        rhs.getConstantValue().value() != 0)
       return {lhs.getConstantValue().value() / rhs.getConstantValue().value()};
     return {};
   }
@@ -663,7 +669,8 @@ private:
   std::optional<int64_t> getConstantValue(OpTy op, const AxisInfo &lhs,
                                           const AxisInfo &rhs) override {
     if (lhs.getConstantValue().has_value() &&
-        rhs.getConstantValue().has_value())
+        rhs.getConstantValue().has_value() &&
+        rhs.getConstantValue().value() != 0)
       return {lhs.getConstantValue().value() % rhs.getConstantValue().value()};
     else if (rhs.getConstantValue().has_value() &&
              rhs.getConstantValue().value() == 1)


### PR DESCRIPTION
Fixes stride inference in Intel AxisInfo analysis for multiplication and division to avoid reporting invalid/incorrect strides, addressing the bug identified in #6217.