### PR TITLE
[SYCL] Add G31 support (#6133)

### DIFF
--- a/benchmarks/cutlass_kernel/CMakeLists.txt
+++ b/benchmarks/cutlass_kernel/CMakeLists.txt
@@ -16,6 +16,12 @@ endfunction()
 
 parse_sycl_compiler_version(SYCL_COMPILER_VERSION)
 
+set(SYCL_GPU_TARGETS "intel_gpu_pvc,intel_gpu_bmg_g21")
+
+if (SYCL_COMPILER_VERSION GREATER_EQUAL 20251010)
+  string(APPEND SYCL_GPU_TARGETS ",intel_gpu_bmg_g31")
+endif()
+
 set(SPIRV_EXTENSIONS "+SPV_INTEL_split_barrier")
 
 if (SYCL_COMPILER_VERSION GREATER_EQUAL 20250200)
@@ -25,9 +31,17 @@ endif()
 set(CUTLASS_KERNEL_FLAGS ${CUTLASS_KERNEL_FLAGS}
   -fsycl
   -fsycl-device-code-split=per_kernel
-  -fsycl-targets=intel_gpu_pvc,intel_gpu_bmg_g21
+  -fsycl-targets=${SYCL_GPU_TARGETS}
   "SHELL:-Xspirv-translator=intel_gpu_pvc --spirv-ext=${SPIRV_EXTENSIONS}"
   "SHELL:-Xspirv-translator=intel_gpu_bmg_g21 --spirv-ext=${SPIRV_EXTENSIONS}"
+)
+
+if (SYCL_COMPILER_VERSION GREATER_EQUAL 20251010)
+  list(APPEND CUTLASS_KERNEL_FLAGS
+    "SHELL:-Xspirv-translator=intel_gpu_bmg_g31 --spirv-ext=${SPIRV_EXTENSIONS}")
+endif()
+
+list(APPEND CUTLASS_KERNEL_FLAGS
   -Xs "-options \"-igc_opts 'VISAOptions=-perfmodel,VectorAliasBBThreshold=1000,ExtraOCLOptions=-cl-intel-256-GRF-per-thread'\" -options -ze-opt-large-register-file"
 )
 
@@ -58,7 +72,7 @@ add_custom_target(generate_gemm_config DEPENDS ${GEMM_CONFIG_OUTPUT})
 
 Python3_add_library(cutlass_kernel MODULE WITH_SOABI python_main.cpp)
 
-target_compile_options(cutlass_kernel PRIVATE "-fsycl" "-fsycl-targets=intel_gpu_pvc,intel_gpu_bmg_g21")
+target_compile_options(cutlass_kernel PRIVATE "-fsycl" "-fsycl-targets=${SYCL_GPU_TARGETS}")
 target_compile_options(cutlass_kernel PRIVATE "-DCUTLASS_ENABLE_SYCL")
 target_compile_options(cutlass_kernel PRIVATE "-DSYCL_INTEL_TARGET")
 target_compile_definitions(cutlass_kernel PRIVATE GEMM_CONFIG_HEADER=\"${GEMM_CONFIG_OUTPUT}\")

--- a/third_party/intel/backend/arch_parser.c
+++ b/third_party/intel/backend/arch_parser.c
@@ -28,6 +28,9 @@ extern "C" EXPORT_FUNC const char *parse_device_arch(uint64_t dev_arch) {
   case sycl::ext::oneapi::experimental::architecture::intel_gpu_arl_s:
     arch = "arl_s";
     break;
+#if __SYCL_COMPILER_VERSION >= 20251010
+  case sycl::ext::oneapi::experimental::architecture::intel_gpu_bmg_g31:
+#endif
   case sycl::ext::oneapi::experimental::architecture::intel_gpu_bmg_g21:
     arch = "bmg";
     break;


### PR DESCRIPTION
Available since 2025.3 oneAPI

https://www.intel.com/content/www/us/en/developer/articles/release-notes/oneapi-dpcpp/2025.html

- BMG G31 and WCL Architecture Support: Added BMG G31 and WCL architectures to sycl_ext_oneapi_device_architecture.

(cherry picked from commit 7ac08582b8c30d32273e3b1d3512c062c9c28117)