### PR TITLE
[LoadStoreOpToLLVM] Fix descriptor load to respect ttig.one_matrix_per_load attribute

### DIFF
--- a/test/TritonIntelGPU/descriptor-load-block-2d.mlir
+++ b/test/TritonIntelGPU/descriptor-load-block-2d.mlir
@@ -273,6 +273,27 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 
 // -----
 
+// Test: DescriptorLoadOp with column_major and ttig.one_matrix_per_load attribute
+// generates transposed 2D block loads with smaller tile_height (16 instead of 32).
+// This verifies that the descriptor load path respects the one_matrix_per_load
+// attribute, matching the block pointer load behavior.
+
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [8, 1], repCluster = [2, 2], A = [16, 16], B = [16, 32], C = [16, 32]}>
+#dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth=2}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: @descriptor_load_column_major_one_matrix_per_load
+  tt.func public @descriptor_load_column_major_one_matrix_per_load(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i32, %arg5: i32) {
+    %c1_i64 = arith.constant 1 : i64
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <tensor<32x64xf16>>
+    // With one_matrix_per_load, tile_height should be 16 (not doubled to 32).
+    // CHECK-COUNT-8: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 32, tile_width = 8, tile_height = 16, v_blocks = 1, transpose = true, vnni_transform = false, cache_control = Default}
+    %load = tt.descriptor_load %desc[%arg4, %arg5] {ttig.block_io = "column_major", ttig.one_matrix_per_load} : !tt.tensordesc<tensor<32x64xf16>> -> tensor<64x32xf16, #dot1>
+    tt.return
+  }
+}
+
+// -----
+
 // Test: DescriptorLoadOp with row_major block_io attribute and dot_op B encoding
 // generates standard (non-transposed) 2D block loads with VNNI transform.
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2722,9 +2722,17 @@ struct DescriptorLoadOpToBlockIOConversion
     unsigned elemSizeInBits = eltTy.getIntOrFloatBitWidth();
 
     // Tile size computation (no mask for descriptors).
+    // FIXME: Remove once IGC can split large 2D block loads.
+    std::optional<bool> oneMatrixPerLoadForBT =
+        mlir::triton::tools::isEnvValueBool(mlir::triton::tools::getStrEnv(
+            "TRITON_INTEL_ONE_MATRIX_PER_LOAD_BT"));
+    if (!oneMatrixPerLoadForBT.has_value())
+      oneMatrixPerLoadForBT =
+          op->hasAttr(triton::gpu::intel::TritonIntelGPUDialect::
+                          getOneMatrixPerLoadAttrName());
     BlockIOTileSizeInfo sizeInfo = getBlockIOTileSize<true /*load*/>(
         llEncoding.value(), contiguousDim, elemSizeInBits,
-        /*maskAxisInfo=*/nullptr, /*oneMatrixPerLoadForBT=*/false);
+        /*maskAxisInfo=*/nullptr, *oneMatrixPerLoadForBT);
     if (!sizeInfo.isValid())
       return failure();
 


### PR DESCRIPTION
DescriptorLoadOpToBlockIOConversion was hardcoding oneMatrixPerLoadForBT=false when calling getBlockIOTileSize(), while the equivalent LoadOpToBlockIOConversion (block pointer path) reads the ttig.one_matrix_per_load attribute from the op.