### PR TITLE
Revert "[SYCL][XPU] Use event-less SYCL APIs whenever possible"

### DIFF
--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -523,9 +523,6 @@ def make_launcher(constants, signature):
 #include <iostream>
 #include <iomanip>
 #include <level_zero/ze_api.h>
-#if __SYCL_COMPILER_VERSION >= 20250604
-#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
-#endif
 #include <sycl/sycl.hpp>
 { "#include <ATen/record_function.h>" if COMPILATION_HELPER.inject_pytorch_dep else "" }
 
@@ -696,11 +693,7 @@ static void sycl_kernel_launch(uint32_t gridX, uint32_t gridY, uint32_t gridZ,
       cgh.parallel_for(parallel_work_size, kernel_ptr);
     }}
   }};
-#if __SYCL_COMPILER_VERSION >= 20250604
-  sycl::ext::oneapi::experimental::submit(stream, cgf);
-#else
-  stream.submit(cgf);
-#endif
+  auto event = stream.submit(cgf);
 }}
 // end sycl
 

--- a/third_party/intel/tools/intel/compile.cpp
+++ b/third_party/intel/tools/intel/compile.cpp
@@ -5,9 +5,6 @@
 #include <string.h>
 #include <sstream>
 #include <level_zero/ze_api.h>
-#if __SYCL_COMPILER_VERSION >= 20250604
-#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
-#endif
 #include <sycl/sycl.hpp>
 
 // helpers to check for ze errors
@@ -176,11 +173,7 @@ int32_t {kernel_name}(sycl::queue &stream, {signature}) {{
         cgh.parallel_for(parallel_work_size, sycl_kernel);
     }}
   }};
-#if __SYCL_COMPILER_VERSION >= 20250604
-  sycl::ext::oneapi::experimental::submit(stream, cgf);
-#else
   stream.submit(cgf);
-#endif
   stream.wait_and_throw();
   return 0;
 }}

--- a/utils/SPIRVRunner/SPIRVRunner.cpp
+++ b/utils/SPIRVRunner/SPIRVRunner.cpp
@@ -1,9 +1,5 @@
 #include <level_zero/ze_api.h>
-#if __SYCL_COMPILER_VERSION >= 20250604
-#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
-#endif
 #include <sycl/sycl.hpp>
-
 #include <torch/torch.h>
 
 #include "llvm_parser.h"
@@ -323,11 +319,7 @@ static void sycl_kernel_launch(sycl::queue &stream, sycl::kernel &kernel_ptr,
     double duration = static_cast<double>(end - start) / 1000000;
     std::cout << "Kernel execution time: " << duration << " ms" << std::endl;
   } else {
-#if __SYCL_COMPILER_VERSION >= 20250604
-    sycl::ext::oneapi::experimental::submit(stream, cgf);
-#else
     stream.submit(cgf);
-#endif
   }
   stream.wait_and_throw();
 }
@@ -437,17 +429,12 @@ std::vector<TensorBuffer> launchKernel(sycl::queue stream, sycl::kernel kernel,
 
   // copy back the output tensors
   for (const auto &item : triton_args.host_outbuffers) {
-#if __SYCL_COMPILER_VERSION >= 20250604
-    sycl::ext::oneapi::experimental::memcpy(
-        stream, tensor_ptr(item.buffer_ptr),
-        triton_args.dev_buffers.at(item.index), item.buffer_ptr.nbytes());
-#else
-    stream.memcpy(tensor_ptr(item.buffer_ptr),
-                  triton_args.dev_buffers.at(item.index),
-                  item.buffer_ptr.nbytes());
-#endif
+    stream
+        .memcpy(tensor_ptr(item.buffer_ptr),
+                triton_args.dev_buffers.at(item.index),
+                item.buffer_ptr.nbytes())
+        .wait_and_throw();
   }
-  stream.wait_and_throw();
 
   for (auto *dev_ptr : triton_args.dev_buffers) {
     if (dev_ptr)


### PR DESCRIPTION
Reverts intel/intel-xpu-backend-for-triton#6305