### PR TITLE
Support PAD_NAN for tensor descriptor block IO loads

### DIFF
--- a/python/test/unit/intel/test_block_load_nan.py
+++ b/python/test/unit/intel/test_block_load_nan.py
@@ -10,11 +10,10 @@ from triton._internal_testing import is_xpu
 @pytest.mark.parametrize("M, N",
                          [[256, 64], [256, 32], [128, 32], [128, 16], [128, 8], [64, 64], [64, 32], [32, 32], [16, 64]])
 @pytest.mark.parametrize("dtype_str", ["float32"])
-@pytest.mark.parametrize("transpose", [True, False])
 @pytest.mark.skipif(not is_xpu(), reason="Block load tests are specific to the XPU backend")
 @pytest.mark.xfail(not triton.runtime.driver.active.get_current_target().arch['has_2d_block_io'],
                    reason="Block loads not supported on this architecture", run=False)
-def test_block_load_dpas_layout(M, N, dtype_str, transpose, device, tmp_path: pathlib.Path):
+def test_block_load_dpas_layout(M, N, dtype_str, device, tmp_path: pathlib.Path):
     # modify the layouts to ensure the correct OCL/SPIRV intrinsic is called for each datatype
     if dtype_str == "float32":
         A_width = 1
@@ -27,7 +26,7 @@ def test_block_load_dpas_layout(M, N, dtype_str, transpose, device, tmp_path: pa
         layouts = "#mma = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [8, 4], repCluster = [4, 2]}>"
         num_warps = 32
 
-    block_io = "\"column_major\"" if transpose else "\"row_major\""
+    block_io = "\"row_major\""
 
     ty = {"float32": "f32", "float16": "f16", "int8": "i8"}[dtype_str]
 
@@ -36,25 +35,29 @@ def test_block_load_dpas_layout(M, N, dtype_str, transpose, device, tmp_path: pa
         tt.func public @block_load_dpas_layout(%arg0: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}, %arg2: !tt.ptr<{ty}> {{tt.divisibility = 16: i32}}, %arg3: !tt.ptr<{ty}> {{tt.divisibility = 16: i32}}) attributes {{noinline = false}} {{
             %0 = tt.get_program_id x : i32
 
+            %Mload_i32 = arith.constant {M-1} : i32
+            %Nload_i32 = arith.constant {N-1} : i32
             %Mload_i64 = arith.constant {M-1} : i64
             %Nload_i64 = arith.constant {N-1} : i64
 
+            %M_i32 = arith.constant {M} : i32
+            %N_i32 = arith.constant {N} : i32
             %M_i64 = arith.constant {M} : i64
             %N_i64 = arith.constant {N} : i64
             %c1_i64 = arith.constant 1 : i64
             %c0_i32 = arith.constant 0 : i32
 
             // A matrix
-            %1 = tt.make_tensor_ptr %arg0, [%Mload_i64, %Nload_i64], [%Nload_i64, %c1_i64], [%0, %c0_i32] {{order = array<i32: 1, 0>}} : <tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>>
-            %2 = tt.load %1 {{padding = 1 : i32, boundaryCheck = array<i32: 0, 1>, ttig.block_io = "row_major"}} : !tt.ptr<tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>>
-            %3 = tt.make_tensor_ptr %arg1, [%M_i64, %N_i64], [%N_i64, %c1_i64], [%0, %c0_i32] {{order = array<i32: 1, 0>}} : <tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>>
-            tt.store %3, %2 {{boundaryCheck = array<i32: 0, 1>}} : !tt.ptr<tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>>
+            %1 = tt.make_tensor_descriptor %arg0, [%Mload_i32, %Nload_i32], [%Nload_i64, %c1_i64]  : <{ty}>, !tt.tensordesc<tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>>
+            %2 = tt.descriptor_load %1[%0, %c0_i32] {{ttig.block_io = "row_major"}} : !tt.tensordesc<tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>> -> tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
+            %3 = tt.make_tensor_descriptor %arg1, [%M_i32, %N_i32], [%N_i64, %c1_i64] : <{ty}>, !tt.tensordesc<tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>>
+            tt.descriptor_store %3[%0, %c0_i32], %2 : !tt.tensordesc<tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>> >, tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
 
             // B matrix
-            %4 = tt.make_tensor_ptr %arg2, [%Nload_i64, %Mload_i64], {"[%c1_i64, %Nload_i64]" if transpose else "[%Mload_i64, %c1_i64]"}, [%c0_i32, %0] {{order = array<i32: 1, 0>}} : <tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>>
-            %5 = tt.load %4 {{padding = 1 : i32, boundaryCheck = array<i32: 0, 1>, ttig.block_io = {block_io} }} : !tt.ptr<tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>>
-            %6 = tt.make_tensor_ptr %arg3, [%N_i64, %M_i64], {"[%c1_i64, %N_i64]" if transpose else "[%M_i64, %c1_i64]"}, [%c0_i32, %0] {{order = array<i32: 1, 0>}} : <tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>>
-            tt.store %6, %5 {{boundaryCheck = array<i32: 0, 1>}} : !tt.ptr<tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>>
+            %4 = tt.make_tensor_descriptor %arg2, [%Nload_i32, %Mload_i32], [%Mload_i64, %c1_i64]  : <{ty}>, !tt.tensordesc<tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>>
+            %5 = tt.descriptor_load %4[%c0_i32, %0] {{ttig.block_io = {block_io} }} : !tt.tensordesc<tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>> -> tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
+            %6 = tt.make_tensor_descriptor %arg3, [%N_i32, %M_i32], [%M_i64, %c1_i64] : <{ty}>, !tt.tensordesc<tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>>
+            tt.descriptor_store %6[%c0_i32, %0], %5 : !tt.tensordesc<tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>> >, tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
 
             tt.return
         }}
@@ -66,25 +69,29 @@ def test_block_load_dpas_layout(M, N, dtype_str, transpose, device, tmp_path: pa
         tt.func public @block_load_dpas_layout(%arg0: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}, %arg2: !tt.ptr<{ty}> {{tt.divisibility = 16: i32}}, %arg3: !tt.ptr<{ty}> {{tt.divisibility = 16: i32}}) attributes {{noinline = false}} {{
             %0 = tt.get_program_id x : i32
 
+            %Mload_i32 = arith.constant {M-1} : i32
+            %Nload_i32 = arith.constant {N-1} : i32
             %Mload_i64 = arith.constant {M-1} : i64
             %Nload_i64 = arith.constant {N-1} : i64
 
+            %M_i32 = arith.constant {M} : i32
+            %N_i32 = arith.constant {N} : i32
             %M_i64 = arith.constant {M} : i64
             %N_i64 = arith.constant {N} : i64
             %c1_i64 = arith.constant 1 : i64
             %c0_i32 = arith.constant 0 : i32
 
             // A matrix
-            %1 = tt.make_tensor_ptr %arg0, [%Mload_i64, %Nload_i64], [%Nload_i64, %c1_i64], [%0, %c0_i32] {{order = array<i32: 1, 0>}} : <tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>>
-            %2 = tt.load %1 {{padding = 2 : i32, boundaryCheck = array<i32: 0, 1>, ttig.block_io = "row_major"}} : !tt.ptr<tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>>
-            %3 = tt.make_tensor_ptr %arg1, [%M_i64, %N_i64], [%N_i64, %c1_i64], [%0, %c0_i32] {{order = array<i32: 1, 0>}} : <tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>>
-            tt.store %3, %2 {{boundaryCheck = array<i32: 0, 1>}} : !tt.ptr<tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>>
+            %1 = tt.make_tensor_descriptor %arg0, [%Mload_i32, %Nload_i32], [%Nload_i64, %c1_i64] {{padding = 2 : i32}} : <{ty}>, !tt.tensordesc<tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>>
+            %2 = tt.descriptor_load %1[%0, %c0_i32] {{ttig.block_io = "row_major"}} : !tt.tensordesc<tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>> -> tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
+            %3 = tt.make_tensor_descriptor %arg1, [%M_i32, %N_i32], [%N_i64, %c1_i64] : <{ty}>, !tt.tensordesc<tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>>
+            tt.descriptor_store %3[%0, %c0_i32], %2 : !tt.tensordesc<tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>> >, tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
 
             // B matrix
-            %4 = tt.make_tensor_ptr %arg2, [%Nload_i64, %Mload_i64], {"[%c1_i64, %Nload_i64]" if transpose else "[%Mload_i64, %c1_i64]"}, [%c0_i32, %0] {{order = array<i32: 1, 0>}} : <tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>>
-            %5 = tt.load %4 {{padding = 2 : i32, boundaryCheck = array<i32: 0, 1>, ttig.block_io = {block_io} }} : !tt.ptr<tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>>
-            %6 = tt.make_tensor_ptr %arg3, [%N_i64, %M_i64], {"[%c1_i64, %N_i64]" if transpose else "[%M_i64, %c1_i64]"}, [%c0_i32, %0] {{order = array<i32: 1, 0>}} : <tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>>
-            tt.store %6, %5 {{boundaryCheck = array<i32: 0, 1>}} : !tt.ptr<tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>>
+            %4 = tt.make_tensor_descriptor %arg2, [%Nload_i32, %Mload_i32], [%Mload_i64, %c1_i64] {{padding = 2 : i32}} : <{ty}>, !tt.tensordesc<tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>>
+            %5 = tt.descriptor_load %4[%c0_i32, %0] {{ttig.block_io = {block_io} }} : !tt.tensordesc<tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>> -> tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
+            %6 = tt.make_tensor_descriptor %arg3, [%N_i32, %M_i32], [%M_i64, %c1_i64] : <{ty}>, !tt.tensordesc<tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>>
+            tt.descriptor_store %6[%c0_i32, %0], %5 : !tt.tensordesc<tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>> >, tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
 
             tt.return
         }}
@@ -96,7 +103,7 @@ def test_block_load_dpas_layout(M, N, dtype_str, transpose, device, tmp_path: pa
     a_ref = torch.ones((M, N), dtype=torch_dtype, device=device)
     b_ref = torch.ones((N, M), dtype=torch_dtype, device=device)
     x_ref = torch.empty_like(a_ref)
-    y_ref = torch.empty_like(b_ref.T if transpose else b_ref)
+    y_ref = torch.empty_like(b_ref)
 
     temp_file = tmp_path / "test_block_load_dpas_layout_ref.ttgir"
     temp_file.write_text(ref_ir)
@@ -110,7 +117,7 @@ def test_block_load_dpas_layout(M, N, dtype_str, transpose, device, tmp_path: pa
     a = torch.ones((M, N), dtype=torch_dtype, device=device)
     b = torch.ones((N, M), dtype=torch_dtype, device=device)
     x = torch.empty_like(a)
-    y = torch.empty_like(b.T if transpose else b)
+    y = torch.empty_like(b)
 
     temp_file = tmp_path / "test_block_load_dpas_layout.ttgir"
     temp_file.write_text(ir)
@@ -120,5 +127,4 @@ def test_block_load_dpas_layout(M, N, dtype_str, transpose, device, tmp_path: pa
 
     torch.set_printoptions(profile="full", precision=2, sci_mode=0, linewidth=200)
 
-    assert torch.allclose(x_ref, x, equal_nan=True) and torch.allclose(y_ref.T if transpose else y_ref,
-                                                                       y.T if transpose else y, equal_nan=True)
+    assert torch.allclose(x_ref, x, equal_nan=True) and torch.allclose(y_ref, y, equal_nan=True)

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -537,6 +537,43 @@ struct LoadStoreConversionBase {
                                         rewriter, boundaryCheck, padding);
   }
 
+  /// Build per-element NaN masks for out-of-bounds elements.
+  ///
+  /// Returns a vector of i1 values, one per thread element, where `true`
+  /// means the element is in-bounds. The caller should select NaN for
+  /// elements where the mask is `false`.
+  ///
+  /// \p offsets     Base offsets for each dimension (e.g. descriptor indices).
+  /// \p shapes      Boundary shapes for each dimension (i64).
+  /// \p tensorType  The result tensor type (determines layout and element
+  ///                count).
+  SmallVector<Value> buildNaNMasks(Location loc, ArrayRef<Value> offsets,
+                                   ArrayRef<Value> shapes,
+                                   RankedTensorType tensorType,
+                                   ConversionPatternRewriter &rewriter) const {
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    size_t rank = tensorType.getRank();
+    assert(offsets.size() == rank && shapes.size() == rank);
+
+    const unsigned numElems = getTotalElemsPerThread(tensorType);
+    auto indices = emitIndices(loc, rewriter, targetInfo,
+                               tensorType.getEncoding(), tensorType, true);
+
+    SmallVector<Value> maskElems;
+    for (unsigned i = 0; i < numElems; ++i) {
+      SmallVector<Value> index = indices[i];
+      Value mask = b.int_val(1, 1);
+      for (unsigned j = 0; j < rank; ++j) {
+        Value idxInTensor = b.add(index[j], offsets[j]);
+        Value inBounds = b.icmp_slt(idxInTensor, b.trunc(i32_ty, shapes[j]));
+        Value isPos = b.icmp_sge(idxInTensor, b.i32_val(0));
+        mask = b.and_(b.and_(inBounds, mask), isPos).getResult();
+      }
+      maskElems.push_back(mask);
+    }
+    return maskElems;
+  }
+
   // Ensure the operation doesn't have attributes that the IGC predicated
   // instruction cannot handle.
   template <
@@ -702,13 +739,11 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
     if (tensorTy.getRank() < 2)
       return false;
 
-    // Verify the descriptor traces back to a MakeTensorDescOp with PAD_ZERO.
+    // Verify the descriptor traces back to a MakeTensorDescOp.
     auto makeTensorDesc =
         triton::intel::findDefiningOpOfType<triton::MakeTensorDescOp>(
             op.getDesc());
     if (!makeTensorDesc)
-      return false;
-    if (makeTensorDesc->getPadding() != triton::PaddingOption::PAD_ZERO)
       return false;
 
     // Reject non-contiguous inner dimension.
@@ -2742,6 +2777,14 @@ struct DescriptorLoadOpToBlockIOConversion
     if (!isDescriptorBlockIOCandidate(op))
       return failure();
 
+    // Get the padding option from the defining MakeTensorDescOp.
+    PaddingOption padding = PaddingOption::PAD_ZERO;
+    if (auto makeDescOp =
+            triton::intel::findDefiningOpOfType<triton::MakeTensorDescOp>(
+                op.getDesc())) {
+      padding = makeDescOp->getPadding();
+    }
+
     // Result type and encoding setup.
     Type resultType = op.getType();
     auto tensorType = cast<RankedTensorType>(resultType);
@@ -2974,6 +3017,21 @@ struct DescriptorLoadOpToBlockIOConversion
           b.add(descIndices[descBlockColIdx], misalignElems);
     }
 
+    // Build NaN masks for PAD_NAN descriptors. The 2D block load hardware
+    // zero-pads OOB accesses; for NaN padding we post-select NaN values.
+    SmallVector<Value> nanMaskElems;
+    if (padding == PaddingOption::PAD_NAN) {
+      // Map descriptor shapes/indices to result dimension space.
+      SmallVector<Value> resultOffsets(rank), resultShapes(rank);
+      for (unsigned i = 0; i < rank; ++i) {
+        unsigned descDim = mapResultDimToDescDim(i);
+        resultOffsets[i] = descIndices[descDim];
+        resultShapes[i] = desc.shapes[descDim];
+      }
+      nanMaskElems =
+          buildNaNMasks(loc, resultOffsets, resultShapes, tensorType, rewriter);
+    }
+
     SmallVector<Value> unpackedLoadedVals(numElems);
     for (size_t elemIdx = 0; elemIdx < numElems; elemIdx += numElemsPerLoad) {
       unsigned registerIdx = regMapping.apply({{kRegister, elemIdx}})[0].second;
@@ -3023,13 +3081,11 @@ struct DescriptorLoadOpToBlockIOConversion
           /*transpose*/ isTransposeRequired,
           /*vnni_transform*/ !isTransposeRequired && useVNNIFormat);
 
-      // Descriptors always have boundary checking, so no mask/other/NaN
-      // padding is needed.
       unpackBlockLoadResult(ret, unpackedLoadedVals, elemIdx, regMapping,
                             shuffleMapping, packedDPASOperandType, unpackedType,
                             numValuesPerLoad, numPackedVals,
-                            /*pred=*/Value(), /*otherElems=*/{},
-                            /*nanMaskElems=*/{}, loc, rewriter, ctx);
+                            /*pred=*/Value(), /*otherElems=*/{}, nanMaskElems,
+                            loc, rewriter, ctx);
     }
 
     auto typeConverter = getTypeConverter();


### PR DESCRIPTION
Remove the PAD_ZERO restriction from isDescriptorBlockIOCandidate so that descriptor loads with NaN padding can use the 2D block IO path.

Add buildNaNMasks() to compute per-element in-bounds masks from descriptor shapes and offsets. For PAD_NAN descriptors, the 2D block load hardware zero-pads OOB accesses; the masks are used to post-select NaN values for out-of-bounds elements via unpackBlockLoadResult.

Convert test_block_load_nan.py from block pointers to tensor descriptors.