### PR TITLE
Use LoopAwareCSE in make_ttgir to reduce register pressure

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -318,12 +318,12 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         if (opt.reduce_variable_liveness):
             intel.passes.ttgpuir.add_reduce_variable_liveness(pm)
 
+        passes.ttir.add_loop_aware_cse(pm)
         passes.ttgpuir.add_fuse_nested_loops(pm)
 
         passes.common.add_canonicalizer(pm)
         passes.ttir.add_triton_licm(pm)
         passes.common.add_canonicalizer(pm)
-        passes.ttir.add_loop_aware_cse(pm)
         passes.ttgpuir.add_combine_tensor_select_and_if(pm)
 
         passes.ttgpuir.add_optimize_thread_locality(pm)

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -323,6 +323,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         passes.common.add_canonicalizer(pm)
         passes.ttir.add_triton_licm(pm)
         passes.common.add_canonicalizer(pm)
+        passes.ttir.add_loop_aware_cse(pm)
         passes.ttgpuir.add_combine_tensor_select_and_if(pm)
 
         passes.ttgpuir.add_optimize_thread_locality(pm)
@@ -333,7 +334,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         intel.passes.ttgpuir.add_remove_layout_conversions(pm)
         intel.passes.ttgpuir.add_reduce_data_duplication(pm)
         passes.ttgpuir.add_reorder_instructions(pm)
-        passes.common.add_cse(pm)
+        passes.ttir.add_loop_aware_cse(pm)
         passes.common.add_symbol_dce(pm)
         passes.common.add_sccp(pm)
         passes.common.add_canonicalizer(pm)


### PR DESCRIPTION
- Add upstream `LoopAwareCSE` pass to `make_ttgir`, aligning with NVIDIA/AMD backends
- Replace the final standard CSE with LoopAwareCSE (strict superset — runs standard CSE internally)

Closes #6649