### PR TITLE
[MaterializeBlockPointer] Restrict 1D strided store reshape to single row tiles

### DIFF
--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-llvm.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-llvm.mlir
@@ -13,7 +13,6 @@
 #blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
   // CHECK-LABEL: llvm.func spir_kernelcc @test_1d_reshape_to_2d_blockstore
-  // CHECK: triton_gen.2Dblockstore {{.*}} {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = Default}
   // CHECK-NOT: triton_gen.2Dblockstore
   tt.func @test_1d_reshape_to_2d_blockstore(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<1024xf16, #blocked1d>) {
     %idx = tt.make_range {start = 0 : i32, end = 1024 : i32} : tensor<1024xi32, #blocked1d>
@@ -38,7 +37,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
   // CHECK-LABEL: llvm.func spir_kernelcc @test_1d_reshape_dense_true_mask
-  // CHECK: triton_gen.2Dblockstore {{.*}} {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = Default}
   // CHECK-NOT: triton_gen.2Dblockstore
   tt.func @test_1d_reshape_dense_true_mask(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<1024xf16, #blocked1d>) {
     %idx = tt.make_range {start = 0 : i32, end = 1024 : i32} : tensor<1024xi32, #blocked1d>

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape.mlir
@@ -19,9 +19,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %off = arith.addi %rem, %mul : tensor<1024xi32, #blocked1d>
     %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked1d>
     %ptrs = tt.addptr %base, %off : tensor<1024x!tt.ptr<f16>, #blocked1d>, tensor<1024xi32, #blocked1d>
-    // CHECK: tt.reshape
-    // CHECK: tt.reshape
-    // CHECK: tt.store %{{.*}}, %{{.*}} {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64} : tensor<32x32x!tt.ptr<f16>
+    // CHECK-NOT: tt.reshape
+    // CHECK: tt.store %{{.*}}, %{{.*}} : tensor<1024x!tt.ptr<f16>
     tt.store %ptrs, %arg1 : tensor<1024x!tt.ptr<f16>, #blocked1d>
     tt.return
   }
@@ -47,8 +46,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked1d>
     %ptrs = tt.addptr %base, %off : tensor<1024x!tt.ptr<f16>, #blocked1d>, tensor<1024xi32, #blocked1d>
     %mask = arith.constant dense<true> : tensor<1024xi1, #blocked1d>
-    // CHECK: tt.reshape
-    // CHECK: tt.store %{{.*}}, %{{.*}} {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64} : tensor<32x32x!tt.ptr<f16>
+    // CHECK-NOT: tt.reshape
+    // CHECK: tt.store %{{.*}}, %{{.*}}, %{{.*}} : tensor<1024x!tt.ptr<f16>
     tt.store %ptrs, %arg1, %mask : tensor<1024x!tt.ptr<f16>, #blocked1d>
     tt.return
   }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -515,6 +515,14 @@ private:
     }
     int64_t H = numElements / W;
 
+    // TODO: The 2D block store lowering in StoreOpToBlockIOConversion
+    // does not correctly handle multi-row tiles (H > 1) because offsetY
+    // is hardcoded to 0. Restrict to H == 1 until the lowering is fixed.
+    if (H != 1) {
+      LDBG("H=" << H << " > 1 not yet supported, skip 1D reshape");
+      return;
+    }
+
     LDBG("Detected strided pattern: W=" << W << ", H=" << H << ", S=" << S);
 
     // 4b. Validate HW constraints for 2D block store.


### PR DESCRIPTION
reshape1DStridedStore() reshapes 1D store [N] -> 2D [H, W] for block IO. When H > 1, the 2D block store writes data to wrong positions.

W/A: skip when H > 1.

Related to this this issue #6634 , fixes densenet121, phlippe_densenet, ghostnet_100 fail_accuracy (reshape1DStridedStore)