### PR TITLE
[CRI] Fix partitioned shared layout by replacing pointer vector with …

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -616,18 +616,20 @@ lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
                    warpId, rewriter, targetInfo, maybeMaxVecElems, emitLdSt);
 }
 
-// Build a vector containing multiple base pointers for dynamic indexing.
-static Value buildBasePtrVector(Location loc, RewriterBase &rewriter,
-                                ArrayRef<Value> smemBases) {
-  assert(smemBases.size() > 1 && "Need multiple bases to build a vector");
+// Select the correct base pointer using a chain of select operations.
+// This avoids building a vector of pointers with dynamic extractelement,
+// which would require SPV_INTEL_masked_gather_scatter which is failed
+// by ocloc.
+static Value selectFromBases(Location loc, RewriterBase &rewriter,
+                             ArrayRef<Value> smemBases, Value idx) {
+  assert(smemBases.size() > 1 && "Need multiple bases to select from");
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  auto ptrTy = smemBases[0].getType();
-  auto vecTy = VectorType::get({static_cast<int64_t>(smemBases.size())}, ptrTy);
-  Value basesVec = b.undef(vecTy);
-  for (size_t i = 0; i < smemBases.size(); ++i) {
-    basesVec = b.insert_element(basesVec, smemBases[i], b.i32_val(i));
+  Value result = smemBases.back();
+  for (int i = static_cast<int>(smemBases.size()) - 2; i >= 0; --i) {
+    Value cmp = b.icmp_eq(idx, b.i32_val(i));
+    result = b.select(cmp, smemBases[i], result);
   }
-  return basesVec;
+  return result;
 }
 
 SmallVector<Value>
@@ -666,10 +668,8 @@ lowerLdSt(Location loc, MLIRContext *ctx, LinearLayout cvt,
   // Extract the partition sublayout before stripping it for vectorization.
   auto inDimNames = to_vector(cvt.getInDimNames());
   LinearLayout partitionLayout;
-  Value basesVec;
   if (isPartitioned) {
     partitionLayout = cvt.sublayout(inDimNames, {kPartition});
-    basesVec = buildBasePtrVector(loc, rewriter, smemBases);
   }
 
   // Strip kPartition output for vectorization analysis.
@@ -769,7 +769,7 @@ lowerLdSt(Location loc, MLIRContext *ctx, LinearLayout cvt,
                                                   {kWarp, warpId},
                                                   {kBlock, blockId}});
         Value partitionIdx = partitionResult[0].second;
-        smemBase = b.extract_element(basesVec, partitionIdx);
+        smemBase = selectFromBases(loc, rewriter, smemBases, partitionIdx);
       }
 
       std::optional<Value> innerCtaOffset;

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -4,7 +4,7 @@ import pytest
 import triton
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
-from triton._internal_testing import is_xpu, is_xpu_cri, is_cuda, is_hip, is_hopper_or_newer, get_hip_lds_size
+from triton._internal_testing import is_xpu, is_cuda, is_hip, is_hopper_or_newer, get_hip_lds_size
 from triton.experimental.gluon.language.amd.gfx1250 import PartitionedSharedLayout
 
 THREADS_PER_WARP = triton.runtime.driver.active.get_current_target().warp_size
@@ -1451,9 +1451,6 @@ def test_partitioned_shared_layout(M, K, num_partitions, num_groups, partition_d
     - partition_dim: Dimension along which to partition (0=rows, 1=cols)
     - partition_layout_type: Layout within each piece ("swizzled" or "padded")
     """
-    if is_xpu_cri() and partition_layout_type == "swizzled":
-        pytest.skip("FIXME: #6480")
-
     blocked_layout = ttgl.BlockedLayout(
         size_per_thread=[1, 8],
         threads_per_warp=[THREADS_PER_WARP // 4, 4],


### PR DESCRIPTION
Replace buildBasePtrVector() + extractelement with selectFromBases() that generates a chain of select instructions. The SPIR-V spec does not allow vectors of pointers, the LLVM-to-SPIR-V translator requires SPV_INTEL_masked_gather_scatter to handle them, which ocloc does not support.

The select chain is equivalent to what LLVM O3 already does for 2-element vectors, but made explicit for all partition counts.
