### PR TITLE
[Python] Lower block pointers to tensor descriptors in frontend

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1710,7 +1710,7 @@ def _canonicalize_block_ptr_static_tuple(values, name: str, *, positive: bool = 
     return tuple(converted)
 
 
-def _canonicalize_block_ptr_dynamic_tuple(values, name: str, _semantic) -> tuple:
+def _canonicalize_block_ptr_dynamic_tuple(values, name: str, _semantic, target_dtype=int64) -> tuple:
     converted = []
     for value in _as_list_like(values):
         value = _semantic.to_tensor(value)
@@ -1718,8 +1718,8 @@ def _canonicalize_block_ptr_dynamic_tuple(values, name: str, _semantic) -> tuple
             raise ValueError(f"Expected `{name}` entries to be scalar tensors")
         if not value.dtype.is_int():
             raise ValueError(f"Expected `{name}` entries to be integers")
-        if value.dtype != int64:
-            value = _semantic.cast(value, int64)
+        if value.dtype != target_dtype:
+            value = _semantic.cast(value, target_dtype)
         converted.append(value)
     return tuple(converted)
 
@@ -1747,6 +1747,7 @@ class _block_ptr:
     offsets: tuple
     block_shape: tuple
     order: tuple
+    _inner_stride_one: constexpr
 
     __triton_block_ptr__ = True
 
@@ -1756,10 +1757,15 @@ class _block_ptr:
         if isinstance(base.type.element_ty, block_type):
             raise ValueError("Expected `base` to point to a scalar element type")
 
+        # Check if inner stride is constant 1 before canonicalization converts to IR tensors.
+        last_stride_val = _unwrap_if_constexpr(_as_list_like(strides)[-1])
+        inner_stride_is_one = isinstance(last_stride_val, int) and last_stride_val == 1
+        self._inner_stride_one = constexpr(inner_stride_is_one)
+
         self.base = base
         self.shape = _canonicalize_block_ptr_dynamic_tuple(shape, "shape", _semantic)
         self.strides = _canonicalize_block_ptr_dynamic_tuple(strides, "strides", _semantic)
-        self.offsets = _canonicalize_block_ptr_dynamic_tuple(offsets, "offsets", _semantic)
+        self.offsets = _canonicalize_block_ptr_dynamic_tuple(offsets, "offsets", _semantic, target_dtype=int32)
         self.block_shape = _canonicalize_block_ptr_static_tuple(block_shape, "block_shape", positive=True)
         self.order = _canonicalize_block_ptr_static_tuple(order, "order")
 
@@ -1799,13 +1805,48 @@ class _block_ptr:
 
     def advance(self, offsets, _semantic=None):
         new_offsets = []
-        offsets = _canonicalize_block_ptr_dynamic_tuple(offsets, "offsets", _semantic)
+        offsets = _canonicalize_block_ptr_dynamic_tuple(offsets, "offsets", _semantic, target_dtype=int32)
         if len(offsets) != len(self.offsets):
             raise ValueError(f"Expected `offsets` to have length {len(self.offsets)} but received {len(offsets)}")
         for old_offset, delta in zip(self.offsets, offsets):
             new_offsets.append(add(old_offset, delta, _semantic=_semantic))
-        return _block_ptr(self.base, self.shape, self.strides, tuple(new_offsets), self.block_shape, self.order,
-                          _semantic=_semantic)
+        result = _block_ptr(self.base, self.shape, self.strides, tuple(new_offsets), self.block_shape, self.order,
+                            _semantic=_semantic)
+        # Propagate stride eligibility since self.strides are already tensors
+        # and _unwrap_if_constexpr won't recover the original int value.
+        result._inner_stride_one = self._inner_stride_one
+        return result
+
+    def _is_tdesc_eligible(self, boundary_check, _semantic):
+        """Check if this block pointer can be lowered to a tensor descriptor."""
+        if not hasattr(_semantic, 'builder') or not hasattr(_semantic.builder, 'options'):
+            return False
+        if _semantic.builder.options.backend_name != 'intel':
+            return False
+        if not self._inner_stride_one.value:
+            return False
+        rank = len(self._tile_shape())
+        checked_dims = _canonicalize_block_ptr_boundary_check(boundary_check, rank)
+        return checked_dims == set(builtins.range(rank))
+
+    def _make_tensor_desc(self, padding_option, _semantic):
+        """Create a MakeTensorDescOp and return a tensor_descriptor_base."""
+        base = self.base
+        if base.type.element_ty == int1:
+            base = _semantic.cast(base, pointer_type(int8, base.type.address_space))
+        elem_ty = base.type.element_ty
+        is_signed = elem_ty.is_int_signed()
+        padding = _semantic._str_to_padding_option(padding_option)
+        if padding is None:
+            padding = ir.PADDING_OPTION.PAD_ZERO
+        if elem_ty.is_int() and padding == ir.PADDING_OPTION.PAD_NAN:
+            raise ValueError("Padding option `nan` is not supported for integer block pointers")
+        shape_handles = [_semantic.cast(s, int32).handle for s in self.shape]
+        stride_handles = [s.handle for s in self.strides]
+        block_shape_ints = self._tile_shape()
+        handle = _semantic.builder.create_make_tensor_descriptor(base.handle, shape_handles, stride_handles,
+                                                                 block_shape_ints, is_signed, padding)
+        return tensor_descriptor_base(handle, block_type(elem_ty, block_shape_ints))
 
     def load(self, mask=None, other=None, boundary_check=(), padding_option="", cache_modifier="", eviction_policy="",
              volatile=False, _semantic=None):
@@ -1818,6 +1859,11 @@ class _block_ptr:
         volatile = _unwrap_if_constexpr(volatile)
         if padding_option is None:
             padding_option = ""
+
+        if self._is_tdesc_eligible(boundary_check, _semantic):
+            desc = self._make_tensor_desc(padding_option or "zero", _semantic)
+            return _semantic.descriptor_load(desc, list(self.offsets), cache_modifier or "", eviction_policy or "")
+
         ptrs, mask = self._materialize(boundary_check, _semantic=_semantic)
 
         if padding_option == "":
@@ -1840,6 +1886,13 @@ class _block_ptr:
 
         cache_modifier = _unwrap_if_constexpr(cache_modifier)
         eviction_policy = _unwrap_if_constexpr(eviction_policy)
+
+        if self._is_tdesc_eligible(boundary_check, _semantic):
+            desc = self._make_tensor_desc("zero", _semantic)
+            value = _semantic.to_tensor(value)
+            value = _semantic.cast(value, desc.dtype)
+            return _semantic.descriptor_store(desc, value, list(self.offsets))
+
         ptrs, mask = self._materialize(boundary_check, _semantic=_semantic)
         return store(ptrs, value, mask=mask, cache_modifier=cache_modifier, eviction_policy=eviction_policy,
                      _semantic=_semantic)
@@ -2428,6 +2481,11 @@ def load(pointer, mask=None, other=None, boundary_check=(), padding_option="", c
     :param volatile: changes volatile option in NVIDIA PTX
     :type volatile: bool, optional
     """
+    if _is_block_ptr(pointer):
+        return pointer.load(mask=mask, other=other, boundary_check=boundary_check, padding_option=padding_option,
+                            cache_modifier=cache_modifier, eviction_policy=eviction_policy, volatile=volatile,
+                            _semantic=_semantic)
+
     # `mask` and `other` can be constexpr
     mask = _unwrap_if_constexpr(mask)
     other = _unwrap_if_constexpr(other)
@@ -2498,6 +2556,10 @@ def store(pointer, value, mask=None, boundary_check=(), cache_modifier="", evict
     :param eviction_policy: changes eviction policy in NVIDIA PTX
     :type eviction_policy: str, optional, should be one of {"", "evict_first", "evict_last"}
     """
+    if _is_block_ptr(pointer):
+        return pointer.store(value, mask=mask, boundary_check=boundary_check, cache_modifier=cache_modifier,
+                             eviction_policy=eviction_policy, _semantic=_semantic)
+
     # `value` can be constexpr
     value = _semantic.to_tensor(value)
     mask = _unwrap_if_constexpr(mask)
@@ -2521,7 +2583,8 @@ def make_block_ptr(base: tensor, shape, strides, offsets, block_shape, order, _s
     :param order: The order of the original data format
     """
     warn("tl.make_block_ptr is deprecated. Use TensorDescriptor or tl.make_tensor_descriptor instead.")
-    return _semantic.make_block_ptr(base, shape, strides, offsets, block_shape, order)
+    base = _semantic.to_tensor(base)
+    return _block_ptr(base, shape, strides, offsets, block_shape, order, _semantic=_semantic)
 
 
 @must_use_result(
@@ -2536,7 +2599,9 @@ def advance(base, offsets, _semantic=None):
     :param base: the block pointer to advance
     :param offsets: the offsets to advance, a tuple by dimension
     """
-    return _semantic.advance(base, offsets)
+    if _is_block_ptr(base):
+        return base.advance(offsets, _semantic=_semantic)
+    raise ValueError("`tl.advance` only supports block pointers created by `tl.make_block_ptr`")
 
 
 @builtin


### PR DESCRIPTION
Make `tl.make_block_ptr` return a Python-level `_block_ptr` object instead of emitting `MakeTensorPtrOp` IR. 
At load/store time, if the block pointer is eligible (XPU backend, inner stride == 1, all dims boundary-checked), emit `MakeTensorDescOp`/`DescriptorLoadOp`/ `DescriptorStoreOp` directly. Otherwise, fall back to the existing `_block_ptr._materialize()` path which expands to pointer arithmetic.