### PR TITLE
Elementwise prefetch: software pipelining for non-dot loads (Xe3P+)

### DIFF
--- a/test/TritonIntelGPU/loop-pipeline-elementwise.mlir
+++ b/test/TritonIntelGPU/loop-pipeline-elementwise.mlir
@@ -1,0 +1,152 @@
+// RUN: triton-opt %s -split-input-file -tritonintelgpu-pipeline="num-stages=3" | FileCheck %s
+
+// COM: Test that the pipeline pass creates ttig.prefetch ops for elementwise
+// COM: loads (BlockedEncodingAttr, NOT DotOperandEncodingAttr) inside scf.for
+// COM: loops when the loads have the "ttig.block_io" attribute and rank >= 2.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io", "ttig.support_prefetch_256b"} {
+  // CHECK-LABEL: tt.func public @elementwise_prefetch
+  tt.func public @elementwise_prefetch(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>, %arg3: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %cst = arith.constant dense<32> : tensor<32x32xi32, #blocked>
+
+    // COM: Build pointer tensors for two elementwise loads.
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<32x1xi32, #blocked>
+    %2 = arith.constant dense<32> : tensor<32x1xi32, #blocked>
+    %3 = arith.muli %1, %2 : tensor<32x1xi32, #blocked>
+    %4 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked>
+    %6 = tt.broadcast %3 : tensor<32x1xi32, #blocked> -> tensor<32x32xi32, #blocked>
+    %7 = tt.broadcast %5 : tensor<1x32xi32, #blocked> -> tensor<32x32xi32, #blocked>
+    %8 = arith.addi %6, %7 : tensor<32x32xi32, #blocked>
+
+    %splat_a = tt.splat %arg0 : !tt.ptr<f16> -> tensor<32x32x!tt.ptr<f16>, #blocked>
+    %ptr_a = tt.addptr %splat_a, %8 : tensor<32x32x!tt.ptr<f16>, #blocked>, tensor<32x32xi32, #blocked>
+
+    %splat_b = tt.splat %arg1 : !tt.ptr<f16> -> tensor<32x32x!tt.ptr<f16>, #blocked>
+    %ptr_b = tt.addptr %splat_b, %8 : tensor<32x32x!tt.ptr<f16>, #blocked>, tensor<32x32xi32, #blocked>
+
+    %splat_c = tt.splat %arg2 : !tt.ptr<f16> -> tensor<32x32x!tt.ptr<f16>, #blocked>
+    %ptr_c = tt.addptr %splat_c, %8 : tensor<32x32x!tt.ptr<f16>, #blocked>, tensor<32x32xi32, #blocked>
+
+    %n_steps = arith.divsi %arg3, %c32_i32 : i32
+
+    // COM: Verify prefetch ops are created before and inside the loop.
+    // CHECK: ttig.prefetch {{.*}} : tensor<32x32x!tt.ptr<f16>, #{{.*}}>
+    // CHECK: ttig.prefetch {{.*}} : tensor<32x32x!tt.ptr<f16>, #{{.*}}>
+    // CHECK: ttig.prefetch {{.*}} : tensor<32x32x!tt.ptr<f16>, #{{.*}}>
+    // CHECK: ttig.prefetch {{.*}} : tensor<32x32x!tt.ptr<f16>, #{{.*}}>
+    // CHECK: scf.for
+    // CHECK:   ttig.prefetch {{.*}} : tensor<32x32x!tt.ptr<f16>, #{{.*}}>
+    // CHECK:   ttig.prefetch {{.*}} : tensor<32x32x!tt.ptr<f16>, #{{.*}}>
+    // CHECK:   tt.load {{.*}} : tensor<32x32x!tt.ptr<f16>, #{{.*}}>
+    // CHECK:   tt.load {{.*}} : tensor<32x32x!tt.ptr<f16>, #{{.*}}>
+    // CHECK:   arith.addf
+    // CHECK:   tt.store
+    // CHECK:   scf.yield
+    %9:2 = scf.for %iv = %c0_i32 to %n_steps step %c1_i32 iter_args(%arg_a = %ptr_a, %arg_b = %ptr_b) -> (tensor<32x32x!tt.ptr<f16>, #blocked>, tensor<32x32x!tt.ptr<f16>, #blocked>) : i32 {
+      %ld_a = tt.load %arg_a {ttig.block_io = "row_major"} : tensor<32x32x!tt.ptr<f16>, #blocked>
+      %ld_b = tt.load %arg_b {ttig.block_io = "row_major"} : tensor<32x32x!tt.ptr<f16>, #blocked>
+      %sum = arith.addf %ld_a, %ld_b : tensor<32x32xf16, #blocked>
+      tt.store %ptr_c, %sum : tensor<32x32x!tt.ptr<f16>, #blocked>
+      %next_a = tt.addptr %arg_a, %cst : tensor<32x32x!tt.ptr<f16>, #blocked>, tensor<32x32xi32, #blocked>
+      %next_b = tt.addptr %arg_b, %cst : tensor<32x32x!tt.ptr<f16>, #blocked>, tensor<32x32xi32, #blocked>
+      scf.yield %next_a, %next_b : tensor<32x32x!tt.ptr<f16>, #blocked>, tensor<32x32x!tt.ptr<f16>, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Test that loads WITHOUT the "ttig.block_io" attribute do NOT get
+// COM: prefetch ops created by the pipeline pass.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: tt.func public @no_blockio_no_prefetch
+  tt.func public @no_blockio_no_prefetch(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %cst = arith.constant dense<64> : tensor<64x64xi32, #blocked>
+
+    %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+    %2 = arith.constant dense<64> : tensor<64x1xi32, #blocked>
+    %3 = arith.muli %1, %2 : tensor<64x1xi32, #blocked>
+    %4 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %6 = tt.broadcast %3 : tensor<64x1xi32, #blocked> -> tensor<64x64xi32, #blocked>
+    %7 = tt.broadcast %5 : tensor<1x64xi32, #blocked> -> tensor<64x64xi32, #blocked>
+    %8 = arith.addi %6, %7 : tensor<64x64xi32, #blocked>
+
+    %splat_a = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x64x!tt.ptr<f16>, #blocked>
+    %ptr_a = tt.addptr %splat_a, %8 : tensor<64x64x!tt.ptr<f16>, #blocked>, tensor<64x64xi32, #blocked>
+
+    %splat_b = tt.splat %arg1 : !tt.ptr<f16> -> tensor<64x64x!tt.ptr<f16>, #blocked>
+    %ptr_b = tt.addptr %splat_b, %8 : tensor<64x64x!tt.ptr<f16>, #blocked>, tensor<64x64xi32, #blocked>
+
+    %n_steps = arith.divsi %arg2, %c64_i32 : i32
+
+    // COM: Without block_io attribute, no prefetch should be inserted.
+    // CHECK-NOT: ttig.prefetch
+    // CHECK: scf.for
+    // CHECK-NOT: ttig.prefetch
+    // CHECK:   tt.load
+    // CHECK:   tt.load
+    // CHECK:   arith.addf
+    // CHECK:   scf.yield
+    %9:2 = scf.for %iv = %c0_i32 to %n_steps step %c1_i32 iter_args(%arg_a = %ptr_a, %arg_b = %ptr_b) -> (tensor<64x64x!tt.ptr<f16>, #blocked>, tensor<64x64x!tt.ptr<f16>, #blocked>) : i32 {
+      %ld_a = tt.load %arg_a : tensor<64x64x!tt.ptr<f16>, #blocked>
+      %ld_b = tt.load %arg_b : tensor<64x64x!tt.ptr<f16>, #blocked>
+      %sum = arith.addf %ld_a, %ld_b : tensor<64x64xf16, #blocked>
+      %next_a = tt.addptr %arg_a, %cst : tensor<64x64x!tt.ptr<f16>, #blocked>, tensor<64x64xi32, #blocked>
+      %next_b = tt.addptr %arg_b, %cst : tensor<64x64x!tt.ptr<f16>, #blocked>, tensor<64x64xi32, #blocked>
+      scf.yield %next_a, %next_b : tensor<64x64x!tt.ptr<f16>, #blocked>, tensor<64x64x!tt.ptr<f16>, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Test that rank-1 loads with block_io do NOT get prefetch ops.
+// COM: The pipeline pass requires rank >= 2.
+
+#blocked1d = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [16], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io", "ttig.support_prefetch_256b"} {
+  // CHECK-LABEL: tt.func public @rank1_no_prefetch
+  tt.func public @rank1_no_prefetch(%arg0: !tt.ptr<f16>, %arg1: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c256_i32 = arith.constant 256 : i32
+    %cst = arith.constant dense<256> : tensor<256xi32, #blocked1d>
+
+    %0 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #blocked1d>
+    %splat_a = tt.splat %arg0 : !tt.ptr<f16> -> tensor<256x!tt.ptr<f16>, #blocked1d>
+    %ptr_a = tt.addptr %splat_a, %0 : tensor<256x!tt.ptr<f16>, #blocked1d>, tensor<256xi32, #blocked1d>
+
+    %n_steps = arith.divsi %arg1, %c256_i32 : i32
+
+    // COM: Rank-1 load should not be prefetched even with block_io.
+    // CHECK-NOT: ttig.prefetch
+    // CHECK: scf.for
+    // CHECK-NOT: ttig.prefetch
+    // CHECK:   tt.load
+    // CHECK:   scf.yield
+    %9 = scf.for %iv = %c0_i32 to %n_steps step %c1_i32 iter_args(%arg_a = %ptr_a) -> (tensor<256x!tt.ptr<f16>, #blocked1d>) : i32 {
+      %ld_a = tt.load %arg_a {ttig.block_io = "row_major"} : tensor<256x!tt.ptr<f16>, #blocked1d>
+      %next_a = tt.addptr %arg_a, %cst : tensor<256x!tt.ptr<f16>, #blocked1d>, tensor<256xi32, #blocked1d>
+      scf.yield %next_a : tensor<256x!tt.ptr<f16>, #blocked1d>
+    }
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
+++ b/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
@@ -1,0 +1,69 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm | FileCheck %s
+
+// COM: Test that the lowering pass converts ttig.prefetch on blocked-encoding
+// COM: tensors (not DotOperandEncodingAttr) to triton_gen.2DBlockPrefetch
+// COM: operations via the cooperative prefetch path.
+
+// COM: Test case: f16 blocked prefetch, 128x64 tensor, 4 warps.
+// COM: With 128x64xf16 and 4 warps (no 256B prefetch support):
+// COM:   tileHeight=32, tileWidth=32 -> vBlocks=2, tile_width=16
+// COM:   warpsM=2, warpsN=2
+// COM:   numTilesPerWarp = (128*64) / (32*32*4) = 2
+// COM: Expect 2 triton_gen.2Dblockprefetch ops per prefetch invocation.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_prefetch_256b"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_blocked_f16
+  tt.func public @prefetch_blocked_f16(%arg0: !tt.ptr<f16>) {
+    // COM: Build a 128x64 tensor-of-pointers with row stride = 64.
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xi32, #blocked>
+    %2 = arith.constant dense<64> : tensor<128x1xi32, #blocked>
+    %3 = arith.muli %1, %2 : tensor<128x1xi32, #blocked>
+    %4 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %6 = tt.broadcast %3 : tensor<128x1xi32, #blocked> -> tensor<128x64xi32, #blocked>
+    %7 = tt.broadcast %5 : tensor<1x64xi32, #blocked> -> tensor<128x64xi32, #blocked>
+    %8 = arith.addi %6, %7 : tensor<128x64xi32, #blocked>
+    %9 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    %ptr = tt.addptr %9, %8 : tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<128x64xi32, #blocked>
+
+    // CHECK-COUNT-2: triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1C_L3C}
+    ttig.prefetch %ptr {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 0, 0>, ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f16>, #blocked>
+
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Test case: f32 blocked prefetch, 128x64 tensor, 4 warps.
+// COM: With 128x64xf32 and 4 warps (with 256B prefetch support):
+// COM:   tileHeight=32, tileWidth=64 (256 bytes / 4 bytes = 64)
+// COM:   warpsM=4, warpsN=1
+// COM:   numTilesPerWarp = (128*64) / (32*64*4) = 1
+// COM: Expect 1 triton_gen.2Dblockprefetch op.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_prefetch_256b"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_blocked_f32
+  tt.func public @prefetch_blocked_f32(%arg0: !tt.ptr<f32>) {
+    // COM: Build a 128x64 tensor-of-pointers with row stride = 64.
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xi32, #blocked>
+    %2 = arith.constant dense<64> : tensor<128x1xi32, #blocked>
+    %3 = arith.muli %1, %2 : tensor<128x1xi32, #blocked>
+    %4 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %6 = tt.broadcast %3 : tensor<128x1xi32, #blocked> -> tensor<128x64xi32, #blocked>
+    %7 = tt.broadcast %5 : tensor<1x64xi32, #blocked> -> tensor<128x64xi32, #blocked>
+    %8 = arith.addi %6, %7 : tensor<128x64xi32, #blocked>
+    %9 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x64x!tt.ptr<f32>, #blocked>
+    %ptr = tt.addptr %9, %8 : tensor<128x64x!tt.ptr<f32>, #blocked>, tensor<128x64xi32, #blocked>
+
+    // CHECK-COUNT-1: triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 32, tile_width = 64, tile_height = 32, v_blocks = 1, cache_control = L1C_L3C}
+    ttig.prefetch %ptr {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 0, 0>, ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f32>, #blocked>
+
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
+++ b/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
@@ -187,3 +187,36 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32,
     tt.return
   }
 }
+
+// -----
+
+// COM: Test case: cooperative prefetch with `cache = 3 : i32` (= CacheModifier::CG).
+// COM: Mirrors @prefetch_blocked_f16 but asserts that the CG modifier propagates
+// COM: through the prefetch lowering to `cache_control = L1UC_L3C` (L1 bypass).
+// COM: This is the path exercised when the `tritonintelgpu-annotate-cache-control`
+// COM: pass tags a non-dot streaming load with `.cg` and the pipeliner forwards
+// COM: the modifier to the created prefetch — the prefetch must then match the
+// COM: load's L1-bypass policy instead of dragging the data back into L1.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_prefetch_256b"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_blocked_f16_cg
+  tt.func public @prefetch_blocked_f16_cg(%arg0: !tt.ptr<f16>) {
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xi32, #blocked>
+    %2 = arith.constant dense<64> : tensor<128x1xi32, #blocked>
+    %3 = arith.muli %1, %2 : tensor<128x1xi32, #blocked>
+    %4 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %6 = tt.broadcast %3 : tensor<128x1xi32, #blocked> -> tensor<128x64xi32, #blocked>
+    %7 = tt.broadcast %5 : tensor<1x64xi32, #blocked> -> tensor<128x64xi32, #blocked>
+    %8 = arith.addi %6, %7 : tensor<128x64xi32, #blocked>
+    %9 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    %ptr = tt.addptr %9, %8 : tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<128x64xi32, #blocked>
+
+    // CHECK-COUNT-2: triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1UC_L3C}
+    ttig.prefetch %ptr {boundaryCheck = array<i32>, cache = 3 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 0, 0>, ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f16>, #blocked>
+
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
+++ b/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
@@ -67,3 +67,78 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32,
     tt.return
   }
 }
+
+// -----
+
+// COM: Test case: masked cooperative prefetch (epilogue predication from
+// COM: the loop pipeliner). The pipeliner wraps the mask in `splat(pred)`,
+// COM: and the cooperative path should fold the uniform scalar predicate
+// COM: into offsetY = select(pred, 0, baseHeight) so the HW skips the
+// COM: prefetch out-of-bounds, mirroring the regular-pointer path's trick.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_prefetch_256b"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_blocked_f16_masked
+  tt.func public @prefetch_blocked_f16_masked(%arg0: !tt.ptr<f16>, %pred: i1) {
+    // COM: Build a 128x64 tensor-of-pointers with row stride = 64.
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xi32, #blocked>
+    %2 = arith.constant dense<64> : tensor<128x1xi32, #blocked>
+    %3 = arith.muli %1, %2 : tensor<128x1xi32, #blocked>
+    %4 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %6 = tt.broadcast %3 : tensor<128x1xi32, #blocked> -> tensor<128x64xi32, #blocked>
+    %7 = tt.broadcast %5 : tensor<1x64xi32, #blocked> -> tensor<128x64xi32, #blocked>
+    %8 = arith.addi %6, %7 : tensor<128x64xi32, #blocked>
+    %9 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    %ptr = tt.addptr %9, %8 : tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<128x64xi32, #blocked>
+
+    // COM: tt.getPredMask-shaped mask: splat(%pred).
+    %mask = tt.splat %pred : i1 -> tensor<128x64xi1, #blocked>
+
+    // COM: Uniform mask is extracted as a scalar i1 predicate and folded into
+    // COM: offsetY via `select(pred, origY, baseHeight)` so the HW skips the
+    // COM: prefetch when the predicate is false. Check that the prefetch is
+    // COM: still emitted (twice) and that its offsetY comes from an llvm.select.
+    // CHECK: %[[SEL0:.*]] = llvm.select %{{.*}}, %{{.*}}, %{{.*}} : i1, i32
+    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL0]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK: %[[SEL1:.*]] = llvm.select %{{.*}}, %{{.*}}, %{{.*}} : i1, i32
+    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL1]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1C_L3C}
+    ttig.prefetch %ptr, %mask {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 1, 0>, ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f16>, #blocked>
+
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Test case: non-uniform mask on the cooperative path. An `arith.cmpi`
+// COM: mask cannot be proven uniform, so the cooperative path must bail. The
+// COM: generic pointer path rejects non-dot encodings, so the op is erased
+// COM: with a warning and no 2D block prefetch is emitted.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_prefetch_256b"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_blocked_f16_nonuniform_mask
+  tt.func public @prefetch_blocked_f16_nonuniform_mask(%arg0: !tt.ptr<f16>, %bound: tensor<128x64xi32, #blocked>) {
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xi32, #blocked>
+    %2 = arith.constant dense<64> : tensor<128x1xi32, #blocked>
+    %3 = arith.muli %1, %2 : tensor<128x1xi32, #blocked>
+    %4 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %6 = tt.broadcast %3 : tensor<128x1xi32, #blocked> -> tensor<128x64xi32, #blocked>
+    %7 = tt.broadcast %5 : tensor<1x64xi32, #blocked> -> tensor<128x64xi32, #blocked>
+    %8 = arith.addi %6, %7 : tensor<128x64xi32, #blocked>
+    %9 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    %ptr = tt.addptr %9, %8 : tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<128x64xi32, #blocked>
+
+    // COM: Per-element mask, non-uniform -> cooperative path bails.
+    %mask = arith.cmpi slt, %8, %bound : tensor<128x64xi32, #blocked>
+
+    // CHECK-NOT: triton_gen.2Dblockprefetch
+    ttig.prefetch %ptr, %mask {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 1, 0>, ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f16>, #blocked>
+
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
+++ b/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
@@ -112,6 +112,51 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32,
 
 // -----
 
+// COM: Test case: pipeliner-shaped mask `arith.andi(splat(pred), boundsMask)`.
+// COM: This is what `tt::getPredMask` produces when the prefetch's underlying
+// COM: load already had a mask: the scalar epilogue predicate is splatted and
+// COM: AND'd with the original per-element bounds check. The cooperative path
+// COM: must honor the uniform `pred` component (folded into offsetY) and drop
+// COM: the per-element side (safe for a prefetch — the HW 2D bounds check on
+// COM: the tile still rejects out-of-surface offsets).
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_prefetch_256b"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_blocked_f16_predmask
+  tt.func public @prefetch_blocked_f16_predmask(%arg0: !tt.ptr<f16>, %pred: i1, %bound: tensor<128x64xi32, #blocked>) {
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xi32, #blocked>
+    %2 = arith.constant dense<64> : tensor<128x1xi32, #blocked>
+    %3 = arith.muli %1, %2 : tensor<128x1xi32, #blocked>
+    %4 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %6 = tt.broadcast %3 : tensor<128x1xi32, #blocked> -> tensor<128x64xi32, #blocked>
+    %7 = tt.broadcast %5 : tensor<1x64xi32, #blocked> -> tensor<128x64xi32, #blocked>
+    %8 = arith.addi %6, %7 : tensor<128x64xi32, #blocked>
+    %9 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    %ptr = tt.addptr %9, %8 : tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<128x64xi32, #blocked>
+
+    // COM: `tt::getPredMask(..., currentMask=boundsMask, pred=%pred)` layout:
+    // COM:   %splat = tt.splat %pred : i1 -> tensor<...xi1>
+    // COM:   %mask  = arith.andi %splat, %boundsMask
+    %splatPred = tt.splat %pred : i1 -> tensor<128x64xi1, #blocked>
+    %boundsMask = arith.cmpi slt, %8, %bound : tensor<128x64xi32, #blocked>
+    %mask = arith.andi %splatPred, %boundsMask : tensor<128x64xi1, #blocked>
+
+    // COM: The uniform `%pred` is folded into offsetY via llvm.select; the
+    // COM: per-element `%boundsMask` is dropped (safe for a prefetch hint).
+    // CHECK: %[[SEL0:.*]] = llvm.select %{{.*}}, %{{.*}}, %{{.*}} : i1, i32
+    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL0]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK: %[[SEL1:.*]] = llvm.select %{{.*}}, %{{.*}}, %{{.*}} : i1, i32
+    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL1]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1C_L3C}
+    ttig.prefetch %ptr, %mask {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 1, 0>, ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f16>, #blocked>
+
+    tt.return
+  }
+}
+
+// -----
+
 // COM: Test case: non-uniform mask on the cooperative path. An `arith.cmpi`
 // COM: mask cannot be proven uniform, so the cooperative path must bail. The
 // COM: generic pointer path rejects non-dot encodings, so the op is erased

--- a/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
+++ b/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
@@ -5,7 +5,7 @@
 // COM: operations via the cooperative prefetch path.
 
 // COM: Test case: f16 blocked prefetch, 128x64 tensor, 4 warps.
-// COM: With 128x64xf16 and 4 warps (no 256B prefetch support):
+// COM: With 128x64xf16 and 4 warps (256B prefetch support enabled):
 // COM:   tileHeight=32, tileWidth=32 -> vBlocks=2, tile_width=16
 // COM:   warpsM=2, warpsN=2
 // COM:   numTilesPerWarp = (128*64) / (32*32*4) = 2

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1941,51 +1941,66 @@ struct PrefetchOpConversion
     if (!memoryRowMajor)
       return failure();
 
-    // Extract a scalar `i1` predicate from a (possibly `arith.andi`-nested)
-    // tensor mask. Scalar leaves and `splat(scalar)` operands contribute to
-    // the uniform predicate; non-uniform leaves (e.g., `arith.cmpi`) are
-    // ignored — safe for a prefetch hint. Returns nullptr if no uniform
-    // predicate can be recovered (i.e., the mask is entirely non-uniform).
-    auto extractUniformPred = [&](Value mask) -> Value {
-      SmallVector<Value> worklist{mask};
-      SmallVector<Value> uniformSrcs;
-      while (!worklist.empty()) {
-        Value v = worklist.pop_back_val();
-        if (!isa<RankedTensorType>(v.getType())) {
-          uniformSrcs.push_back(v);
-          continue;
-        }
-        if (auto splat = v.getDefiningOp<triton::SplatOp>()) {
-          uniformSrcs.push_back(splat.getSrc());
-          continue;
-        }
-        if (auto andOp = v.getDefiningOp<arith::AndIOp>()) {
-          worklist.push_back(andOp.getLhs());
-          worklist.push_back(andOp.getRhs());
-          continue;
-        }
-        // Non-uniform leaf (e.g., arith.cmpi) — ignored.
+    // A tensor value is "uniform" if `AxisInfo` proves its constancy covers
+    // the full shape in every dimension (same semantics as the regular path
+    // at line 1729–1736). Scalars are trivially uniform.
+    auto isUniform = [&](Value v) {
+      auto ty = dyn_cast<RankedTensorType>(v.getType());
+      if (!ty)
+        return true;
+      AxisInfo *info =
+          const_cast<triton::intel::ModuleAxisInfoAnalysis &>(axisAnalysisPass)
+              .getAxisInfo(v);
+      if (!info)
+        return false;
+      ArrayRef<int64_t> shape = ty.getShape();
+      for (unsigned d = 0, e = ty.getRank(); d < e; ++d)
+        if (info->getConstancy(d) < static_cast<unsigned>(shape[d]))
+          return false;
+      return true;
+    };
+
+    // Collect operands that `AxisInfo` proves are uniform, descending
+    // through `arith.andi` chains (as produced by `tt::getPredMask`).
+    // Non-uniform leaves are dropped — safe for a prefetch hint.
+    SmallVector<Value> uniformOps;
+    std::function<void(Value)> collect = [&](Value v) {
+      if (isUniform(v)) {
+        uniformOps.push_back(v);
+        return;
       }
-      if (uniformSrcs.empty())
-        return Value();
-      Value acc = rewriter.getRemappedValue(uniformSrcs.front());
-      if (!acc)
-        return Value();
-      auto tb = TritonLLVMOpBuilder(op.getLoc(), rewriter);
-      for (Value v : ArrayRef<Value>(uniformSrcs).drop_front()) {
-        Value remapped = rewriter.getRemappedValue(v);
-        if (!remapped)
-          return Value();
-        acc = tb.and_(acc, remapped);
+      if (auto andOp = v.getDefiningOp<arith::AndIOp>()) {
+        collect(andOp.getLhs());
+        collect(andOp.getRhs());
       }
-      return acc;
     };
 
     Value scalarPred;
     if (Value mask = op.getMask()) {
-      scalarPred = extractUniformPred(mask);
-      if (!scalarPred)
+      collect(mask);
+      if (uniformOps.empty())
         return failure();
+
+      // Reduce each uniform operand to a scalar `i1` (element 0 of the
+      // packed LLVM representation — all lanes hold the same value by
+      // definition of uniformity) and AND them together.
+      auto tb = TritonLLVMOpBuilder(op.getLoc(), rewriter);
+      for (Value v : uniformOps) {
+        Value remapped = rewriter.getRemappedValue(v);
+        if (!remapped)
+          return failure();
+        Value scalar;
+        if (isa<RankedTensorType>(v.getType())) {
+          SmallVector<Value> elems =
+              unpackLLElements(op.getLoc(), remapped, rewriter);
+          if (elems.empty())
+            return failure();
+          scalar = elems[0];
+        } else {
+          scalar = remapped;
+        }
+        scalarPred = scalarPred ? tb.and_(scalarPred, scalar) : scalar;
+      }
     }
 
     auto tensorOfPointers = dyn_cast<RankedTensorType>(op.getPtr().getType());

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1511,6 +1511,24 @@ static LinearLayout getPrefetchLinearLayout(MLIRContext *ctx,
                                 tensorShape);
 }
 
+// Prefetch-specific cache control mapping. Differs from LoadOp in that
+// `NONE` defaults to L1C_L3C (traditional prefetch-aggressively policy)
+// rather than DEFAULT. Explicit user/pass-set modifiers (e.g., `.cg` from
+// the AnnotateCacheControl pass) still propagate through.
+static TritonGEN::LoadCacheControl prefetchCacheControl(CacheModifier cm) {
+  switch (cm) {
+  case CacheModifier::NONE:
+  case CacheModifier::CA:
+    return TritonGEN::LoadCacheControl::L1C_L3C;
+  case CacheModifier::CG:
+    return TritonGEN::LoadCacheControl::L1UC_L3C;
+  case CacheModifier::CV:
+    return TritonGEN::LoadCacheControl::L1UC_L3UC;
+  default:
+    return TritonGEN::LoadCacheControl::L1C_L3C;
+  }
+}
+
 /// Emit 2D block prefetch operations for a tiled prefetch.
 ///
 /// Converts base dimensions to bytes, determines vBlocks from element size,
@@ -1523,7 +1541,9 @@ static LogicalResult emit2DBlockPrefetchOps(
     unsigned tileHeightInElem, unsigned numTilesPerWarp,
     unsigned tileSizeInElem, const LinearLayout &llEncoding, unsigned rank = 2,
     ArrayRef<Value> extraDimStridesInBytes = {},
-    ArrayRef<Value> extraDimBaseOffsets = {}, Value scalarPred = {}) {
+    ArrayRef<Value> extraDimBaseOffsets = {}, Value scalarPred = {},
+    TritonGEN::LoadCacheControl cacheOpt =
+        TritonGEN::LoadCacheControl::L1C_L3C) {
   assert(extraDimStridesInBytes.size() == rank - 2 &&
          extraDimBaseOffsets.size() == rank - 2 &&
          "extraDim arrays must have rank - 2 elements");
@@ -1608,7 +1628,7 @@ static LogicalResult emit2DBlockPrefetchOps(
         /*tile_width*/ tileWidthInElem,
         /*tile_height*/ tileHeightInElem,
         /*v_blocks*/ vBlocks,
-        /*cache_opt*/ TritonGEN::LoadCacheControl::L1C_L3C);
+        /*cache_opt*/ cacheOpt);
     if (failed(newOp.verify())) {
       // Delete the op so that the verifier will not abort the pass
       // pipeline later, as we can fail this path and try a different
@@ -1874,7 +1894,7 @@ struct PrefetchOpConversion
                   /*tile_width*/ tileWidthInElem,
                   /*tile_height*/ tileHeightInElem,
                   /*v_blocks*/ vBlocks,
-                  /*cache_opt*/ TritonGEN::LoadCacheControl::L1C_L3C);
+                  /*cache_opt*/ prefetchCacheControl(op.getCache()));
               if (failed(newOp.verify())) {
                 // delete the op so that the verifier will not abort the pass
                 // pipeline later, as we can fail this path and try a different
@@ -2063,7 +2083,7 @@ struct PrefetchOpConversion
         op, rewriter, loc, base, baseWidth, baseHeight, rowStride, offsetBaseX,
         offsetBaseY, eltTy, tileWidthInElem, tileHeightInElem, numTilesPerWarp,
         tileSizeInElem, llEncoding, rank, extraDimStrides, extraDimBaseOffsets,
-        scalarPred);
+        scalarPred, prefetchCacheControl(op.getCache()));
   }
 };
 
@@ -2185,7 +2205,8 @@ struct DescriptorPrefetchOpConversion
         op, rewriter, loc, desc.base, baseWidth, baseHeight, rowStride,
         offsetBaseX, offsetBaseY, eltTy, tileWidthInElem, tileHeightInElem,
         numTilesPerWarp, tileSizeInElem, llEncoding, rank, extraDimStrides,
-        extraDimBaseOffsets);
+        extraDimBaseOffsets, /*scalarPred=*/Value{},
+        prefetchCacheControl(op.getCache()));
   }
 };
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1905,8 +1905,7 @@ struct PrefetchOpConversion
     if (!memoryRowMajor)
       return failure();
 
-    auto tensorOfPointers =
-        dyn_cast<RankedTensorType>(op.getPtr().getType());
+    auto tensorOfPointers = dyn_cast<RankedTensorType>(op.getPtr().getType());
     if (!tensorOfPointers)
       return failure();
     unsigned rank = tensorOfPointers.getRank();

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1915,6 +1915,11 @@ struct PrefetchOpConversion
     Type elementType = ptrType.getPointeeType();
     Type eltTy = getTypeConverter()->convertType(elementType);
     unsigned elemSizeInBits = eltTy.getIntOrFloatBitWidth();
+    // 2D block prefetch requires byte-addressable element sizes. Sub-byte
+    // types (e.g. i1, i4) would trigger division by zero in
+    // get2DPrefetchWarpsPerCTA and downstream byte-based math.
+    if (elemSizeInBits < 8 || elemSizeInBits % 8 != 0)
+      return failure();
     unsigned elemSizeInBytes = elemSizeInBits / 8;
 
     int numWarps = triton::gpu::lookupNumWarps(op);
@@ -1938,10 +1943,24 @@ struct PrefetchOpConversion
     Location loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-    // Recover base pointer from the tensor-of-pointers.
-    Value llPtr = adaptor.getPtr();
-    SmallVector<Value> ptrElems = unpackLLElements(loc, llPtr, rewriter);
-    Value base = targetInfo.shuffleIdx(rewriter, loc, ptrElems[0], 0);
+    // Recover a uniform scalar base pointer from the tensor-of-pointers.
+    // The cooperative path relies on a single base with per-warp offsets added
+    // later via applyLinearLayout(kWarp=warpId). Using ptrElems[0] would give
+    // each warp its register-0 pointer, which already encodes that warp's
+    // position — combining it with the warp offset would double-shift the
+    // address. Require the tensor-of-pointers to be produced by a chain of
+    // `tt.addptr` ending in `tt.splat(%base)` so we can extract the scalar
+    // `%base` as the uniform pointer. Otherwise bail out so the generic
+    // fallback can handle it.
+    Value cur = op.getPtr();
+    while (auto addPtrOp = cur.getDefiningOp<triton::AddPtrOp>())
+      cur = addPtrOp.getPtr();
+    auto splatOp = cur.getDefiningOp<triton::SplatOp>();
+    if (!splatOp)
+      return failure();
+    Value base = rewriter.getRemappedValue(splatOp.getSrc());
+    if (!base)
+      return failure();
 
     // Row stride in elements (i64) -- emit2DBlockPrefetchOps converts to bytes.
     int stride = getStride(op.getPtr(), rank - 2);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1633,15 +1633,19 @@ struct PrefetchOpConversion
   matchAndRewrite(triton::gpu::intel::PrefetchOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     LogicalResult res = rewriteRegularPointerPrefetch(op, adaptor, rewriter);
+    if (succeeded(res))
+      return success();
+
+    res = rewriteCooperativePrefetch(op, adaptor, rewriter);
+    if (succeeded(res))
+      return success();
 
     // FIXME: the prefetch lowering code should never fail. Currently it does in
     // some cases. We should address those cases instead of removing the
     // prefetch operation.
-    if (failed(res)) {
-      op.emitWarning("Prefetch operation could not be converted to LLVM. "
-                     "The operation was erased.");
-      rewriter.eraseOp(op);
-    }
+    op.emitWarning("Prefetch operation could not be converted to LLVM. "
+                   "The operation was erased.");
+    rewriter.eraseOp(op);
 
     return success();
   }
@@ -1877,6 +1881,101 @@ struct PrefetchOpConversion
 
     rewriter.eraseOp(op);
     return success();
+  }
+
+  /// Handle prefetch for loads with BlockedEncodingAttr (non-dot).
+  /// Follows the same cooperative 2D-block-prefetch pattern as
+  /// DescriptorPrefetchOpConversion::rewriteTensorDescriptorPrefetch() but
+  /// extracts base/stride from tensor-of-pointers instead of a descriptor.
+  LogicalResult
+  rewriteCooperativePrefetch(triton::gpu::intel::PrefetchOp op,
+                             OpAdaptor adaptor,
+                             ConversionPatternRewriter &rewriter) const {
+    Attribute blockIOAttr =
+        op->getAttr(TritonIntelGPUDialect::getBlockIOAttrName());
+    if (!blockIOAttr)
+      return failure();
+
+    // Masked prefetches (from pipeline epilogue predication) are not handled
+    // by the cooperative path — the base pointer may be out of bounds.
+    if (op.getMask())
+      return failure();
+
+    const bool memoryRowMajor = isMemoryRowMajor(op);
+    if (!memoryRowMajor)
+      return failure();
+
+    auto tensorOfPointers = cast<RankedTensorType>(op.getPtr().getType());
+    unsigned rank = tensorOfPointers.getRank();
+    if (rank < 2)
+      return failure();
+
+    ArrayRef<int64_t> tensorShape = tensorOfPointers.getShape();
+    auto ptrType = cast<PointerType>(tensorOfPointers.getElementType());
+    Type elementType = ptrType.getPointeeType();
+    Type eltTy = getTypeConverter()->convertType(elementType);
+    unsigned elemSizeInBits = eltTy.getIntOrFloatBitWidth();
+    unsigned elemSizeInBytes = elemSizeInBits / 8;
+
+    int numWarps = triton::gpu::lookupNumWarps(op);
+    auto m = op->getParentOfType<ModuleOp>();
+    bool isPrefetch256BSupported =
+        m->hasAttr(TritonIntelGPUDialect::getSupportPrefetch256BAttrName());
+
+    auto [tileHeightInElem, tileWidthInElem, warpsM, warpsN] =
+        get2DPrefetchWarpsPerCTA(tensorShape, eltTy, numWarps,
+                                 isPrefetch256BSupported);
+    auto llEncoding = getPrefetchLinearLayout(
+        getContext(), tensorShape, {tileHeightInElem, tileWidthInElem},
+        {warpsM, warpsN});
+
+    unsigned tileSizeInElem = tileHeightInElem * tileWidthInElem;
+    int64_t totalElems = 1;
+    for (auto s : tensorShape)
+      totalElems *= s;
+    unsigned numTilesPerWarp = totalElems / (tileSizeInElem * numWarps);
+
+    Location loc = op.getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+    // Recover base pointer from the tensor-of-pointers.
+    Value llPtr = adaptor.getPtr();
+    SmallVector<Value> ptrElems = unpackLLElements(loc, llPtr, rewriter);
+    Value base = targetInfo.shuffleIdx(rewriter, loc, ptrElems[0], 0);
+
+    // Row stride in elements (i64) -- emit2DBlockPrefetchOps converts to bytes.
+    int stride = getStride(op.getPtr(), rank - 2);
+    if (stride < 0)
+      return failure();
+    Value rowStride = b.i64_val(stride);
+
+    // Surface dimensions for the 2D block prefetch hardware.
+    // baseWidth must equal the row stride (surface width) because the HW
+    // computes addresses as base + y * pitch + x. Using the tile width would
+    // be wrong when pitch > tile width.
+    // baseHeight uses the tile height — each warp's offsetY stays within the
+    // tile, so this is sufficient for bounds checking.
+    Value baseWidth = b.i64_val(stride);
+    Value baseHeight = b.i64_val(tensorShape[rank - 2]);
+
+    // Offsets start at 0; per-warp offsets computed by emit2DBlockPrefetchOps.
+    Value offsetBaseX = b.i32_val(0);
+    Value offsetBaseY = b.i32_val(0);
+
+    // Prepare extra-dim strides (bytes, i64) and base offsets (i32) for
+    // rank > 2.
+    SmallVector<Value> extraDimStrides, extraDimBaseOffsets;
+    for (unsigned d = 0; d < rank - 2; ++d) {
+      int dimStride = getStride(op.getPtr(), d);
+      extraDimStrides.push_back(
+          b.i64_val(dimStride > 0 ? dimStride * elemSizeInBytes : 0));
+      extraDimBaseOffsets.push_back(b.i32_val(0));
+    }
+
+    return emit2DBlockPrefetchOps(
+        op, rewriter, loc, base, baseWidth, baseHeight, rowStride, offsetBaseX,
+        offsetBaseY, eltTy, tileWidthInElem, tileHeightInElem, numTilesPerWarp,
+        tileSizeInElem, llEncoding, rank, extraDimStrides, extraDimBaseOffsets);
   }
 };
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1,6 +1,7 @@
 #include "Dialect/TritonIntelGPU/IR/Dialect.h"
 #include "intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/TypeUtilities.h"
@@ -1903,39 +1904,68 @@ struct PrefetchOpConversion
     if (!blockIOAttr)
       return failure();
 
-    // Masked prefetches can arise from loop-pipeline epilogue predication,
-    // which turns a scalar `pred` into `splat(pred)` via tt::getPredMask. The
-    // cooperative path uses a single uniform base pointer plus per-warp
-    // offsets and can only honor a uniform (scalar) predicate. If the mask is
-    // provably uniform (a splat, or already scalar), extract a single i1 and
-    // apply it to offsetY below. Otherwise bail so the generic path, which
-    // supports per-element masks, can handle it.
+    // Masked prefetches can arise from loop-pipeline epilogue predication.
+    // `MatmulLoopPipeline::predicateOp` wraps the existing mask with
+    // `tt::getPredMask`, which yields either `splat(pred)` (when the prefetch
+    // had no prior mask) or `arith.andi(splat(pred), priorMask)` (when it
+    // did, e.g. the load had a bounds check). The cooperative path uses a
+    // single uniform base pointer plus per-warp offsets and can only honor a
+    // uniform (scalar) predicate; the per-element `priorMask` component
+    // cannot be applied here. Because a prefetch is a hint (dropping a
+    // per-element mask is safe — the HW bounds check on the 2D surface
+    // still rejects out-of-surface offsets), we extract any uniform
+    // component(s) and AND them into a scalar predicate. If no uniform
+    // component can be found (e.g., the mask is purely `arith.cmpi`), bail
+    // so the generic path can handle it.
     const bool memoryRowMajor = isMemoryRowMajor(op);
     if (!memoryRowMajor)
       return failure();
 
+    // Extract a scalar `i1` predicate from a (possibly `arith.andi`-nested)
+    // tensor mask. Scalar leaves and `splat(scalar)` operands contribute to
+    // the uniform predicate; non-uniform leaves (e.g., `arith.cmpi`) are
+    // ignored — safe for a prefetch hint. Returns nullptr if no uniform
+    // predicate can be recovered (i.e., the mask is entirely non-uniform).
+    auto extractUniformPred = [&](Value mask) -> Value {
+      SmallVector<Value> worklist{mask};
+      SmallVector<Value> uniformSrcs;
+      while (!worklist.empty()) {
+        Value v = worklist.pop_back_val();
+        if (!isa<RankedTensorType>(v.getType())) {
+          uniformSrcs.push_back(v);
+          continue;
+        }
+        if (auto splat = v.getDefiningOp<triton::SplatOp>()) {
+          uniformSrcs.push_back(splat.getSrc());
+          continue;
+        }
+        if (auto andOp = v.getDefiningOp<arith::AndIOp>()) {
+          worklist.push_back(andOp.getLhs());
+          worklist.push_back(andOp.getRhs());
+          continue;
+        }
+        // Non-uniform leaf (e.g., arith.cmpi) — ignored.
+      }
+      if (uniformSrcs.empty())
+        return Value();
+      Value acc = rewriter.getRemappedValue(uniformSrcs.front());
+      if (!acc)
+        return Value();
+      auto tb = TritonLLVMOpBuilder(op.getLoc(), rewriter);
+      for (Value v : ArrayRef<Value>(uniformSrcs).drop_front()) {
+        Value remapped = rewriter.getRemappedValue(v);
+        if (!remapped)
+          return Value();
+        acc = tb.and_(acc, remapped);
+      }
+      return acc;
+    };
+
     Value scalarPred;
     if (Value mask = op.getMask()) {
-      bool uniform = false;
-      if (isa<RankedTensorType>(mask.getType()))
-        uniform = mask.getDefiningOp<triton::SplatOp>() != nullptr;
-      else
-        uniform = true;
-      if (!uniform)
+      scalarPred = extractUniformPred(mask);
+      if (!scalarPred)
         return failure();
-
-      Value llMask = adaptor.getMask();
-      if (!llMask)
-        return failure();
-      if (isa<RankedTensorType>(mask.getType())) {
-        SmallVector<Value> maskElems =
-            unpackLLElements(op.getLoc(), llMask, rewriter);
-        if (maskElems.empty())
-          return failure();
-        scalarPred = maskElems[0];
-      } else {
-        scalarPred = llMask;
-      }
     }
 
     auto tensorOfPointers = dyn_cast<RankedTensorType>(op.getPtr().getType());

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1522,7 +1522,7 @@ static LogicalResult emit2DBlockPrefetchOps(
     unsigned tileHeightInElem, unsigned numTilesPerWarp,
     unsigned tileSizeInElem, const LinearLayout &llEncoding, unsigned rank = 2,
     ArrayRef<Value> extraDimStridesInBytes = {},
-    ArrayRef<Value> extraDimBaseOffsets = {}) {
+    ArrayRef<Value> extraDimBaseOffsets = {}, Value scalarPred = {}) {
   assert(extraDimStridesInBytes.size() == rank - 2 &&
          extraDimBaseOffsets.size() == rank - 2 &&
          "extraDim arrays must have rank - 2 elements");
@@ -1576,6 +1576,13 @@ static LogicalResult emit2DBlockPrefetchOps(
         {{kOffset, b.i32_val(off)}, {kWarp, warpId}, {kBlock, b.i32_val(0)}});
     Value offsetX = b.add(offsets[rank - 1].second, offsetBaseX);
     Value offsetY = b.add(offsets[rank - 2].second, offsetBaseY);
+
+    // If a uniform predicate is supplied (e.g. from loop-pipeline epilogue
+    // predication), set offsetY to baseHeight when the predicate is false so
+    // the HW out-of-bounds check skips the prefetch without generating
+    // spurious traffic.
+    if (scalarPred)
+      offsetY = b.select(scalarPred, offsetY, baseHeight);
 
     // Fold extra dimensions (beyond the inner 2) into the base pointer.
     Value adjustedBase = base;
@@ -1896,14 +1903,40 @@ struct PrefetchOpConversion
     if (!blockIOAttr)
       return failure();
 
-    // Masked prefetches (from pipeline epilogue predication) are not handled
-    // by the cooperative path — the base pointer may be out of bounds.
-    if (op.getMask())
-      return failure();
-
+    // Masked prefetches can arise from loop-pipeline epilogue predication,
+    // which turns a scalar `pred` into `splat(pred)` via tt::getPredMask. The
+    // cooperative path uses a single uniform base pointer plus per-warp
+    // offsets and can only honor a uniform (scalar) predicate. If the mask is
+    // provably uniform (a splat, or already scalar), extract a single i1 and
+    // apply it to offsetY below. Otherwise bail so the generic path, which
+    // supports per-element masks, can handle it.
     const bool memoryRowMajor = isMemoryRowMajor(op);
     if (!memoryRowMajor)
       return failure();
+
+    Value scalarPred;
+    if (Value mask = op.getMask()) {
+      bool uniform = false;
+      if (isa<RankedTensorType>(mask.getType()))
+        uniform = mask.getDefiningOp<triton::SplatOp>() != nullptr;
+      else
+        uniform = true;
+      if (!uniform)
+        return failure();
+
+      Value llMask = adaptor.getMask();
+      if (!llMask)
+        return failure();
+      if (isa<RankedTensorType>(mask.getType())) {
+        SmallVector<Value> maskElems =
+            unpackLLElements(op.getLoc(), llMask, rewriter);
+        if (maskElems.empty())
+          return failure();
+        scalarPred = maskElems[0];
+      } else {
+        scalarPred = llMask;
+      }
+    }
 
     auto tensorOfPointers = dyn_cast<RankedTensorType>(op.getPtr().getType());
     if (!tensorOfPointers)
@@ -1999,7 +2032,8 @@ struct PrefetchOpConversion
     return emit2DBlockPrefetchOps(
         op, rewriter, loc, base, baseWidth, baseHeight, rowStride, offsetBaseX,
         offsetBaseY, eltTy, tileWidthInElem, tileHeightInElem, numTilesPerWarp,
-        tileSizeInElem, llEncoding, rank, extraDimStrides, extraDimBaseOffsets);
+        tileSizeInElem, llEncoding, rank, extraDimStrides, extraDimBaseOffsets,
+        scalarPred);
   }
 };
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1905,7 +1905,10 @@ struct PrefetchOpConversion
     if (!memoryRowMajor)
       return failure();
 
-    auto tensorOfPointers = cast<RankedTensorType>(op.getPtr().getType());
+    auto tensorOfPointers =
+        dyn_cast<RankedTensorType>(op.getPtr().getType());
+    if (!tensorOfPointers)
+      return failure();
     unsigned rank = tensorOfPointers.getRank();
     if (rank < 2)
       return failure();
@@ -1972,8 +1975,8 @@ struct PrefetchOpConversion
     // baseWidth must equal the row stride (surface width) because the HW
     // computes addresses as base + y * pitch + x. Using the tile width would
     // be wrong when pitch > tile width.
-    // baseHeight uses the tile height — each warp's offsetY stays within the
-    // tile, so this is sufficient for bounds checking.
+    // baseHeight is the full logical tensor height (surface height), not the
+    // tile height, so the hardware's bounds checking spans the whole tensor.
     Value baseWidth = b.i64_val(stride);
     Value baseHeight = b.i64_val(tensorShape[rank - 2]);
 
@@ -1982,12 +1985,15 @@ struct PrefetchOpConversion
     Value offsetBaseY = b.i32_val(0);
 
     // Prepare extra-dim strides (bytes, i64) and base offsets (i32) for
-    // rank > 2.
+    // rank > 2. Silently substituting 0 for an unknown/negative stride
+    // would synthesize aliasing addresses across outer-dim slices (all
+    // slices would prefetch the same (x,y) surface), so bail out instead.
     SmallVector<Value> extraDimStrides, extraDimBaseOffsets;
     for (unsigned d = 0; d < rank - 2; ++d) {
       int dimStride = getStride(op.getPtr(), d);
-      extraDimStrides.push_back(
-          b.i64_val(dimStride > 0 ? dimStride * elemSizeInBytes : 0));
+      if (dimStride <= 0)
+        return failure();
+      extraDimStrides.push_back(b.i64_val(dimStride * elemSizeInBytes));
       extraDimBaseOffsets.push_back(b.i32_val(0));
     }
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -20,17 +20,86 @@ namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
 namespace ttgi = mlir::triton::gpu::intel;
 
+static ttg::DotOperandEncodingAttr allTransitiveUsesHaveDotEncoding(Value val);
+
 namespace {
 
-/// Represent a candidate load operation which is used by operations that
-/// convert its layout to a 'dot' layout (e.g. ttg.convert_layout).
-struct LoadDotOperand {
-  LoadDotOperand(Operation *load,
-                 ttg::DotOperandEncodingAttr dotOperandEncoding)
-      : load(load), dotOperandEncoding(dotOperandEncoding) {}
-  Operation *load;
-  ttg::DotOperandEncodingAttr dotOperandEncoding;
+/// A load operation eligible for prefetching. Only tt::LoadOp and
+/// tt::DescriptorLoadOp are valid. Static predicates centralize the
+/// candidacy logic.
+struct PrefetchCandidate {
+  explicit PrefetchCandidate(Operation *op) : op(op) {
+    assert((isa<tt::LoadOp, tt::DescriptorLoadOp>(op)) &&
+           "only tt::LoadOp and tt::DescriptorLoadOp can be prefetched");
+  }
+  Operation *op;
+
+  /// Whether \p op has the block_io attribute and rank >= 2 result type,
+  /// making it eligible for 2D block prefetching.
+  static bool isCandidate(Operation *op) {
+    if (!isa<tt::LoadOp, tt::DescriptorLoadOp>(op))
+      return false;
+    if (!op->getAttr(ttgi::TritonIntelGPUDialect::getBlockIOAttrName()))
+      return false;
+    auto resultTy = dyn_cast<RankedTensorType>(op->getResultTypes()[0]);
+    return resultTy && resultTy.getRank() >= 2;
+  }
+
+  /// Whether all transitive uses of \p op's result feed a dot operation.
+  static bool feedsDot(Operation *op) {
+    return allTransitiveUsesHaveDotEncoding(op->getResult(0)) != nullptr;
+  }
 };
+
+/// Return the multi-buffered byte cost of a load's result tensor.
+/// Each prefetched load is kept live for \p numStages iterations.
+static unsigned getTileBytes(Operation *op, int numStages) {
+  auto tensorType = dyn_cast<RankedTensorType>(op->getResultTypes()[0]);
+  if (!tensorType)
+    return 0;
+  unsigned bits = tensorType.getElementType().getIntOrFloatBitWidth();
+  int64_t numElems = tensorType.getNumElements();
+  return static_cast<unsigned>(numElems * bits / 8) * numStages;
+}
+
+/// Collect all prefetch candidates from the loop body. Dot-feeding loads
+/// are always collected; elementwise loads are only collected on architectures
+/// with 256B prefetch support (Xe3P+), where software prefetch can outpace the
+/// hardware prefetcher.
+static SmallVector<PrefetchCandidate>
+collectPrefetchCandidates(scf::ForOp forOp, int numStages) {
+  constexpr unsigned kMaxElementwisePrefetchOps = 4;
+  constexpr unsigned kMaxPerLoadPrefetchBytes = 16384;
+
+  auto moduleOp = forOp->getParentOfType<ModuleOp>();
+  bool enableElementwisePrefetch = moduleOp->hasAttr(
+      ttgi::TritonIntelGPUDialect::getSupportPrefetch256BAttrName());
+
+  unsigned numElementwisePrefetch = 0;
+
+  SmallVector<PrefetchCandidate> candidates;
+  // We cannot use forOp.walk(...) here because we only want to visit the
+  // operations in the loop body block.
+  for (Operation &op : forOp) {
+    if (!PrefetchCandidate::isCandidate(&op))
+      continue;
+
+    if (PrefetchCandidate::feedsDot(&op)) {
+      candidates.emplace_back(&op);
+    } else if (enableElementwisePrefetch &&
+               numElementwisePrefetch < kMaxElementwisePrefetchOps) {
+      unsigned tileBytes = getTileBytes(&op, numStages);
+      if (tileBytes > kMaxPerLoadPrefetchBytes) {
+        LDBG("Skipping elementwise prefetch: per-load budget exceeded ("
+             << tileBytes << " > " << kMaxPerLoadPrefetchBytes << " bytes)");
+        continue;
+      }
+      candidates.emplace_back(&op);
+      ++numElementwisePrefetch;
+    }
+  }
+  return candidates;
+}
 
 } // namespace
 
@@ -47,8 +116,6 @@ static void appendToYield(scf::ForOp forOp, ArrayRef<Value> newOperands) {
   scf::YieldOp::create(builder, yieldOp->getLoc(), operands);
   yieldOp->erase();
 }
-
-static ttg::DotOperandEncodingAttr allTransitiveUsesHaveDotEncoding(Value val);
 
 static ttg::DotOperandEncodingAttr getDotEncodingFromUser(Operation *user) {
   if (user->getNumResults() != 1)
@@ -111,66 +178,17 @@ static void createPrefetchOp(scf::ForOp &forOp, tt::DescriptorLoadOp loadOp) {
   prefetchOp->setAttrs(attrs);
 }
 
-/// Create prefetch operations for the given loads.
+/// Create prefetch operations for the given load candidates.
 static void createPrefetchOps(scf::ForOp &forOp,
-                              ArrayRef<LoadDotOperand> loads) {
-  assert(!loads.empty() && "Expecting at least one load operation");
-  for (const LoadDotOperand &loadOperand : loads) {
-    if (auto loadOp = dyn_cast<tt::LoadOp>(loadOperand.load)) {
-      createPrefetchOp(forOp, loadOp);
-    } else if (auto descriptorLoadOp =
-                   dyn_cast<tt::DescriptorLoadOp>(loadOperand.load)) {
-      createPrefetchOp(forOp, descriptorLoadOp);
-    } else {
-      llvm_unreachable("Unsupported load operation type");
-    }
-  }
-}
-
-/// Return the transitive use of the load which is a dot operand.
-static std::optional<LoadDotOperand> loadDotOperand(Operation *loadOp) {
-  Value result = loadOp->getResult(0);
-  if (ttg::DotOperandEncodingAttr attr =
-          allTransitiveUsesHaveDotEncoding(result))
-    return LoadDotOperand(loadOp, attr);
-  return std::nullopt;
-}
-
-/// Collect loads to pipeline. Return success if we can pipeline this loop.
-static void collectOpsToPipeline(scf::ForOp forOp,
-                                 SmallVectorImpl<LoadDotOperand> &loadOps) {
-  assert(loadOps.empty() && "Expecting an empty list of load operations");
-
-  ModuleOp moduleOp = forOp->getParentOfType<ModuleOp>();
-  mlir::triton::ModuleAxisInfoAnalysis axisInfoAnalysis(moduleOp);
-
-  // We cannot use forOp.walk(...) here because we only want to visit the
-  // operations in the loop body block.
-  for (Operation &op : forOp) {
-    if (isa<tt::LoadOp, tt::DescriptorLoadOp>(&op)) {
-      // In order to avoid polluting the cache, do not prefetch loads unless the
-      // memory they reference is densely structured.
-      Attribute blockIOAttr =
-          op.getAttr(mlir::triton::gpu::intel::TritonIntelGPUDialect::
-                         getBlockIOAttrName());
-      if (!blockIOAttr) {
-        LDBG("Skipping LoadOp without block_io attribute" << op);
-        continue;
-      }
-
-      RankedTensorType resultTy =
-          dyn_cast<RankedTensorType>(op.getResultTypes()[0]);
-      // Rank > 2 tensors are handled by folding batch dims into the base
-      // pointer via GEP (see emit2DBlockPrefetchOps in LoadStoreOpToLLVM.cpp).
-      if (!resultTy || resultTy.getRank() < 2) {
-        LDBG("Skipping LoadOp with rank < 2 tensor type" << op);
-        continue;
-      }
-
-      std::optional<LoadDotOperand> loadWithDotOperand = loadDotOperand(&op);
-      if (loadWithDotOperand.has_value())
-        loadOps.push_back(loadWithDotOperand.value());
-    }
+                              ArrayRef<PrefetchCandidate> candidates) {
+  assert(!candidates.empty() && "Expecting at least one candidate");
+  for (const PrefetchCandidate &candidate : candidates) {
+    TypeSwitch<Operation *>(candidate.op)
+        .Case<tt::LoadOp, tt::DescriptorLoadOp>(
+            [&](auto loadOp) { createPrefetchOp(forOp, loadOp); })
+        .Default([](Operation *op) {
+          llvm_unreachable("Unsupported load operation type");
+        });
   }
 }
 
@@ -318,9 +336,9 @@ bool ttgi::preProcessLoopAndGetSchedule(scf::ForOp &forOp, int numStages,
                                         mlir::scf::PipeliningOption &options) {
   // 1. First collect "interesting" operations with a stage where to schedule
   // them. This gives a coarse scheduling for the loop.
-  SmallVector<LoadDotOperand> loads;
-  collectOpsToPipeline(forOp, loads);
-  if (loads.empty()) {
+  SmallVector<PrefetchCandidate> candidates =
+      collectPrefetchCandidates(forOp, numStages);
+  if (candidates.empty()) {
     LDBG("No loads to pipeline");
     return false;
   }
@@ -328,8 +346,8 @@ bool ttgi::preProcessLoopAndGetSchedule(scf::ForOp &forOp, int numStages,
   LLVM_DEBUG({
     DBGS() << "Loads to pipeline:\n";
     unsigned prefetchBytes = 0;
-    for (LoadDotOperand &load : loads) {
-      Operation *op = load.load;
+    for (const PrefetchCandidate &candidate : candidates) {
+      Operation *op = candidate.op;
       RankedTensorType tensorType =
           dyn_cast<RankedTensorType>(op->getResultTypes()[0]);
       if (tensorType) {
@@ -350,7 +368,7 @@ bool ttgi::preProcessLoopAndGetSchedule(scf::ForOp &forOp, int numStages,
   });
 
   // 2. Create the prefetching operations for the loads collected.
-  createPrefetchOps(forOp, loads);
+  createPrefetchOps(forOp, candidates);
 
   // 3. Create the final schedule for the kernel loop. This will dictate the
   // stages and order of operations to the pipeline expander.

--- a/third_party/intel/lib/TritonIntelGPUTransforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -10,6 +10,8 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/MathExtras.h"
+#include <limits>
 
 #define DEBUG_TYPE "tritonintelgpu-pipeline"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
@@ -53,13 +55,22 @@ struct PrefetchCandidate {
 
 /// Return the multi-buffered byte cost of a load's result tensor.
 /// Each prefetched load is kept live for \p numStages iterations.
+/// Returns UINT_MAX when the tensor is non-ranked or has dynamic
+/// dimensions, so callers that compare against a byte budget skip the
+/// load conservatively. Uses ceil-div on bits/8 to avoid under-counting
+/// sub-byte types, and widens arithmetic to int64_t to avoid overflow
+/// on large tensors before saturating back to unsigned.
 static unsigned getTileBytes(Operation *op, int numStages) {
   auto tensorType = dyn_cast<RankedTensorType>(op->getResultTypes()[0]);
-  if (!tensorType)
-    return 0;
+  if (!tensorType || !tensorType.hasStaticShape())
+    return std::numeric_limits<unsigned>::max();
   unsigned bits = tensorType.getElementType().getIntOrFloatBitWidth();
   int64_t numElems = tensorType.getNumElements();
-  return static_cast<unsigned>(numElems * bits / 8) * numStages;
+  int64_t bytesPerElem = llvm::divideCeil(bits, 8u);
+  int64_t totalBytes = numElems * bytesPerElem * numStages;
+  return (totalBytes > std::numeric_limits<unsigned>::max())
+             ? std::numeric_limits<unsigned>::max()
+             : static_cast<unsigned>(totalBytes);
 }
 
 /// Collect all prefetch candidates from the loop body. Dot-feeding loads


### PR DESCRIPTION
Extend the software pipelining pass to prefetch elementwise loads (non-dot) with `block_io` attribute
Resolves #6711