### PR TITLE
[TEST] Fix test_abs_fp8: mark unsupported fp8 types as xfail on XPU

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1081,7 +1081,7 @@ def test_abs_fp8(in_dtype, device):
             pytest.skip("float8e4b8/float8e5b16 not supported on CUDA")
     elif is_xpu():
         if in_dtype in (tl.float8e4b8, tl.float8e5b16):
-            pytest.skip("FIXME: Ensure float8e4b8/float8e5b16 not supported on XPU (#6326)")
+            pytest.xfail("float8e4b8/float8e5b16 not supported on XPU")
 
     @triton.jit
     def abs_kernel(X, Z, SIZE: tl.constexpr):


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

XPU hardware only supports default-bias fp8 types (`fp8e4m3` bias 7, `fp8e5m2` bias 15). The non-default bias types `float8e4b8` and `float8e5b16` were skipped via `pytest.skip`, which hides them from test results entirely.

Change to `pytest.xfail` so the expected failure is tracked and will surface automatically if hardware support is added in the future.

Confirmed by @mieshkiwrk in #6326.

Fixes #6326

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it modifies existing test behavior (skip -> xfail) as directed by maintainer.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
