### PR TITLE
[TritonGEN] Use GenISA for 2D block store 32b_4r4x1c

### DIFF
--- a/test/TritonGEN/tritongen-2Dblockstore-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockstore-to-llvm.mlir
@@ -152,6 +152,20 @@ llvm.func @triton_gen.2Dblockstore(%ptr : !llvm.ptr<1>, %base_width : i32, %base
 
 // -----
 
+llvm.func @triton_gen.2Dblockstore(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xi16>) {
+  // CHECK:    [[ELEM_BITS:%.*]] = llvm.mlir.constant(32 : i32) : i32
+  // CHECK:    [[TILE_WIDTH:%.*]] = llvm.mlir.constant(4 : i32) : i32
+  // CHECK:    [[TILE_HEIGHT:%.*]] = llvm.mlir.constant(4 : i32) : i32
+  // CHECK:    [[VBLOCKS:%.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK:    [[TRANSPOSE:%.*]] = llvm.mlir.constant(false) : i1
+  // CHECK:    [[VNNI:%.*]] = llvm.mlir.constant(false) : i1
+  // CHECK:    llvm.call spir_funccc @llvm.genx.GenISA.LSC2DBlockWrite.v4i16({{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, [[ELEM_BITS]], [[TILE_WIDTH]], [[TILE_HEIGHT]], [[VBLOCKS]], [[TRANSPOSE]], [[VNNI]], {{.*}})
+  triton_gen.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32, tile_width=4, tile_height=4, v_blocks=1, cache_control=Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32, vector<4xi16>)
+  llvm.return
+}
+
+// -----
+
 llvm.func @triton_gen.2Dblockstore(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<8xi16>) {
   // CHECK:    [[ELEM_BITS:%.*]] = llvm.mlir.constant(32 : i32) : i32
   // CHECK:    [[TILE_WIDTH:%.*]] = llvm.mlir.constant(4 : i32) : i32

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -165,6 +165,11 @@ static bool isSPVBuiltinAvailableImpl(TritonGEN::Matrix2DBlockLoadOp op) {
 static bool isSPVBuiltinAvailableImpl(TritonGEN::Matrix2DBlockStoreOp op) {
   // FIXME: The following signatures are not valid in SPV interface.
 
+  // intel_sub_group_2d_block_write_32b_4r4x1c
+  if (op.getElemSizeInBits() == 32 && op.getTileHeight() == 4 &&
+      op.getTileWidth() == 4 && op.getVBlocks() == 1)
+    return false;
+
   // FIXME: The SPV block store only support subgroup size 16.
   int subGroupSize = triton::gpu::TritonGPUDialect::getThreadsPerWarp(
       op->getParentOfType<mlir::ModuleOp>());


### PR DESCRIPTION
Fixes #6529

CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/23820551218