### PR TITLE
[RLC] Make backward remat iteration count configurable, default to 1

### DIFF
--- a/test/TritonIntelGPU/backward_combine_dpas_dot_layout.mlir
+++ b/test/TritonIntelGPU/backward_combine_dpas_dot_layout.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file -tritonintelgpu-remove-layout-conversions 2>&1 | FileCheck %s
+// RUN: triton-opt %s -split-input-file -tritonintelgpu-remove-layout-conversions='max-backward-remat-iterations=10' 2>&1 | FileCheck %s
 
 // COM: Case 1:
 // COM: Checks that the loads for the operands of a tt.dot operation are placed

--- a/test/TritonIntelGPU/combine.mlir
+++ b/test/TritonIntelGPU/combine.mlir
@@ -1,5 +1,5 @@
-// RUN: env TRITON_INTEL_REMOVELAYOUTCONVERSION_SUPPORT_FOR_LOOP=0 triton-opt %s -split-input-file -allow-unregistered-dialect -tritonintelgpu-remove-layout-conversions 2>&1 | FileCheck --check-prefixes=CHECK %s
-// RUN: env TRITON_INTEL_REMOVELAYOUTCONVERSION_SUPPORT_FOR_LOOP=1 triton-opt %s -split-input-file -allow-unregistered-dialect -tritonintelgpu-remove-layout-conversions 2>&1 | FileCheck --check-prefixes=CHECK,FOR-SUPPORT %s
+// RUN: env TRITON_INTEL_REMOVELAYOUTCONVERSION_SUPPORT_FOR_LOOP=0 triton-opt %s -split-input-file -allow-unregistered-dialect -tritonintelgpu-remove-layout-conversions='max-backward-remat-iterations=10' 2>&1 | FileCheck --check-prefixes=CHECK %s
+// RUN: env TRITON_INTEL_REMOVELAYOUTCONVERSION_SUPPORT_FOR_LOOP=1 triton-opt %s -split-input-file -allow-unregistered-dialect -tritonintelgpu-remove-layout-conversions='max-backward-remat-iterations=10' 2>&1 | FileCheck --check-prefixes=CHECK,FOR-SUPPORT %s
 
 #layout0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #layout1 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -109,6 +109,11 @@ def TritonIntelGPURemoveLayoutConversions : Pass<"tritonintelgpu-remove-layout-c
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
                            "mlir::triton::TritonDialect"];
 
+  let options = [
+    Option<"maxBackwardRematIterations", "max-backward-remat-iterations",
+           "unsigned", /*default*/"1",
+           "Maximum number of backward rematerialization iterations">,
+  ];
 }
 
 def TritonIntelGPUReduceDataDuplication: Pass<"tritonintelgpu-reduce-data-duplication", "mlir::ModuleOp"> {

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -2251,6 +2251,11 @@ class TritonIntelGPURemoveLayoutConversionsPass
     : public triton::gpu::intel::impl::
           TritonIntelGPURemoveLayoutConversionsBase<
               TritonIntelGPURemoveLayoutConversionsPass> {
+  using Base =
+      triton::gpu::intel::impl::TritonIntelGPURemoveLayoutConversionsBase<
+          TritonIntelGPURemoveLayoutConversionsPass>;
+  using Base::Base;
+
 public:
   // Cleanup convert ops.
   void cleanupConvertOps() {
@@ -2296,7 +2301,9 @@ public:
     // (reduceLoopCarriedValues, forwardPropagateRemat) can create new
     // ConvertLayoutOps during each iteration, so bound the loop to prevent
     // non-termination in pathological cases.
-    constexpr unsigned kMaxBackwardRematIterations = 10;
+    // TODO: Increase the default once the IGC crash on paged-attention kernels
+    // is resolved (see
+    // https://github.com/intel/intel-xpu-backend-for-triton/issues/6447).
     unsigned iteration = 0;
     bool changed = false;
     do {
@@ -2310,11 +2317,11 @@ public:
 
       // Cleanup dummy converts created during backward remat.
       cleanupConvertOps();
-    } while (changed && ++iteration < kMaxBackwardRematIterations);
+    } while (changed && ++iteration < maxBackwardRematIterations);
 
-    if (iteration >= kMaxBackwardRematIterations)
+    if (iteration >= maxBackwardRematIterations)
       LDBG("backward rematerialization reached iteration cap ("
-           << kMaxBackwardRematIterations << ")");
+           << maxBackwardRematIterations << ")");
 
     // 3. For remaining converts, try to hoist them above cast generating larger
     // size types in order to reduce the cost of the convert op.


### PR DESCRIPTION
## Summary

- Adds a `max-backward-remat-iterations` pass option to `tritonintelgpu-remove-layout-conversions` (default: **1**)
- Replaces the hardcoded iteration cap of 10 introduced in PR #6380
- Lit tests pass `max-backward-remat-iterations=10` to preserve multi-iteration test coverage

## Motivation

Iterative backward rematerialization (#6380) produces valid IR that triggers an IGC SIGFPE crash on paged-attention flex attention kernels (PVC Max 1100). Defaulting to 1 iteration avoids the crash while keeping the capability available via the pass option.

Fixes #6447