### PR TITLE
[Analysis] Remove block pointer handling from AxisInfoExt and StrideInfo

### DIFF
--- a/test/Analysis/intel/test-axis-info.mlir
+++ b/test/Analysis/intel/test-axis-info.mlir
@@ -912,40 +912,6 @@ tt.func @unrealized_conversion_cast(%arg0: tensor<128x128xi32> {tt.contiguity = 
 
 // -----
 
-// CHECK-LABEL: @make_tensor_ptr
-tt.func public @make_tensor_ptr(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f8E5M2> {tt.divisibility = 32 : i32}, %arg2: i64 {tt.divisibility = 16 : i32}) {
-  %c0_i32 = arith.constant 0 : i32
-  %c1_i64 = arith.constant 1 : i64
-  %c3_i64 = arith.constant 3 : i64
-  %c31_i64 = arith.constant 31 : i64
-  %c32_i64 = arith.constant 32 : i64
-  %c128_i64 = arith.constant 128 : i64
-  // CHECK: tt.make_tensor_ptr %arg0, {{.*}} => contiguity = [128, 32], divisibility = [1, 1], constancy = [1, 1], constant_value = <none>
-  %0 = tt.make_tensor_ptr %arg0, [%c128_i64, %c32_i64], [%c1_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : !tt.ptr<tensor<128x32xf16>>
-  // CHECK: tt.make_tensor_ptr %arg1, {{.*}} => contiguity = [32, 1], divisibility = [16, 1], constancy = [1, 1], constant_value = <none>
-  %1 = tt.make_tensor_ptr %arg1, [%c32_i64, %c32_i64], [%c1_i64, %arg2], [%c0_i32, %c0_i32] {order = array<i32: 0, 1>} : <tensor<64x16xf8E5M2>>
-  // CHECK: tt.make_tensor_ptr %arg1, {{.*}} => contiguity = [1, 64], divisibility = [1, 16], constancy = [1, 1], constant_value = <none>
-  %2 = tt.make_tensor_ptr %arg1, [%arg2, %c128_i64], [%arg2, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 0, 1>} : <tensor<32x64xf8E5M2>>
-
-  // CHECK: tt.make_tensor_ptr %arg0, {{.*}} => contiguity = [4, 128, 32], divisibility = [1, 1, 1], constancy = [1, 1, 1], constant_value = <none>
-  %3 = tt.make_tensor_ptr %arg0, [%c128_i64, %c128_i64, %c32_i64], [%c1_i64, %c1_i64, %c1_i64], [%c0_i32, %c0_i32, %c0_i32] {order = array<i32: 2, 1, 0>} : !tt.ptr<tensor<4x128x32xf16>>
-  // CHECK: tt.make_tensor_ptr %arg1, {{.*}} => contiguity = [1, 32, 1], divisibility = [1, 16, 1], constancy = [1, 1, 1], constant_value = <none>
-  %4 = tt.make_tensor_ptr %arg1, [%c128_i64, %c32_i64, %c32_i64], [%c128_i64, %c1_i64, %arg2], [%c0_i32, %c0_i32, %c0_i32] {order = array<i32: 0, 1, 2>} : <tensor<4x64x16xf8E5M2>>
-  // CHECK: tt.make_tensor_ptr %arg1, {{.*}} => contiguity = [1, 1, 64], divisibility = [1, 1, 16], constancy = [1, 1, 1], constant_value = <none>
-  %5 = tt.make_tensor_ptr %arg1, [%c128_i64, %arg2, %c128_i64], [%c128_i64, %arg2, %c1_i64], [%c0_i32, %c0_i32, %c0_i32] {order = array<i32: 0, 1, 2>} : <tensor<4x32x64xf8E5M2>>
-
-  // COM: The shape is not aligned on power of 2. The contiguity is [1, 1].
-  // CHECK: tt.make_tensor_ptr %arg1, {{.*}} => contiguity = [1, 1], divisibility = [1, 1], constancy = [1, 1], constant_value = <none>
-  %22 = tt.make_tensor_ptr %arg1, [%c31_i64, %c31_i64], [%c1_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 0, 1>} : <tensor<32x64xf8E5M2>>
-
-  // COM: One dim stride is odd 3. The divisibility is [1, 1].
-  // CHECK: tt.make_tensor_ptr %arg1, {{.*}} => contiguity = [1, 64], divisibility = [1, 1], constancy = [1, 1], constant_value = <none>
-  %23 = tt.make_tensor_ptr %arg1, [%c128_i64, %c128_i64], [%c3_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 0, 1>} : <tensor<32x64xf8E5M2>>
-  tt.return
-}
-
-// -----
-
 // CHECK-LABEL: @make_tensor_descriptor
 tt.func public @make_tensor_descriptor(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f32> {tt.divisibility = 32 : i32}, %arg2: i64 {tt.divisibility = 16 : i32}) {
   %c0_i32 = arith.constant 0 : i32

--- a/test/Analysis/intel/test-stride-info.mlir
+++ b/test/Analysis/intel/test-stride-info.mlir
@@ -319,34 +319,6 @@ tt.func @passthrough_bitcast() {
 
 // -----
 
-// CHECK-LABEL: @make_tensor_ptr_known_strides
-tt.func @make_tensor_ptr_known_strides(%arg0: !tt.ptr<f16>) {
-  %c0_i32 = arith.constant 0 : i32
-  %c1_i64 = arith.constant 1 : i64
-  %c32_i64 = arith.constant 32 : i64
-  %c128_i64 = arith.constant 128 : i64
-  // constant stride operands [32, 1] => stride = [32, 1]
-  // CHECK: tt.make_tensor_ptr {{.*}} => stride = [32, 1]
-  %0 = tt.make_tensor_ptr %arg0, [%c128_i64, %c32_i64], [%c32_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : !tt.ptr<tensor<128x32xf16>>
-  tt.return
-}
-
-// -----
-
-// CHECK-LABEL: @make_tensor_ptr_unknown_stride
-tt.func @make_tensor_ptr_unknown_stride(%arg0: !tt.ptr<f16>, %stride: i64) {
-  %c0_i32 = arith.constant 0 : i32
-  %c1_i64 = arith.constant 1 : i64
-  %c128_i64 = arith.constant 128 : i64
-  %c32_i64 = arith.constant 32 : i64
-  // non-constant stride operand => unknown stride
-  // CHECK: tt.make_tensor_ptr {{.*}} => stride = [-1, -1]
-  %0 = tt.make_tensor_ptr %arg0, [%c128_i64, %c32_i64], [%stride, %stride], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : !tt.ptr<tensor<128x32xf16>>
-  tt.return
-}
-
-// -----
-
 // CHECK-LABEL: @make_tensor_desc_known_strides
 tt.func @make_tensor_desc_known_strides(%arg0: !tt.ptr<f16>) {
   %c1_i64 = arith.constant 1 : i64
@@ -626,21 +598,5 @@ tt.func @contiguity_hint_partial() {
   // Hint (16) < dim size (32) => not fully contiguous, stride stays unknown.
   // CHECK: arith.remsi {{.*}} => stride = [-1]
   %0 = arith.remsi %range, %c8 {tt.contiguity = dense<16> : tensor<1xi32>} : tensor<32xi32>
-  tt.return
-}
-
-// -----
-
-// CHECK-LABEL: @advance_passthrough
-tt.func @advance_passthrough(%arg0: !tt.ptr<f16>) {
-  %c0_i32 = arith.constant 0 : i32
-  %c1_i64 = arith.constant 1 : i64
-  %c128_i64 = arith.constant 128 : i64
-  %c32_i64 = arith.constant 32 : i64
-  // CHECK: tt.make_tensor_ptr {{.*}} => stride = [1, 1]
-  %ptr = tt.make_tensor_ptr %arg0, [%c128_i64, %c32_i64], [%c1_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : !tt.ptr<tensor<128x32xf16>>
-  // advance passes through stride from operand 0
-  // CHECK: tt.advance {{.*}} => stride = [1, 1]
-  %1 = tt.advance %ptr, [%c0_i32, %c0_i32] : !tt.ptr<tensor<128x32xf16>>
   tt.return
 }

--- a/third_party/intel/include/Analysis/AxisInfoExt.h
+++ b/third_party/intel/include/Analysis/AxisInfoExt.h
@@ -8,8 +8,7 @@ namespace mlir::triton::intel {
 /// Intel-specific AxisInfo extension.
 ///
 /// Subclasses AxisInfoAnalysis to register Intel-specific visitors
-/// (MakeTensorPtrOp, AdvanceOp, MakeTensorDescOp, DescriptorLoadOp,
-/// LLVM dialect ops, IndexCastOp).
+/// (MakeTensorDescOp, DescriptorLoadOp, LLVM dialect ops, IndexCastOp).
 class AxisInfoAnalysisExt : public triton::AxisInfoAnalysis {
 public:
   AxisInfoAnalysisExt(DataFlowSolver &solver);

--- a/third_party/intel/lib/Analysis/AxisInfoExt.cpp
+++ b/third_party/intel/lib/Analysis/AxisInfoExt.cpp
@@ -106,18 +106,15 @@ protected:
 // Intel-specific visitors
 //===----------------------------------------------------------------------===//
 
-/// Compute AxisInfo for ops that create a block pointer or tensor descriptor.
+/// Compute AxisInfo for ops that create a tensor descriptor.
 ///
-/// Both MakeTensorPtrOp and MakeTensorDescOp share the same operand layout:
+/// MakeTensorDescOp has the following operand layout:
 ///   operand 0            – base pointer
 ///   operands [1, rank)   – shape values  (rank operands)
 ///   operands [rank+1, 2*rank] – stride values (rank operands)
-/// and the same stride / contiguity / divisibility / constancy logic.
-/// The only difference between the two ops is how the block shape and rank are
-/// extracted from the result type, which is passed in by the caller.
 static AxisInfo
-makeTensorPtrAxisInfo(Type elemTy, ArrayRef<int64_t> blkShape, unsigned rank,
-                      ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) {
+makeTensorDescAxisInfo(Type elemTy, ArrayRef<int64_t> blkShape, unsigned rank,
+                       ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) {
   assert(operands.size() >= rank * 2 + 1 &&
          "Insufficient operands for AxisInfo analysis");
   SmallVector<AxisInfo, 2> strideInfo, shapeInfo;
@@ -157,8 +154,6 @@ makeTensorPtrAxisInfo(Type elemTy, ArrayRef<int64_t> blkShape, unsigned rank,
     //  [nullptr,  nullptr,  nullptr,  nullptr,]]
     // clang-format on
     // The contiguity of the two dim should be 1.
-    // FIXME: We didn't check the offsets for block pointer as it is going to be
-    // deprecated.
     int64_t contiguous = shapeInfo[dim].getDivisibility(0);
     contiguity.push_back(strideInfo[dim].getConstantValue() == 1
                              ? std::min(contiguous, blkShape[dim])
@@ -178,45 +173,6 @@ makeTensorPtrAxisInfo(Type elemTy, ArrayRef<int64_t> blkShape, unsigned rank,
                   std::move(constancy), std::nullopt);
 }
 
-class MakeTensorPtrOpAxisInfoVisitor final
-    : public AxisInfoVisitorImpl<triton::MakeTensorPtrOp> {
-public:
-  using AxisInfoVisitorImpl<triton::MakeTensorPtrOp>::AxisInfoVisitorImpl;
-
-  AxisInfo
-  getAxisInfo(triton::MakeTensorPtrOp op,
-              ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
-    LDBG("MakeTensorPtrOpAxisInfoVisitor: " << *op);
-
-    auto tensorType = cast<RankedTensorType>(
-        cast<PointerType>(op.getResult().getType()).getPointeeType());
-    unsigned rank = op.getShape().size();
-
-    auto axisInfo = makeTensorPtrAxisInfo(
-        tensorType.getElementType(), tensorType.getShape(), rank, operands);
-
-    LLVM_DEBUG({
-      std::string axisStr;
-      llvm::raw_string_ostream os(axisStr);
-      axisInfo.print(os);
-      LDBG("-- " << axisStr);
-    });
-
-    return axisInfo;
-  }
-};
-
-class AdvanceOpAxisInfoVisitor final
-    : public AxisInfoVisitorImpl<triton::AdvanceOp> {
-public:
-  using AxisInfoVisitorImpl<triton::AdvanceOp>::AxisInfoVisitorImpl;
-  AxisInfo
-  getAxisInfo(triton::AdvanceOp op,
-              ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
-    return operands[0]->getValue();
-  }
-};
-
 class MakeTensorDescOpAxisInfoVisitor final
     : public AxisInfoVisitorImpl<triton::MakeTensorDescOp> {
 public:
@@ -234,7 +190,7 @@ public:
     assert(operands.size() >= rank * 2 + 1 &&
            "Insufficient operands for MakeTensorDescOp AxisInfo analysis");
 
-    auto axisInfo = makeTensorPtrAxisInfo(
+    auto axisInfo = makeTensorDescAxisInfo(
         tensorType.getElementType(), tensorType.getShape(), rank, operands);
 
     LLVM_DEBUG({
@@ -403,8 +359,6 @@ private:
 
 AxisInfoAnalysisExt::AxisInfoAnalysisExt(DataFlowSolver &solver)
     : triton::AxisInfoAnalysis(solver) {
-  visitors.append<MakeTensorPtrOpAxisInfoVisitor>();
-  visitors.append<AdvanceOpAxisInfoVisitor>();
   visitors.append<MakeTensorDescOpAxisInfoVisitor>();
   visitors.append<DescriptorLoadOpAxisInfoVisitor>();
   visitors.append<CastOpAxisInfoVisitor<arith::IndexCastOp>>();

--- a/third_party/intel/lib/Analysis/StrideInfo.cpp
+++ b/third_party/intel/lib/Analysis/StrideInfo.cpp
@@ -22,9 +22,6 @@ StrideInfo StrideInfo::getPessimisticValueState(Value value) {
   Type ty = value.getType();
   if (auto tensorTy = dyn_cast<RankedTensorType>(ty))
     rank = tensorTy.getRank();
-  else if (auto ptrTy = dyn_cast<triton::PointerType>(ty))
-    if (auto tensorTy = dyn_cast<RankedTensorType>(ptrTy.getPointeeType()))
-      rank = tensorTy.getRank();
   if (auto descTy = dyn_cast<triton::TensorDescInterface>(ty))
     rank = descTy.getBlockType().getRank();
 
@@ -160,19 +157,6 @@ public:
       ArrayRef<const dataflow::Lattice<StrideInfo> *> operands) const override {
     assert(op->getNumOperands() == 1 &&
            "PassThroughStrideVisitor expects a single-operand op");
-    return operands[0]->getValue();
-  }
-};
-
-// AdvanceOp: stride passes from operand 0 (the pointer operand).
-// AdvanceOp has variadic offsets so it cannot use PassThroughStrideVisitor.
-class AdvanceOpStrideVisitor final
-    : public StrideInfoVisitorImpl<triton::AdvanceOp> {
-public:
-  StrideInfo getStrideInfo(
-      triton::AdvanceOp op,
-      ArrayRef<const dataflow::Lattice<StrideInfo> *> operands) const override {
-    assert(!operands.empty() && "AdvanceOp must have at least one operand");
     return operands[0]->getValue();
   }
 };
@@ -425,21 +409,6 @@ public:
   }
 };
 
-class MakeTensorPtrOpStrideVisitor final
-    : public StrideInfoVisitorImpl<triton::MakeTensorPtrOp> {
-public:
-  StrideInfo getStrideInfo(
-      triton::MakeTensorPtrOp op,
-      ArrayRef<const dataflow::Lattice<StrideInfo> *> operands) const override {
-    StrideInfo::DimVectorT result;
-    for (Value s : op.getStrides()) {
-      auto val = this->getConstantValue(s);
-      result.push_back(val.has_value() ? val.value() : -1);
-    }
-    return StrideInfo(std::move(result));
-  }
-};
-
 class MakeTensorDescOpStrideVisitor final
     : public StrideInfoVisitorImpl<triton::MakeTensorDescOp> {
 public:
@@ -504,7 +473,6 @@ public:
                     PassThroughStrideVisitor<arith::IndexCastOp>,
                     PassThroughStrideVisitor<triton::gpu::ConvertLayoutOp>,
                     PassThroughStrideVisitor<triton::BitcastOp>>();
-    visitors.append<AdvanceOpStrideVisitor>();
     visitors.append<UnrealizedConversionCastStrideVisitor>();
     visitors.append<MakeRangeOpStrideVisitor>();
     visitors.append<PoisonOpStrideVisitor>();
@@ -524,7 +492,6 @@ public:
     visitors.append<ExpandDimsOpStrideVisitor>();
     visitors.append<BroadcastOpStrideVisitor>();
     visitors.append<TransOpStrideVisitor>();
-    visitors.append<MakeTensorPtrOpStrideVisitor>();
     visitors.append<MakeTensorDescOpStrideVisitor>();
     visitors.append<DescriptorLoadOpStrideVisitor>();
     visitors.setAxisInfoLookup(std::move(axisInfoLookup));


### PR DESCRIPTION
Block pointers are lowered to tensor descriptors or tensor of pointers before reaching these analyses. Remove all dead block pointer code paths (MakeTensorPtrOp, AdvanceOp, PointerType rank extraction) and their associated tests.