### PR TITLE
[SYCL-TLA] Fix missed cutlass -> sycl-tla re-naming for flags 

### DIFF
--- a/benchmarks/sycl_tla_kernel/CMakeLists.txt
+++ b/benchmarks/sycl_tla_kernel/CMakeLists.txt
@@ -37,11 +37,11 @@ set(SYCL_TLA_KERNEL_FLAGS ${SYCL_TLA_KERNEL_FLAGS}
 )
 
 if (SYCL_COMPILER_VERSION GREATER_EQUAL 20251010)
-  list(APPEND CUTLASS_KERNEL_FLAGS
+  list(APPEND SYCL_TLA_KERNEL_FLAGS
     "SHELL:-Xspirv-translator=intel_gpu_bmg_g31 --spirv-ext=${SPIRV_EXTENSIONS}")
 endif()
 
-list(APPEND CUTLASS_KERNEL_FLAGS
+list(APPEND SYCL_TLA_KERNEL_FLAGS
   -Xs "-options \"-igc_opts 'VISAOptions=-perfmodel,VectorAliasBBThreshold=1000,ExtraOCLOptions=-cl-intel-256-GRF-per-thread'\" -options -ze-opt-large-register-file"
 )
 


### PR DESCRIPTION
`CUTLASS_KERNEL_FLAGS` -> `SYCL_TLA_KERNEL_FLAGS`