### PR TITLE
[LoadStoreOpToLLVM] Honor eviction_policy hints via LSC cache modes

### DIFF
--- a/test/Conversion/intel/load_store_to_llvm.mlir
+++ b/test/Conversion/intel/load_store_to_llvm.mlir
@@ -87,7 +87,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttig.sup
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttig.support_predicated_io} {
   // CHECK-LABEL: load_evict_first_predicated
   tt.func @load_evict_first_predicated(%ptr: tensor<1024x!tt.ptr<f32>, #blocked>, %mask: tensor<1024xi1, #blocked>) {
-    // CHECK: triton_gen.predicated_load {{.*}} {cache_control = L1IAR_L3C} : (!llvm.ptr<1>, i64, i1, i32) -> i32
+    // CHECK: triton_gen.predicated_load {{.*}} {cache_control = L1IAR_L3C} : (!llvm.ptr<1>, i1, i32) -> i32
     %val = tt.load %ptr, %mask evictionPolicy = evict_first : tensor<1024x!tt.ptr<f32>, #blocked>
     tt.return
   }
@@ -102,7 +102,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttig.sup
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttig.support_predicated_io} {
   // CHECK-LABEL: load_evict_last_predicated
   tt.func @load_evict_last_predicated(%ptr: tensor<1024x!tt.ptr<f32>, #blocked>, %mask: tensor<1024xi1, #blocked>) {
-    // CHECK: triton_gen.predicated_load {{.*}} {cache_control = L1C_L3C} : (!llvm.ptr<1>, i64, i1, i32) -> i32
+    // CHECK: triton_gen.predicated_load {{.*}} {cache_control = L1C_L3C} : (!llvm.ptr<1>, i1, i32) -> i32
     %val = tt.load %ptr, %mask evictionPolicy = evict_last : tensor<1024x!tt.ptr<f32>, #blocked>
     tt.return
   }
@@ -116,7 +116,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttig.sup
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttig.support_predicated_io} {
   // CHECK-LABEL: explicit_cache_wins_over_eviction
   tt.func @explicit_cache_wins_over_eviction(%ptr: tensor<1024x!tt.ptr<f32>, #blocked>, %mask: tensor<1024xi1, #blocked>) {
-    // CHECK: triton_gen.predicated_load {{.*}} {cache_control = L1UC_L3C} : (!llvm.ptr<1>, i64, i1, i32) -> i32
+    // CHECK: triton_gen.predicated_load {{.*}} {cache_control = L1UC_L3C} : (!llvm.ptr<1>, i1, i32) -> i32
     %val = tt.load %ptr, %mask cacheModifier = cg evictionPolicy = evict_last : tensor<1024x!tt.ptr<f32>, #blocked>
     tt.return
   }
@@ -154,7 +154,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttig.sup
   // CHECK-LABEL: descriptor_load_evict_first_predicated
   tt.func @descriptor_load_evict_first_predicated(%desc: !tt.tensordesc<128xf32>) {
     %c0_i32 = arith.constant 0 : i32
-    // CHECK: triton_gen.predicated_load {{.*}} {cache_control = L1IAR_L3C} : (!llvm.ptr<1>, i64, i1, i32) -> i32
+    // CHECK: triton_gen.predicated_load {{.*}} {cache_control = L1IAR_L3C} : (!llvm.ptr<1>, i1, i32) -> i32
     %val = tt.descriptor_load %desc[%c0_i32] evictionPolicy = evict_first : !tt.tensordesc<128xf32> -> tensor<128xf32, #blocked>
     tt.return
   }

--- a/test/Conversion/intel/load_store_to_llvm.mlir
+++ b/test/Conversion/intel/load_store_to_llvm.mlir
@@ -77,3 +77,70 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttig.sup
     tt.return
   }
 }
+
+// -----
+
+// COM: evict_first without an explicit cache modifier routes to L1IAR_L3C and
+// COM: triggers the `nontemporal` flag on the non-predicated scalar load path.
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttig.support_predicated_io} {
+  // CHECK-LABEL: load_evict_first_predicated
+  tt.func @load_evict_first_predicated(%ptr: tensor<1024x!tt.ptr<f32>, #blocked>, %mask: tensor<1024xi1, #blocked>) {
+    // CHECK: triton_gen.predicated_load {{.*}} {cache_control = L1IAR_L3C} : (!llvm.ptr<1>, i64, i1, i32) -> i32
+    %val = tt.load %ptr, %mask evictionPolicy = evict_first : tensor<1024x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: evict_last without an explicit cache modifier routes to L1C_L3C on the
+// COM: predicated load path and stays temporal on the scalar path.
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttig.support_predicated_io} {
+  // CHECK-LABEL: load_evict_last_predicated
+  tt.func @load_evict_last_predicated(%ptr: tensor<1024x!tt.ptr<f32>, #blocked>, %mask: tensor<1024xi1, #blocked>) {
+    // CHECK: triton_gen.predicated_load {{.*}} {cache_control = L1C_L3C} : (!llvm.ptr<1>, i64, i1, i32) -> i32
+    %val = tt.load %ptr, %mask evictionPolicy = evict_last : tensor<1024x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: An explicit cache modifier always wins over the eviction policy hint.
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttig.support_predicated_io} {
+  // CHECK-LABEL: explicit_cache_wins_over_eviction
+  tt.func @explicit_cache_wins_over_eviction(%ptr: tensor<1024x!tt.ptr<f32>, #blocked>, %mask: tensor<1024xi1, #blocked>) {
+    // CHECK: triton_gen.predicated_load {{.*}} {cache_control = L1UC_L3C} : (!llvm.ptr<1>, i64, i1, i32) -> i32
+    %val = tt.load %ptr, %mask cacheModifier = cg evictionPolicy = evict_last : tensor<1024x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: evict_first on the non-predicated scalar load path adds the nontemporal
+// COM: flag to the underlying llvm.load, without an explicit cache modifier.
+
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  // CHECK-LABEL: load_evict_first_scalar
+  tt.func @load_evict_first_scalar(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+    %c256_i32 = arith.constant 256 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c256_i32 : i32
+    %2 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #blocked0>
+    %3 = tt.splat %1 : i32 -> tensor<256xi32, #blocked0>
+    %4 = arith.addi %3, %2 : tensor<256xi32, #blocked0>
+    %5 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>, #blocked0>
+    %6 = tt.addptr %5, %4 : tensor<256x!tt.ptr<f32>, #blocked0>, tensor<256xi32, #blocked0>
+    %7 = tt.load %6 evictionPolicy = evict_first : tensor<256x!tt.ptr<f32>, #blocked0>
+    // CHECK-COUNT-2: llvm.load {{.*}} {alignment = 16 : i64, nontemporal} : !llvm.ptr<1> -> vector<4xi32>
+    tt.return
+  }
+}

--- a/test/Conversion/intel/load_store_to_llvm.mlir
+++ b/test/Conversion/intel/load_store_to_llvm.mlir
@@ -144,3 +144,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
     tt.return
   }
 }
+
+// -----
+
+// COM: descriptor_load with evict_first routes to L1IAR_L3C on the predicated path.
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttig.support_predicated_io} {
+  // CHECK-LABEL: descriptor_load_evict_first_predicated
+  tt.func @descriptor_load_evict_first_predicated(%desc: !tt.tensordesc<tensor<128xf32>>) {
+    %c0_i32 = arith.constant 0 : i32
+    // CHECK: triton_gen.predicated_load {{.*}} {cache_control = L1IAR_L3C} : (!llvm.ptr<1>, i64, i1, i32) -> i32
+    %val = tt.descriptor_load %desc[%c0_i32] evictionPolicy = evict_first : !tt.tensordesc<tensor<128xf32>> -> tensor<128xf32, #blocked>
+    tt.return
+  }
+}

--- a/test/Conversion/intel/load_store_to_llvm.mlir
+++ b/test/Conversion/intel/load_store_to_llvm.mlir
@@ -152,10 +152,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 #blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttig.support_predicated_io} {
   // CHECK-LABEL: descriptor_load_evict_first_predicated
-  tt.func @descriptor_load_evict_first_predicated(%desc: !tt.tensordesc<tensor<128xf32>>) {
+  tt.func @descriptor_load_evict_first_predicated(%desc: !tt.tensordesc<128xf32>) {
     %c0_i32 = arith.constant 0 : i32
     // CHECK: triton_gen.predicated_load {{.*}} {cache_control = L1IAR_L3C} : (!llvm.ptr<1>, i64, i1, i32) -> i32
-    %val = tt.descriptor_load %desc[%c0_i32] evictionPolicy = evict_first : !tt.tensordesc<tensor<128xf32>> -> tensor<128xf32, #blocked>
+    %val = tt.descriptor_load %desc[%c0_i32] evictionPolicy = evict_first : !tt.tensordesc<128xf32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }

--- a/test/TritonIntelGPU/annotate-cache-control.mlir
+++ b/test/TritonIntelGPU/annotate-cache-control.mlir
@@ -259,6 +259,38 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
 
 // -----
 
+// COM: Test l2 — user-specified eviction policy (evict_first / evict_last)
+// COM: must NOT be overridden. The lowering maps these to precise LSC cache
+// COM: modes; stamping .cg here would lose the user's intent.
+
+#blocked1d = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [16], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: @user_evict_first_preserved
+  tt.func public @user_evict_first_preserved(%ptr: tensor<1024x!tt.ptr<f32>, #blocked1d>) -> tensor<1024xf32, #blocked1d> {
+    // CHECK: tt.load
+    // CHECK-NOT: cacheModifier = cg
+    %0 = tt.load %ptr evictionPolicy = evict_first : tensor<1024x!tt.ptr<f32>, #blocked1d>
+    tt.return %0 : tensor<1024xf32, #blocked1d>
+  }
+}
+
+// -----
+
+// COM: Test l3 — evict_last is also honored: pass must not stamp .cg.
+
+#blocked1d = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [16], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: @user_evict_last_preserved
+  tt.func public @user_evict_last_preserved(%ptr: tensor<1024x!tt.ptr<f32>, #blocked1d>) -> tensor<1024xf32, #blocked1d> {
+    // CHECK: tt.load
+    // CHECK-NOT: cacheModifier = cg
+    %0 = tt.load %ptr evictionPolicy = evict_last : tensor<1024x!tt.ptr<f32>, #blocked1d>
+    tt.return %0 : tensor<1024xf32, #blocked1d>
+  }
+}
+
+// -----
+
 // COM: Test m — forward-flow filter: X is a read-only arg, but its loaded
 // COM: value is combined with DW (an RW arg) and stored back to DW. The
 // COM: forward-flow filter blocks .cg on the load of X to preserve L1

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -567,8 +567,9 @@ struct LoadStoreConversionBase {
     }
   }
 
-  template <typename OpType, typename = std::enable_if_t<llvm::is_one_of<
-                                 OpType, LoadOp, StoreOp>::value>>
+  template <typename OpType,
+            typename = std::enable_if_t<llvm::is_one_of<
+                OpType, LoadOp, StoreOp, DescriptorLoadOp>::value>>
   bool getNonTemporalFlag(OpType op) const {
     switch (op.getCache()) {
     case triton::CacheModifier::CG:
@@ -581,7 +582,11 @@ struct LoadStoreConversionBase {
       // No explicit cache modifier: derive from eviction policy hint.
       // EVICT_FIRST implies single-use; map to nontemporal so IGC bypasses L1.
       // EVICT_LAST implies reuse; keep the default (temporal) behavior.
-      return op.getEvict() == triton::EvictionPolicy::EVICT_FIRST;
+      // Only load ops carry eviction policy; stores always return false here.
+      if constexpr (std::is_same_v<OpType, LoadOp> ||
+                    std::is_same_v<OpType, DescriptorLoadOp>)
+        return op.getEvict() == triton::EvictionPolicy::EVICT_FIRST;
+      return false;
     default:
       return false;
     }
@@ -2291,7 +2296,7 @@ struct DescriptorLoadOpConversion
       auto createLoadWithAttrs = [&]() {
         return SmallVector<Value>{b.load(retTy, addrElem, alignment,
                                          /*isVolatile=*/false,
-                                         /*isNonTemporal=*/false)};
+                                         getNonTemporalFlag(op))};
       };
 
       Value ret;

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -496,6 +496,16 @@ struct LoadStoreConversionBase {
   }
 
   // Convert Triton cache modifier to Intel GEN load cache control enum.
+  //
+  // Explicit cache modifiers (cg/cv/ca) always win. When no cache modifier is
+  // set, fall back to the frontend-provided eviction policy hint (e.g.
+  // inductor's `eviction_policy='evict_last'`) and route it to the closest
+  // LSC cache mode:
+  //   EVICT_FIRST -> L1IAR_L3C  (invalidate-after-read: data is used once;
+  //                              free the L1 line immediately after delivery)
+  //   EVICT_LAST  -> L1C_L3C    (cache at all levels: keep the line warm for
+  //                              anticipated reuse)
+  //   NORMAL      -> DEFAULT    (let the hardware decide)
   template <typename OpType, typename = std::enable_if_t<llvm::is_one_of<
                                  OpType, LoadOp, DescriptorLoadOp>::value>>
   TritonGEN::LoadCacheControl tritonToIntelCacheModifier(OpType &op) const {
@@ -509,6 +519,14 @@ struct LoadStoreConversionBase {
      **/
     switch (cacheModifier) {
     case CacheModifier::NONE:
+      switch (op.getEvict()) {
+      case EvictionPolicy::EVICT_FIRST:
+        return TritonGEN::LoadCacheControl::L1IAR_L3C;
+      case EvictionPolicy::EVICT_LAST:
+        return TritonGEN::LoadCacheControl::L1C_L3C;
+      case EvictionPolicy::NORMAL:
+        break;
+      }
       return TritonGEN::LoadCacheControl::DEFAULT;
     case CacheModifier::CG:
       return TritonGEN::LoadCacheControl::L1UC_L3C;
@@ -558,6 +576,12 @@ struct LoadStoreConversionBase {
     case triton::CacheModifier::CV:
       return true;
     case triton::CacheModifier::CA:
+      return false;
+    case triton::CacheModifier::NONE:
+      // No explicit cache modifier: derive from eviction policy hint.
+      // EVICT_FIRST implies single-use; map to nontemporal so IGC bypasses L1.
+      // EVICT_LAST implies reuse; keep the default (temporal) behavior.
+      return op.getEvict() == triton::EvictionPolicy::EVICT_FIRST;
     default:
       return false;
     }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/AnnotateCacheControl.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/AnnotateCacheControl.cpp
@@ -349,6 +349,12 @@ private:
     if (load.getCache() != tt::CacheModifier::NONE)
       return false;
 
+    // Gate 1b: user-specified eviction policy (e.g. evict_first/evict_last
+    // from inductor) is honored at lowering time via LSC cache modes — do
+    // not override it here.
+    if (load.getEvict() != tt::EvictionPolicy::NORMAL)
+      return false;
+
     // Gate 2: scalar loads don't get encoding-based annotation.
     auto loadTy = dyn_cast<RankedTensorType>(load.getType());
     if (!loadTy)


### PR DESCRIPTION
Route the frontend `eviction_policy` hint on `tt.load` / `tt.descriptor_load` to the closest LSC load-cache-control mode when no explicit `cache_modifier` is set:

| `eviction_policy` | LSC load mode | Rationale |
|---|---|---|
| `evict_first` | `L1IAR_L3C` | Single-use: invalidate-after-read frees L1 on delivery |
| `evict_last` | `L1C_L3C` | Reused: cache at all levels |
| `evict_normal` | `DEFAULT` | Unchanged (previous behavior) |

Explicit `cache_modifier` (e.g. `.cg`, `.ca`) always wins over the eviction hint.

`getNonTemporalFlag` also starts honoring `evict_first` on the non-predicated scalar load path (`nontemporal` on the underlying `llvm.load`).