### PR TITLE
[AnnotateCacheControl] Use LinearLayout to detect warp-broadcast loads

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -558,7 +558,7 @@ class intel_knobs(base_knobs):
     gen_native_code: env_bool = env_bool("TRITON_XPU_GEN_NATIVE_CODE", False)
     opt_reduction_locality: env_bool = env_bool("TRITON_INTEL_OPTIMIZE_REDUCTION_LOCALITY", False)
     disable_igc_opt: env_bool = env_bool("TRITON_INTEL_DISABLE_IGC_OPT", False)
-    disable_annotate_cache_control: env_bool = env_bool("TRITON_INTEL_DISABLE_ANNOTATE_CACHE_CONTROL", True)
+    disable_annotate_cache_control: env_bool = env_bool("TRITON_INTEL_DISABLE_ANNOTATE_CACHE_CONTROL", False)
 
     enable_dump_spirv_kernel_args: env_bool = env_bool("TRITON_XPU_ENABLE_DUMP_SPIRV_KERNEL_ARGS", False)
     dump_spirv_kernel_args_dir: env_opt_str = env_opt_str("TRITON_XPU_DUMP_SPIRV_KERNEL_ARGS_DIR")

--- a/test/TritonIntelGPU/annotate-cache-control.mlir
+++ b/test/TritonIntelGPU/annotate-cache-control.mlir
@@ -475,3 +475,37 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     tt.return
   }
 }
+
+// -----
+
+// COM: Test u — Linear encoding with all-zero warp basis vectors: every warp
+// COM: reads the same data, so L1 reuse is valuable. .cg must NOT be applied.
+// COM: This pattern appears in flex_decoding where Q is broadcast across warps.
+
+// CHECK-LABEL: @load_linear_warp_broadcast
+#linear_wb = #ttg.linear<{register = [[0, 16], [0, 32], [0, 64]], lane = [[0, 1], [0, 2], [0, 4], [0, 8]], warp = [[0, 0]], block = []}>
+module attributes {"ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @load_linear_warp_broadcast(%arg0: tensor<1x128x!tt.ptr<f16>, #linear_wb>) -> tensor<1x128xf16, #linear_wb> {
+    // CHECK: tt.load
+    // CHECK-NOT: cacheModifier = cg
+    // CHECK-SAME: tensor<1x128x!tt.ptr<f16>, #{{.*}}>
+    %0 = tt.load %arg0 : tensor<1x128x!tt.ptr<f16>, #linear_wb>
+    tt.return %0 : tensor<1x128xf16, #linear_wb>
+  }
+}
+
+// -----
+
+// COM: Test v — Linear encoding with non-zero warp basis vectors: warps read
+// COM: different data, no cross-warp L1 reuse. .cg should be applied.
+
+// CHECK-LABEL: @load_linear_warp_partitioned
+#linear_wp = #ttg.linear<{register = [[0, 16], [0, 32], [0, 64]], lane = [[0, 1], [0, 2], [0, 4], [0, 8]], warp = [[1, 0]], block = []}>
+module attributes {"ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @load_linear_warp_partitioned(%arg0: tensor<2x128x!tt.ptr<f16>, #linear_wp>) -> tensor<2x128xf16, #linear_wp> {
+    // CHECK: tt.load
+    // CHECK-SAME: cacheModifier = cg
+    %0 = tt.load %arg0 : tensor<2x128x!tt.ptr<f16>, #linear_wp>
+    tt.return %0 : tensor<2x128xf16, #linear_wp>
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/AnnotateCacheControl.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/AnnotateCacheControl.cpp
@@ -2,9 +2,12 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
+#include "triton/Tools/LinearLayout.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/MathExtras.h"
 
 namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
@@ -81,6 +84,18 @@ static bool propagateThroughSCF(OpOperand &use,
   return false;
 }
 
+// Attempts to compute the LinearLayout for the given tensor type.
+// Returns std::nullopt when the layout cannot be computed (e.g. non-power-of-2
+// shapes, which would trigger assertions inside toLinearLayout).
+static std::optional<tt::LinearLayout> tryGetLinearLayout(RankedTensorType ty) {
+  for (int64_t dim : ty.getShape())
+    if (!llvm::isPowerOf2_64(dim))
+      return std::nullopt;
+  if (!ty.getEncoding())
+    return std::nullopt;
+  return ttg::toLinearLayout(ty);
+}
+
 // Returns true when `.cg` annotation should be suppressed on `loadOp` because
 // the HW access pattern implied by the load's result encoding already yields
 // cross-subgroup L1 reuse. Replaces an older forward-dataflow heuristic
@@ -103,6 +118,18 @@ static bool skipForL1Reuse(tt::LoadOp loadOp) {
   if (auto dotEnc = dyn_cast<ttg::DotOperandEncodingAttr>(enc))
     if (isa<ttg::MmaEncodingTrait>(dotEnc.getParent()))
       return true;
+
+  // Warp-broadcast check via LinearLayout: if every warp accesses the same
+  // tensor elements, the data benefits from L1 reuse across subgroups.
+  if (std::optional<tt::LinearLayout> ll = tryGetLinearLayout(tensorTy)) {
+    auto kWarp = StringAttr::get(loadOp.getContext(), "warp");
+    if (!ll->hasInDim(kWarp))
+      return true;
+    SmallVector<StringAttr> outDims(ll->getOutDimNames().begin(),
+                                    ll->getOutDimNames().end());
+    if (ll->sublayoutIsZero({kWarp}, outDims))
+      return true;
+  }
 
   // Scale operand of tt.dot_scaled: scales are consumed by the same
   // DPAS-backed matmul as the A/B operands and benefit from the same


### PR DESCRIPTION
Suppress .cg cache annotation on loads whose LinearLayout shows the
warp dimension is absent or zero, indicating all subgroups access the
same elements and benefit from L1 reuse.

Fixes #6810