### PR TITLE
Add PyTorch patch to add compilation cache dir to the autotuning output

### DIFF
--- a/scripts/patch-pytorch-installed.sh
+++ b/scripts/patch-pytorch-installed.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# This script applies required patches on top of an installed PyTorch wheel.
+# Unlike patch-pytorch.sh which operates on a cloned git repo, this script
+# patches Python files in-place within site-packages.
+
+set -euo pipefail
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PYTHON="${PYTHON:-python3}"
+
+SITE_ROOT=$("$PYTHON" -c "
+import pathlib, importlib.util
+spec = importlib.util.find_spec('torch')
+if spec is None or spec.origin is None:
+    raise SystemExit('ERROR: torch not found in current Python environment')
+print(pathlib.Path(spec.origin).parent.parent)
+") || {
+  echo "ERROR: Could not find PyTorch installation."
+  exit 1
+}
+
+apply_patch() {
+  echo "Applying patch $1"
+  if [[ -f "$SCRIPTS_DIR/$1" ]]; then
+    patch -p1 -d "$SITE_ROOT" < "$SCRIPTS_DIR/$1"
+  else
+    echo "ERROR: Patch file not found: $SCRIPTS_DIR/$1"
+    return 1
+  fi
+}
+
+echo "Applying PyTorch patches in $SITE_ROOT"
+
+# put your patch applies here
+apply_patch ./patch/inductor_autotune_cache_dir.patch

--- a/scripts/patch/inductor_autotune_cache_dir.patch
+++ b/scripts/patch/inductor_autotune_cache_dir.patch
@@ -1,0 +1,65 @@
+diff --git a/torch/_inductor/select_algorithm.py b/torch/_inductor/select_algorithm.py
+--- a/torch/_inductor/select_algorithm.py
++++ b/torch/_inductor/select_algorithm.py
+@@ -78,1 +78,1 @@
+-from .runtime.triton_heuristics import FixedGrid
++from .runtime.triton_heuristics import FixedGrid, triton_cache_dir, triton_hash_to_path_key
+
+ if TYPE_CHECKING:
+@@ -2594,6 +2594,37 @@
+     return choices
+
+
++def _get_triton_cache_dir(choice):
++    """Extract Triton cache directory from a benchmarked TritonTemplateCaller.
++
++    After autotuning, each choice's CachingAutotuner holds compile_results
++    populated by triton.compile().  For regular CompiledKernel the metadata
++    namedtuple carries ``cache_dir`` directly; for StaticallyLaunched variants
++    the metadata is discarded, but the kernel hash is retained so the path can
++    be reconstructed.
++    """
++    try:
++        mod = PyCodeCache.load_by_key_path(
++            choice.bmreq.module_cache_key, choice.bmreq.module_path
++        )
++        kernel = getattr(mod, choice.bmreq.kernel_name, None)
++        if kernel is None or not kernel.compile_results:
++            return None
++        result = kernel.compile_results[0]
++        compiled_kernel = result.kernel
++        # CompiledKernel keeps full metadata including cache_dir
++        metadata = getattr(compiled_kernel, "metadata", None)
++        if metadata is not None:
++            return getattr(metadata, "cache_dir", None)
++        # StaticallyLaunchedXpuKernel/CudaKernel: reconstruct from hash
++        kernel_hash = getattr(compiled_kernel, "hash", None)
++        if kernel_hash is not None:
++            device = result.compile_meta.get("device", 0)
++            return os.path.join(
++                triton_cache_dir(device),
++                triton_hash_to_path_key(kernel_hash),
++            )
++    except Exception:
++        log.debug("Failed to extract triton cache dir", exc_info=True)
++    return None
++
++
+ class AlgorithmSelectorCache(PersistentCache):
+     """
+     A persistent cache for algorithm selection results used in autotuning of GEMMs
+@@ -3626,6 +3657,14 @@
+                 sys.stderr.write(
+                     f"  {choice.name} {result:.4f} ms {best_time / result:.1%} {kernel_description}\n"
+                 )
++                if isinstance(choice, TritonTemplateCaller):
++                    cache_dir = _get_triton_cache_dir(choice)
++                    if cache_dir:
++                        sys.stderr.write(f"    cache_dir: {cache_dir}\n")
++                    else:
++                        sys.stderr.write(
++                            f"    module_path: {choice.bmreq.module_path}\n"
++                        )
+             else:
+                 sys.stderr.write(
+                     f"  {choice.name} {result:.4f} ms <DIVIDED BY ZERO ERROR>\n"


### PR DESCRIPTION
Adding a patch that adds Triton compilation cache directory to PyTorch inductor's autotuning output, enabling mapping between autotuner-selected configs and their IGC shader dumps.
Together with TRITON_INTEL_ENABLE_IGC_SHADER_DUMP option (#4482) it allows to locate the Triton and IGC shader dumps for the exact chosen kernel - effectively mapping the performance of the benchmark and the relevant dumps.