### PR TITLE
[LoadStoreOpToLLVM] Pre-apply alignment in descriptor load lowering

### DIFF
--- a/test/TritonIntelGPU/descriptor-load-block-2d.mlir
+++ b/test/TritonIntelGPU/descriptor-load-block-2d.mlir
@@ -52,6 +52,42 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
 
 // -----
 
+// Test: Descriptor load pre-applies 64-byte alignment compensation to the base
+// pointer and column offset. This ensures multi-tile loads build tile offsets
+// relative to an alignment-adjusted base, preventing LLVM from factoring out
+// a suboptimal common subexpression across operand loads.
+
+#dpas_align = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0_align = #ttg.dot_op<{opIdx = 0, parent = #dpas_align, kWidth=1}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: @descriptor_load_pre_alignment
+  tt.func public @descriptor_load_pre_alignment(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i32, %arg5: i32) {
+    %c1_i64 = arith.constant 1 : i64
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <tensor<64x32xf16>>
+
+    // Verify base pointer alignment: ptr & ~0x3f (clear lower 6 bits).
+    // CHECK: %[[BASE:.*]] = llvm.extractvalue {{.*}}[4]
+    // CHECK: %[[ADDR:.*]] = llvm.ptrtoint %[[BASE]] : !llvm.ptr<1> to i64
+    // CHECK: %[[ALIGNED_ADDR:.*]] = llvm.and %[[ADDR]], {{.*}} : i64
+    // CHECK: %[[ALIGNED_PTR:.*]] = llvm.inttoptr %[[ALIGNED_ADDR]] : i64 to !llvm.ptr<1>
+
+    // Verify offset extraction and column index adjustment.
+    // CHECK: %[[OFFSET_BYTES:.*]] = llvm.and %[[ADDR]], {{.*}} : i64
+    // CHECK: %[[OFFSET_I32:.*]] = llvm.trunc %[[OFFSET_BYTES]] : i64 to i32
+    // CHECK: %[[MISALIGN_ELEMS:.*]] = llvm.udiv %[[OFFSET_I32]]
+    // CHECK: %[[ADJ_BASE_WIDTH:.*]] = llvm.add {{.*}}, %[[OFFSET_I32]]
+    // CHECK: %[[ADJ_COL:.*]] = llvm.add %{{.*}}, %[[MISALIGN_ELEMS]]
+
+    // Verify both 2D block loads use the aligned pointer and adjusted width.
+    // CHECK: triton_gen.2Dblockload %[[ALIGNED_PTR]], %[[ADJ_BASE_WIDTH]]
+    // CHECK: triton_gen.2Dblockload %[[ALIGNED_PTR]], %[[ADJ_BASE_WIDTH]]
+    %load = tt.descriptor_load %desc[%arg4, %arg5] {ttig.block_io = "row_major"} : !tt.tensordesc<tensor<64x32xf16>> -> tensor<64x32xf16, #dot0_align>
+    tt.return
+  }
+}
+
+// -----
+
 // Test: DescriptorLoadOp with dot_op B encoding generates 2D block loads
 // with VNNI transform.
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2948,6 +2948,32 @@ struct DescriptorLoadOpToBlockIOConversion
     unsigned blockColIdx = isTransposeRequired ? rowDim : colDim;
     unsigned blockRowIdx = isTransposeRequired ? colDim : rowDim;
 
+    // FIXME: This is a workaround for suboptimal instruction scheduling.
+    // Remove once IGC handles the or-expression reassociation correctly
+    // (see https://github.com/intel/intel-xpu-backend-for-triton/issues/6540).
+    //
+    // Pre-apply 64-byte alignment compensation to the base pointer and column
+    // offset. This bakes the alignment adjustment into the column index BEFORE
+    // per-tile layout offsets are added, ensuring LLVM builds tile 1's
+    // x-coordinate as (tile0_x + delta) rather than (descIndex + delta) +
+    // misalign. Without this, LLVM's CSE factors out (descIndex + delta) as a
+    // common subexpression shared across different operand loads, producing a
+    // suboptimal instruction schedule.
+    constexpr int64_t ALIGNMENT_MASK = 0x3f;
+    unsigned descBlockColIdx =
+        mapResultDimToDescDim(isTransposeRequired ? rowDim : colDim);
+    {
+      Value baseAddr = b.ptrtoint(int_ty(64), desc.base);
+      Value alignedBaseAddr = b.and_(baseAddr, b.i64_val(~ALIGNMENT_MASK));
+      desc.base = b.inttoptr(ptr_ty(ctx, 1), alignedBaseAddr);
+      Value offsetInBytes =
+          b.trunc(i32_ty, b.and_(baseAddr, b.i64_val(ALIGNMENT_MASK)));
+      Value misalignElems = b.udiv(offsetInBytes, elemBytes);
+      baseWidth = b.add(baseWidth, offsetInBytes);
+      descIndices[descBlockColIdx] =
+          b.add(descIndices[descBlockColIdx], misalignElems);
+    }
+
     SmallVector<Value> unpackedLoadedVals(numElems);
     for (size_t elemIdx = 0; elemIdx < numElems; elemIdx += numElemsPerLoad) {
       unsigned registerIdx = regMapping.apply({{kRegister, elemIdx}})[0].second;


### PR DESCRIPTION
Fixes #6456 

- Pre-apply 64-byte alignment compensation to the base pointer and column offset in descriptor load lowering, before per-tile layout offsets are added
- This bakes the alignment adjustment into the column index so LLVM builds tile 1's x-coordinate as `(tile0_x + delta)` rather than `(descIndex + delta) + misalign`
- Without this, LLVM's CSE factors out `(descIndex + delta)` as a common subexpression shared across different operand loads (A and B), producing a suboptimal `or` expression tree that causes IGC to generate worse instruction scheduling

🤖 Generated with [Claude Code](https://claude.com/claude-code)