### PR TITLE
[XPU][DRIVER] reorder PyKernelArgType fields to match C++17 declaration order; fix for g++

### DIFF
--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -564,9 +564,9 @@ static PyTypeObject PyKernelArgType = {
     .tp_itemsize = 0,
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_doc = "Kernel Argument Metadata",
-    .tp_new = PyType_GenericNew,
-    .tp_init = (initproc)PyKernelArg_init,
     .tp_dealloc = (destructor)PyKernelArg_dealloc,
+    .tp_init = (initproc)PyKernelArg_init,
+    .tp_new = PyType_GenericNew,
 };
 
 static inline void gpuAssert(ze_result_t code, const char *file, int line) {


### PR DESCRIPTION
During helion tests, we got the error:

```
2026-04-16T06:02:53.7778315Z E               subprocess.CalledProcessError: Command '['/usr/bin/g++', '/tmp/tmpjxtmxl9o/main.cpp', '-O3', '-shared', '-Wno-psabi', '-fPIC', '-lsycl', '-lze_loader', '-L/__w/helion/helion/.venv/lib', '-L/__w/helion/helion/.venv/lib', '-L/__w/helion/helion/.venv/lib', '-L/__w/helion/helion/.venv/lib', '-L/__w/helion/helion/.venv/lib/python3.12/site-packages/triton/backends/intel/lib', '-I/usr/local/include', '-I/__w/helion/helion/.venv/include', '-I/__w/helion/helion/.venv/include', '-I/__w/helion/helion/.venv/lib/python3.12/site-packages/triton/backends/intel/include', '-I/tmp/tmpjxtmxl9o', '-I/opt/conda/include/python3.12', '-o', '/tmp/tmpjxtmxl9o/spirv_utils.cpython-312-x86_64-linux-gnu.so', '-Wl,-rpath,/__w/helion/helion/.venv/lib', '-Wl,-rpath,/__w/helion/helion/.venv/lib', '-Wl,-rpath,/__w/helion/helion/.venv/lib', '-Wl,-rpath,/__w/helion/helion/.venv/lib', '--std=c++17', '-Wno-deprecated-declarations', '-DSYCL_DISABLE_FSYCL_SYCLHPP_WARNING']' returned non-zero exit status 1.

2026-04-16T06:02:53.7750156Z             subprocess.run(cc_cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
2026-04-16T06:02:53.7750265Z         except subprocess.CalledProcessError as e:
2026-04-16T06:02:53.7750366Z             output = e.stdout.decode(*SUBPROCESS_DECODE_ARGS)
2026-04-16T06:02:53.7750432Z >           raise RuntimeError(output)
2026-04-16T06:02:53.7750788Z E           RuntimeError: /tmp/tmpt9awco48/main.cpp: In function ‘int PyKernelArg_init(PyKernelArgObject*, PyObject*, PyObject*)’:
2026-04-16T06:02:53.7751091Z E           /tmp/tmpt9awco48/main.cpp:545:28: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
2026-04-16T06:02:53.7751207Z E             545 |   static char *kwlist[] = {"nested_tuple", "type", NULL};
2026-04-16T06:02:53.7751284Z E                 |                            ^~~~~~~~~~~~~~
2026-04-16T06:02:53.7751579Z E           /tmp/tmpt9awco48/main.cpp:545:44: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
2026-04-16T06:02:53.7751689Z E             545 |   static char *kwlist[] = {"nested_tuple", "type", NULL};
2026-04-16T06:02:53.7751769Z E                 |                                            ^~~~~~
2026-04-16T06:02:53.7751859Z E           /tmp/tmpt9awco48/main.cpp: At global scope:
2026-04-16T06:02:53.7752316Z E           /tmp/tmpt9awco48/main.cpp:570:1: error: designator order for field ‘_typeobject::tp_init’ does not match declaration order in ‘PyTypeObject’ {aka ‘_typeobject’}
2026-04-16T06:02:53.7752372Z E             570 | };
2026-04-16T06:02:53.7752426Z E                 | ^
2026-04-16T06:02:53.7752430Z 
2026-04-16T06:02:53.7752570Z .venv/lib/python3.12/site-packages/triton/runtime/build.py:153: RuntimeError
```

So need to reorder the PyKernelArgType fields to make it work with g++. 