### PR TITLE
[INTEL] Fix vLLM startup segfault: initialize Level Zero early and improve XPU init error handling (debuggable failures vs. hard crash)

### DIFF
--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -104,6 +104,50 @@ static void zeConstructError(const char *file, int line, const char *message,
   PyGILState_Release(gil_state);
 }
 
+// Level Zero helpers for `extern "C"` Python entry points (return NULL on
+// failure). Layering (each expands at most once per use site; no extra work vs
+// inlining): FAIL_MSG* -> FAIL_IF*; SET_INTEL_ERR + return -> FAIL_SET_INTEL;
+// TRITON_ZE_CHECK evaluates a ze_result_t expression once.
+#define TRITON_ZE_FAIL_MSG(msg)                                                \
+  do {                                                                         \
+    zeConstructError(__FILE__, __LINE__, (msg));                               \
+    return NULL;                                                               \
+  } while (0)
+
+#define TRITON_ZE_FAIL_MSG_INTEL(msg)                                          \
+  do {                                                                         \
+    zeConstructError(__FILE__, __LINE__, (msg), true);                         \
+    return NULL;                                                               \
+  } while (0)
+
+#define TRITON_ZE_FAIL_IF(cond, msg)                                           \
+  do {                                                                         \
+    if (cond)                                                                  \
+      TRITON_ZE_FAIL_MSG((msg));                                               \
+  } while (0)
+
+#define TRITON_ZE_FAIL_IF_INTEL(cond, msg)                                     \
+  do {                                                                         \
+    if (cond)                                                                  \
+      TRITON_ZE_FAIL_MSG_INTEL((msg));                                         \
+  } while (0)
+
+#define TRITON_ZE_SET_INTEL_ERR(file, line, ze_res)                            \
+  zeConstructError((file), (line), parseZeResultCode(ze_res).data(), true)
+
+#define TRITON_ZE_FAIL_SET_INTEL(file, line, ze_res)                           \
+  do {                                                                         \
+    TRITON_ZE_SET_INTEL_ERR(file, line, ze_res);                               \
+    return NULL;                                                               \
+  } while (0)
+
+#define TRITON_ZE_CHECK(expr)                                                  \
+  do {                                                                         \
+    ze_result_t triton_ze_r__ = (expr);                                        \
+    if (triton_ze_r__ != ZE_RESULT_SUCCESS)                                    \
+      TRITON_ZE_FAIL_SET_INTEL(__FILE__, __LINE__, triton_ze_r__);             \
+  } while (0)
+
 template <typename T>
 static inline T
 checkZeCodeAndSetPyErr(const std::tuple<T, ze_result_t> syclTuple,
@@ -112,30 +156,24 @@ checkZeCodeAndSetPyErr(const std::tuple<T, ze_result_t> syclTuple,
   if (code == ZE_RESULT_SUCCESS)
     return std::get<0>(syclTuple);
 
-  zeConstructError(file, line, parseZeResultCode(code).data(),
-                   /* useIntelGPUError */ true);
+  TRITON_ZE_SET_INTEL_ERR(file, line, code);
   return std::get<0>(syclTuple);
 }
 
 extern "C" EXPORT_FUNC PyObject *get_device_properties(int device_id) {
-  if (device_id >= g_sycl_l0_device_list.size()) {
-    zeConstructError(__FILE__, __LINE__, "Device is not found");
-    return NULL;
-  }
+  TRITON_ZE_FAIL_IF(device_id >= g_sycl_l0_device_list.size(),
+                    "Device is not found");
   const auto device = g_sycl_l0_device_list[device_id];
 
   // Get device handle
   ze_device_handle_t phDevice = device.second;
-  if (!phDevice) {
-    zeConstructError(__FILE__, __LINE__,
-                     "Level Zero device handle is null for this device index.");
-    return NULL;
-  }
+  TRITON_ZE_FAIL_IF(!phDevice, "Level Zero device handle is null for this "
+                               "device index.");
 
   // create a struct to hold device properties
   ze_device_properties_t device_properties = {};
   device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
-  zeDeviceGetProperties(phDevice, &device_properties);
+  TRITON_ZE_CHECK(zeDeviceGetProperties(phDevice, &device_properties));
 
   int multiprocessor_count =
       device_properties.numSlices * device_properties.numSubslicesPerSlice;
@@ -144,31 +182,42 @@ extern "C" EXPORT_FUNC PyObject *get_device_properties(int device_id) {
 
   ze_device_compute_properties_t compute_properties = {};
   compute_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_COMPUTE_PROPERTIES;
-  zeDeviceGetComputeProperties(phDevice, &compute_properties);
+  TRITON_ZE_CHECK(zeDeviceGetComputeProperties(phDevice, &compute_properties));
   int max_shared_mem = compute_properties.maxSharedLocalMemory;
   int max_group_size = compute_properties.maxTotalGroupSize;
   int num_subgroup_sizes = compute_properties.numSubGroupSizes;
-  PyObject *subgroup_sizes = PyTuple_New(num_subgroup_sizes);
-  for (int i = 0; i < num_subgroup_sizes; i++) {
-    PyTuple_SetItem(subgroup_sizes, i,
-                    PyLong_FromLong(compute_properties.subGroupSizes[i]));
-  }
 
   uint32_t memoryCount = 0;
-  zeDeviceGetMemoryProperties(phDevice, &memoryCount, nullptr);
-  auto pMemoryProperties = new ze_device_memory_properties_t[memoryCount];
+  TRITON_ZE_CHECK(zeDeviceGetMemoryProperties(phDevice, &memoryCount, nullptr));
+  TRITON_ZE_FAIL_IF_INTEL(memoryCount == 0,
+                          "zeDeviceGetMemoryProperties reported zero memory "
+                          "heaps.");
+
+  std::vector<ze_device_memory_properties_t> memory_properties(memoryCount);
   for (uint32_t mem = 0; mem < memoryCount; ++mem) {
-    pMemoryProperties[mem].stype = ZE_STRUCTURE_TYPE_DEVICE_MEMORY_PROPERTIES;
-    pMemoryProperties[mem].pNext = nullptr;
+    memory_properties[mem].stype = ZE_STRUCTURE_TYPE_DEVICE_MEMORY_PROPERTIES;
+    memory_properties[mem].pNext = nullptr;
   }
-  zeDeviceGetMemoryProperties(phDevice, &memoryCount, pMemoryProperties);
+  TRITON_ZE_CHECK(zeDeviceGetMemoryProperties(phDevice, &memoryCount,
+                                              memory_properties.data()));
 
   // To align with other backends - convert MHz to KHz
   // https://github.com/intel/compute-runtime/blob/cfa007e5519d3a038d726b62237b86fca9a49e2c/shared/source/xe_hpc_core/linux/product_helper_pvc.cpp#L51
-  int mem_clock_rate = pMemoryProperties[0].maxClockRate * 1000;
-  int mem_bus_width = pMemoryProperties[0].maxBusWidth;
+  int mem_clock_rate = memory_properties[0].maxClockRate * 1000;
+  int mem_bus_width = memory_properties[0].maxBusWidth;
 
-  delete[] pMemoryProperties;
+  PyObject *subgroup_sizes = PyTuple_New(num_subgroup_sizes);
+  if (!subgroup_sizes) {
+    return NULL;
+  }
+  for (int i = 0; i < num_subgroup_sizes; i++) {
+    PyObject *item = PyLong_FromLong(compute_properties.subGroupSizes[i]);
+    if (!item) {
+      Py_DECREF(subgroup_sizes);
+      return NULL;
+    }
+    PyTuple_SetItem(subgroup_sizes, i, item);
+  }
 
   return Py_BuildValue("{s:i, s:i, s:i, s:i, s:i, s:i, s:N}", "max_shared_mem",
                        max_shared_mem, "multiprocessor_count",
@@ -313,21 +362,16 @@ extern "C" EXPORT_FUNC PyObject *load_binary(PyObject *args) {
     return NULL;
   }
 
-  if (devId >= g_sycl_l0_device_list.size()) {
-    zeConstructError(__FILE__, __LINE__, "Device is not found");
-    return NULL;
-  }
+  TRITON_ZE_FAIL_IF(devId >= g_sycl_l0_device_list.size(),
+                    "Device is not found");
 
   BuildFlags build_flags(build_flags_ptr);
 
   const auto &sycl_l0_device_pair = g_sycl_l0_device_list[devId];
   const sycl::device sycl_device = sycl_l0_device_pair.first;
   const auto l0_device = sycl_l0_device_pair.second;
-  if (!l0_device) {
-    zeConstructError(__FILE__, __LINE__,
-                     "Level Zero device handle is null for load_binary.");
-    return NULL;
-  }
+  TRITON_ZE_FAIL_IF(!l0_device,
+                    "Level Zero device handle is null for load_binary.");
 
   const std::string kernel_name = name;
   const size_t binary_size = PyBytes_Size(py_bytes);
@@ -336,6 +380,8 @@ extern "C" EXPORT_FUNC PyObject *load_binary(PyObject *args) {
   const auto &ctx = get_default_context(sycl_device);
   const auto l0_context =
       sycl::get_native<sycl::backend::ext_oneapi_level_zero>(ctx);
+  TRITON_ZE_FAIL_IF(!l0_context,
+                    "Level Zero context handle is null for load_binary.");
 
   ze_device_compute_properties_t compute_properties = {};
   compute_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_COMPUTE_PROPERTIES;
@@ -474,21 +520,11 @@ extern "C" EXPORT_FUNC PyObject *load_binary(PyObject *args) {
 
 extern "C" EXPORT_FUNC PyObject *init_devices(PyObject *cap) {
   void *queue = NULL;
-  if (!(queue = PyLong_AsVoidPtr(cap))) {
-    zeConstructError(__FILE__, __LINE__,
-                     "Failed to convert PyObject to void* for queue");
-    return NULL;
-  }
+  TRITON_ZE_FAIL_IF(!(queue = PyLong_AsVoidPtr(cap)),
+                    "Failed to convert PyObject to void* for queue");
   sycl::queue *sycl_queue = static_cast<sycl::queue *>(queue);
 
-  {
-    ze_result_t zr = zeInit(ZE_INIT_FLAG_GPU_ONLY);
-    if (zr != ZE_RESULT_SUCCESS) {
-      const std::string ze_msg = parseZeResultCode(zr);
-      zeConstructError(__FILE__, __LINE__, ze_msg.c_str());
-      return NULL;
-    }
-  }
+  TRITON_ZE_CHECK(zeInit(ZE_INIT_FLAG_GPU_ONLY));
 
   auto sycl_context = sycl_queue->get_context();
 
@@ -510,23 +546,17 @@ extern "C" EXPORT_FUNC PyObject *init_devices(PyObject *cap) {
     g_sycl_l0_device_list.push_back(std::make_pair(sycl_devices[i], zeDev));
   }
 
-  if (usableDeviceCount == 0) {
-    zeConstructError(
-        __FILE__, __LINE__,
-        "No Level Zero device handle from the queue's SYCL context.");
-    return NULL;
-  }
+  TRITON_ZE_FAIL_IF(usableDeviceCount == 0,
+                    "No Level Zero device handle from the queue's SYCL "
+                    "context.");
 
   return Py_BuildValue("(i)", deviceCount);
 }
 
 extern "C" EXPORT_FUNC PyObject *wait_on_sycl_queue(PyObject *cap) {
   void *queue = NULL;
-  if (!(queue = PyLong_AsVoidPtr(cap))) {
-    zeConstructError(__FILE__, __LINE__,
-                     "Failed to convert PyObject to void* for queue");
-    return NULL;
-  }
+  TRITON_ZE_FAIL_IF(!(queue = PyLong_AsVoidPtr(cap)),
+                    "Failed to convert PyObject to void* for queue");
   sycl::queue *sycl_queue = static_cast<sycl::queue *>(queue);
   sycl_queue->wait();
   Py_RETURN_NONE;
@@ -542,16 +572,12 @@ extern "C" EXPORT_FUNC PyObject *sycl_queue_memset(PyObject *args) {
   }
 
   sycl::queue *queue = static_cast<sycl::queue *>(PyLong_AsVoidPtr(py_queue));
-  if (!queue) {
-    zeConstructError(__FILE__, __LINE__, "Invalid SYCL queue pointer");
-    return NULL;
-  }
+  TRITON_ZE_FAIL_IF(!queue, "Invalid SYCL queue pointer");
 
   try {
     queue->memset((void *)ptr, value, (size_t)count);
   } catch (const sycl::exception &e) {
-    zeConstructError(__FILE__, __LINE__, e.what());
-    return NULL;
+    TRITON_ZE_FAIL_MSG(e.what());
   }
 
   Py_RETURN_NONE;

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -126,6 +126,11 @@ extern "C" EXPORT_FUNC PyObject *get_device_properties(int device_id) {
 
   // Get device handle
   ze_device_handle_t phDevice = device.second;
+  if (!phDevice) {
+    zeConstructError(__FILE__, __LINE__,
+                     "Level Zero device handle is null for this device index.");
+    return NULL;
+  }
 
   // create a struct to hold device properties
   ze_device_properties_t device_properties = {};
@@ -318,6 +323,11 @@ extern "C" EXPORT_FUNC PyObject *load_binary(PyObject *args) {
   const auto &sycl_l0_device_pair = g_sycl_l0_device_list[devId];
   const sycl::device sycl_device = sycl_l0_device_pair.first;
   const auto l0_device = sycl_l0_device_pair.second;
+  if (!l0_device) {
+    zeConstructError(__FILE__, __LINE__,
+                     "Level Zero device handle is null for load_binary.");
+    return NULL;
+  }
 
   const std::string kernel_name = name;
   const size_t binary_size = PyBytes_Size(py_bytes);
@@ -471,17 +481,40 @@ extern "C" EXPORT_FUNC PyObject *init_devices(PyObject *cap) {
   }
   sycl::queue *sycl_queue = static_cast<sycl::queue *>(queue);
 
+  {
+    ze_result_t zr = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+    if (zr != ZE_RESULT_SUCCESS) {
+      const std::string ze_msg = parseZeResultCode(zr);
+      zeConstructError(__FILE__, __LINE__, ze_msg.c_str());
+      return NULL;
+    }
+  }
+
   auto sycl_context = sycl_queue->get_context();
 
   // Get sycl-device
   const std::vector<sycl::device> &sycl_devices = sycl_context.get_devices();
 
-  // Retrieve l0 devices
+  g_sycl_l0_device_list.clear();
+
   const uint32_t deviceCount = sycl_devices.size();
+  g_sycl_l0_device_list.reserve(deviceCount);
+  size_t usableDeviceCount = 0;
   for (uint32_t i = 0; i < deviceCount; ++i) {
-    g_sycl_l0_device_list.push_back(std::make_pair(
-        sycl_devices[i], sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
-                             sycl_devices[i])));
+    ze_device_handle_t zeDev =
+        sycl::get_native<sycl::backend::ext_oneapi_level_zero>(sycl_devices[i]);
+    if (zeDev)
+      ++usableDeviceCount;
+    // Keep indices stable: callers pass torch.xpu device ordinals (dense),
+    // so we must not compact this list based on availability of native handles.
+    g_sycl_l0_device_list.push_back(std::make_pair(sycl_devices[i], zeDev));
+  }
+
+  if (usableDeviceCount == 0) {
+    zeConstructError(
+        __FILE__, __LINE__,
+        "No Level Zero device handle from the queue's SYCL context.");
+    return NULL;
   }
 
   return Py_BuildValue("(i)", deviceCount);
@@ -587,6 +620,13 @@ static inline bool checkDevicePointer(void *ptr, int idx,
   }
   auto context = queue.get_context();
   auto handle = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(context);
+  if (!handle) {
+    PyErr_Format(PyExc_RuntimeError,
+                 "Level Zero context handle is null while validating pointer "
+                 "argument (at %d).",
+                 idx);
+    return false;
+  }
   ze_memory_allocation_properties_t prop;
   prop.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
   prop.pNext = nullptr;

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -340,6 +340,8 @@ class XPUUtils(object):
         return cls.instance
 
     def __init__(self):
+        if getattr(self, "_xpu_utils_init_done", False):
+            return
         dirname = os.path.dirname(os.path.realpath(__file__))
         # we save `spirv_utils` module so that the destructor is not called prematurely, which will unload the dll
         # and can cause `Fatal Python error: Segmentation fault`
@@ -364,6 +366,7 @@ class XPUUtils(object):
         self.unload_module = lambda module: None
         self.launch = mod.launch
         self.build_signature_metadata = mod.build_signature_metadata
+        self._xpu_utils_init_done = True
 
     def get_current_device(self):
         import torch

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -333,14 +333,16 @@ def compile_module_from_src(src: str, name: str):
 
 
 class XPUUtils(object):
+    _instance = None
 
     def __new__(cls):
-        if not hasattr(cls, "instance"):
-            cls.instance = super(XPUUtils, cls).__new__(cls)
-        return cls.instance
+        if cls._instance is None:
+            cls._instance = super(XPUUtils, cls).__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
 
     def __init__(self):
-        if getattr(self, "_xpu_utils_init_done", False):
+        if self._initialized:
             return
         dirname = os.path.dirname(os.path.realpath(__file__))
         # we save `spirv_utils` module so that the destructor is not called prematurely, which will unload the dll
@@ -366,7 +368,7 @@ class XPUUtils(object):
         self.unload_module = lambda module: None
         self.launch = mod.launch
         self.build_signature_metadata = mod.build_signature_metadata
-        self._xpu_utils_init_done = True
+        self._initialized = True
 
     def get_current_device(self):
         import torch


### PR DESCRIPTION
# Summary
This PR fixes a reproducible `SIGSEGV` observed when starting **vLLM** on Intel XPU. The crash happens inside the JIT-built `spirv_utils` extension (built from Triton’s Intel backend `driver.c`) when it calls Level Zero APIs before the Level Zero loader path is reliably initialized in the current process.

In addition to the fix, this PR **hardens initialization paths and adds explicit error handling** so that future initialization issues surface as **clear Python errors** (with actionable messages) instead of an opaque native segfault, making debugging significantly easier.

# Impact

- **User-visible consequence**: `python -m vllm.entrypoints.openai.api_server` can crash during startup with `Engine core initialization failed`, because the `EngineCore` subprocess segfaults.
- This is easy to miss from Python logs (no Python exception), but it is clearly visible in `dmesg` and in a native backtrace.
- With this PR, initialization failures are more likely to produce a **readable error** (e.g., “no usable Level Zero device handle”) rather than terminating the process with a segfault.

# How it manifested (dmesg)
```
[czw kwi 23 15:57:34 2026] VLLM::EngineCor[178864]: segfault at 18 ip 00007f638cc3aa57 sp 00007fff88e63530 error 4 in spirv_utils.cpython-312-x86_64-linux-gnu.so[28a57,7f638cc2c000+6b000] likely on CPU 12 (core 24, socket 0)
[czw kwi 23 15:57:34 2026] Code: 00 00 00 48 8d 2d 11 da 07 00 48 89 74 24 08 48 89 ef e8 4c 22 ff ff 48 8b 74 24 08 85 c0 74 cb 48 8d 05 fc da 07 00 48 8b 00 <48> 8b 40 18 48 8b 80 f8 00 00 00 48 85 c0 74 29 48 89 ef 48 89 74
```
Notes:

- segfault at 18 strongly suggests a NULL/invalid dereference at offset 0x18
- The faulting module is spirv_utils.cpython-312-x86_64-linux-gnu.so

# Native backtrace (representative)
```
Thread 1 "VLLM::EngineCor" received signal SIGSEGV, Segmentation fault.
0x0000705724055cc7 in zeDeviceGetProperties () from /mnt/build/lucasso/triton/triton-home/.triton/cache/7JNRCCHCLNRXOZNILIUOPQKE5QH34YSENBKSSY4LDTUN3NQNWZWQ/spirv_utils.cpython-312-x86_64-linux-gnu.so
(gdb) bt
#0  0x0000705724055cc7 in zeDeviceGetProperties () from /mnt/build/lucasso/triton/triton-home/.triton/cache/7JNRCCHCLNRXOZNILIUOPQKE5QH34YSENBKSSY4LDTUN3NQNWZWQ/spirv_utils.cpython-312-x86_64-linux-gnu.so
#1  0x000070572404563e in get_device_properties (device_id=0) at /tmp/tmpoie7eqrq/main.cpp:77
#2  0x000070599996fb16 in ?? () from /lib/x86_64-linux-gnu/libffi.so.8
#3  0x000070599996c3ef in ?? () from /lib/x86_64-linux-gnu/libffi.so.8
#4  0x000070599996f0be in ffi_call () from /lib/x86_64-linux-gnu/libffi.so.8
#5  0x000070599885ccbf in ?? () from /usr/lib/python3.12/lib-dynload/_ctypes.cpython-312-x86_64-linux-gnu.so
```

# Root cause (high level)
`spirv_utils` is a per-process, JIT-compiled extension and may be loaded/called in a process where the Level Zero loader path has not been initialized yet (for example vLLM’s multiprocess `EngineCore` lifecycle). If the first Level Zero call comes from these per-DSO stubs before initialization, it can crash inside `ze*` entry points.

# Fix and debugability improvements

- Call `zeInit(ZE_INIT_FLAG_GPU_ONLY)` at the start of `init_devices` to ensure Level Zero is initialized before any subsequent `ze*` usage in the JIT module.
- Harden device enumeration:
  - Clear and rebuild `g_sycl_l0_device_list`
  - Skip SYCL devices with a null L0 native handle
  - Error out if no usable L0 devices remain (readable error instead of continuing into a crash)
- Add null-handle guards in `get_device_properties` and `load_binary` so invalid handles are reported as explicit errors rather than crashing deep inside `ze*`.
- Make `XPUUtils` initialization in `driver.py` one-shot, so `init_devices` is not re-run on every access to the driver singleton (more predictable init, fewer chances for re-init corner cases).

# Testing

Reproduced the crash when starting vLLM (OpenAI API server) on XPU; verified that after this change the EngineCore no longer segfaults at startup in the previously failing configuration.