### PR TITLE
Don't use shebang for Windows to build PTI

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -128,7 +128,7 @@ jobs:
           .venv\Scripts\activate.ps1
           Invoke-BatchFile "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           cd ${{ env.NEW_WORKSPACE }}
-          bash -c './scripts/install-pti.sh --build-level-zero'
+          bash -c 'export OSTYPE; ./scripts/install-pti.sh --build-level-zero'
           $PTI_LIBS_DIR = python ./scripts/pti_lib.py
           ls $PTI_LIBS_DIR
           echo "PATH=$PTI_LIBS_DIR;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -128,7 +128,7 @@ jobs:
           .venv\Scripts\activate.ps1
           Invoke-BatchFile "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           cd ${{ env.NEW_WORKSPACE }}
-          bash -c 'bash ./scripts/install-pti.sh --build-level-zero'
+          bash ./scripts/install-pti.sh --build-level-zero
           $PTI_LIBS_DIR = python ./scripts/pti_lib.py
           ls $PTI_LIBS_DIR
           echo "PATH=$PTI_LIBS_DIR;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -128,7 +128,7 @@ jobs:
           .venv\Scripts\activate.ps1
           Invoke-BatchFile "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           cd ${{ env.NEW_WORKSPACE }}
-          bash -c 'export OSTYPE; ./scripts/install-pti.sh --build-level-zero'
+          bash -c 'bash ./scripts/install-pti.sh --build-level-zero'
           $PTI_LIBS_DIR = python ./scripts/pti_lib.py
           ls $PTI_LIBS_DIR
           echo "PATH=$PTI_LIBS_DIR;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append


### PR DESCRIPTION
It looks like `#!/usr/bin/env bash` selects a wrong bash which does not export the OSTYPE variable. So for Windows we will call bash as an interpreter directly.

Fixes #6817

Test run (passed the failure point, then cancelled to conserve resources): https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/25333556956