### PR TITLE
[Utility] Skip backward propagation when encoding already matches

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
@@ -322,6 +322,13 @@ LogicalResult getConvertBackwardSlice(
           auto srcEncoding = ttgi::inferSrcEncoding(definingOp, encoding);
           if (!srcEncoding)
             return failure();
+          // If the inferred layout matches the original one we don't need to
+          // keep propagating.
+          if (auto operandType =
+                  dyn_cast<RankedTensorType>(operand.get().getType())) {
+            if (srcEncoding == operandType.getEncoding())
+              continue;
+          }
           enqueue(operand, srcEncoding);
         }
       }


### PR DESCRIPTION
Port upstream optimization to getConvertBackwardSlice that skips enqueueing
operands whose encoding already matches the inferred target encoding.
Pure compile-time improvement — no IR or codegen changes.

Closes #6620