### PR TITLE
[CI] Install cmake from pip in `auto-update-translator-cid.yml` the same way we do it for benchmarks

### DIFF
--- a/.github/workflows/auto-update-translator-cid.yml
+++ b/.github/workflows/auto-update-translator-cid.yml
@@ -52,6 +52,10 @@ jobs:
         with:
           python-version: '3.10'
 
+      - name: Install Python build dependencies
+        run: |
+          pip install cmake
+
       - name: Setup PyTorch
         if: ${{ env.TARGET_PRID == null }}
         uses: ./.github/actions/setup-pytorch


### PR DESCRIPTION
https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/22760786586/job/66016584068 (no more cmake error)