### PR TITLE
[TEST][MaterializeBlockPointer] Add `H == 1` test coverage for 1D strided store reshape

### DIFF
--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-llvm.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-llvm.mlir
@@ -4,17 +4,43 @@
 // COM: reshapes it to a 2D store with ttig.block_io and ttig.block_io_stride,
 // COM: is lowered all the way to triton_gen.2Dblockstore by the LLVM conversion.
 
-// COM: Test 1: Canonical strided pattern — 1D store with W=32, S=96, fp16, 1024 elements.
-// COM: MaterializeBlockPointer detects the offset pattern:
-// COM:   arith.addi(arith.remui(idx, 32), arith.muli(arith.divui(idx, 32), 96))
-// COM: and reshapes [1024] -> [32, 32] with stride=96. The LLVM conversion should
-// COM: then emit a triton_gen.2Dblockstore with elem_size=16, tile_width=32, tile_height=8.
+// COM: Test 1: Single-row tile (H == 1) — should produce 2D block store.
+// COM: numElements=32, W=32, S=96, f16, numWarps=1.
+// COM: MaterializeBlockPointer reshapes [32] -> [1, 32] with stride=96.
+// COM: The LLVM conversion should emit a triton_gen.2Dblockstore.
+
+#blocked1d = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @test_1d_reshape_h1_blockstore
+  // CHECK: triton_gen.2Dblockstore
+  tt.func @test_1d_reshape_h1_blockstore(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<32xf16, #blocked1d>) {
+    %idx = tt.make_range {start = 0 : i32, end = 32 : i32} : tensor<32xi32, #blocked1d>
+    %cst32 = arith.constant dense<32> : tensor<32xi32, #blocked1d>
+    %cst96 = arith.constant dense<96> : tensor<32xi32, #blocked1d>
+    %rem = arith.remui %idx, %cst32 : tensor<32xi32, #blocked1d>
+    %div = arith.divui %idx, %cst32 : tensor<32xi32, #blocked1d>
+    %mul = arith.muli %div, %cst96 : tensor<32xi32, #blocked1d>
+    %off = arith.addi %rem, %mul : tensor<32xi32, #blocked1d>
+    %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<32x!tt.ptr<f16>, #blocked1d>
+    %ptrs = tt.addptr %base, %off : tensor<32x!tt.ptr<f16>, #blocked1d>, tensor<32xi32, #blocked1d>
+    tt.store %ptrs, %arg1 : tensor<32x!tt.ptr<f16>, #blocked1d>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Test 2: Multi-row tile (H > 1) — no 2D block store emitted.
+// COM: numElements=1024, W=32, S=96, fp16, numWarps=4, H = 1024/32 = 32.
+// COM: FIXME: The 2D block store lowering does not correctly handle H > 1
+// COM: because offsetY is hardcoded to 0. Once the lowering is fixed, this
+// COM: test should expect triton_gen.2Dblockstore.
 
 #blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
-  // CHECK-LABEL: llvm.func spir_kernelcc @test_1d_reshape_to_2d_blockstore
+  // CHECK-LABEL: llvm.func spir_kernelcc @test_1d_reshape_multi_row
   // CHECK-NOT: triton_gen.2Dblockstore
-  tt.func @test_1d_reshape_to_2d_blockstore(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<1024xf16, #blocked1d>) {
+  tt.func @test_1d_reshape_multi_row(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<1024xf16, #blocked1d>) {
     %idx = tt.make_range {start = 0 : i32, end = 1024 : i32} : tensor<1024xi32, #blocked1d>
     %cst32 = arith.constant dense<32> : tensor<1024xi32, #blocked1d>
     %cst96 = arith.constant dense<96> : tensor<1024xi32, #blocked1d>
@@ -31,32 +57,32 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
-// COM: Test 2: Masked store with dense<true> constant — should also lower to 2D block store.
+// COM: Test 3: Masked store with dense<true> constant — should also lower to 2D block store.
 // COM: matchPattern/m_One recognizes dense<true> as provably all-true.
 
-#blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+#blocked1d = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
   // CHECK-LABEL: llvm.func spir_kernelcc @test_1d_reshape_dense_true_mask
-  // CHECK-NOT: triton_gen.2Dblockstore
-  tt.func @test_1d_reshape_dense_true_mask(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<1024xf16, #blocked1d>) {
-    %idx = tt.make_range {start = 0 : i32, end = 1024 : i32} : tensor<1024xi32, #blocked1d>
-    %cst32 = arith.constant dense<32> : tensor<1024xi32, #blocked1d>
-    %cst96 = arith.constant dense<96> : tensor<1024xi32, #blocked1d>
-    %rem = arith.remui %idx, %cst32 : tensor<1024xi32, #blocked1d>
-    %div = arith.divui %idx, %cst32 : tensor<1024xi32, #blocked1d>
-    %mul = arith.muli %div, %cst96 : tensor<1024xi32, #blocked1d>
-    %off = arith.addi %rem, %mul : tensor<1024xi32, #blocked1d>
-    %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked1d>
-    %ptrs = tt.addptr %base, %off : tensor<1024x!tt.ptr<f16>, #blocked1d>, tensor<1024xi32, #blocked1d>
-    %mask = arith.constant dense<true> : tensor<1024xi1, #blocked1d>
-    tt.store %ptrs, %arg1, %mask : tensor<1024x!tt.ptr<f16>, #blocked1d>
+  // CHECK: triton_gen.2Dblockstore
+  tt.func @test_1d_reshape_dense_true_mask(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<32xf16, #blocked1d>) {
+    %idx = tt.make_range {start = 0 : i32, end = 32 : i32} : tensor<32xi32, #blocked1d>
+    %cst32 = arith.constant dense<32> : tensor<32xi32, #blocked1d>
+    %cst96 = arith.constant dense<96> : tensor<32xi32, #blocked1d>
+    %rem = arith.remui %idx, %cst32 : tensor<32xi32, #blocked1d>
+    %div = arith.divui %idx, %cst32 : tensor<32xi32, #blocked1d>
+    %mul = arith.muli %div, %cst96 : tensor<32xi32, #blocked1d>
+    %off = arith.addi %rem, %mul : tensor<32xi32, #blocked1d>
+    %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<32x!tt.ptr<f16>, #blocked1d>
+    %ptrs = tt.addptr %base, %off : tensor<32x!tt.ptr<f16>, #blocked1d>, tensor<32xi32, #blocked1d>
+    %mask = arith.constant dense<true> : tensor<32xi1, #blocked1d>
+    tt.store %ptrs, %arg1, %mask : tensor<32x!tt.ptr<f16>, #blocked1d>
     tt.return
   }
 }
 
 // -----
 
-// COM: Test 3: Non-canonical index — should NOT produce 2D block store.
+// COM: Test 4: Non-canonical index — should NOT produce 2D block store.
 // COM: The index is 2 * tt.make_range, so MaterializeBlockPointer rejects it,
 // COM: and the store falls through to scalar scatter.
 

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape.mlir
@@ -1,15 +1,43 @@
 // RUN: triton-opt %s -split-input-file -tritonintelgpu-materialize-block-pointer | FileCheck %s
 
-// COM: Test 1: Canonical strided pattern — 1D store with W=32, S=96, fp16, 1024 elements.
-// COM: The pass should detect the offset pattern:
-// COM:   arith.addi(arith.remui(idx, 32), arith.muli(arith.divui(idx, 32), 96))
-// COM: where idx = tt.make_range(0, 1024), and reshape the 1D store [1024] -> [32, 32]
-// COM: with ttig.block_io = "row_major" and ttig.block_io_stride = 96.
+// COM: Test 1: Single-row tile (H == 1) — reshape optimization fires.
+// COM: numElements=32, W=32, S=96, f16, numWarps=1.
+// COM: H = 32/32 = 1 → the pass should reshape [32] -> [1, 32] and set
+// COM: ttig.block_io = "row_major" with ttig.block_io_stride = 96.
+
+#blocked1d = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @test_single_row_h1
+  tt.func @test_single_row_h1(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<32xf16, #blocked1d>) {
+    %idx = tt.make_range {start = 0 : i32, end = 32 : i32} : tensor<32xi32, #blocked1d>
+    %cst32 = arith.constant dense<32> : tensor<32xi32, #blocked1d>
+    %cst96 = arith.constant dense<96> : tensor<32xi32, #blocked1d>
+    %rem = arith.remui %idx, %cst32 : tensor<32xi32, #blocked1d>
+    %div = arith.divui %idx, %cst32 : tensor<32xi32, #blocked1d>
+    %mul = arith.muli %div, %cst96 : tensor<32xi32, #blocked1d>
+    %off = arith.addi %rem, %mul : tensor<32xi32, #blocked1d>
+    %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<32x!tt.ptr<f16>, #blocked1d>
+    %ptrs = tt.addptr %base, %off : tensor<32x!tt.ptr<f16>, #blocked1d>, tensor<32xi32, #blocked1d>
+    // CHECK: tt.reshape
+    // CHECK: tt.reshape
+    // CHECK: tt.store %{{.*}}, %{{.*}} {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64} : tensor<1x32x!tt.ptr<f16>
+    tt.store %ptrs, %arg1 : tensor<32x!tt.ptr<f16>, #blocked1d>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Test 2: Multi-row tile (H > 1).
+// COM: numElements=1024, W=32, S=96, fp16, numWarps=4, H = 1024/32 = 32.
+// COM: FIXME: The 2D block store lowering does not correctly handle H > 1
+// COM: because offsetY is hardcoded to 0. Once the lowering is fixed, this
+// COM: test should expect tt.reshape and ttig.block_io attributes.
 
 #blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
-  // CHECK-LABEL: tt.func @test_canonical_pattern
-  tt.func @test_canonical_pattern(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<1024xf16, #blocked1d>) {
+  // CHECK-LABEL: tt.func @test_multi_row_h32
+  tt.func @test_multi_row_h32(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<1024xf16, #blocked1d>) {
     %idx = tt.make_range {start = 0 : i32, end = 1024 : i32} : tensor<1024xi32, #blocked1d>
     %cst32 = arith.constant dense<32> : tensor<1024xi32, #blocked1d>
     %cst96 = arith.constant dense<96> : tensor<1024xi32, #blocked1d>
@@ -28,34 +56,35 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
-// COM: Test 2: Masked store with dense<true> constant — should still be reshaped.
+// COM: Test 3: Masked store with dense<true> constant — should still be reshaped.
 // COM: The mask is a direct dense<true> tensor constant (not splat(true)).
 // COM: matchPattern/m_One recognizes this as provably all-true.
 
-#blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+#blocked1d = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
   // CHECK-LABEL: tt.func @test_dense_true_mask
-  tt.func @test_dense_true_mask(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<1024xf16, #blocked1d>) {
-    %idx = tt.make_range {start = 0 : i32, end = 1024 : i32} : tensor<1024xi32, #blocked1d>
-    %cst32 = arith.constant dense<32> : tensor<1024xi32, #blocked1d>
-    %cst96 = arith.constant dense<96> : tensor<1024xi32, #blocked1d>
-    %rem = arith.remui %idx, %cst32 : tensor<1024xi32, #blocked1d>
-    %div = arith.divui %idx, %cst32 : tensor<1024xi32, #blocked1d>
-    %mul = arith.muli %div, %cst96 : tensor<1024xi32, #blocked1d>
-    %off = arith.addi %rem, %mul : tensor<1024xi32, #blocked1d>
-    %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked1d>
-    %ptrs = tt.addptr %base, %off : tensor<1024x!tt.ptr<f16>, #blocked1d>, tensor<1024xi32, #blocked1d>
-    %mask = arith.constant dense<true> : tensor<1024xi1, #blocked1d>
-    // CHECK-NOT: tt.reshape
-    // CHECK: tt.store %{{.*}}, %{{.*}}, %{{.*}} : tensor<1024x!tt.ptr<f16>
-    tt.store %ptrs, %arg1, %mask : tensor<1024x!tt.ptr<f16>, #blocked1d>
+  tt.func @test_dense_true_mask(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<32xf16, #blocked1d>) {
+    %idx = tt.make_range {start = 0 : i32, end = 32 : i32} : tensor<32xi32, #blocked1d>
+    %cst32 = arith.constant dense<32> : tensor<32xi32, #blocked1d>
+    %cst96 = arith.constant dense<96> : tensor<32xi32, #blocked1d>
+    %rem = arith.remui %idx, %cst32 : tensor<32xi32, #blocked1d>
+    %div = arith.divui %idx, %cst32 : tensor<32xi32, #blocked1d>
+    %mul = arith.muli %div, %cst96 : tensor<32xi32, #blocked1d>
+    %off = arith.addi %rem, %mul : tensor<32xi32, #blocked1d>
+    %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<32x!tt.ptr<f16>, #blocked1d>
+    %ptrs = tt.addptr %base, %off : tensor<32x!tt.ptr<f16>, #blocked1d>, tensor<32xi32, #blocked1d>
+    %mask = arith.constant dense<true> : tensor<32xi1, #blocked1d>
+    // CHECK: tt.reshape
+    // CHECK: tt.reshape
+    // CHECK: tt.store %{{.*}}, %{{.*}} {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64} : tensor<1x32x!tt.ptr<f16>
+    tt.store %ptrs, %arg1, %mask : tensor<32x!tt.ptr<f16>, #blocked1d>
     tt.return
   }
 }
 
 // -----
 
-// COM: Test 3: Non-canonical index rejection — scaled index.
+// COM: Test 4: Non-canonical index rejection — scaled index.
 // COM: The index is 2 * tt.make_range instead of plain tt.make_range.
 // COM: The isCanonicalLinearIndex check should reject this because remui's
 // COM: LHS is arith.muli, not tt.make_range(0, N).
@@ -85,28 +114,28 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
-// COM: Test 4: Non-trivial mask rejection.
+// COM: Test 5: Non-trivial mask rejection.
 // COM: Same strided offset pattern as Test 1 but the store has a real mask
 // COM: argument (not splat(true)). The pass should reject this and leave the
 // COM: 1D store unchanged.
 
-#blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+#blocked1d = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
   // CHECK-LABEL: tt.func @test_non_trivial_mask
-  tt.func @test_non_trivial_mask(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<1024xf16, #blocked1d>, %mask: tensor<1024xi1, #blocked1d>) {
-    %idx = tt.make_range {start = 0 : i32, end = 1024 : i32} : tensor<1024xi32, #blocked1d>
-    %cst32 = arith.constant dense<32> : tensor<1024xi32, #blocked1d>
-    %cst96 = arith.constant dense<96> : tensor<1024xi32, #blocked1d>
-    %rem = arith.remui %idx, %cst32 : tensor<1024xi32, #blocked1d>
-    %div = arith.divui %idx, %cst32 : tensor<1024xi32, #blocked1d>
-    %mul = arith.muli %div, %cst96 : tensor<1024xi32, #blocked1d>
-    %off = arith.addi %rem, %mul : tensor<1024xi32, #blocked1d>
-    %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked1d>
-    %ptrs = tt.addptr %base, %off : tensor<1024x!tt.ptr<f16>, #blocked1d>, tensor<1024xi32, #blocked1d>
+  tt.func @test_non_trivial_mask(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<32xf16, #blocked1d>, %mask: tensor<32xi1, #blocked1d>) {
+    %idx = tt.make_range {start = 0 : i32, end = 32 : i32} : tensor<32xi32, #blocked1d>
+    %cst32 = arith.constant dense<32> : tensor<32xi32, #blocked1d>
+    %cst96 = arith.constant dense<96> : tensor<32xi32, #blocked1d>
+    %rem = arith.remui %idx, %cst32 : tensor<32xi32, #blocked1d>
+    %div = arith.divui %idx, %cst32 : tensor<32xi32, #blocked1d>
+    %mul = arith.muli %div, %cst96 : tensor<32xi32, #blocked1d>
+    %off = arith.addi %rem, %mul : tensor<32xi32, #blocked1d>
+    %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<32x!tt.ptr<f16>, #blocked1d>
+    %ptrs = tt.addptr %base, %off : tensor<32x!tt.ptr<f16>, #blocked1d>, tensor<32xi32, #blocked1d>
     // CHECK-NOT: tt.reshape
     // CHECK: tt.store
     // CHECK-NOT: ttig.block_io
-    tt.store %ptrs, %arg1, %mask : tensor<1024x!tt.ptr<f16>, #blocked1d>
+    tt.store %ptrs, %arg1, %mask : tensor<32x!tt.ptr<f16>, #blocked1d>
     tt.return
   }
 }


### PR DESCRIPTION
PR #6682 restricted reshape1DStridedStore() to H == 1 but all existing tests had H > 1 (1024 elements / W=32 = H=32), leaving the only working code path untested.

- Add positive H == 1 tests (numElements=32, W=32, numWarps=1) that verify the reshape fires and lowers to triton_gen.2Dblockstore
- Switch mask and non-trivial-mask tests to H == 1 so they exercise the mask logic rather than being short-circuited by the H > 1 guard
- Add FIXME comments on H > 1 tests documenting the offsetY bug
- Reorder tests: positive case first, then negative/rejection cases