### PR TITLE
[RemoveLayoutConversions] Allow hoistConvertDotOperand across UpcastFpOpInterface

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -1733,7 +1733,8 @@ void LayoutRematerialization::hoistConvertDotOperand(
   // threads We do views and elementwise pure ops for now
   auto noDataMovement = [](Operation *op) {
     return (op->hasTrait<OpTrait::Elementwise>() && isMemoryEffectFree(op)) ||
-           isa<tt::BroadcastOp, ttg::Fp4ToFpOp, ttg::ConvertLayoutOp>(op) ||
+           isa<tt::BroadcastOp, ttg::Fp4ToFpOp, ttg::ConvertLayoutOp,
+               ttg::UpcastFpOpInterface>(op) ||
            isView(op);
   };
   // Stop the slice as soon as we find an operation that cannot be done without

--- a/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
@@ -312,7 +312,11 @@ LogicalResult getConvertBackwardSlice(
       }
       for (auto [i, operand] : llvm::enumerate(definingOp->getOpOperands())) {
         if (isa<RankedTensorType>(operand.get().getType())) {
-          auto srcEncoding = ttgi::inferSrcEncoding(definingOp, encoding);
+          Attribute srcEncoding;
+          if (auto upcast = dyn_cast<gpu::UpcastFpOpInterface>(definingOp))
+            srcEncoding = upcast.inferSrcEncoding(i, encoding);
+          else
+            srcEncoding = ttgi::inferSrcEncoding(definingOp, encoding);
           if (!srcEncoding)
             return failure();
           enqueue(operand, srcEncoding);


### PR DESCRIPTION
Align with upstream Triton: add `UpcastFpOpInterface` to the `noDataMovement` lambda and add per-operand `inferSrcEncoding` dispatch in `getConvertBackwardSlice`. No Intel ops implement this interface today; however this prevents upstream divergence.