### PR TITLE
[TritonIntelGPU] Add ttig.2d_block_load and ttig.2d_block_load_from_ptr ops

### DIFF
--- a/test/TritonIntelGPU/tritonintelgpu-invalid.mlir
+++ b/test/TritonIntelGPU/tritonintelgpu-invalid.mlir
@@ -104,7 +104,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
   tt.func @ttig.2d_block_load.rank1(%base_ptr: !tt.ptr<f16>, %width: i32, %height: i32, %pitch: i32, %x: i32, %y: i32) -> tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>> {
     // expected-error @below {{'ttig.2d_block_load' op result tensor must have rank >= 2, got 1}}
-    %0 = "ttig.2d_block_load"(%base_ptr, %width, %height, %pitch, %x, %y) <{memory_layout = 0 : i32}> : (!tt.ptr<f16>, i32, i32, i32, i32, i32) -> tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>>
+    %0 = ttig.2d_block_load %base_ptr, %width, %height, %pitch[%x, %y] {row_major} : !tt.ptr<f16> -> tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>>
     tt.return %0 : tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>>
   }
 }
@@ -114,21 +114,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
-  tt.func @ttig.2d_block_ptr_load.rank1(%ptr: tensor<32x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #dot0}>>, %width: i32, %height: i32, %pitch: i32) -> tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>> {
-    // expected-error @below {{'ttig.2d_block_ptr_load' op result tensor must have rank >= 2, got 1}}
-    %0 = "ttig.2d_block_ptr_load"(%ptr, %width, %height, %pitch) <{memory_layout = 0 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0, 0>}> : (tensor<32x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #dot0}>>, i32, i32, i32) -> tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>>
+  tt.func @ttig.2d_block_load_from_ptr.rank1(%ptr: tensor<32x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #dot0}>>) -> tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>> {
+    // expected-error @below {{'ttig.2d_block_load_from_ptr' op result tensor must have rank >= 2, got 1}}
+    %0 = ttig.2d_block_load_from_ptr %ptr {row_major} {base_width = 64 : i32, base_height = 8 : i32, base_pitch = 256 : i32} : (tensor<32x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #dot0}>>) -> (tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>>)
     tt.return %0 : tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>>
   }
 }
 
 // -----
 
+// COM: mask-without-other test uses generic format since the custom format
+// COM: requires mask and other to co-occur.
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
-  tt.func @ttig.2d_block_ptr_load.mask_without_other(%ptr: tensor<64x32x!tt.ptr<f16>, #dot0>, %width: i32, %height: i32, %pitch: i32, %mask: tensor<64x32xi1, #dot0>) -> tensor<64x32xf16, #dot0> {
-    // expected-error @below {{'ttig.2d_block_ptr_load' op 'other' must be present when 'mask' is present}}
-    %0 = "ttig.2d_block_ptr_load"(%ptr, %width, %height, %pitch, %mask) <{memory_layout = 0 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 0>}> : (tensor<64x32x!tt.ptr<f16>, #dot0>, i32, i32, i32, tensor<64x32xi1, #dot0>) -> tensor<64x32xf16, #dot0>
+  tt.func @ttig.2d_block_load_from_ptr.mask_without_other(%ptr: tensor<64x32x!tt.ptr<f16>, #dot0>, %mask: tensor<64x32xi1, #dot0>) -> tensor<64x32xf16, #dot0> {
+    // expected-error @below {{'ttig.2d_block_load_from_ptr' op 'other' must be present when 'mask' is present}}
+    %0 = "ttig.2d_block_load_from_ptr"(%ptr, %mask) <{base_width = 64 : i32, base_height = 8 : i32, base_pitch = 256 : i32, memory_layout = 0 : i32, operandSegmentSizes = array<i32: 1, 1, 0>}> : (tensor<64x32x!tt.ptr<f16>, #dot0>, tensor<64x32xi1, #dot0>) -> tensor<64x32xf16, #dot0>
     tt.return %0 : tensor<64x32xf16, #dot0>
   }
 }

--- a/test/TritonIntelGPU/tritonintelgpu-invalid.mlir
+++ b/test/TritonIntelGPU/tritonintelgpu-invalid.mlir
@@ -99,6 +99,42 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  tt.func @ttig.2d_block_load.rank1(%base_ptr: !tt.ptr<f16>, %width: i32, %height: i32, %pitch: i32, %x: i32, %y: i32) -> tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>> {
+    // expected-error @below {{'ttig.2d_block_load' op result tensor must have rank >= 2, got 1}}
+    %0 = "ttig.2d_block_load"(%base_ptr, %width, %height, %pitch, %x, %y) <{memory_layout = 0 : i32}> : (!tt.ptr<f16>, i32, i32, i32, i32, i32) -> tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>>
+    tt.return %0 : tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>>
+  }
+}
+
+// -----
+
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  tt.func @ttig.2d_block_ptr_load.rank1(%ptr: tensor<32x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #dot0}>>, %width: i32, %height: i32, %pitch: i32) -> tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>> {
+    // expected-error @below {{'ttig.2d_block_ptr_load' op result tensor must have rank >= 2, got 1}}
+    %0 = "ttig.2d_block_ptr_load"(%ptr, %width, %height, %pitch) <{memory_layout = 0 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0, 0>}> : (tensor<32x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #dot0}>>, i32, i32, i32) -> tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>>
+    tt.return %0 : tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>>
+  }
+}
+
+// -----
+
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  tt.func @ttig.2d_block_ptr_load.mask_without_other(%ptr: tensor<64x32x!tt.ptr<f16>, #dot0>, %width: i32, %height: i32, %pitch: i32, %mask: tensor<64x32xi1, #dot0>) -> tensor<64x32xf16, #dot0> {
+    // expected-error @below {{'ttig.2d_block_ptr_load' op 'other' must be present when 'mask' is present}}
+    %0 = "ttig.2d_block_ptr_load"(%ptr, %width, %height, %pitch, %mask) <{memory_layout = 0 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 0>}> : (tensor<64x32x!tt.ptr<f16>, #dot0>, i32, i32, i32, tensor<64x32xi1, #dot0>) -> tensor<64x32xf16, #dot0>
+    tt.return %0 : tensor<64x32xf16, #dot0>
+  }
+}
+
+// -----
+
 tt.func @ttig.descriptor_prefetch.indices_mismatch(%desc: !tt.tensordesc<256x32xf16>, %x: i32) {
   // expected-error @below {{'ttig.descriptor_prefetch' op expected 2 indices, but got 1}}
   ttig.descriptor_prefetch %desc[%x] : !tt.tensordesc<256x32xf16>

--- a/test/TritonIntelGPU/tritonintelgpu.mlir
+++ b/test/TritonIntelGPU/tritonintelgpu.mlir
@@ -29,15 +29,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
   tt.func @ttig.2d_block_load(%base_ptr: !tt.ptr<f16>, %width: i32, %height: i32, %pitch: i32, %x: i32, %y: i32) -> tensor<64x32xf16, #dot0> {
     // CHECK-LABEL: @ttig.2d_block_load
-    // CHECK: "ttig.2d_block_load"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5) <{memory_layout = 0 : i32}>
-    %0 = "ttig.2d_block_load"(%base_ptr, %width, %height, %pitch, %x, %y) <{memory_layout = 0 : i32}> : (!tt.ptr<f16>, i32, i32, i32, i32, i32) -> tensor<64x32xf16, #dot0>
+    // CHECK: ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] {row_major}
+    %0 = ttig.2d_block_load %base_ptr, %width, %height, %pitch[%x, %y] {row_major} : !tt.ptr<f16> -> tensor<64x32xf16, #dot0>
     tt.return %0 : tensor<64x32xf16, #dot0>
   }
 
   tt.func @ttig.2d_block_load_pad_nan(%base_ptr: !tt.ptr<f16>, %width: i32, %height: i32, %pitch: i32, %x: i32, %y: i32) -> tensor<64x32xf16, #dot0> {
     // CHECK-LABEL: @ttig.2d_block_load_pad_nan
-    // CHECK: "ttig.2d_block_load"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5) <{memory_layout = 0 : i32, pad_nan}>
-    %0 = "ttig.2d_block_load"(%base_ptr, %width, %height, %pitch, %x, %y) <{memory_layout = 0 : i32, pad_nan}> : (!tt.ptr<f16>, i32, i32, i32, i32, i32) -> tensor<64x32xf16, #dot0>
+    // CHECK: ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] {row_major, pad_nan}
+    %0 = ttig.2d_block_load %base_ptr, %width, %height, %pitch[%x, %y] {row_major, pad_nan} : !tt.ptr<f16> -> tensor<64x32xf16, #dot0>
     tt.return %0 : tensor<64x32xf16, #dot0>
   }
 }
@@ -47,17 +47,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
-  tt.func @ttig.2d_block_ptr_load(%ptr: tensor<64x32x!tt.ptr<f16>, #dot0>, %width: i32, %height: i32, %pitch: i32) -> tensor<64x32xf16, #dot0> {
-    // CHECK-LABEL: @ttig.2d_block_ptr_load
-    // CHECK: "ttig.2d_block_ptr_load"(%arg0, %arg1, %arg2, %arg3) <{memory_layout = 0 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0, 0>}>
-    %0 = "ttig.2d_block_ptr_load"(%ptr, %width, %height, %pitch) <{memory_layout = 0 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0, 0>}> : (tensor<64x32x!tt.ptr<f16>, #dot0>, i32, i32, i32) -> tensor<64x32xf16, #dot0>
+  tt.func @ttig.2d_block_load_from_ptr(%ptr: tensor<64x32x!tt.ptr<f16>, #dot0>) -> tensor<64x32xf16, #dot0> {
+    // CHECK-LABEL: @ttig.2d_block_load_from_ptr
+    // CHECK: ttig.2d_block_load_from_ptr %arg0 {row_major} {base_height = 8 : i32, base_pitch = 256 : i32, base_width = 64 : i32}
+    %0 = ttig.2d_block_load_from_ptr %ptr {row_major} {base_width = 64 : i32, base_height = 8 : i32, base_pitch = 256 : i32} : (tensor<64x32x!tt.ptr<f16>, #dot0>) -> (tensor<64x32xf16, #dot0>)
     tt.return %0 : tensor<64x32xf16, #dot0>
   }
 
-  tt.func @ttig.2d_block_ptr_load_with_mask(%ptr: tensor<64x32x!tt.ptr<f16>, #dot0>, %width: i32, %height: i32, %pitch: i32, %mask: tensor<64x32xi1, #dot0>, %other: tensor<64x32xf16, #dot0>) -> tensor<64x32xf16, #dot0> {
-    // CHECK-LABEL: @ttig.2d_block_ptr_load_with_mask
-    // CHECK: "ttig.2d_block_ptr_load"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5) <{memory_layout = 0 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1>}>
-    %0 = "ttig.2d_block_ptr_load"(%ptr, %width, %height, %pitch, %mask, %other) <{memory_layout = 0 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1>}> : (tensor<64x32x!tt.ptr<f16>, #dot0>, i32, i32, i32, tensor<64x32xi1, #dot0>, tensor<64x32xf16, #dot0>) -> tensor<64x32xf16, #dot0>
+  tt.func @ttig.2d_block_load_from_ptr_with_mask(%ptr: tensor<64x32x!tt.ptr<f16>, #dot0>, %mask: tensor<64x32xi1, #dot0>, %other: tensor<64x32xf16, #dot0>) -> tensor<64x32xf16, #dot0> {
+    // CHECK-LABEL: @ttig.2d_block_load_from_ptr_with_mask
+    // CHECK: ttig.2d_block_load_from_ptr %arg0, %arg1, %arg2 {row_major} {base_height = 8 : i32, base_pitch = 256 : i32, base_width = 64 : i32}
+    %0 = ttig.2d_block_load_from_ptr %ptr, %mask, %other {row_major} {base_width = 64 : i32, base_height = 8 : i32, base_pitch = 256 : i32} : (tensor<64x32x!tt.ptr<f16>, #dot0>, tensor<64x32xi1, #dot0>, tensor<64x32xf16, #dot0>) -> (tensor<64x32xf16, #dot0>)
     tt.return %0 : tensor<64x32xf16, #dot0>
   }
 }

--- a/test/TritonIntelGPU/tritonintelgpu.mlir
+++ b/test/TritonIntelGPU/tritonintelgpu.mlir
@@ -24,6 +24,46 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 
 // -----
 
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  tt.func @ttig.2d_block_load(%base_ptr: !tt.ptr<f16>, %width: i32, %height: i32, %pitch: i32, %x: i32, %y: i32) -> tensor<64x32xf16, #dot0> {
+    // CHECK-LABEL: @ttig.2d_block_load
+    // CHECK: "ttig.2d_block_load"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5) <{memory_layout = 0 : i32}>
+    %0 = "ttig.2d_block_load"(%base_ptr, %width, %height, %pitch, %x, %y) <{memory_layout = 0 : i32}> : (!tt.ptr<f16>, i32, i32, i32, i32, i32) -> tensor<64x32xf16, #dot0>
+    tt.return %0 : tensor<64x32xf16, #dot0>
+  }
+
+  tt.func @ttig.2d_block_load_pad_nan(%base_ptr: !tt.ptr<f16>, %width: i32, %height: i32, %pitch: i32, %x: i32, %y: i32) -> tensor<64x32xf16, #dot0> {
+    // CHECK-LABEL: @ttig.2d_block_load_pad_nan
+    // CHECK: "ttig.2d_block_load"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5) <{memory_layout = 0 : i32, pad_nan}>
+    %0 = "ttig.2d_block_load"(%base_ptr, %width, %height, %pitch, %x, %y) <{memory_layout = 0 : i32, pad_nan}> : (!tt.ptr<f16>, i32, i32, i32, i32, i32) -> tensor<64x32xf16, #dot0>
+    tt.return %0 : tensor<64x32xf16, #dot0>
+  }
+}
+
+// -----
+
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  tt.func @ttig.2d_block_ptr_load(%ptr: tensor<64x32x!tt.ptr<f16>, #dot0>, %width: i32, %height: i32, %pitch: i32) -> tensor<64x32xf16, #dot0> {
+    // CHECK-LABEL: @ttig.2d_block_ptr_load
+    // CHECK: "ttig.2d_block_ptr_load"(%arg0, %arg1, %arg2, %arg3) <{memory_layout = 0 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0, 0>}>
+    %0 = "ttig.2d_block_ptr_load"(%ptr, %width, %height, %pitch) <{memory_layout = 0 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0, 0>}> : (tensor<64x32x!tt.ptr<f16>, #dot0>, i32, i32, i32) -> tensor<64x32xf16, #dot0>
+    tt.return %0 : tensor<64x32xf16, #dot0>
+  }
+
+  tt.func @ttig.2d_block_ptr_load_with_mask(%ptr: tensor<64x32x!tt.ptr<f16>, #dot0>, %width: i32, %height: i32, %pitch: i32, %mask: tensor<64x32xi1, #dot0>, %other: tensor<64x32xf16, #dot0>) -> tensor<64x32xf16, #dot0> {
+    // CHECK-LABEL: @ttig.2d_block_ptr_load_with_mask
+    // CHECK: "ttig.2d_block_ptr_load"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5) <{memory_layout = 0 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1>}>
+    %0 = "ttig.2d_block_ptr_load"(%ptr, %width, %height, %pitch, %mask, %other) <{memory_layout = 0 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1>}> : (tensor<64x32x!tt.ptr<f16>, #dot0>, i32, i32, i32, tensor<64x32xi1, #dot0>, tensor<64x32xf16, #dot0>) -> tensor<64x32xf16, #dot0>
+    tt.return %0 : tensor<64x32xf16, #dot0>
+  }
+}
+
+// -----
+
 tt.func @ttig.descriptor_prefetch(%desc: !tt.tensordesc<256x32xf16>, %x: i32, %y: i32) {
   // CHECK-LABEL: @ttig.descriptor_prefetch
   // CHECK:         ttig.descriptor_prefetch %arg0[%arg1, %arg2] : !tt.tensordesc<256x32xf16>

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -184,4 +184,79 @@ def TTIG_SubGroupTransposeOp
   let hasVerifier = 1;
 }
 
+
+def TTIG_Subgroup2DBlockLoadOp : TTIG_Op<"2d_block_load"> {
+  let summary = "2D block load from a descriptor-based surface";
+  let description = [{
+    Loads a 2D tile from a memory surface described by decomposed parameters.
+    Created from `tt.descriptor_load` ops where the surface parameters are
+    extracted from the `tt.make_tensor_descriptor` that defined the descriptor.
+
+    One `ttig.2d_block_load` may lower to multiple `triton_gen.2Dblockload`
+    ops when the tensor requires splitting across warps/registers.
+
+    Tile computation (`tile_height`, `tile_width`, `v_blocks`, `transpose`,
+    etc.) is performed during LLVM lowering from the result tensor's encoding.
+
+    The `offset_x` and `offset_y` are surface-level offsets (from the
+    descriptor indices) that are combined with per-sub-tile linear layout
+    offsets during LLVM lowering.
+
+    When `pad_nan` is true, the LLVM lowering builds boundary masks from
+    the surface dimensions and fills out-of-bounds elements with NaN.
+    When false (default), the hardware zero-fills out-of-bounds elements.
+  }];
+
+  let arguments = (ins
+    Arg<TT_Ptr, "scalar base pointer to the memory surface", [MemRead]>:$base_ptr,
+    I32:$base_width,
+    I32:$base_height,
+    I32:$base_pitch,
+    I32:$offset_x,
+    I32:$offset_y,
+    OptionalAttr<UnitAttr>:$pad_nan,
+    TTIG_BlockIOMode:$memory_layout
+  );
+
+  let results = (outs TT_Tensor:$result);
+  let hasVerifier = 1;
+}
+
+def TTIG_Subgroup2DBlockPtrLoadOp : TTIG_Op<"2d_block_ptr_load", [
+  AttrSizedOperandSegments
+]> {
+  let summary = "2D block load from a tensor of pointers";
+  let description = [{
+    Loads a 2D tile using a tensor of pointers. Created from `tt.load` ops
+    on pointer tensors that are eligible for 2D block I/O.
+
+    Unlike `ttig.2d_block_load` which takes a scalar base pointer and
+    surface-level offsets, this op retains the full pointer tensor. During
+    LLVM lowering, the per-sub-tile base address is extracted from
+    `ptrElems[registerIdx]` and subtraction-based addressing is used:
+    the column offset from the linear layout is subtracted from the pointer
+    to reach the row start, then passed as the block load's X coordinate.
+
+    One `ttig.2d_block_ptr_load` may lower to multiple
+    `triton_gen.2Dblockload` ops when the tensor requires splitting across
+    warps/registers.
+
+    Tile computation (`tile_height`, `tile_width`, `v_blocks`, `transpose`,
+    etc.) is performed during LLVM lowering from the result tensor's encoding.
+  }];
+
+  let arguments = (ins
+    Arg<TT_PtrLike, "tensor of pointers to the memory surface", [MemRead]>:$ptr,
+    I32:$base_width,
+    I32:$base_height,
+    I32:$base_pitch,
+    Optional<TT_BoolLike>:$mask,
+    Optional<TT_Type>:$other,
+    TTIG_BlockIOMode:$memory_layout
+  );
+
+  let results = (outs TT_Tensor:$result);
+  let hasVerifier = 1;
+}
+
 #endif

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -23,6 +23,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 //===----------------------------------------------------------------------===//
 
 def L2Cache : Resource<"::mlir::triton::gpu::intel::L2Cache">;
+def GlobalMemory : Resource<"::mlir::triton::GlobalMemory">;
 
 //===----------------------------------------------------------------------===//
 // TritonIntelGPU op definitions
@@ -202,13 +203,14 @@ def TTIG_Subgroup2DBlockLoadOp : TTIG_Op<"2d_block_load"> {
     descriptor indices) that are combined with per-sub-tile linear layout
     offsets during LLVM lowering.
 
-    When `pad_nan` is true, the LLVM lowering builds boundary masks from
+    When `pad_nan` is set, the LLVM lowering builds boundary masks from
     the surface dimensions and fills out-of-bounds elements with NaN.
-    When false (default), the hardware zero-fills out-of-bounds elements.
+    Otherwise, the hardware zero-fills out-of-bounds elements.
   }];
 
   let arguments = (ins
-    Arg<TT_Ptr, "scalar base pointer to the memory surface", [MemRead]>:$base_ptr,
+    Arg<TT_Ptr, "scalar base pointer to the memory surface",
+        [MemRead<GlobalMemory>]>:$base_ptr,
     I32:$base_width,
     I32:$base_height,
     I32:$base_pitch,
@@ -219,10 +221,16 @@ def TTIG_Subgroup2DBlockLoadOp : TTIG_Op<"2d_block_load"> {
   );
 
   let results = (outs TT_Tensor:$result);
+  let assemblyFormat = [{
+    $base_ptr `,` $base_width `,` $base_height `,` $base_pitch
+    `[` $offset_x `,` $offset_y `]`
+    `{` $memory_layout (`,` `pad_nan` $pad_nan^)? `}`
+    attr-dict `:` type($base_ptr) `->` type($result)
+  }];
   let hasVerifier = 1;
 }
 
-def TTIG_Subgroup2DBlockPtrLoadOp : TTIG_Op<"2d_block_ptr_load", [
+def TTIG_Subgroup2DBlockLoadFromPtrOp : TTIG_Op<"2d_block_load_from_ptr", [
   AttrSizedOperandSegments
 ]> {
   let summary = "2D block load from a tensor of pointers";
@@ -237,25 +245,37 @@ def TTIG_Subgroup2DBlockPtrLoadOp : TTIG_Op<"2d_block_ptr_load", [
     the column offset from the linear layout is subtracted from the pointer
     to reach the row start, then passed as the block load's X coordinate.
 
-    One `ttig.2d_block_ptr_load` may lower to multiple
+    One `ttig.2d_block_load_from_ptr` may lower to multiple
     `triton_gen.2Dblockload` ops when the tensor requires splitting across
     warps/registers.
 
     Tile computation (`tile_height`, `tile_width`, `v_blocks`, `transpose`,
     etc.) is performed during LLVM lowering from the result tensor's encoding.
+
+    Precondition (not verified): The pointer tensor must describe a 2D
+    rectangular slice of a strided surface, i.e.
+    `ptr[i,j] = base + i*row_stride + j*elem_size` for a constant `base`
+    and known `row_stride`. Creating this op from a ptr tensor that does not
+    satisfy this precondition produces undefined behavior at lowering.
   }];
 
   let arguments = (ins
-    Arg<TT_PtrLike, "tensor of pointers to the memory surface", [MemRead]>:$ptr,
-    I32:$base_width,
-    I32:$base_height,
-    I32:$base_pitch,
+    Arg<TT_PtrLike, "tensor of pointers to the memory surface",
+        [MemRead<GlobalMemory>]>:$ptr,
     Optional<TT_BoolLike>:$mask,
     Optional<TT_Type>:$other,
+    I32Attr:$base_width,
+    I32Attr:$base_height,
+    I32Attr:$base_pitch,
     TTIG_BlockIOMode:$memory_layout
   );
 
   let results = (outs TT_Tensor:$result);
+  let assemblyFormat = [{
+    $ptr (`,` $mask^ `,` $other)?
+    ` ` `{` $memory_layout `}`
+    attr-dict `:` functional-type(operands, results)
+  }];
   let hasVerifier = 1;
 }
 

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
@@ -133,7 +133,7 @@ LogicalResult Subgroup2DBlockLoadOp::verify() {
   return success();
 }
 
-LogicalResult Subgroup2DBlockPtrLoadOp::verify() {
+LogicalResult Subgroup2DBlockLoadFromPtrOp::verify() {
   auto resultType = dyn_cast<RankedTensorType>(getResult().getType());
   if (!resultType)
     return emitOpError("result must be a ranked tensor type");

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
@@ -121,4 +121,31 @@ LogicalResult SubGroupTransposeOp::verify() {
   return success();
 }
 
+LogicalResult Subgroup2DBlockLoadOp::verify() {
+  auto resultType = dyn_cast<RankedTensorType>(getResult().getType());
+  if (!resultType)
+    return emitOpError("result must be a ranked tensor type");
+
+  if (resultType.getRank() < 2)
+    return emitOpError("result tensor must have rank >= 2, got ")
+           << resultType.getRank();
+
+  return success();
+}
+
+LogicalResult Subgroup2DBlockPtrLoadOp::verify() {
+  auto resultType = dyn_cast<RankedTensorType>(getResult().getType());
+  if (!resultType)
+    return emitOpError("result must be a ranked tensor type");
+
+  if (resultType.getRank() < 2)
+    return emitOpError("result tensor must have rank >= 2, got ")
+           << resultType.getRank();
+
+  if (getMask() && !getOther())
+    return emitOpError("'other' must be present when 'mask' is present");
+
+  return success();
+}
+
 } // namespace mlir::triton::gpu::intel


### PR DESCRIPTION
Add two new ops to the TritonIntelGPU dialect for 2D block I/O:

- ttig.2d_block_load: for descriptor-based loads, takes a scalar base pointer with decomposed surface parameters (width, height, pitch, offsets) and a pad_nan flag for NaN padding.

- ttig.2d_block_load_from_ptr: for pointer-based loads, takes a tensor of pointers with surface parameters and optional mask/other operands.

These ops capture the decision to use 2D block I/O at the TTGIR level, separating it from the LLVM lowering mechanics.