### PR TITLE
[vLLM] pin xgrammar version to remove avoid tvm dependency added later version

### DIFF
--- a/scripts/vllm/install-vllm.sh
+++ b/scripts/vllm/install-vllm.sh
@@ -234,7 +234,7 @@ function install_vllm {
 
   # Install xgrammar separately without dependencies (already removed from requirements above)
   # xgrammar depends on triton, but we already have it installed, so --no-deps is safe
-  python -m pip install --no-deps 'xgrammar<1.0.0,>=0.1.32'
+  python -m pip install --no-deps 'xgrammar==0.1.32'
 
   # Install minimal test dependencies only (not the full xpu-test.txt)
   # The full requirements are very large and cause pip resolver issues.


### PR DESCRIPTION
The most recent `xgrammar` version (0.1.34) adds a dependency on `tvm_ffi` (https://github.com/mlc-ai/xgrammar/releases/tag/v0.1.34). Since we install `xgrammar` with `--no-deps`, this caused an error on BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/25161118259. I'm not sure why we do not see the same error on the max1550 runners, there must be some change in environment.

To fix this issue, we can either (1) pin `xgrammar` to a version before the `tvm_ffi` dependency or (2) install `apache-tvm` along with `xgrammar`. This patch implements (1).

vLLM benchmarks: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/25181475100
vLLM benchmarks BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/25181488599 (unified attention bf16 OOM failure is known and tracked by https://github.com/intel/intel-xpu-backend-for-triton/issues/6759)
vLLM tests: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/25181495286