### PR TITLE
[Plugins][Test] Remove merge conflict markers from plugin tests

### DIFF
--- a/test/Plugins/test-dialect-plugin.mlir
+++ b/test/Plugins/test-dialect-plugin.mlir
@@ -4,12 +4,8 @@
 // RUN: -split-input-file --convert-plugin-gpu-to-llvm --convert-triton-gpu-to-llvm %s | \
 // RUN: FileCheck %s
 
-<<<<<<< HEAD
-// REQUIRES: plugins, shared-libs
-=======
-// REQUIRES: triton-ext-enabled
+// REQUIRES: plugins, triton-ext-enabled
 // XFAIL: *
->>>>>>> 6cb844590c72cd8e0e827007c2d5cd04fc64b1bb
 
 #blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
 module attributes {"ttg.num-warps" = 8 : i32} {

--- a/test/Plugins/test-plugin.mlir
+++ b/test/Plugins/test-plugin.mlir
@@ -10,12 +10,8 @@
 
 // RUN: triton-opt -split-input-file %s | FileCheck %s -allow-unused-prefixes --check-prefix=CHECK-BASE
 
-<<<<<<< HEAD
-// REQUIRES: plugins, shared-libs
-=======
-// REQUIRES: triton-ext-enabled
+// REQUIRES: plugins, triton-ext-enabled
 // XFAIL: *
->>>>>>> 6cb844590c72cd8e0e827007c2d5cd04fc64b1bb
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.target" = "cuda:80"} {
   // CHECK-PLUGIN: func @foo()


### PR DESCRIPTION
The plugins requirement for these tests will be removed by https://github.com/intel/intel-xpu-backend-for-triton/pull/6470.