### PR TITLE
[RemoveLayoutConversions] Skip hoistConvertDotOperand across width-changing ops

### DIFF
--- a/test/TritonIntelGPU/hoist-convert-dot-operand.mlir
+++ b/test/TritonIntelGPU/hoist-convert-dot-operand.mlir
@@ -64,3 +64,98 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return
   }
 }
+
+// -----
+
+// COM: Negative case: an fp8 -> fp16 upcast sits between the load and the
+// COM: convert_layout. The convert target is #dot_op<dpas, kWidth=2> whose
+// COM: kWidth is parameterized for the fp16 dot operand. The hoist must NOT
+// COM: cross the upcast — doing so would place a convert_layout on 8-bit
+// COM: data with a layout sized for 16-bit, collapsing to a sub-group
+// COM: transpose-through-SLM and disabling 2D block I/O on the load.
+// COM: Issue #6737.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [1, 4], order = [1, 0]}>
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+#dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: @no_hoist_across_fp8_upcast
+  tt.func public @no_hoist_across_fp8_upcast(
+      %arg0: !tt.ptr<f8E4M3FN>, %arg1: !tt.ptr<f16>,
+      %arg2: !tt.ptr<f32>, %arg4: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x256xf32, #dpas>
+    %desc_a = tt.make_tensor_descriptor %arg0, [%arg4, %arg4], [%c0_i64, %c1_i64] : <f8E4M3FN>, <64x32xf8E4M3FN>
+    %desc_b = tt.make_tensor_descriptor %arg1, [%arg4, %arg4], [%c0_i64, %c1_i64] : <f16>, <32x256xf16>
+    // CHECK: scf.for
+    // COM: The f8 descriptor_load must remain paired with fp_to_fp (not with a
+    // COM: convert_layout). The convert_layout must stay on the fp16 side.
+    // CHECK:   %[[A_F8:.*]] = tt.descriptor_load {{.*}} -> tensor<64x32xf8E4M3FN, #blocked>
+    // CHECK-NOT: ttg.convert_layout %[[A_F8]]
+    // CHECK:   %[[A_F16:.*]] = tt.fp_to_fp %[[A_F8]] : tensor<64x32xf8E4M3FN, #blocked> -> tensor<64x32xf16, #blocked>
+    // CHECK:   ttg.convert_layout %[[A_F16]] : tensor<64x32xf16, #blocked> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    // CHECK:   tt.dot
+    // CHECK:   scf.yield
+    %result = scf.for %iv = %c0_i32 to %arg4 step %c32_i32 iter_args(%acc = %cst) -> (tensor<64x256xf32, #dpas>) : i32 {
+      %a_f8 = tt.descriptor_load %desc_a[%c0_i32, %iv] : !tt.tensordesc<64x32xf8E4M3FN> -> tensor<64x32xf8E4M3FN, #blocked>
+      %a_f16 = tt.fp_to_fp %a_f8 : tensor<64x32xf8E4M3FN, #blocked> -> tensor<64x32xf16, #blocked>
+      %b = tt.descriptor_load %desc_b[%iv, %c0_i32] : !tt.tensordesc<32x256xf16> -> tensor<32x256xf16, #blocked1>
+      %a_dot = ttg.convert_layout %a_f16 : tensor<64x32xf16, #blocked> -> tensor<64x32xf16, #dot0>
+      %b_dot = ttg.convert_layout %b : tensor<32x256xf16, #blocked1> -> tensor<32x256xf16, #dot1>
+      %d = tt.dot %a_dot, %b_dot, %acc, inputPrecision = tf32 : tensor<64x32xf16, #dot0> * tensor<32x256xf16, #dot1> -> tensor<64x256xf32, #dpas>
+      scf.yield %d : tensor<64x256xf32, #dpas>
+    }
+    %desc_c = tt.make_tensor_descriptor %arg2, [%arg4, %arg4], [%c0_i64, %c1_i64] : <f32>, <64x256xf32>
+    tt.descriptor_store %desc_c[%c0_i32, %c0_i32], %result : !tt.tensordesc<64x256xf32>, tensor<64x256xf32, #dpas>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Negative case: an arith.extf f16 -> f32 sits between the load and the
+// COM: convert_layout. Same reasoning as the fp8 upcast case.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [1, 4], order = [1, 0]}>
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 1, threadsPerWarp = 16, warpsPerCTA = [1, 4], repCluster = [1, 1], A = [8, 8], B = [8, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+#dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: @no_hoist_across_extf
+  tt.func public @no_hoist_across_extf(
+      %arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f32>,
+      %arg2: !tt.ptr<f32>, %arg4: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x256xf32, #dpas>
+    %desc_a = tt.make_tensor_descriptor %arg0, [%arg4, %arg4], [%c0_i64, %c1_i64] : <f16>, <64x32xf16>
+    %desc_b = tt.make_tensor_descriptor %arg1, [%arg4, %arg4], [%c0_i64, %c1_i64] : <f32>, <32x256xf32>
+    // CHECK: scf.for
+    // CHECK:   %[[A_F16:.*]] = tt.descriptor_load {{.*}} -> tensor<64x32xf16, #blocked>
+    // CHECK-NOT: ttg.convert_layout %[[A_F16]]
+    // CHECK:   %[[A_F32:.*]] = arith.extf %[[A_F16]] : tensor<64x32xf16, #blocked> to tensor<64x32xf32, #blocked>
+    // CHECK:   ttg.convert_layout %[[A_F32]]
+    // CHECK:   tt.dot
+    // CHECK:   scf.yield
+    %result = scf.for %iv = %c0_i32 to %arg4 step %c32_i32 iter_args(%acc = %cst) -> (tensor<64x256xf32, #dpas>) : i32 {
+      %a_f16 = tt.descriptor_load %desc_a[%c0_i32, %iv] : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #blocked>
+      %a_f32 = arith.extf %a_f16 : tensor<64x32xf16, #blocked> to tensor<64x32xf32, #blocked>
+      %b = tt.descriptor_load %desc_b[%iv, %c0_i32] : !tt.tensordesc<32x256xf32> -> tensor<32x256xf32, #blocked1>
+      %a_dot = ttg.convert_layout %a_f32 : tensor<64x32xf32, #blocked> -> tensor<64x32xf32, #dot0>
+      %b_dot = ttg.convert_layout %b : tensor<32x256xf32, #blocked1> -> tensor<32x256xf32, #dot1>
+      %d = tt.dot %a_dot, %b_dot, %acc, inputPrecision = tf32 : tensor<64x32xf32, #dot0> * tensor<32x256xf32, #dot1> -> tensor<64x256xf32, #dpas>
+      scf.yield %d : tensor<64x256xf32, #dpas>
+    }
+    %desc_c = tt.make_tensor_descriptor %arg2, [%arg4, %arg4], [%c0_i64, %c1_i64] : <f32>, <64x256xf32>
+    tt.descriptor_store %desc_c[%c0_i32, %c0_i32], %result : !tt.tensordesc<64x256xf32>, tensor<64x256xf32, #dpas>
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -1748,6 +1748,29 @@ void LayoutRematerialization::hoistConvertDotOperand(
   if (result.failed())
     return;
 
+  // Bail if any leaf load has a different element bitwidth than the convert
+  // target. The target DotOperandEncodingAttr's kWidth / opsPerChannel is
+  // parameterized for the dot-operand element width; propagating it back
+  // across a width-changing op (e.g. tt.fp_to_fp fp8->fp16, arith.extf)
+  // produces a convert_layout on a narrower element with a layout that does
+  // not match any efficient 2D block I/O or sub-group shuffle, forcing a
+  // sub-group-transpose-through-SLM fallback and disabling block I/O on the
+  // load. See issue #6737.
+  unsigned targetBitwidth = targetType.getElementType().getIntOrFloatBitWidth();
+  for (Value v : slice) {
+    Operation *def = v.getDefiningOp();
+    if (!def || !isa<tt::LoadOp, tt::DescriptorLoadOp>(def))
+      continue;
+    auto loadTy = cast<RankedTensorType>(v.getType());
+    if (loadTy.getElementType().getIntOrFloatBitWidth() != targetBitwidth) {
+      LDBG("  Leaf load element bitwidth ("
+           << loadTy.getElementType().getIntOrFloatBitWidth()
+           << ") differs from convert target bitwidth (" << targetBitwidth
+           << "); skipping hoist to avoid degrading dot-operand encoding");
+      return;
+    }
+  }
+
   IRMapping mapping;
   OpBuilder builder(convertOp.getContext());
   SetVector<Value> innerSlice;


### PR DESCRIPTION
Fixes #6737. Hoisting the convert across an upcast (e.g. fp8->fp16) placed it on narrower data with a #dot_op<dpas> kWidth sized for the wider dot operand, forcing SLM-transpose fallback and disabling 2D block I/O. Bail if any leaf load's element bitwidth differs from the convert target's.