### PR TITLE
Move `TensorDescToBlockPointer` back to before `SoftwarePipeliner`

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -313,8 +313,8 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         intel.passes.ttgpuir.add_materialize_block_pointer(pm)
         intel.passes.ttgpuir.add_remove_layout_conversions(pm)
         intel.passes.ttgpuir.add_optimize_dot_operands(pm)
-        intel.passes.ttgpuir.add_pipeline(pm, opt.num_stages, opt.use_barrier)
         intel.passes.ttir.add_convert_tdesc_to_block_pointer(pm)
+        intel.passes.ttgpuir.add_pipeline(pm, opt.num_stages, opt.use_barrier)
 
         if (opt.reduce_variable_liveness):
             intel.passes.ttgpuir.add_reduce_variable_liveness(pm)


### PR DESCRIPTION
GEMM has a performance regression on BMG from moving `TensorDescToBlockPointer` after `SoftwarePipeliner`, temporally move it back until a fix is identified.

Fixes #6456: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/23461992574