### PR TITLE
[Proton][XPU] don't perform automatic status checking for `viewGetNextRecord` function, as we handle it manually

### DIFF
--- a/third_party/proton/csrc/lib/Profiler/Xpupti/XpuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Xpupti/XpuptiProfiler.cpp
@@ -216,7 +216,7 @@ void XpuptiProfiler::XpuptiProfilerPimpl::completeBuffer(uint8_t *buffer,
   std::map<uint64_t, std::reference_wrapper<XpuptiProfiler::ExternIdState>>
       externIdToStateCache;
   do {
-    status = xpupti::viewGetNextRecord<true>(buffer, validSize, &activity);
+    status = xpupti::viewGetNextRecord<false>(buffer, validSize, &activity);
     if (status == pti_result::PTI_SUCCESS) {
       auto correlationId = processActivity(
           profiler.correlation.corrIdToExternId,


### PR DESCRIPTION
Thanks @jfedorov! Good catch