### PR TITLE
[TEST] Fix lit test failures due to non-deterministic operation ordering

### DIFF
--- a/test/Conversion/intel/tritongpu_to_gen_dot.mlir
+++ b/test/Conversion/intel/tritongpu_to_gen_dot.mlir
@@ -576,8 +576,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     // CHECK:           %[[C_3_1:.*]] = llvm.insertelement %[[VAL_353]], %[[VAL_416]]{{\[}}%[[CST_7]] : i32] : vector<8xf32>
 
     // COM: Total 16 dpas ops unrolled.
-    // CHECK:           %[[B_0_0:.*]] = llvm.bitcast %[[VAL_237]] : vector<16xf16> to vector<8xi32>
-    // CHECK:           %[[A_0_0:.*]] = llvm.bitcast %[[VAL_93]] : vector<8xf16> to vector<8xi16>
+    // CHECK-DAG:       %[[B_0_0:.*]] = llvm.bitcast %[[VAL_237]] : vector<16xf16> to vector<8xi32>
+    // CHECK-DAG:       %[[A_0_0:.*]] = llvm.bitcast %[[VAL_93]] : vector<8xf16> to vector<8xi16>
     // CHECK:           %[[C_0_0_0:.*]] = llvm.call spir_funccc @_Z45__spirv_SubgroupMatrixMultiplyAccumulateINTELiDv8_sDv8_iDv8_fi(%{{.*}}, %[[A_0_0]], %[[B_0_0]], %[[C_0_0]], %{{.*}})
     // CHECK:           %[[A_1_0:.*]] = llvm.bitcast %[[VAL_102]] : vector<8xf16> to vector<8xi16>
     // CHECK:           %[[C_1_0_0:.*]] = llvm.call spir_funccc @_Z45__spirv_SubgroupMatrixMultiplyAccumulateINTELiDv8_sDv8_iDv8_fi(%{{.*}}, %[[A_1_0]], %[[B_0_0]], %[[C_1_0]], %{{.*}})
@@ -596,8 +596,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     // AGGRESSIVE-REUSE:              %[[C_1_1_0:.*]] = llvm.call spir_funccc @_Z45__spirv_SubgroupMatrixMultiplyAccumulateINTELiDv8_sDv8_iDv8_fi(%{{.*}}, %[[A_1_0]], %[[B_0_1]], %[[C_1_1]], %{{.*}})
     // AGGRESSIVE-REUSE:              %[[C_0_1_0:.*]] = llvm.call spir_funccc @_Z45__spirv_SubgroupMatrixMultiplyAccumulateINTELiDv8_sDv8_iDv8_fi(%{{.*}}, %[[A_0_0]], %[[B_0_1]], %[[C_0_1]], %{{.*}})
 
-    // CHECK:           %[[B_1_0:.*]] = llvm.bitcast %[[VAL_271]] : vector<16xf16> to vector<8xi32>
-    // CHECK:           %[[A_0_1:.*]] = llvm.bitcast %[[VAL_129]] : vector<8xf16> to vector<8xi16>
+    // CHECK-DAG:       %[[B_1_0:.*]] = llvm.bitcast %[[VAL_271]] : vector<16xf16> to vector<8xi32>
+    // CHECK-DAG:       %[[A_0_1:.*]] = llvm.bitcast %[[VAL_129]] : vector<8xf16> to vector<8xi16>
     // CHECK:           {{.*}} = llvm.call spir_funccc @_Z45__spirv_SubgroupMatrixMultiplyAccumulateINTELiDv8_sDv8_iDv8_fi(%{{.*}}, %[[A_0_1]], %[[B_1_0]], %[[C_0_0_0]], %{{.*}})
     // CHECK:           %[[A_1_1:.*]] = llvm.bitcast %[[VAL_138]] : vector<8xf16> to vector<8xi16>
     // CHECK:           {{.*}} = llvm.call spir_funccc @_Z45__spirv_SubgroupMatrixMultiplyAccumulateINTELiDv8_sDv8_iDv8_fi(%{{.*}}, %[[A_1_1]], %[[B_1_0]], %[[C_1_0_0]], %{{.*}})

--- a/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
@@ -112,8 +112,8 @@ llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_
   // CHECK-DAG:   [[ZERO_1:%.*]] = llvm.mlir.constant(0 : i32) : i32
   // CHECK-DAG:   [[ONE:%.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-DAG:   [[UNDEF:%.*]] = llvm.mlir.undef : vector<2xi32>
-  // CHECK-NEXT:  [[COORD0:%.*]] = llvm.insertelement [[ADD_1]], [[UNDEF]][[[ZERO_1]] : i32] : vector<2xi32>
-  // CHECK-NEXT:  [[COORD1:%.*]] = llvm.insertelement %arg5, [[COORD0]][[[ONE]] : i32] : vector<2xi32>
+  // CHECK-DAG:   [[COORD0:%.*]] = llvm.insertelement [[ADD_1]], [[UNDEF]][[[ZERO_1]] : i32] : vector<2xi32>
+  // CHECK-DAG:   [[COORD1:%.*]] = llvm.insertelement %arg5, [[COORD0]][[[ONE]] : i32] : vector<2xi32>
   // CHECK-DAG:   [[ElemSize:%.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-DAG:   [[TileWidth:%.*]] = llvm.mlir.constant(16 : i32) : i32
   // CHECK-DAG:   [[TileHeight:%.*]] = llvm.mlir.constant(8 : i32) : i32

--- a/test/TritonGEN/tritongen-2Dblockprefetch-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockprefetch-to-llvm.mlir
@@ -18,8 +18,8 @@ llvm.func @triton_gen.2Dblockprefetch(%ptr : !llvm.ptr<1>, %base_width : i32, %b
   // CHECK-DAG:  [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
   // CHECK-DAG:  [[ONE:%.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-DAG:  [[UNDEF:%.*]] = llvm.mlir.undef : vector<2xi32>
-  // CHECK-NEXT: [[COORD0:%.*]] = llvm.insertelement [[ADD_1]], [[UNDEF]][[[ZERO]] : i32] : vector<2xi32>
-  // CHECK-NEXT: [[COORD1:%.*]] = llvm.insertelement %arg5, [[COORD0]][[[ONE]] : i32] : vector<2xi32>
+  // CHECK-DAG:  [[COORD0:%.*]] = llvm.insertelement [[ADD_1]], [[UNDEF]][[[ZERO]] : i32] : vector<2xi32>
+  // CHECK-DAG:  [[COORD1:%.*]] = llvm.insertelement %arg5, [[COORD0]][[[ONE]] : i32] : vector<2xi32>
   // CHECK:      [[ElemSize:%.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: [[TileWidth:%.*]] = llvm.mlir.constant(32 : i32) : i32
   // CHECK-NEXT: [[TileHeight:%.*]] = llvm.mlir.constant(8 : i32) : i32

--- a/test/TritonGEN/tritongen-2Dblockstore-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockstore-to-llvm.mlir
@@ -37,8 +37,8 @@ llvm.func @triton_gen.2Dblockstore(%ptr : !llvm.ptr<1>, %base_width : i32, %base
   // CHECK-DAG:   [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
   // CHECK-DAG:   [[ONE:%.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-DAG:   [[UNDEF:%.*]] = llvm.mlir.undef : vector<2xi32>
-  // CHECK-NEXT:  [[COORD0:%.*]] = llvm.insertelement [[ADD_1]], [[UNDEF]][[[ZERO]] : i32] : vector<2xi32>
-  // CHECK-NEXT:  [[COORD1:%.*]] = llvm.insertelement %arg5, [[COORD0]][[[ONE]] : i32] : vector<2xi32>
+  // CHECK-DAG:   [[COORD0:%.*]] = llvm.insertelement [[ADD_1]], [[UNDEF]][[[ZERO]] : i32] : vector<2xi32>
+  // CHECK-DAG:   [[COORD1:%.*]] = llvm.insertelement %arg5, [[COORD0]][[[ONE]] : i32] : vector<2xi32>
   // CHECK-DAG:   [[ElemSize:%.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-DAG:   [[TileWidth:%.*]] = llvm.mlir.constant(16 : i32) : i32
   // CHECK-DAG:   [[TileHeight:%.*]] = llvm.mlir.constant(8 : i32) : i32


### PR DESCRIPTION
MLIR can generate certain operations (constants, vector construction, bitcasts) in different orders across builds. 
Changed CHECK to CHECK-DAG only where operations can genuinely reorder:
- Coordinate vector construction: constants and insertelement ops
- DPAS bitcast pairs: B and A bitcasts that appear before DPAS calls