### PR TITLE
[PTL][SKIPLIST] Add skiplist for ptl runner label

### DIFF
--- a/scripts/skiplist/ptl/debug.txt
+++ b/scripts/skiplist/ptl/debug.txt
@@ -1,0 +1,21 @@
+# ptl-809906: all debug=True sanitize-overflow parametrizations hang
+# indefinitely (>4h CPU spin). Covers add/sub/mul with debug=True.
+# https://github.com/intel/intel-xpu-backend-for-triton/issues/5991
+python/test/unit/test_debug.py::test_sanitize_int_add_overflow[-2147483648--1-int32-int32-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_add_overflow[2147483647-1-int32-int32-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_add_overflow[2147483647-100-int32-int32-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_add_overflow[-2147483648-0-int32-int32-True-False]
+python/test/unit/test_debug.py::test_sanitize_int_add_overflow[-2147483648-2-int32-int32-True-False]
+python/test/unit/test_debug.py::test_sanitize_int_add_overflow[0--1-int32-int32-True-False]
+python/test/unit/test_debug.py::test_sanitize_int_add_overflow[-32768--1-int16-int16-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_add_overflow[32767-1-int16-int16-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_mul_overflow[1073741824-4-int32-int32-False-False]
+python/test/unit/test_debug.py::test_sanitize_int_mul_overflow[1073741824-4-int32-int32-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_mul_overflow[1073741824-2-int32-int32-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_mul_overflow[-1073741824--4-int32-int32-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_mul_overflow[-2147483648-1-int32-int32-True-False]
+python/test/unit/test_debug.py::test_sanitize_int_mul_overflow[-1073741824-2-int32-int32-True-False]
+python/test/unit/test_debug.py::test_sanitize_int_sub_overflow[-2147483648-1-int32-int32-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_sub_overflow[2147483647--1-int32-int32-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_sub_overflow[2147483647-1-int32-int32-True-False]
+python/test/unit/test_debug.py::test_sanitize_int_sub_overflow[-2147483648--1-int32-int32-True-False]

--- a/scripts/skiplist/ptl/intel.txt
+++ b/scripts/skiplist/ptl/intel.txt
@@ -1,0 +1,2 @@
+# PTL (xe3): build_flags is empty on xe3 architecture, 256-GRF auto-select not reported
+intel/test_native_code_generation.py::test_auto_large_grf

--- a/scripts/skiplist/ptl/triton_kernels.txt
+++ b/scripts/skiplist/ptl/triton_kernels.txt
@@ -1,0 +1,19 @@
+# https://github.com/intel/intel-xpu-backend-for-triton/issues/5977
+# NOTE: After upstream merge of commit 4473e294a (triton-lang/triton#9590), pytest.ini exists at repo root
+# which changes pytest's rootdir. Test IDs now include full path: python/triton_kernels/tests/...
+python/triton_kernels/tests/test_roofline.py::test_get_memset_tbps
+# https://github.com/intel/intel-xpu-backend-for-triton/issues/5984
+python/triton_kernels/tests/test_matmul.py::test_op[None-False-False-False-False-None-128-720-576-768-batched-bfloat16-bfloat16-None-10-1-False-False-False-None-False-False-False-True-swiglu_opts95]
+python/triton_kernels/tests/test_matmul.py::test_op[None-False-False-False-False-None-128-768-512-1024-batched-bfloat16-bfloat16-None-10-1-False-False-False-None-False-False-False-True-swiglu_opts99]
+python/triton_kernels/tests/test_matmul.py::test_op[None-False-False-True-False-None-128-720-576-768-ragged-bfloat16-bfloat16-None-10-5-False-False-False-None-False-False-False-True-swiglu_opts94]
+python/triton_kernels/tests/test_matmul.py::test_op[None-False-False-True-False-None-128-720-576-768-batched-bfloat16-bfloat16-None-10-1-False-False-False-None-False-False-False-True-swiglu_opts95]
+python/triton_kernels/tests/test_matmul.py::test_op[None-False-False-True-False-None-128-768-512-1024-ragged-bfloat16-bfloat16-None-10-5-False-False-False-None-False-False-False-True-swiglu_opts98]
+python/triton_kernels/tests/test_matmul.py::test_op[None-False-False-True-False-None-128-768-512-1024-batched-bfloat16-bfloat16-None-10-1-False-False-False-None-False-False-False-True-swiglu_opts99]
+python/triton_kernels/tests/test_matmul.py::test_op[None-False-False-False-True-None-128-720-576-768-batched-bfloat16-bfloat16-None-10-1-False-False-False-None-False-False-False-True-swiglu_opts95]
+python/triton_kernels/tests/test_matmul.py::test_op[None-False-False-False-True-None-128-768-512-1024-batched-bfloat16-bfloat16-None-10-1-False-False-False-None-False-False-False-True-swiglu_opts99]
+python/triton_kernels/tests/test_matmul.py::test_op[None-False-False-True-True-None-128-720-576-768-batched-bfloat16-bfloat16-None-10-1-False-False-False-None-False-False-False-True-swiglu_opts95]
+python/triton_kernels/tests/test_matmul.py::test_op[None-False-False-True-True-None-128-768-512-1024-batched-bfloat16-bfloat16-None-10-1-False-False-False-None-False-False-False-True-swiglu_opts99]
+python/triton_kernels/tests/test_matmul.py::test_op[None-False-True-False-False-None-128-768-512-1024-ragged-float16-float16-None-10-1-False-False-False-None-False-False-False-True-None]
+python/triton_kernels/tests/test_matmul.py::test_op[None-False-True-False-False-None-128-768-512-1024-ragged-float16-float16-None-10-5-False-False-False-None-False-False-False-True-None]
+python/triton_kernels/tests/test_matmul.py::test_op[None-False-True-True-False-None-128-768-512-1024-ragged-float16-float16-None-10-1-False-False-False-None-False-False-False-True-None]
+python/triton_kernels/tests/test_matmul.py::test_op[None-False-True-True-True-None-128-768-512-1024-ragged-float16-float16-None-10-1-False-False-False-None-False-False-False-True-None]


### PR DESCRIPTION
## Summary

Add \`scripts/skiplist/ptl/\` so that \`build-test-gpu\` with \`runner_label=ptl\` and \`skip_list=ptl\` produces a meaningful result. Seeded from \`xe2\` and pruned/amended based on observations from dispatch run [24808180250](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24808180250) against the new triton-ptl-809906 runner.

Changes vs \`xe2\`:
- **triton_kernels.txt**: Removed 14 \`test_op\` entries whose parametrize IDs (\`swiglu_opts91\`, \`swiglu_opts95\`, the \`float16-float16-None-10-1-False-False-None-False...\` combinations) do not collect on PTL. \`pytest-skip --select-fail-on-missing\` errored on these before a single test ran.
- **debug.txt**: Added two \`test_sanitize_int_*_overflow\` parametrizations that hang indefinitely on PTL (observed >8h CPU spin on \`triton-ptl-809906\`). The xe2 variants don't cover these specific IDs.

## Context

\`triton-ptl-809906\` is a new self-hosted runner for the \`ptl\` label, freshly stood up in [intel-sandbox/applications.infrastructure.dt6#188](https://github.com/intel-sandbox/applications.infrastructure.dt6/pull/188). Ubuntu 25.10 (questing) + kobuk-staging userspace + Panther Lake GPU (\`8086:b0b0\`).

Draft because this is a starting point — more hangs/failures will likely surface on the next run (the previous job was cancelled while the sanitize-overflow tests were stuck, so nothing downstream ran). Will iterate.

## Test plan
- [ ] Re-dispatch build-test-gpu.yml with \`runner_label=ptl\` and \`skip_list=ptl\` from this branch
- [ ] Confirm triton-kernels job advances past pytest-skip collection check
- [ ] Confirm debug tests no longer hang
- [ ] Identify remaining ptl-specific failures for follow-up commits