### PR TITLE
[TritonIntelGPU] Add LowerTo2DBlockLoad pass for descriptor loads

### DIFF
--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
@@ -65,3 +65,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     tt.return %0 : tensor<64x32xf16, #dot0>
   }
 }
+
+// -----
+
+// COM: 3D descriptor load with batch dimension. The leading batch index should
+// COM: be folded into the base pointer via tt.addptr, and the inner-2 dims
+// COM: produce the 2D block load surface params.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4, 2], repCluster = [1, 1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @descriptor_load_batch
+  tt.func @descriptor_load_batch(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i64, %arg5: i64, %batch_idx: i32) -> tensor<2x64x32xf16, #dot0> {
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2, %arg3], [%arg4, %arg5, %c1_i64] : <f16>, <2x64x32xf16>
+    // CHECK: %[[BATCH_EXT:.*]] = arith.extsi %arg6 : i32 to i64
+    // CHECK: %[[BATCH_OFF:.*]] = arith.muli %[[BATCH_EXT]], %arg4
+    // CHECK: %[[ADJ_PTR:.*]] = tt.addptr %arg0, %[[BATCH_OFF]]
+    // CHECK: ttig.2d_block_load %[[ADJ_PTR]]
+    %0 = tt.descriptor_load %desc[%batch_idx, %c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<2x64x32xf16> -> tensor<2x64x32xf16, #dot0>
+    tt.return %0 : tensor<2x64x32xf16, #dot0>
+  }
+}

--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
@@ -1,0 +1,67 @@
+// RUN: triton-opt %s -split-input-file --tritonintelgpu-lower-to-2d-block-load | FileCheck %s --implicit-check-not=tt.descriptor_load
+
+// COM: Descriptor-based load with block_io attribute should be converted to
+// COM: ttig.2d_block_load with surface params from make_tensor_descriptor.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @tensor_descriptor_load
+  tt.func @tensor_descriptor_load(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64) -> tensor<64x32xf16, #dot0> {
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
+    // CHECK-DAG: %[[ELEM_BYTES:.*]] = arith.constant 2 : i32
+    // CHECK-DAG: %[[ZERO:.*]] = arith.constant 0 : i32
+    // CHECK: %[[BW:.*]] = arith.muli %arg2, %[[ELEM_BYTES]]
+    // CHECK: %[[ST:.*]] = arith.trunci %arg3
+    // CHECK: %[[BP:.*]] = arith.muli %[[ST]], %[[ELEM_BYTES]]
+    // CHECK: ttig.2d_block_load %arg0, %[[BW]], %arg1, %[[BP]][%[[ZERO]], %[[ZERO]]] {row_major}
+    %0 = tt.descriptor_load %desc[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #dot0>
+    tt.return %0 : tensor<64x32xf16, #dot0>
+  }
+}
+
+// -----
+
+// COM: Column-major descriptor load. The memory_layout attribute is set to
+// COM: column_major, which tells the LLVM lowering to use transposed block
+// COM: reads. Surface params are the same as row_major (they describe physical
+// COM: memory layout).
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @descriptor_load_column_major
+  tt.func @descriptor_load_column_major(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64) -> tensor<32x64xf16, #dot1> {
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
+    // CHECK-DAG: %[[ELEM_BYTES:.*]] = arith.constant 2 : i32
+    // CHECK-DAG: %[[ZERO:.*]] = arith.constant 0 : i32
+    // CHECK: %[[BW:.*]] = arith.muli %arg2, %[[ELEM_BYTES]]
+    // CHECK: %[[ST:.*]] = arith.trunci %arg3
+    // CHECK: %[[BP:.*]] = arith.muli %[[ST]], %[[ELEM_BYTES]]
+    // CHECK: ttig.2d_block_load %arg0, %[[BW]], %arg1, %[[BP]][%[[ZERO]], %[[ZERO]]] {column_major}
+    %0 = tt.descriptor_load %desc[%c0_i32, %c0_i32] {ttig.block_io = "column_major"} : !tt.tensordesc<64x32xf16> -> tensor<32x64xf16, #dot1>
+    tt.return %0 : tensor<32x64xf16, #dot1>
+  }
+}
+
+// -----
+
+// COM: Descriptor load with NaN padding. The pass sets the pad_nan attribute
+// COM: on the ttig.2d_block_load op so the LLVM lowering builds boundary
+// COM: masks and fills out-of-bounds elements with NaN.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @descriptor_load_pad_nan
+  tt.func @descriptor_load_pad_nan(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64) -> tensor<64x32xf16, #dot0> {
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] {padding = 2 : i32} : <f16>, <64x32xf16>
+    // CHECK: ttig.2d_block_load
+    // CHECK-SAME: {row_major, pad_nan}
+    %0 = tt.descriptor_load %desc[%c0_i32, %c0_i32] {ttig.block_io = "row_major", ttig.desc_padding = 2 : i32} : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #dot0>
+    tt.return %0 : tensor<64x32xf16, #dot0>
+  }
+}

--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/invalid.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/invalid.mlir
@@ -1,0 +1,34 @@
+// RUN: triton-opt %s -split-input-file --tritonintelgpu-lower-to-2d-block-load | FileCheck %s --implicit-check-not=ttig.2d_block_load
+
+// COM: Descriptor load without ttig.block_io attribute should NOT be converted
+// COM: to ttig.2d_block_load — it must remain as tt.descriptor_load.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @descriptor_load_no_block_io
+  tt.func @descriptor_load_no_block_io(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64) -> tensor<64x32xf16, #dot0> {
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
+    // CHECK: tt.descriptor_load
+    %0 = tt.descriptor_load %desc[%c0_i32, %c0_i32] : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #dot0>
+    tt.return %0 : tensor<64x32xf16, #dot0>
+  }
+}
+
+// -----
+
+// COM: Module without support_2d_block_io attribute should skip the pass entirely.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: tt.func @no_2d_block_support
+  tt.func @no_2d_block_support(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64) -> tensor<64x32xf16, #dot0> {
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
+    // CHECK: tt.descriptor_load
+    %0 = tt.descriptor_load %desc[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #dot0>
+    tt.return %0 : tensor<64x32xf16, #dot0>
+  }
+}

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
@@ -79,6 +79,12 @@ FailureOr<LinearLayout> computeTransposeShuffleMapping(
 bool check2DBlockAddressPayloadRestriction(unsigned packedElemSizeInBits,
                                            unsigned tileWidth);
 
+/// Validate that a load with the given encoding and element size can be
+/// lowered to 2D block I/O. Checks tile size, HW address restrictions, and
+/// inner-dim constraints. Returns true if valid.
+bool validate2DBlockLoadTile(const LinearLayout &ll, unsigned memContiguousDim,
+                             unsigned elemSizeInBits);
+
 } // namespace mlir::triton::gpu::intel
 
 #endif // TRITONINTELGPU_TRANSFORMS_BLOCKIOUTILS_H

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
@@ -80,10 +80,11 @@ bool check2DBlockAddressPayloadRestriction(unsigned packedElemSizeInBits,
                                            unsigned tileWidth);
 
 /// Validate that a load with the given encoding and element size can be
-/// lowered to 2D block I/O. Checks tile size, HW address restrictions, and
-/// inner-dim constraints. Returns true if valid.
+/// lowered to 2D block I/O. Checks tile size, HW address restrictions,
+/// inner-dim constraints, and transpose shuffle mapping. Returns true if valid.
 bool validate2DBlockLoadTile(const LinearLayout &ll, unsigned memContiguousDim,
-                             unsigned elemSizeInBits);
+                             unsigned elemSizeInBits,
+                             RankedTensorType tensorType);
 
 } // namespace mlir::triton::gpu::intel
 

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -352,15 +352,16 @@ def TritonIntelGPULowerTo2DBlockLoad
   let summary = "Lower eligible loads to ttig.2d_block_load ops";
 
   let description = [{
-    Converts eligible `tt.load` and `tt.descriptor_load` operations into
-    `ttig.2d_block_load` operations with decomposed surface parameters. This
-    separates the decision to use 2D block I/O from the LLVM lowering mechanics.
-    Loads that cannot be converted remain unchanged and are handled by existing
-    LLVM lowering patterns.
+    Converts eligible `tt.descriptor_load` operations into `ttig.2d_block_load`
+    operations with decomposed surface parameters. This separates the decision
+    to use 2D block I/O from the LLVM lowering mechanics. Loads that cannot be
+    converted remain unchanged and are handled by existing LLVM lowering
+    patterns.
   }];
 
   let dependentDialects = [
     "mlir::arith::ArithDialect",
+    "mlir::triton::TritonDialect",
     "mlir::triton::gpu::intel::TritonIntelGPUDialect"
   ];
 }

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -347,4 +347,22 @@ def TritonIntelGPUAnnotateCacheControl
                            "mlir::scf::SCFDialect"];
 }
 
+def TritonIntelGPULowerTo2DBlockLoad
+    : Pass<"tritonintelgpu-lower-to-2d-block-load", "mlir::ModuleOp"> {
+  let summary = "Lower eligible loads to ttig.2d_block_load ops";
+
+  let description = [{
+    Converts eligible `tt.load` and `tt.descriptor_load` operations into
+    `ttig.2d_block_load` operations with decomposed surface parameters. This
+    separates the decision to use 2D block I/O from the LLVM lowering mechanics.
+    Loads that cannot be converted remain unchanged and are handled by existing
+    LLVM lowering patterns.
+  }];
+
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::triton::gpu::intel::TritonIntelGPUDialect"
+  ];
+}
+
 #endif // TRITON_INTEL_GPU_PASSES

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -477,4 +477,38 @@ FailureOr<LinearLayout> computeTransposeShuffleMapping(
   return shuffleMapping;
 }
 
+bool validate2DBlockLoadTile(const LinearLayout &ll, unsigned memContiguousDim,
+                             unsigned elemSizeInBits) {
+  // Descriptor loads have no mask, so maskAxisInfo is nullptr.
+  // oneMatrixPerLoadForBT is not needed for validation — it only limits
+  // transpose tile expansion, which doesn't affect basic validity.
+  auto sizeInfo = getBlockIOTileSize<true>(ll, memContiguousDim, elemSizeInBits,
+                                           /*maskAxisInfo=*/nullptr,
+                                           /*oneMatrixPerLoadForBT=*/false);
+  if (!sizeInfo.isValid())
+    return false;
+
+  // The 2D block I/O tile must use only the inner 2 dims. Reject if
+  // rowDim or colDim falls in a batch dimension.
+  unsigned rank = ll.getNumOutDims();
+  if (rank > 2) {
+    int innerDimStart = static_cast<int>(rank - 2);
+    if (sizeInfo.rowDim < innerDimStart || sizeInfo.colDim < innerDimStart)
+      return false;
+  }
+
+  unsigned packedElemSizeInBits = elemSizeInBits * sizeInfo.numElemPerPackedVal;
+  if (!check2DBlockAddressPayloadRestriction(packedElemSizeInBits,
+                                             sizeInfo.tileWidth))
+    return false;
+
+  constexpr int MAX_WIDTH = 64;
+  unsigned totalBytesPerRowPerMatrix =
+      sizeInfo.tileWidth * packedElemSizeInBits / 8;
+  if (totalBytesPerRowPerMatrix > MAX_WIDTH)
+    return false;
+
+  return true;
+}
+
 } // namespace mlir::triton::gpu::intel

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -478,7 +478,8 @@ FailureOr<LinearLayout> computeTransposeShuffleMapping(
 }
 
 bool validate2DBlockLoadTile(const LinearLayout &ll, unsigned memContiguousDim,
-                             unsigned elemSizeInBits) {
+                             unsigned elemSizeInBits,
+                             RankedTensorType tensorType) {
   // Descriptor loads have no mask, so maskAxisInfo is nullptr.
   // oneMatrixPerLoadForBT is not needed for validation — it only limits
   // transpose tile expansion, which doesn't affect basic validity.
@@ -507,6 +508,48 @@ bool validate2DBlockLoadTile(const LinearLayout &ll, unsigned memContiguousDim,
       sizeInfo.tileWidth * packedElemSizeInBits / 8;
   if (totalBytesPerRowPerMatrix > MAX_WIDTH)
     return false;
+
+  // For transposed loads, verify computeTransposeShuffleMapping will succeed.
+  // sizeInfo.vBlocks is already capped by getBlockIOTileSize<true>.
+  if (sizeInfo.transpose && sizeInfo.regPackedBases.has_value()) {
+    MLIRContext *ctx = ll.getBases().begin()->first.getContext();
+    StringAttr kRegister = StringAttr::get(ctx, "register");
+    std::vector<std::vector<int>> bases(sizeInfo.regPackedBases->size());
+    llvm::transform(*sizeInfo.regPackedBases, bases.begin(),
+                    [](int base) { return std::vector<int>{base}; });
+    LinearLayout regMapping({{kRegister, bases}},
+                            {{kRegister, ll.getInDimSize(kRegister)}},
+                            /*requireSurjective=*/true);
+
+    unsigned threadsPerWarp = ll.getInDimSize(StringAttr::get(ctx, "lane"));
+    int64_t numElemsPerLoad =
+        mlir::ceil(sizeInfo.tileHeight * sizeInfo.tileWidth *
+                       sizeInfo.numElemPerPackedVal * sizeInfo.vBlocks,
+                   (int)threadsPerWarp);
+
+    bool hasDPASOperandType = false;
+    if (hasDpasEncoding(tensorType) || hasDotDpasEncoding(tensorType)) {
+      auto dpasLayout = getDpasLayout(tensorType);
+      unsigned opsPerChannel = dpasLayout.getOpsPerChannel();
+      auto opIdx = getOpIdx(tensorType);
+
+      bool matchesDPASPrecision =
+          (opsPerChannel == 4 && elemSizeInBits == 8) ||
+          (opsPerChannel == 2 && elemSizeInBits == 16) ||
+          (opsPerChannel == 1 && elemSizeInBits == 32);
+      if (matchesDPASPrecision && (opIdx == DpasEncodingAttr::OpIdx::OperandA ||
+                                   opIdx == DpasEncodingAttr::OpIdx::OperandB))
+        hasDPASOperandType = true;
+      if (opIdx == DpasEncodingAttr::OpIdx::OperandC)
+        hasDPASOperandType = true;
+    }
+
+    if (failed(computeTransposeShuffleMapping(
+            tensorType, regMapping, numElemsPerLoad,
+            sizeInfo.numElemPerPackedVal, sizeInfo.tileHeight, threadsPerWarp,
+            hasDPASOperandType, ctx)))
+      return false;
+  }
 
   return true;
 }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_triton_library(TritonIntelGPUTransforms
   BlockIOUtils.cpp
   DecomposeScaledBlocked.cpp
   HoistLayoutConversions.cpp
+  LowerTo2DBlockLoad.cpp
   MaterializeBlockPointer.cpp
   OptimizeDotOperands.cpp
   OptimizeReductionLocality.cpp

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -57,7 +57,7 @@ static bool isMemoryRowMajor(Operation *op) {
       ttgi::TritonIntelGPUDialect::getBlockIOAttrName());
   assert(blockIOAttr && "expected block_io attribute");
   auto mode = ttgi::symbolizeBlockIOMode(blockIOAttr.getValue());
-  return *mode == ttgi::BlockIOMode::RowMajor;
+  return !mode || *mode == ttgi::BlockIOMode::RowMajor;
 }
 
 struct TritonIntelGPULowerTo2DBlockLoadPass

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -113,7 +113,7 @@ private:
         cast<ttg::DistributedEncodingTrait>(encoding).toLinearLayout(
             tensorTy.getShape());
     if (!ttgi::validate2DBlockLoadTile(llEncoding, contiguousDim,
-                                       elemSizeInBits)) {
+                                       elemSizeInBits, tensorTy)) {
       LDBG("Tile validation failed for descriptor load: " << *op);
       return;
     }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -1,0 +1,215 @@
+#include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h"
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h"
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/Utility.h"
+#include "intel/include/Utils/Utility.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Tools/LinearLayout.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
+#include "llvm/Support/Debug.h"
+#include <optional>
+
+#define DEBUG_TYPE "tritonintelgpu-lower-to-2d-block-load"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+namespace ttgi = mlir::triton::gpu::intel;
+using LinearLayout = mlir::triton::LinearLayout;
+
+namespace mlir::triton::gpu::intel {
+#define GEN_PASS_DEF_TRITONINTELGPULOWERTO2DBLOCKLOAD
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
+} // namespace mlir::triton::gpu::intel
+
+namespace {
+
+/// Check whether a descriptor load is eligible for 2D block IO lowering.
+static bool isBlockIOEligible(tt::DescriptorLoadOp op) {
+  if (!op->getAttr(ttgi::TritonIntelGPUDialect::getBlockIOAttrName()))
+    return false;
+
+  auto tensorTy = cast<RankedTensorType>(op.getType());
+  if (tensorTy.getRank() < 2)
+    return false;
+
+  bool hasDpas =
+      ttgi::hasDpasEncoding(tensorTy) || ttgi::hasDotDpasEncoding(tensorTy);
+
+  std::optional<bool> enableBlockIOForAllLayout = tt::tools::isEnvValueBool(
+      tt::tools::getStrEnv("TRITON_INTEL_ENABLE_BLOCK_IO_ALL_LAYOUTS"));
+  if (enableBlockIOForAllLayout.has_value() &&
+      !enableBlockIOForAllLayout.value() && !hasDpas)
+    return false;
+
+  return true;
+}
+
+/// Determine whether memory layout is row-major from the block_io attribute.
+static bool isMemoryRowMajor(Operation *op) {
+  auto blockIOAttr = op->getAttrOfType<StringAttr>(
+      ttgi::TritonIntelGPUDialect::getBlockIOAttrName());
+  assert(blockIOAttr && "expected block_io attribute");
+  auto mode = ttgi::symbolizeBlockIOMode(blockIOAttr.getValue());
+  return *mode == ttgi::BlockIOMode::RowMajor;
+}
+
+struct TritonIntelGPULowerTo2DBlockLoadPass
+    : public ttgi::impl::TritonIntelGPULowerTo2DBlockLoadBase<
+          TritonIntelGPULowerTo2DBlockLoadPass> {
+public:
+  using ttgi::impl::TritonIntelGPULowerTo2DBlockLoadBase<
+      TritonIntelGPULowerTo2DBlockLoadPass>::
+      TritonIntelGPULowerTo2DBlockLoadBase;
+
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    if (!mod->hasAttr(
+            ttgi::TritonIntelGPUDialect::getSupport2DBlockIOAttrName()))
+      return;
+
+    SmallVector<tt::DescriptorLoadOp> descLoadOps;
+    mod.walk([&](tt::DescriptorLoadOp op) { descLoadOps.push_back(op); });
+
+    for (auto op : descLoadOps)
+      convertDescriptorLoadOp(op);
+  }
+
+private:
+  /// Convert a tt.descriptor_load to ttig.2d_block_load.
+  void convertDescriptorLoadOp(tt::DescriptorLoadOp op) {
+    if (!isBlockIOEligible(op))
+      return;
+
+    auto tensorTy = cast<RankedTensorType>(op.getType());
+    unsigned rank = tensorTy.getRank();
+    unsigned elemSizeInBits = tensorTy.getElementTypeBitWidth();
+
+    // Find the MakeTensorDescOp that created the descriptor.
+    Value desc = op.getDesc();
+    std::optional<tt::MakeTensorDescOp> makeTensorDescOp =
+        tt::intel::findDefiningOpOfType<tt::MakeTensorDescOp>(desc);
+    if (!makeTensorDescOp) {
+      LDBG("Could not find MakeTensorDescOp for: " << *op);
+      return;
+    }
+
+    auto descType = cast<tt::TensorDescType>(desc.getType());
+    unsigned descRank = descType.getBlockType().getRank();
+    assert(descRank >= rank && "descriptor rank must be >= result tensor rank");
+
+    bool memoryRowMajor = isMemoryRowMajor(op);
+
+    // Validate that tile computation will succeed during LLVM lowering.
+    unsigned contiguousDim = memoryRowMajor ? rank - 1 : rank - 2;
+    Attribute encoding = tensorTy.getEncoding();
+    LinearLayout llEncoding =
+        cast<ttg::DistributedEncodingTrait>(encoding).toLinearLayout(
+            tensorTy.getShape());
+    if (!ttgi::validate2DBlockLoadTile(llEncoding, contiguousDim,
+                                       elemSizeInBits)) {
+      LDBG("Tile validation failed for descriptor load: " << *op);
+      return;
+    }
+
+    OpBuilder builder(op);
+    Location loc = op.getLoc();
+    Type i32Ty = builder.getI32Type();
+
+    auto memLayout = memoryRowMajor ? ttgi::BlockIOMode::RowMajor
+                                    : ttgi::BlockIOMode::ColumnMajor;
+
+    // Extract surface parameters from MakeTensorDescOp.
+    // The surface parameters describe the physical memory layout and are the
+    // SAME regardless of row_major/column_major. The memory_layout attribute
+    // tells the LLVM lowering to set contiguousDim, which triggers the
+    // transpose flag in the HW instruction via getBlockIOTileSize.
+    Value basePtr = makeTensorDescOp->getBase();
+    Operation::operand_range shapes = makeTensorDescOp->getShape();
+    Operation::operand_range strides = makeTensorDescOp->getStrides();
+    SmallVector<Value> indices(op.getIndices().begin(), op.getIndices().end());
+    assert(indices.size() == descRank &&
+           "descriptor index count must match descriptor rank");
+
+    // Fold batch indices into base_ptr. This handles both rank-reducing loads
+    // (descRank > rank: leading descriptor dims are dropped) and same-rank
+    // loads with rank > 2 (batch dims before the inner-2 dims).
+    unsigned numBatchDims = descRank - 2;
+    for (unsigned d = 0; d < numBatchDims; ++d) {
+      Value batchOffset = arith::MulIOp::create(
+          builder, loc,
+          arith::ExtSIOp::create(builder, loc, builder.getI64Type(),
+                                 indices[d]),
+          strides[d]);
+      basePtr = tt::AddPtrOp::create(builder, loc, basePtr.getType(), basePtr,
+                                     batchOffset);
+    }
+
+    // Helper to truncate to i32 only if needed.
+    auto toI32 = [&](Value v) -> Value {
+      if (v.getType().getIntOrFloatBitWidth() > 32)
+        return arith::TruncIOp::create(builder, loc, i32Ty, v);
+      return v;
+    };
+
+    // If the pitch stride is a known constant AND the descriptor/result ranks
+    // match, validate HW constraints (>= 64 bytes, 16-byte aligned).
+    // For rank-reducing loads, the stride interpretation may differ from the
+    // 2D surface pitch, so skip static validation (runtime will handle it).
+    if (rank == descRank) {
+      std::optional<int64_t> pitchStride =
+          tt::intel::getFoldedConstantValue(strides[descRank - 2]);
+      if (pitchStride) {
+        int64_t pitchBytes = *pitchStride * elemSizeInBits / 8;
+        if (pitchBytes < 64 || (pitchBytes % 16) != 0) {
+          LDBG("Invalid pitch " << pitchBytes
+                                << " for descriptor load: " << *op);
+          return;
+        }
+      }
+    }
+
+    // Surface width = inner dimension size * element bytes.
+    // Surface height = second-to-last dimension size.
+    // Pitch = stride of the second-to-last dimension * element bytes.
+    // (In a tensor descriptor, the last stride is always 1.)
+    Value elemBytes =
+        arith::ConstantIntOp::create(builder, loc, elemSizeInBits / 8, 32);
+    Value baseWidth = arith::MulIOp::create(
+        builder, loc, toI32(shapes[descRank - 1]), elemBytes);
+    Value baseHeight = toI32(shapes[descRank - 2]);
+    Value basePitch = arith::MulIOp::create(
+        builder, loc, toI32(strides[descRank - 2]), elemBytes);
+
+    // Inner-2 indices: X = inner dim (descRank-1), Y = second-to-last.
+    Value offsetX = indices[descRank - 1];
+    Value offsetY = indices[descRank - 2];
+
+    // Determine padding mode from the descriptor.
+    bool padNan = makeTensorDescOp->getPadding() == tt::PaddingOption::PAD_NAN;
+    UnitAttr padNanAttr = padNan ? builder.getUnitAttr() : UnitAttr();
+
+    auto blockLoadOp = ttgi::Subgroup2DBlockLoadOp::create(
+        builder, loc, op.getType(), basePtr, baseWidth, baseHeight, basePitch,
+        offsetX, offsetY, padNanAttr,
+        ttgi::BlockIOModeAttr::get(builder.getContext(), memLayout));
+
+    // Propagate one_matrix_per_load attribute if present.
+    if (op->hasAttr(ttgi::TritonIntelGPUDialect::getOneMatrixPerLoadAttrName()))
+      blockLoadOp->setAttr(
+          ttgi::TritonIntelGPUDialect::getOneMatrixPerLoadAttrName(),
+          builder.getUnitAttr());
+
+    op.replaceAllUsesWith(blockLoadOp.getResult());
+    op.erase();
+    LDBG("Converted descriptor load to ttig.2d_block_load: " << *blockLoadOp);
+  }
+};
+
+} // namespace

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -102,7 +102,8 @@ private:
 
     auto descType = cast<tt::TensorDescType>(desc.getType());
     unsigned descRank = descType.getBlockType().getRank();
-    assert(descRank >= rank && "descriptor rank must be >= result tensor rank");
+    assert(descRank == rank &&
+           "descriptor and result tensor must have same rank");
 
     bool memoryRowMajor = isMemoryRowMajor(op);
 
@@ -137,9 +138,9 @@ private:
     assert(indices.size() == descRank &&
            "descriptor index count must match descriptor rank");
 
-    // Fold batch indices into base_ptr. This handles both rank-reducing loads
-    // (descRank > rank: leading descriptor dims are dropped) and same-rank
-    // loads with rank > 2 (batch dims before the inner-2 dims).
+    // Fold batch indices into base_ptr for rank > 2 loads. The leading
+    // dimensions (before the inner-2 dims) are batch dims whose offsets
+    // are multiplied by the corresponding strides and added to the pointer.
     unsigned numBatchDims = descRank - 2;
     for (unsigned d = 0; d < numBatchDims; ++d) {
       Value batchOffset = arith::MulIOp::create(
@@ -158,20 +159,15 @@ private:
       return v;
     };
 
-    // If the pitch stride is a known constant AND the descriptor/result ranks
-    // match, validate HW constraints (>= 64 bytes, 16-byte aligned).
-    // For rank-reducing loads, the stride interpretation may differ from the
-    // 2D surface pitch, so skip static validation (runtime will handle it).
-    if (rank == descRank) {
-      std::optional<int64_t> pitchStride =
-          tt::intel::getFoldedConstantValue(strides[descRank - 2]);
-      if (pitchStride) {
-        int64_t pitchBytes = *pitchStride * elemSizeInBits / 8;
-        if (pitchBytes < 64 || (pitchBytes % 16) != 0) {
-          LDBG("Invalid pitch " << pitchBytes
-                                << " for descriptor load: " << *op);
-          return;
-        }
+    // If the pitch stride is a known constant, validate HW constraints
+    // (>= 64 bytes, 16-byte aligned).
+    std::optional<int64_t> pitchStride =
+        tt::intel::getFoldedConstantValue(strides[descRank - 2]);
+    if (pitchStride) {
+      int64_t pitchBytes = *pitchStride * elemSizeInBits / 8;
+      if (pitchBytes < 64 || (pitchBytes % 16) != 0) {
+        LDBG("Invalid pitch " << pitchBytes << " for descriptor load: " << *op);
+        return;
       }
     }
 


### PR DESCRIPTION
Add a TTGIR pass that converts eligible tt.descriptor_load ops to ttig.2d_block_load by decomposing surface parameters (width, height, pitch, offsets) from the defining tt.make_tensor_descriptor.

The pass handles row-major, column-major, >2 dim tensors, and NaN padding descriptor loads. It is not yet added to the compilation pipeline — LLVM lowering for ttig.2d_block_load will be added separately.

Also adds validate2DBlockLoadTile to BlockIOUtils for pre-checking tile validity (tile size, HW address restrictions, inner-dim constraints) before conversion.