### PR TITLE
Replace CF predicated loads with unconditional load + select

### DIFF
--- a/test/Conversion/intel/tritongpu_to_gen.mlir
+++ b/test/Conversion/intel/tritongpu_to_gen.mlir
@@ -29,21 +29,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttig.su
     // CHECK:      [[BCAST1:%.*]] = llvm.bitcast [[ARG0_0]] : !llvm.ptr<1> to !llvm.ptr<1>
     // PREDICATED: [[ALIGNMENT:%.*]] = llvm.mlir.constant(4 : i64) : i64
     // PREDICATED: [[V1:%.*]] = llvm.call spir_funccc @llvm.genx.GenISA.PredicatedLoad.i32.p1i32.i32([[BCAST1]], [[ALIGNMENT]], [[ARG1_0]], [[BCAST0]]) {{.*}} : (!llvm.ptr<1>, i64, i1, i32) -> i32
-    // NO-PREDICATED:      llvm.cond_br [[ARG1_0]], ^bb1, ^bb2([[BCAST0]] : i32)
-    // NO-PREDICATED-NEXT: ^bb1:
-    // NO-PREDICATED-NEXT:   [[LOAD1:%.*]] = llvm.load [[BCAST1]] {alignment = 4 : i64} : !llvm.ptr<1> -> i32
-    // NO-PREDICATED-NEXT:   llvm.br ^bb2([[LOAD1]] : i32)
-    // NO-PREDICATED-NEXT: ^bb2([[V1:%.*]]: i32):
+    // NO-PREDICATED:      [[LOAD1:%.*]] = llvm.load [[BCAST1]] {alignment = 4 : i64} : !llvm.ptr<1> -> i32
+    // NO-PREDICATED-NEXT: [[V1:%.*]] = llvm.select [[ARG1_0]], [[LOAD1]], [[BCAST0]] : i1, i32
     // CHECK-NEXT:   [[EE1:%.*]] = llvm.bitcast [[V1]] : i32 to f32
     // CHECK:        [[BCAST2:%.*]] = llvm.bitcast {{.*}} : vector<1xf32> to i32
     // CHECK:        [[BCAST3:%.*]] = llvm.bitcast [[ARG0_1]] : !llvm.ptr<1> to !llvm.ptr<1>
     // PREDICATED: [[ALIGNMENT:%.*]] = llvm.mlir.constant(4 : i64) : i64
     // PREDICATED: [[V2:%.*]] = llvm.call spir_funccc @llvm.genx.GenISA.PredicatedLoad.i32.p1i32.i32([[BCAST3]], [[ALIGNMENT]], [[ARG1_1]], [[BCAST2]]) {{.*}} : (!llvm.ptr<1>, i64, i1, i32) -> i32
-    // NO-PREDICATED:        llvm.cond_br [[ARG1_1]], ^bb3, ^bb4([[BCAST2]] : i32)
-    // NO-PREDICATED-NEXT: ^bb3:
-    // NO-PREDICATED-NEXT:   [[LOAD2:%.*]] = llvm.load [[BCAST3]] {alignment = 4 : i64} : !llvm.ptr<1> -> i32
-    // NO-PREDICATED-NEXT:   llvm.br ^bb4([[LOAD2]] : i32)
-    // NO-PREDICATED-NEXT: ^bb4([[V2:%.*]]: i32):
+    // NO-PREDICATED:        [[LOAD2:%.*]] = llvm.load [[BCAST3]] {alignment = 4 : i64} : !llvm.ptr<1> -> i32
+    // NO-PREDICATED-NEXT:   [[V2:%.*]] = llvm.select [[ARG1_1]], [[LOAD2]], [[BCAST2]] : i1, i32
     // CHECK-NEXT:   [[EE2:%.*]] = llvm.bitcast [[V2]] : i32 to f32
     // CHECK-NEXT:   [[RES1:%.*]] = llvm.mlir.undef : !llvm.struct<(f32, f32)>
     // CHECK-NEXT:   [[RES2:%.*]] = llvm.insertvalue [[EE1]], [[RES1]][0] : !llvm.struct<(f32, f32)>
@@ -71,21 +65,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttig.su
     // CHECK:      [[BCAST1:%.*]] = llvm.bitcast [[ARG0_0]] : !llvm.ptr<1> to !llvm.ptr<1>
     // PREDICATED: [[ALIGNMENT:%.*]] = llvm.mlir.constant(4 : i64) : i64
     // PREDICATED: [[V1:%.*]] = llvm.call spir_funccc @llvm.genx.GenISA.PredicatedLoad.i32.p1i32.i32([[BCAST1]], [[ALIGNMENT]], [[ARG1_0]], [[BCAST0]]) {{.*}} : (!llvm.ptr<1>, i64, i1, i32) -> i32
-    // NO-PREDICATED:      llvm.cond_br [[ARG1_0]], ^bb1, ^bb2([[BCAST0]] : i32)
-    // NO-PREDICATED-NEXT: ^bb1:
-    // NO-PREDICATED-NEXT:   [[LOAD1:%.*]] = llvm.load [[BCAST1]] {alignment = 4 : i64} : !llvm.ptr<1> -> i32
-    // NO-PREDICATED-NEXT:   llvm.br ^bb2([[LOAD1]] : i32)
-    // NO-PREDICATED-NEXT: ^bb2([[V1:%.*]]: i32):
+    // NO-PREDICATED:      [[LOAD1:%.*]] = llvm.load [[BCAST1]] {alignment = 4 : i64} : !llvm.ptr<1> -> i32
+    // NO-PREDICATED-NEXT: [[V1:%.*]] = llvm.select [[ARG1_0]], [[LOAD1]], [[BCAST0]] : i1, i32
     // CHECK-NEXT:   [[EE1:%.*]] = llvm.bitcast [[V1]] : i32 to f32
     // CHECK:        [[BCAST2:%.*]] = llvm.bitcast {{.*}} : vector<1xf32> to i32
     // CHECK:        [[BCAST3:%.*]] = llvm.bitcast [[ARG0_1]] : !llvm.ptr<1> to !llvm.ptr<1>
     // PREDICATED: [[ALIGNMENT:%.*]] = llvm.mlir.constant(4 : i64) : i64
     // PREDICATED: [[V2:%.*]] = llvm.call spir_funccc @llvm.genx.GenISA.PredicatedLoad.i32.p1i32.i32([[BCAST3]], [[ALIGNMENT]], [[ARG1_1]], [[BCAST2]]) {{.*}} : (!llvm.ptr<1>, i64, i1, i32) -> i32
-    // NO-PREDICATED:        llvm.cond_br [[ARG1_1]], ^bb3, ^bb4([[BCAST2]] : i32)
-    // NO-PREDICATED-NEXT: ^bb3:
-    // NO-PREDICATED-NEXT:   [[LOAD2:%.*]] = llvm.load [[BCAST3]] {alignment = 4 : i64} : !llvm.ptr<1> -> i32
-    // NO-PREDICATED-NEXT:   llvm.br ^bb4([[LOAD2]] : i32)
-    // NO-PREDICATED-NEXT: ^bb4([[V2:%.*]]: i32):
+    // NO-PREDICATED:        [[LOAD2:%.*]] = llvm.load [[BCAST3]] {alignment = 4 : i64} : !llvm.ptr<1> -> i32
+    // NO-PREDICATED-NEXT:   [[V2:%.*]] = llvm.select [[ARG1_1]], [[LOAD2]], [[BCAST2]] : i1, i32
     // CHECK-NEXT:   [[EE2:%.*]] = llvm.bitcast [[V2]] : i32 to f32
     // CHECK-NEXT:   [[RES1:%.*]] = llvm.mlir.undef : !llvm.struct<(f32, f32)>
     // CHECK-NEXT:   [[RES2:%.*]] = llvm.insertvalue [[EE1]], [[RES1]][0] : !llvm.struct<(f32, f32)>
@@ -125,88 +113,57 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttig.su
     // CHECK:      [[BCAST1:%.*]] = llvm.bitcast [[ARG0_0]] : !llvm.ptr<1> to !llvm.ptr<1>
     // PREDICATED: [[ALIGNMENT:%.*]] = llvm.mlir.constant(2 : i64) : i64
     // PREDICATED: [[V1:%.*]] = llvm.call spir_funccc @llvm.genx.GenISA.PredicatedLoad.i16.p1i16.i16([[BCAST1]], [[ALIGNMENT]], [[ARG1_0]], [[BCAST0]]) {{.*}} : (!llvm.ptr<1>, i64, i1, i16) -> i16
-    // NO-PREDICATED:      llvm.cond_br [[ARG1_0]], ^bb1, ^bb2([[BCAST0]] : i16)
-    // NO-PREDICATED-NEXT: ^bb1:
-    // NO-PREDICATED-NEXT:   [[LOAD1:%.*]] = llvm.load [[BCAST1]] {alignment = 2 : i64} : !llvm.ptr<1> -> i16
-    // NO-PREDICATED-NEXT:   llvm.br ^bb2([[LOAD1]] : i16)
-    // NO-PREDICATED-NEXT: ^bb2([[V1:%.*]]: i16):
+    // NO-PREDICATED:      [[LOAD1:%.*]] = llvm.load [[BCAST1]] {alignment = 2 : i64} : !llvm.ptr<1> -> i16
+    // NO-PREDICATED-NEXT: [[V1:%.*]] = llvm.select [[ARG1_0]], [[LOAD1]], [[BCAST0]] : i1, i16
     // CHECK-NEXT:   [[EE1:%.*]] = llvm.bitcast [[V1]] : i16 to f16
     // CHECK:        [[BCAST2:%.*]] = llvm.bitcast {{.*}} : vector<1xf16> to i16
     // CHECK:        [[BCAST3:%.*]] = llvm.bitcast [[ARG0_1]] : !llvm.ptr<1> to !llvm.ptr<1>
     // PREDICATED: [[ALIGNMENT:%.*]] = llvm.mlir.constant(2 : i64) : i64
     // PREDICATED: [[V2:%.*]] = llvm.call spir_funccc @llvm.genx.GenISA.PredicatedLoad.i16.p1i16.i16([[BCAST3]], [[ALIGNMENT]], [[ARG1_1]], [[BCAST2]]) {{.*}} : (!llvm.ptr<1>, i64, i1, i16) -> i16
-    // NO-PREDICATED:        llvm.cond_br [[ARG1_1]], ^bb3, ^bb4([[BCAST2]] : i16)
-
-    // NO-PREDICATED-NEXT: ^bb3:
-    // NO-PREDICATED-NEXT:   [[LOAD2:%.*]] = llvm.load [[BCAST3]] {alignment = 2 : i64} : !llvm.ptr<1> -> i16
-    // NO-PREDICATED-NEXT:   llvm.br ^bb4([[LOAD2]] : i16)
-    // NO-PREDICATED-NEXT: ^bb4([[V2:%.*]]: i16):
+    // NO-PREDICATED:        [[LOAD2:%.*]] = llvm.load [[BCAST3]] {alignment = 2 : i64} : !llvm.ptr<1> -> i16
+    // NO-PREDICATED-NEXT:   [[V2:%.*]] = llvm.select [[ARG1_1]], [[LOAD2]], [[BCAST2]] : i1, i16
     // CHECK-NEXT:   [[EE2:%.*]] = llvm.bitcast [[V2]] : i16 to f16
     // CHECK:        [[BCAST4:%.*]] = llvm.bitcast {{.*}} : vector<1xf16> to i16
     // CHECK:        [[BCAST5:%.*]] = llvm.bitcast [[ARG0_2]] : !llvm.ptr<1> to !llvm.ptr<1>
     // PREDICATED: [[ALIGNMENT:%.*]] = llvm.mlir.constant(2 : i64) : i64
     // PREDICATED: [[V3:%.*]] = llvm.call spir_funccc @llvm.genx.GenISA.PredicatedLoad.i16.p1i16.i16([[BCAST5]], [[ALIGNMENT]], [[ARG1_2]], [[BCAST4]]) {{.*}} : (!llvm.ptr<1>, i64, i1, i16) -> i16
-    // NO-PREDICATED:        llvm.cond_br [[ARG1_2]], ^bb5, ^bb6([[BCAST4]] : i16)
-
-    // NO-PREDICATED-NEXT: ^bb5:
-    // NO-PREDICATED-NEXT:   [[LOAD3:%.*]] = llvm.load [[BCAST5]] {alignment = 2 : i64} : !llvm.ptr<1> -> i16
-    // NO-PREDICATED-NEXT:   llvm.br ^bb6([[LOAD3]] : i16)
-    // NO-PREDICATED-NEXT: ^bb6([[V3:%.*]]: i16):
+    // NO-PREDICATED:        [[LOAD3:%.*]] = llvm.load [[BCAST5]] {alignment = 2 : i64} : !llvm.ptr<1> -> i16
+    // NO-PREDICATED-NEXT:   [[V3:%.*]] = llvm.select [[ARG1_2]], [[LOAD3]], [[BCAST4]] : i1, i16
     // CHECK-NEXT:   [[EE3:%.*]] = llvm.bitcast [[V3]] : i16 to f16
     // CHECK:        [[BCAST5:%.*]] = llvm.bitcast {{.*}} : vector<1xf16> to i16
     // CHECK:        [[BCAST6:%.*]] = llvm.bitcast [[ARG0_3]] : !llvm.ptr<1> to !llvm.ptr<1>
     // PREDICATED: [[ALIGNMENT:%.*]] = llvm.mlir.constant(2 : i64) : i64
     // PREDICATED: [[V4:%.*]] = llvm.call spir_funccc @llvm.genx.GenISA.PredicatedLoad.i16.p1i16.i16([[BCAST6]], [[ALIGNMENT]], [[ARG1_3]], [[BCAST5]]) {{.*}} : (!llvm.ptr<1>, i64, i1, i16) -> i16
-    // NO-PREDICATED:        llvm.cond_br [[ARG1_3]], ^bb7, ^bb8([[BCAST5]] : i16)
-
-    // NO-PREDICATED-NEXT: ^bb7:
-    // NO-PREDICATED-NEXT:   [[LOAD4:%.*]] = llvm.load [[BCAST6]] {alignment = 2 : i64} : !llvm.ptr<1> -> i16
-    // NO-PREDICATED-NEXT:   llvm.br ^bb8([[LOAD4]] : i16)
-    // NO-PREDICATED-NEXT: ^bb8([[V4:%.*]]: i16):
+    // NO-PREDICATED:        [[LOAD4:%.*]] = llvm.load [[BCAST6]] {alignment = 2 : i64} : !llvm.ptr<1> -> i16
+    // NO-PREDICATED-NEXT:   [[V4:%.*]] = llvm.select [[ARG1_3]], [[LOAD4]], [[BCAST5]] : i1, i16
     // CHECK-NEXT:   [[EE4:%.*]] = llvm.bitcast [[V4]] : i16 to f16
     // CHECK:        [[BCAST7:%.*]] = llvm.bitcast {{.*}} : vector<1xf16> to i16
     // CHECK:        [[BCAST8:%.*]] = llvm.bitcast [[ARG0_4]] : !llvm.ptr<1> to !llvm.ptr<1>
     // PREDICATED: [[ALIGNMENT:%.*]] = llvm.mlir.constant(2 : i64) : i64
     // PREDICATED: [[V5:%.*]] = llvm.call spir_funccc @llvm.genx.GenISA.PredicatedLoad.i16.p1i16.i16([[BCAST8]], [[ALIGNMENT]], [[ARG1_4]], [[BCAST7]]) {{.*}} : (!llvm.ptr<1>, i64, i1, i16) -> i16
-    // NO-PREDICATED:        llvm.cond_br [[ARG1_4]], ^bb9, ^bb10([[BCAST7]] : i16)
-
-    // NO-PREDICATED-NEXT: ^bb9:
-    // NO-PREDICATED-NEXT:   [[LOAD5:%.*]] = llvm.load [[BCAST8]] {alignment = 2 : i64} : !llvm.ptr<1> -> i16
-    // NO-PREDICATED-NEXT:   llvm.br ^bb10([[LOAD5]] : i16)
-    // NO-PREDICATED-NEXT: ^bb10([[V5:%.*]]: i16):
+    // NO-PREDICATED:        [[LOAD5:%.*]] = llvm.load [[BCAST8]] {alignment = 2 : i64} : !llvm.ptr<1> -> i16
+    // NO-PREDICATED-NEXT:   [[V5:%.*]] = llvm.select [[ARG1_4]], [[LOAD5]], [[BCAST7]] : i1, i16
     // CHECK-NEXT:   [[EE5:%.*]] = llvm.bitcast [[V5]] : i16 to f16
     // CHECK:        [[BCAST8:%.*]] = llvm.bitcast {{.*}} : vector<1xf16> to i16
     // CHECK:        [[BCAST9:%.*]] = llvm.bitcast [[ARG0_5]] : !llvm.ptr<1> to !llvm.ptr<1>
     // PREDICATED: [[ALIGNMENT:%.*]] = llvm.mlir.constant(2 : i64) : i64
     // PREDICATED: [[V6:%.*]] = llvm.call spir_funccc @llvm.genx.GenISA.PredicatedLoad.i16.p1i16.i16([[BCAST9]], [[ALIGNMENT]], [[ARG1_5]], [[BCAST8]]) {{.*}} : (!llvm.ptr<1>, i64, i1, i16) -> i16
-    // NO-PREDICATED:        llvm.cond_br [[ARG1_5]], ^bb11, ^bb12([[BCAST8]] : i16)
-
-    // NO-PREDICATED-NEXT: ^bb11:
-    // NO-PREDICATED-NEXT:   [[LOAD6:%.*]] = llvm.load [[BCAST9]] {alignment = 2 : i64} : !llvm.ptr<1> -> i16
-    // NO-PREDICATED-NEXT:   llvm.br ^bb12([[LOAD6]] : i16)
-    // NO-PREDICATED-NEXT: ^bb12([[V6:%.*]]: i16):
+    // NO-PREDICATED:        [[LOAD6:%.*]] = llvm.load [[BCAST9]] {alignment = 2 : i64} : !llvm.ptr<1> -> i16
+    // NO-PREDICATED-NEXT:   [[V6:%.*]] = llvm.select [[ARG1_5]], [[LOAD6]], [[BCAST8]] : i1, i16
     // CHECK-NEXT:   [[EE6:%.*]] = llvm.bitcast [[V6]] : i16 to f16
     // CHECK:        [[BCAST10:%.*]] = llvm.bitcast {{.*}} : vector<1xf16> to i16
     // CHECK:        [[BCAST11:%.*]] = llvm.bitcast [[ARG0_6]] : !llvm.ptr<1> to !llvm.ptr<1>
     // PREDICATED: [[ALIGNMENT:%.*]] = llvm.mlir.constant(2 : i64) : i64
     // PREDICATED: [[V7:%.*]] = llvm.call spir_funccc @llvm.genx.GenISA.PredicatedLoad.i16.p1i16.i16([[BCAST11]], [[ALIGNMENT]], [[ARG1_6]], [[BCAST10]]) {{.*}} : (!llvm.ptr<1>, i64, i1, i16) -> i16
-    // NO-PREDICATED:        llvm.cond_br [[ARG1_6]], ^bb13, ^bb14([[BCAST10]] : i16)
-
-    // NO-PREDICATED-NEXT: ^bb13:
-    // NO-PREDICATED-NEXT:   [[LOAD7:%.*]] = llvm.load [[BCAST11]] {alignment = 2 : i64} : !llvm.ptr<1> -> i16
-    // NO-PREDICATED-NEXT:   llvm.br ^bb14([[LOAD7]] : i16)
-    // NO-PREDICATED-NEXT: ^bb14([[V7:%.*]]: i16):
+    // NO-PREDICATED:        [[LOAD7:%.*]] = llvm.load [[BCAST11]] {alignment = 2 : i64} : !llvm.ptr<1> -> i16
+    // NO-PREDICATED-NEXT:   [[V7:%.*]] = llvm.select [[ARG1_6]], [[LOAD7]], [[BCAST10]] : i1, i16
     // CHECK-NEXT:   [[EE7:%.*]] = llvm.bitcast [[V7]] : i16 to f16
     // CHECK:        [[BCAST12:%.*]] = llvm.bitcast {{.*}} : vector<1xf16> to i16
     // CHECK:        [[BCAST13:%.*]] = llvm.bitcast [[ARG0_7]] : !llvm.ptr<1> to !llvm.ptr<1>
     // PREDICATED: [[ALIGNMENT:%.*]] = llvm.mlir.constant(2 : i64) : i64
     // PREDICATED: [[V8:%.*]] = llvm.call spir_funccc @llvm.genx.GenISA.PredicatedLoad.i16.p1i16.i16([[BCAST13]], [[ALIGNMENT]], [[ARG1_7]], [[BCAST12]]) {{.*}} : (!llvm.ptr<1>, i64, i1, i16) -> i16
-    // NO-PREDICATED:        llvm.cond_br [[ARG1_7]], ^bb15, ^bb16([[BCAST12]] : i16)
-
-    // NO-PREDICATED-NEXT: ^bb15:
-    // NO-PREDICATED-NEXT:   [[LOAD8:%.*]] = llvm.load [[BCAST13]] {alignment = 2 : i64} : !llvm.ptr<1> -> i16
-    // NO-PREDICATED-NEXT:   llvm.br ^bb16([[LOAD8]] : i16)
-    // NO-PREDICATED-NEXT: ^bb16([[V8:%.*]]: i16):
+    // NO-PREDICATED:        [[LOAD8:%.*]] = llvm.load [[BCAST13]] {alignment = 2 : i64} : !llvm.ptr<1> -> i16
+    // NO-PREDICATED-NEXT:   [[V8:%.*]] = llvm.select [[ARG1_7]], [[LOAD8]], [[BCAST12]] : i1, i16
     // CHECK-NEXT:   [[EE8:%.*]] = llvm.bitcast [[V8]] : i16 to f16
     // CHECK-NEXT:   [[RES1:%.*]] = llvm.mlir.undef : !llvm.struct<(f16, f16, f16, f16, f16, f16, f16, f16)>
     // CHECK-NEXT:   [[RES2:%.*]] = llvm.insertvalue [[EE1]], [[RES1]][0] : !llvm.struct<(f16, f16, f16, f16, f16, f16, f16, f16)>

--- a/test/TritonIntelGPU/descriptor_load_store_to_llvm.mlir
+++ b/test/TritonIntelGPU/descriptor_load_store_to_llvm.mlir
@@ -47,13 +47,9 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK: %[[DIM1_INBOUNDS:.*]] = llvm.and %[[IDX1_LT_SHAPE1]], %[[DIM0_PRED]] : i1
     // CHECK: %[[PRED:.*]] = llvm.and %[[DIM1_INBOUNDS]], %[[IDX1_GE_ZERO]] : i1
 
-    // Verify predicated load: conditional branch based on bounds check
-    // If in-bounds, go to load block; otherwise skip with default value
-    // CHECK: llvm.cond_br %[[PRED]], ^[[BB_LOAD:bb[0-9]+]], ^[[BB_MERGE:bb[0-9]+]](%{{.*}} : i32)
-    // CHECK: ^[[BB_LOAD]]:
-    // CHECK: %[[LOADED:.*]] = llvm.load %{{.*}} : !llvm.ptr<1> -> i32
-    // CHECK: llvm.br ^[[BB_MERGE]](%[[LOADED]] : i32)
-    // CHECK: ^[[BB_MERGE]](%{{.*}}: i32):
+    // Verify unconditional load + select: always load, then select based on bounds
+    // CHECK: %[[LOADED:.*]] = llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<1> -> i32
+    // CHECK: llvm.select %[[PRED]], %[[LOADED]], %{{.*}} : i1, i32
 
     // CHECK: llvm.return
     %3 = tt.descriptor_load %0[%arg1, %arg2] : !tt.tensordesc<tensor<4x4xf32>> -> tensor<4x4xf32, #blocked>

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2849,10 +2849,13 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
             rewriter, loc, retTy, addrElem, b.i64_val(alignment), pred, other_,
             cacheModifier);
       } else {
-        Block &endBlock = LLVM::intel::createPredicatedBlock(
-            rewriter, loc, pred, SmallVector<Value, 1>{other_},
-            createLoadWithAttrs);
-        ret = *endBlock.args_begin();
+        // Unconditional load + select avoids LLVM O3 misoptimization of
+        // consecutive CF predicated blocks sharing the same predicate.
+        // SimplifyCFG inserts llvm.assume at a merge point reachable from
+        // the false path, which is UB when the mask is false, causing LLVM
+        // to make downstream stores unconditional.
+        Value loaded = createLoadWithAttrs()[0];
+        ret = b.select(pred, loaded, other_);
       }
       assert(ret && "Expecting a valid value");
 
@@ -3078,10 +3081,13 @@ struct DescriptorLoadOpConversion
             rewriter, loc, retTy, addrElem, b.i64_val(alignment), pred, other_,
             cacheModifier);
       } else {
-        Block &endBlock = LLVM::intel::createPredicatedBlock(
-            rewriter, loc, pred, SmallVector<Value, 1>{other_},
-            createLoadWithAttrs);
-        ret = *endBlock.args_begin();
+        // Unconditional load + select avoids LLVM O3 misoptimization of
+        // consecutive CF predicated blocks sharing the same predicate.
+        // SimplifyCFG inserts llvm.assume at a merge point reachable from
+        // the false path, which is UB when the mask is false, causing LLVM
+        // to make downstream stores unconditional.
+        Value loaded = createLoadWithAttrs()[0];
+        ret = b.select(pred, loaded, other_);
       }
       assert(ret && "Expecting a valid value");
 


### PR DESCRIPTION
#6401 

When a Triton kernel has multiple masked loads with the same mask (common in Inductor-fused kernels), the old code generated separate if/else blocks for each load. The LLVM optimizer may merge these blocks and incorrectly assume that the mask is always true, removing protection from stores. As a result, out-of-bounds threads can write garbage to memory, causing  random accuracy failures.

Fix: replace the if/else blocks with an unconditional load followed by a select. The load always executes and select chooses the correct value based on the mask. Since there are no branches, the optimizer has nothing to mis merge.

Additionally, when TRITON_INTEL_PREDICATED_LOAD=1 is set, this path is not affected by the issue.
