### PR TITLE
[HistogramOpToLLVM] Replace ballot-based algorithm with atomic-per-element

### DIFF
--- a/test/Conversion/intel/histogram_to_llvm.mlir
+++ b/test/Conversion/intel/histogram_to_llvm.mlir
@@ -1,0 +1,18 @@
+// RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s
+
+// COM: Verify that the Intel histogram lowering produces atomic-per-element
+// COM: code (atomicrmw add) and does NOT produce ballot/ctpop instructions.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [16], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: @histogram_atomic
+  // CHECK: llvm.icmp "ult"
+  // CHECK: llvm.atomicrmw add
+  // CHECK-NOT: ballot
+  // CHECK-NOT: ctpop
+  tt.func @histogram_atomic(%src: tensor<256xi32, #blocked>, %mask: tensor<256xi1, #blocked>, %out_ptr: tensor<8x!tt.ptr<i32>, #blocked>) {
+    %hist = tt.histogram %src, %mask : tensor<256xi32, #blocked> -> tensor<8xi32, #blocked>
+    tt.store %out_ptr, %hist : tensor<8x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/HistogramOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/HistogramOpToLLVM.cpp
@@ -4,92 +4,21 @@ using namespace mlir;
 using namespace mlir::triton;
 using namespace mlir::triton::gpu;
 
-// Compute a histogram within a warp. This uses an algorithm by @apgoucher
-// that does the following:
-// Create a ballot for each bit of the bin index (there
-// are only log2(num_bins) of these) and then apply bitwise operations to get
-// the indicator functions for the bins owned by this particular thread, and
-// only popcount those.
-static SmallVector<Value> computeWarpLevelHistogram(
-    Location loc, RankedTensorType srcType, SmallVector<Value> &srcValues,
-    SmallVector<Value> &maskValues, int numBins, int numThreadPerWarp,
-    Value threadId, ConversionPatternRewriter &rewriter,
-    const TargetInfoBase &targetInfo) {
+static void atomicAddOne(Value ptr, Location loc,
+                         ConversionPatternRewriter &rewriter) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  assert(numBins % numThreadPerWarp == 0 &&
-         "numBins must be divisible by numThreadPerWarp");
-  Value zero = b.i32_val(0);
-  int numBits = llvm::Log2_64(numBins);
-  int numBitsLaneId = llvm::Log2_64(numThreadPerWarp);
-  unsigned numElementsPerThreads = getTotalElemsPerThread(srcType);
-  // The histogram is distributed across threads, each thread owns `numBins /
-  // numThreadPerWarp` bins.
-  SmallVector<Value> warpLevelHistogram(numBins / numThreadPerWarp, zero);
-  for (int i = 0; i < numElementsPerThreads; ++i) {
-    Value value = srcValues[i];
-    SmallVector<Value> ballotBits;
-    for (int j = 0; j < numBits; ++j) {
-      Value bitSet = b.and_(value, b.i32_val(1 << j));
-      Value cmp = b.icmp_ne(bitSet, zero);
-      Value bit =
-          targetInfo.ballot(rewriter, loc, int_ty(numThreadPerWarp), cmp);
-      ballotBits.push_back(bit);
-    }
-    uint64_t fullMaskValue = (1ll << numThreadPerWarp) - 1u;
-    Value fullMask = b.int_val(numThreadPerWarp, fullMaskValue);
-    Value mask = fullMask;
-    for (int i = 0; i < numBitsLaneId; i++) {
-      Value updateMask =
-          b.select(b.icmp_ne(b.and_(threadId, b.i32_val(1 << i)), zero),
-                   b.int_val(numThreadPerWarp, 0), fullMask);
-      mask = b.and_(
-          mask, b.xor_(ballotBits[i + numBits - numBitsLaneId], updateMask));
-    }
-    // save a ballot bit to capture the input mask
-    Value inputMaskBit = fullMask;
-    if (maskValues.size() > 0) {
-      inputMaskBit = targetInfo.ballot(rewriter, loc, int_ty(numThreadPerWarp),
-                                       maskValues[i]);
-    }
-    // mask out the values for which input mask is invalid
-    mask = b.and_(mask, inputMaskBit);
-    // at this point, 'mask' tells you which elements are in a bin owned by this
-    // thread.
-    for (int k = 0; k < warpLevelHistogram.size(); k++) {
-      Value binMask = mask;
-      for (int j = 0; j < numBits - numBitsLaneId; j++) {
-        Value updateMask =
-            b.int_val(numThreadPerWarp, ((k & (1 << j)) ? 0 : fullMaskValue));
-        binMask = b.and_(binMask, b.xor_(ballotBits[j], updateMask));
-      }
-      // at this point, 'bin_mask' tells you which elements are in the kth bin
-      // owned by this thread.
-      Value bitCount = LLVM::CtPopOp::create(rewriter, loc,
-                                             int_ty(numThreadPerWarp), binMask);
-      if (numThreadPerWarp > 32)
-        bitCount = b.trunc(i32_ty, bitCount);
-      else if (numThreadPerWarp < 32)
-        bitCount = b.zext(i32_ty, bitCount);
-      warpLevelHistogram[k] = b.add(warpLevelHistogram[k], bitCount);
-    }
-  }
-  return warpLevelHistogram;
+  LLVM::AtomicRMWOp::create(rewriter, loc, LLVM::AtomicBinOp::add, ptr,
+                            b.i32_val(1), LLVM::AtomicOrdering::monotonic);
 }
 
-static void atomicAdd(Value ptr, Value val, Location loc,
-                      ConversionPatternRewriter &rewriter) {
-  LLVM::AtomicRMWOp::create(rewriter, loc, LLVM::AtomicBinOp::add, ptr, val,
-                            LLVM::AtomicOrdering::monotonic);
-}
-
-static SmallVector<Value> computeCrossWarpHistogram(
-    Location loc, ConversionPatternRewriter &rewriter, RankedTensorType srcType,
-    Value baseSharedMemPtr, const SmallVector<Value> &warpLevelHistogram,
-    int numBins, int numThreadPerWarp, const SmallVector<Value> &indices,
-    Value threadId, int numWarps) {
+static SmallVector<Value>
+computeHistogram(Location loc, ConversionPatternRewriter &rewriter,
+                 Value baseSharedMemPtr, const SmallVector<Value> &srcValues,
+                 const SmallVector<Value> &maskValues, int numBins,
+                 int numThreadPerWarp, const SmallVector<Value> &indices,
+                 Value threadId, int numWarps) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   SmallVector<Value> histogramValues;
-  Value laneId = b.and_(threadId, b.i32_val(numThreadPerWarp - 1));
   // Initialize the shared memory with zeros.
   int64_t numElementPerThread =
       ceil<int64_t>(numBins, numThreadPerWarp * numWarps);
@@ -102,20 +31,24 @@ static SmallVector<Value> computeCrossWarpHistogram(
     b.store(b.i32_val(0), sharedMemPtr);
   }
   b.barrier(triton::gpu::AddrSpace::Local);
-  Block *afterAtomics = nullptr;
+
   // Apply atomic add to update the histogram in shared memory.
-  for (int i = 0; i < warpLevelHistogram.size(); ++i) {
-    Value warpLevelHistogramValue = warpLevelHistogram[i];
-    Value offset = b.add(b.mul(laneId, b.i32_val(warpLevelHistogram.size())),
-                         b.i32_val(i));
-    Value sharedMemPtr =
-        b.gep(baseSharedMemPtr.getType(), i32_ty, baseSharedMemPtr, offset);
-    atomicAdd(sharedMemPtr, warpLevelHistogramValue, loc, rewriter);
+  Value numBinsValue = b.i32_val(numBins);
+  for (int i = 0; i < srcValues.size(); ++i) {
+    Value updatePred = b.icmp_ult(srcValues[i], numBinsValue);
+    if (!maskValues.empty())
+      updatePred = b.and_(updatePred, maskValues[i]);
+
+    auto [prevBlock, ifBlock, thenBlock] =
+        createIfBlock(rewriter, loc, updatePred);
+    (void)prevBlock;
+    rewriter.setInsertionPointToStart(ifBlock);
+    Value sharedMemPtr = b.gep(baseSharedMemPtr.getType(), i32_ty,
+                               baseSharedMemPtr, srcValues[i]);
+    atomicAddOne(sharedMemPtr, loc, rewriter);
+    rewriter.setInsertionPointToStart(thenBlock);
   }
-  if (afterAtomics) {
-    LLVM::BrOp::create(rewriter, loc, afterAtomics);
-    rewriter.setInsertionPointToStart(afterAtomics);
-  }
+
   b.barrier(triton::gpu::AddrSpace::Local);
   // load the histogram to register with the right layout.
   for (Value index : indices) {
@@ -161,20 +94,10 @@ public:
             numThreadsPerWarp == 64) &&
            "Only supports 16, 32 or 64 threads per warp");
     int numWarps = triton::gpu::lookupNumWarps(op);
-    // Pad out the bins so that we have at least one bin per thread within a
-    // warp.
-    numBins = std::max(numBins, numThreadsPerWarp);
     Value threadId = getThreadId(rewriter, loc);
     auto srcType = op.getSrc().getType();
-    // First compute a warp local histogram based on values owned by each warps.
-    SmallVector<Value> warpLevelHistogram = computeWarpLevelHistogram(
-        loc, srcType, srcValues, maskValues, numBins, numThreadsPerWarp,
-        threadId, rewriter, targetInfo);
 
-    // Then use atomic to update the histogram in shared memory.
-    // TODO: we could skip this for cases with num_warps=1 as long as we can
-    // generate the right layout. Currently the warp level histogram generates
-    // data in the default blocked layout.
+    // Use atomic adds to update the histogram in shared memory.
     Value baseSharedMemPtr =
         LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
     auto dstType = op.getType();
@@ -184,8 +107,8 @@ public:
     SmallVector<Value> innerDimIndices;
     for (int i = 0; i < indices.size(); ++i)
       innerDimIndices.push_back(indices[i][0]);
-    SmallVector<Value> histogramValue = computeCrossWarpHistogram(
-        loc, rewriter, srcType, baseSharedMemPtr, warpLevelHistogram, numBins,
+    SmallVector<Value> histogramValue = computeHistogram(
+        loc, rewriter, baseSharedMemPtr, srcValues, maskValues, numBins,
         numThreadsPerWarp, innerDimIndices, threadId, numWarps);
 
     // Depending on the layout, some threads may have duplicate data. We can


### PR DESCRIPTION
Port upstream commit 7861e9055 that simplifies the histogram lowering
by using per-element atomic increments in shared memory instead of the
ballot+popcount two-stage approach. Simpler, easier to maintain, and
reduces upstream divergence.

Closes #6622