### PR TITLE
[vLLM] Add vLLM build dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ llvm-project/
 llvm-project-*/
 .llvm-project/
 
+/vllm/
+
 # Triton Python module builds
 dist/
 python/triton*.egg-info/


### PR DESCRIPTION
This patch adds the `vllm` dir at the first level of the project to the ignore list. This is where vLLM is built by `test-triton.sh --install-vllm`. 