### PR TITLE
[TritonIntelGPU] Implement PredicatedOpInterface on PrefetchOp

### DIFF
--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -48,6 +48,7 @@ def TTIG_AllocOp : TTIG_Op<"alloc", [MemoryEffects<[MemAlloc]>]> {
 
 def TTIG_PrefetchOp : TTIG_Op<"prefetch", [
   MemoryEffects<[MemWrite<L2Cache>]>,
+  DeclareOpInterfaceMethods<PredicatedOpInterface>,
   TypesMatchWith<"mask type matches ptr type", "ptr", "mask", "getI1SameShape(getPointeeType($_self))",
                  "($_op.getOperands().size() <= 1) || std::equal_to<>()">,
 ]> {

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
@@ -93,6 +93,12 @@ void PrefetchOp::build(OpBuilder &builder, OperationState &state, Value ptr,
   PrefetchOp::build(builder, state, ptr, /*mask=*/{}, cache, evict, isVolatile);
 }
 
+Value PrefetchOp::getPredicateOperand() { return getMask(); }
+void PrefetchOp::setPredicateOperand(Value pred) {
+  getMaskMutable().assign(pred);
+}
+Type PrefetchOp::getPredicateOperandTypeLike() { return getPtr().getType(); }
+
 LogicalResult DescriptorPrefetchOp::verify() {
   auto descType = getDesc().getType();
   unsigned blockRank = descType.getBlockType().getRank();


### PR DESCRIPTION
Wire `ttig::PrefetchOp` into `PredicatedOpInterface` so the shared pipeliner combines its mask with loop-stage predicates. Mirrors upstream `LoadOp`/`StoreOp`.

Closes #6729