### PR TITLE
Fix `boundary_check` bug of `tl.make_block_ptr` for column-major for SGLANG

### DIFF
--- a/test/Triton/Intel/RemoveBoundaryChecks/remove-boundary-checks.mlir
+++ b/test/Triton/Intel/RemoveBoundaryChecks/remove-boundary-checks.mlir
@@ -21,6 +21,25 @@ tt.func public @simple_load(%load_ptr: !tt.ptr<f16> {tt.divisibility = 16 : i32}
 // -----
 
 module {
+tt.func public @preserve_boundary_check_for_column_major(%load_ptr: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+  %c1_i64 = arith.constant 1 : i64
+  %c4_i64 = arith.constant 4 : i64
+  %c64_i64 = arith.constant 64 : i64
+  %c0_i32 = arith.constant 0 : i32
+  // boundaryCheck(1) must guard the second dimension (%c4_i64):
+  // 0 + 64 > 4, so the check cannot be removed.
+  %ptr = tt.make_tensor_ptr %load_ptr, [%c4_i64, %c4_i64], [%c1_i64, %c4_i64], [%c0_i32, %c0_i32] {order = array<i32: 0, 1>} : <tensor<4x64xf16>>
+  %load = tt.load %ptr {boundaryCheck = array<i32: 1>} : !tt.ptr<tensor<4x64xf16>>
+  tt.return
+}
+// CHECK-LABEL: preserve_boundary_check_for_column_major
+// CHECK: [[PTR:%.*]] = tt.make_tensor_ptr
+// CHECK: tt.load [[PTR]] {boundaryCheck = array<i32: 1>} : !tt.ptr<tensor<4x64xf16>>
+}
+
+// -----
+
+module {
 tt.func public @load_in_for_loop1(%load_ptr0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %load_ptr1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RemoveBoundaryChecks.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RemoveBoundaryChecks.cpp
@@ -45,18 +45,8 @@ public:
 
       SmallVector<int> newBoundaryCheck;
       for (int boundIdx : loadOp.getBoundaryCheck()) {
-        // `boundaryCheck` indices are in the same coordinate space as
-        // make_tensor_ptr shape/offset operands.
-        int idx = boundIdx;
-        if (idx < 0 || idx >= makeTensorPtrOp.getOffsets().size()) {
-          LLVM_DEBUG(llvm::dbgs().indent(2)
-                     << "Check at index " << boundIdx
-                     << " is necessary (invalid boundary check index)\n");
-          newBoundaryCheck.push_back(boundIdx);
-          continue;
-        }
-        Value offset = makeTensorPtrOp.getOffsets()[idx];
-        Value shape = makeTensorPtrOp.getShape()[idx];
+        Value offset = makeTensorPtrOp.getOffsets()[boundIdx];
+        Value shape = makeTensorPtrOp.getShape()[boundIdx];
         auto resType = cast<RankedTensorType>(loadOp.getResult().getType());
         ArrayRef<int64_t> resShape = resType.getShape();
         std::optional<int64_t> offsetVal = getConstantIntValue(offset),
@@ -72,7 +62,7 @@ public:
         }
 
         // Case 1: offset and shape are constant.
-        if (offsetVal && ((*offsetVal + resShape[idx]) <= *shapeVal)) {
+        if (offsetVal && ((*offsetVal + resShape[boundIdx]) <= *shapeVal)) {
           LLVM_DEBUG(llvm::dbgs().indent(2)
                      << "Check at index " << boundIdx << " is unnecessary\n");
           continue;
@@ -99,7 +89,7 @@ public:
           }
 
           APInt maxIV = (*optRange).smax();
-          if (maxIV.getSExtValue() + resShape[idx] <= shapeVal) {
+          if (maxIV.getSExtValue() + resShape[boundIdx] <= *shapeVal) {
             LLVM_DEBUG(llvm::dbgs().indent(2)
                        << "Check at index " << boundIdx << " is unnecessary\n");
             continue;

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RemoveBoundaryChecks.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RemoveBoundaryChecks.cpp
@@ -45,8 +45,16 @@ public:
 
       SmallVector<int> newBoundaryCheck;
       for (int boundIdx : loadOp.getBoundaryCheck()) {
-        ArrayRef<int> order = makeTensorPtrOp.getOrder();
-        int idx = order.size() - order[boundIdx] - 1;
+        // `boundaryCheck` indices are in the same coordinate space as
+        // make_tensor_ptr shape/offset operands.
+        int idx = boundIdx;
+        if (idx < 0 || idx >= makeTensorPtrOp.getOffsets().size()) {
+          LLVM_DEBUG(llvm::dbgs().indent(2)
+                     << "Check at index " << boundIdx
+                     << " is necessary (invalid boundary check index)\n");
+          newBoundaryCheck.push_back(boundIdx);
+          continue;
+        }
         Value offset = makeTensorPtrOp.getOffsets()[idx];
         Value shape = makeTensorPtrOp.getShape()[idx];
         auto resType = cast<RankedTensorType>(loadOp.getResult().getType());


### PR DESCRIPTION
E2E accuracy: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24985280889 (pass)

Flex attn: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24985314090 (pass)
Flex dec: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24985328173 (pass)

LTS run:
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24990810226/job/73175656077 (wrong parameters)
* https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24996592686/job/73195081715 (pass)

Benchmarks: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/24997105056 (pass)