### PR TITLE
[NFI] Move getOpIdx, getDpasLayout, computeTransposeShuffleMapping to BlockIOUtils

### DIFF
--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
@@ -1,6 +1,9 @@
 #ifndef TRITONINTELGPU_TRANSFORMS_BLOCKIOUTILS_H
 #define TRITONINTELGPU_TRANSFORMS_BLOCKIOUTILS_H
 
+#include "intel/include/Dialect/TritonIntelGPU/IR/Attributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Support/LogicalResult.h"
 #include "triton/Analysis/AxisInfo.h"
 #include "triton/Tools/LinearLayout.h"
 #include "llvm/ADT/SetVector.h"
@@ -53,6 +56,21 @@ getBlockIOTileSize<true>(const LinearLayout &, unsigned, unsigned, AxisInfo *,
 extern template BlockIOTileSizeInfo
 getBlockIOTileSize<false>(const LinearLayout &, unsigned, unsigned, AxisInfo *,
                           bool);
+
+/// Get the DPAS operand index from a tensor type's encoding.
+DpasEncodingAttr::OpIdx getOpIdx(RankedTensorType tensorTy);
+
+/// Get the DPAS layout from a tensor type's encoding.
+DpasEncodingAttr getDpasLayout(RankedTensorType tensorTy);
+
+/// Compute the shuffle mapping for transposed 2D block loads.
+/// Returns failure if the transpose configuration is unsupported.
+/// Used by both the TTGIR validation (to reject unsupported configs)
+/// and the LLVM lowering (to produce the actual mapping).
+FailureOr<LinearLayout> computeTransposeShuffleMapping(
+    RankedTensorType tensorType, const LinearLayout &regMapping,
+    int64_t numElemsPerLoad, unsigned numPackedVals, unsigned tileHeight,
+    unsigned threadsPerWarp, bool hasDPASOperandType, MLIRContext *ctx);
 
 /// Check whether the packed element size and tile width satisfy the
 /// 2D block address payload hardware restrictions.

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
@@ -58,9 +58,11 @@ getBlockIOTileSize<false>(const LinearLayout &, unsigned, unsigned, AxisInfo *,
                           bool);
 
 /// Get the DPAS operand index from a tensor type's encoding.
+/// The encoding must be DPAS or DotOperand-with-DPAS parent.
 DpasEncodingAttr::OpIdx getOpIdx(RankedTensorType tensorTy);
 
 /// Get the DPAS layout from a tensor type's encoding.
+/// The encoding must be DPAS or DotOperand-with-DPAS parent.
 DpasEncodingAttr getDpasLayout(RankedTensorType tensorTy);
 
 /// Compute the shuffle mapping for transposed 2D block loads.

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -689,20 +689,11 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
   }
 
   static DpasEncodingAttr::OpIdx getOpIdx(RankedTensorType tensorTy) {
-    if (hasDpasEncoding(tensorTy))
-      return DpasEncodingAttr::OpIdx::OperandC;
-
-    assert(hasDotDpasEncoding(tensorTy) && "Expecting dot layout");
-    DotOperandEncodingAttr dotLayout = getDotEncoding(tensorTy).value();
-    return static_cast<DpasEncodingAttr::OpIdx>(dotLayout.getOpIdx());
+    return triton::gpu::intel::getOpIdx(tensorTy);
   }
 
   static DpasEncodingAttr getDpasLayout(RankedTensorType tensorTy) {
-    Attribute encoding = tensorTy.getEncoding();
-    return cast<DpasEncodingAttr>(
-        hasDpasEncoding(tensorTy)
-            ? encoding
-            : getDotEncoding(tensorTy).value().getParent());
+    return triton::gpu::intel::getDpasLayout(tensorTy);
   }
 
   // Returns the pitch (stride in bytes) for a regular pointer.
@@ -911,73 +902,13 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
     return cfg;
   }
 
-  /// Compute the shuffle mapping for transposed 2D block loads.
-  /// Returns failure if the transpose configuration is unsupported.
   static FailureOr<LinearLayout> computeTransposeShuffleMapping(
       RankedTensorType tensorType, const LinearLayout &regMapping,
       int64_t numElemsPerLoad, unsigned numPackedVals, unsigned tileHeight,
       unsigned threadsPerWarp, bool hasDPASOperandType, MLIRContext *ctx) {
-    StringAttr kRegister = S("register");
-    LinearLayout shuffleMapping =
-        LinearLayout::identity1D(numElemsPerLoad, kRegister, kRegister);
-
-    // Improve this. The current 2D block load only transposes the matrix at
-    // i32 granularity. We still need to perform an additional in-register
-    // transpose from i32 -> (N × ElemSizeInBits) tiles, using the tile width.
-    // At the moment, we can only achieve this using a bitcast operation,
-    // which implicitly uses the sub-group size as the transpose width. To
-    // optimize further, we should implement this with inline VISA
-    // instructions.
-
-    // tileHeight becomes width after transposing.
-    unsigned widthToTranspose = tileHeight;
-    if (hasDPASOperandType) {
-      // For the DPAS related layout, we will do the shuffle at first in the
-      // unpacking of the elements at the DPAS operands granularity.
-      // And then we will do the transposing. So the transposing width is DPAS
-      // op shapes.
-      DpasEncodingAttr::OpIdx opIdx = getOpIdx(tensorType);
-      DpasEncodingAttr dpasLayout = getDpasLayout(tensorType);
-      switch (opIdx) {
-      case DpasEncodingAttr::OpIdx::OperandA: {
-        widthToTranspose = dpasLayout.getDPASInstShapeA()[1];
-        break;
-      }
-      case DpasEncodingAttr::OpIdx::OperandB: {
-        widthToTranspose = dpasLayout.getDPASInstShapeB()[1];
-        break;
-      }
-      case DpasEncodingAttr::OpIdx::OperandC: {
-        widthToTranspose = dpasLayout.getDPASInstShapeC()[1];
-        break;
-      }
-      }
-      // For shuffle the transposed Dot operands matrix, we can shuffle the
-      // loaded matrix in an reverse order.
-      auto invertMapping = regMapping.invert();
-      bool foundSurjective = false;
-      for (unsigned numElemsPerSurjectiveTile = numElemsPerLoad;
-           numElemsPerSurjectiveTile > 0; numElemsPerSurjectiveTile >>= 1) {
-        auto layout =
-            invertMapping.resizeInDim(kRegister, numElemsPerSurjectiveTile)
-                .resizeOutDim(kRegister, numElemsPerSurjectiveTile);
-        if (layout.isSurjective()) {
-          shuffleMapping =
-              layout * LinearLayout::identity1D(numElemsPerLoad /
-                                                    numElemsPerSurjectiveTile,
-                                                kRegister, kRegister);
-          foundSurjective = true;
-          break;
-        }
-      }
-      if (!foundSurjective)
-        return failure();
-    }
-
-    if (numPackedVals > 1 && (widthToTranspose) != threadsPerWarp)
-      return failure();
-
-    return shuffleMapping;
+    return triton::gpu::intel::computeTransposeShuffleMapping(
+        tensorType, regMapping, numElemsPerLoad, numPackedVals, tileHeight,
+        threadsPerWarp, hasDPASOperandType, ctx);
   }
 
   /// Unpack a 2D block load result into individual element values.

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -1,6 +1,8 @@
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h"
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/Utility.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/MathExtras.h"
 #include <numeric>
@@ -389,6 +391,92 @@ bool check2DBlockAddressPayloadRestriction(unsigned packedElemSizeInBits,
     return false;
   }
   return true;
+}
+
+DpasEncodingAttr::OpIdx getOpIdx(RankedTensorType tensorTy) {
+  if (hasDpasEncoding(tensorTy))
+    return DpasEncodingAttr::OpIdx::OperandC;
+  assert(hasDotDpasEncoding(tensorTy) && "Expecting dot layout");
+  auto dotLayout =
+      cast<triton::gpu::DotOperandEncodingAttr>(tensorTy.getEncoding());
+  return static_cast<DpasEncodingAttr::OpIdx>(dotLayout.getOpIdx());
+}
+
+DpasEncodingAttr getDpasLayout(RankedTensorType tensorTy) {
+  Attribute encoding = tensorTy.getEncoding();
+  return cast<DpasEncodingAttr>(
+      hasDpasEncoding(tensorTy)
+          ? encoding
+          : cast<triton::gpu::DotOperandEncodingAttr>(encoding).getParent());
+}
+
+/// Compute the shuffle mapping for transposed 2D block loads.
+/// Returns failure if the transpose configuration is unsupported.
+FailureOr<LinearLayout> computeTransposeShuffleMapping(
+    RankedTensorType tensorType, const LinearLayout &regMapping,
+    int64_t numElemsPerLoad, unsigned numPackedVals, unsigned tileHeight,
+    unsigned threadsPerWarp, bool hasDPASOperandType, MLIRContext *ctx) {
+  StringAttr kRegister = StringAttr::get(ctx, "register");
+  LinearLayout shuffleMapping =
+      LinearLayout::identity1D(numElemsPerLoad, kRegister, kRegister);
+
+  // Improve this. The current 2D block load only transposes the matrix at
+  // i32 granularity. We still need to perform an additional in-register
+  // transpose from i32 -> (N × ElemSizeInBits) tiles, using the tile width.
+  // At the moment, we can only achieve this using a bitcast operation,
+  // which implicitly uses the sub-group size as the transpose width. To
+  // optimize further, we should implement this with inline VISA
+  // instructions.
+
+  // tileHeight becomes width after transposing.
+  unsigned widthToTranspose = tileHeight;
+  if (hasDPASOperandType) {
+    // For the DPAS related layout, we will do the shuffle at first in the
+    // unpacking of the elements at the DPAS operands granularity.
+    // And then we will do the transposing. So the transposing width is DPAS
+    // op shapes.
+    DpasEncodingAttr::OpIdx opIdx = getOpIdx(tensorType);
+    DpasEncodingAttr dpasLayout = getDpasLayout(tensorType);
+    switch (opIdx) {
+    case DpasEncodingAttr::OpIdx::OperandA: {
+      widthToTranspose = dpasLayout.getDPASInstShapeA()[1];
+      break;
+    }
+    case DpasEncodingAttr::OpIdx::OperandB: {
+      widthToTranspose = dpasLayout.getDPASInstShapeB()[1];
+      break;
+    }
+    case DpasEncodingAttr::OpIdx::OperandC: {
+      widthToTranspose = dpasLayout.getDPASInstShapeC()[1];
+      break;
+    }
+    }
+    // For shuffle the transposed Dot operands matrix, we can shuffle the
+    // loaded matrix in an reverse order.
+    auto invertMapping = regMapping.invert();
+    bool foundSurjective = false;
+    for (unsigned numElemsPerSurjectiveTile = numElemsPerLoad;
+         numElemsPerSurjectiveTile > 0; numElemsPerSurjectiveTile >>= 1) {
+      auto layout =
+          invertMapping.resizeInDim(kRegister, numElemsPerSurjectiveTile)
+              .resizeOutDim(kRegister, numElemsPerSurjectiveTile);
+      if (layout.isSurjective()) {
+        shuffleMapping =
+            layout * LinearLayout::identity1D(numElemsPerLoad /
+                                                  numElemsPerSurjectiveTile,
+                                              kRegister, kRegister);
+        foundSurjective = true;
+        break;
+      }
+    }
+    if (!foundSurjective)
+      return failure();
+  }
+
+  if (numPackedVals > 1 && (widthToTranspose) != threadsPerWarp)
+    return failure();
+
+  return shuffleMapping;
 }
 
 } // namespace mlir::triton::gpu::intel

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -410,8 +410,6 @@ DpasEncodingAttr getDpasLayout(RankedTensorType tensorTy) {
           : cast<triton::gpu::DotOperandEncodingAttr>(encoding).getParent());
 }
 
-/// Compute the shuffle mapping for transposed 2D block loads.
-/// Returns failure if the transpose configuration is unsupported.
 FailureOr<LinearLayout> computeTransposeShuffleMapping(
     RankedTensorType tensorType, const LinearLayout &regMapping,
     int64_t numElemsPerLoad, unsigned numPackedVals, unsigned tileHeight,


### PR DESCRIPTION
Move three static functions from BlockIOConversionBase in LoadStoreOpToLLVM.cpp to BlockIOUtils.h/.cpp so they can be shared by both the LLVM lowering and the TTGIR-level validation in validate2DBlockLoadTile.

The LoadStoreOpToLLVM.cpp versions are replaced with thin forwarders.