### PR TITLE
Fix sporadic build failure due to missing TritonGEN tablegen dependency

### DIFF
--- a/third_party/intel/lib/GPUToTritonGEN/CMakeLists.txt
+++ b/third_party/intel/lib/GPUToTritonGEN/CMakeLists.txt
@@ -8,6 +8,8 @@ add_triton_library(GPUToTritonGEN
   DEPENDS
   GPUToTritonGENConversionPassIncGen
   GPUToTritonGENIncGen
+  TritonGENAttrDefsIncGen
+  TritonGENTableGen
 
   LINK_LIBS PUBLIC
   MLIRArithToLLVM
@@ -18,4 +20,5 @@ add_triton_library(GPUToTritonGEN
   MLIRLLVMDialect
   MLIRMemRefToLLVM
   MLIRPass
+  TritonGENIR
 )


### PR DESCRIPTION
GPUToTritonGENPass.cpp includes TritonGENDialect.h which transitively requires TritonGENOpsAttrDefs.h.inc, but the GPUToTritonGEN CMake target did not depend on the tablegen targets that generate these files. Under high parallelism (-j64) this caused sporadic 'No such file or directory' build failures when ninja scheduled the compilation before tablegen.

Add TritonGENAttrDefsIncGen and TritonGENTableGen to DEPENDS and TritonGENIR to LINK_LIBS to ensure correct build ordering.

Closing #6492 