### PR TITLE
Remove transitive TritonGENDialect.h include from TritonIntelGPU/IR/Dialect.h

### DIFF
--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/Dialect.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/Dialect.h
@@ -11,7 +11,6 @@
 
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
-#include "intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h"
 #include "intel/include/Dialect/TritonIntelGPU/IR/Attributes.h"
 #include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h.inc"
 

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/Utils.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/Utils.h
@@ -11,6 +11,7 @@
 
 #include "intel/include/Analysis/AxisInfo.h"
 #include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Operation.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include <triton/Tools/Sys/GetEnv.hpp>

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
@@ -1,6 +1,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
 #include "Dialect/TritonIntelGPU/IR/Attributes.h"
+#include "intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h"
 #include "intel/include/Dialect/TritonIntelGPU/IR/LinearLayoutConversions.h"
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/Utility.h"
 #include "mlir/IR/DialectImplementation.h"

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
@@ -15,6 +15,7 @@
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 
+#include "intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h"
 #include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
 
 #define GET_OP_CLASSES

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -3,6 +3,7 @@
 #include "llvm/ADT/TypeSwitch.h"
 
 #include "intel/include/Analysis/Utility.h"
+#include "intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h"
 
 namespace mlir::triton::gpu {
 namespace {

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1,4 +1,5 @@
 #include "Dialect/TritonIntelGPU/IR/Dialect.h"
+#include "intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/IR/Matchers.h"

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.cpp
@@ -10,6 +10,7 @@
 #include "Dialect/TritonIntelGPU/IR/Utils.h"
 #include "SPIRVTargetInfo.h"
 #include "Utility.h"
+#include "intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h"
 
 #if defined(_MSC_VER) && !defined(__clang__)
 // from https://gist.github.com/pps83/3210a2f980fd02bb2ba2e5a1fc4a2ef0

--- a/third_party/intel/lib/TritonIntelGPUTransforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Pipeliner/SoftwarePipeliner.cpp
@@ -3,6 +3,7 @@
 
 #include "Pipeliner/Schedule.h"
 
+#include "intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h"
 #include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RewriteStackPtr.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RewriteStackPtr.cpp
@@ -1,3 +1,4 @@
+#include "intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h"
 #include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"

--- a/third_party/intel/lib/Utils/LibCallEmitter.cpp
+++ b/third_party/intel/lib/Utils/LibCallEmitter.cpp
@@ -1,6 +1,7 @@
 #include "LibCallEmitter.h"
 
 #include "Dialect/TritonIntelGPU/IR/Utils.h"
+#include "intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h"
 
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 


### PR DESCRIPTION
TritonIntelGPU/IR/Dialect.h included the monolithic TritonGENDialect.h (250KB+, 65 op classes), causing 54 .o files to rebuild whenever any TritonGEN operation changed.

Move the include to the .cpp files that actually need it (Dialect.cpp, Ops.cpp, and 6 lowering/transform files). Add the missing direct include of mlir/Dialect/LLVMIR/LLVMDialect.h to Utils.h, which relied on it transitively for LLVM::cconv.

This reduces the rebuild fan-out for TritonGENDialect.h from 54 to 25 object files.