### PR TITLE
[RemoveLayoutConversion]: Fix rematerialization for atomic operations

### DIFF
--- a/python/test/unit/intel/test_atomic.py
+++ b/python/test/unit/intel/test_atomic.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+
+
+@pytest.mark.parametrize("BLOCK_M, BLOCK_N", [(128, 128), (64, 128), (32, 128), (32, 64), (32, 32)])
+def test_tensor_atomic_rmw_2d_grid(BLOCK_M, BLOCK_N, device):
+    """Regression: atomic_add must not be duplicated by remove-layout-conversions
+    when the grid has multiple row-tile programs (BLOCK_M < M)."""
+    M, N = 128, 128
+
+    @triton.jit
+    def kernel(dy_ptr, x_ptr, M: tl.constexpr, N: tl.constexpr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+        pid = tl.program_id(0)
+        num_blocks_m = tl.cdiv(M, BLOCK_M)
+        pid_m = pid % num_blocks_m
+        pid_n = pid // num_blocks_m
+        rows = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        cols = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        x = tl.load(x_ptr + rows[:, None] * N + cols[None, :])
+        val = tl.sum(x, axis=1)
+        tl.atomic_add(dy_ptr + rows, val, sem="relaxed")
+
+    x = torch.ones(M, N, device=device, dtype=torch.float32)
+    dy = torch.zeros(M, device=device, dtype=torch.float32)
+    nm = triton.cdiv(M, BLOCK_M)
+    nn = triton.cdiv(N, BLOCK_N)
+    kernel[(nm * nn, )](dy, x, M, N, BLOCK_M, BLOCK_N, num_warps=4)
+
+    expected = torch.full((M, ), float(N), device=device, dtype=torch.float32)
+    np.testing.assert_allclose(dy.cpu().numpy(), expected.cpu().numpy(), rtol=1e-4)
+
+
+@pytest.mark.parametrize("BLOCK_M, BLOCK_N", [(128, 128), (64, 128), (32, 128), (32, 64), (32, 32)])
+def test_tensor_atomic_rmw_2d_grid_with_1d_load(BLOCK_M, BLOCK_N, device):
+    """Regression: atomic_add must not be duplicated by remove-layout-conversions
+    when a 1D row load (y_ptr + rows) shares the `rows` variable with the 2D
+    load and the atomic pointer.  This pattern triggers the bug more aggressively
+    than the 2D-only case (at lower nm values, with up to 3x over-count)."""
+    M, N = 128, 128
+
+    @triton.jit
+    def kernel(dy_ptr, x_ptr, y_ptr, M: tl.constexpr, N: tl.constexpr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+        pid = tl.program_id(0)
+        num_blocks_m = tl.cdiv(M, BLOCK_M)
+        pid_m = pid % num_blocks_m
+        pid_n = pid // num_blocks_m
+        rows = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        cols = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        x = tl.load(x_ptr + rows[:, None] * N + cols[None, :])
+        y = tl.load(y_ptr + rows)
+        val = (x * y[:, None]).sum(axis=1)
+        tl.atomic_add(dy_ptr + rows, val, sem="relaxed")
+
+    x = torch.ones(M, N, device=device, dtype=torch.float32)
+    y = torch.ones(M, device=device, dtype=torch.float32)
+    dy = torch.zeros(M, device=device, dtype=torch.float32)
+    nm = triton.cdiv(M, BLOCK_M)
+    nn = triton.cdiv(N, BLOCK_N)
+    kernel[(nm * nn, )](dy, x, y, M, N, BLOCK_M, BLOCK_N, num_warps=4)
+
+    expected = torch.full((M, ), float(N), device=device, dtype=torch.float32)
+    np.testing.assert_allclose(dy.cpu().numpy(), expected.cpu().numpy(), rtol=1e-4)

--- a/test/TritonIntelGPU/RemoveLayoutConversions/atomic_rmw_no_duplicate.mlir
+++ b/test/TritonIntelGPU/RemoveLayoutConversions/atomic_rmw_no_duplicate.mlir
@@ -1,0 +1,65 @@
+// RUN: triton-opt %s -tritonintelgpu-remove-layout-conversions | FileCheck %s
+
+// COM: Verify that the remove-layout-conversions pass does not duplicate
+//      tt.atomic_rmw operations. Duplicating side-effecting atomics causes
+//      incorrect results (e.g., double-counting with atomic_add).
+
+// CHECK-LABEL: @atomic_rmw_no_duplicate
+// CHECK: tt.atomic_rmw
+// CHECK-NOT: tt.atomic_rmw
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.min_sg_size = 16 : i32, ttig.support_2d_block_io, ttig.support_subgroup_matrix_multiply_accumulate} {
+  tt.func public @atomic_rmw_no_duplicate(%dy_ptr: !tt.ptr<f32>, %x_ptr: !tt.ptr<f32>, %row_off: i32, %col_off: i32) {
+    %cst = arith.constant dense<true> : tensor<32xi1, #blocked>
+    %cst_0 = arith.constant dense<128> : tensor<32x1xi32, #blocked1>
+    %range = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #blocked>
+    %row_splat = tt.splat %row_off : i32 -> tensor<32xi32, #blocked>
+    // %rows is shared between the 2D load path and the atomic pointer path.
+    %rows = arith.addi %row_splat, %range : tensor<32xi32, #blocked>
+    %col_splat = tt.splat %col_off : i32 -> tensor<32xi32, #blocked>
+    %cols = arith.addi %col_splat, %range : tensor<32xi32, #blocked>
+
+    // 2D load path: rows → slice → expand_dims → broadcast → load → reduce.
+    %r_slice = ttg.convert_layout %rows : tensor<32xi32, #blocked> -> tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked2}>>
+    %r_exp = tt.expand_dims %r_slice {axis = 1 : i32} : tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked2}>> -> tensor<32x1xi32, #blocked2>
+    %r_cvt = ttg.convert_layout %r_exp : tensor<32x1xi32, #blocked2> -> tensor<32x1xi32, #blocked1>
+    %r_mul = arith.muli %r_cvt, %cst_0 : tensor<32x1xi32, #blocked1>
+    %x_splat = tt.splat %x_ptr : !tt.ptr<f32> -> tensor<32x1x!tt.ptr<f32>, #blocked1>
+    %x_addr = tt.addptr %x_splat, %r_mul : tensor<32x1x!tt.ptr<f32>, #blocked1>, tensor<32x1xi32, #blocked1>
+    %c_slice = ttg.convert_layout %cols : tensor<32xi32, #blocked> -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked3}>>
+    %c_exp = tt.expand_dims %c_slice {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked3}>> -> tensor<1x32xi32, #blocked3>
+    %c_cvt = ttg.convert_layout %c_exp : tensor<1x32xi32, #blocked3> -> tensor<1x32xi32, #blocked4>
+    %x_bcast = tt.broadcast %x_addr : tensor<32x1x!tt.ptr<f32>, #blocked1> -> tensor<32x32x!tt.ptr<f32>, #blocked1>
+    %x_cvt = ttg.convert_layout %x_bcast : tensor<32x32x!tt.ptr<f32>, #blocked1> -> tensor<32x32x!tt.ptr<f32>, #blocked4>
+    %c_bcast = tt.broadcast %c_cvt : tensor<1x32xi32, #blocked4> -> tensor<32x32xi32, #blocked4>
+    %ld_addr = tt.addptr %x_cvt, %c_bcast : tensor<32x32x!tt.ptr<f32>, #blocked4>, tensor<32x32xi32, #blocked4>
+    %ld_cvt = ttg.convert_layout %ld_addr : tensor<32x32x!tt.ptr<f32>, #blocked4> -> tensor<32x32x!tt.ptr<f32>, #blocked5>
+    %loaded = tt.load %ld_cvt : tensor<32x32x!tt.ptr<f32>, #blocked5>
+    %ld_back = ttg.convert_layout %loaded : tensor<32x32xf32, #blocked5> -> tensor<32x32xf32, #blocked4>
+    %reduced = "tt.reduce"(%ld_back) <{axis = 1 : i32}> ({
+    ^bb0(%a: f32, %b: f32):
+      %s = arith.addf %a, %b : f32
+      tt.reduce.return %s : f32
+    }) : (tensor<32x32xf32, #blocked4>) -> tensor<32xf32, #ttg.slice<{dim = 1, parent = #blocked4}>>
+    %val = ttg.convert_layout %reduced : tensor<32xf32, #ttg.slice<{dim = 1, parent = #blocked4}>> -> tensor<32xf32, #blocked>
+
+    // Atomic path: uses %rows for pointer computation.
+    %dy_splat = tt.splat %dy_ptr : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>, #blocked>
+    %dy_addr = tt.addptr %dy_splat, %rows : tensor<32x!tt.ptr<f32>, #blocked>, tensor<32xi32, #blocked>
+
+    // Identity convert_layouts inserted by coalesce.
+    %ptr_id = ttg.convert_layout %dy_addr : tensor<32x!tt.ptr<f32>, #blocked> -> tensor<32x!tt.ptr<f32>, #blocked>
+    %val_id = ttg.convert_layout %val : tensor<32xf32, #blocked> -> tensor<32xf32, #blocked>
+    %msk_id = ttg.convert_layout %cst : tensor<32xi1, #blocked> -> tensor<32xi1, #blocked>
+
+    // This atomic must NOT be duplicated by the pass.
+    %result = tt.atomic_rmw fadd, relaxed, gpu, %ptr_id, %val_id, %msk_id : (tensor<32x!tt.ptr<f32>, #blocked>, tensor<32xf32, #blocked>, tensor<32xi1, #blocked>) -> tensor<32xf32, #blocked>
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -1485,6 +1485,11 @@ LayoutRematerialization::propagateToUsers(DenseMap<Value, Attribute> &values,
   SmallVector<Value> changed;
   for (OpOperand &use : value.getUses()) {
     Operation *user = use.getOwner();
+    // Do not propagate layout through side-effecting operations like atomics.
+    // Cloning them with a different encoding would cause them to execute
+    // multiple times, producing incorrect results (e.g., double-counting).
+    if (!canBeRemat(user))
+      continue;
     if (user->hasTrait<OpTrait::SameOperandsAndResultEncoding>() ||
         user->hasTrait<OpTrait::Elementwise>())
       setEncoding(values, user->getResults(), layout, changed, user);


### PR DESCRIPTION
Fixes incorrect rematerialization in the Intel RemoveLayoutConversions transform by preventing layout propagation through non-rematerializable (notably side-effecting atomic) operations, which could otherwise lead to duplicated atomics and incorrect results.