### PR TITLE
Remove CPU RAM check from gemm_postop_addmatrix int8 benchmark

### DIFF
--- a/benchmarks/setup.py
+++ b/benchmarks/setup.py
@@ -114,7 +114,6 @@ setup(
         "torch>=2.6",
         "pandas<3.0",
         "scipy",
-        "psutil",
         "tabulate",
         "matplotlib",
     ],

--- a/benchmarks/triton_kernels_benchmark/gemm_postop_addmatrix_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_postop_addmatrix_benchmark.py
@@ -12,7 +12,6 @@ import triton
 import triton.language as tl
 
 import triton_kernels_benchmark as benchmark_suite
-import psutil
 
 INT8_ONLY_OPTION = os.getenv('INT8_ONLY', '0') == '1'
 ALL_DTYPES_OPTION = os.getenv('ALL_DTYPES', '0') == '1'
@@ -252,7 +251,6 @@ X_VALS = [[1, 1024 * i, 1024 * i, 1024 * i, dtype]
 
 DEVICE_NAME = torch.xpu.get_device_name()
 DEVICE_TOTAL_MEMORY = torch.xpu.get_device_properties().total_memory
-RAM_TOTAL = psutil.virtual_memory().total
 
 # keep in sync with `def dtypes`
 DTYPES_SIZE = {
@@ -274,15 +272,6 @@ def is_enough_memory(x_val):
     enough_memory = required_memory < DEVICE_TOTAL_MEMORY
     if not enough_memory:
         print(f"'{x_val}' combination skipped for '{DEVICE_NAME}'; {required_memory=} but {DEVICE_TOTAL_MEMORY=}")
-    if enough_memory and not dtype.is_floating_point:
-        # a: (B, M, K, int32)
-        # b: (B, K, N, int32)
-        # torch.matmul result: (B, M, N) int32
-        size = 4
-        required_memory = B * M * K * size + B * K * N * size + B * M * N * size
-        enough_memory = required_memory < RAM_TOTAL
-        if not enough_memory:
-            print(f"'{x_val}' combination skipped for '{DEVICE_NAME}'; {required_memory=} but {RAM_TOTAL=}")
     return enough_memory
 
 
@@ -339,12 +328,7 @@ def benchmark(B, M, N, K, dtype, provider):
             assert len(a.shape) == 2, 'Expecting shape of length 2'
             c = torch.empty((M, N), device='xpu', dtype=res_dtype)
         triton_fn = lambda: matmul(a, b, d, c)
-        if not dtype.is_floating_point:
-            # Torch does not support integer calculation in matmul
-            torch_fn = lambda: torch.matmul(a.to(device='cpu', dtype=res_dtype), b.to(device='cpu', dtype=res_dtype)
-                                            ).to(device='xpu', dtype=res_dtype).add_(d)
-        else:
-            torch_fn = lambda: torch.matmul(a, b).add_(d)
+        torch_fn = lambda: torch.matmul(a, b).add_(d)
         rtol = 1e-2 if a.dtype == torch.bfloat16 else 1e-3
         if dtype.is_floating_point or [B, M, N, K] in [[1, 1024, 1024, 1024], [1, 2048, 2048, 2048],
                                                        [1, 512, 8192, 32768], [4, 32768, 4096, 128]]:


### PR DESCRIPTION
The int8 validation path was copying tensors to CPU for torch.matmul, requiring a host RAM gate that caused different shapes to run on machines with different system memory. Since torch.matmul with int8 works on XPU (already used by the onednn provider), use the GPU path for validation too and drop the psutil dependency.

Fixes partial #6509

BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24491007630
PVC: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24491021644