### PR TITLE
Fix bug that the transpose load uses the wrong base width and base hight.

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2397,12 +2397,14 @@ public:
     SmallVector<Value> shapes = getShapes(rewriter, ptr, unpackedPtr);
     Value baseWidth, baseHeight;
     if (isTensorPointerType(ptr.getType())) {
-      baseWidth = b.trunc(i32_ty, shapes[memoryRowMajor ? colDim : rowDim]);
-      baseHeight = b.trunc(i32_ty, shapes[memoryRowMajor ? rowDim : colDim]);
+      baseWidth =
+          b.trunc(i32_ty, shapes[isTransposeRequired ? rowDim : colDim]);
+      baseHeight =
+          b.trunc(i32_ty, shapes[isTransposeRequired ? colDim : rowDim]);
       baseWidth = b.mul(baseWidth, b.i32_val(elemSizeInBits / 8));
     } else {
       // If the stride is 0, we want to load only the first row.
-      int stride = getStride(ptr, memoryRowMajor ? rowDim : colDim);
+      int stride = getStride(ptr, isTransposeRequired ? colDim : rowDim);
       baseHeight = b.i32_val((stride == 0 ? 1 : tileHeight));
       baseWidth = b.i32_val(vBlocks * tileWidth * (packedElemSizeInBits / 8));
     }


### PR DESCRIPTION
This issue is found in the CI test of the PR #https://github.com/intel/intel-xpu-backend-for-triton/pull/5757

When the rank size = 2, the code `baseWidth = b.trunc(i32_ty, shapes[memoryRowMajor ? colDim : rowDim]);` is correct.

But for the rank size > 2, it is in-correct. Need to use `isTransposeRequired` to chose the shape size of the column dim or row dim as the sufferface width or hight.

@anthonycanino I add the changes to the descriptor load/store as well. Please help check,

I will add the test case.

