### PR TITLE
fix: move tp_dealloc before tp_flags in PyKernelArgType (C++17)

### DIFF
--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -562,9 +562,9 @@ static PyTypeObject PyKernelArgType = {
         "triton.backends.intel.PyKernelArg",
     .tp_basicsize = sizeof(PyKernelArgObject),
     .tp_itemsize = 0,
+    .tp_dealloc = (destructor)PyKernelArg_dealloc,
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_doc = "Kernel Argument Metadata",
-    .tp_dealloc = (destructor)PyKernelArg_dealloc,
     .tp_init = (initproc)PyKernelArg_init,
     .tp_new = PyType_GenericNew,
 };


### PR DESCRIPTION
be54288 fixed the relative order of tp_dealloc/tp_init/tp_new, but tp_dealloc (field position 5 in _typeobject) still appeared after tp_flags (position 20) and tp_doc (position 21) in the initializer, which is a C++17 designated-initializer ordering violation.

Move tp_dealloc before tp_flags to fully satisfy the C++17 requirement that designated initializers appear in struct declaration order.
