### PR TITLE
Unskip `test_core.py::test_noinline[shared]` test since it's already fixed in agama 1222

### DIFF
--- a/scripts/skiplist/a770/language.txt
+++ b/scripts/skiplist/a770/language.txt
@@ -14,7 +14,6 @@ python/test/unit/language/test_core.py::test_dot3d[4-4-32-32-32-32-32-float64-fl
 python/test/unit/language/test_core.py::test_dot3d[4-8-32-32-32-32-32-float64-float64]
 python/test/unit/language/test_core.py::test_dot3d[4-16-32-32-32-32-32-float64-float64]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/983
-python/test/unit/language/test_core.py::test_noinline[shared]
 # test_dot
 python/test/unit/language/test_core.py::test_dot[r".*-float64-1-None"]@regexp
 python/test/unit/language/test_core.py::test_dot[r"1-64-128-128-2-.*"]@regexp

--- a/scripts/skiplist/arl-h/language.txt
+++ b/scripts/skiplist/arl-h/language.txt
@@ -7,8 +7,6 @@ python/test/unit/language/test_core.py::test_dot3d[8-2-32-32-32-8-16-float16-flo
 python/test/unit/language/test_core.py::test_dot3d[8-4-32-32-32-8-16-float16-float16]
 python/test/unit/language/test_core.py::test_dot3d[8-1-32-32-32-8-16-float16-float16]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/983
-python/test/unit/language/test_core.py::test_noinline[shared]
-
 # test_dot
 python/test/unit/language/test_core.py::test_dot[r"1-128-128-64-2-.*"]@regexp
 python/test/unit/language/test_core.py::test_dot[r"1-64-128-128-2-.*"]@regexp

--- a/scripts/skiplist/arl-s/language.txt
+++ b/scripts/skiplist/arl-s/language.txt
@@ -7,7 +7,6 @@ python/test/unit/language/test_core.py::test_dot3d[8-2-32-32-32-8-16-float16-flo
 python/test/unit/language/test_core.py::test_dot3d[8-4-32-32-32-8-16-float16-float16]
 python/test/unit/language/test_core.py::test_dot3d[8-1-32-32-32-8-16-float16-float16]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/983
-python/test/unit/language/test_core.py::test_noinline[shared]
 # test_dot
 python/test/unit/language/test_core.py::test_dot[r"1-64-128-128-2-.*"]@regexp
 python/test/unit/language/test_core.py::test_dot[r"1-128-128-64-2-.*"]@regexp

--- a/scripts/skiplist/mtl/language.txt
+++ b/scripts/skiplist/mtl/language.txt
@@ -5,7 +5,6 @@ python/test/unit/language/test_core.py::test_dot3d[r".*-float16-float32"]@regexp
 python/test/unit/language/test_core.py::test_dot3d[r".*-32-32-float16-float16"]@regexp
 
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/983
-python/test/unit/language/test_core.py::test_noinline[shared]
 python/test/unit/language/test_core.py::test_dot_max_num_imprecise_acc[r".*-128-128-256-256"]@regexp
 python/test/unit/language/test_block_pointer.py::test_block_ptr_matmul_no_scf
 python/test/unit/language/test_pipeliner.py::test_pipeline_matmul[True]


### PR DESCRIPTION
A770: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/25107874297 ([passed](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/25107874297/job/73578857492#step:16:14734))

Closes #1082