### PR TITLE
[vLLM][Scripts] Remove sed search and replace (cuda -> xpu) commands

### DIFF
--- a/benchmarks/vllm/Agents.md
+++ b/benchmarks/vllm/Agents.md
@@ -9,7 +9,7 @@ For the purposes of this repository, vllm installation consists of:
 1. Activating a Python environment that has triton, pytorch, oneapi
 2. Running [`scripts/test-triton.sh --install-vllm`](../../scripts/test-triton.sh)
 
-This installation internally will clone the vllm repo into a local folder, checkout the commit pinned via [`vllm-pin.txt`](vllm-pin.txt), apply our local patch [`vllm-fix.patch`](vllm-fix.patch), and apply some regexp changes to the vllm repo.
+This installation internally will clone the vllm repo into a local folder, checkout the commit pinned via [`vllm-pin.txt`](vllm-pin.txt), apply our local patch [`vllm-fix.patch`](vllm-fix.patch), and apply other common substitutions defined in [`vllm-xpu-patch.py`](../../scripts/vllm/vllm_xpu_patch.py).
 
 These patches are necessary because vllm doesn't yet support XPU completely.
 

--- a/scripts/vllm/install-vllm.sh
+++ b/scripts/vllm/install-vllm.sh
@@ -156,13 +156,6 @@ function patch_vllm {
     echo "**** vllm-fix.patch already applied or conflicts, skipping. ****"
   fi
 
-  # Targeted sed transformations for kernel test files
-  sed -i 's/device="cuda"/device="xpu"/g' \
-    tests/kernels/moe/utils.py \
-    tests/kernels/attention/test_triton_unified_attention.py
-  sed -i 's/set_default_device("cuda")/set_default_device("xpu")/g' \
-    tests/kernels/attention/test_triton_unified_attention.py
-
   # AST-based XPU adaptation for spec_decode/mrv2 test files
   python "$SCRIPTS_DIR/vllm/vllm_xpu_patch.py" "$VLLM_PROJ"
 


### PR DESCRIPTION
This patch removes some unnecessary sed replacement commands. These replacements should be done in `scripts/vllm/vllm-xpu-patch.py`. This patch also updates Agent docs to reflect the change.

vLLM tests: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24263750909
vLLM benchmarks: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24263763275
vLLM benchmarks BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24263775346