### PR TITLE
Rewrite remaining block pointers to tensor of pointers

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -270,6 +270,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         pm.enable_debug()
         passes.common.add_inliner(pm)
         intel.passes.ttir.add_convert_block_pointer_to_tdesc(pm)
+        passes.ttir.add_rewrite_tensor_pointer(pm)
         intel.passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)
         passes.common.add_cse(pm)
         passes.ttir.add_triton_licm(pm)


### PR DESCRIPTION
`convert_block_pointer_to_tdesc` only translate some block pointers to tensor descriptors, adding `rewrite_tensor_pointer` ensures no block pointer left to be handled.