### PR TITLE
[BLOCKIO] Read block_io attribute in DescriptorStoreOp lowering

### DIFF
--- a/test/TritonIntelGPU/descriptor-load-block-2d.mlir
+++ b/test/TritonIntelGPU/descriptor-load-block-2d.mlir
@@ -21,7 +21,7 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     // Verify 2D block loads are generated for dot A operand.
     // For DPAS A with f16: tile_height=8, tile_width=16, v_blocks=2.
     // CHECK-COUNT-2: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 2, transpose = false, vnni_transform = false, cache_control = Default}
-    %load = tt.descriptor_load %desc[%arg4, %arg5] : !tt.tensordesc<tensor<64x32xf16>> -> tensor<64x32xf16, #dot0>
+    %load = tt.descriptor_load %desc[%arg4, %arg5] {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<64x32xf16>> -> tensor<64x32xf16, #dot0>
     tt.return
   }
 }
@@ -40,7 +40,7 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <tensor<32x64xf16>>
     // For DPAS B with f16: tile_height=32, tile_width=16, v_blocks=1, vnni_transform=true.
     // CHECK-COUNT-2: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 1, transpose = false, vnni_transform = true, cache_control = Default}
-    %load = tt.descriptor_load %desc[%arg4, %arg5] : !tt.tensordesc<tensor<32x64xf16>> -> tensor<32x64xf16, #dot1>
+    %load = tt.descriptor_load %desc[%arg4, %arg5] {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<32x64xf16>> -> tensor<32x64xf16, #dot1>
     tt.return
   }
 }
@@ -58,7 +58,7 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f32>, <tensor<64x32xf32>>
     // For DPAS A with f32: tile_height=8, tile_width=8, v_blocks=2.
     // CHECK-COUNT-2: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 32, tile_width = 8, tile_height = 8, v_blocks = 2, transpose = false, vnni_transform = false, cache_control = Default}
-    %load = tt.descriptor_load %desc[%arg4, %arg5] : !tt.tensordesc<tensor<64x32xf32>> -> tensor<64x32xf32, #dot0>
+    %load = tt.descriptor_load %desc[%arg4, %arg5] {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<64x32xf32>> -> tensor<64x32xf32, #dot0>
     tt.return
   }
 }
@@ -94,7 +94,7 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
   tt.func public @descriptor_load_blocked_no_block_io(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i32, %arg5: i32) {
     %c1_i64 = arith.constant 1 : i64
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <tensor<64x32xf16>>
-    %load = tt.descriptor_load %desc[%arg4, %arg5] : !tt.tensordesc<tensor<64x32xf16>> -> tensor<64x32xf16, #blocked>
+    %load = tt.descriptor_load %desc[%arg4, %arg5] {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<64x32xf16>> -> tensor<64x32xf16, #blocked>
     tt.return
   }
 }
@@ -151,9 +151,9 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     %descA = tt.make_tensor_descriptor %arg0, [%arg2, %arg4], [%arg5, %c1_i64] : <f16>, <tensor<64x32xf16>>
     %descB = tt.make_tensor_descriptor %arg1, [%arg4, %arg3], [%arg6, %c1_i64] : <f16>, <tensor<32x64xf16>>
     // CHECK-COUNT-2: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 2, transpose = false, vnni_transform = false, cache_control = Default}
-    %A = tt.descriptor_load %descA[%c0_i32, %c0_i32] : !tt.tensordesc<tensor<64x32xf16>> -> tensor<64x32xf16, #dot0>
+    %A = tt.descriptor_load %descA[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<64x32xf16>> -> tensor<64x32xf16, #dot0>
     // CHECK-COUNT-2: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 1, transpose = false, vnni_transform = true, cache_control = Default}
-    %B = tt.descriptor_load %descB[%c0_i32, %c0_i32] : !tt.tensordesc<tensor<32x64xf16>> -> tensor<32x64xf16, #dot1>
+    %B = tt.descriptor_load %descB[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<32x64xf16>> -> tensor<32x64xf16, #dot1>
     // CHECK-COUNT-8: triton_gen.dpas {{.*}} {pa = f16, pb = f16, rc = 8}
     %D = tt.dot %A, %B, %C, inputPrecision = tf32 : tensor<64x32xf16, #dot0> * tensor<32x64xf16, #dot1> -> tensor<64x64xf32, #dpas>
     %0 = ttg.convert_layout %D : tensor<64x64xf32, #dpas> -> tensor<64x64xf32, #blocked>
@@ -186,8 +186,8 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
 
 // -----
 
-// Test: DescriptorLoadOp with explicit row_major block_io attribute generates
-// standard (non-transposed) 2D block loads, same as the no-attribute case.
+// Test: DescriptorLoadOp with row_major block_io attribute and dot_op B encoding
+// generates standard (non-transposed) 2D block loads with VNNI transform.
 
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth=2}>

--- a/test/TritonIntelGPU/descriptor-store-block-2d.mlir
+++ b/test/TritonIntelGPU/descriptor-store-block-2d.mlir
@@ -23,7 +23,7 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <tensor<64x64xf16, #dpas>>
     // 4 warps x 2 warps, repCluster [1,1], C shape [8,16] => 4 stores total.
     // CHECK-COUNT-4: triton_gen.2Dblockstore {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
-    tt.descriptor_store %desc[%c0_i32, %c0_i32], %cst : !tt.tensordesc<tensor<64x64xf16, #dpas>>, tensor<64x64xf16, #dpas>
+    tt.descriptor_store %desc[%c0_i32, %c0_i32], %cst {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<64x64xf16, #dpas>>, tensor<64x64xf16, #dpas>
     tt.return
   }
 }
@@ -42,7 +42,7 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f32>, <tensor<64x64xf32, #dpas>>
     // 8 warps x 4 warps, repCluster [1,1], C shape [8,16] => 32 warps tile 64x64 exactly => 1 store per warp.
     // CHECK-COUNT-1: triton_gen.2Dblockstore {{.*}} {elem_size_in_bits = 32, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
-    tt.descriptor_store %desc[%c0_i32, %c0_i32], %cst : !tt.tensordesc<tensor<64x64xf32, #dpas>>, tensor<64x64xf32, #dpas>
+    tt.descriptor_store %desc[%c0_i32, %c0_i32], %cst {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<64x64xf32, #dpas>>, tensor<64x64xf32, #dpas>
     tt.return
   }
 }
@@ -114,7 +114,7 @@ module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32,
     // Remaining 7 stores (repCluster [4,2] => 8 total stores).
     // CHECK-COUNT-7: triton_gen.2Dblockstore {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <tensor<32x32xf16, #dpas>>
-    tt.descriptor_store %desc[%c0_i32, %c0_i32], %cst : !tt.tensordesc<tensor<32x32xf16, #dpas>>, tensor<32x32xf16, #dpas>
+    tt.descriptor_store %desc[%c0_i32, %c0_i32], %cst {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<32x32xf16, #dpas>>, tensor<32x32xf16, #dpas>
     tt.return
   }
 }
@@ -136,7 +136,7 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
       %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <tensor<64x16xf16, #blocked>>
       // DPAS-LAYOUT-NOT: triton_gen.2Dblockstore
       // ALL-LAYOUT-COUNT-32: triton_gen.2Dblockstore {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 1, v_blocks = 1, cache_control = Default}
-      tt.descriptor_store %desc[%c0_i32, %c0_i32], %cst : !tt.tensordesc<tensor<64x16xf16, #blocked>>, tensor<64x16xf16, #blocked>
+      tt.descriptor_store %desc[%c0_i32, %c0_i32], %cst {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<64x16xf16, #blocked>>, tensor<64x16xf16, #blocked>
       tt.return
   }
 }
@@ -195,16 +195,16 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     %descD = tt.make_tensor_descriptor %arg2, [%arg3, %arg4], [%arg8, %c1_i64] : <f16>, <tensor<64x64xf16, #dpas>>
     // Loads for A operand: 4 warps along M, repCluster [1,1], A tile [8,16] => 2 loads.
     // CHECK-COUNT-2: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 2, transpose = false, vnni_transform = false, cache_control = Default}
-    %A = tt.descriptor_load %descA[%c0_i32, %c0_i32] : !tt.tensordesc<tensor<64x32xf16>> -> tensor<64x32xf16, #dot0>
+    %A = tt.descriptor_load %descA[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<64x32xf16>> -> tensor<64x32xf16, #dot0>
     // Loads for B operand: 2 warps along N, repCluster [1,1], B tile [16,16] => 2 loads with VNNI.
     // CHECK-COUNT-2: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 1, transpose = false, vnni_transform = true, cache_control = Default}
-    %B = tt.descriptor_load %descB[%c0_i32, %c0_i32] : !tt.tensordesc<tensor<32x64xf16>> -> tensor<32x64xf16, #dot1>
+    %B = tt.descriptor_load %descB[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<32x64xf16>> -> tensor<32x64xf16, #dot1>
     // DPAS instructions: 8 total.
     // CHECK-COUNT-8: triton_gen.dpas {{.*}} {pa = f16, pb = f16, rc = 8}
     %D = tt.dot %A, %B, %C, inputPrecision = tf32 : tensor<64x32xf16, #dot0> * tensor<32x64xf16, #dot1> -> tensor<64x64xf16, #dpas>
     // Stores for result: 4 warps x 2 warps, repCluster [1,1], C shape [8,16] => 4 stores.
     // CHECK-COUNT-4: triton_gen.2Dblockstore {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
-    tt.descriptor_store %descD[%c0_i32, %c0_i32], %D : !tt.tensordesc<tensor<64x64xf16, #dpas>>, tensor<64x64xf16, #dpas>
+    tt.descriptor_store %descD[%c0_i32, %c0_i32], %D {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<64x64xf16, #dpas>>, tensor<64x64xf16, #dpas>
     tt.return
   }
 }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -602,6 +602,11 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
       return false;
     }
 
+    // Require block_io attribute (set by MaterializeBlockPointer).
+    if (!op->template getAttrOfType<StringAttr>(
+            triton::gpu::intel::TritonIntelGPUDialect::getBlockIOAttrName()))
+      return false;
+
     std::optional<bool> enableBlockIOForAllLayout =
         mlir::triton::tools::isEnvValueBool(mlir::triton::tools::getStrEnv(
             "TRITON_INTEL_ENABLE_BLOCK_IO_ALL_LAYOUTS"));
@@ -2463,13 +2468,14 @@ struct DescriptorLoadOpToBlockIOConversion
     assert(llEncoding.has_value() &&
            "unexpected failure when getting linear layout");
 
-    // Read memory layout from block_io attribute.
-    // Descriptors are row-major by definition; column_major is set by
-    // FuseTransWithDescriptorLoad. Default to row_major when absent.
+    // Read memory layout from block_io attribute (set by
+    // MaterializeBlockPointer; column_major set by
+    // FuseTransWithDescriptorLoad).
     StringRef blockIOName = TritonIntelGPUDialect::getBlockIOAttrName();
     StringAttr blockIOAttr = op->getAttrOfType<StringAttr>(blockIOName);
-    if (!blockIOAttr)
-      blockIOAttr = StringAttr::get(rewriter.getContext(), "row_major");
+    assert(
+        blockIOAttr &&
+        "block_io attribute required; checked by isDescriptorBlockIOCandidate");
     const unsigned rank = tensorType.getRank();
     bool memoryRowMajor = (blockIOAttr.getValue() == "row_major");
     unsigned contiguousDim = memoryRowMajor ? rank - 1 : rank - 2;
@@ -3270,14 +3276,15 @@ struct DescriptorStoreOpToBlockIOConversion
     if (!isDescriptorBlockIOCandidate(op))
       return failure();
 
-    // TODO: DescriptorStoreOp does not currently carry a "block_io" attribute
-    // the way StoreOp does (set by MaterializeBlockPointer). Without this
-    // attribute we cannot determine the memory layout (row_major vs
-    // column_major). For now, we assume row_major and rely on layout
-    // encoding checks below to bail out on unsupported cases.
-    // Once the pipeline annotates DescriptorStoreOp with block_io, this
-    // should be updated to read the attribute.
-    const bool memoryRowMajor = true;
+    // Read memory layout from block_io attribute (set by
+    // MaterializeBlockPointer).
+    StringRef blockIOName = TritonIntelGPUDialect::getBlockIOAttrName();
+    StringAttr blockIOAttr = op->getAttrOfType<StringAttr>(blockIOName);
+    assert(
+        blockIOAttr &&
+        "block_io attribute required; checked by isDescriptorBlockIOCandidate");
+    const bool memoryRowMajor = (blockIOAttr.getValue() == "row_major");
+    assert(memoryRowMajor && "column_major descriptor store not yet supported");
 
     // Get source tensor type and encoding.
     auto tensorType = cast<RankedTensorType>(op.getSrc().getType());


### PR DESCRIPTION
MaterializeBlockPointer now sets ttig.block_io on DescriptorStoreOp. Update the lowering to read the attribute instead of hardcoding row_major.

