### PR TITLE
[DecomposeScaledBlocked] Add explicit Utility.h include

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeScaledBlocked.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeScaledBlocked.cpp
@@ -8,6 +8,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 
 using namespace mlir;
 using namespace mlir::triton;


### PR DESCRIPTION
Add explicit `#include "triton/Dialect/TritonGPU/Transforms/Utility.h"` to match upstream.

The file uses `lookupNumWarps` and `getDefaultBlockedEncoding` from this header but relied on a transitive include through `Dialect.h`.