### PR TITLE
[ReduceOpToLLVM] Minor changes

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceOpToLLVM.cpp
@@ -344,7 +344,7 @@ private:
         vals.push_back(std::move(cur));
       }
 
-#ifdef TRITON_INTEL_REDUCE_USE_LEFT_FOLD_THREAD_REDUCE
+#if TRITON_INTEL_REDUCE_USE_LEFT_FOLD_THREAD_REDUCE
       // Use a deterministic left fold to avoid extra reassociation error in
       // low-precision reductions.
       SmallVector<Value> acc = vals.front();

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceOpToLLVM.cpp
@@ -327,7 +327,10 @@ private:
         vectorCombineRegion ? *vectorCombineRegion : op.getCombineOp();
 
     Operation &combinerOp = combineRegion.front().front();
+
+#if !TRITON_INTEL_REDUCE_USE_LEFT_FOLD_THREAD_REDUCE
     unsigned arity = targetInfo.getReductionTreeArity(&combinerOp);
+#endif
 
     // Perform a tree reduction
     unsigned numOperands = accs.size();


### PR DESCRIPTION
- Use `#if` instead of `#ifdef` - address review comment https://github.com/intel/intel-xpu-backend-for-triton/pull/6667/changes#r3112270306
- Guard `arity` definition, as `getReductionTreeArity` is undefined in release branch, and only needed when `TRITON_INTEL_REDUCE_USE_LEFT_FOLD_THREAD_REDUCE=0`