### PR TITLE
[RemoveLayoutConversions] Port copy-on-write semantics to getRematerializableSlice

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -227,8 +227,8 @@ public:
                           std::function<bool(Operation *)> stopPropagation);
 
   LogicalResult getRematerializableSlice(
-      OpOperand &root, Attribute rootEncoding, SetVector<Value> &slice,
-      DenseMap<Value, Attribute> &layout,
+      OpOperand &root, Attribute rootEncoding, SetVector<Value> &sliceArg,
+      DenseMap<Value, Attribute> &layoutArg,
       std::function<bool(Operation *)> stopPropagation = nullptr);
 
 private:
@@ -1365,9 +1365,13 @@ LogicalResult LayoutRematerialization::getConvertBackwardSlice(
 }
 
 LogicalResult LayoutRematerialization::getRematerializableSlice(
-    OpOperand &root, Attribute rootEncoding, SetVector<Value> &slice,
-    DenseMap<Value, Attribute> &layout,
+    OpOperand &root, Attribute rootEncoding, SetVector<Value> &sliceArg,
+    DenseMap<Value, Attribute> &layoutArg,
     std::function<bool(Operation *)> stopPropagation) {
+  // Operate on copies of the input, we do not want to modify them unless we
+  // have succeeded.
+  SetVector<Value> slice = sliceArg;
+  DenseMap<Value, Attribute> layout = layoutArg;
   LogicalResult result = getConvertBackwardSlice(root, rootEncoding, slice,
                                                  layout, stopPropagation);
   if (result.failed() || slice.empty())
@@ -1380,6 +1384,8 @@ LogicalResult LayoutRematerialization::getRematerializableSlice(
         return failure();
     }
   }
+  sliceArg = std::move(slice);
+  layoutArg = std::move(layout);
   return success();
 }
 


### PR DESCRIPTION
Operate on copies of slice and layout parameters, writing back only on
success. Prevents partial state corruption on failure.

Closes #6572