### PR TITLE
[BLOCKIO] Fix issue in getBlockIOTileSize for the case that the rowDim is not same as the memory contigous dim for transpose case.

### DIFF
--- a/test/TritonIntelGPU/descriptor-load-block-2d.mlir
+++ b/test/TritonIntelGPU/descriptor-load-block-2d.mlir
@@ -217,3 +217,18 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     tt.return
   }
 }
+
+// -----
+
+// COM: The blocked layout with threadsPerWarp = [8, 2, 1], order = [1, 2, 0] defines a tile on dimensions 0 and 1.
+// COM: However, only dimension 2 is contiguous in memory, so a transposed block load is not legal for this layout.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [8, 2, 1], warpsPerCTA = [64, 1, 1], order = [1, 2, 0]}>
+module attributes {"ttg.num-warps" = 64 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @kernel_trans(
+  // CHECK: llvm.load
+  // CHECK-NOT: triton_gen.2Dblockload
+  tt.func public @kernel_trans(%arg0: !tt.tensordesc<tensor<32x2x16xf32>>, %idx: i32) -> tensor<32x2x16xf32, #blocked> {
+    %0 = tt.descriptor_load %arg0[%idx, %idx, %idx] {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<32x2x16xf32>> -> tensor<32x2x16xf32, #blocked>
+    tt.return %0 : tensor<32x2x16xf32, #blocked>
+  }
+}

--- a/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
+++ b/test/TritonIntelGPU/tensor-pointer-load-block-2d.mlir
@@ -846,3 +846,18 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32,
     tt.return %11 : tensor<128x128xf32, #blocked>
   }
 }
+
+// -----
+
+// COM: The blocked layout with threadsPerWarp = [8, 2, 1], order = [1, 2, 0] defines a tile on dimensions 0 and 1.
+// COM: However, only dimension 2 is contiguous in memory, so a transposed block load is not legal for this layout.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [8, 2, 1], warpsPerCTA = [64, 1, 1], order = [1, 2, 0]}>
+module attributes {"ttg.num-warps" = 64 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @kernel_trans(
+  // CHECK: llvm.load
+  // CHECK-NOT: triton_gen.2Dblockload
+  tt.func public @kernel_trans(%arg0: tensor<32x2x16x!tt.ptr<f32>, #blocked>) -> tensor<32x2x16xf32, #blocked> {
+    %0 = tt.load %arg0 {ttig.block_io = "row_major"} : tensor<32x2x16x!tt.ptr<f32>, #blocked>
+    tt.return %0 : tensor<32x2x16xf32, #blocked>
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1132,6 +1132,14 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
       regPackBases.insert(1 << regBaseIter);
     }
 
+    if (transpose) {
+      // For transpose, the row dim has to be the memory contiguous dim.
+      // If rowDim is determined (>= 0) and it is not memory contiguous dim,
+      // reject.
+      if (rowDim >= 0 && rowDim != memContiguousDim)
+        return BlockIOTileSizeInfo::unknown();
+    }
+
     if (rowDim < 0)
       rowDim = (fastChangeDim != 0) ? 0 : 1;
 


### PR DESCRIPTION
Fixes a BlockIO tile-size selection bug in Triton Intel GPU lowering when generating transposed 2D block IO for layouts where the “row” dimension does not match the memory-contiguous dimension. 

The column dimenssion is defined by the register layout. If the value in memory isn't contiguous along the same dimenssion, the transpose 2D block IO has to be used. In this case, the row dimenssion has to be the dim which is contiguous on memory.