### PR TITLE
Merge OpenAI Triton commit  `4473e29`

### DIFF
--- a/.github/workflows/integration-tests-nvidia.yml
+++ b/.github/workflows/integration-tests-nvidia.yml
@@ -90,8 +90,10 @@ jobs:
         run: ccache --print-stats
       - name: Run lit tests
         run: make test-lit
-      - name: Run python tests on CUDA
+      - name: Run triton tests
         run: make NUM_PROCS=24 test-unit
+      - name: Run gluon tests
+        run: make NUM_PROCS=24 test-gluon
       - name: Run interpreter tests
         if: ${{ matrix.config.runner_type == 'nvidia-h100' }}
         run: make test-interpret

--- a/Makefile
+++ b/Makefile
@@ -31,33 +31,26 @@ test-cpp:
 
 .PHONY: test-unit
 test-unit: all
-	cd python/test/unit && $(PYTEST) --tb=short -s -n $(NUM_PROCS) --ignore=language/test_line_info.py \
-		--ignore=language/test_subprocess.py --ignore=test_debug.py --ignore=plugins/test_dialect_plugin.py --ignore=plugins/test_plugin.py
-	$(PYTEST) --tb=short -s -n $(NUM_PROCS) python/test/unit/language/test_subprocess.py
-	$(PYTEST) --tb=short -s -n $(NUM_PROCS) python/test/unit/test_debug.py --forked
-	$(PYTEST) --tb=short -s -n 6 python/triton_kernels/tests/
-	TRITON_DISABLE_LINE_INFO=0 $(PYTEST) --tb=short -s python/test/unit/language/test_line_info.py
+	cd python/test/unit && $(PYTEST) -n $(NUM_PROCS) --ignore-glob='plugins/*' --ignore=test_debug.py
+	$(PYTEST) -n $(NUM_PROCS) python/test/unit/test_debug.py
+	$(PYTEST) -n 6 python/triton_kernels/tests/
 	# Run attention separately to avoid out of gpu memory
-	$(PYTEST) --tb=short -vs python/tutorials/06-fused-attention.py
-	$(PYTEST) --tb=short -n $(NUM_PROCS) -vs python/tutorials/gluon
-	$(PYTEST) --tb=short -vs python/examples/gluon/01-attention-forward.py
+	$(PYTEST) python/tutorials/06-fused-attention.py
 	TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=python/triton/instrumentation/libGPUInstrumentationTestLib.so \
 		$(PYTEST) --capture=tee-sys -rfs -vvv python/test/unit/instrumentation/test_gpuhello.py
 	TRITON_PASS_PLUGIN_PATH=python/triton/plugins/libTritonPluginsTestLib.so \
 		$(PYTEST) -vvv python/test/unit/plugins/test_plugin.py
 	TRITON_PASS_PLUGIN_PATH=python/triton/plugins/libMLIRDialectPlugin.so \
-		$(PYTEST) -s -vvv python/test/unit/plugins/test_dialect_plugin.py
-	$(PYTEST) --tb=short -s -n $(NUM_PROCS) python/test/gluon
+		$(PYTEST) -vvv python/test/unit/plugins/test_dialect_plugin.py
 
 .PHONY: test-gluon
 test-gluon: all
-	$(PYTEST) --tb=short -s -n $(NUM_PROCS) python/test/gluon
-	$(PYTEST) --tb=short -vs python/examples/gluon/01-attention-forward.py
-	$(PYTEST) --tb=short -n $(NUM_PROCS) -vs python/tutorials/gluon
+	$(PYTEST) -n $(NUM_PROCS) python/test/gluon/ python/tutorials/gluon/
+	$(PYTEST) -n 2 python/examples/gluon/
 
 .PHONY: test-regression
 test-regression: all
-	$(PYTEST) --tb=short -s -n $(NUM_PROCS) python/test/regression
+	$(PYTEST) -n $(NUM_PROCS) python/test/regression
 
 .PHONY: test-microbenchmark
 test-microbenchmark: all
@@ -65,17 +58,17 @@ test-microbenchmark: all
 
 .PHONY: test-interpret
 test-interpret: all
-	cd python/test/unit && TRITON_INTERPRET=1 $(PYTEST) --tb=short -s -n 16 -m interpreter cuda language/test_core.py language/test_standard.py \
+	cd python/test/unit && TRITON_INTERPRET=1 $(PYTEST) -n 16 -m interpreter cuda language/test_core.py language/test_standard.py \
 		language/test_random.py language/test_block_pointer.py language/test_subprocess.py language/test_line_info.py \
 		language/test_tuple.py runtime/test_launch.py runtime/test_autotuner.py::test_kwargs[False] \
 		../../tutorials/06-fused-attention.py::test_op --device=cpu
 
 .PHONY: test-proton
 test-proton: all
-	$(PYTEST) --tb=short -s -n 8 third_party/proton/test --ignore=third_party/proton/test/test_override.py -k "not test_overhead and not test_hw_trace"
-	$(PYTEST) --tb=short -s third_party/proton/test/test_profile.py::test_hw_trace
-	$(PYTEST) --tb=short -s third_party/proton/test/test_override.py
-	$(PYTEST) --tb=short -s third_party/proton/test/test_instrumentation.py::test_overhead
+	$(PYTEST) -n 8 third_party/proton/test --ignore=third_party/proton/test/test_override.py -k "not test_overhead and not test_hw_trace"
+	$(PYTEST) third_party/proton/test/test_profile.py::test_hw_trace
+	$(PYTEST) third_party/proton/test/test_override.py
+	$(PYTEST) third_party/proton/test/test_instrumentation.py::test_overhead
 
 .PHONY: test-python
 test-python: test-unit test-regression test-interpret test-proton

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -568,7 +568,10 @@ LogicalResult TCGen5MMAOp::verify() {
            << retType.getElementTypeBitWidth() << " but got "
            << retEnc.getColStride();
   // The maximum size of a MMA instruction is 128x256
-  if (retEnc.getBlockN() > 256)
+  auto ctaShape = getShapePerCTA(retEnc.getCGALayout().getCTASplitNum(),
+                                 retType.getShape());
+  auto instrSizeN = std::min<unsigned>(retEnc.getBlockN(), ctaShape[1]);
+  if (instrSizeN > 256)
     return emitOpError("The block size of the return operand must be less than "
                        "or equal to 256");
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
@@ -87,6 +87,11 @@ struct TCGen5MMAScaleSharedToTmemConversion
     MLIRContext *context = op->getContext();
     auto aScaleType = op.getAScale().getType();
     auto bScaleType = op.getBScale().getType();
+    if (aScaleType.getShape() != aScaleType.getAllocShape() ||
+        bScaleType.getShape() != bScaleType.getAllocShape()) {
+      op.emitError("subviews NYI");
+      return failure();
+    }
     int blockM = op.getBlockM();
     int blockN = op.getBlockN();
     bool anyChanged = false;

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
@@ -269,8 +269,6 @@ public:
         tmemStoreOp.getDst().getType().getEncoding());
     if (!tmemEnc)
       return failure();
-    int M = tmemEnc.getBlockM();
-    int N = tmemEnc.getBlockN();
     int numWarps = ttg::lookupNumWarps(tmemStoreOp);
     // Compute the alternative layout.
     std::optional<LinearLayout> ll =
@@ -336,8 +334,6 @@ public:
         tmemLoadOp.getSrc().getType().getEncoding());
     if (!tmemEnc)
       return failure();
-    int M = tmemEnc.getBlockM();
-    int N = tmemEnc.getBlockN();
     int numWarps = ttg::lookupNumWarps(tmemLoadOp);
     auto oldType = tmemLoadOp.getType();
     auto memType = cast<gpu::MemDescType>(tmemLoadOp.getSrc().getType());

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --tb=short
+markers = interpreter: indicate whether interpreter supports the test

--- a/python/examples/gluon/01-attention-forward.py
+++ b/python/examples/gluon/01-attention-forward.py
@@ -14,8 +14,8 @@ from triton.experimental.gluon.language.nvidia.hopper import fence_async_shared
 from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     allocate_tensor_memory,
-    get_tmem_reg_layout,
     tensor_memory_descriptor,
+    tensor_memory_descriptor_type,
     tma,
     mbarrier,
     tcgen05_mma,
@@ -244,13 +244,18 @@ class AttentionConfig:
         self.p_tmem_layout = gl.constexpr(TensorMemoryLayout((qk_instr_shape[0], qk_instr_shape[1]), col_stride=1))
         o_splitn_tmem_layout: gl.constexpr = TensorMemoryLayout(
             (o_instr_shape[0], o_instr_shape[1] // self.SPLIT_D_FACTOR), col_stride=1)
+        qk_tmem_ty: gl.constexpr = tensor_memory_descriptor_type(gl.float32, self.qk_shape, self.qk_tmem_layout,
+                                                                 self.qk_shape)
+        o_splitn_tmem_ty: gl.constexpr = tensor_memory_descriptor_type(
+            gl.float32,
+            [self.o_shape[0], self.o_shape[1] // self.SPLIT_D_FACTOR],
+            o_splitn_tmem_layout,
+            self.o_shape,
+        )
 
-        self.qk_layout = gl.constexpr(
-            get_tmem_reg_layout(gl.float32, self.qk_shape, self.qk_tmem_layout, self.num_warps,
-                                instr_variant="32x32b_splitn"))
-        self.o_splitn_layout = gl.constexpr(
-            get_tmem_reg_layout(gl.float32, (self.o_shape[0], self.o_shape[1] // self.SPLIT_D_FACTOR),
-                                o_splitn_tmem_layout, self.num_warps))
+        self.qk_layout = gl.constexpr(qk_tmem_ty.get_reg_layout(num_warps=self.num_warps,
+                                                                instr_variant="32x32b_splitn"))
+        self.o_splitn_layout = gl.constexpr(o_splitn_tmem_ty.get_reg_layout(num_warps=self.num_warps))
         self.alpha_2d_layout = gl.constexpr(gl.BlockedLayout([1, 1], [32, 1], [self.num_warps, 1], [0, 1]))
 
         is_fp16 = self.dtype.value in [gl.float16, gl.bfloat16]
@@ -561,19 +566,17 @@ def _compute_and_store_exp2(config, qk, p_tmem):
 @gluon.jit
 def _subtiled_qk_load(config, s_tmem, use_tmem_red: gl.constexpr):
     SIZE: gl.constexpr = s_tmem.shape[1] // config.SPLIT_QK_LOAD_FACTOR
-    s = s_tmem.slice(0, SIZE)
-    layout: gl.constexpr = get_tmem_reg_layout(gl.float32, s.shape, s.layout, config.num_warps)
     qks = ()
     if use_tmem_red:
         red_total = None
         for i in gl.static_range(config.SPLIT_QK_LOAD_FACTOR):
-            vals, reds = s_tmem.slice(i * SIZE, SIZE).load_max(layout)
+            vals, reds = s_tmem.slice(i * SIZE, SIZE).load_max()
             red_total = reds if red_total is None else gl.maximum(red_total, reds)
             qks = qks + (vals, )
         return _join_n(qks), red_total
     else:
         for i in gl.static_range(config.SPLIT_QK_LOAD_FACTOR):
-            qks = qks + (s_tmem.slice(i * SIZE, SIZE).load(layout), )
+            qks = qks + (s_tmem.slice(i * SIZE, SIZE).load(), )
         return _join_n(qks), None
 
 

--- a/python/examples/gluon/03-matmul-multicta.py
+++ b/python/examples/gluon/03-matmul-multicta.py
@@ -10,12 +10,11 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     allocate_tensor_memory,
     clc,
-    get_tmem_reg_layout,
     tcgen05_commit,
     tcgen05_mma,
     tensor_memory_descriptor,
 )
-from triton.experimental.gluon.language.nvidia.hopper import fence_async_shared, mbarrier, tma
+from triton.experimental.gluon.language.nvidia.hopper import mbarrier, tma
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 from triton.language.core import _aggregate as aggregate
 
@@ -411,16 +410,9 @@ def matmul_epilogue_partition(p):
         for s in gl.static_range(SUBTILE_FACTOR):
             acc_sub = acc_buf.slice(SPLIT_TILE_N * s, SPLIT_TILE_N)
             acc_smem = acc_smems.index(sub_acc_state.index)
-            acc = acc_sub.load(
-                get_tmem_reg_layout(
-                    gl.float32,
-                    (TILE_M, SPLIT_TILE_N),
-                    acc_sub.type.layout,
-                    gl.num_warps(),
-                )).to(dtype)
+            acc = acc_sub.load().to(dtype)
             tma.store_wait(pendings=1)
             acc_smem.store(acc)
-            fence_async_shared()
             tma.async_copy_shared_to_global(p.c_desc, [off_m, off_n + SPLIT_TILE_N * s], acc_smem)
             sub_acc_state = sub_acc_state.next()
         # Signal that the accumulator slot can be reused only after all stores are done.
@@ -467,7 +459,7 @@ def _matmul_kernel(
     tmem_layout: gl.constexpr = TensorMemoryLayout(
         [BLOCK_SIZE_M, BLOCK_N],
         col_stride=1,
-        cta_split_num=(2, 1) if TWO_CTAS else None,
+        cga_layout=[[1, 0]] if TWO_CTAS else [],
         two_ctas=TWO_CTAS,
     )
     acc_bufs = allocate_tensor_memory(gl.float32, [ACC_STAGES, BLOCK_M, BLOCK_N], tmem_layout)
@@ -549,11 +541,6 @@ def matmul_with_config(
     if a.dtype != torch.float16 or b.dtype != torch.float16:
         raise ValueError("matmul only supports fp16 inputs")
 
-    tile_m = block_size_m * (2 if two_ctas else 1)
-    tile_n = block_size_n * (2 if two_ctas else 1)
-    if M % tile_m != 0 or N % tile_n != 0 or K % block_size_k != 0:
-        raise ValueError(f"Shape {(M, N, K)} incompatible with tile {(tile_m, tile_n, block_size_k)}")
-
     if out is None:
         c = torch.empty((M, N), device=a.device, dtype=a.dtype)
     else:
@@ -586,9 +573,6 @@ def matmul_with_config(
     def grid(meta):
         tile_m = meta["BLOCK_SIZE_M"] * (2 if bool(meta["TWO_CTAS"]) else 1)
         tile_n = meta["BLOCK_SIZE_N"] * (2 if bool(meta["TWO_CTAS"]) else 1)
-        block_k = meta["BLOCK_SIZE_K"]
-        if M % tile_m != 0 or N % tile_n != 0 or K % block_k != 0:
-            raise ValueError(f"Shape {(M, N, K)} incompatible with tile {(tile_m, tile_n, block_k)}")
         num_tiles = triton.cdiv(M, tile_m) * triton.cdiv(N, tile_n)
         return (num_tiles, )
 
@@ -632,9 +616,6 @@ def matmul(a, b):
     def grid(meta):
         tile_m = meta["BLOCK_SIZE_M"] * (2 if bool(meta["TWO_CTAS"]) else 1)
         tile_n = meta["BLOCK_SIZE_N"] * (2 if bool(meta["TWO_CTAS"]) else 1)
-        block_k = meta["BLOCK_SIZE_K"]
-        if M % tile_m != 0 or N % tile_n != 0 or K % block_k != 0:
-            raise ValueError(f"Shape {(M, N, K)} incompatible with tile {(tile_m, tile_n, block_k)}")
         num_tiles = triton.cdiv(M, tile_m) * triton.cdiv(N, tile_n)
         return (num_tiles, )
 
@@ -642,81 +623,55 @@ def matmul(a, b):
     return c
 
 
+# Subset of matmul_get_configs
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
-@pytest.mark.parametrize(
-    "grid_minor_dim,grid_tile_width,stages,block_size_n",
-    [
-        (0, 1, 2, 128),
-        (1, 8, 4, 128),
-        (0, 16, 2, 256),
-    ],
-)
-def test_matmul_single_cta_configs(grid_minor_dim, grid_tile_width, stages, block_size_n):
-    M, N, K = 512, 512, 256
+@pytest.mark.parametrize("BLOCK_SIZE_M", [128])
+@pytest.mark.parametrize("BLOCK_SIZE_N", [128, 256])
+@pytest.mark.parametrize("BLOCK_SIZE_K", [64, 128])
+@pytest.mark.parametrize("GRID_MINOR_DIM", [0, 1])
+@pytest.mark.parametrize("GRID_TILE_WIDTH", [1, 8])
+@pytest.mark.parametrize("TWO_CTAS", [False, True])
+@pytest.mark.parametrize("STAGES", [2, 4])
+@pytest.mark.parametrize("ACC_STAGES", [2, 3])
+@pytest.mark.parametrize("EPILOGUE_SIZE_N", [32, 64])
+@pytest.mark.parametrize("M, N, K", [(100, 200, 200)])
+def test_matmul_matches_torch(
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_K,
+    GRID_MINOR_DIM,
+    GRID_TILE_WIDTH,
+    TWO_CTAS,
+    STAGES,
+    ACC_STAGES,
+    EPILOGUE_SIZE_N,
+):
+    if TWO_CTAS and BLOCK_SIZE_N > 128:
+        pytest.skip("Unsupported config")
+
     torch.manual_seed(0)
     a = torch.rand((M, K), device=torch.device("cuda"), dtype=torch.float16)
     b = torch.rand((K, N), device=torch.device("cuda"), dtype=torch.float16)
     expected = torch.matmul(a, b)
-    actual = matmul_with_config(
-        a,
-        b,
-        block_size_m=128,
-        block_size_n=block_size_n,
-        block_size_k=64,
-        grid_minor_dim=grid_minor_dim,
-        grid_tile_width=grid_tile_width,
-        stages=stages,
-        two_ctas=False,
-        epilogue_size_n=32,
-    )
-    torch.testing.assert_close(expected, actual, atol=1e-1, rtol=1e-2)
-
-
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
-@pytest.mark.parametrize(
-    "grid_minor_dim,grid_tile_width,stages",
-    [
-        (1, 1, 2),
-        (1, 4, 4),
-        (0, 12, 6),
-        (0, 8, 4),
-    ],
-)
-def test_matmul_two_cta_configs(grid_minor_dim, grid_tile_width, stages):
-    M, N, K = 512, 512, 256
-    torch.manual_seed(0)
-    a = torch.rand((M, K), device=torch.device("cuda"), dtype=torch.float16)
-    b = torch.rand((K, N), device=torch.device("cuda"), dtype=torch.float16)
-    expected = torch.matmul(a, b)
-    actual = matmul_with_config(
-        a,
-        b,
-        block_size_m=128,
-        block_size_n=128,
-        block_size_k=64,
-        grid_minor_dim=grid_minor_dim,
-        grid_tile_width=grid_tile_width,
-        stages=stages,
-        two_ctas=True,
-        epilogue_size_n=32,
-    )
-    torch.testing.assert_close(expected, actual, atol=1e-1, rtol=1e-2)
-
-
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
-@pytest.mark.parametrize(
-    "M,N,K",
-    [
-        (256, 256, 128),
-        (512, 256, 256),
-    ],
-)
-def test_matmul_autotuned_matches_torch(M, N, K):
-    torch.manual_seed(0)
-    a = torch.rand((M, K), device=torch.device("cuda"), dtype=torch.float16)
-    b = torch.rand((K, N), device=torch.device("cuda"), dtype=torch.float16)
-    expected = torch.matmul(a, b)
-    actual = matmul(a, b)
+    try:
+        actual = matmul_with_config(
+            a,
+            b,
+            block_size_m=BLOCK_SIZE_M,
+            block_size_n=BLOCK_SIZE_N,
+            block_size_k=BLOCK_SIZE_K,
+            grid_minor_dim=GRID_MINOR_DIM,
+            grid_tile_width=GRID_TILE_WIDTH,
+            stages=STAGES,
+            acc_stages=ACC_STAGES,
+            two_ctas=TWO_CTAS,
+            epilogue_size_n=EPILOGUE_SIZE_N,
+        )
+    except triton.OutOfResources:
+        pytest.skip("Out of resources")
     torch.testing.assert_close(expected, actual, atol=1e-1, rtol=1e-2)
 
 

--- a/python/examples/pytest.ini
+++ b/python/examples/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = *.py

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -1119,8 +1119,8 @@ void init_gluon_ir(py::module &&m) {
   m.def(
       "compute_tmem_reg_layout",
       [](py::object elementTyObj, std::vector<int64_t> shape,
-         py::object layoutObj, unsigned numWarps,
-         const std::string &atomName) -> py::object {
+         std::vector<int64_t> allocShape, py::object layoutObj,
+         unsigned numWarps, const std::string &atomName) -> py::object {
         DialectRegistry registry;
         registry.insert<triton::TritonDialect, ttg::TritonGPUDialect,
                         ttng::TritonNvidiaGPUDialect, gluon::GluonDialect>();
@@ -1135,8 +1135,6 @@ void init_gluon_ir(py::module &&m) {
         auto elementType = elementTyObj.attr("to_ir")(builderObj).cast<Type>();
         auto layoutAttr =
             layoutObj.attr("_to_ir")(builderObj).cast<Attribute>();
-        auto allocShape = shape;
-
         auto ctx = builder.getContext();
         auto memDescTy = builder.getChecked<ttg::MemDescType>(
             shape, elementType, layoutAttr,

--- a/python/test-requirements.txt
+++ b/python/test-requirements.txt
@@ -3,6 +3,7 @@ isort
 numpy
 pytest
 pytest-forked
+pytest-instafail
 pytest-xdist
 scipy>=1.7.1
 llnl-hatchet

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -6,7 +6,10 @@ import contextlib
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", "interpreter: indicate whether interpreter supports the test")
+    # If pytest-sugar is not active, enable instafail
+    if not config.pluginmanager.hasplugin("sugar"):
+        config.option.instafail = True
+
     if os.name == "nt":
         config.addinivalue_line("markers", "forked: subprocess analogue of pytest.mark.forked on Windows")
 

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -410,7 +410,6 @@ def test_tcgen5_mma(FAILURE, MEM_ACCESS_KIND, device, run_wrapper, monkeypatch):
             res = acc.load(blocked_layout)
             smemAcc = ttgl.allocate_shared_memory(input_desc.dtype, [XBLOCK, XBLOCK], input_desc.layout,
                                                   res.to(input_desc.dtype))
-            blackwell.fence_async_shared()
             tma.async_copy_shared_to_global(input_desc, [0, 0], smemAcc)
             tma.store_wait(0)
         elif MEM_ACCESS_KIND == "tmem_store":
@@ -1958,7 +1957,6 @@ def load_local_alloc_mma_write_after_read_kernel(a_ptr, K, BLOCK_M: ttgl.constex
         a_value = ttgl.load(a_ptr + offs_m * BLOCK_K + (offs_k + k))
 
         a_smem = ttgl.allocate_shared_memory(ttgl.float16, [BLOCK_M, BLOCK_K], smem_layout, a_value)
-        blackwell.fence_async_shared()
         blackwell.tcgen05_mma(a_smem, b_smem, tmem, use_acc=use_acc)
         use_acc = True
     blackwell.tcgen05_commit(bar)

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -26,7 +26,7 @@ from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
 from triton.experimental.gluon.language.nvidia.ampere import async_copy, mma_v2
-from triton.experimental.gluon.language.nvidia.hopper import tma, mbarrier, fence_async_shared
+from triton.experimental.gluon.language.nvidia.hopper import tma, mbarrier
 from triton.experimental.gluon.language.nvidia import hopper
 from triton.experimental.gluon.language.amd.cdna4 import async_copy as cdna4_async_copy
 from triton.experimental.gluon.language.extra import libdevice
@@ -34,7 +34,6 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     TensorMemoryScalesLayout,
     allocate_tensor_memory,
-    get_tmem_reg_layout,
     tcgen05_mma_barrier_count,
     tcgen05_mma,
     tcgen05_mma_scaled,
@@ -294,13 +293,7 @@ def tcgen05_mma_multicast_commit_kernel(a_desc, b_desc, out_ptrs, BLOCK_M: ttgl.
     mbarrier.wait(mma_bar, phase=0, deps=[smem_a, smem_b])
     mbarrier.invalidate(mma_bar)
 
-    tmem_reg_layout: ttgl.constexpr = get_tmem_reg_layout(
-        ttgl.float32,
-        (BLOCK_M, BLOCK_N),
-        acc_tmem_layout,
-        num_warps=ttgl.num_warps(),
-    )
-    out = acc_tmem.load(tmem_reg_layout)
+    out = acc_tmem.load()
     out = ttgl.convert_layout(out, blocked_c)
 
     out_offs_m = ttgl.arange(0, BLOCK_M)[:, None]
@@ -531,7 +524,6 @@ def mma_kernel(a, b, out, M: ttgl.constexpr, N: ttgl.constexpr, K: ttgl.constexp
 
     if USE_TCGEN05:
         two_ctas: ttgl.constexpr = acc_layout.two_ctas
-        fence_async_shared(cluster=two_ctas)
         mma_barrier = mbarrier.allocate_mbarrier()
         mbarrier.init(mma_barrier, count=1)
         # Need to synchronise all the CTAs after the mbarrier initialisation
@@ -545,15 +537,8 @@ def mma_kernel(a, b, out, M: ttgl.constexpr, N: ttgl.constexpr, K: ttgl.constexp
         mbarrier.wait(mma_barrier, phase=0, deps=[smem_a, smem_b])
         mbarrier.invalidate(mma_barrier)
 
-        tmem_reg_layout: ttgl.constexpr = get_tmem_reg_layout(
-            acc_dtype,
-            (M, N),
-            acc_layout,
-            num_warps=ttgl.num_warps(),
-        )
-        acc = acc_tmem.load(tmem_reg_layout)
+        acc = acc_tmem.load()
     else:
-        fence_async_shared()
         acc = ttgl.zeros([M, N], dtype=acc_dtype, layout=acc_layout)
         acc = hopper.warpgroup_mma(smem_a, smem_b, acc, is_async=ASYNC)
 
@@ -656,13 +641,7 @@ def tma_mma_shared_inputs_kernel(a_desc, b_desc, out_ptr, BLOCK_M: ttgl.constexp
 
     if use_tcgen05:
         mbarrier.invalidate(mma_bar)
-        reg_layout: ttgl.constexpr = get_tmem_reg_layout(
-            ttgl.float32,
-            (BLOCK_M, BLOCK_N),
-            acc_tmem_layout,
-            num_warps=ttgl.num_warps(),
-        )
-        acc = acc_tmem.load(reg_layout)
+        acc = acc_tmem.load()
 
     acc = ttgl.convert_layout(acc, block_layout_c)
     offs_m = ttgl.arange(0, BLOCK_M)[:, None]
@@ -1361,7 +1340,6 @@ def test_tmem_copy_2d():
         mbarrier.init(barrier, count=1)
 
         smem.store(value)
-        fence_async_shared()
         tcgen05_copy(smem, tmem)
         tcgen05_commit(barrier)
         mbarrier.wait(barrier, phase=0)
@@ -1402,7 +1380,7 @@ def test_tmem_subslice_block_m_64():
         s_tmem = allocate_tensor_memory(ttgl.float32, (BLOCK_M, N), layout=tmem_layout)
         o_tmem = allocate_tensor_memory(ttgl.float32, (BLOCK_M, N), layout=tmem_layout)
 
-        layout: ttgl.constexpr = get_tmem_reg_layout(ttgl.float32, (BLOCK_M, N), tmem_layout, num_warps=4)
+        layout: ttgl.constexpr = s_tmem.get_reg_layout()
 
         offsets = ttgl.arange(0, BLOCK_M)[:, None] * N + ttgl.arange(0, N)[None, :]
         offsets = ttgl.set_auto_layout(offsets, layout)
@@ -1411,21 +1389,20 @@ def test_tmem_subslice_block_m_64():
         s_tmem.store(s)
         o_tmem.store(s)
 
-        p_tmem_layout: ttgl.constexpr = TensorMemoryLayout((BLOCK_M, BLOCK_N), col_stride=1)
-        p_tmem = s_tmem.slice(0, N // 2)._reinterpret(ttgl.float16, [BLOCK_M, N], p_tmem_layout)
+        p_tmem = s_tmem.slice(0, N // 2)._reinterpret(ttgl.float16, [BLOCK_M, N], tmem_layout)
         p_tmem.store(ttgl.full((BLOCK_M, N), 0.0, dtype=ttgl.float16, layout=layout))
 
         d1_tmem_layout: ttgl.constexpr = TensorMemoryLayout((BLOCK_M, 2), col_stride=1)
-        d1_layout: ttgl.constexpr = get_tmem_reg_layout(ttgl.float32, (BLOCK_M, 2), d1_tmem_layout, num_warps=4)
 
         m_tmem = s_tmem.slice(N // 4, 2)._reinterpret(ttgl.float32, [BLOCK_M, 2], d1_tmem_layout)
+        d1_layout: ttgl.constexpr = m_tmem.get_reg_layout()
         m_tmem.store(ttgl.full((BLOCK_M, 2), 2.0, dtype=ttgl.float32, layout=d1_layout))
         l_tmem = s_tmem.slice(N // 4 + 2, 2)._reinterpret(ttgl.float32, [BLOCK_M, 2], d1_tmem_layout)
         l_tmem.store(ttgl.full((BLOCK_M, 2), 3.0, dtype=ttgl.float32, layout=d1_layout))
         a_tmem = s_tmem.slice(N // 4 + 4, 2)._reinterpret(ttgl.float32, [BLOCK_M, 2], d1_tmem_layout)
         a_tmem.store(ttgl.full((BLOCK_M, 2), 4.0, dtype=ttgl.float32, layout=d1_layout))
 
-        s = s_tmem.load(layout)
+        s = s_tmem.load()
 
         ttgl.store(out_ptr + offsets, s)
 
@@ -1483,8 +1460,10 @@ def test_block_m_64_mma():
 
         a_tmem_layout: ttgl.constexpr = TensorMemoryLayout((BLOCK_M, BLOCK_N), col_stride=1)
         acc_tmem_layout: ttgl.constexpr = TensorMemoryLayout((BLOCK_M, BLOCK_N), col_stride=1)
-        a_layout: ttgl.constexpr = get_tmem_reg_layout(ttgl.float16, (BLOCK_M, N), a_tmem_layout, num_warps=4,
-                                                       instr_variant="32x32b_splitn")
+        al_tmem = allocate_tensor_memory(ttgl.float16, (BLOCK_M, N), layout=a_tmem_layout)
+        ar_tmem = allocate_tensor_memory(ttgl.float16, (BLOCK_M, N), layout=a_tmem_layout)
+        acc_tmem = allocate_tensor_memory(ttgl.float32, (BLOCK_M, N), layout=acc_tmem_layout)
+        a_layout: ttgl.constexpr = al_tmem.get_reg_layout(instr_variant="32x32b_splitn")
         b_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 32], [4, 1], [1, 0])
         a_offsets = ttgl.set_auto_layout(a_offsets, a_layout)
         b_offsets = ttgl.set_auto_layout(b_offsets, b_layout)
@@ -1492,10 +1471,6 @@ def test_block_m_64_mma():
         a = ttgl.load(a_ptr + a_offsets)
         b = ttgl.load(b_ptr + b_offsets)
         c = ttgl.load(c_ptr + a_offsets)
-
-        al_tmem = allocate_tensor_memory(ttgl.float16, (BLOCK_M, N), layout=a_tmem_layout)
-        ar_tmem = allocate_tensor_memory(ttgl.float16, (BLOCK_M, N), layout=a_tmem_layout)
-        acc_tmem = allocate_tensor_memory(ttgl.float32, (BLOCK_M, N), layout=acc_tmem_layout)
 
         a0, a1 = a.reshape((BLOCK_M, 2, N // 2)).permute(0, 2, 1).split()
 
@@ -1639,12 +1614,12 @@ def test_tmem_copy_no_scales(M, N, BLOCK_N, num_warps, swizzle):
             block=(128, BLOCK_N),
             col_stride=32 // in_ptr.dtype.element_ty.primitive_bitwidth,
         )
-        tmem_reg_layout: ttgl.constexpr = get_tmem_reg_layout(
-            in_ptr.dtype.element_ty,
-            (M, N),
-            tmem_layout,
-            num_warps=num_warps,
+        tmem = allocate_tensor_memory(
+            element_ty=in_ptr.dtype.element_ty,
+            shape=[M, N],
+            layout=tmem_layout,
         )
+        tmem_reg_layout: ttgl.constexpr = tmem.get_reg_layout()
         offs_m = ttgl.arange(0, M, ttgl.SliceLayout(1, tmem_reg_layout))
         offs_n = ttgl.arange(0, N, ttgl.SliceLayout(0, tmem_reg_layout))
         offs = offs_m[:, None] * N + offs_n[None, :]
@@ -1655,17 +1630,12 @@ def test_tmem_copy_no_scales(M, N, BLOCK_N, num_warps, swizzle):
         smem = ttgl.allocate_shared_memory(in_ptr.dtype.element_ty, [M, N], layout=smem_layout)
 
         smem.store(input)
-        tmem = allocate_tensor_memory(
-            element_ty=in_ptr.dtype.element_ty,
-            shape=[M, N],
-            layout=tmem_layout,
-        )
         bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
         mbarrier.init(bar, count=1)
         tcgen05_copy(smem, tmem)
         tcgen05_commit(bar)
         mbarrier.wait(bar, phase=0)
-        output = tmem.load(tmem_reg_layout)
+        output = tmem.load()
         ttgl.store(out_ptr + offs, output)
 
     input = torch.arange(M * N, device="cuda").reshape(M, N).to(torch.int32)
@@ -2022,23 +1992,24 @@ def test_tcgen05_mma_scaled_minimal():
 
         # Accumulator in TMEM initialized to ones
         acc_tmem_layout: ttgl.constexpr = TensorMemoryLayout([M, N], col_stride=1)
-        tmem_reg_layout: ttgl.constexpr = get_tmem_reg_layout(ttgl.float32, (M, N), acc_tmem_layout, ttgl.num_warps())
+        acc_tmem = allocate_tensor_memory(ttgl.float32, [M, N], acc_tmem_layout)
+        tmem_reg_layout: ttgl.constexpr = acc_tmem.get_reg_layout()
         acc_init = ttgl.zeros([M, N], ttgl.float32, layout=tmem_reg_layout)
-        acc_tmem = allocate_tensor_memory(ttgl.float32, [M, N], acc_tmem_layout, acc_init)
+        acc_tmem.store(acc_init)
 
         # Zero scales in TMEM
         scale_layout: ttgl.constexpr = TensorMemoryScalesLayout()
-        scale_reg_layout_m: ttgl.constexpr = get_tmem_reg_layout(ttgl.int8, (M, K // 32), scale_layout,
-                                                                 ttgl.num_warps())
-        scale_reg_layout_n: ttgl.constexpr = get_tmem_reg_layout(ttgl.int8, (N, K // 32), scale_layout,
-                                                                 ttgl.num_warps())
+        a_scale_tmem = allocate_tensor_memory(a_scale.dtype.element_ty, [M, K // 32], scale_layout)
+        b_scale_tmem = allocate_tensor_memory(b_scale.dtype.element_ty, [N, K // 32], scale_layout)
+        scale_reg_layout_m: ttgl.constexpr = a_scale_tmem.get_reg_layout()
+        scale_reg_layout_n: ttgl.constexpr = b_scale_tmem.get_reg_layout()
         scale_offs_k = ttgl.arange(0, (K // 32), layout=ttgl.SliceLayout(0, scale_reg_layout_m))[None, :]
         scale_offs_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, scale_reg_layout_m))[:, None]
         scale_offs_n = ttgl.arange(0, N, layout=ttgl.SliceLayout(1, scale_reg_layout_n))[:, None]
         a_scale_init = ttgl.load(a_scale + scale_offs_m * (K // 32) + scale_offs_k)
         b_scale_init = ttgl.load(b_scale + scale_offs_n * (K // 32) + scale_offs_k)
-        a_scale_tmem = allocate_tensor_memory(ttgl.int8, [M, K // 32], scale_layout, a_scale_init)
-        b_scale_tmem = allocate_tensor_memory(ttgl.int8, [M, K // 32], scale_layout, b_scale_init)
+        a_scale_tmem.store(a_scale_init)
+        b_scale_tmem.store(b_scale_init)
 
         # Issue a single scaled MMA and commit
         bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
@@ -2048,7 +2019,7 @@ def test_tcgen05_mma_scaled_minimal():
         mbarrier.wait(bar, phase=0)
 
         # Load result from TMEM and store to global
-        out_reg = acc_tmem.load(tmem_reg_layout)
+        out_reg = acc_tmem.load()
         store_layout: ttgl.constexpr = reg_layout
         offs_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, store_layout))[:, None]
         offs_n = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, store_layout))[None, :]
@@ -3386,12 +3357,7 @@ def tmem_reduction_kernel(
     )
 
     # Get register layout for TMEM access
-    tmem_reg_layout: ttgl.constexpr = get_tmem_reg_layout(
-        in_ptr.dtype.element_ty,
-        (M, N),
-        tmem_layout,
-        num_warps=num_warps,
-    )
+    tmem_reg_layout: ttgl.constexpr = tmem.get_reg_layout()
 
     # Store input to TMEM
     input_data = ttgl.convert_layout(input_data, tmem_reg_layout)
@@ -3399,9 +3365,9 @@ def tmem_reduction_kernel(
 
     # Load from TMEM with reduction
     if RED_OP == "min":
-        output, reduced = tmem.load_min(tmem_reg_layout, abs=USE_ABS, propagate_nan=PROPAGATE_NAN)
+        output, reduced = tmem.load_min(abs=USE_ABS, propagate_nan=PROPAGATE_NAN)
     elif RED_OP == "max":
-        output, reduced = tmem.load_max(tmem_reg_layout, abs=USE_ABS, propagate_nan=PROPAGATE_NAN)
+        output, reduced = tmem.load_max(abs=USE_ABS, propagate_nan=PROPAGATE_NAN)
 
     # Store full output
     output = ttgl.convert_layout(output, global_memory_layout)
@@ -3664,7 +3630,6 @@ def mma_scaled_tcgen05_copy_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale
 
         a_scale = unswizzle_scales_shared_memory(a_scale_smem, BLOCK_M, BLOCK_K, VEC_SIZE)
         b_scale = unswizzle_scales_shared_memory(b_scale_smem, BLOCK_N, BLOCK_K, VEC_SIZE)
-        fence_async_shared()
         tcgen05_copy(a_scale, a_scale_tmem)
         tcgen05_copy(b_scale, b_scale_tmem)
 
@@ -3678,15 +3643,12 @@ def mma_scaled_tcgen05_copy_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale
 
     mbarrier.invalidate(tma_bar)
     mbarrier.invalidate(mma_bar)
-    acc_reg_layout: ttgl.constexpr = get_tmem_reg_layout(ttgl.float32, (BLOCK_M, BLOCK_N), tmem_layout,
-                                                         ttgl.num_warps())
-    acc = acc_tmem.load(acc_reg_layout)
+    acc = acc_tmem.load()
     if two_ctas:
         acc = ttgl.convert_layout(acc, block_layout_c)
     acc = acc.to(c_desc.dtype)
     acc_smem = ttgl.allocate_shared_memory(c_desc.dtype, c_desc.block_type.shape, c_desc.layout)
     acc_smem.store(acc)
-    fence_async_shared()
     tma.async_copy_shared_to_global(c_desc, [off_m, off_n], acc_smem)
     tma.store_wait(0)
 

--- a/python/test/unit/language/test_line_info.py
+++ b/python/test/unit/language/test_line_info.py
@@ -597,3 +597,8 @@ def test_line_and_column_numbers(fresh_triton_cache):
 
     check_template = inspect.getsource(kernel_basic.fn)
     run_filecheck("placeholder", h.asm["ttir"], check_template)
+
+
+@pytest.fixture(autouse=True)
+def with_line_info(fresh_knobs):
+    fresh_knobs.compilation.disable_line_info = False

--- a/python/triton/tools/triton_to_gluon_translator/translator_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/translator_helpers.py
@@ -9,13 +9,12 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     TensorMemoryScalesLayout,
     allocate_tensor_memory,
-    get_tmem_reg_layout,
     tcgen05_commit,
     tcgen05_mma,
     tcgen05_mma_scaled,
 )
 from triton.experimental.gluon.language.nvidia.blackwell import tma as tma_blackwell
-from triton.experimental.gluon.language.nvidia.hopper import fence_async_shared, mbarrier, tma
+from triton.experimental.gluon.language.nvidia.hopper import mbarrier, tma
 from triton.language.core import _unwrap_if_constexpr
 
 
@@ -153,14 +152,13 @@ def tl_dot_blackwell(
     acc_dtype: ttgl.constexpr = acc.dtype if acc is not None else out_dtype
     col_stride: ttgl.constexpr = 32 // acc_dtype.primitive_bitwidth
     acc_tmem_layout: ttgl.constexpr = TensorMemoryLayout([m, n], col_stride=col_stride)
-
-    tmem_reg_layout: ttgl.constexpr = get_tmem_reg_layout(acc_dtype, (M, N), acc_tmem_layout, ttgl.num_warps())
+    acc_tmem = allocate_tensor_memory(acc_dtype, [M, N], acc_tmem_layout)
+    tmem_reg_layout: ttgl.constexpr = acc_tmem.get_reg_layout()
     if acc is not None:
         acc_temp = ttgl.convert_layout(acc, tmem_reg_layout)
     else:
         acc_temp = ttgl.zeros([M, N], out_dtype, layout=tmem_reg_layout)
-    acc_tmem = allocate_tensor_memory(acc_temp.dtype, [M, N], acc_tmem_layout, acc_temp)
-    fence_async_shared()
+    acc_tmem.store(acc_temp)
     bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
     mbarrier.init(bar, count=1)
     tcgen05_mma(a_smem, b_smem, acc_tmem, use_acc=True)
@@ -169,7 +167,7 @@ def tl_dot_blackwell(
     mbarrier.invalidate(bar)
 
     # Load back from TMEM using a register layout and convert to acc layout
-    out = acc_tmem.load(tmem_reg_layout)
+    out = acc_tmem.load()
     ret_layout: ttgl.constexpr = default_blocked_layout([M, N], ttgl.num_warps())
     out = ttgl.convert_layout(out, ret_layout)
     return out
@@ -464,32 +462,32 @@ def tl_dot_scaled_blackwell(
     acc_dtype: ttgl.constexpr = acc.dtype if acc is not None else out_dtype
     col_stride: ttgl.constexpr = 32 // acc_dtype.primitive_bitwidth
     acc_tmem_layout: ttgl.constexpr = TensorMemoryLayout([m, n], col_stride=col_stride)
-    tmem_reg_layout: ttgl.constexpr = get_tmem_reg_layout(acc_dtype, (M, N), acc_tmem_layout, ttgl.num_warps())
+    acc_tmem = allocate_tensor_memory(acc_dtype, [M, N], acc_tmem_layout)
+    tmem_reg_layout: ttgl.constexpr = acc_tmem.get_reg_layout()
     if acc is not None:
         acc_temp = ttgl.convert_layout(acc, tmem_reg_layout)
     else:
         acc_temp = ttgl.zeros([M, N], out_dtype, layout=tmem_reg_layout)
-    acc_tmem = allocate_tensor_memory(acc_temp.dtype, [M, N], acc_tmem_layout, acc_temp)
-    fence_async_shared()
+    acc_tmem.store(acc_temp)
 
     bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
     mbarrier.init(bar, count=1)
     scale_layout: ttgl.constexpr = TensorMemoryScalesLayout()
-    scale_layout_reg_lhs: ttgl.constexpr = get_tmem_reg_layout(lhs_scale.dtype, lhs_scale.type.shape, scale_layout,
-                                                               ttgl.num_warps())
-    scale_layout_reg_rhs: ttgl.constexpr = get_tmem_reg_layout(rhs_scale.dtype, rhs_scale.type.shape, scale_layout,
-                                                               ttgl.num_warps())
+    a_scale_tmem = allocate_tensor_memory(lhs_scale.dtype, lhs_scale.shape, scale_layout)
+    b_scale_tmem = allocate_tensor_memory(rhs_scale.dtype, rhs_scale.shape, scale_layout)
+    scale_layout_reg_lhs: ttgl.constexpr = a_scale_tmem.get_reg_layout()
+    scale_layout_reg_rhs: ttgl.constexpr = b_scale_tmem.get_reg_layout()
     lhs_scale = ttgl.convert_layout(lhs_scale, scale_layout_reg_lhs)
     rhs_scale = ttgl.convert_layout(rhs_scale, scale_layout_reg_rhs)
-    a_scale_tmem = allocate_tensor_memory(lhs_scale.dtype, lhs_scale.shape, scale_layout, lhs_scale)
-    b_scale_tmem = allocate_tensor_memory(rhs_scale.dtype, rhs_scale.shape, scale_layout, rhs_scale)
+    a_scale_tmem.store(lhs_scale)
+    b_scale_tmem.store(rhs_scale)
 
     tcgen05_mma_scaled(a_smem, b_smem, acc_tmem, a_scale_tmem, b_scale_tmem, lhs_format, rhs_format, use_acc=True)
     tcgen05_commit(bar)
     mbarrier.wait(bar, phase=0)
     mbarrier.invalidate(bar)
     # Load back from TMEM using a register layout and convert to acc layout
-    out = acc_tmem.load(tmem_reg_layout)
+    out = acc_tmem.load()
     ret_layout: ttgl.constexpr = default_blocked_layout([M, N], ttgl.num_warps())
     out = ttgl.convert_layout(out, ret_layout)
     return out
@@ -578,7 +576,6 @@ def tl_obj_scatter(obj, value, x_offsets, y_offset):
         desc = obj
         desc_shape: ttgl.constexpr = [x_offsets.shape[0], desc.block_shape[1]]
         alloc = ttgl.allocate_shared_memory(desc.dtype, desc_shape, desc.layout, value)
-        fence_async_shared()
         x_offsets_layout: ttgl.constexpr = ttgl.SliceLayout(
             0,
             ttgl.BlockedLayout([1, 4], [get_num_threads_per_warp(), 1], [1, ttgl.num_warps()], [1, 0]),
@@ -599,7 +596,6 @@ def tl_make_tensor_descriptor(base, shape, strides, block_shape, padding_option=
 @gluon.jit
 def tl_store_tensor_descriptor(desc, offsets, value):
     alloc = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout, value)
-    fence_async_shared()
     tma.async_copy_shared_to_global(desc, offsets, alloc)
     tma.store_wait(0)
     alloc._keep_alive()

--- a/python/tutorials/gluon/06-tcgen05.py
+++ b/python/tutorials/gluon/06-tcgen05.py
@@ -23,7 +23,6 @@ from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     allocate_tensor_memory,
-    get_tmem_reg_layout,
     tma,
     mbarrier,
     tcgen05_mma,
@@ -116,17 +115,12 @@ def tmem_example_kernel(in_ptr, out_ptr, M: gl.constexpr, N: gl.constexpr, num_w
         layout=tmem_layout,
     )
 
-    # Get the register layout needed to access the tensor memory using a helper.
-    tmem_reg_layout: gl.constexpr = get_tmem_reg_layout(
-        in_ptr.dtype.element_ty,
-        (M, N),
-        tmem_layout,
-        num_warps=num_warps,
-    )
+    # Get the register layout needed to access the tensor memory from the descriptor.
+    tmem_reg_layout: gl.constexpr = tmem.get_reg_layout()
 
     input = gl.convert_layout(input, tmem_reg_layout)
     tmem.store(input)
-    output = tmem.load(tmem_reg_layout)
+    output = tmem.load()
     output = gl.convert_layout(output, global_memory_layout)
 
     gl.store(out_ptr + offs, output)
@@ -188,12 +182,7 @@ def small_mma_kernel(a_desc, b_desc, c_desc, d_desc, tmem_block: gl.constexpr,  
         col_stride=32 // d_desc.dtype.primitive_bitwidth,
     )
     acc_tmem = allocate_tensor_memory(d_desc.dtype, [M, N], acc_tmem_layout)
-    acc_reg_layout: gl.constexpr = get_tmem_reg_layout(
-        d_desc.dtype,
-        (M, N),
-        acc_tmem_layout,
-        num_warps,
-    )
+    acc_reg_layout: gl.constexpr = acc_tmem.get_reg_layout()
     acc = c_smem.load(acc_reg_layout)
     acc_tmem.store(acc)
 
@@ -205,12 +194,7 @@ def small_mma_kernel(a_desc, b_desc, c_desc, d_desc, tmem_block: gl.constexpr,  
         )
         lhs_tmem = allocate_tensor_memory(a_desc.dtype, [M, K], lhs_tmem_layout)
 
-        lhs_reg_layout: gl.constexpr = get_tmem_reg_layout(
-            a_desc.dtype,
-            (M, K),
-            lhs_tmem_layout,
-            num_warps,
-        )
+        lhs_reg_layout: gl.constexpr = lhs_tmem.get_reg_layout()
         lhs = a_smem.load(lhs_reg_layout)
         lhs_tmem.store(lhs)
         a = lhs_tmem
@@ -261,7 +245,7 @@ def small_mma_kernel(a_desc, b_desc, c_desc, d_desc, tmem_block: gl.constexpr,  
     # way to zero the accumulator.
 
     d_smem = gl.allocate_shared_memory(d_desc.dtype, d_desc.block_type.shape, d_desc.layout)
-    acc = acc_tmem.load(acc_reg_layout)
+    acc = acc_tmem.load()
     d_smem.store(acc)
     fence_async_shared()
     tma.async_copy_shared_to_global(d_desc, [0, 0], d_smem)
@@ -362,13 +346,7 @@ def blocked_matmul_kernel(a_desc, b_desc, c_desc, TRANSPOSE_B: gl.constexpr, num
     mbarrier.invalidate(tma_bar)
     mbarrier.invalidate(mma_bar)
 
-    acc_reg_layout: gl.constexpr = get_tmem_reg_layout(
-        gl.float32,
-        (BLOCK_M, BLOCK_N),
-        tmem_layout,
-        num_warps,
-    )
-    acc = acc_tmem.load(acc_reg_layout)
+    acc = acc_tmem.load()
 
     # Downcast accumulator and store tile of C.
     c_smem = gl.allocate_shared_memory(dtype, c_desc.block_type.shape, c_desc.layout)
@@ -585,13 +563,6 @@ def blocked_matmul_pipelined_kernel(a_desc, b_desc, c_desc, num_warps: gl.conste
         tma.async_copy_global_to_shared(a_desc, [off_m + BLOCK_M, k], load_v_bar, v_bufs.index(load_index))
         k += BLOCK_K
 
-    acc_reg_layout: gl.constexpr = get_tmem_reg_layout(
-        gl.float32,
-        (BLOCK_M, BLOCK_N),
-        tmem_layout,
-        num_warps,
-    )
-
     mma_index, mma_phase, mma_counter = get_and_increment(mma_counter)
     ub_bar = mma_ub_bars.index(mma_index)
     vb_bar = mma_vb_bars.index(mma_index)
@@ -617,14 +588,14 @@ def blocked_matmul_pipelined_kernel(a_desc, b_desc, c_desc, num_warps: gl.conste
     # Wait UBN, UB epilogue
     mbarrier.wait(ub_bar, epilogue_phase)
     c_smem = gl.allocate_shared_memory(dtype, c_desc.block_type.shape, c_desc.layout)
-    ub = ub_tmem.load(acc_reg_layout)
+    ub = ub_tmem.load()
     c_smem.store(ub.to(dtype))
     fence_async_shared()
     tma.async_copy_shared_to_global(c_desc, [off_m, off_n], c_smem)
 
     # Wait VBN, VB epilogue
     mbarrier.wait(vb_bar, epilogue_phase)
-    vb = vb_tmem.load(acc_reg_layout)
+    vb = vb_tmem.load()
     tma.store_wait(pendings=0)
     c_smem.store(vb.to(dtype))
     fence_async_shared()

--- a/python/tutorials/gluon/07-persistence.py
+++ b/python/tutorials/gluon/07-persistence.py
@@ -48,7 +48,6 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     tensor_memory_descriptor,
     allocate_tensor_memory,
-    get_tmem_reg_layout,
     tcgen05_mma,
     tcgen05_commit,
 )
@@ -130,7 +129,6 @@ class MMAv5:
     acc_tmem: tensor_memory_descriptor
     bar: gl.shared_memory_descriptor
     counter: gl.tensor
-    reg_layout: gl.constexpr
 
     @gluon.jit
     def initialize(dtype: gl.constexpr, BLOCK_M: gl.constexpr, BLOCK_N: gl.constexpr, num_warps: gl.constexpr):
@@ -138,14 +136,13 @@ class MMAv5:
         acc_tmem = allocate_tensor_memory(gl.float32, [BLOCK_M, BLOCK_N], layout)
         bar = gl.allocate_shared_memory(gl.int64, [1], mbarrier.MBarrierLayout())
         mbarrier.init(bar, count=1)
-        reg_layout: gl.constexpr = get_tmem_reg_layout(gl.float32, (BLOCK_M, BLOCK_N), layout, num_warps)
-        return MMAv5(gl.to_tensor(False), acc_tmem, bar, gl.to_tensor(0), reg_layout)
+        return MMAv5(gl.to_tensor(False), acc_tmem, bar, gl.to_tensor(0))
 
     @gluon.jit
     def issue_async_mma(self, a, b):
         tcgen05_mma(a, b, self.acc_tmem, use_acc=self.use_acc)
         tcgen05_commit(self.bar)
-        return MMAv5(gl.to_tensor(True), self.acc_tmem, self.bar, self.counter + 1, self.reg_layout)
+        return MMAv5(gl.to_tensor(True), self.acc_tmem, self.bar, self.counter + 1)
 
     @gluon.jit
     def wait_num_outstanding(self, num_outstanding: gl.constexpr):
@@ -154,8 +151,8 @@ class MMAv5:
 
     @gluon.jit
     def take_result(self):
-        next = MMAv5(gl.to_tensor(False), self.acc_tmem, self.bar, self.counter, self.reg_layout)
-        return self.acc_tmem.load(self.reg_layout), next
+        next = MMAv5(gl.to_tensor(False), self.acc_tmem, self.bar, self.counter)
+        return self.acc_tmem.load(), next
 
 
 def select_mma_impl():

--- a/python/tutorials/gluon/08-warp-specialization.py
+++ b/python/tutorials/gluon/08-warp-specialization.py
@@ -35,7 +35,6 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     tensor_memory_descriptor,
     allocate_tensor_memory,
-    get_tmem_reg_layout,
     tcgen05_mma,
     tcgen05_commit,
 )
@@ -510,13 +509,6 @@ def matmul_epilogue_partition(p, SchedulerImpl: gl.constexpr):
     acc_empty_bars = p.acc_empty_bars
     acc_ready_bars = p.acc_ready_bars
     acc_state = Counter.create(0, p.acc_empty_bars.shape[0])
-    acc_tmem_layout: gl.constexpr = TensorMemoryLayout([BLOCK_M, BLOCK_N], col_stride=1)
-    acc_layout: gl.constexpr = get_tmem_reg_layout(
-        dtype,
-        (BLOCK_M, BLOCK_N),
-        acc_tmem_layout,
-        p.num_warps,
-    )
     SPLIT_N: gl.constexpr = BLOCK_N // p.SUBTILE_FACTOR
     acc_smem = gl.allocate_shared_memory(dtype, [BLOCK_M, SPLIT_N], p.c_desc.layout)
 
@@ -529,7 +521,7 @@ def matmul_epilogue_partition(p, SchedulerImpl: gl.constexpr):
         # Wait for the accumulator. Since BLOCK_N=256, we need to interleave
         # the TMEM loads with the SMEM stores to avoid spilling.
         mbarrier.wait(acc_ready_bars.index(acc_state.index), acc_state.phase)
-        acc = p.acc_bufs.index(acc_state.index).load(acc_layout)
+        acc = p.acc_bufs.index(acc_state.index).load()
         acc_state = acc_state.next()
 
         accs = _split_n(acc, p.SUBTILE_FACTOR)

--- a/python/tutorials/gluon/11-tcgen05-mma-scaled.py
+++ b/python/tutorials/gluon/11-tcgen05-mma-scaled.py
@@ -74,7 +74,6 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     TensorMemoryScalesLayout,
     allocate_tensor_memory,
-    get_tmem_reg_layout,
     fence_async_shared,
     tensor_memory_descriptor,
     tcgen05_copy,
@@ -198,10 +197,8 @@ def simple_mma_scaled_kernel(a_desc, b_desc, c_desc, a_scale_ptr, a_scale_stride
 
         # We have to write the scales to tensor memory. Convert them into a the right
         # layout so we can write into tensor memory with layout `TensorMemoryScalesLayout`.
-        a_scale_layout: gl.constexpr = get_tmem_reg_layout(a_scale.dtype, a_scale.type.shape, scale_layout,
-                                                           gl.num_warps())
-        b_scale_layout: gl.constexpr = get_tmem_reg_layout(b_scale.dtype, b_scale.type.shape, scale_layout,
-                                                           gl.num_warps())
+        a_scale_layout: gl.constexpr = a_scale_tmem.get_reg_layout()
+        b_scale_layout: gl.constexpr = b_scale_tmem.get_reg_layout()
         a_scale = gl.convert_layout(a_scale, a_scale_layout)
         b_scale = gl.convert_layout(b_scale, b_scale_layout)
         a_scale_tmem.store(a_scale)
@@ -232,8 +229,7 @@ def simple_mma_scaled_kernel(a_desc, b_desc, c_desc, a_scale_ptr, a_scale_stride
     mbarrier.invalidate(mma_bar)
 
     # Load the accumulator tile from tensor memory and convert it to the output dtype.
-    acc_reg_layout: gl.constexpr = get_tmem_reg_layout(gl.float32, (BLOCK_M, BLOCK_N), tmem_layout, gl.num_warps())
-    acc = acc_tmem.load(acc_reg_layout)
+    acc = acc_tmem.load()
     acc = acc.to(c_desc.dtype)
 
     # Write the accumulator via TMA store.
@@ -513,10 +509,8 @@ def mma_scaled_contig_kernel(a_desc, b_desc, c_desc, a_scale_ptr, b_scale_ptr, V
         b_scale = b_scale.reshape(BLOCK_N, SCALE_BLOCK_K)
 
         # ======= Begin unchanged code from `simple_mma_scaled_kernel` =======
-        a_scale_layout: gl.constexpr = get_tmem_reg_layout(a_scale.dtype, a_scale.type.shape, scale_layout,
-                                                           gl.num_warps())
-        b_scale_layout: gl.constexpr = get_tmem_reg_layout(b_scale.dtype, b_scale.type.shape, scale_layout,
-                                                           gl.num_warps())
+        a_scale_layout: gl.constexpr = a_scale_tmem.get_reg_layout()
+        b_scale_layout: gl.constexpr = b_scale_tmem.get_reg_layout()
         a_scale = gl.convert_layout(a_scale, a_scale_layout)
         b_scale = gl.convert_layout(b_scale, b_scale_layout)
         a_scale_tmem.store(a_scale)
@@ -533,8 +527,7 @@ def mma_scaled_contig_kernel(a_desc, b_desc, c_desc, a_scale_ptr, b_scale_ptr, V
 
     mbarrier.invalidate(bar)
     mbarrier.invalidate(mma_bar)
-    acc_reg_layout: gl.constexpr = get_tmem_reg_layout(gl.float32, (BLOCK_M, BLOCK_N), tmem_layout, gl.num_warps())
-    acc = acc_tmem.load(acc_reg_layout)
+    acc = acc_tmem.load()
     acc = acc.to(c_desc.dtype)
     acc_smem = gl.allocate_shared_memory(c_desc.dtype, c_desc.block_type.shape, c_desc.layout)
     acc_smem.store(acc)
@@ -743,10 +736,8 @@ def mma_scaled_packed_block_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale
         # which to load the scales from shared memory such that after unswizzling,
         # they have the right 2D layout for the store to TMEM. Instead, we will use
         # AutoLayout to let the compiler backwards propagate the layout.
-        a_scale_layout: gl.constexpr = get_tmem_reg_layout(a_scale_desc.dtype, [BLOCK_M, BLOCK_K // VEC_SIZE],
-                                                           scale_layout, gl.num_warps())
-        b_scale_layout: gl.constexpr = get_tmem_reg_layout(b_scale_desc.dtype, [BLOCK_N, BLOCK_K // VEC_SIZE],
-                                                           scale_layout, gl.num_warps())
+        a_scale_layout: gl.constexpr = a_scale_tmem.get_reg_layout()
+        b_scale_layout: gl.constexpr = b_scale_tmem.get_reg_layout()
 
         # Load the scales with AutoLayout. Subsequent operations, including the unswizzling,
         # will be generic over the layout.
@@ -775,8 +766,7 @@ def mma_scaled_packed_block_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale
 
     mbarrier.invalidate(bar)
     mbarrier.invalidate(mma_bar)
-    acc_reg_layout: gl.constexpr = get_tmem_reg_layout(gl.float32, (BLOCK_M, BLOCK_N), tmem_layout, gl.num_warps())
-    acc = acc_tmem.load(acc_reg_layout)
+    acc = acc_tmem.load()
     acc = acc.to(c_desc.dtype)
     acc_smem = gl.allocate_shared_memory(c_desc.dtype, c_desc.block_type.shape, c_desc.layout)
     acc_smem.store(acc)
@@ -1045,8 +1035,7 @@ def mma_scaled_tcgen05_copy_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale
 
     mbarrier.invalidate(bar)
     mbarrier.invalidate(mma_bar)
-    acc_reg_layout: gl.constexpr = get_tmem_reg_layout(gl.float32, (BLOCK_M, BLOCK_N), tmem_layout, gl.num_warps())
-    acc = acc_tmem.load(acc_reg_layout)
+    acc = acc_tmem.load()
     acc = acc.to(c_desc.dtype)
     acc_smem = gl.allocate_shared_memory(c_desc.dtype, c_desc.block_type.shape, c_desc.layout)
     acc_smem.store(acc)
@@ -1246,7 +1235,6 @@ def mma_scaled_pipelined_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale_de
     # of tensor memory, which leaves no room for the scales' tensor memory.
     num_acc_buffers: gl.constexpr = 2 if BLOCK_N < 256 else 1
     tmem_layout: gl.constexpr = TensorMemoryLayout([BLOCK_M, BLOCK_N], col_stride=1)
-    acc_reg_layout: gl.constexpr = get_tmem_reg_layout(gl.float32, (BLOCK_M, BLOCK_N), tmem_layout, gl.num_warps())
     acc_bufs = allocate_tensor_memory(gl.float32, [num_acc_buffers, BLOCK_M, BLOCK_N], tmem_layout)
     acc_idx = 0
 
@@ -1320,7 +1308,7 @@ def mma_scaled_pipelined_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale_de
                                                     acc_bufs.index(acc_idx), use_acc=False, pred=has_next_tile)
         mbarrier.wait(mma_bars.index(mma_consumer.index), mma_consumer.phase)
         mma_consumer = mma_consumer.next()
-        acc = cur_acc_buf.load(acc_reg_layout)
+        acc = cur_acc_buf.load()
         if num_acc_buffers == 1:
             # Wait for all threads to finish loading from accumulator
             gl.barrier()
@@ -1405,15 +1393,13 @@ def mma_scaled_mma_partition(p):
 
 @gluon.jit
 def mma_scaled_epilogue_partition(p):
-    acc_layout: gl.constexpr = get_tmem_reg_layout(p.c_desc.dtype, (p.BLOCK_M, p.BLOCK_N), p.acc_bufs.type.layout,
-                                                   gl.num_warps())
     acc_state = t8.Counter.create(0, p.acc_empty_bars.shape[0])
     acc_smem = gl.allocate_shared_memory(p.c_desc.dtype, p.c_desc.block_type.shape, p.c_desc.layout)
     scheduler = p.SchedulerImpl.initialize(p.M, p.N, p.BLOCK_M, p.BLOCK_N)
     for idx in range(scheduler.get_num_tiles()):
         pid_m, pid_n = scheduler.get_tile(idx)
         mbarrier.wait(p.acc_ready_bars.index(acc_state.index), acc_state.phase)
-        acc = p.acc_bufs.index(acc_state.index).load(acc_layout)
+        acc = p.acc_bufs.index(acc_state.index).load()
         mbarrier.arrive(p.acc_empty_bars.index(acc_state.index), count=1)
         acc_state = acc_state.next()
 

--- a/python/tutorials/pytest.ini
+++ b/python/tutorials/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = *.py

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -100,6 +100,34 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32} {
 
 // -----
 
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tc_gen5_mma_subslice_acc
+  // CHECK-DAG: %[[TMEM_SUBSLICE_OFFSET:.+]] = llvm.mlir.constant(64 : i32) : i32
+  // CHECK-DAG: %[[TMEM_BASE:.+]] = llvm.ptrtoint %arg2{{.*}} : !llvm.ptr<3> to i32
+  // CHECK: %[[TMEM_SUBSLICE_BASE_INT:.+]] = llvm.add %[[TMEM_BASE]], %[[TMEM_SUBSLICE_OFFSET]] : i32
+  // CHECK: %[[TMEM_SUBSLICE_PTR:.+]] = llvm.inttoptr %[[TMEM_SUBSLICE_BASE_INT]] : i32 to !llvm.ptr<3>
+  // CHECK: %[[TMEM_SUBSLICE_BASE:.+]] = llvm.ptrtoint %[[TMEM_SUBSLICE_PTR]] : !llvm.ptr<3> to i32
+  // CHECK-COUNT-4: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_SUBSLICE_BASE]]
+  // CHECK-COUNT-4: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 128 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_SUBSLICE_BASE]]
+  tt.func @tc_gen5_mma_subslice_acc(%a: !ttg.memdesc<256x64xf16, #shared, #ttg.shared_memory>,
+                                    %b: !ttg.memdesc<64x64xf16, #shared1, #ttg.shared_memory>,
+                                    %c: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
+    %false = arith.constant false
+    %true = arith.constant true
+    %sub = ttng.tmem_subslice %c {N = 64 : i32} : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
+    ttng.tc_gen5_mma %a, %b, %sub, %false, %true :
+       !ttg.memdesc<256x64xf16, #shared, #ttg.shared_memory>,
+       !ttg.memdesc<64x64xf16, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
+    tt.return
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
@@ -888,6 +916,24 @@ tt.func private @subslice_16x32bx2_interleaved_block4_offset(%arg0: !ttg.memdesc
   // CHECK: llvm.add [[PTR]], [[OFFSET]] : i32
   %0 = ttng.tmem_subslice %arg0 {N = 80 : i32} : !ttg.memdesc<64x128xf32, #bm64_bn32, #tmem> -> !ttg.memdesc<64x16xf32, #bm64_bn32, #tmem, 64x128>
   tt.return %0 : !ttg.memdesc<64x16xf32, #bm64_bn32, #tmem, 64x128>
+}
+
+}
+
+// -----
+
+#bm128_bn256_cga = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1, CGALayout = [[1, 0], [2, 0]]>
+#tmem = #ttng.tensor_memory
+
+module attributes {"ttg.target" = "cuda:100", "ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 4 : i32} {
+
+// CHECK-LABEL: @subslice_cga_allocshape_preserved
+tt.func private @subslice_cga_allocshape_preserved(%arg0: !ttg.memdesc<512x256xf32, #bm128_bn256_cga, #tmem>) -> !ttg.memdesc<512x32xf32, #bm128_bn256_cga, #tmem, 512x256> {
+  // CHECK: [[OFFSET:%.*]] = llvm.mlir.constant(32 : i32)
+  // CHECK: [[PTR:%.*]] = llvm.ptrtoint
+  // CHECK: llvm.add [[PTR]], [[OFFSET]] : i32
+  %0 = ttng.tmem_subslice %arg0 {N = 32 : i32} : !ttg.memdesc<512x256xf32, #bm128_bn256_cga, #tmem> -> !ttg.memdesc<512x32xf32, #bm128_bn256_cga, #tmem, 512x256>
+  tt.return %0 : !ttg.memdesc<512x32xf32, #bm128_bn256_cga, #tmem, 512x256>
 }
 
 }

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -550,6 +550,16 @@ void init_triton_amd(py::module &&m) {
   });
 
   auto hipBlas = m.def_submodule("hipblas");
+  // For ROCm installed via TheRock wheels: Preload hipblaslt library via
+  // rocm_sdk if available. When using TheRock wheel installs, libhipblaslt
+  // resides within the Python wheel package rather than in the standard
+  // /opt/rocm/lib location. This preload ensures the library is properly
+  // loaded before HipblasLtInstance tries to dlopen it, allowing the dynamic
+  // linker to find it from the ROCm wheel's bundled libraries.
+  try {
+    py::module_::import("rocm_sdk").attr("preload_libraries")("hipblaslt");
+  } catch (...) {
+  }
   py::class_<HipblasLtInstance>(hipBlas, "HipblasLt")
       .def(py::init<>([&](py::object &workspace) {
         auto wrk_ptr = workspace.attr("data_ptr")().cast<uint64_t>();

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -915,6 +915,7 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
       int numWarps = mlir::triton::gpu::lookupNumWarps(op);
       builder.setInsertionPoint(op);
 
+      // TODO: This should probably be written as memdesc_subslice
       // calculate new tmem type.
       auto retType = cast<MemDescType>(tmemAllocOp.getType());
       SmallVector<int64_t> shape{retType.getShape().begin(),

--- a/third_party/proton/tutorials/intra_kernel/example_dsl.py
+++ b/third_party/proton/tutorials/intra_kernel/example_dsl.py
@@ -12,7 +12,6 @@ import triton.profiler.language as pl
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
 from triton.experimental.gluon.language.nvidia.hopper import (
-    fence_async_shared,
     mbarrier,
     tma,
     warpgroup_mma,
@@ -263,7 +262,6 @@ def blocked_matmul_pipelined_kernel(a_desc, b_desc, c_desc, num_warps: gl.conste
 
     c_smem = gl.allocate_shared_memory(dtype, c_desc.block_type.shape, c_desc.layout)
     c_smem.store(acc.to(dtype))
-    fence_async_shared()
     tma.async_copy_shared_to_global(c_desc, [off_m, off_n], c_smem)
     tma.store_wait(pendings=0)
 


### PR DESCRIPTION
This PR changes the Triton base from https://github.com/intel/intel-xpu-backend-for-triton/commit/f7abce786e76cc411a63ba93ce1cd0430b2f0ac5 to https://github.com/intel/intel-xpu-backend-for-triton/commit/4473e294a12021df111dbb76dc9f849802c03ffd (Mar 2).

Pass rate: 97.53% -> 97.53%