### PR TITLE
[GPUToTritonGEN] Handle Constant address space in memory space conversion

### DIFF
--- a/third_party/intel/lib/GPUToTritonGEN/GPUToTritonGENPass.cpp
+++ b/third_party/intel/lib/GPUToTritonGEN/GPUToTritonGENPass.cpp
@@ -105,6 +105,8 @@ struct GPUToTritonGENPass
             return TritonGEN::TritonGENMemorySpace::kWorkgroup;
           case mlir::gpu::AddressSpace::Private:
             return TritonGEN::TritonGENMemorySpace::kFunction;
+          case mlir::gpu::AddressSpace::Constant:
+            return TritonGEN::TritonGENMemorySpace::kUniformConstant;
           }
           llvm_unreachable("unknown address space enum value");
           return 0;


### PR DESCRIPTION
## Summary
- Adds missing case for `mlir::gpu::AddressSpace::Constant` in GPUToTritonGEN pass
- Maps Constant address space to `TritonGENMemorySpace::kUniformConstant` following SPIR-V storage class convention

## Problem
Compilation fails with error:
```
enumeration value 'Constant' not handled in switch [-Werror,-Wswitch]
```

## Solution
Added the missing switch case at GPUToTritonGENPass.cpp:107 to handle the Constant address space enum value introduced in the upstream MLIR GPU dialect.

## Test plan
- [x] Build completes without errors
- [x] Follows SPIR-V storage class convention documented in TritonGENMemorySpace.h

🤖 Generated with [Claude Code](https://claude.com/claude-code)