### PR TITLE
[LTS] Fix build failure from StrideInfo

### DIFF
--- a/third_party/intel/lib/Analysis/StrideInfo.cpp
+++ b/third_party/intel/lib/Analysis/StrideInfo.cpp
@@ -199,7 +199,7 @@ public:
   StrideInfo getStrideInfo(
       triton::MakeRangeOp op,
       ArrayRef<const dataflow::Lattice<StrideInfo> *> operands) const override {
-    return StrideInfo(StrideInfo::DimVectorT{1}); //
+    return StrideInfo(StrideInfo::DimVectorT{1});
   }
 };
 


### PR DESCRIPTION
LTS uses older gcc version which complained when rolling works fine

`{0}` was ambigous on GCC11  because it couldn't match `ArrayRef<int64_t>`, changed to `DimVectorT` as used on upstream inside `AxisInfo`

LTS: `11.4.0`
Rolling: `13.3.0`

```cpp
[162/662] Building CXX object third_party/intel/lib/Analysis/CMakeFiles/TritonIntelAnalysis.dir/StrideInfo.cpp.o
FAILED: third_party/intel/lib/Analysis/CMakeFiles/TritonIntelAnalysis.dir/StrideInfo.cpp.o
/usr/bin/c++  -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/build/cmake.linux-x86_64-cpython-3.10/third_party/intel/lib/Analysis -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/lib/Analysis -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/include -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/. -I/cache/triton-llvm-84afafd71beffd505db1536cb097cad2f1e33a73858dff8c48364d1adc59993e-1/llvm-979132a0-ubuntu-x64/include -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/build/cmake.linux-x86_64-cpython-3.10/include -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/build/cmake.linux-x86_64-cpython-3.10/third_party -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/python/src -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/include -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/build/cmake.linux-x86_64-cpython-3.10/third_party/intel/include -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/lib -D__STDC_FORMAT_MACROS  -fPIC -std=gnu++17 -Werror -Wno-covered-switch-default -fvisibility=hidden -g -std=gnu++17 -fno-exceptions -fno-rtti -MD -MT third_party/intel/lib/Analysis/CMakeFiles/TritonIntelAnalysis.dir/StrideInfo.cpp.o -MF third_party/intel/lib/Analysis/CMakeFiles/TritonIntelAnalysis.dir/StrideInfo.cpp.o.d -o third_party/intel/lib/Analysis/CMakeFiles/TritonIntelAnalysis.dir/StrideInfo.cpp.o -c /runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/lib/Analysis/StrideInfo.cpp
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/lib/Analysis/StrideInfo.cpp: In member function 'virtual mlir::triton::intel::StrideInfo mlir::triton::intel::{anonymous}::MakeRangeOpStrideVisitor::getStrideInfo(mlir::triton::MakeRangeOp, llvm::ArrayRef<const mlir::dataflow::Lattice<mlir::triton::intel::StrideInfo>*>) const':
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/lib/Analysis/StrideInfo.cpp:202:26: error: call of overloaded 'StrideInfo(<brace-enclosed initializer list>)' is ambiguous
  202 |     return StrideInfo({1});
      |                          ^
In file included from /runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/lib/Analysis/StrideInfo.cpp:1:
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/include/Analysis/StrideInfo.h:17:12: note: candidate: 'mlir::triton::intel::StrideInfo::StrideInfo(llvm::ArrayRef<long int>)'
   17 |   explicit StrideInfo(ArrayRef<int64_t> stride) : stride(stride) {}
      |            ^~~~~~~~~~
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/include/Analysis/StrideInfo.h:12:7: note: candidate: 'mlir::triton::intel::StrideInfo::StrideInfo(const mlir::triton::intel::StrideInfo&)'
   12 | class StrideInfo {
      |       ^~~~~~~~~~
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/include/Analysis/StrideInfo.h:12:7: note: candidate: 'mlir::triton::intel::StrideInfo::StrideInfo(mlir::triton::intel::StrideInfo&&)'
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/lib/Analysis/StrideInfo.cpp: In member function 'virtual void mlir::triton::intel::{anonymous}::StrideAnalysis::visitNonControlFlowArguments(mlir::Operation*, const mlir::RegionSuccessor&, mlir::ValueRange, llvm::ArrayRef<mlir::dataflow::Lattice<mlir::triton::intel::StrideInfo>*>)':
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/lib/Analysis/StrideInfo.cpp:489:31: error: call of overloaded 'StrideInfo(<brace-enclosed initializer list>)' is ambiguous
  489 |       auto iv = StrideInfo({0});
      |                               ^
In file included from /runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/lib/Analysis/StrideInfo.cpp:1:
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/include/Analysis/StrideInfo.h:17:12: note: candidate: 'mlir::triton::intel::StrideInfo::StrideInfo(llvm::ArrayRef<long int>)'
   17 |   explicit StrideInfo(ArrayRef<int64_t> stride) : stride(stride) {}
      |            ^~~~~~~~~~
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/include/Analysis/StrideInfo.h:12:7: note: candidate: 'mlir::triton::intel::StrideInfo::StrideInfo(const mlir::triton::intel::StrideInfo&)'
   12 | class StrideInfo {
      |       ^~~~~~~~~~
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/include/Analysis/StrideInfo.h:12:7: note: candidate: 'mlir::triton::intel::StrideInfo::StrideInfo(mlir::triton::intel::StrideInfo&&)'
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/lib/Analysis/StrideInfo.cpp: In instantiation of 'mlir::triton::intel::StrideInfo mlir::triton::intel::{anonymous}::ConstantOpStrideVisitor<OpTy>::getStrideInfo(OpTy, llvm::ArrayRef<const mlir::dataflow::Lattice<mlir::triton::intel::StrideInfo>*>) const [with OpTy = mlir::LLVM::ConstantOp]':
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/lib/Analysis/StrideInfo.cpp:218:14:   required from here
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/lib/Analysis/StrideInfo.cpp:230:14: error: call of overloaded 'StrideInfo(<brace-enclosed initializer list>)' is ambiguous
  230 |       return StrideInfo({0});
      |              ^~~~~~~~~~~~~~~
In file included from /runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/lib/Analysis/StrideInfo.cpp:1:
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/include/Analysis/StrideInfo.h:17:12: note: candidate: 'mlir::triton::intel::StrideInfo::StrideInfo(llvm::ArrayRef<long int>)'
   17 |   explicit StrideInfo(ArrayRef<int64_t> stride) : stride(stride) {}
      |            ^~~~~~~~~~
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/include/Analysis/StrideInfo.h:12:7: note: candidate: 'mlir::triton::intel::StrideInfo::StrideInfo(const mlir::triton::intel::StrideInfo&)'
   12 | class StrideInfo {
      |       ^~~~~~~~~~
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/include/Analysis/StrideInfo.h:12:7: note: candidate: 'mlir::triton::intel::StrideInfo::StrideInfo(mlir::triton::intel::StrideInfo&&)'
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/lib/Analysis/StrideInfo.cpp: In instantiation of 'mlir::triton::intel::StrideInfo mlir::triton::intel::{anonymous}::ConstantOpStrideVisitor<OpTy>::getStrideInfo(OpTy, llvm::ArrayRef<const mlir::dataflow::Lattice<mlir::triton::intel::StrideInfo>*>) const [with OpTy = mlir::arith::ConstantOp]':
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/lib/Analysis/StrideInfo.cpp:218:14:   required from here
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/lib/Analysis/StrideInfo.cpp:230:14: error: call of overloaded 'StrideInfo(<brace-enclosed initializer list>)' is ambiguous
  230 |       return StrideInfo({0});
      |              ^~~~~~~~~~~~~~~
In file included from /runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/lib/Analysis/StrideInfo.cpp:1:
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/include/Analysis/StrideInfo.h:17:12: note: candidate: 'mlir::triton::intel::StrideInfo::StrideInfo(llvm::ArrayRef<long int>)'
   17 |   explicit StrideInfo(ArrayRef<int64_t> stride) : stride(stride) {}
      |            ^~~~~~~~~~
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/include/Analysis/StrideInfo.h:12:7: note: candidate: 'mlir::triton::intel::StrideInfo::StrideInfo(const mlir::triton::intel::StrideInfo&)'
   12 | class StrideInfo {
      |       ^~~~~~~~~~
/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party/intel/include/Analysis/StrideInfo.h:12:7: note: candidate: 'mlir::triton::intel::StrideInfo::StrideInfo(mlir::triton::intel::StrideInfo&&)'
At global scope:
cc1plus: note: unrecognized command-line option '-Wno-covered-switch-default' may have been intended to silence earlier diagnostics

```