### PR TITLE
[ElementwiseOpToLLVM] Guard sqrt_cr/divide_cr builtins behind `SPV_INTEL_rounded_divide_sqrt` capability

### DIFF
--- a/test/Conversion/intel/precise_math_to_llvm.mlir
+++ b/test/Conversion/intel/precise_math_to_llvm.mlir
@@ -36,13 +36,15 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 
-// COM: Test that precise sqrt lowers to __imf_sqrt_rn for f64
+// COM: Test that precise sqrt and divf lower to __imf_* f64 builtins
 // COM: when ttig.support_rounded_divide_sqrt is absent.
 module attributes {"ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @precise_math_imf_fallback_f64
-  tt.func public @precise_math_imf_fallback_f64(%arg0: tensor<128xf64, #blocked>) {
+  tt.func public @precise_math_imf_fallback_f64(%arg0: tensor<128xf64, #blocked>, %arg1: tensor<128xf64, #blocked>) {
     // CHECK: llvm.call spir_funccc @__imf_sqrt_rn
     %0 = tt.precise_sqrt %arg0 : tensor<128xf64, #blocked>
+    // CHECK: llvm.call spir_funccc @__imf_ddiv_rn
+    %1 = tt.precise_divf %arg0, %arg1 : tensor<128xf64, #blocked>
     tt.return
   }
 }

--- a/test/Conversion/intel/precise_math_to_llvm.mlir
+++ b/test/Conversion/intel/precise_math_to_llvm.mlir
@@ -1,0 +1,48 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+// COM: Test that precise sqrt and divf lower to sqrt_cr/divide_cr builtins
+// COM: when ttig.support_rounded_divide_sqrt is present.
+module attributes {"ttg.num-warps" = 4 : i32, ttig.support_rounded_divide_sqrt} {
+  // CHECK-LABEL: @precise_math_rounded_divide_sqrt
+  tt.func public @precise_math_rounded_divide_sqrt(%arg0: tensor<128xf32, #blocked>, %arg1: tensor<128xf32, #blocked>) {
+    // CHECK: llvm.call spir_funccc @_Z7sqrt_crf
+    %0 = tt.precise_sqrt %arg0 : tensor<128xf32, #blocked>
+    // CHECK: llvm.call spir_funccc @_Z9divide_crff
+    %1 = tt.precise_divf %arg0, %arg1 : tensor<128xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+// COM: Test that precise sqrt and divf lower to __imf_* f32 builtins
+// COM: when ttig.support_rounded_divide_sqrt is absent.
+module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @precise_math_imf_fallback_f32
+  tt.func public @precise_math_imf_fallback_f32(%arg0: tensor<128xf32, #blocked>, %arg1: tensor<128xf32, #blocked>) {
+    // CHECK: llvm.call spir_funccc @__imf_sqrtf_rn
+    %0 = tt.precise_sqrt %arg0 : tensor<128xf32, #blocked>
+    // CHECK: llvm.call spir_funccc @__imf_fdiv_rn
+    %1 = tt.precise_divf %arg0, %arg1 : tensor<128xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+// COM: Test that precise sqrt lowers to __imf_sqrt_rn for f64
+// COM: when ttig.support_rounded_divide_sqrt is absent.
+module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @precise_math_imf_fallback_f64
+  tt.func public @precise_math_imf_fallback_f64(%arg0: tensor<128xf64, #blocked>) {
+    // CHECK: llvm.call spir_funccc @__imf_sqrt_rn
+    %0 = tt.precise_sqrt %arg0 : tensor<128xf64, #blocked>
+    tt.return
+  }
+}

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -177,6 +177,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         dev_prop['has_f4_conversions'] = tgt_prop.get('has_f4_conversions', False)
         dev_prop['has_f8_conversions'] = tgt_prop.get('has_f8_conversions', False)
         dev_prop['has_256b_prefetch'] = tgt_prop.get('has_256b_prefetch', False)
+        dev_prop['has_rounded_divide_sqrt'] = tgt_prop.get('has_rounded_divide_sqrt', not is_lts)
 
         if '__intel_already_queried_extensions__' not in tgt_prop:
             # All GPUs with the same device_id have the same extensions, so we just
@@ -259,6 +260,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         module_opts.support_256b_prefetch = properties["has_256b_prefetch"]
         module_opts.support_subgroup_matrix_multiply_accumulate_bf8 = properties[
             "has_subgroup_matrix_multiply_accumulate_bfloat8"]
+        module_opts.support_rounded_divide_sqrt = properties["has_rounded_divide_sqrt"]
         module_opts.threads_per_warp = opt.warp_size
         module_opts.target_arch = cls.target_arch
 

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
@@ -117,6 +117,12 @@ def TritonIntelGPU_Dialect : Dialect {
       return "ttig.support_prefetch_256b";
     }
 
+    /// Get the name of the attribute used to indicate whether rounded divide
+    /// and sqrt operations are available.
+    static constexpr llvm::StringRef getSupportRoundedDivideSqrtAttrName() {
+      return "ttig.support_rounded_divide_sqrt";
+    }
+
     /// FIXME: Remove once IGC can split large 2D block loads.
     /// Get the name of the attribute used to indicate that a load operation
     /// should use 'one matrix per load'.

--- a/third_party/intel/include/TritonAnnotateModule/Passes.td
+++ b/third_party/intel/include/TritonAnnotateModule/Passes.td
@@ -55,7 +55,9 @@ def TritonAnnotateModule: Pass<"triton-annotate-module", "mlir::ModuleOp"> {
     Option<"isLTS", "is-lts", "bool", /*default*/"false",
            "whether driver is LTS">,
     Option<"supportPrefetch256Bytes", "support-prefetch-256b", "bool", /*default*/"false",
-           "whether prefetch 256 bytes is supported">
+           "whether prefetch 256 bytes is supported">,
+    Option<"supportRoundedDivideSqrt", "support-rounded-divide-sqrt", "bool", /*default*/"false",
+           "whether rounded divide and sqrt operations are available">
   ];
 }
 

--- a/third_party/intel/lib/TritonAnnotateModule/TritonAnnotateModule.cpp
+++ b/third_party/intel/lib/TritonAnnotateModule/TritonAnnotateModule.cpp
@@ -81,6 +81,11 @@ struct TritonAnnotateModule
           ttgi::TritonIntelGPUDialect::getSupportPredicatedIOAttrName(),
           builder.getUnitAttr());
 
+    if (supportRoundedDivideSqrt)
+      mod->setAttr(
+          ttgi::TritonIntelGPUDialect::getSupportRoundedDivideSqrtAttrName(),
+          builder.getUnitAttr());
+
     if (isLTS)
       mod->setAttr(ttgi::TritonIntelGPUDialect::getIsLTSAttrName(),
                    builder.getUnitAttr());

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1344,23 +1344,13 @@ struct PreciseSqrtOpConversion
       return {callOp.getResult()};
     }
 
-    // Fallback: __imf_sqrt_rn operates on f64, so upcast if needed.
-    auto b = TritonLLVMOpBuilder(loc, rewriter);
-    Value input = operandsRanges[0][0];
-    Type origTy = input.getType();
-    bool needsCast = !origTy.isF64();
-    if (needsCast)
-      input = b.fpext(f64_ty, input);
-    Type callElemTy = needsCast ? f64_ty : elemTy;
-    SmallVector<Value> callOperands{input};
-    SmallVector<Type> callArgTypes(ValueRange(callOperands).getTypes());
+    // Fallback: use type-appropriate __imf_sqrt*_rn builtin.
+    StringRef fnName = elemTy.isF32() ? "__imf_sqrtf_rn" : "__imf_sqrt_rn";
+    SmallVector<Type> argTypes(ValueRange(operandsRanges[0]).getTypes());
     LLVM::CallOp callOp = intel::createDeviceFunctionCall(
-        rewriter, "__imf_sqrt_rn", callElemTy, callArgTypes, callOperands,
+        rewriter, fnName, elemTy, argTypes, operandsRanges[0],
         /*paramAttrs=*/{}, intel::noUnwindWillReturnAttrs);
-    Value result = callOp.getResult();
-    if (needsCast)
-      result = LLVM::FPTruncOp::create(rewriter, loc, origTy, result);
-    return {result};
+    return {callOp.getResult()};
   }
 };
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1380,10 +1380,11 @@ struct PreciseDivFOpConversion
       return {callOp.getResult()};
     }
 
-    // Fallback: __imf_fdiv_rn operates on the native element type.
+    // Fallback: use type-appropriate __imf_*div_rn builtin.
+    StringRef fnName = elemTy.isF32() ? "__imf_fdiv_rn" : "__imf_ddiv_rn";
     SmallVector<Type> argTypes(ValueRange(operandsRanges[0]).getTypes());
     LLVM::CallOp callOp = intel::createDeviceFunctionCall(
-        rewriter, "__imf_fdiv_rn", elemTy, argTypes, operandsRanges[0],
+        rewriter, fnName, elemTy, argTypes, operandsRanges[0],
         /*paramAttrs=*/{}, intel::noUnwindWillReturnAttrs);
     return {callOp.getResult()};
   }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1,5 +1,6 @@
 #include "PatternTritonGPUOpToLLVM.h"
 #include "Utility.h"
+#include "Utils/LLVMIntr.h"
 #include "mlir/Conversion/ArithCommon/AttrToLLVMConverter.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/MLIRContext.h"
@@ -1318,71 +1319,84 @@ struct AbsFOpConversion
   }
 };
 
-template <typename TritonOp>
-struct OpToExternCallConversion
-    : public ElementwiseOpConversionBase<TritonOp,
-                                         OpToExternCallConversion<TritonOp>> {
+struct PreciseSqrtOpConversion
+    : ElementwiseOpConversionBase<PreciseSqrtOp, PreciseSqrtOpConversion> {
   using Base =
-      ElementwiseOpConversionBase<TritonOp, OpToExternCallConversion<TritonOp>>;
+      ElementwiseOpConversionBase<PreciseSqrtOp, PreciseSqrtOpConversion>;
   using Base::Base;
   using Adaptor = typename Base::OpAdaptor;
 
-  explicit OpToExternCallConversion(LLVMTypeConverter &typeConverter,
-                                    ModuleAxisInfoAnalysis &axisAnalysisPass,
-                                    StringRef externFuncName,
-                                    StringRef fallbackFuncName,
-                                    PatternBenefit benefit)
-      : Base::ElementwiseOpConversionBase(typeConverter, axisAnalysisPass,
-                                          benefit),
-        funcName(externFuncName), fallbackName(fallbackFuncName) {}
-
-  SmallVector<Value> createDestOps(TritonOp op, Adaptor adaptor,
+  SmallVector<Value> createDestOps(PreciseSqrtOp op, Adaptor adaptor,
                                    ConversionPatternRewriter &rewriter,
-                                   Type elemTy, MultipleOperandsRange operands,
+                                   Type elemTy,
+                                   MultipleOperandsRange operandsRanges,
                                    Location loc) const {
-    bool useRoundedDivideSqrt = mlir::LLVM::intel::hasModuleAttr(
-        op, triton::gpu::intel::TritonIntelGPUDialect::
-                getSupportRoundedDivideSqrtAttrName());
+    namespace intel = mlir::triton::gpu::intel;
 
-    if (useRoundedDivideSqrt) {
-      Type funcType = getFunctionType(elemTy, operands[0]);
-      SmallVector<Type> operandTypes(ValueRange(operands[0]).getTypes());
-      std::string fnName =
-          mlir::triton::gpu::intel::mangle(funcName, operandTypes);
-      LLVM::LLVMFuncOp funcOp =
-          appendOrGetExternFuncOp(rewriter, op, fnName, funcType);
-      funcOp.setCConv(triton::gpu::intel::getDefaultCConv(op));
-      auto callOp = LLVM::createLLVMCallOp(rewriter, loc, funcOp, operands[0]);
-      callOp.setCConv(funcOp.getCConv());
+    if (mlir::LLVM::intel::hasModuleAttr(
+            op, intel::TritonIntelGPUDialect::
+                    getSupportRoundedDivideSqrtAttrName())) {
+      SmallVector<Type> operandTypes(ValueRange(operandsRanges[0]).getTypes());
+      std::string fnName = intel::mangle("sqrt_cr", operandTypes);
+      LLVM::CallOp callOp = intel::createDeviceFunctionCall(
+          rewriter, fnName, elemTy, operandTypes, operandsRanges[0],
+          /*paramAttrs=*/{}, intel::noUnwindWillReturnAttrs);
       return {callOp.getResult()};
     }
 
-    // Fallback to __imf_* builtins.
+    // Fallback: __imf_sqrt_rn operates on f64, so upcast if needed.
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    Value input = operands[0][0];
+    Value input = operandsRanges[0][0];
     Type origTy = input.getType();
-    // __imf_sqrt_rn operates on f64, so upcast if needed.
-    bool needsCast = fallbackName == "__imf_sqrt_rn" && !origTy.isF64();
+    bool needsCast = !origTy.isF64();
     if (needsCast)
       input = b.fpext(f64_ty, input);
     Type callElemTy = needsCast ? f64_ty : elemTy;
-    SmallVector<Value> callOperands =
-        needsCast ? SmallVector<Value>{input} : SmallVector<Value>(operands[0]);
-    Type funcType = getFunctionType(callElemTy, callOperands);
-    LLVM::LLVMFuncOp funcOp =
-        appendOrGetExternFuncOp(rewriter, op, fallbackName, funcType);
-    funcOp.setCConv(triton::gpu::intel::getDefaultCConv(op));
-    auto callOp = LLVM::createLLVMCallOp(rewriter, loc, funcOp, callOperands);
-    callOp.setCConv(funcOp.getCConv());
+    SmallVector<Value> callOperands{input};
+    SmallVector<Type> callArgTypes(ValueRange(callOperands).getTypes());
+    LLVM::CallOp callOp = intel::createDeviceFunctionCall(
+        rewriter, "__imf_sqrt_rn", callElemTy, callArgTypes, callOperands,
+        /*paramAttrs=*/{}, intel::noUnwindWillReturnAttrs);
     Value result = callOp.getResult();
     if (needsCast)
       result = LLVM::FPTruncOp::create(rewriter, loc, origTy, result);
     return {result};
   }
+};
 
-private:
-  StringRef funcName;
-  StringRef fallbackName;
+struct PreciseDivFOpConversion
+    : ElementwiseOpConversionBase<triton::PreciseDivFOp,
+                                  PreciseDivFOpConversion> {
+  using Base = ElementwiseOpConversionBase<triton::PreciseDivFOp,
+                                           PreciseDivFOpConversion>;
+  using Base::Base;
+  using Adaptor = typename Base::OpAdaptor;
+
+  SmallVector<Value> createDestOps(triton::PreciseDivFOp op, Adaptor adaptor,
+                                   ConversionPatternRewriter &rewriter,
+                                   Type elemTy,
+                                   MultipleOperandsRange operandsRanges,
+                                   Location loc) const {
+    namespace intel = mlir::triton::gpu::intel;
+
+    if (mlir::LLVM::intel::hasModuleAttr(
+            op, intel::TritonIntelGPUDialect::
+                    getSupportRoundedDivideSqrtAttrName())) {
+      SmallVector<Type> operandTypes(ValueRange(operandsRanges[0]).getTypes());
+      std::string fnName = intel::mangle("divide_cr", operandTypes);
+      LLVM::CallOp callOp = intel::createDeviceFunctionCall(
+          rewriter, fnName, elemTy, operandTypes, operandsRanges[0],
+          /*paramAttrs=*/{}, intel::noUnwindWillReturnAttrs);
+      return {callOp.getResult()};
+    }
+
+    // Fallback: __imf_fdiv_rn operates on the native element type.
+    SmallVector<Type> argTypes(ValueRange(operandsRanges[0]).getTypes());
+    LLVM::CallOp callOp = intel::createDeviceFunctionCall(
+        rewriter, "__imf_fdiv_rn", elemTy, argTypes, operandsRanges[0],
+        /*paramAttrs=*/{}, intel::noUnwindWillReturnAttrs);
+    return {callOp.getResult()};
+  }
 };
 
 // Following two patterns are copied from the common part to fix-up calling
@@ -1457,10 +1471,10 @@ void populateElementwiseOpToLLVMPatterns(
     ModuleAxisInfoAnalysis &axisInfoAnalysis, const TargetInfoBase &targetInfo,
     PatternBenefit benefit) {
 
-  patterns.add<OpToExternCallConversion<triton::PreciseSqrtOp>>(
-      typeConverter, axisInfoAnalysis, "sqrt_cr", "__imf_sqrt_rn", benefit);
-  patterns.add<OpToExternCallConversion<triton::PreciseDivFOp>>(
-      typeConverter, axisInfoAnalysis, "divide_cr", "__imf_fdiv_rn", benefit);
+  patterns.add<PreciseSqrtOpConversion>(typeConverter, axisInfoAnalysis,
+                                        benefit);
+  patterns.add<PreciseDivFOpConversion>(typeConverter, axisInfoAnalysis,
+                                        benefit);
   patterns.add<MulhiUIOpConversion>(typeConverter, axisInfoAnalysis, targetInfo,
                                     benefit);
   patterns.add<ExternElementwiseOpConversion>(typeConverter, axisInfoAnalysis,

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1330,29 +1330,59 @@ struct OpToExternCallConversion
   explicit OpToExternCallConversion(LLVMTypeConverter &typeConverter,
                                     ModuleAxisInfoAnalysis &axisAnalysisPass,
                                     StringRef externFuncName,
+                                    StringRef fallbackFuncName,
                                     PatternBenefit benefit)
       : Base::ElementwiseOpConversionBase(typeConverter, axisAnalysisPass,
                                           benefit),
-        funcName(externFuncName) {}
+        funcName(externFuncName), fallbackName(fallbackFuncName) {}
 
   SmallVector<Value> createDestOps(TritonOp op, Adaptor adaptor,
                                    ConversionPatternRewriter &rewriter,
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
-    Type funcType = getFunctionType(elemTy, operands[0]);
-    SmallVector<Type> operandTypes(ValueRange(operands[0]).getTypes());
-    std::string fnName =
-        mlir::triton::gpu::intel::mangle(funcName, operandTypes);
+    bool useRoundedDivideSqrt = mlir::LLVM::intel::hasModuleAttr(
+        op, triton::gpu::intel::TritonIntelGPUDialect::
+                getSupportRoundedDivideSqrtAttrName());
+
+    if (useRoundedDivideSqrt) {
+      Type funcType = getFunctionType(elemTy, operands[0]);
+      SmallVector<Type> operandTypes(ValueRange(operands[0]).getTypes());
+      std::string fnName =
+          mlir::triton::gpu::intel::mangle(funcName, operandTypes);
+      LLVM::LLVMFuncOp funcOp =
+          appendOrGetExternFuncOp(rewriter, op, fnName, funcType);
+      funcOp.setCConv(triton::gpu::intel::getDefaultCConv(op));
+      auto callOp = LLVM::createLLVMCallOp(rewriter, loc, funcOp, operands[0]);
+      callOp.setCConv(funcOp.getCConv());
+      return {callOp.getResult()};
+    }
+
+    // Fallback to __imf_* builtins.
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    Value input = operands[0][0];
+    Type origTy = input.getType();
+    // __imf_sqrt_rn operates on f64, so upcast if needed.
+    bool needsCast = fallbackName == "__imf_sqrt_rn" && !origTy.isF64();
+    if (needsCast)
+      input = b.fpext(f64_ty, input);
+    Type callElemTy = needsCast ? f64_ty : elemTy;
+    SmallVector<Value> callOperands =
+        needsCast ? SmallVector<Value>{input} : SmallVector<Value>(operands[0]);
+    Type funcType = getFunctionType(callElemTy, callOperands);
     LLVM::LLVMFuncOp funcOp =
-        appendOrGetExternFuncOp(rewriter, op, fnName, funcType);
+        appendOrGetExternFuncOp(rewriter, op, fallbackName, funcType);
     funcOp.setCConv(triton::gpu::intel::getDefaultCConv(op));
-    auto callOp = LLVM::createLLVMCallOp(rewriter, loc, funcOp, operands[0]);
+    auto callOp = LLVM::createLLVMCallOp(rewriter, loc, funcOp, callOperands);
     callOp.setCConv(funcOp.getCConv());
-    return {callOp.getResult()};
+    Value result = callOp.getResult();
+    if (needsCast)
+      result = LLVM::FPTruncOp::create(rewriter, loc, origTy, result);
+    return {result};
   }
 
 private:
   StringRef funcName;
+  StringRef fallbackName;
 };
 
 // Following two patterns are copied from the common part to fix-up calling
@@ -1428,9 +1458,9 @@ void populateElementwiseOpToLLVMPatterns(
     PatternBenefit benefit) {
 
   patterns.add<OpToExternCallConversion<triton::PreciseSqrtOp>>(
-      typeConverter, axisInfoAnalysis, "sqrt_cr", benefit);
+      typeConverter, axisInfoAnalysis, "sqrt_cr", "__imf_sqrt_rn", benefit);
   patterns.add<OpToExternCallConversion<triton::PreciseDivFOp>>(
-      typeConverter, axisInfoAnalysis, "divide_cr", benefit);
+      typeConverter, axisInfoAnalysis, "divide_cr", "__imf_fdiv_rn", benefit);
   patterns.add<MulhiUIOpConversion>(typeConverter, axisInfoAnalysis, targetInfo,
                                     benefit);
   patterns.add<ExternElementwiseOpConversion>(typeConverter, axisInfoAnalysis,

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -127,6 +127,9 @@ void init_triton_intel_passes_ttgpuir(py::module &&m) {
       .def_readwrite(
           "support_256b_prefetch",
           &gpu::intel::TritonAnnotateModuleOptions::supportPrefetch256Bytes)
+      .def_readwrite(
+          "support_rounded_divide_sqrt",
+          &gpu::intel::TritonAnnotateModuleOptions::supportRoundedDivideSqrt)
       .def_readwrite("threads_per_warp",
                      &gpu::intel::TritonAnnotateModuleOptions::threadsPerWarp)
       .def_readwrite("target_arch",


### PR DESCRIPTION
On LTS driver, fallback to `__imf` functions due to #6261.