### PR TITLE
[vLLM][CI] Also run vllm tests workflow on Thursdays

### DIFF
--- a/.github/workflows/vllm-tests.yml
+++ b/.github/workflows/vllm-tests.yml
@@ -30,7 +30,8 @@ on:
         default: false
 
   schedule:
-    # Sunday 2:05AM PST (UTC-8) or 3:05AM PDT (UTC-7)
+    # Thursday/Sunday 2:05AM PST (UTC-8) or 3:05AM PDT (UTC-7)
+    - cron: "5 10 * * THU"
     - cron: "5 10 * * SUN"
 
 # Cancel in-progress scheduled runs. Manual runs are never cancelled.


### PR DESCRIPTION
Increase frequency of running the vllm test workflow to twice a week. This will help us better monitor the vllm tests and detect regressions faster.