### PR TITLE
[LoadStoreOpToLLVM] Remove unnecessary sub_group_shuffle in descriptor load lowering

### DIFF
--- a/test/TritonIntelGPU/descriptor-load-block-2d.mlir
+++ b/test/TritonIntelGPU/descriptor-load-block-2d.mlir
@@ -19,6 +19,9 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     // CHECK: llvm.insertvalue {{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <tensor<64x32xf16>>
     // Verify 2D block loads are generated for dot A operand.
+    // The base pointer from the descriptor is already uniform — no sub-group
+    // shuffle should be emitted.
+    // CHECK-NOT: sub_group_shuffle
     // For DPAS A with f16: tile_height=8, tile_width=16, v_blocks=2.
     // CHECK-COUNT-2: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 2, transpose = false, vnni_transform = false, cache_control = Default}
     %load = tt.descriptor_load %desc[%arg4, %arg5] {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<64x32xf16>> -> tensor<64x32xf16, #dot0>

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2878,8 +2878,7 @@ struct DescriptorLoadOpToBlockIOConversion
                                         {kWarp, warpId},
                                         {kBlock, b.i32_val(0)}});
 
-      // Use the base pointer for all tiles (descriptors share a single base).
-      Value addrElem = targetInfo.shuffleIdx(rewriter, loc, desc.base, 0);
+      Value addrElem = desc.base;
       Value offsetX, offsetY;
       Value adjustedBaseWidth = baseWidth;
       Value adjustedBaseHeight = baseHeight;


### PR DESCRIPTION
The descriptor load path was broadcasting the base pointer via sub_group_shuffle to lane 0 before every 2D block load, but the pointer originates from a scalar tt.ptr argument via tt.make_tensor_descriptor and is already uniform across all lanes.