### PR TITLE
[NFC] Remove remaining Intel block pointer references

### DIFF
--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -31,8 +31,6 @@ def L2Cache : Resource<"::mlir::triton::gpu::intel::L2Cache">;
 class TTIG_Op<string mnemonic, list<Trait> traits = []> :
     Op<TritonIntelGPU_Dialect, mnemonic, !listconcat(traits, [VerifyMemDescLayoutsTrait])>;
 
-def TT_TensorOrTensorPtr : AnyTypeOf<[TT_Tensor, TT_TensorPtr]>;
-
 def TTIG_AllocOp : TTIG_Op<"alloc", [MemoryEffects<[MemAlloc]>]> {
   let summary = "Memory allocation operation";
   let description = [{
@@ -63,7 +61,7 @@ def TTIG_PrefetchOp : TTIG_Op<"prefetch", [
       ```
   }];
   let arguments = (ins
-    Arg<AnyTypeOf<[TT_PtrLike, TT_TensorPtr]>, "Global memory pointer", [MemRead]>:$ptr,
+    Arg<TT_PtrLike, "Global memory pointer", [MemRead]>:$ptr,
     Optional<TT_BoolLike>:$mask,
     TT_CacheModifierAttr:$cache,
     TT_EvictionPolicyAttr:$evict,

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/Utils.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/Utils.h
@@ -25,10 +25,7 @@ inline unsigned getNumElementsPerThread(
     mlir::triton::intel::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
   Value val = getMemAccessPtr(op);
   Type valTy = val.getType();
-  auto ty =
-      isTensorPointerType(valTy)
-          ? cast<RankedTensorType>(cast<PointerType>(valTy).getPointeeType())
-          : cast<RankedTensorType>(valTy);
+  auto ty = cast<RankedTensorType>(valTy);
   auto shapePerCTA = getShapePerCTA(ty);
   mlir::triton::AxisInfo &valInfo = *axisInfoAnalysis.getAxisInfo(val);
 

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -78,8 +78,8 @@ def TritonIntelGPURemoveLayoutConversions : Pass<"tritonintelgpu-remove-layout-c
     #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [1, 4], order = [1, 0]}>
     #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4], A = [8, 16], B = [16, 16], C = [8, 16]}>
     ...
-    %28 = tt.load %arg11 {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<64x32xf16, #blocked>>
-    %29 = tt.load %arg12 {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<32x256xf16, #blocked1>>
+    %28 = tt.descriptor_load %desc_a[%off_m, %off_k] : !tt.tensordesc<tensor<64x32xf16>> -> tensor<64x32xf16, #blocked>
+    %29 = tt.descriptor_load %desc_b[%off_k, %off_n] : !tt.tensordesc<tensor<32x256xf16>> -> tensor<32x256xf16, #blocked1>
     %30 = ttg.convert_layout %28 : tensor<64x32xf16, #blocked> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #dpas}>>
     %31 = ttg.convert_layout %29 : tensor<32x256xf16, #blocked1> -> tensor<32x256xf16, #ttg.dot_op<{opIdx = 1, parent = #dpas}>>
     %32 = tt.dot %30, %31, %arg10, inputPrecision = tf32 : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #dpas}>> * tensor<32x256xf16, #ttg.dot_op<{opIdx = 1, parent = #dpas}>> -> tensor<64x256xf32, #dpas>
@@ -92,8 +92,8 @@ def TritonIntelGPURemoveLayoutConversions : Pass<"tritonintelgpu-remove-layout-c
     ```mlir
     #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4], A = [8, 16], B = [16, 16], C = [8, 16]}>
     ...
-    %28 = tt.load %arg11 {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #dpas}>>>
-    %29 = tt.load %arg12 {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<32x256xf16, #ttg.dot_op<{opIdx = 1, parent = #dpas}>>
+    %28 = tt.descriptor_load %desc_a[%off_m, %off_k] : !tt.tensordesc<tensor<64x32xf16>> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #dpas}>>
+    %29 = tt.descriptor_load %desc_b[%off_k, %off_n] : !tt.tensordesc<tensor<32x256xf16>> -> tensor<32x256xf16, #ttg.dot_op<{opIdx = 1, parent = #dpas}>>
     %32 = tt.dot %28, %29, %arg10, inputPrecision = tf32 : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #dpas}>> * tensor<32x256xf16, #ttg.dot_op<{opIdx = 1, parent = #dpas}>> -> tensor<64x256xf32, #dpas>
     ```
 

--- a/third_party/intel/include/Utils/Utility.h
+++ b/third_party/intel/include/Utils/Utility.h
@@ -8,7 +8,6 @@
 
 namespace mlir {
 namespace triton {
-class MakeTensorPtrOp;
 class MakeTensorDescOp;
 } // namespace triton
 
@@ -41,9 +40,8 @@ void eraseOperations(SmallPtrSetImpl<Operation *> &operations);
 
 // Find the defining operation of type `OpTy` for the given value.
 // Note: traverses block arguments and loop yields, etc...
-template <typename OpTy,
-          typename = std::enable_if<llvm::is_one_of<
-              OpTy, triton::MakeTensorPtrOp, triton::MakeTensorDescOp>::value>>
+template <typename OpTy, typename = std::enable_if<std::is_same<
+                             OpTy, triton::MakeTensorDescOp>::value>>
 std::optional<OpTy> findDefiningOpOfType(Value val) {
   if (auto arg = dyn_cast<BlockArgument>(val)) {
     Operation *parentOp = arg.getParentBlock()->getParentOp();
@@ -65,8 +63,6 @@ std::optional<OpTy> findDefiningOpOfType(Value val) {
     return std::nullopt;
   if (auto callOp = val.getDefiningOp<triton::CallOp>())
     return std::nullopt;
-  if (auto advanceOp = val.getDefiningOp<triton::AdvanceOp>())
-    return findDefiningOpOfType<OpTy>(advanceOp.getPtr());
   if (auto makePtrOp = val.getDefiningOp<OpTy>())
     return makePtrOp;
   if (auto opRes = dyn_cast<OpResult>(val)) {

--- a/third_party/intel/lib/Dialect/Triton/Transforms/FuseReshape.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/FuseReshape.cpp
@@ -308,11 +308,10 @@ private:
     Location loc = user->getLoc();
     if (auto loadOp = dyn_cast<tt::LoadOp>(user)) {
       OpBuilder rewriter(loadOp);
-      auto newLoadOp = tt::LoadOp::create(
-          rewriter, loadOp.getLoc(), newVal, loadOp.getMask(),
-          loadOp.getOther(), loadOp.getBoundaryCheckAttr(),
-          loadOp.getPaddingAttr(), loadOp.getCache(), loadOp.getEvict(),
-          loadOp.getIsVolatile());
+      auto newLoadOp = tt::LoadOp::create(rewriter, loadOp.getLoc(), newVal,
+                                          loadOp.getMask(), loadOp.getOther(),
+                                          loadOp.getCache(), loadOp.getEvict(),
+                                          loadOp.getIsVolatile());
       newLoadOp->setAttrs(loadOp->getAttrs());
       mapping.map(static_cast<Operation *>(loadOp),
                   static_cast<Operation *>(newLoadOp));

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RemoveMasks.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RemoveMasks.cpp
@@ -37,9 +37,8 @@ static Operation *dropMask(Operation *op, bool maskVal) {
       .Case<tt::LoadOp>([&](auto loadOp) {
         if (maskVal) {
           auto newLoadOp = tt::LoadOp::create(
-              builder, loc, loadOp.getPtr(), loadOp.getBoundaryCheck(),
-              loadOp.getPadding(), loadOp.getCache(), loadOp.getEvict(),
-              loadOp.getIsVolatile());
+              builder, loc, loadOp.getPtr(), loadOp.getCache(),
+              loadOp.getEvict(), loadOp.getIsVolatile());
           loadOp->replaceAllUsesWith(newLoadOp);
         } else {
           Operation *cstOp =
@@ -492,21 +491,6 @@ public:
            "Expecting a non-empty collection of masked operations");
 
     // Limitation
-    // Currently we can version the loop only if it doesn't have downward
-    // exposed uses of return values that are a tensor of pointers.
-    // Note: this is due to the fact the results yielded by the 2 versioning
-    // branches have different types for ptr (only in one versioned loop
-    // tensor of ptrs are changed to block ptrs) 'then' part of the versioning
-    // branch and leave them as is in the 'else' branch).
-    auto canVersion = [](scf::ForOp &forOp) {
-      return llvm::any_of(forOp.getResults(), [](Value res) {
-        return !tt::isTensorPointerType(res.getType()) ||
-               res.getUsers().empty();
-      });
-    };
-    if (!canVersion(forOp))
-      return false;
-
     auto getMask = [](Operation *maskedOp) {
       assert(isa<tt::LoadOp>(maskedOp) ||
              isa<tt::StoreOp>(maskedOp) &&

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -202,7 +202,7 @@ struct LoadStoreConversionBase {
   }
 
   unsigned getVectorSize(Value ptr) const {
-    if (!isTensorOrTensorPointerType(ptr.getType()))
+    if (!isa<RankedTensorType>(ptr.getType()))
       return 1;
 
     unsigned contiguity = getContiguity(ptr);
@@ -1967,10 +1967,8 @@ struct DescriptorPrefetchOpConversion
         unpackDescriptor(adaptor.getDesc(), rank, loc, rewriter);
 
     // Get base width and height from the descriptor shape fields.
-    // TODO: For a block pointer, baseWidth/baseHeight come from the
-    // MakeTensorPtrOp shape operands which represent the bounds of the
-    // underlying memory, not the tile shape. For tensor descriptors, the shape
-    // fields in the struct similarly represent the underlying memory bounds
+    // TODO: baseWidth/baseHeight come from the MakeTensorDescOp shape operands
+    // which represent the bounds of the underlying memory, not the tile shape
     // (set by MakeTensorDescOp). Verify this is consistent.
     Value baseWidth = desc.shapes[colIdx];
     Value baseHeight = desc.shapes[rowIdx];

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -174,9 +174,6 @@ private:
     }
 
     Value ptr = op.getPtr();
-    assert(!tt::isTensorPointerType(ptr.getType()) &&
-           "Expected pointer refer to a tensor.");
-
     auto tensorTy = dyn_cast<RankedTensorType>(ptr.getType());
     if (!tensorTy)
       return;

--- a/third_party/intel/lib/TritonIntelGPUTransforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -258,7 +258,7 @@ createSchedule(scf::ForOp forOp, int numStages) {
       // (typically `advanceOp`).
       // As prefetchOp dependencies are assigned to stage 0, this type of loads
       // must not be explicitely assigned to stage `numStages - 1`.
-      if (mlir::triton::isTensorOrTensorPointerType(loadOp.getPtr().getType()))
+      if (isa<RankedTensorType>(loadOp.getPtr().getType()))
         loadOps.emplace_back(&op);
     }
     if (isa<tt::DescriptorLoadOp>(op))

--- a/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
@@ -39,10 +39,7 @@ RankedTensorType getRankedTensorType(OpType op) {
 }
 
 RankedTensorType getRankedTensorType(Type ptrTy) {
-  return tt::isTensorPointerType(ptrTy)
-             ? cast<RankedTensorType>(
-                   cast<tt::PointerType>(ptrTy).getPointeeType())
-             : dyn_cast<RankedTensorType>(ptrTy);
+  return dyn_cast<RankedTensorType>(ptrTy);
 }
 
 static bool isSingleValue(Value value) {
@@ -221,7 +218,7 @@ LogicalResult getConvertBackwardSlice(
   enqueue(root, rootEncoding);
 
   auto updateLayout = [&](Value value, Attribute encoding) {
-    assert(isTensorOrTensorPointerType(value.getType()));
+    assert(isa<RankedTensorType>(value.getType()));
 
     if (RankedTensorType tensorType = getRankedTensorType(value.getType()))
       if (tensorType.getEncoding() == encoding)
@@ -239,7 +236,7 @@ LogicalResult getConvertBackwardSlice(
     auto [currentValueUse, encoding] = queue.back();
     Value currentValue = currentValueUse->get();
     queue.pop_back();
-    if (!isTensorOrTensorPointerType(currentValue.getType()))
+    if (!isa<RankedTensorType>(currentValue.getType()))
       continue;
 
     // Skip propagating through for op results for now.
@@ -287,8 +284,7 @@ LogicalResult getConvertBackwardSlice(
     if (auto *definingOp = currentValue.getDefiningOp()) {
       // If the op has multiple results we need to update all results layout.
       for (Value result : definingOp->getResults()) {
-        if (result == currentValue ||
-            !isTensorOrTensorPointerType(result.getType()))
+        if (result == currentValue || !isa<RankedTensorType>(result.getType()))
           continue;
         if (failed(updateLayout(result, encoding)))
           return failure();
@@ -313,7 +309,7 @@ LogicalResult getConvertBackwardSlice(
         continue;
       }
       for (auto [i, operand] : llvm::enumerate(definingOp->getOpOperands())) {
-        if (isTensorOrTensorPointerType(operand.get().getType())) {
+        if (isa<RankedTensorType>(operand.get().getType())) {
           auto srcEncoding = ttgi::inferSrcEncoding(definingOp, encoding);
           if (!srcEncoding)
             return failure();


### PR DESCRIPTION
Clean up dead code referencing MakeTensorPtrOp, AdvanceOp, isTensorPointerType, and related block pointer APIs in Intel third_party code. These are unreachable since block pointers are now lowered in the Python frontend.