### PR TITLE
Disable annotate cache control

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -558,7 +558,7 @@ class intel_knobs(base_knobs):
     gen_native_code: env_bool = env_bool("TRITON_XPU_GEN_NATIVE_CODE", False)
     opt_reduction_locality: env_bool = env_bool("TRITON_INTEL_OPTIMIZE_REDUCTION_LOCALITY", False)
     disable_igc_opt: env_bool = env_bool("TRITON_INTEL_DISABLE_IGC_OPT", False)
-    disable_annotate_cache_control: env_bool = env_bool("TRITON_INTEL_DISABLE_ANNOTATE_CACHE_CONTROL", False)
+    disable_annotate_cache_control: env_bool = env_bool("TRITON_INTEL_DISABLE_ANNOTATE_CACHE_CONTROL", True)
 
     enable_dump_spirv_kernel_args: env_bool = env_bool("TRITON_XPU_ENABLE_DUMP_SPIRV_KERNEL_ARGS", False)
     dump_spirv_kernel_args_dir: env_opt_str = env_opt_str("TRITON_XPU_DUMP_SPIRV_KERNEL_ARGS_DIR")


### PR DESCRIPTION
66eb8d088b — [TTGIR] Add tritonintelgpu-annotate-cache-control pass (#6723) causes significant performance regressions, especially on decode-like workloads (N_CTX_q=1) where throughput drops by up to ~5.8x.

<img width="1847" height="758" alt="image" src="https://github.com/user-attachments/assets/f4246a3d-0622-4063-a594-a09dec94b9d6" />
