### PR TITLE
[LoadStoreOpToLLVM] Fix rank-reducing tensor descriptor load/store lowering

### DIFF
--- a/test/TritonIntelGPU/descriptor-load-block-2d.mlir
+++ b/test/TritonIntelGPU/descriptor-load-block-2d.mlir
@@ -36,7 +36,7 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
                    "ttig.support_2d_block_io"} {
   // CHECK-LABEL: @descriptor_load_rank_reducing_row_major
-  // CHECK: triton_gen.2Dblockload
+  // CHECK-COUNT-2: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 2, transpose = false, vnni_transform = false, cache_control = Default}
   tt.func public @descriptor_load_rank_reducing_row_major(
       %arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i32,
       %arg5: i32) {

--- a/test/TritonIntelGPU/descriptor-store-block-2d.mlir
+++ b/test/TritonIntelGPU/descriptor-store-block-2d.mlir
@@ -29,6 +29,47 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
 }
 
 // -----
+// Test: Rank-reducing descriptor store with block IO.
+// Descriptor rank is 3 while source tensor rank is 2.
+
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 1], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @store_rank_reducing_dpas_tdesc
+  // CHECK-COUNT-8: triton_gen.2Dblockstore {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = Default}
+  tt.func public @store_rank_reducing_dpas_tdesc(%arg0: !tt.ptr<f16>, %arg1: i32,
+                                                  %arg2: i32, %arg3: i64) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf16, #dpas>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %desc = tt.make_tensor_descriptor %arg0, [%c1_i32, %arg1, %arg2], [%arg3, %c1_i64, %c1_i64] : <f16>, <tensor<1x32x32xf16, #dpas>>
+    tt.descriptor_store %desc[%c0_i32, %c0_i32, %c0_i32], %cst {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<1x32x32xf16, #dpas>>, tensor<32x32xf16, #dpas>
+    tt.return
+  }
+}
+
+// -----
+// Test: Rank-reducing descriptor store without block IO attribute uses generic
+// gather/scatter lowering (no 2D block store emitted).
+
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 1], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @store_rank_reducing_generic_tdesc
+  // CHECK-NOT: triton_gen.2Dblockstore
+  tt.func public @store_rank_reducing_generic_tdesc(%arg0: !tt.ptr<f16>,
+                                                     %arg1: i32, %arg2: i32,
+                                                     %arg3: i64) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf16, #dpas>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %desc = tt.make_tensor_descriptor %arg0, [%c1_i32, %arg1, %arg2], [%arg3, %c1_i64, %c1_i64] : <f16>, <tensor<1x32x32xf16, #dpas>>
+    tt.descriptor_store %desc[%c0_i32, %c0_i32, %c0_i32], %cst : !tt.tensordesc<tensor<1x32x32xf16, #dpas>>, tensor<32x32xf16, #dpas>
+    tt.return
+  }
+}
+
+// -----
 // Test 2: f32 dpas layout store — f32 element type produces different tile dims.
 // Mirrors blockptr_store.mlir f32 variant.
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -146,7 +146,7 @@ static DescriptorFields unpackDescriptor(Value llDesc, unsigned rank,
 /// For rank-reducing ops, the result/source tensor shape must exactly match the
 /// inner dimensions of the descriptor block type after stripping the leading
 /// (outer) dimensions:
-///
+///   desc_shape[i] == 1                        for all i in [0, rankDelta)
 ///   desc_shape[rankDelta + i] == tensor_shape[i]   for all i in [0, rank)
 ///
 /// This is not checked by the upstream verifier (which only checks total
@@ -159,6 +159,16 @@ static void assertDescriptorInnerShapeCompatible(
   const size_t rank = tensorShape.size();
   assert(descRank >= rank && "descriptor rank must be >= tensor rank");
   const size_t rankDelta = descRank - rank;
+  for (size_t i = 0; i < rankDelta; ++i) {
+    if (descBlockShape[i] != 1) {
+      op->emitError()
+          << "rank-reducing descriptor op only supports dropping leading "
+             "dimensions of size 1, but descriptor dim["
+          << i << "] = " << descBlockShape[i];
+      llvm_unreachable("rank-reducing descriptor dropped dim mismatch");
+    }
+  }
+
   for (size_t i = 0; i < rank; ++i) {
     size_t descDim = rankDelta + i;
     if (permuteInnerDims && rank >= 2) {


### PR DESCRIPTION
This PR fixes descriptor lowering when descriptor rank is higher than the load/store tensor rank, and adds regression coverage for rank-reducing descriptor load.