### PR TITLE
[CI] Fix 'Test with pip' workflow

### DIFF
--- a/.github/workflows/pip-test.yml
+++ b/.github/workflows/pip-test.yml
@@ -66,6 +66,7 @@ jobs:
         run: |
           curl -sSLO --retry 10 https://raw.githubusercontent.com/pytorch/pytorch/$(<.github/pins/pytorch.txt)/.github/scripts/generate_binary_build_matrix.py
           sed -i 's/^\(\s*\)validate_nccl_dep_consistency(arch_version)/\1pass/' generate_binary_build_matrix.py
+          sed -i 's/^\(\s*\)validate_cudnn_version_consistency(arch_version)/\1pass/' generate_binary_build_matrix.py
           python -c "from generate_binary_build_matrix import PYTORCH_EXTRA_INSTALL_REQUIREMENTS; print('\n'.join(PYTORCH_EXTRA_INSTALL_REQUIREMENTS['xpu'].split(' | ')))" | tee /tmp/requirements.txt
           pip install -r /tmp/requirements.txt
           pip install transformers==4.54.0


### PR DESCRIPTION
This workflow is failing currently on `main` branch: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/23750426218 because of the newly introduced `validate_cudnn_version_consistency` in https://github.com/pytorch/pytorch/commit/d90beed1de2becebbb991df7991971edd398bdbc

For our use case, we don't need to install cuDNN.