### PR TITLE
[DecomposeScaledBlocked] Reduce upstream divergence

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeScaledBlocked.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeScaledBlocked.cpp
@@ -149,6 +149,32 @@ private:
     return reshapeScale;
   }
 
+  TypedValue<RankedTensorType>
+  extendAndBroadcastScale(PatternRewriter &rewriter, DotScaledOp scaledDotOp,
+                          TypedValue<RankedTensorType> &scale,
+                          FloatType computeType, RankedTensorType dstType,
+                          int opIdx) const {
+    auto loc = scale.getLoc();
+    auto mod = scaledDotOp->getParentOfType<ModuleOp>();
+    auto v = opIdx == 0 ? scaledDotOp.getA() : scaledDotOp.getB();
+    auto rank = v.getType().getRank();
+    auto kDim = opIdx == 0 ? rank - 1 : rank - 2;
+
+    // Transpose scale for RHS operand (inplace — caller sees the change).
+    if (opIdx == 1) {
+      auto order = getTransposeOrder(rank);
+      scale = TransOp::create(rewriter, loc, scale, order);
+    }
+
+    // 1) Cast scale to compute type (fp16/bf16)
+    auto scale16 = scaleTo16(rewriter, scale, computeType);
+
+    // 2) Broadcast scale to the same shape as v and convert the layout
+    auto reshapeScale =
+        broadcastScale(rewriter, scaledDotOp, mod, scale16, kDim);
+    return ConvertLayoutOp::create(rewriter, loc, dstType, reshapeScale);
+  }
+
   TypedValue<RankedTensorType> maskNan(PatternRewriter &rewriter,
                                        DotScaledOp scaledDotOp, ModuleOp mod,
                                        TypedValue<RankedTensorType> mxfp,
@@ -195,7 +221,6 @@ private:
         (opIdx == 0 ? scaledDotOp.getAElemType() : scaledDotOp.getBElemType());
     auto fastMath = scaledDotOp.getFastMath();
 
-    auto *ctx = rewriter.getContext();
     auto loc = v.getLoc();
     auto mod = scaledDotOp->getParentOfType<ModuleOp>();
     auto rank = v.getType().getRank();
@@ -219,24 +244,11 @@ private:
     if (!scale)
       return v;
 
-    // For some weird reason, we take the scale with shape as if it were coming
-    // from the lhs even when it's the rhs. In a normal world, we should accept
-    // this parametre transposed, as we do with the mxfp.
-    if (opIdx == 1) {
-      auto order = getTransposeOrder(rank);
-      scale = TransOp::create(rewriter, loc, scale, order);
-    }
+    // 1) Cast scale to fp16/bf16, broadcast it and convert its layout
+    auto reshapeScale = extendAndBroadcastScale(
+        rewriter, scaledDotOp, scale, computeType, v.getType(), opIdx);
 
-    // 1) Cast scale to compute type (fp16/bf16)
-    auto scale16 = scaleTo16(rewriter, scale, computeType);
-
-    // 2) Broadcast scale to the same shape and layout as v
-    auto reshapeScale =
-        broadcastScale(rewriter, scaledDotOp, mod, scale16, kDim);
-    reshapeScale =
-        ConvertLayoutOp::create(rewriter, loc, v.getType(), reshapeScale);
-
-    // 3) Multiply
+    // 2) Multiply
     auto mxfp = cast<TypedValue<RankedTensorType>>(
         arith::MulFOp::create(rewriter, loc, v, reshapeScale).getResult());
 
@@ -244,7 +256,7 @@ private:
     if (fastMath)
       return mxfp;
 
-    // 4) If the scale is NaN, return NaN, else return the scaled value.
+    // 3) If the scale is NaN, return NaN, else return the scaled value.
     return maskNan(rewriter, scaledDotOp, mod, mxfp, scale, kDim);
   }
 };

--- a/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeScaledBlocked.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeScaledBlocked.cpp
@@ -81,6 +81,12 @@ private:
     assert(computeType == rewriter.getBF16Type() ||
            computeType == rewriter.getF16Type());
 
+    if (isa<FloatType>(scaleTy.getElementType())) {
+      auto scaleType = scaleTy.clone(computeType);
+      return cast<TypedValue<RankedTensorType>>(
+          FpToFpOp::create(rewriter, loc, scaleType, scale).getResult());
+    }
+
     // Choose an fp type that can fit the scale value.
     FloatType largeFpType = computeType == rewriter.getF16Type()
                                 ? rewriter.getF32Type()
@@ -176,23 +182,38 @@ private:
   }
 
   TypedValue<RankedTensorType> maskNan(PatternRewriter &rewriter,
-                                       DotScaledOp scaledDotOp, ModuleOp mod,
+                                       DotScaledOp scaledDotOp,
                                        TypedValue<RankedTensorType> mxfp,
                                        TypedValue<RankedTensorType> scale,
                                        int dim) const {
+    // Skip NaN checks if fastMath
+    if (scaledDotOp.getFastMath())
+      return mxfp;
+
     // Implement tl.where(scale == 0xFF, float("nan"), mxfp)
     auto loc = scale.getLoc();
+    auto mod = scaledDotOp->getParentOfType<ModuleOp>();
 
     // Scale is NaN
     auto scaleTy = scale.getType();
-    auto constFF = arith::ConstantOp::create(
-        rewriter, loc, scaleTy,
-        DenseElementsAttr::get(scaleTy,
-                               APInt(scaleTy.getElementTypeBitWidth(), 0xff)));
-    auto scaleIsNan = cast<TypedValue<RankedTensorType>>(
-        arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::eq, scale,
-                              constFF)
-            .getResult());
+    TypedValue<RankedTensorType> scaleIsNan;
+    if (isa<FloatType>(scaleTy.getElementType())) {
+      auto computeType = cast<FloatType>(mxfp.getType().getElementType());
+      auto scaleFp = scaleTo16(rewriter, scale, computeType);
+      scaleIsNan = cast<TypedValue<RankedTensorType>>(
+          arith::CmpFOp::create(rewriter, loc, arith::CmpFPredicate::UNO,
+                                scaleFp, scaleFp)
+              .getResult());
+    } else {
+      auto constFF = arith::ConstantOp::create(
+          rewriter, loc, scaleTy,
+          DenseElementsAttr::get(
+              scaleTy, APInt(scaleTy.getElementTypeBitWidth(), 0xff)));
+      scaleIsNan = cast<TypedValue<RankedTensorType>>(
+          arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::eq, scale,
+                                constFF)
+              .getResult());
+    }
     auto cond = broadcastScale(rewriter, scaledDotOp, mod, scaleIsNan, dim);
     // Make scale is NaN compatible with mxfp
     auto condTy = cond.getType();
@@ -219,10 +240,8 @@ private:
     auto isFp4 =
         ScaleDotElemType::E2M1 ==
         (opIdx == 0 ? scaledDotOp.getAElemType() : scaledDotOp.getBElemType());
-    auto fastMath = scaledDotOp.getFastMath();
 
     auto loc = v.getLoc();
-    auto mod = scaledDotOp->getParentOfType<ModuleOp>();
     auto rank = v.getType().getRank();
     auto kDim = opIdx == 0 ? rank - 1 : rank - 2;
 
@@ -252,12 +271,8 @@ private:
     auto mxfp = cast<TypedValue<RankedTensorType>>(
         arith::MulFOp::create(rewriter, loc, v, reshapeScale).getResult());
 
-    // Skip NaN checks if fastMath
-    if (fastMath)
-      return mxfp;
-
     // 3) If the scale is NaN, return NaN, else return the scaled value.
-    return maskNan(rewriter, scaledDotOp, mod, mxfp, scale, kDim);
+    return maskNan(rewriter, scaledDotOp, mxfp, scale, kDim);
   }
 };
 


### PR DESCRIPTION
Fixes #6618

Extract `extendAndBroadcastScale` from `scaleArg`, matching upstream's structure. Encapsulate `fastMath` check and `ModuleOp` lookup inside `maskNan`. Add float-type scale NaN detection (`arith.cmpf UNO`) alongside the existing integer `== 0xFF` path, and float-type early path in `scaleTo16` via `FpToFpOp`.