### PR TITLE
[OptimizeDotOperands] Support rank > 2 descriptor loads in transpose fusion

### DIFF
--- a/test/TritonIntelGPU/descriptor-load-block-2d.mlir
+++ b/test/TritonIntelGPU/descriptor-load-block-2d.mlir
@@ -232,3 +232,23 @@ module attributes {"ttg.num-warps" = 64 : i32, "ttg.threads-per-warp" = 16 : i32
     tt.return %0 : tensor<32x2x16xf32, #blocked>
   }
 }
+
+// -----
+
+// COM: Rank-3 descriptor load with column_major block_io attribute (produced by
+// COM: FuseTransWithDescriptorLoad for rank-3 tensors). The descriptor has shape
+// COM: [2, 64, 32] and the result has inner dims transposed: [2, 32, 64].
+// COM: Since 2D block IO only supports rank-2 tensors, the lowering falls back
+// COM: to the gather path using llvm.getelementptr.
+#blocked3d = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 1, 16], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @descriptor_load_rank3_column_major(
+  // CHECK-NOT: triton_gen.2Dblockload
+  // CHECK: llvm.getelementptr
+  tt.func public @descriptor_load_rank3_column_major(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i64, %arg5: i64, %arg6: i32, %arg7: i32, %arg8: i32) {
+    %c1_i64 = arith.constant 1 : i64
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2, %arg3], [%arg4, %arg5, %c1_i64] : <f16>, <tensor<2x64x32xf16>>
+    %load = tt.descriptor_load %desc[%arg6, %arg7, %arg8] {ttig.block_io = "column_major"} : !tt.tensordesc<tensor<2x64x32xf16>> -> tensor<2x32x64xf16, #blocked3d>
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/dot-operands.mlir
+++ b/test/TritonIntelGPU/dot-operands.mlir
@@ -604,3 +604,26 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
   // CHECK-NOT: ttg.convert_layout
   // CHECK: tt.dot
 }
+
+// -----
+
+// COM: Negative test: rank-3 TransOp with exotic order [1, 0, 2] swaps the
+// COM: outer (batch) and middle dims instead of the innermost two dims.
+// COM: This transpose does NOT produce a shape usable by tt.dot, so the
+// COM: descriptor_load + trans fusion must NOT fire.
+#mma3d = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4, 2], repCluster = [1, 1, 1]}>
+#blocked3d = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 1, 16], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>
+#blocked3d_exotic_trans = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 1, 16], warpsPerCTA = [8, 1, 1], order = [2, 0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
+  tt.func public @doNotFuseDescriptorLoadWithTrans_exoticOrder(%arg0: !tt.ptr<f16>, %N: i32, %K: i32, %strideBb: i64, %strideBn: i64) -> tensor<64x2x32xf16, #blocked3d_exotic_trans> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %descB = tt.make_tensor_descriptor %arg0, [%N, %N, %K], [%strideBb, %strideBn, %c1_i64] : <f16>, <tensor<2x64x32xf16>>
+    %loadB = tt.descriptor_load %descB[%c0_i32, %c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<2x64x32xf16>> -> tensor<2x64x32xf16, #blocked3d>
+    %transB = tt.trans %loadB {order = array<i32: 1, 0, 2>} : tensor<2x64x32xf16, #blocked3d> -> tensor<64x2x32xf16, #blocked3d_exotic_trans>
+    tt.return %transB : tensor<64x2x32xf16, #blocked3d_exotic_trans>
+  }
+  // CHECK-LABEL: doNotFuseDescriptorLoadWithTrans_exoticOrder
+  // CHECK: tt.trans
+  // CHECK-NOT: ttig.block_io = "column_major"
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -3103,6 +3103,7 @@ struct DescriptorLoadOpConversion
         permOffsets[i] = indices[i];
       }
       // Swap only the inner 2 dimensions (2D block I/O constraint).
+      assert(rank >= 2 && "column_major descriptor load requires rank >= 2");
       std::swap(permShapes[rank - 2], permShapes[rank - 1]);
       std::swap(permStrides[rank - 2], permStrides[rank - 1]);
       std::swap(permOffsets[rank - 2], permOffsets[rank - 1]);

--- a/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
@@ -463,6 +463,23 @@ private:
     if (cast<RankedTensorType>(descLoadOp.getType()).getRank() < 2)
       return false;
 
+    // Validate that the transpose only swaps the innermost 2 dimensions
+    // (identity on outer dims). block_io = "column_major" in the lowering
+    // only handles this inner-2-dim swap.
+    // TODO: Support general permutations when a richer block_io encoding is
+    //       available.
+    {
+      ArrayRef<int32_t> order = transOp.getOrder();
+      unsigned rank = order.size();
+      for (unsigned i = 0; i + 2 < rank; ++i) {
+        if (order[i] != static_cast<int32_t>(i))
+          return false;
+      }
+      if (order[rank - 2] != static_cast<int32_t>(rank - 1) ||
+          order[rank - 1] != static_cast<int32_t>(rank - 2))
+        return false;
+    }
+
     // Must be able to find the defining MakeTensorDescOp.
     auto makeTensorDescOp =
         tt::intel::findDefiningOpOfType<tt::MakeTensorDescOp>(
@@ -527,8 +544,12 @@ private:
       if (attr.getName() != blockIOName)
         newLoad->setDiscardableAttr(attr.getName(), attr.getValue());
 
-    // Set block_io = column_major: signals that the result type dimensions
-    // are transposed relative to the descriptor's block shape dimensions.
+    // Set block_io = column_major: signals that the result type's inner two
+    // dimensions are transposed relative to the descriptor's block shape.
+    // Outer (batch) dimensions are preserved unchanged.
+    // TODO: To support general permutations (not just inner-2-dim swap),
+    //       replace column_major with a richer encoding carrying the full
+    //       permutation (e.g., an ArrayAttr).
     newLoad->setAttr(blockIOName,
                      StringAttr::get(transOp.getContext(),
                                      ttgi::stringifyBlockIOMode(


### PR DESCRIPTION
Updates Intel Triton dot-operand transpose fusion to handle descriptor loads with rank > 2 (e.g., batched descriptors), and adjusts the LLVM lowering to interpret ttig.block_io = "column_major" as an inner-2-dim swap rather than a full rank reversal.