### PR TITLE
[Lowering] Replace vector extract with select chain for partitioned shared layout 

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -666,10 +666,8 @@ lowerLdSt(Location loc, MLIRContext *ctx, LinearLayout cvt,
   // Extract the partition sublayout before stripping it for vectorization.
   auto inDimNames = to_vector(cvt.getInDimNames());
   LinearLayout partitionLayout;
-  Value basesVec;
   if (isPartitioned) {
     partitionLayout = cvt.sublayout(inDimNames, {kPartition});
-    basesVec = buildBasePtrVector(loc, rewriter, smemBases);
   }
 
   // Strip kPartition output for vectorization analysis.
@@ -769,7 +767,10 @@ lowerLdSt(Location loc, MLIRContext *ctx, LinearLayout cvt,
                                                   {kWarp, warpId},
                                                   {kBlock, blockId}});
         Value partitionIdx = partitionResult[0].second;
-        smemBase = b.extract_element(basesVec, partitionIdx);
+        for (size_t p = 1; p < smemBases.size(); ++p) {
+          Value cmp = b.icmp_eq(partitionIdx, b.i32_val(p));
+          smemBase = b.select(cmp, smemBases[p], smemBase);
+        }
       }
 
       std::optional<Value> innerCtaOffset;

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -4,7 +4,7 @@ import pytest
 import triton
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
-from triton._internal_testing import is_xpu, is_xpu_cri, is_cuda, is_hip, is_hopper_or_newer, get_hip_lds_size
+from triton._internal_testing import is_xpu, is_cuda, is_hip, is_hopper_or_newer, get_hip_lds_size
 from triton.experimental.gluon.language.amd.gfx1250 import PartitionedSharedLayout
 
 THREADS_PER_WARP = triton.runtime.driver.active.get_current_target().warp_size
@@ -1451,9 +1451,6 @@ def test_partitioned_shared_layout(M, K, num_partitions, num_groups, partition_d
     - partition_dim: Dimension along which to partition (0=rows, 1=cols)
     - partition_layout_type: Layout within each piece ("swizzled" or "padded")
     """
-    if is_xpu_cri() and partition_layout_type == "swizzled":
-        pytest.skip("FIXME: #6480")
-
     blocked_layout = ttgl.BlockedLayout(
         size_per_thread=[1, 8],
         threads_per_warp=[THREADS_PER_WARP // 4, 4],

--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -107,7 +107,7 @@ public:
 
 static SPIRV::TranslatorOpts getSPIRVOpts() {
   SPIRV::TranslatorOpts SPIRVOpts{SPIRV::VersionNumber::SPIRV_1_4};
-  static constexpr std::array<SPIRV::ExtensionID, 26> AllowedExtensions{
+  static constexpr std::array<SPIRV::ExtensionID, 25> AllowedExtensions{
       SPIRV::ExtensionID::SPV_EXT_shader_atomic_float_add,
       SPIRV::ExtensionID::SPV_EXT_shader_atomic_float16_add,
       SPIRV::ExtensionID::SPV_EXT_float8,
@@ -123,7 +123,6 @@ static SPIRV::TranslatorOpts getSPIRVOpts() {
       SPIRV::ExtensionID::SPV_INTEL_fp_fast_math_mode,
       SPIRV::ExtensionID::SPV_INTEL_inline_assembly,
       SPIRV::ExtensionID::SPV_INTEL_kernel_attributes,
-      SPIRV::ExtensionID::SPV_INTEL_masked_gather_scatter,
       SPIRV::ExtensionID::SPV_INTEL_memory_access_aliasing,
       SPIRV::ExtensionID::SPV_INTEL_split_barrier,
       SPIRV::ExtensionID::SPV_INTEL_subgroup_matrix_multiply_accumulate,


### PR DESCRIPTION
Fixes #6499 and #6480 
Fixed same issue as #6581 
Replace extract_element on vector-of-pointers with select chain to avoid SPV_INTEL_masked_gather_scatter dependency in SPIR-V translation.

