### PR TITLE
[vLLM][CI] Add vllm-tests bmg workflow

### DIFF
--- a/.github/workflows/vllm-tests-bmg.yml
+++ b/.github/workflows/vllm-tests-bmg.yml
@@ -1,0 +1,15 @@
+name: vLLM tests, BMG
+
+permissions: read-all
+
+on:
+  schedule:
+    # Thursday/Sunday 2:05AM PST (UTC-8) or 3:05AM PDT (UTC-7)
+    - cron: "5 10 * * THU"
+    - cron: "5 10 * * SUN"
+
+jobs:
+  tests:
+    uses: ./.github/workflows/vllm-tests.yml
+    with:
+      runner_label: b580


### PR DESCRIPTION
We should be running the vllm-tests workflow on bmg. The schedule is the same as for the max1550 vllm-tests workflow.

Run to make sure the vllm-tests are passing on BMG (b580): https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24250885548