### PR TITLE
Revert "Enable TRITON_INTEL_PREDICATED_LOAD" (#6605)

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -463,19 +463,18 @@ struct LoadStoreConversionBase {
     // There's an IGC bug with predicated load so it is disabled by default.
     // On the other hand, predicated store is expected to be correct and it is
     // enabled by default. Both can be overridden by env vars.
-    static const std::optional<bool> usePredicatedLoad =
-        tools::isEnvValueBool(tools::getStrEnv("TRITON_INTEL_PREDICATED_LOAD"));
+    static const bool canUsePredicatedLoad =
+        tools::getBoolEnv("TRITON_INTEL_PREDICATED_LOAD");
     static const std::optional<bool> usePredicatedStore = tools::isEnvValueBool(
         tools::getStrEnv("TRITON_INTEL_PREDICATED_STORE"));
 
     // SPIRV predicated load/store does not support volatile qualifier.
     if constexpr (std::is_same_v<OpType, LoadOp>) {
-      return (!usePredicatedLoad.has_value() || usePredicatedLoad.value()) &&
-             !op.getIsVolatile();
+      return canUsePredicatedLoad && !op.getIsVolatile();
     } else if constexpr (std::is_same_v<OpType, StoreOp>) {
       return !usePredicatedStore.has_value() || usePredicatedStore.value();
     } else if constexpr (std::is_same_v<OpType, DescriptorLoadOp>) {
-      return !usePredicatedLoad.has_value() || usePredicatedLoad.value();
+      return canUsePredicatedLoad;
     } else if constexpr (std::is_same_v<OpType, DescriptorStoreOp>) {
       return !usePredicatedStore.has_value() || usePredicatedStore.value();
     }


### PR DESCRIPTION
## Summary

Reverts commit eb4d690f1 which changed `TRITON_INTEL_PREDICATED_LOAD` from opt-in (default off) to opt-out (default on). This causes 40 persistent matmul test failures on Xe2 (B580, B60) with wildly incorrect numerical results (100x+ over tolerance) and spurious infinities.

Fixes #6656

## Bisect results

The regression window was narrowed to 3 commits between `98a682b` (clean, Apr 10) and `a2bad4a` (broken, Apr 11) by inspecting actual assertion errors in triton-kernels logs across both B580 and B60 runners:

- **Revert both `eb4d690` + `a2bad4a`**: [passed](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24370020901) — 1763 passed, 0 failed
- **Revert only `eb4d690`** (keep sanitize-overflow): [passed](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24374798257) — confirms `eb4d690` is the sole cause

All 40 failing tests are persistent matmul configurations (`is_persistent=True`) in `test_matmul.py::test_op` with bfloat16/float16 dtypes, batched/ragged modes, and SwiGLU epilogues.

## What changed

The commit changed predicated load from **opt-in** to **opt-out**:

```cpp
// Before (opt-in, default off):
static const bool canUsePredicatedLoad =
    tools::getBoolEnv("TRITON_INTEL_PREDICATED_LOAD");

// After (opt-out, default on):
static const std::optional<bool> usePredicatedLoad =
    tools::isEnvValueBool(tools::getStrEnv("TRITON_INTEL_PREDICATED_LOAD"));
// ...
return (!usePredicatedLoad.has_value() || usePredicatedLoad.value()) && ...
```

The original code comment notes: *"There's an IGC bug with predicated load so it is disabled by default."*

## Test plan

- [x] B580 triton-kernels pass (verified via bisect runs above)
- [x] Pre-commit checks
- [x] Standard CI integration tests