### PR TITLE
Use generic_launcher to reduce launch time

### DIFF
--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -45,7 +45,7 @@ def _cc_cmd(cc, src, out, include_dirs, library_dirs, libraries):
             cc_cmd += ["-fPIC"]
         else:
             cc_cmd += ["-Wno-deprecated-declarations"]
-        cc_cmd += [f'-l{lib}' for lib in libraries]
+        cc_cmd += [f'-l:{lib}' if '.so' in lib else f'-l{lib}' for lib in libraries]
         cc_cmd += [f"-L{dir}" for dir in library_dirs]
         cc_cmd += [f"-I{dir}" for dir in include_dirs]
         cc_cmd += ["-o", out]

--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -45,7 +45,7 @@ def _cc_cmd(cc, src, out, include_dirs, library_dirs, libraries):
             cc_cmd += ["-fPIC"]
         else:
             cc_cmd += ["-Wno-deprecated-declarations"]
-        cc_cmd += [f'-l:{lib}' if '.so' in lib else f'-l{lib}' for lib in libraries]
+        cc_cmd += [_library_flag(lib) for lib in libraries]
         cc_cmd += [f"-L{dir}" for dir in library_dirs]
         cc_cmd += [f"-I{dir}" for dir in include_dirs]
         cc_cmd += ["-o", out]

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -658,10 +658,67 @@ extern "C" EXPORT_FUNC PyObject *generic_launch(PyObject *args) {
     return NULL;
   }
 
+  // Pointer validation: matches the per-kernel compiled launcher's
+  // checkDevicePointer behaviour.  Enabled by default; set
+  // TRITON_XPU_VALIDATE_POINTERS=0 to skip (faster launch, no Level Zero
+  // round-trip per pointer arg, but invalid pointers become hard crashes).
+  static bool validatePtrs = []() {
+    const char *s = std::getenv("TRITON_XPU_VALIDATE_POINTERS");
+    if (!s)
+      return true; // default: on
+    std::string v(s);
+    std::transform(v.begin(), v.end(), v.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    return !(v == "0" || v == "false" || v == "off");
+  }();
+  if (validatePtrs) {
+    auto l0Context = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
+        stream.get_context());
+    int nArgsCheck = (int)typeBuf.len;
+    for (int i = 0; i < nArgsCheck; ++i) {
+      if (types[i] != ARG_PTR)
+        continue;
+      void *ptr;
+      memcpy(&ptr, vals + i * 8, sizeof(ptr));
+      if (!ptr)
+        continue;
+      ze_memory_allocation_properties_t prop = {};
+      prop.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
+      ze_device_handle_t device;
+      ze_result_t res = zeMemGetAllocProperties((ze_context_handle_t)l0Context,
+                                                ptr, &prop, &device);
+      if (res != ZE_RESULT_SUCCESS) {
+        releaseBuffers();
+        PyErr_Format(PyExc_ValueError,
+                     "Cannot get memory properties for Pointer argument "
+                     "(at %d, err=%d)",
+                     i, (int)res);
+        return NULL;
+      }
+      if (prop.type == ZE_MEMORY_TYPE_UNKNOWN) {
+        releaseBuffers();
+        PyErr_Format(PyExc_ValueError,
+                     "Pointer argument (at %d) doesn't reference "
+                     "accessible memory.",
+                     i);
+        return NULL;
+      }
+    }
+  }
+
   // Validate arg count: user args + global_scratch + profile_scratch [+ slm].
   int nArgs = (int)typeBuf.len;
   int expectedArgs = nArgs + 2 + (sharedMemory ? 1 : 0);
-  int kernelArgs = (int)kernel.get_info<sycl::info::kernel::num_args>();
+  int kernelArgs = 0;
+  try {
+    kernelArgs = (int)kernel.get_info<sycl::info::kernel::num_args>();
+  } catch (const sycl::exception &e) {
+    releaseBuffers();
+    PyErr_Format(PyExc_RuntimeError,
+                 "generic_launch: failed to query kernel arg count: %s",
+                 e.what());
+    return NULL;
+  }
   if (expectedArgs != kernelArgs) {
     releaseBuffers();
     PyErr_Format(PyExc_ValueError,
@@ -692,7 +749,14 @@ extern "C" EXPORT_FUNC PyObject *generic_launch(PyObject *args) {
     cgh.parallel_for(ndRange, kernel);
   };
 
-  stream.submit(cgf);
+  try {
+    stream.submit(cgf);
+  } catch (const sycl::exception &e) {
+    releaseBuffers();
+    PyErr_Format(PyExc_RuntimeError, "generic_launch: SYCL submit failed: %s",
+                 e.what());
+    return NULL;
+  }
 
   releaseBuffers();
 

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -516,3 +516,182 @@ extern "C" EXPORT_FUNC PyObject *sycl_queue_memset(PyObject *args) {
 
   Py_RETURN_NONE;
 }
+
+// Generic launcher: precompiled, type-erased kernel launch.
+// Python packs arg values into a flat 8-byte-per-slot buffer with a
+// parallel type-id array; this function dispatches set_arg by byte width.
+// Enabled by TRITON_XPU_GENERIC_LAUNCHER=1
+
+// Size-based type IDs — must match _ARG_* constants in driver.py.
+enum ArgType : uint8_t { ARG_PTR = 0, ARG_1B, ARG_2B, ARG_4B, ARG_8B };
+
+static inline void setArgByType(sycl::handler &cgh, int idx, uint8_t ty,
+                                const void *slot) {
+  // Use memcpy to read from the unaligned Python buffer (Py_buffer guarantees
+  // only 1-byte alignment).  Casting directly to uint16_t*/uint32_t*/uint64_t*
+  // and dereferencing would be undefined behaviour on strict-alignment targets.
+  switch (ty) {
+  case ARG_PTR: {
+    void *v;
+    memcpy(&v, slot, sizeof(v));
+    cgh.set_arg(idx, v);
+    break;
+  }
+  case ARG_1B:
+    cgh.set_arg(idx, *static_cast<const uint8_t *>(slot));
+    break;
+  case ARG_2B: {
+    uint16_t v;
+    memcpy(&v, slot, sizeof(v));
+    cgh.set_arg(idx, v);
+    break;
+  }
+  case ARG_4B: {
+    uint32_t v;
+    memcpy(&v, slot, sizeof(v));
+    cgh.set_arg(idx, v);
+    break;
+  }
+  default: {
+    uint64_t v;
+    memcpy(&v, slot, sizeof(v));
+    cgh.set_arg(idx, v);
+    break;
+  }
+  }
+}
+
+// generic_launch(gridX, gridY, gridZ, stream, kernel, kernel_metadata,
+//                launch_metadata, enter_hook, exit_hook,
+//                arg_types_bytes, arg_values_buffer)
+extern "C" EXPORT_FUNC PyObject *generic_launch(PyObject *args) {
+  int gridX, gridY, gridZ;
+  PyObject *pyStream, *pyKernel;
+  PyObject *kernelMeta, *launchMeta, *enterHook, *exitHook;
+  Py_buffer typeBuf, valBuf;
+
+  if (!PyArg_ParseTuple(args, "iiiOOOOOOs*s*", &gridX, &gridY, &gridZ,
+                        &pyStream, &pyKernel, &kernelMeta, &launchMeta,
+                        &enterHook, &exitHook, &typeBuf, &valBuf)) {
+    return NULL;
+  }
+
+  auto releaseBuffers = [&]() {
+    PyBuffer_Release(&typeBuf);
+    PyBuffer_Release(&valBuf);
+  };
+
+  // Extract kernel metadata.
+  PyObject *numWarpsAttr = PyObject_GetAttrString(kernelMeta, "num_warps");
+  if (numWarpsAttr == nullptr) {
+    releaseBuffers();
+    return NULL;
+  }
+  int numWarps = PyLong_AsLong(numWarpsAttr);
+  if (numWarps == -1 && PyErr_Occurred()) {
+    Py_DECREF(numWarpsAttr);
+    releaseBuffers();
+    return NULL;
+  }
+  Py_DECREF(numWarpsAttr);
+
+  PyObject *sharedAttr = PyObject_GetAttrString(kernelMeta, "shared");
+  if (sharedAttr == nullptr) {
+    releaseBuffers();
+    return NULL;
+  }
+  int sharedMemory = PyLong_AsLong(sharedAttr);
+  if (sharedMemory == -1 && PyErr_Occurred()) {
+    Py_DECREF(sharedAttr);
+    releaseBuffers();
+    return NULL;
+  }
+  Py_DECREF(sharedAttr);
+
+  PyObject *tpwAttr =
+      PyObject_GetAttrString(kernelMeta, "threads_per_warp");
+  if (tpwAttr == nullptr) {
+    releaseBuffers();
+    return NULL;
+  }
+  int threadsPerWarp = PyLong_AsLong(tpwAttr);
+  if (threadsPerWarp == -1 && PyErr_Occurred()) {
+    Py_DECREF(tpwAttr);
+    releaseBuffers();
+    return NULL;
+  }
+  Py_DECREF(tpwAttr);
+
+  // Launch enter hook.
+  if (enterHook != Py_None) {
+    PyObject *ret = PyObject_CallOneArg(enterHook, launchMeta);
+    if (!ret) {
+      releaseBuffers();
+      return NULL;
+    }
+    Py_DECREF(ret);
+  }
+
+  void *pStream = PyLong_AsVoidPtr(pyStream);
+  if (!pStream || !pyKernel) {
+    releaseBuffers();
+    return NULL;
+  }
+  sycl::queue stream = *static_cast<sycl::queue *>(pStream);
+  sycl::kernel *kernelPtr = reinterpret_cast<sycl::kernel *>(
+      PyCapsule_GetPointer(pyKernel, "kernel"));
+  if (!kernelPtr) {
+    releaseBuffers();
+    return NULL;
+  }
+  sycl::kernel kernel = *kernelPtr;
+
+  const auto *types = static_cast<const uint8_t *>(typeBuf.buf);
+  const auto *vals = static_cast<const uint8_t *>(valBuf.buf);
+
+  // Each arg occupies exactly 8 bytes in the value buffer.
+  if (valBuf.len != (Py_ssize_t)typeBuf.len * 8) {
+    releaseBuffers();
+    PyErr_Format(
+        PyExc_ValueError,
+        "generic_launch: valBuf length (%zd) != typeBuf length (%zd) * 8",
+        valBuf.len, typeBuf.len);
+    return NULL;
+  }
+
+  sycl::range<3> globalRange(gridZ, gridY,
+                             (size_t)gridX * threadsPerWarp * numWarps);
+  sycl::range<3> localRange(1, 1, (size_t)numWarps * threadsPerWarp);
+  sycl::nd_range<3> ndRange(globalRange, localRange);
+
+  auto cgf = [&](sycl::handler &cgh) {
+    int nArgs = (int)typeBuf.len;
+    for (int i = 0; i < nArgs; ++i)
+      setArgByType(cgh, i, types[i], vals + i * 8);
+
+    // Implicit params: global_scratch, profile_scratch (nullptr).
+    void *nullPtr = nullptr;
+    cgh.set_arg(nArgs, nullPtr);
+    cgh.set_arg(nArgs + 1, nullPtr);
+
+    if (sharedMemory) {
+      auto localBuf = sycl::local_accessor<int8_t, 1>(sharedMemory, cgh);
+      cgh.set_arg(nArgs + 2, localBuf);
+    }
+    cgh.parallel_for(ndRange, kernel);
+  };
+
+  stream.submit(cgf);
+
+  releaseBuffers();
+
+  // Launch exit hook.
+  if (exitHook != Py_None) {
+    PyObject *ret = PyObject_CallOneArg(exitHook, launchMeta);
+    if (!ret)
+      return NULL;
+    Py_DECREF(ret);
+  }
+
+  Py_RETURN_NONE;
+}

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -659,13 +659,26 @@ extern "C" EXPORT_FUNC PyObject *generic_launch(PyObject *args) {
     return NULL;
   }
 
+  // Validate arg count: user args + global_scratch + profile_scratch [+ slm].
+  int nArgs = (int)typeBuf.len;
+  int expectedArgs = nArgs + 2 + (sharedMemory ? 1 : 0);
+  int kernelArgs =
+      (int)kernel.get_info<sycl::info::kernel::num_args>();
+  if (expectedArgs != kernelArgs) {
+    releaseBuffers();
+    PyErr_Format(PyExc_ValueError,
+                 "generic_launch: argument count mismatch: expected %d "
+                 "(user %d + implicit %d) but kernel has %d",
+                 expectedArgs, nArgs, expectedArgs - nArgs, kernelArgs);
+    return NULL;
+  }
+
   sycl::range<3> globalRange(gridZ, gridY,
                              (size_t)gridX * threadsPerWarp * numWarps);
   sycl::range<3> localRange(1, 1, (size_t)numWarps * threadsPerWarp);
   sycl::nd_range<3> ndRange(globalRange, localRange);
 
   auto cgf = [&](sycl::handler &cgh) {
-    int nArgs = (int)typeBuf.len;
     for (int i = 0; i < nArgs; ++i)
       setArgByType(cgh, i, types[i], vals + i * 8);
 

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -608,8 +608,7 @@ extern "C" EXPORT_FUNC PyObject *generic_launch(PyObject *args) {
   }
   Py_DECREF(sharedAttr);
 
-  PyObject *tpwAttr =
-      PyObject_GetAttrString(kernelMeta, "threads_per_warp");
+  PyObject *tpwAttr = PyObject_GetAttrString(kernelMeta, "threads_per_warp");
   if (tpwAttr == nullptr) {
     releaseBuffers();
     return NULL;
@@ -662,8 +661,7 @@ extern "C" EXPORT_FUNC PyObject *generic_launch(PyObject *args) {
   // Validate arg count: user args + global_scratch + profile_scratch [+ slm].
   int nArgs = (int)typeBuf.len;
   int expectedArgs = nArgs + 2 + (sharedMemory ? 1 : 0);
-  int kernelArgs =
-      (int)kernel.get_info<sycl::info::kernel::num_args>();
+  int kernelArgs = (int)kernel.get_info<sycl::info::kernel::num_args>();
   if (expectedArgs != kernelArgs) {
     releaseBuffers();
     PyErr_Format(PyExc_ValueError,

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -517,115 +517,368 @@ extern "C" EXPORT_FUNC PyObject *sycl_queue_memset(PyObject *args) {
   Py_RETURN_NONE;
 }
 
-// Generic launcher: precompiled, type-erased kernel launch.
-// Python packs arg values into a flat 8-byte-per-slot buffer with a
-// parallel type-id array; this function dispatches set_arg by byte width.
-// Enabled by TRITON_XPU_GENERIC_LAUNCHER=1
+// ==========================================================================
+// Generic launcher — matches the CUDA/AMD design:
+//   - buildSignatureMetadata: called ONCE at kernel init; maps type strings
+//     to extractor indices (a bytes object cached in the Python launcher).
+//   - generic_launch: called on EVERY launch; receives raw Python arg objects
+//     and the cached bytes blob; uses alloca (no heap) and a function-pointer
+//     table (no switch) to extract and set each argument.
+// ==========================================================================
 
-// Size-based type IDs — must match _ARG_* constants in driver.py.
-enum ArgType : uint8_t { ARG_PTR = 0, ARG_1B, ARG_2B, ARG_4B, ARG_8B };
+// --------------------------------------------------------------------------
+// Extractor type enum and function-pointer table
+// --------------------------------------------------------------------------
 
-static inline void setArgByType(sycl::handler &cgh, int idx, uint8_t ty,
-                                const void *slot) {
-  // Use memcpy to read from the unaligned Python buffer (Py_buffer guarantees
-  // only 1-byte alignment).  Casting directly to uint16_t*/uint32_t*/uint64_t*
-  // and dereferencing would be undefined behaviour on strict-alignment targets.
-  switch (ty) {
-  case ARG_PTR: {
-    void *v;
-    memcpy(&v, slot, sizeof(v));
-    cgh.set_arg(idx, v);
-    break;
+typedef bool (*ExtractorFunc)(void *dst, PyObject *obj);
+typedef void (*SetArgFunc)(sycl::handler &cgh, int idx, const void *val);
+
+typedef struct {
+  ExtractorFunc extract; // write the C value from a Python object into dst
+  SetArgFunc setArg;     // call cgh.set_arg with the correctly-typed value
+  size_t size;           // sizeof the C type
+  const char *names[3];  // Triton type strings that map to this extractor
+} Extractor;
+
+// Extractor indices — stored in the pre-built signature metadata bytes.
+typedef enum {
+  EX_UNKNOWN = 0,
+  EX_PTR,  // any '*...' pointer type
+  EX_I8,   // i8
+  EX_I16,  // i16
+  EX_I32,  // i1, i32
+  EX_I64,  // i64
+  EX_U8,   // u8
+  EX_U16,  // u16
+  EX_U32,  // u1, u32
+  EX_U64,  // u64
+  EX_FP16, // fp16
+  EX_BF16, // bf16
+  EX_FP32, // fp32, f32
+  EX_FP64, // fp64
+  EX_COUNT
+} ExtractorIndex;
+
+// --- individual extractor functions ---
+
+static bool extractPtr(void *dst, PyObject *obj) {
+  void **out = static_cast<void **>(dst);
+  if (obj == Py_None) {
+    *out = nullptr;
+    return true;
   }
-  case ARG_1B:
-    cgh.set_arg(idx, *static_cast<const uint8_t *>(slot));
-    break;
-  case ARG_2B: {
-    uint16_t v;
-    memcpy(&v, slot, sizeof(v));
-    cgh.set_arg(idx, v);
-    break;
+  if (PyLong_Check(obj)) {
+    *out = PyLong_AsVoidPtr(obj);
+    return !PyErr_Occurred();
   }
-  case ARG_4B: {
-    uint32_t v;
-    memcpy(&v, slot, sizeof(v));
-    cgh.set_arg(idx, v);
-    break;
-  }
-  default: {
-    uint64_t v;
-    memcpy(&v, slot, sizeof(v));
-    cgh.set_arg(idx, v);
-    break;
-  }
-  }
+  // obj has a .data_ptr() method (e.g. torch.Tensor)
+  static PyObject *s_data_ptr = PyUnicode_InternFromString("data_ptr");
+  PyObject *ret = PyObject_CallMethodNoArgs(obj, s_data_ptr);
+  if (!ret)
+    return false;
+  *out = PyLong_AsVoidPtr(ret);
+  Py_DECREF(ret);
+  return !PyErr_Occurred();
 }
 
+static bool extractI8(void *dst, PyObject *obj) {
+  *static_cast<int8_t *>(dst) = (int8_t)PyLong_AsLong(obj);
+  return !PyErr_Occurred();
+}
+static bool extractI16(void *dst, PyObject *obj) {
+  *static_cast<int16_t *>(dst) = (int16_t)PyLong_AsLong(obj);
+  return !PyErr_Occurred();
+}
+static bool extractI32(void *dst, PyObject *obj) {
+  *static_cast<int32_t *>(dst) = (int32_t)PyLong_AsLong(obj);
+  return !PyErr_Occurred();
+}
+static bool extractI64(void *dst, PyObject *obj) {
+  *static_cast<int64_t *>(dst) = PyLong_AsLongLong(obj);
+  return !PyErr_Occurred();
+}
+static bool extractU8(void *dst, PyObject *obj) {
+  *static_cast<uint8_t *>(dst) = (uint8_t)PyLong_AsUnsignedLong(obj);
+  return !PyErr_Occurred();
+}
+static bool extractU16(void *dst, PyObject *obj) {
+  *static_cast<uint16_t *>(dst) = (uint16_t)PyLong_AsUnsignedLong(obj);
+  return !PyErr_Occurred();
+}
+static bool extractU32(void *dst, PyObject *obj) {
+  *static_cast<uint32_t *>(dst) = (uint32_t)PyLong_AsUnsignedLong(obj);
+  return !PyErr_Occurred();
+}
+static bool extractU64(void *dst, PyObject *obj) {
+  *static_cast<uint64_t *>(dst) = PyLong_AsUnsignedLongLong(obj);
+  return !PyErr_Occurred();
+}
+static bool extractFP16(void *dst, PyObject *obj) {
+  double d = PyFloat_AsDouble(obj);
+  if (PyErr_Occurred())
+    return false;
+  uint16_t v;
+  PyFloat_Pack2(d, reinterpret_cast<char *>(&v), 1);
+  *static_cast<uint16_t *>(dst) = v;
+  return !PyErr_Occurred();
+}
+static bool extractBF16(void *dst, PyObject *obj) {
+  float f = (float)PyFloat_AsDouble(obj);
+  if (PyErr_Occurred())
+    return false;
+  uint32_t u;
+  memcpy(&u, &f, sizeof(u));
+  *static_cast<uint16_t *>(dst) = (uint16_t)(u >> 16);
+  return true;
+}
+static bool extractFP32(void *dst, PyObject *obj) {
+  float f = (float)PyFloat_AsDouble(obj);
+  if (PyErr_Occurred())
+    return false;
+  memcpy(dst, &f, sizeof(f));
+  return true;
+}
+static bool extractFP64(void *dst, PyObject *obj) {
+  double d = PyFloat_AsDouble(obj);
+  if (PyErr_Occurred())
+    return false;
+  memcpy(dst, &d, sizeof(d));
+  return true;
+}
+
+// The table — indexed by ExtractorIndex.
+
+// setArg_* helpers: call cgh.set_arg with the correctly-typed value.
+// SYCL's set_arg is a template, so we need one wrapper per type.
+#define DEFINE_SET_ARG(name, T)                                                \
+  static void setArg_##name(sycl::handler &cgh, int idx, const void *val) {    \
+    cgh.set_arg(idx, *static_cast<const T *>(val));                            \
+  }
+// Pointer needs its own implementation: val points to a void* (the pointer
+// value), and casting const void* -> const void** removes qualifiers.
+// Use memcpy to load the stored pointer value safely.
+static void setArg_ptr(sycl::handler &cgh, int idx, const void *val) {
+  void *p;
+  memcpy(&p, val, sizeof(p));
+  cgh.set_arg(idx, p);
+}
+DEFINE_SET_ARG(i8, int8_t)
+DEFINE_SET_ARG(i16, int16_t)
+DEFINE_SET_ARG(i32, int32_t)
+DEFINE_SET_ARG(i64, int64_t)
+DEFINE_SET_ARG(u8, uint8_t)
+DEFINE_SET_ARG(u16, uint16_t)
+DEFINE_SET_ARG(u32, uint32_t)
+DEFINE_SET_ARG(u64, uint64_t)
+DEFINE_SET_ARG(fp16, uint16_t) // fp16/bf16 stored as raw bits in uint16_t
+DEFINE_SET_ARG(bf16, uint16_t)
+DEFINE_SET_ARG(fp32, float)
+DEFINE_SET_ARG(fp64, double)
+#undef DEFINE_SET_ARG
+
+static const Extractor g_extractors[EX_COUNT] = {
+    [EX_UNKNOWN] = {nullptr, nullptr, 0, {}},
+    [EX_PTR] = {extractPtr, setArg_ptr, sizeof(void *), {}},
+    [EX_I8] = {extractI8, setArg_i8, sizeof(int8_t), {"i8", nullptr, nullptr}},
+    [EX_I16] = {extractI16,
+                setArg_i16,
+                sizeof(int16_t),
+                {"i16", nullptr, nullptr}},
+    [EX_I32] = {extractI32,
+                setArg_i32,
+                sizeof(int32_t),
+                {"i1", "i32", nullptr}},
+    [EX_I64] = {extractI64,
+                setArg_i64,
+                sizeof(int64_t),
+                {"i64", nullptr, nullptr}},
+    [EX_U8] = {extractU8, setArg_u8, sizeof(uint8_t), {"u8", nullptr, nullptr}},
+    [EX_U16] = {extractU16,
+                setArg_u16,
+                sizeof(uint16_t),
+                {"u16", nullptr, nullptr}},
+    [EX_U32] = {extractU32,
+                setArg_u32,
+                sizeof(uint32_t),
+                {"u1", "u32", nullptr}},
+    [EX_U64] = {extractU64,
+                setArg_u64,
+                sizeof(uint64_t),
+                {"u64", nullptr, nullptr}},
+    [EX_FP16] = {extractFP16,
+                 setArg_fp16,
+                 sizeof(uint16_t),
+                 {"fp16", nullptr, nullptr}},
+    [EX_BF16] = {extractBF16,
+                 setArg_bf16,
+                 sizeof(uint16_t),
+                 {"bf16", nullptr, nullptr}},
+    [EX_FP32] = {extractFP32,
+                 setArg_fp32,
+                 sizeof(float),
+                 {"fp32", "f32", nullptr}},
+    [EX_FP64] = {extractFP64,
+                 setArg_fp64,
+                 sizeof(double),
+                 {"fp64", nullptr, nullptr}},
+};
+
+static ExtractorIndex getExtractorIndex(const char *ty) {
+  if (ty[0] == '*')
+    return EX_PTR;
+  for (int i = EX_I8; i < EX_COUNT; ++i) {
+    for (int j = 0; j < 3 && g_extractors[i].names[j]; ++j) {
+      if (strcmp(ty, g_extractors[i].names[j]) == 0)
+        return (ExtractorIndex)i;
+    }
+  }
+  return EX_UNKNOWN;
+}
+
+// --------------------------------------------------------------------------
+// Pointer validation helper — shared between buildSignatureMetadata (which
+// checks at launch time) and the inline check inside generic_launch.
+// --------------------------------------------------------------------------
+
+static bool validatePointer(void *ptr, int idx, ze_context_handle_t l0ctx) {
+  if (!ptr)
+    return true; // nullptr is always valid
+  ze_memory_allocation_properties_t prop = {};
+  prop.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
+  ze_device_handle_t dev;
+  ze_result_t res = zeMemGetAllocProperties(l0ctx, ptr, &prop, &dev);
+  if (res != ZE_RESULT_SUCCESS) {
+    PyErr_Format(PyExc_ValueError,
+                 "Cannot get memory properties for Pointer argument "
+                 "(at %d, err=%d)",
+                 idx, (int)res);
+    return false;
+  }
+  if (prop.type == ZE_MEMORY_TYPE_UNKNOWN) {
+    PyErr_Format(PyExc_ValueError,
+                 "Pointer argument (at %d) doesn't reference "
+                 "accessible memory.",
+                 idx);
+    return false;
+  }
+  return true;
+}
+
+// --------------------------------------------------------------------------
+// buildSignatureMetadata(sig_list) -> bytes
+//
+// Called ONCE when a kernel is first compiled.  Converts a Python list of
+// Triton type strings (e.g. ['*f32', 'i32', 'constexpr']) into a compact
+// bytes object of ExtractorIndex values.  EX_UNKNOWN (0) is used for
+// constexpr entries so generic_launch can skip them with a single check.
+// --------------------------------------------------------------------------
+
+extern "C" EXPORT_FUNC PyObject *buildSignatureMetadata(PyObject *args) {
+  PyObject *sig_list;
+  if (!PyArg_ParseTuple(args, "O", &sig_list))
+    return NULL;
+
+  PyObject *fast = PySequence_Fast(sig_list, "signature must be a sequence");
+  if (!fast)
+    return NULL;
+
+  Py_ssize_t n = PySequence_Fast_GET_SIZE(fast);
+  PyObject *result = PyBytes_FromStringAndSize(nullptr, n);
+  if (!result) {
+    Py_DECREF(fast);
+    return NULL;
+  }
+  char *buf = PyBytes_AS_STRING(result);
+
+  PyObject **items = PySequence_Fast_ITEMS(fast);
+  for (Py_ssize_t i = 0; i < n; ++i) {
+    const char *ty = PyUnicode_AsUTF8(items[i]);
+    if (!ty) {
+      Py_DECREF(fast);
+      Py_DECREF(result);
+      return NULL;
+    }
+    ExtractorIndex idx =
+        (strcmp(ty, "constexpr") == 0) ? EX_UNKNOWN : getExtractorIndex(ty);
+    if (idx == EX_UNKNOWN && strcmp(ty, "constexpr") != 0) {
+      PyErr_Format(PyExc_ValueError,
+                   "buildSignatureMetadata: unknown Triton type '%s'", ty);
+      Py_DECREF(fast);
+      Py_DECREF(result);
+      return NULL;
+    }
+    buf[i] = (char)(uint8_t)idx;
+  }
+
+  Py_DECREF(fast);
+  return result;
+}
+
+// --------------------------------------------------------------------------
 // generic_launch(gridX, gridY, gridZ, stream, kernel, kernel_metadata,
 //                launch_metadata, enter_hook, exit_hook,
-//                arg_types_bytes, arg_values_buffer)
+//                sig_metadata,   <- bytes from buildSignatureMetadata
+//                kernel_args)    <- tuple of raw Python arg objects
+//
+// Hot path: no heap allocation, no Python-side packing loop.
+// alloca() keeps everything on the C stack (like CUDA/AMD backends).
+// --------------------------------------------------------------------------
+
 extern "C" EXPORT_FUNC PyObject *generic_launch(PyObject *args) {
   int gridX, gridY, gridZ;
   PyObject *pyStream, *pyKernel;
   PyObject *kernelMeta, *launchMeta, *enterHook, *exitHook;
-  Py_buffer typeBuf, valBuf;
+  Py_buffer sigBuf;
+  PyObject *kernelArgs;
 
-  if (!PyArg_ParseTuple(args, "iiiOOOOOOs*s*", &gridX, &gridY, &gridZ,
-                        &pyStream, &pyKernel, &kernelMeta, &launchMeta,
-                        &enterHook, &exitHook, &typeBuf, &valBuf)) {
+  if (!PyArg_ParseTuple(args, "iiiOOOOOOs*O", &gridX, &gridY, &gridZ, &pyStream,
+                        &pyKernel, &kernelMeta, &launchMeta, &enterHook,
+                        &exitHook, &sigBuf, &kernelArgs)) {
     return NULL;
   }
-
-  auto releaseBuffers = [&]() {
-    PyBuffer_Release(&typeBuf);
-    PyBuffer_Release(&valBuf);
-  };
 
   // Extract kernel metadata.
   PyObject *numWarpsAttr = PyObject_GetAttrString(kernelMeta, "num_warps");
-  if (numWarpsAttr == nullptr) {
-    releaseBuffers();
+  if (!numWarpsAttr) {
+    PyBuffer_Release(&sigBuf);
     return NULL;
   }
-  int numWarps = PyLong_AsLong(numWarpsAttr);
-  if (numWarps == -1 && PyErr_Occurred()) {
-    Py_DECREF(numWarpsAttr);
-    releaseBuffers();
-    return NULL;
-  }
+  int numWarps = (int)PyLong_AsLong(numWarpsAttr);
   Py_DECREF(numWarpsAttr);
+  if (numWarps == -1 && PyErr_Occurred()) {
+    PyBuffer_Release(&sigBuf);
+    return NULL;
+  }
 
   PyObject *sharedAttr = PyObject_GetAttrString(kernelMeta, "shared");
-  if (sharedAttr == nullptr) {
-    releaseBuffers();
+  if (!sharedAttr) {
+    PyBuffer_Release(&sigBuf);
     return NULL;
   }
-  int sharedMemory = PyLong_AsLong(sharedAttr);
-  if (sharedMemory == -1 && PyErr_Occurred()) {
-    Py_DECREF(sharedAttr);
-    releaseBuffers();
-    return NULL;
-  }
+  int sharedMemory = (int)PyLong_AsLong(sharedAttr);
   Py_DECREF(sharedAttr);
+  if (sharedMemory == -1 && PyErr_Occurred()) {
+    PyBuffer_Release(&sigBuf);
+    return NULL;
+  }
 
   PyObject *tpwAttr = PyObject_GetAttrString(kernelMeta, "threads_per_warp");
-  if (tpwAttr == nullptr) {
-    releaseBuffers();
+  if (!tpwAttr) {
+    PyBuffer_Release(&sigBuf);
     return NULL;
   }
-  int threadsPerWarp = PyLong_AsLong(tpwAttr);
-  if (threadsPerWarp == -1 && PyErr_Occurred()) {
-    Py_DECREF(tpwAttr);
-    releaseBuffers();
-    return NULL;
-  }
+  int threadsPerWarp = (int)PyLong_AsLong(tpwAttr);
   Py_DECREF(tpwAttr);
+  if (threadsPerWarp == -1 && PyErr_Occurred()) {
+    PyBuffer_Release(&sigBuf);
+    return NULL;
+  }
 
   // Launch enter hook.
   if (enterHook != Py_None) {
     PyObject *ret = PyObject_CallOneArg(enterHook, launchMeta);
     if (!ret) {
-      releaseBuffers();
+      PyBuffer_Release(&sigBuf);
       return NULL;
     }
     Py_DECREF(ret);
@@ -633,118 +886,124 @@ extern "C" EXPORT_FUNC PyObject *generic_launch(PyObject *args) {
 
   void *pStream = PyLong_AsVoidPtr(pyStream);
   if (!pStream || !pyKernel) {
-    releaseBuffers();
+    PyBuffer_Release(&sigBuf);
     return NULL;
   }
   sycl::queue stream = *static_cast<sycl::queue *>(pStream);
   sycl::kernel *kernelPtr = reinterpret_cast<sycl::kernel *>(
       PyCapsule_GetPointer(pyKernel, "kernel"));
   if (!kernelPtr) {
-    releaseBuffers();
+    PyBuffer_Release(&sigBuf);
     return NULL;
   }
   sycl::kernel kernel = *kernelPtr;
 
-  const auto *types = static_cast<const uint8_t *>(typeBuf.buf);
-  const auto *vals = static_cast<const uint8_t *>(valBuf.buf);
+  // sig_metadata is a bytes object built by buildSignatureMetadata.
+  // Each byte is an ExtractorIndex; EX_UNKNOWN means constexpr (skip).
+  const uint8_t *sigData = static_cast<const uint8_t *>(sigBuf.buf);
+  Py_ssize_t sigLen = sigBuf.len;
 
-  // Each arg occupies exactly 8 bytes in the value buffer.
-  if (valBuf.len != (Py_ssize_t)typeBuf.len * 8) {
-    releaseBuffers();
-    PyErr_Format(
-        PyExc_ValueError,
-        "generic_launch: valBuf length (%zd) != typeBuf length (%zd) * 8",
-        valBuf.len, typeBuf.len);
+  // Flatten kernelArgs into a fast sequence.
+  PyObject *fastArgs =
+      PySequence_Fast(kernelArgs, "kernel_args must be a sequence");
+  if (!fastArgs) {
+    PyBuffer_Release(&sigBuf);
     return NULL;
   }
+  Py_ssize_t nRawArgs = PySequence_Fast_GET_SIZE(fastArgs);
+  PyObject **rawArgs = PySequence_Fast_ITEMS(fastArgs);
 
-  // Pointer validation: matches the per-kernel compiled launcher's
-  // checkDevicePointer behaviour.  Enabled by default; set
-  // TRITON_XPU_VALIDATE_POINTERS=0 to skip (faster launch, no Level Zero
-  // round-trip per pointer arg, but invalid pointers become hard crashes).
+  // Count kernel (non-constexpr) args.
+  int nKernelArgs = 0;
+  for (Py_ssize_t i = 0; i < sigLen; ++i)
+    if (sigData[i] != EX_UNKNOWN)
+      ++nKernelArgs;
+
+  // Stack-allocate an array of (storage_ptr, setArg_fn) pairs — one per
+  // kernel arg.  Both alloca calls MUST stay in this function's stack frame.
+  void **params = static_cast<void **>(alloca(nKernelArgs * sizeof(void *)));
+  SetArgFunc *setArgFns =
+      static_cast<SetArgFunc *>(alloca(nKernelArgs * sizeof(SetArgFunc)));
+
+  // Pointer validation flag — read once, static.
   static bool validatePtrs = []() {
     const char *s = std::getenv("TRITON_XPU_VALIDATE_POINTERS");
     if (!s)
-      return true; // default: on
+      return true;
     std::string v(s);
     std::transform(v.begin(), v.end(), v.begin(),
                    [](unsigned char c) { return std::tolower(c); });
     return !(v == "0" || v == "false" || v == "off");
   }();
-  if (validatePtrs) {
-    auto l0Context = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
-        stream.get_context());
-    int nArgsCheck = (int)typeBuf.len;
-    for (int i = 0; i < nArgsCheck; ++i) {
-      if (types[i] != ARG_PTR)
-        continue;
-      void *ptr;
-      memcpy(&ptr, vals + i * 8, sizeof(ptr));
-      if (!ptr)
-        continue;
-      ze_memory_allocation_properties_t prop = {};
-      prop.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
-      ze_device_handle_t device;
-      ze_result_t res = zeMemGetAllocProperties((ze_context_handle_t)l0Context,
-                                                ptr, &prop, &device);
-      if (res != ZE_RESULT_SUCCESS) {
-        releaseBuffers();
-        PyErr_Format(PyExc_ValueError,
-                     "Cannot get memory properties for Pointer argument "
-                     "(at %d, err=%d)",
-                     i, (int)res);
-        return NULL;
-      }
-      if (prop.type == ZE_MEMORY_TYPE_UNKNOWN) {
-        releaseBuffers();
-        PyErr_Format(PyExc_ValueError,
-                     "Pointer argument (at %d) doesn't reference "
-                     "accessible memory.",
-                     i);
+
+  ze_context_handle_t l0ctx = nullptr;
+  if (validatePtrs)
+    l0ctx = static_cast<ze_context_handle_t>(
+        sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
+            stream.get_context()));
+
+  // Extract each arg from the Python object using the pre-built metadata.
+  int paramIdx = 0;
+  Py_ssize_t rawIdx = 0;
+  for (Py_ssize_t i = 0; i < sigLen; ++i) {
+    uint8_t exIdx = sigData[i];
+    if (exIdx == EX_UNKNOWN) { // constexpr — skip
+      ++rawIdx;
+      continue;
+    }
+    if (rawIdx >= nRawArgs) {
+      PyErr_SetString(PyExc_ValueError,
+                      "generic_launch: fewer kernel args than signature slots");
+      Py_DECREF(fastArgs);
+      PyBuffer_Release(&sigBuf);
+      return NULL;
+    }
+    const Extractor &ex = g_extractors[exIdx];
+    void *storage = alloca(ex.size);
+    PyObject *obj = rawArgs[rawIdx++];
+    if (!ex.extract(storage, obj)) {
+      Py_DECREF(fastArgs);
+      PyBuffer_Release(&sigBuf);
+      return NULL;
+    }
+    // Validate pointers against the Level Zero memory model.
+    if (validatePtrs && exIdx == EX_PTR) {
+      void *ptr = *static_cast<void **>(storage);
+      if (!validatePointer(ptr, paramIdx, l0ctx)) {
+        Py_DECREF(fastArgs);
+        PyBuffer_Release(&sigBuf);
         return NULL;
       }
     }
+    params[paramIdx] = storage;
+    setArgFns[paramIdx] = ex.setArg;
+    ++paramIdx;
   }
 
-  // Validate arg count: user args + global_scratch + profile_scratch [+ slm].
-  int nArgs = (int)typeBuf.len;
-  int expectedArgs = nArgs + 2 + (sharedMemory ? 1 : 0);
-  int kernelArgs = 0;
-  try {
-    kernelArgs = (int)kernel.get_info<sycl::info::kernel::num_args>();
-  } catch (const sycl::exception &e) {
-    releaseBuffers();
-    PyErr_Format(PyExc_RuntimeError,
-                 "generic_launch: failed to query kernel arg count: %s",
-                 e.what());
-    return NULL;
-  }
-  if (expectedArgs != kernelArgs) {
-    releaseBuffers();
-    PyErr_Format(PyExc_ValueError,
-                 "generic_launch: argument count mismatch: expected %d "
-                 "(user %d + implicit %d) but kernel has %d",
-                 expectedArgs, nArgs, expectedArgs - nArgs, kernelArgs);
-    return NULL;
-  }
+  Py_DECREF(fastArgs);
+  PyBuffer_Release(&sigBuf);
 
   sycl::range<3> globalRange(gridZ, gridY,
                              (size_t)gridX * threadsPerWarp * numWarps);
   sycl::range<3> localRange(1, 1, (size_t)numWarps * threadsPerWarp);
   sycl::nd_range<3> ndRange(globalRange, localRange);
 
+  // Capture nKernelArgs and sharedMemory by value so the lambda is safe
+  // after this function returns (submit is asynchronous w.r.t. the host,
+  // but the command-group function itself is called synchronously before
+  // submit() returns — so stack-allocated params[] are safe here).
   auto cgf = [&](sycl::handler &cgh) {
-    for (int i = 0; i < nArgs; ++i)
-      setArgByType(cgh, i, types[i], vals + i * 8);
+    for (int i = 0; i < nKernelArgs; ++i)
+      setArgFns[i](cgh, i, params[i]);
 
     // Implicit params: global_scratch, profile_scratch (nullptr).
     void *nullPtr = nullptr;
-    cgh.set_arg(nArgs, nullPtr);
-    cgh.set_arg(nArgs + 1, nullPtr);
+    cgh.set_arg(nKernelArgs, nullPtr);
+    cgh.set_arg(nKernelArgs + 1, nullPtr);
 
     if (sharedMemory) {
       auto localBuf = sycl::local_accessor<int8_t, 1>(sharedMemory, cgh);
-      cgh.set_arg(nArgs + 2, localBuf);
+      cgh.set_arg(nKernelArgs + 2, localBuf);
     }
     cgh.parallel_for(ndRange, kernel);
   };
@@ -752,13 +1011,10 @@ extern "C" EXPORT_FUNC PyObject *generic_launch(PyObject *args) {
   try {
     stream.submit(cgf);
   } catch (const sycl::exception &e) {
-    releaseBuffers();
     PyErr_Format(PyExc_RuntimeError, "generic_launch: SYCL submit failed: %s",
                  e.what());
     return NULL;
   }
-
-  releaseBuffers();
 
   // Launch exit hook.
   if (exitHook != Py_None) {

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -41,11 +41,9 @@ def find_sycl(include_dir: list[str]) -> tuple[list[str], list[str]]:
       AssertionError: if library was not found.
     """
     include_dir = include_dir.copy()
-    assertion_message = (
-        "sycl headers not found, please install `icpx` compiler, "
-        "or provide `ONEAPI_ROOT` environment "
-        "or install `intel-sycl-rt>=2025.0.0` wheel"
-    )
+    assertion_message = ("sycl headers not found, please install `icpx` compiler, "
+                         "or provide `ONEAPI_ROOT` environment "
+                         "or install `intel-sycl-rt>=2025.0.0` wheel")
     icpx_path = shutil.which("icpx")
     if icpx_path:
         # only `icpx` compiler knows where sycl runtime binaries and header files are
@@ -157,10 +155,11 @@ COMPILATION_HELPER = CompilationHelper()
 
 
 class ArchParser:
+
     def __init__(self, cache_path: str):
         self.shared_library = ctypes.CDLL(cache_path)
         self.shared_library.parse_device_arch.restype = ctypes.c_char_p
-        self.shared_library.parse_device_arch.argtypes = (ctypes.c_uint64,)
+        self.shared_library.parse_device_arch.argtypes = (ctypes.c_uint64, )
 
     def __getattribute__(self, name):
         if name == "parse_device_arch":
@@ -179,42 +178,43 @@ class ArchParser:
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                self.shared_library.dlclose.argtypes = (ctypes.c_void_p,)
+                self.shared_library.dlclose.argtypes = (ctypes.c_void_p, )
                 self.shared_library.dlclose(handle)
     else:
 
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64,)
+                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64, )
                 ctypes.windll.kernel32.FreeLibrary(handle)
 
 
 class SpirvUtils:
+
     def __init__(self, cache_path: str):
         self.shared_library = ctypes.PyDLL(cache_path)
         methods = ("init_devices", "load_binary", "wait_on_sycl_queue", "sycl_queue_memset")
         for method in methods:
             getattr(self.shared_library, method).restype = ctypes.py_object
-            getattr(self.shared_library, method).argtypes = (ctypes.py_object,)
+            getattr(self.shared_library, method).argtypes = (ctypes.py_object, )
         self.shared_library.get_device_properties.restype = ctypes.py_object
-        self.shared_library.get_device_properties.argtypes = (ctypes.c_int,)
+        self.shared_library.get_device_properties.argtypes = (ctypes.c_int, )
         self.shared_library.get_last_selected_build_flags.restype = ctypes.py_object
         # generic_launch may not exist in older cached builds
         if hasattr(self.shared_library, "generic_launch"):
             self.shared_library.generic_launch.restype = ctypes.py_object
-            self.shared_library.generic_launch.argtypes = (ctypes.py_object,)
+            self.shared_library.generic_launch.argtypes = (ctypes.py_object, )
             self.generic_launch = self.shared_library.generic_launch
         else:
             self.generic_launch = None
 
     def __getattribute__(self, name):
         if name in (
-            "get_device_properties",
-            "init_devices",
-            "wait_on_sycl_queue",
-            "get_last_selected_build_flags",
-            "sycl_queue_memset",
+                "get_device_properties",
+                "init_devices",
+                "wait_on_sycl_queue",
+                "get_last_selected_build_flags",
+                "sycl_queue_memset",
         ):
             shared_library = super().__getattribute__("shared_library")
             return getattr(shared_library, name)
@@ -241,14 +241,14 @@ class SpirvUtils:
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                self.shared_library.dlclose.argtypes = (ctypes.c_void_p,)
+                self.shared_library.dlclose.argtypes = (ctypes.c_void_p, )
                 self.shared_library.dlclose(handle)
     else:
 
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64,)
+                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64, )
                 ctypes.windll.kernel32.FreeLibrary(handle)
 
 
@@ -260,7 +260,7 @@ class ExtensionUtils:
         self.shared_library.check_extension.restype = ctypes.py_object
         self.shared_library.check_extension.argtypes = (ctypes.c_int, ctypes.c_char_p)
         self.shared_library.get_device_id.restype = ctypes.py_object
-        self.shared_library.get_device_id.argtypes = (ctypes.c_int,)
+        self.shared_library.get_device_id.argtypes = (ctypes.c_int, )
 
     def check_extension(self, device_id: int, extension: bytes) -> bool:
         return self.shared_library.check_extension(device_id, extension)
@@ -273,22 +273,23 @@ class ExtensionUtils:
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                self.shared_library.dlclose.argtypes = (ctypes.c_void_p,)
+                self.shared_library.dlclose.argtypes = (ctypes.c_void_p, )
                 self.shared_library.dlclose(handle)
     else:
 
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64,)
+                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64, )
                 ctypes.windll.kernel32.FreeLibrary(handle)
 
 
 class TritonLauncher:
+
     def __init__(self, cache_path: str):
         self.shared_library = ctypes.PyDLL(cache_path)
         self.shared_library.launch.restype = ctypes.py_object
-        self.shared_library.launch.argtypes = (ctypes.py_object,)
+        self.shared_library.launch.argtypes = (ctypes.py_object, )
 
     def __getattribute__(self, name):
         if name == "launch":
@@ -302,14 +303,14 @@ class TritonLauncher:
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                self.shared_library.dlclose.argtypes = (ctypes.c_void_p,)
+                self.shared_library.dlclose.argtypes = (ctypes.c_void_p, )
                 self.shared_library.dlclose(handle)
     else:
 
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64,)
+                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64, )
                 ctypes.windll.kernel32.FreeLibrary(handle)
 
 
@@ -364,6 +365,7 @@ def compile_module_from_src(src: str, name: str):
 
 
 class XPUUtils(object):
+
     def __new__(cls):
         if not hasattr(cls, "instance"):
             cls.instance = super(XPUUtils, cls).__new__(cls)
@@ -841,8 +843,8 @@ def wrap_handle_tensordesc(launcher, signature):
             cur = cur.setdefault(step, {})
 
     def inner(args):
-        meta_args = args[: len(_BASE_ARGS_FORMAT)]
-        kernel_args = args[len(_BASE_ARGS_FORMAT) :]
+        meta_args = args[:len(_BASE_ARGS_FORMAT)]
+        kernel_args = args[len(_BASE_ARGS_FORMAT):]
         wrapped = make_tensordesc_args(
             kernel_args,
             signature_vals,
@@ -902,7 +904,7 @@ def serialize_args(args, constants, signature):
             args_dict["argument_list"].append(new_arg)
             counts["tensors"] += 1
         if isinstance(arg, numbers.Number):
-            if (counts["karg_cnt"],) not in constants.keys():
+            if (counts["karg_cnt"], ) not in constants.keys():
                 new_arg = {
                     "name": f"scalarArg_{counts['scalars']}",
                     "type": "scalar",
@@ -932,21 +934,11 @@ _ARG_8B = 4
 # Each slot in the values buffer is exactly 8 bytes; smaller types are
 # zero-padded to fill the slot (little-endian, padding bytes are 'x').
 _TY_INFO: dict[str, tuple[int, str]] = {
-    "i1": (_ARG_1B, "<Bxxxxxxx"),
-    "i8": (_ARG_1B, "<bxxxxxxx"),
-    "i16": (_ARG_2B, "<hxxxxxx"),
-    "i32": (_ARG_4B, "<ixxxx"),
-    "i64": (_ARG_8B, "<q"),
-    "u1": (_ARG_1B, "<Bxxxxxxx"),
-    "u8": (_ARG_1B, "<Bxxxxxxx"),
-    "u16": (_ARG_2B, "<Hxxxxxx"),
-    "u32": (_ARG_4B, "<Ixxxx"),
-    "u64": (_ARG_8B, "<Q"),
-    "fp16": (_ARG_2B, "<exxxxxx"),
-    "fp32": (_ARG_4B, "<fxxxx"),
-    "f32": (_ARG_4B, "<fxxxx"),
-    "fp64": (_ARG_8B, "<d"),
-    "bf16": (_ARG_2B, None),  # special-cased: no struct format letter for bf16
+    "i1": (_ARG_1B, "<Bxxxxxxx"), "i8": (_ARG_1B, "<bxxxxxxx"), "i16": (_ARG_2B, "<hxxxxxx"), "i32":
+    (_ARG_4B, "<ixxxx"), "i64": (_ARG_8B, "<q"), "u1": (_ARG_1B, "<Bxxxxxxx"), "u8": (_ARG_1B, "<Bxxxxxxx"), "u16":
+    (_ARG_2B, "<Hxxxxxx"), "u32": (_ARG_4B, "<Ixxxx"), "u64": (_ARG_8B, "<Q"), "fp16": (_ARG_2B, "<exxxxxx"), "fp32":
+    (_ARG_4B, "<fxxxx"), "f32": (_ARG_4B, "<fxxxx"), "fp64": (_ARG_8B, "<d"), "bf16":
+    (_ARG_2B, None),  # special-cased: no struct format letter for bf16
 }
 
 
@@ -1005,10 +997,8 @@ def _make_generic_launcher(constants, signature):
     # at the cost of a less informative error on an invalid pointer.
     generic_launch_fn = triton.runtime.driver.active.utils.generic_launch
     if generic_launch_fn is None:
-        raise RuntimeError(
-            "generic_launch not available in the XPU driver shared library. "
-            "Clear ~/.triton/cache and rebuild to pick up the updated driver.c."
-        )
+        raise RuntimeError("generic_launch not available in the XPU driver shared library. "
+                           "Clear ~/.triton/cache and rebuild to pick up the updated driver.c.")
 
     def launcher(all_args):
         kernel_args = all_args[9:]
@@ -1020,7 +1010,7 @@ def _make_generic_launcher(constants, signature):
                 p = val.data_ptr() if hasattr(val, "data_ptr") else (0 if val is None else int(val))
                 struct.pack_into("<Q", buf, off, p)
             elif pack_fmts[j] is None:
-                buf[off : off + 8] = _pack_bf16(val)
+                buf[off:off + 8] = _pack_bf16(val)
             else:
                 struct.pack_into(pack_fmts[j], buf, off, val)
         generic_launch_fn((*all_args[:9], type_bytes, buf))
@@ -1029,9 +1019,10 @@ def _make_generic_launcher(constants, signature):
 
 
 class XPULauncher(object):
+
     def __init__(self, src, metadata):
         constants = src.constants if hasattr(src, "constants") else dict()
-        arg_idx = lambda x: (src.fn.arg_names.index(x),) if isinstance(x, str) else x
+        arg_idx = lambda x: (src.fn.arg_names.index(x), ) if isinstance(x, str) else x
         constants = {arg_idx(idx): value for idx, value in constants.items()}
         signature = {idx: value for idx, value in src.signature.items()}
 
@@ -1099,6 +1090,7 @@ class XPULauncher(object):
 
 
 class XPUDriver(DriverBase):
+
     def __init__(self):
         self.launcher_cls = XPULauncher
         super().__init__()
@@ -1130,9 +1122,8 @@ class XPUDriver(DriverBase):
         def update_device_arch(dev_property):
             if not (arch := knobs.intel.device_arch):
                 dirname = os.path.dirname(os.path.realpath(__file__))
-                parser = compile_module_from_src(
-                    src=Path(os.path.join(dirname, "arch_parser.c")).read_text(), name="arch_utils"
-                )
+                parser = compile_module_from_src(src=Path(os.path.join(dirname, "arch_parser.c")).read_text(),
+                                                 name="arch_utils")
                 arch = parser.parse_device_arch(dev_property["architecture"])
             dev_property["arch"] = arch
 

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -991,10 +991,9 @@ def _make_generic_launcher(constants, signature):
 
     # Fetch the precompiled launch function once at launcher-creation time,
     # matching the pattern used by CudaLauncher (utils.launch stored at init).
-    # Note: the static icpx-compiled launcher validates pointer args via
-    # zeMemGetAllocProperties.  That check is intentionally omitted here;
-    # the trade-off is faster launch (no Level Zero round-trip per pointer arg)
-    # at the cost of a less informative error on an invalid pointer.
+    # Note: like the static icpx-compiled launcher, generic_launch validates
+    # pointer args via zeMemGetAllocProperties by default.  Set
+    # TRITON_XPU_VALIDATE_POINTERS=0 to skip validation for faster launch.
     generic_launch_fn = triton.runtime.driver.active.utils.generic_launch
     if generic_launch_fn is None:
         raise RuntimeError("generic_launch not available in the XPU driver shared library. "

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -5,6 +5,7 @@ import sys
 import hashlib
 import shutil
 import ctypes
+import struct
 import sysconfig
 import tempfile
 from pathlib import Path
@@ -40,9 +41,11 @@ def find_sycl(include_dir: list[str]) -> tuple[list[str], list[str]]:
       AssertionError: if library was not found.
     """
     include_dir = include_dir.copy()
-    assertion_message = ("sycl headers not found, please install `icpx` compiler, "
-                         "or provide `ONEAPI_ROOT` environment "
-                         "or install `intel-sycl-rt>=2025.0.0` wheel")
+    assertion_message = (
+        "sycl headers not found, please install `icpx` compiler, "
+        "or provide `ONEAPI_ROOT` environment "
+        "or install `intel-sycl-rt>=2025.0.0` wheel"
+    )
     icpx_path = shutil.which("icpx")
     if icpx_path:
         # only `icpx` compiler knows where sycl runtime binaries and header files are
@@ -55,7 +58,7 @@ def find_sycl(include_dir: list[str]) -> tuple[list[str], list[str]]:
     if oneapi_root:
         include_dir += [
             os.path.join(oneapi_root, "compiler/latest/include"),
-            os.path.join(oneapi_root, "compiler/latest/include/sycl")
+            os.path.join(oneapi_root, "compiler/latest/include/sycl"),
         ]
         sycl_dir = os.path.join(oneapi_root, "compiler/latest/lib")
         return include_dir, [sycl_dir]
@@ -96,7 +99,7 @@ class CompilationHelper:
         self._library_dir = None
         self._include_dir = None
         self._libsycl_dir = None
-        self.libraries = ['sycl', 'ze_loader']
+        self.libraries = ["sycl", "ze_loader"]
 
     @property
     def inject_pytorch_dep(self):
@@ -129,7 +132,7 @@ class CompilationHelper:
                 os.path.join(torch_path, "../../include/torch/csrc/api/include"),
             ]
             library_dir += [os.path.join(torch_path, "../../lib")]
-            self.libraries += ['torch']
+            self.libraries += ["torch"]
 
         self._library_dir = library_dir
         self._include_dir = include_dir
@@ -154,11 +157,10 @@ COMPILATION_HELPER = CompilationHelper()
 
 
 class ArchParser:
-
     def __init__(self, cache_path: str):
         self.shared_library = ctypes.CDLL(cache_path)
         self.shared_library.parse_device_arch.restype = ctypes.c_char_p
-        self.shared_library.parse_device_arch.argtypes = (ctypes.c_uint64, )
+        self.shared_library.parse_device_arch.argtypes = (ctypes.c_uint64,)
 
     def __getattribute__(self, name):
         if name == "parse_device_arch":
@@ -172,37 +174,48 @@ class ArchParser:
 
         return super().__getattribute__(name)
 
-    if os.name != 'nt':
+    if os.name != "nt":
 
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                self.shared_library.dlclose.argtypes = (ctypes.c_void_p, )
+                self.shared_library.dlclose.argtypes = (ctypes.c_void_p,)
                 self.shared_library.dlclose(handle)
     else:
 
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64, )
+                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64,)
                 ctypes.windll.kernel32.FreeLibrary(handle)
 
 
 class SpirvUtils:
-
     def __init__(self, cache_path: str):
         self.shared_library = ctypes.PyDLL(cache_path)
         methods = ("init_devices", "load_binary", "wait_on_sycl_queue", "sycl_queue_memset")
         for method in methods:
             getattr(self.shared_library, method).restype = ctypes.py_object
-            getattr(self.shared_library, method).argtypes = (ctypes.py_object, )
+            getattr(self.shared_library, method).argtypes = (ctypes.py_object,)
         self.shared_library.get_device_properties.restype = ctypes.py_object
-        self.shared_library.get_device_properties.argtypes = (ctypes.c_int, )
+        self.shared_library.get_device_properties.argtypes = (ctypes.c_int,)
         self.shared_library.get_last_selected_build_flags.restype = ctypes.py_object
+        # generic_launch may not exist in older cached builds
+        if hasattr(self.shared_library, "generic_launch"):
+            self.shared_library.generic_launch.restype = ctypes.py_object
+            self.shared_library.generic_launch.argtypes = (ctypes.py_object,)
+            self.generic_launch = self.shared_library.generic_launch
+        else:
+            self.generic_launch = None
 
     def __getattribute__(self, name):
-        if name in ("get_device_properties", "init_devices", "wait_on_sycl_queue", "get_last_selected_build_flags",
-                    "sycl_queue_memset"):
+        if name in (
+            "get_device_properties",
+            "init_devices",
+            "wait_on_sycl_queue",
+            "get_last_selected_build_flags",
+            "sycl_queue_memset",
+        ):
             shared_library = super().__getattribute__("shared_library")
             return getattr(shared_library, name)
 
@@ -218,23 +231,24 @@ class SpirvUtils:
         except Exception as e:
             if str(e).startswith("ZE_"):
                 from triton.runtime.errors import IntelGPUError
+
                 raise IntelGPUError("Error during Intel load_binary: " + str(e)) from e
             else:
                 raise e
 
-    if os.name != 'nt':
+    if os.name != "nt":
 
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                self.shared_library.dlclose.argtypes = (ctypes.c_void_p, )
+                self.shared_library.dlclose.argtypes = (ctypes.c_void_p,)
                 self.shared_library.dlclose(handle)
     else:
 
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64, )
+                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64,)
                 ctypes.windll.kernel32.FreeLibrary(handle)
 
 
@@ -246,7 +260,7 @@ class ExtensionUtils:
         self.shared_library.check_extension.restype = ctypes.py_object
         self.shared_library.check_extension.argtypes = (ctypes.c_int, ctypes.c_char_p)
         self.shared_library.get_device_id.restype = ctypes.py_object
-        self.shared_library.get_device_id.argtypes = (ctypes.c_int, )
+        self.shared_library.get_device_id.argtypes = (ctypes.c_int,)
 
     def check_extension(self, device_id: int, extension: bytes) -> bool:
         return self.shared_library.check_extension(device_id, extension)
@@ -254,28 +268,27 @@ class ExtensionUtils:
     def get_device_id(self, device_idx: int) -> int:
         return self.shared_library.get_device_id(device_idx)
 
-    if os.name != 'nt':
+    if os.name != "nt":
 
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                self.shared_library.dlclose.argtypes = (ctypes.c_void_p, )
+                self.shared_library.dlclose.argtypes = (ctypes.c_void_p,)
                 self.shared_library.dlclose(handle)
     else:
 
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64, )
+                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64,)
                 ctypes.windll.kernel32.FreeLibrary(handle)
 
 
 class TritonLauncher:
-
     def __init__(self, cache_path: str):
         self.shared_library = ctypes.PyDLL(cache_path)
         self.shared_library.launch.restype = ctypes.py_object
-        self.shared_library.launch.argtypes = (ctypes.py_object, )
+        self.shared_library.launch.argtypes = (ctypes.py_object,)
 
     def __getattribute__(self, name):
         if name == "launch":
@@ -284,19 +297,19 @@ class TritonLauncher:
 
         return super().__getattribute__(name)
 
-    if os.name != 'nt':
+    if os.name != "nt":
 
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                self.shared_library.dlclose.argtypes = (ctypes.c_void_p, )
+                self.shared_library.dlclose.argtypes = (ctypes.c_void_p,)
                 self.shared_library.dlclose(handle)
     else:
 
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64, )
+                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64,)
                 ctypes.windll.kernel32.FreeLibrary(handle)
 
 
@@ -319,20 +332,27 @@ def compile_module_from_src(src: str, name: str):
                 else:
                     extra_compiler_args += ["-Wl,-rpath," + dir for dir in COMPILATION_HELPER.libsycl_dir]
 
-            so = _build(name, src_path, tmpdir, COMPILATION_HELPER.library_dir, COMPILATION_HELPER.include_dir,
-                        COMPILATION_HELPER.libraries, ccflags=extra_compiler_args)
+            so = _build(
+                name,
+                src_path,
+                tmpdir,
+                COMPILATION_HELPER.library_dir,
+                COMPILATION_HELPER.include_dir,
+                COMPILATION_HELPER.libraries,
+                ccflags=extra_compiler_args,
+            )
             with open(so, "rb") as f:
                 cache_path = cache.put(f.read(), f"{name}{suffix}", binary=True)
 
-    if name == 'arch_utils':
+    if name == "arch_utils":
         return ArchParser(cache_path)
-    if name == 'spirv_utils':
+    if name == "spirv_utils":
         return SpirvUtils(cache_path)
-    if name == 'extension_utils_impl':
+    if name == "extension_utils_impl":
         return ExtensionUtils(cache_path)
-    if name == '__triton_launcher':
+    if name == "__triton_launcher":
         return TritonLauncher(cache_path)
-    if name == 'proton_utils':
+    if name == "proton_utils":
         return cache_path
 
     return _load_module_from_path(name, cache_path)
@@ -344,7 +364,6 @@ def compile_module_from_src(src: str, name: str):
 
 
 class XPUUtils(object):
-
     def __new__(cls):
         if not hasattr(cls, "instance"):
             cls.instance = super(XPUUtils, cls).__new__(cls)
@@ -361,14 +380,17 @@ class XPUUtils(object):
         self.wait_on_sycl_queue = mod.wait_on_sycl_queue
         self.get_last_selected_build_flags = mod.get_last_selected_build_flags
         self.sycl_queue_memset = mod.sycl_queue_memset
+        self.generic_launch = getattr(mod, "generic_launch", None)
         self.unload_module = lambda module: None
 
     def get_current_device(self):
         import torch
+
         return torch.xpu.current_device()
 
     def get_sycl_queue(self):
         import torch
+
         return torch.xpu.current_stream().sycl_queue
 
     def wait(self):
@@ -385,7 +407,7 @@ class XPUUtils(object):
 
 
 def ty_to_cpp(ty):
-    if ty[0] == '*':
+    if ty[0] == "*":
         return "void*"
     return {
         "i1": "int8_t",
@@ -435,9 +457,9 @@ def make_launcher(constants, signature):
 
     def _extracted_type(ty):
         if isinstance(ty, tuple):
-            val = ','.join(map(_extracted_type, ty))
+            val = ",".join(map(_extracted_type, ty))
             return f"[{val}]"
-        if ty[0] == '*':
+        if ty[0] == "*":
             return "PyObject*"
         if ty in ("constexpr"):
             return "PyObject*"
@@ -445,9 +467,9 @@ def make_launcher(constants, signature):
 
     def format_of(ty):
         if isinstance(ty, tuple):
-            val = ''.join(map(format_of, ty))
+            val = "".join(map(format_of, ty))
             return f"({val})"
-        if ty[0] == '*':
+        if ty[0] == "*":
             return "O"
         if ty in ("constexpr"):
             return "O"
@@ -469,14 +491,14 @@ def make_launcher(constants, signature):
     expand_signature = upstream_expand_signature(signature.values(), tensordesc_meta=None, descriptor_type="*i8")
     signature = {i: s for i, s in enumerate(expand_signature)}
 
-    args_format = ''.join([format_of(ty) for ty in signature.values()])
+    args_format = "".join([format_of(ty) for ty in signature.values()])
     format = _BASE_ARGS_FORMAT + args_format
 
     flat_signature = []
     for sig in signature.values():
         _flatten_signature(sig, flat_signature)
     signature = {i: s for i, s in enumerate(flat_signature)}
-    args_list = ', ' + ', '.join(f"&_arg{i}" for i, ty in signature.items()) if len(signature) > 0 else ''
+    args_list = ", " + ", ".join(f"&_arg{i}" for i, ty in signature.items()) if len(signature) > 0 else ""
     # Record the end of regular arguments;
     # subsequent arguments are architecture-specific descriptors.
     arg_decl_list = []
@@ -487,7 +509,7 @@ def make_launcher(constants, signature):
             arg_decl_list.append(f"{FLOAT_STORAGE_TYPE[ty]} arg{i}")
         else:
             arg_decl_list.append(f"{ty_to_cpp(ty)} arg{i}")
-    arg_decls = ', '.join(arg_decl_list)
+    arg_decls = ", ".join(arg_decl_list)
     internal_args_list = []
     for i, ty in signature.items():
         if ty[0] == "*":
@@ -498,7 +520,7 @@ def make_launcher(constants, signature):
             internal_args_list.append(f"_arg{i}")
 
     # generate glue code
-    newline = '\n  '
+    newline = "\n  "
     ptr_decls = [
         f"DevicePtrInfo ptr_info{i} = getPointer(_arg{i}, {i}, stream); if (!ptr_info{i}.valid) return NULL;"
         for i, ty in signature.items()
@@ -524,7 +546,7 @@ def make_launcher(constants, signature):
 #include <iomanip>
 #include <level_zero/ze_api.h>
 #include <sycl/sycl.hpp>
-{ "#include <ATen/record_function.h>" if COMPILATION_HELPER.inject_pytorch_dep else "" }
+{"#include <ATen/record_function.h>" if COMPILATION_HELPER.inject_pytorch_dep else ""}
 
 #if defined(_WIN32)
 #define EXPORT_FUNC __declspec(dllexport)
@@ -638,10 +660,10 @@ static inline void set_scalar_arg(sycl::handler &cgh, int index, const void *val
 static void sycl_kernel_launch(uint32_t gridX, uint32_t gridY, uint32_t gridZ,
                                int num_warps, int threads_per_warp, int shared_memory,
                                sycl::queue& stream, sycl::kernel& kernel_ptr,
-                               void* global_scratch, void* profile_scratch{', ' + arg_decls if len(arg_decls) > 0 else ''}) {{
+                               void* global_scratch, void* profile_scratch{", " + arg_decls if len(arg_decls) > 0 else ""}) {{
 
   std::string kernel_name = kernel_ptr.get_info<sycl::info::kernel::function_name>();
-  { 'RECORD_FUNCTION("XPU Triton kernel:" + kernel_name, {});' if COMPILATION_HELPER.inject_pytorch_dep else "" }
+  {'RECORD_FUNCTION("XPU Triton kernel:" + kernel_name, {});' if COMPILATION_HELPER.inject_pytorch_dep else ""}
 
   {params_decl};
   uint32_t num_params = {num_params};
@@ -682,8 +704,8 @@ static void sycl_kernel_launch(uint32_t gridX, uint32_t gridY, uint32_t gridZ,
   assert(num_params == expected_num_params && "number of kernel param not matched");
   // Submit the imported kernel.
   auto cgf = [&](sycl::handler &cgh) {{
-    {" ".join(f'set_scalar_arg<{ty_to_cpp(item)}>(cgh, {idx}, params[{idx}]);' for idx, item in enumerate([signature[i] for i in signature if signature[i] != "constexpr"]))}
-    {" ".join(f'set_scalar_arg<{ty_to_cpp(item)}>(cgh, {idx}, params[{idx}]);' for idx, item in enumerate(["*global_scratch", "*profile_scratch"], start=num_params-2))}
+    {" ".join(f"set_scalar_arg<{ty_to_cpp(item)}>(cgh, {idx}, params[{idx}]);" for idx, item in enumerate([signature[i] for i in signature if signature[i] != "constexpr"]))}
+    {" ".join(f"set_scalar_arg<{ty_to_cpp(item)}>(cgh, {idx}, params[{idx}]);" for idx, item in enumerate(["*global_scratch", "*profile_scratch"], start=num_params - 2))}
     if (shared_memory) {{
       using share_mem_t = sycl::local_accessor<int8_t, 1>;
       share_mem_t local_buffer = share_mem_t(shared_memory, cgh);
@@ -775,7 +797,7 @@ extern "C" EXPORT_FUNC PyObject* launch(PyObject* args) {{
 
   {newline.join(ptr_decls)}
   {newline.join(float_storage_decls)}
-  sycl_kernel_launch(gridX, gridY, gridZ, num_warps, threads_per_warp, shared_memory, stream, kernel, global_scratch, profile_scratch{',' + ', '.join(internal_args_list) if len(internal_args_list) > 0 else ''});
+  sycl_kernel_launch(gridX, gridY, gridZ, num_warps, threads_per_warp, shared_memory, stream, kernel, global_scratch, profile_scratch{"," + ", ".join(internal_args_list) if len(internal_args_list) > 0 else ""});
   if (PyErr_Occurred()) {{
     return NULL;
   }}
@@ -819,8 +841,8 @@ def wrap_handle_tensordesc(launcher, signature):
             cur = cur.setdefault(step, {})
 
     def inner(args):
-        meta_args = args[:len(_BASE_ARGS_FORMAT)]
-        kernel_args = args[len(_BASE_ARGS_FORMAT):]
+        meta_args = args[: len(_BASE_ARGS_FORMAT)]
+        kernel_args = args[len(_BASE_ARGS_FORMAT) :]
         wrapped = make_tensordesc_args(
             kernel_args,
             signature_vals,
@@ -837,18 +859,19 @@ def wrap_handle_tensordesc(launcher, signature):
 def serialize_args(args, constants, signature):
     import torch
     import numbers
+
     dir_path = knobs.intel.dump_spirv_kernel_args
     if not os.path.exists(dir_path):
         os.makedirs(dir_path)
         print(f"Path to directory consisting of SPIR-V Runner data: {dir_path}")
 
     def serialize_kernel_metadata(arg, args_dict):
-        args_dict['num_warps'] = arg.num_warps
-        args_dict['threads_per_warp'] = arg.threads_per_warp
-        args_dict['shared_memory'] = arg.shared
-        args_dict['kernel_name'] = arg.name
-        args_dict['spv_name'] = f"{arg.name}.spv"
-        args_dict['build_flags'] = arg.build_flags
+        args_dict["num_warps"] = arg.num_warps
+        args_dict["threads_per_warp"] = arg.threads_per_warp
+        args_dict["shared_memory"] = arg.shared
+        args_dict["kernel_name"] = arg.name
+        args_dict["spv_name"] = f"{arg.name}.spv"
+        args_dict["build_flags"] = arg.build_flags
 
     cnt = 0
     args_dict = {"gridX": int(args[cnt]), "gridY": int(args[cnt + 1]), "gridZ": int(args[cnt + 2])}
@@ -860,49 +883,164 @@ def serialize_args(args, constants, signature):
     # 6: launch_metadata
     # 7: launch_enter_hook
     # 8: launch_exit_hook
-    args_dict['argument_list'] = []
+    args_dict["argument_list"] = []
     counts = {"tensors": 0, "scalars": 0, "karg_cnt": 0}
     cnt += 9
     for arg in args[cnt:]:
-        sig_name = list(signature.keys())[counts['karg_cnt']]
+        sig_name = list(signature.keys())[counts["karg_cnt"]]
         if isinstance(arg, torch.Tensor):
             cpu_tensor = arg.cpu()
             tensor_path = os.path.join(dir_path, f"tensor_{counts['tensors']}.pt")
-            with open(tensor_path, 'wb') as f:
+            with open(tensor_path, "wb") as f:
                 torch.save(cpu_tensor, f)
             new_arg = {
-                "name": f"tensor_{counts['tensors']}", "type": "tensor", "dtype": str(arg.dtype), "ctype":
-                signature[sig_name]
+                "name": f"tensor_{counts['tensors']}",
+                "type": "tensor",
+                "dtype": str(arg.dtype),
+                "ctype": signature[sig_name],
             }
-            args_dict['argument_list'].append(new_arg)
-            counts['tensors'] += 1
+            args_dict["argument_list"].append(new_arg)
+            counts["tensors"] += 1
         if isinstance(arg, numbers.Number):
-            if (counts['karg_cnt'], ) not in constants.keys():
+            if (counts["karg_cnt"],) not in constants.keys():
                 new_arg = {
-                    "name": f"scalarArg_{counts['scalars']}", "type": "scalar", "value": arg, "ctype":
-                    signature[sig_name]
+                    "name": f"scalarArg_{counts['scalars']}",
+                    "type": "scalar",
+                    "value": arg,
+                    "ctype": signature[sig_name],
                 }
-                args_dict['argument_list'].append(new_arg)
-            counts['scalars'] += 1
-        counts['karg_cnt'] += 1
+                args_dict["argument_list"].append(new_arg)
+            counts["scalars"] += 1
+        counts["karg_cnt"] += 1
 
     # Dump argument info as a JSON file
-    json_path = os.path.join(dir_path, 'args_data.json')
-    with open(json_path, 'w') as json_file:
+    json_path = os.path.join(dir_path, "args_data.json")
+    with open(json_path, "w") as json_file:
         import json
+
         json.dump(args_dict, json_file, indent=4)
 
 
-class XPULauncher(object):
+# Size-based type IDs — must match ArgType enum in driver.c.
+_ARG_PTR = 0
+_ARG_1B = 1
+_ARG_2B = 2
+_ARG_4B = 3
+_ARG_8B = 4
 
+# Triton type string -> (size_id, struct pack format).
+# Each slot in the values buffer is exactly 8 bytes; smaller types are
+# zero-padded to fill the slot (little-endian, padding bytes are 'x').
+_TY_INFO: dict[str, tuple[int, str]] = {
+    "i1": (_ARG_1B, "<Bxxxxxxx"),
+    "i8": (_ARG_1B, "<bxxxxxxx"),
+    "i16": (_ARG_2B, "<hxxxxxx"),
+    "i32": (_ARG_4B, "<ixxxx"),
+    "i64": (_ARG_8B, "<q"),
+    "u1": (_ARG_1B, "<Bxxxxxxx"),
+    "u8": (_ARG_1B, "<Bxxxxxxx"),
+    "u16": (_ARG_2B, "<Hxxxxxx"),
+    "u32": (_ARG_4B, "<Ixxxx"),
+    "u64": (_ARG_8B, "<Q"),
+    "fp16": (_ARG_2B, "<exxxxxx"),
+    "fp32": (_ARG_4B, "<fxxxx"),
+    "f32": (_ARG_4B, "<fxxxx"),
+    "fp64": (_ARG_8B, "<d"),
+    "bf16": (_ARG_2B, None),  # special-cased: no struct format letter for bf16
+}
+
+
+def _pack_bf16(val: float) -> bytes:
+    """Pack a Python float as a bf16 value in an 8-byte slot (little-endian)."""
+    raw = struct.pack("<f", float(val))
+    bf16_bits = int.from_bytes(raw, "little") >> 16
+    return struct.pack("<Hxxxxxx", bf16_bits)
+
+
+def _make_generic_launcher(constants, signature):
+    """Return a launcher that calls the precompiled generic_launch C function.
+
+    Arg types are resolved once at init; values are packed into a flat
+    8-bytes-per-slot buffer on every call, avoiding per-kernel icpx compilation.
+    """
+    import triton
+
+    expanded = upstream_expand_signature(signature.values(), tensordesc_meta=None, descriptor_type="*i8")
+
+    def _flatten(sig, out):
+        if isinstance(sig, tuple):
+            for x in sig:
+                _flatten(x, out)
+        else:
+            out.append(sig)
+
+    flat = []
+    for sig in expanded:
+        _flatten(sig, flat)
+
+    type_ids = []
+    pack_fmts = []
+    arg_indices = []
+    for i, ty in enumerate(flat):
+        if ty == "constexpr":
+            continue
+        if ty[0] == "*":
+            type_ids.append(_ARG_PTR)
+            pack_fmts.append("<Q")
+        else:
+            if ty not in _TY_INFO:
+                raise TypeError(f"Unsupported Triton argument type in launcher signature: {ty}")
+            tid, fmt = _TY_INFO[ty]
+            type_ids.append(tid)
+            pack_fmts.append(fmt)
+        arg_indices.append(i)
+
+    type_bytes = bytes(type_ids)
+
+    # Fetch the precompiled launch function once at launcher-creation time,
+    # matching the pattern used by CudaLauncher (utils.launch stored at init).
+    # Note: the static icpx-compiled launcher validates pointer args via
+    # zeMemGetAllocProperties.  That check is intentionally omitted here;
+    # the trade-off is faster launch (no Level Zero round-trip per pointer arg)
+    # at the cost of a less informative error on an invalid pointer.
+    generic_launch_fn = triton.runtime.driver.active.utils.generic_launch
+    if generic_launch_fn is None:
+        raise RuntimeError(
+            "generic_launch not available in the XPU driver shared library. "
+            "Clear ~/.triton/cache and rebuild to pick up the updated driver.c."
+        )
+
+    def launcher(all_args):
+        kernel_args = all_args[9:]
+        buf = bytearray(len(type_ids) * 8)
+        for j, idx in enumerate(arg_indices):
+            val = kernel_args[idx]
+            off = j * 8
+            if type_ids[j] == _ARG_PTR:
+                p = val.data_ptr() if hasattr(val, "data_ptr") else (0 if val is None else int(val))
+                struct.pack_into("<Q", buf, off, p)
+            elif pack_fmts[j] is None:
+                buf[off : off + 8] = _pack_bf16(val)
+            else:
+                struct.pack_into(pack_fmts[j], buf, off, val)
+        generic_launch_fn((*all_args[:9], type_bytes, buf))
+
+    return launcher
+
+
+class XPULauncher(object):
     def __init__(self, src, metadata):
         constants = src.constants if hasattr(src, "constants") else dict()
-        arg_idx = lambda x: (src.fn.arg_names.index(x), ) if isinstance(x, str) else x
+        arg_idx = lambda x: (src.fn.arg_names.index(x),) if isinstance(x, str) else x
         constants = {arg_idx(idx): value for idx, value in constants.items()}
         signature = {idx: value for idx, value in src.signature.items()}
-        src = make_launcher(constants, signature)
-        self.mod = compile_module_from_src(src=src, name="__triton_launcher")
-        self.launch = wrap_handle_tensordesc(self.mod.launch, signature)
+
+        if os.environ.get("TRITON_XPU_GENERIC_LAUNCHER", "1") == "1":
+            self.launch = wrap_handle_tensordesc(_make_generic_launcher(constants, signature), signature)
+        else:
+            launcher_src = make_launcher(constants, signature)
+            self.mod = compile_module_from_src(src=launcher_src, name="__triton_launcher")
+            self.launch = wrap_handle_tensordesc(self.mod.launch, signature)
 
         # Serialize KernelArguments for SPIR-V Runner
         self.serialize_kernel_args = knobs.intel.dump_spirv_kernel_args
@@ -961,7 +1099,6 @@ class XPULauncher(object):
 
 
 class XPUDriver(DriverBase):
-
     def __init__(self):
         self.launcher_cls = XPULauncher
         super().__init__()
@@ -980,6 +1117,7 @@ class XPUDriver(DriverBase):
 
     def get_current_stream(self, device):
         import torch
+
         return torch.xpu.current_stream().sycl_queue
 
     @lru_cache
@@ -992,8 +1130,9 @@ class XPUDriver(DriverBase):
         def update_device_arch(dev_property):
             if not (arch := knobs.intel.device_arch):
                 dirname = os.path.dirname(os.path.realpath(__file__))
-                parser = compile_module_from_src(src=Path(os.path.join(dirname, "arch_parser.c")).read_text(),
-                                                 name="arch_utils")
+                parser = compile_module_from_src(
+                    src=Path(os.path.join(dirname, "arch_parser.c")).read_text(), name="arch_utils"
+                )
                 arch = parser.parse_device_arch(dev_property["architecture"])
             dev_property["arch"] = arch
 
@@ -1019,16 +1158,19 @@ class XPUDriver(DriverBase):
 
     def get_active_torch_device(self):
         import torch
+
         return torch.device("xpu", self.get_current_device())
 
     def get_device_interface(self):
         import torch
+
         return torch.xpu
 
     @staticmethod
     def is_active():
         try:
             import torch
+
             return torch.xpu.is_available()
         except ImportError:
             return False
@@ -1038,6 +1180,7 @@ class XPUDriver(DriverBase):
 
     def get_benchmarker(self):
         from triton.testing import do_bench
+
         return do_bench
 
     def get_empty_cache_for_benchmark(self):
@@ -1047,7 +1190,7 @@ class XPUDriver(DriverBase):
         # before each kernel call to make sure that the L2 cache
         # doesn't contain any input data before the run
         cache_size = 256 * 1024 * 1024
-        return torch.empty(int(cache_size // 4), dtype=torch.int, device='xpu')
+        return torch.empty(int(cache_size // 4), dtype=torch.int, device="xpu")
 
     def clear_cache(self, cache):
         cache.zero_()

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -954,9 +954,12 @@ def _make_generic_launcher(constants, signature):
     expanded = upstream_expand_signature(signature.values(), tensordesc_meta=None, descriptor_type="*i8")
 
     flat_types = []
+    has_tuple_arg = False
 
     def _flatten_types(sig):
+        nonlocal has_tuple_arg
         if isinstance(sig, tuple):
+            has_tuple_arg = True
             for x in sig:
                 _flatten_types(x)
         else:
@@ -970,10 +973,33 @@ def _make_generic_launcher(constants, signature):
     # it correctly (same ctypes/PyDLL calling convention as generic_launch).
     sig_bytes = build_sig_meta((flat_types,))
 
-    def launcher(all_args):
-        # Hot path: pass raw Python objects directly to C.
-        # C side extracts values, allocates on the stack, and calls set_arg.
-        generic_launch_fn((*all_args[:9], sig_bytes, all_args[9:]))
+    if has_tuple_arg:
+        # Some kernel args are tuples (e.g. fn_args, strides).  The C extractor
+        # expects a flat sequence of scalar/pointer values matching flat_types.
+        # We must flatten tuple-typed args while keeping scalar/constexpr args
+        # as single slots (so C's rawIdx accounting stays correct — one slot per
+        # top-level expanded-signature entry for constexpr, one slot per scalar,
+        # and N slots for an N-element tuple).
+        def _flatten_val(val, sig_type, out):
+            """Flatten val according to sig_type structure."""
+            if isinstance(sig_type, tuple):
+                # val should be a tuple of the same length
+                for v, t in zip(val, sig_type):
+                    _flatten_val(v, t, out)
+            else:
+                out.append(val)
+
+        def launcher(all_args):
+            flat = []
+            for v, sig_type in zip(all_args[9:], expanded):
+                _flatten_val(v, sig_type, flat)
+            generic_launch_fn((*all_args[:9], sig_bytes, flat))
+    else:
+
+        def launcher(all_args):
+            # Hot path: pass raw Python objects directly to C.
+            # C side extracts values, allocates on the stack, and calls set_arg.
+            generic_launch_fn((*all_args[:9], sig_bytes, all_args[9:]))
 
     return launcher
 

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -5,7 +5,6 @@ import sys
 import hashlib
 import shutil
 import ctypes
-import struct
 import sysconfig
 import tempfile
 from pathlib import Path
@@ -41,9 +40,11 @@ def find_sycl(include_dir: list[str]) -> tuple[list[str], list[str]]:
       AssertionError: if library was not found.
     """
     include_dir = include_dir.copy()
-    assertion_message = ("sycl headers not found, please install `icpx` compiler, "
-                         "or provide `ONEAPI_ROOT` environment "
-                         "or install `intel-sycl-rt>=2025.0.0` wheel")
+    assertion_message = (
+        "sycl headers not found, please install `icpx` compiler, "
+        "or provide `ONEAPI_ROOT` environment "
+        "or install `intel-sycl-rt>=2025.0.0` wheel"
+    )
     icpx_path = shutil.which("icpx")
     if icpx_path:
         # only `icpx` compiler knows where sycl runtime binaries and header files are
@@ -155,11 +156,10 @@ COMPILATION_HELPER = CompilationHelper()
 
 
 class ArchParser:
-
     def __init__(self, cache_path: str):
         self.shared_library = ctypes.CDLL(cache_path)
         self.shared_library.parse_device_arch.restype = ctypes.c_char_p
-        self.shared_library.parse_device_arch.argtypes = (ctypes.c_uint64, )
+        self.shared_library.parse_device_arch.argtypes = (ctypes.c_uint64,)
 
     def __getattribute__(self, name):
         if name == "parse_device_arch":
@@ -178,43 +178,48 @@ class ArchParser:
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                self.shared_library.dlclose.argtypes = (ctypes.c_void_p, )
+                self.shared_library.dlclose.argtypes = (ctypes.c_void_p,)
                 self.shared_library.dlclose(handle)
     else:
 
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64, )
+                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64,)
                 ctypes.windll.kernel32.FreeLibrary(handle)
 
 
 class SpirvUtils:
-
     def __init__(self, cache_path: str):
         self.shared_library = ctypes.PyDLL(cache_path)
         methods = ("init_devices", "load_binary", "wait_on_sycl_queue", "sycl_queue_memset")
         for method in methods:
             getattr(self.shared_library, method).restype = ctypes.py_object
-            getattr(self.shared_library, method).argtypes = (ctypes.py_object, )
+            getattr(self.shared_library, method).argtypes = (ctypes.py_object,)
         self.shared_library.get_device_properties.restype = ctypes.py_object
-        self.shared_library.get_device_properties.argtypes = (ctypes.c_int, )
+        self.shared_library.get_device_properties.argtypes = (ctypes.c_int,)
         self.shared_library.get_last_selected_build_flags.restype = ctypes.py_object
-        # generic_launch may not exist in older cached builds
+        # generic_launch / buildSignatureMetadata may not exist in older cached builds
         if hasattr(self.shared_library, "generic_launch"):
             self.shared_library.generic_launch.restype = ctypes.py_object
-            self.shared_library.generic_launch.argtypes = (ctypes.py_object, )
+            self.shared_library.generic_launch.argtypes = (ctypes.py_object,)
             self.generic_launch = self.shared_library.generic_launch
         else:
             self.generic_launch = None
+        if hasattr(self.shared_library, "buildSignatureMetadata"):
+            self.shared_library.buildSignatureMetadata.restype = ctypes.py_object
+            self.shared_library.buildSignatureMetadata.argtypes = (ctypes.py_object,)
+            self.build_signature_metadata = self.shared_library.buildSignatureMetadata
+        else:
+            self.build_signature_metadata = None
 
     def __getattribute__(self, name):
         if name in (
-                "get_device_properties",
-                "init_devices",
-                "wait_on_sycl_queue",
-                "get_last_selected_build_flags",
-                "sycl_queue_memset",
+            "get_device_properties",
+            "init_devices",
+            "wait_on_sycl_queue",
+            "get_last_selected_build_flags",
+            "sycl_queue_memset",
         ):
             shared_library = super().__getattribute__("shared_library")
             return getattr(shared_library, name)
@@ -241,14 +246,14 @@ class SpirvUtils:
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                self.shared_library.dlclose.argtypes = (ctypes.c_void_p, )
+                self.shared_library.dlclose.argtypes = (ctypes.c_void_p,)
                 self.shared_library.dlclose(handle)
     else:
 
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64, )
+                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64,)
                 ctypes.windll.kernel32.FreeLibrary(handle)
 
 
@@ -260,7 +265,7 @@ class ExtensionUtils:
         self.shared_library.check_extension.restype = ctypes.py_object
         self.shared_library.check_extension.argtypes = (ctypes.c_int, ctypes.c_char_p)
         self.shared_library.get_device_id.restype = ctypes.py_object
-        self.shared_library.get_device_id.argtypes = (ctypes.c_int, )
+        self.shared_library.get_device_id.argtypes = (ctypes.c_int,)
 
     def check_extension(self, device_id: int, extension: bytes) -> bool:
         return self.shared_library.check_extension(device_id, extension)
@@ -273,23 +278,22 @@ class ExtensionUtils:
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                self.shared_library.dlclose.argtypes = (ctypes.c_void_p, )
+                self.shared_library.dlclose.argtypes = (ctypes.c_void_p,)
                 self.shared_library.dlclose(handle)
     else:
 
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64, )
+                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64,)
                 ctypes.windll.kernel32.FreeLibrary(handle)
 
 
 class TritonLauncher:
-
     def __init__(self, cache_path: str):
         self.shared_library = ctypes.PyDLL(cache_path)
         self.shared_library.launch.restype = ctypes.py_object
-        self.shared_library.launch.argtypes = (ctypes.py_object, )
+        self.shared_library.launch.argtypes = (ctypes.py_object,)
 
     def __getattribute__(self, name):
         if name == "launch":
@@ -303,14 +307,14 @@ class TritonLauncher:
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                self.shared_library.dlclose.argtypes = (ctypes.c_void_p, )
+                self.shared_library.dlclose.argtypes = (ctypes.c_void_p,)
                 self.shared_library.dlclose(handle)
     else:
 
         def __del__(self):
             if hasattr(self, "shared_library"):
                 handle = self.shared_library._handle
-                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64, )
+                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64,)
                 ctypes.windll.kernel32.FreeLibrary(handle)
 
 
@@ -365,7 +369,6 @@ def compile_module_from_src(src: str, name: str):
 
 
 class XPUUtils(object):
-
     def __new__(cls):
         if not hasattr(cls, "instance"):
             cls.instance = super(XPUUtils, cls).__new__(cls)
@@ -383,6 +386,7 @@ class XPUUtils(object):
         self.get_last_selected_build_flags = mod.get_last_selected_build_flags
         self.sycl_queue_memset = mod.sycl_queue_memset
         self.generic_launch = getattr(mod, "generic_launch", None)
+        self.build_signature_metadata = getattr(mod, "build_signature_metadata", None)
         self.unload_module = lambda module: None
 
     def get_current_device(self):
@@ -843,8 +847,8 @@ def wrap_handle_tensordesc(launcher, signature):
             cur = cur.setdefault(step, {})
 
     def inner(args):
-        meta_args = args[:len(_BASE_ARGS_FORMAT)]
-        kernel_args = args[len(_BASE_ARGS_FORMAT):]
+        meta_args = args[: len(_BASE_ARGS_FORMAT)]
+        kernel_args = args[len(_BASE_ARGS_FORMAT) :]
         wrapped = make_tensordesc_args(
             kernel_args,
             signature_vals,
@@ -904,7 +908,7 @@ def serialize_args(args, constants, signature):
             args_dict["argument_list"].append(new_arg)
             counts["tensors"] += 1
         if isinstance(arg, numbers.Number):
-            if (counts["karg_cnt"], ) not in constants.keys():
+            if (counts["karg_cnt"],) not in constants.keys():
                 new_arg = {
                     "name": f"scalarArg_{counts['scalars']}",
                     "type": "scalar",
@@ -923,105 +927,61 @@ def serialize_args(args, constants, signature):
         json.dump(args_dict, json_file, indent=4)
 
 
-# Size-based type IDs — must match ArgType enum in driver.c.
-_ARG_PTR = 0
-_ARG_1B = 1
-_ARG_2B = 2
-_ARG_4B = 3
-_ARG_8B = 4
-
-# Triton type string -> (size_id, struct pack format).
-# Each slot in the values buffer is exactly 8 bytes; smaller types are
-# zero-padded to fill the slot (little-endian, padding bytes are 'x').
-_TY_INFO: dict[str, tuple[int, str]] = {
-    "i1": (_ARG_1B, "<Bxxxxxxx"), "i8": (_ARG_1B, "<bxxxxxxx"), "i16": (_ARG_2B, "<hxxxxxx"), "i32":
-    (_ARG_4B, "<ixxxx"), "i64": (_ARG_8B, "<q"), "u1": (_ARG_1B, "<Bxxxxxxx"), "u8": (_ARG_1B, "<Bxxxxxxx"), "u16":
-    (_ARG_2B, "<Hxxxxxx"), "u32": (_ARG_4B, "<Ixxxx"), "u64": (_ARG_8B, "<Q"), "fp16": (_ARG_2B, "<exxxxxx"), "fp32":
-    (_ARG_4B, "<fxxxx"), "f32": (_ARG_4B, "<fxxxx"), "fp64": (_ARG_8B, "<d"), "bf16":
-    (_ARG_2B, None),  # special-cased: no struct format letter for bf16
-}
-
-
-def _pack_bf16(val: float) -> bytes:
-    """Pack a Python float as a bf16 value in an 8-byte slot (little-endian)."""
-    raw = struct.pack("<f", float(val))
-    bf16_bits = int.from_bytes(raw, "little") >> 16
-    return struct.pack("<Hxxxxxx", bf16_bits)
-
-
 def _make_generic_launcher(constants, signature):
     """Return a launcher that calls the precompiled generic_launch C function.
 
-    Arg types are resolved once at init; values are packed into a flat
-    8-bytes-per-slot buffer on every call, avoiding per-kernel icpx compilation.
+    Matches the CUDA/AMD design:
+    - buildSignatureMetadata is called ONCE at init to convert type strings to
+      a compact bytes blob of extractor indices (cached in sig_bytes).
+    - On every launch the hot path is a single C function call with the raw
+      Python arg objects; all extraction happens in C with alloca (no heap).
     """
     import triton
 
+    utils = triton.runtime.driver.active.utils
+    generic_launch_fn = utils.generic_launch
+    build_sig_meta = utils.build_signature_metadata
+    if generic_launch_fn is None or build_sig_meta is None:
+        raise RuntimeError(
+            "generic_launch / buildSignatureMetadata not available in the XPU "
+            "driver shared library. Clear ~/.triton/cache and rebuild to pick "
+            "up the updated driver.c."
+        )
+
+    # Build a flat list of Triton type strings (including "constexpr" entries)
+    # that mirrors the expanded kernel signature.  buildSignatureMetadata maps
+    # each entry to an ExtractorIndex byte; "constexpr" → EX_UNKNOWN (0).
     expanded = upstream_expand_signature(signature.values(), tensordesc_meta=None, descriptor_type="*i8")
 
-    def _flatten(sig, out):
+    flat_types = []
+
+    def _flatten_types(sig):
         if isinstance(sig, tuple):
             for x in sig:
-                _flatten(x, out)
+                _flatten_types(x)
         else:
-            out.append(sig)
+            flat_types.append(sig)
 
-    flat = []
     for sig in expanded:
-        _flatten(sig, flat)
+        _flatten_types(sig)
 
-    type_ids = []
-    pack_fmts = []
-    arg_indices = []
-    for i, ty in enumerate(flat):
-        if ty == "constexpr":
-            continue
-        if ty[0] == "*":
-            type_ids.append(_ARG_PTR)
-            pack_fmts.append("<Q")
-        else:
-            if ty not in _TY_INFO:
-                raise TypeError(f"Unsupported Triton argument type in launcher signature: {ty}")
-            tid, fmt = _TY_INFO[ty]
-            type_ids.append(tid)
-            pack_fmts.append(fmt)
-        arg_indices.append(i)
-
-    type_bytes = bytes(type_ids)
-
-    # Fetch the precompiled launch function once at launcher-creation time,
-    # matching the pattern used by CudaLauncher (utils.launch stored at init).
-    # Note: like the static icpx-compiled launcher, generic_launch validates
-    # pointer args via zeMemGetAllocProperties by default.  Set
-    # TRITON_XPU_VALIDATE_POINTERS=0 to skip validation for faster launch.
-    generic_launch_fn = triton.runtime.driver.active.utils.generic_launch
-    if generic_launch_fn is None:
-        raise RuntimeError("generic_launch not available in the XPU driver shared library. "
-                           "Clear ~/.triton/cache and rebuild to pick up the updated driver.c.")
+    # One-time call: produces a bytes object cached for all subsequent launches.
+    # Wrap in a 1-tuple so the C-side PyArg_ParseTuple(args, "O", ...) unpacks
+    # it correctly (same ctypes/PyDLL calling convention as generic_launch).
+    sig_bytes = build_sig_meta((flat_types,))
 
     def launcher(all_args):
-        kernel_args = all_args[9:]
-        buf = bytearray(len(type_ids) * 8)
-        for j, idx in enumerate(arg_indices):
-            val = kernel_args[idx]
-            off = j * 8
-            if type_ids[j] == _ARG_PTR:
-                p = val.data_ptr() if hasattr(val, "data_ptr") else (0 if val is None else int(val))
-                struct.pack_into("<Q", buf, off, p)
-            elif pack_fmts[j] is None:
-                buf[off:off + 8] = _pack_bf16(val)
-            else:
-                struct.pack_into(pack_fmts[j], buf, off, val)
-        generic_launch_fn((*all_args[:9], type_bytes, buf))
+        # Hot path: pass raw Python objects directly to C.
+        # C side extracts values, allocates on the stack, and calls set_arg.
+        generic_launch_fn((*all_args[:9], sig_bytes, all_args[9:]))
 
     return launcher
 
 
 class XPULauncher(object):
-
     def __init__(self, src, metadata):
         constants = src.constants if hasattr(src, "constants") else dict()
-        arg_idx = lambda x: (src.fn.arg_names.index(x), ) if isinstance(x, str) else x
+        arg_idx = lambda x: (src.fn.arg_names.index(x),) if isinstance(x, str) else x
         constants = {arg_idx(idx): value for idx, value in constants.items()}
         signature = {idx: value for idx, value in src.signature.items()}
 
@@ -1089,7 +1049,6 @@ class XPULauncher(object):
 
 
 class XPUDriver(DriverBase):
-
     def __init__(self):
         self.launcher_cls = XPULauncher
         super().__init__()
@@ -1121,8 +1080,9 @@ class XPUDriver(DriverBase):
         def update_device_arch(dev_property):
             if not (arch := knobs.intel.device_arch):
                 dirname = os.path.dirname(os.path.realpath(__file__))
-                parser = compile_module_from_src(src=Path(os.path.join(dirname, "arch_parser.c")).read_text(),
-                                                 name="arch_utils")
+                parser = compile_module_from_src(
+                    src=Path(os.path.join(dirname, "arch_parser.c")).read_text(), name="arch_utils"
+                )
                 arch = parser.parse_device_arch(dev_property["architecture"])
             dev_property["arch"] = arch
 


### PR DESCRIPTION
The background is that during the Helion test, we found that the XPU's launch time is significant longer than CUDA. The root cause it that XPU makes the launcher with template, and requires to compile everytime.

```python
            launcher_src = make_launcher(constants, signature)
            self.mod = compile_module_from_src(src=launcher_src, name="__triton_launcher")
            self.launch = wrap_handle_tensordesc(self.mod.launch, signature)
```
The generic launcher is to wrap everything into a pre-compiled .so , and avoid this compile time.

By default enabled for test purpose, use `TRITON_XPU_GENERIC_LAUNCHER=0` to disable, 

**Note:**

1. The code is totally written with github-copilot for fast validation. Please feel free to create a new branch if you wish. 
2. This is slightly different with static launcher. Static launcher also reduced this launch time, but we got case when the tests called `fresh_cache()` before test. So we have to find `/tmp/tmp_111/triton_key` and then `/tmp/tmp_2222/triton_key`, thus although the `triton_key` is the same, it still compile due to the cache miss. Both CUDA/XPU suffers this, but CUDA has significantly smaller compile time because they don't need to recompile.
3. This implementation will increase the `triton.so`'s size, please be aware of that and check whether this is acceptable.

