### PR TITLE
[vLLM][CI] A scheduled vllm test run cancels other in-progress scheduled runs

### DIFF
--- a/.github/workflows/vllm-tests.yml
+++ b/.github/workflows/vllm-tests.yml
@@ -33,7 +33,7 @@ on:
     # Sunday 2:05AM PST (UTC-8) or 3:05AM PDT (UTC-7)
     - cron: "5 10 * * SUN"
 
-# Cancel in-progress schedule runs. Manual runs are never cancelled.
+# Cancel in-progress scheduled runs. Manual runs are never cancelled.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || 'ci' }}
   cancel-in-progress: true


### PR DESCRIPTION
This patch adds the specification to have scheduled runs cancel in-progress scheduled runs for the vllm tests workflow. Manual dispatches are never cancelled.

This is needed in case we increase the frequency of scheduled runs in the future and also to protect us from clogging CI runners in a worst case.