### PR TITLE
[vLLM] Remove patch change that explicitly skips a triton_attn test

### DIFF
--- a/scripts/vllm/vllm-fix.patch
+++ b/scripts/vllm/vllm-fix.patch
@@ -14,21 +14,6 @@ index f3b22d898..bdb82146a 100644
          init_workspace_manager(device)
      yield
      reset_workspace_manager()
-diff --git a/tests/kernels/attention/test_merge_attn_states.py b/tests/kernels/attention/test_merge_attn_states.py
-index 6fccb8ccf..0e4fa2d2d 100644
---- a/tests/kernels/attention/test_merge_attn_states.py
-+++ b/tests/kernels/attention/test_merge_attn_states.py
-@@ -10,6 +10,10 @@ from vllm.v1.attention.ops.triton_merge_attn_states import (
-     merge_attn_states as merge_attn_states_triton,
- )
- 
-+# XPU: Skip entire module - requires CUDA merge kernel for comparison
-+if current_platform.is_xpu():
-+    pytest.skip("Requires CUDA merge kernel for comparison", allow_module_level=True)
-+
- 
- # Naive PyTorch Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
- # can be used to combine partial attention results (in the split-KV case)
 diff --git a/tests/kernels/moe/test_batched_moe.py b/tests/kernels/moe/test_batched_moe.py
 index d78e1947f..e7ffb39e3 100644
 --- a/tests/kernels/moe/test_batched_moe.py

--- a/scripts/vllm/vllm-fix.patch
+++ b/scripts/vllm/vllm-fix.patch
@@ -52,18 +52,9 @@ index d78e1947f..e7ffb39e3 100644
  @pytest.mark.parametrize("input_scales", [False])
  def test_fused_moe_batched_experts(
 diff --git a/tests/kernels/moe/utils.py b/tests/kernels/moe/utils.py
-index 4b693d8c8..3ff3093b4 100644
+index 4b693d8c8..a04281e13 100644
 --- a/tests/kernels/moe/utils.py
 +++ b/tests/kernels/moe/utils.py
-@@ -3,7 +3,7 @@
- 
- import torch
- 
--import vllm._custom_ops as ops
-+from vllm import _custom_ops as ops
- from tests.kernels.quant_utils import per_block_cast_to_int8
- from tests.kernels.quantization.nvfp4_utils import FLOAT4_E2M1_MAX, FLOAT8_E4M3_MAX
- from vllm.model_executor.layers.activation import SiluAndMul
 @@ -314,7 +314,13 @@ def make_test_weight(
                  w_16[idx], None, quant_dtype, per_out_ch_quant, block_shape
              )

--- a/scripts/vllm/vllm_xpu_patch.py
+++ b/scripts/vllm/vllm_xpu_patch.py
@@ -136,15 +136,6 @@ def _find_cuda_patterns(source: str) -> list[dict]:
                     "var_name": target.id,
                 })
 
-        # current_platform.is_cuda() in skipif decorators
-        if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "is_cuda"
-                and isinstance(node.func.value, ast.Name) and node.func.value.id == "current_platform"):
-            patterns.append({
-                "type": "is_cuda_check",
-                "line": node.lineno,
-                "col": node.col_offset,
-            })
-
         # current_platform.get_device_capability() < tuple comparisons
         if isinstance(node, ast.Compare):
             if (isinstance(node.left, ast.Call) and isinstance(node.left.func, ast.Attribute)
@@ -216,14 +207,6 @@ def _apply_patches(source: str, patterns: list[dict]) -> str:
             # Replace torch.cuda.get_device_capability() with torch.xpu.get_device_capability()
             lines[line_idx] = line.replace("torch.cuda.get_device_capability()", "torch.xpu.get_device_capability()")
 
-        elif ptype == "is_cuda_check":
-            # In skipif: not current_platform.is_cuda()
-            # -> not (current_platform.is_cuda() or current_platform.is_xpu())
-            lines[line_idx] = line.replace(
-                "current_platform.is_cuda()",
-                "(current_platform.is_cuda() or current_platform.is_xpu())",
-            )
-
         elif ptype == "device_capability_compare":
             # Handle: if current_platform.get_device_capability() < (X, Y):
             # Strategy: wrap the call in a helper that returns a safe value
@@ -255,13 +238,6 @@ def patch_file(filepath: Path) -> bool:
     patterns = _find_cuda_patterns(source)
     if not patterns:
         return False
-
-    # Skip is_cuda_check transformation in fp8_utils.py
-    # (it's for runtime branching, not test skipping, and XPU has incompatible signatures)
-    if filepath.name == "fp8_utils.py":
-        patterns = [p for p in patterns if p["type"] != "is_cuda_check"]
-        if not patterns:
-            return False
 
     patched = _apply_patches(source, patterns)
     if patched == source:


### PR DESCRIPTION
This patch removes a change from the vLLM patch that explicitly skips a `triton_attn` test. The test is cuda specific and should be skipped, but the test skips itself without adding this change.

Part of https://github.com/intel/intel-xpu-backend-for-triton/issues/6466.

Requires: https://github.com/intel/intel-xpu-backend-for-triton/pull/6717.

vLLM benchmarks: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24688195039
vLLM benchmarks BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24688291942
vLLM tests: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24688175387 (mamba failure is known and tracked by https://github.com/intel/intel-xpu-backend-for-triton/issues/6713)