### PR TITLE
[TritonIntelGPU] Fix BlockScaledDPAS scale operand warp basis to zero

### DIFF
--- a/test/TritonIntelGPU/accelerate-matmul-fp8.mlir
+++ b/test/TritonIntelGPU/accelerate-matmul-fp8.mlir
@@ -44,8 +44,8 @@ module attributes {ttig.min_sg_size = 16 : i32, ttig.support_subgroup_matrix_mul
 // CHECK: #[[$BLOCKED:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [4, 4], order = [1, 0]}>
 // CHECK: #[[$BLOCKED1:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 4], warpsPerCTA = [16, 1], order = [1, 0]}>
 // CHECK: #[[$BLOCKED2:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 8], order = [1, 0]}>
-// CHECK: #[[$LINEARLAYOUT1:.+]] = #ttg.linear<{register = {{\[\[}}0, 1], [8, 0], [16, 0], [0, 2]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [0, 0]], warp = {{\[\[}}0, 0], [0, 0], [32, 0], [64, 0]], block = []}>
-// CHECK: #[[$LINEARLAYOUT2:.+]] = #ttg.linear<{register = {{\[\[}}0, 1], [16, 0], [0, 2]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [8, 0]], warp = {{\[\[}}32, 0], [64, 0], [0, 0], [0, 0]], block = []}>
+// CHECK: #[[$LINEARLAYOUT1:.+]] = #ttg.linear<{register = {{\[\[}}0, 1], [8, 0], [16, 0], [0, 2], [32, 0], [64, 0]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [0, 0]], warp = {{\[\[}}0, 0], [0, 0], [0, 0], [0, 0]], block = []}>
+// CHECK: #[[$LINEARLAYOUT2:.+]] = #ttg.linear<{register = {{\[\[}}0, 1], [16, 0], [0, 2], [32, 0], [64, 0]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [8, 0]], warp = {{\[\[}}0, 0], [0, 0], [0, 0], [0, 0]], block = []}>
 // CHECK: #[[$DPAS:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 4, fp4KPack = 2, threadsPerWarp = 16, warpsPerCTA = [4, 4], repCluster = [4, 2], A = [32, 32], B = [32, 32], C = [32, 32]}>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 8], order = [1, 0]}>
@@ -77,8 +77,8 @@ module attributes {ttig.min_sg_size = 16 : i32, ttig.support_subgroup_matrix_mul
 // CHECK: #[[$BLOCKED:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [4, 4], order = [1, 0]}>
 // CHECK: #[[$BLOCKED1:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 4], warpsPerCTA = [16, 1], order = [1, 0]}>
 // CHECK: #[[$BLOCKED2:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 8], order = [1, 0]}>
-// CHECK: #[[$LINEARLAYOUT1:.+]] = #ttg.linear<{register = {{\[\[}}8, 0], [16, 0], [0, 1]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [0, 0]], warp = {{\[\[}}0, 0], [0, 0], [32, 0], [64, 0]], block = []}>
-// CHECK: #[[$LINEARLAYOUT2:.+]] = #ttg.linear<{register = {{\[\[}}16, 0], [0, 1]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [8, 0]], warp = {{\[\[}}32, 0], [64, 0], [0, 0], [0, 0]], block = []}>
+// CHECK: #[[$LINEARLAYOUT1:.+]] = #ttg.linear<{register = {{\[\[}}8, 0], [16, 0], [0, 1], [32, 0], [64, 0]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [0, 0]], warp = {{\[\[}}0, 0], [0, 0], [0, 0], [0, 0]], block = []}>
+// CHECK: #[[$LINEARLAYOUT2:.+]] = #ttg.linear<{register = {{\[\[}}16, 0], [0, 1], [32, 0], [64, 0]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [8, 0]], warp = {{\[\[}}0, 0], [0, 0], [0, 0], [0, 0]], block = []}>
 // CHECK: #[[$DPAS:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 4, threadsPerWarp = 16, warpsPerCTA = [4, 4], repCluster = [4, 2], A = [32, 32], B = [32, 32], C = [32, 32]}>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 8], order = [1, 0]}>
@@ -151,8 +151,8 @@ module attributes {ttig.min_sg_size = 16 : i32, ttig.support_subgroup_matrix_mul
 // CHECK: #[[$BLOCKED_2:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 8], order = [1, 0]}>
 // CHECK: #[[$BLOCKED_3:.+]] = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 16], warpsPerCTA = [4, 4], order = [1, 0]}>
 // CHECK: #[[$LINEARLAYOUT_0:.+]] = #ttg.linear<{register = {{\[\[}}0, 1], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0]], lane = {{\[\[}}0, 2], [0, 4], [0, 8], [0, 16]], warp = {{\[\[}}0, 32], [0, 64], [0, 128], [1, 0]], block = []}>
-// CHECK: #[[$LINEARLAYOUT_1:.+]] = #ttg.linear<{register = {{\[\[}}8, 0], [16, 0], [0, 1], [0, 2]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [0, 0]], warp = {{\[\[}}0, 0], [0, 0], [32, 0], [64, 0]], block = []}>
-// CHECK: #[[$LINEARLAYOUT_2:.+]] = #ttg.linear<{register = {{\[\[}}16, 0], [0, 1], [0, 2]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [8, 0]], warp = {{\[\[}}32, 0], [64, 0], [0, 0], [0, 0]], block = []}>
+// CHECK: #[[$LINEARLAYOUT_1:.+]] = #ttg.linear<{register = {{\[\[}}8, 0], [16, 0], [0, 1], [0, 2], [32, 0], [64, 0]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [0, 0]], warp = {{\[\[}}0, 0], [0, 0], [0, 0], [0, 0]], block = []}>
+// CHECK: #[[$LINEARLAYOUT_2:.+]] = #ttg.linear<{register = {{\[\[}}16, 0], [0, 1], [0, 2], [32, 0], [64, 0]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [8, 0]], warp = {{\[\[}}0, 0], [0, 0], [0, 0], [0, 0]], block = []}>
 // CHECK: #[[$DPAS:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 4], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 8], order = [1, 0]}>
@@ -187,8 +187,8 @@ module attributes {ttig.min_sg_size = 16 : i32, ttig.support_subgroup_matrix_mul
 // CHECK: #[[$BLOCKED_2:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 8], order = [1, 0]}>
 // CHECK: #[[$BLOCKED_3:.+]] = #ttg.blocked<{sizePerThread = [2, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 8], order = [1, 0]}>
 // CHECK: #[[$LINEARLAYOUT_0:.+]] = #ttg.linear<{register = {{\[\[}}1, 0], [0, 64], [8, 0], [16, 0], [32, 0], [64, 0], [128, 0]], lane = {{\[\[}}0, 1], [0, 2], [0, 4], [0, 8]], warp = {{\[\[}}0, 16], [0, 32], [2, 0], [4, 0]], block = []}>
-// CHECK: #[[$LINEARLAYOUT_1:.+]] = #ttg.linear<{register = {{\[\[}}8, 0], [16, 0], [0, 1], [0, 2]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [0, 0]], warp = {{\[\[}}0, 0], [0, 0], [32, 0], [64, 0]], block = []}>
-// CHECK: #[[$LINEARLAYOUT_2:.+]] = #ttg.linear<{register = {{\[\[}}16, 0], [0, 1], [0, 2]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [8, 0]], warp = {{\[\[}}32, 0], [64, 0], [0, 0], [0, 0]], block = []}>
+// CHECK: #[[$LINEARLAYOUT_1:.+]] = #ttg.linear<{register = {{\[\[}}8, 0], [16, 0], [0, 1], [0, 2], [32, 0], [64, 0]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [0, 0]], warp = {{\[\[}}0, 0], [0, 0], [0, 0], [0, 0]], block = []}>
+// CHECK: #[[$LINEARLAYOUT_2:.+]] = #ttg.linear<{register = {{\[\[}}16, 0], [0, 1], [0, 2], [32, 0], [64, 0]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [8, 0]], warp = {{\[\[}}0, 0], [0, 0], [0, 0], [0, 0]], block = []}>
 // CHECK: #[[$DPAS:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 4], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 8], order = [1, 0]}>
@@ -222,8 +222,8 @@ module attributes {ttig.min_sg_size = 16 : i32, ttig.support_subgroup_matrix_mul
 // CHECK: #[[$BLOCKED1:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 4], warpsPerCTA = [16, 1], order = [1, 0]}>
 // CHECK: #[[$BLOCKED2:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 8], order = [1, 0]}>
 // CHECK: #[[$LINEARLAYOUT0:.+]] = #ttg.linear<{register = {{\[\[}}0, 1], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0]], lane = {{\[\[}}0, 2], [0, 4], [0, 8], [0, 16]], warp = {{\[\[}}0, 32], [0, 64], [1, 0], [2, 0]], block = []}>
-// CHECK: #[[$LINEARLAYOUT1:.+]] = #ttg.linear<{register = {{\[\[}}8, 0], [16, 0], [0, 1]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [0, 0]], warp = {{\[\[}}0, 0], [0, 0], [32, 0], [64, 0]], block = []}>
-// CHECK: #[[$LINEARLAYOUT2:.+]] = #ttg.linear<{register = {{\[\[}}16, 0], [0, 1]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [8, 0]], warp = {{\[\[}}32, 0], [64, 0], [0, 0], [0, 0]], block = []}>
+// CHECK: #[[$LINEARLAYOUT1:.+]] = #ttg.linear<{register = {{\[\[}}8, 0], [16, 0], [0, 1], [32, 0], [64, 0]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [0, 0]], warp = {{\[\[}}0, 0], [0, 0], [0, 0], [0, 0]], block = []}>
+// CHECK: #[[$LINEARLAYOUT2:.+]] = #ttg.linear<{register = {{\[\[}}16, 0], [0, 1], [32, 0], [64, 0]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [8, 0]], warp = {{\[\[}}0, 0], [0, 0], [0, 0], [0, 0]], block = []}>
 // CHECK: #[[$DPAS:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 4], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 8], order = [1, 0]}>
@@ -257,8 +257,8 @@ module attributes {ttig.min_sg_size = 16 : i32, ttig.support_bf16_conversion, tt
 // CHECK: #[[$BLOCKED1:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 4], warpsPerCTA = [16, 1], order = [1, 0]}>
 // CHECK: #[[$BLOCKED2:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 8], order = [1, 0]}>
 // CHECK: #[[$LINEARLAYOUT0:.+]] = #ttg.linear<{register = {{\[\[}}0, 1], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0]], lane = {{\[\[}}0, 2], [0, 4], [0, 8], [0, 16]], warp = {{\[\[}}0, 32], [0, 64], [1, 0], [2, 0]], block = []}>
-// CHECK: #[[$LINEARLAYOUT1:.+]] = #ttg.linear<{register = {{\[\[}}8, 0], [16, 0], [0, 1]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [0, 0]], warp = {{\[\[}}0, 0], [0, 0], [32, 0], [64, 0]], block = []}>
-// CHECK: #[[$LINEARLAYOUT2:.+]] = #ttg.linear<{register = {{\[\[}}16, 0], [0, 1]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [8, 0]], warp = {{\[\[}}32, 0], [64, 0], [0, 0], [0, 0]], block = []}>
+// CHECK: #[[$LINEARLAYOUT1:.+]] = #ttg.linear<{register = {{\[\[}}8, 0], [16, 0], [0, 1], [32, 0], [64, 0]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [0, 0]], warp = {{\[\[}}0, 0], [0, 0], [0, 0], [0, 0]], block = []}>
+// CHECK: #[[$LINEARLAYOUT2:.+]] = #ttg.linear<{register = {{\[\[}}16, 0], [0, 1], [32, 0], [64, 0]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [8, 0]], warp = {{\[\[}}0, 0], [0, 0], [0, 0], [0, 0]], block = []}>
 // CHECK: #[[$DPAS:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 4], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 8], order = [1, 0]}>
@@ -292,8 +292,8 @@ module attributes {ttig.min_sg_size = 16 : i32, ttig.support_bf16_conversion, tt
 // CHECK: #[[$BLOCKED1:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 4], warpsPerCTA = [16, 1], order = [1, 0]}>
 // CHECK: #[[$BLOCKED2:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 8], order = [1, 0]}>
 // CHECK: #[[$LINEARLAYOUT0:.+]] = #ttg.linear<{register = {{\[\[}}0, 1], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0]], lane = {{\[\[}}0, 2], [0, 4], [0, 8], [0, 16]], warp = {{\[\[}}0, 32], [0, 64], [1, 0], [2, 0]], block = []}>
-// CHECK: #[[$LINEARLAYOUT1:.+]] = #ttg.linear<{register = {{\[\[}}8, 0], [16, 0], [0, 1]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [0, 0]], warp = {{\[\[}}0, 0], [0, 0], [32, 0], [64, 0]], block = []}>
-// CHECK: #[[$LINEARLAYOUT2:.+]] = #ttg.linear<{register = {{\[\[}}16, 0], [0, 1]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [8, 0]], warp = {{\[\[}}32, 0], [64, 0], [0, 0], [0, 0]], block = []}>
+// CHECK: #[[$LINEARLAYOUT1:.+]] = #ttg.linear<{register = {{\[\[}}8, 0], [16, 0], [0, 1], [32, 0], [64, 0]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [0, 0]], warp = {{\[\[}}0, 0], [0, 0], [0, 0], [0, 0]], block = []}>
+// CHECK: #[[$LINEARLAYOUT2:.+]] = #ttg.linear<{register = {{\[\[}}16, 0], [0, 1], [32, 0], [64, 0]], lane = {{\[\[}}1, 0], [2, 0], [4, 0], [8, 0]], warp = {{\[\[}}0, 0], [0, 0], [0, 0], [0, 0]], block = []}>
 // CHECK: #[[$DPAS:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 4], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 8], order = [1, 0]}>

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/LinearLayoutConversions.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/LinearLayoutConversions.cpp
@@ -631,9 +631,9 @@ LinearLayout BlockScaledDPAStoLinearLayout(ArrayRef<int64_t> shape,
 
     // Scale operands are warp-broadcast: every warp in the workgroup accesses
     // the same scale values (the DPAS-backed matmul reuses the same scale
-    // across all warps that share K), so all warp bases are zero. This lets
-    // SpatialReuseAnalysis recognize cross-subgroup L1 reuse via a plain
-    // sublayoutIsZero({warp}, outDims) check without a use-site scan.
+    // across all warps that share K), so all warp bases are zero. Encoding
+    // this directly in the LinearLayout makes the broadcast pattern
+    // discoverable via `sublayoutIsZero({warp}, outDims)`.
     tileLayout *= LinearLayout::zeros1D(warpsPerCTA[dpasKDim], kWarp,
                                         outDimNames[scaleOpKDim]);
 

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/LinearLayoutConversions.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/LinearLayoutConversions.cpp
@@ -629,16 +629,20 @@ LinearLayout BlockScaledDPAStoLinearLayout(ArrayRef<int64_t> shape,
     tileLayout *= LinearLayout::identity1D(repCluster[dpasNonKDim], kRegister,
                                            outDimNames[scaleOpNonKDim]);
 
-    // K-dimension is shared among warps
+    // Scale operands are warp-broadcast: every warp in the workgroup accesses
+    // the same scale values (the DPAS-backed matmul reuses the same scale
+    // across all warps that share K), so all warp bases are zero. This lets
+    // SpatialReuseAnalysis recognize cross-subgroup L1 reuse via a plain
+    // sublayoutIsZero({warp}, outDims) check without a use-site scan.
     tileLayout *= LinearLayout::zeros1D(warpsPerCTA[dpasKDim], kWarp,
                                         outDimNames[scaleOpKDim]);
 
-    tileLayout *= LinearLayout::identity1D(warpsPerCTA[dpasNonKDim], kWarp,
-                                           outDimNames[scaleOpNonKDim]);
+    tileLayout *= LinearLayout::zeros1D(warpsPerCTA[dpasNonKDim], kWarp,
+                                        outDimNames[scaleOpNonKDim]);
 
     if (rank == 3)
       tileLayout *=
-          LinearLayout::identity1D(warpsPerCTA[0], kWarp, outDimNames[0]);
+          LinearLayout::zeros1D(warpsPerCTA[0], kWarp, outDimNames[0]);
 
   } else { // Operand Scale B
     auto regBasesB = BlockScaledDPASRegBasesScaleB(opsPerChannel);
@@ -652,15 +656,15 @@ LinearLayout BlockScaledDPAStoLinearLayout(ArrayRef<int64_t> shape,
     tileLayout *= LinearLayout::identity1D(repCluster[dpasNonKDim], kRegister,
                                            outDimNames[scaleOpNonKDim]);
 
-    // K-dimension is shared among warps
-    tileLayout *= LinearLayout::identity1D(warpsPerCTA[dpasNonKDim], kWarp,
-                                           outDimNames[scaleOpNonKDim]);
+    // Scale operands are warp-broadcast (see Scale A branch above).
+    tileLayout *= LinearLayout::zeros1D(warpsPerCTA[dpasNonKDim], kWarp,
+                                        outDimNames[scaleOpNonKDim]);
     tileLayout *= LinearLayout::zeros1D(warpsPerCTA[dpasKDim], kWarp,
                                         outDimNames[scaleOpKDim]);
 
     if (rank == 3)
       tileLayout *=
-          LinearLayout::identity1D(warpsPerCTA[0], kWarp, outDimNames[0]);
+          LinearLayout::zeros1D(warpsPerCTA[0], kWarp, outDimNames[0]);
   }
 
   // Lastly, the layout repeats to match the shape.

--- a/third_party/intel/unittest/Dialect/TritonIntelGPU/DPAStoLinearLayoutTest.cpp
+++ b/third_party/intel/unittest/Dialect/TritonIntelGPU/DPAStoLinearLayoutTest.cpp
@@ -218,16 +218,21 @@ TEST_F(DPAStoLinearLayoutTest, DPAS_withWarpOperandB) {
 }
 
 TEST_F(DPAStoLinearLayoutTest, DPAS_OperandScaleA) {
-  EXPECT_EQ(BlockScaledDPAStoLinearLayout(
-                {128, 2}, dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 32), 3),
-            LinearLayout(
-                {
-                    {S("register"), {{8, 0}, {16, 0}, {0, 1}, {64, 0}}},
-                    {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {0, 0}, {0, 0}}},
-                    {S("warp"), {{0, 0}, {32, 0}}},
-                    {S("block"), {}},
-                },
-                {S("dim0"), S("dim1")}));
+  // Scale operands are warp-broadcast (see BlockScaledDPAStoLinearLayout): all
+  // warp bases are zero. The tile shrinks along the M dimension as a result,
+  // so the remaining dim0 coverage is supplied by additional register bases
+  // instead of by warp identity bases.
+  EXPECT_EQ(
+      BlockScaledDPAStoLinearLayout({128, 2},
+                                    dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 32), 3),
+      LinearLayout(
+          {
+              {S("register"), {{8, 0}, {16, 0}, {0, 1}, {32, 0}, {64, 0}}},
+              {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {0, 0}, {0, 0}}},
+              {S("warp"), {{0, 0}, {0, 0}}},
+              {S("block"), {}},
+          },
+          {S("dim0"), S("dim1")}));
 
   EXPECT_EQ(BlockScaledDPAStoLinearLayout(
                 {128, 4},
@@ -235,23 +240,25 @@ TEST_F(DPAStoLinearLayoutTest, DPAS_OperandScaleA) {
                 3),
             LinearLayout(
                 {
-                    {S("register"), {{0, 1}, {8, 0}, {16, 0}, {0, 2}, {64, 0}}},
+                    {S("register"),
+                     {{0, 1}, {8, 0}, {16, 0}, {0, 2}, {32, 0}, {64, 0}}},
                     {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {0, 0}, {0, 0}}},
-                    {S("warp"), {{0, 0}, {32, 0}}},
+                    {S("warp"), {{0, 0}, {0, 0}}},
                     {S("block"), {}},
                 },
                 {S("dim0"), S("dim1")}));
 
-  EXPECT_EQ(BlockScaledDPAStoLinearLayout(
-                {128, 2}, dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 16), 3),
-            LinearLayout(
-                {
-                    {S("register"), {{8, 0}, {16, 0}, {0, 1}, {64, 0}}},
-                    {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {0, 0}}},
-                    {S("warp"), {{0, 0}, {32, 0}}},
-                    {S("block"), {}},
-                },
-                {S("dim0"), S("dim1")}));
+  EXPECT_EQ(
+      BlockScaledDPAStoLinearLayout({128, 2},
+                                    dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 16), 3),
+      LinearLayout(
+          {
+              {S("register"), {{8, 0}, {16, 0}, {0, 1}, {32, 0}, {64, 0}}},
+              {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {0, 0}}},
+              {S("warp"), {{0, 0}, {0, 0}}},
+              {S("block"), {}},
+          },
+          {S("dim0"), S("dim1")}));
 
   EXPECT_EQ(BlockScaledDPAStoLinearLayout(
                 {128, 4},
@@ -259,9 +266,10 @@ TEST_F(DPAStoLinearLayoutTest, DPAS_OperandScaleA) {
                 3),
             LinearLayout(
                 {
-                    {S("register"), {{0, 1}, {8, 0}, {16, 0}, {0, 2}, {64, 0}}},
+                    {S("register"),
+                     {{0, 1}, {8, 0}, {16, 0}, {0, 2}, {32, 0}, {64, 0}}},
                     {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {0, 0}}},
-                    {S("warp"), {{0, 0}, {32, 0}}},
+                    {S("warp"), {{0, 0}, {0, 0}}},
                     {S("block"), {}},
                 },
                 {S("dim0"), S("dim1")}));
@@ -271,9 +279,14 @@ TEST_F(DPAStoLinearLayoutTest, DPAS_OperandScaleA) {
             LinearLayout(
                 {
                     {S("register"),
-                     {{0, 8, 0}, {0, 16, 0}, {0, 0, 1}, {0, 0, 2}, {0, 64, 0}}},
+                     {{0, 8, 0},
+                      {0, 16, 0},
+                      {0, 0, 1},
+                      {0, 0, 2},
+                      {0, 32, 0},
+                      {0, 64, 0}}},
                     {S("lane"), {{0, 1, 0}, {0, 2, 0}, {0, 4, 0}, {0, 0, 0}}},
-                    {S("warp"), {{0, 0, 0}, {0, 32, 0}}},
+                    {S("warp"), {{0, 0, 0}, {0, 0, 0}}},
                     {S("block"), {}},
                 },
                 {S("dim0"), S("dim1"), S("dim2")}));
@@ -289,25 +302,30 @@ TEST_F(DPAStoLinearLayoutTest, DPAS_OperandScaleA) {
                {{0, 0, 1},
                 {0, 16, 0},
                 {0, 0, 2},
+                {0, 32, 0},
                 {0, 64, 0},
+                {1, 0, 0},
                 {2, 0, 0},
                 {4, 0, 0},
                 {8, 0, 0}}},
               {S("lane"), {{0, 1, 0}, {0, 2, 0}, {0, 4, 0}, {0, 8, 0}}},
-              {S("warp"), {{0, 32, 0}, {1, 0, 0}}},
+              {S("warp"), {{0, 0, 0}, {0, 0, 0}}},
               {S("block"), {}},
           },
           {S("dim0"), S("dim1"), S("dim2")}));
 }
 
 TEST_F(DPAStoLinearLayoutTest, DPAS_OperandScaleB) {
+  // Scale operands are warp-broadcast (see BlockScaledDPAStoLinearLayout): all
+  // warp bases are zero. An extra register basis covers the dim0 elements
+  // that used to be distributed across warps.
   EXPECT_EQ(BlockScaledDPAStoLinearLayout(
                 {128, 2}, dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 32), 4),
             LinearLayout(
                 {
-                    {S("register"), {{16, 0}, {0, 1}, {64, 0}}},
+                    {S("register"), {{16, 0}, {0, 1}, {32, 0}, {64, 0}}},
                     {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {0, 0}}},
-                    {S("warp"), {{32, 0}, {0, 0}}},
+                    {S("warp"), {{0, 0}, {0, 0}}},
                     {S("block"), {}},
                 },
                 {S("dim0"), S("dim1")}));
@@ -315,36 +333,105 @@ TEST_F(DPAStoLinearLayoutTest, DPAS_OperandScaleB) {
                 {128, 2}, dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 16), 4),
             LinearLayout(
                 {
-                    {S("register"), {{16, 0}, {0, 1}, {64, 0}}},
+                    {S("register"), {{16, 0}, {0, 1}, {32, 0}, {64, 0}}},
                     {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}}},
-                    {S("warp"), {{32, 0}, {0, 0}}},
+                    {S("warp"), {{0, 0}, {0, 0}}},
                     {S("block"), {}},
                 },
                 {S("dim0"), S("dim1")}));
-  EXPECT_EQ(BlockScaledDPAStoLinearLayout(
-                {128, 4},
-                dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 32, std::make_optional(2)),
-                4),
-            LinearLayout(
-                {
-                    {S("register"), {{0, 1}, {16, 0}, {0, 2}, {64, 0}}},
-                    {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {0, 0}}},
-                    {S("warp"), {{32, 0}, {0, 0}}},
-                    {S("block"), {}},
-                },
-                {S("dim0"), S("dim1")}));
-  EXPECT_EQ(BlockScaledDPAStoLinearLayout(
-                {128, 4},
-                dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 16, std::make_optional(2)),
-                4),
-            LinearLayout(
-                {
-                    {S("register"), {{0, 1}, {16, 0}, {0, 2}, {64, 0}}},
-                    {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}}},
-                    {S("warp"), {{32, 0}, {0, 0}}},
-                    {S("block"), {}},
-                },
-                {S("dim0"), S("dim1")}));
+  EXPECT_EQ(
+      BlockScaledDPAStoLinearLayout(
+          {128, 4},
+          dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 32, std::make_optional(2)), 4),
+      LinearLayout(
+          {
+              {S("register"), {{0, 1}, {16, 0}, {0, 2}, {32, 0}, {64, 0}}},
+              {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {0, 0}}},
+              {S("warp"), {{0, 0}, {0, 0}}},
+              {S("block"), {}},
+          },
+          {S("dim0"), S("dim1")}));
+  EXPECT_EQ(
+      BlockScaledDPAStoLinearLayout(
+          {128, 4},
+          dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 16, std::make_optional(2)), 4),
+      LinearLayout(
+          {
+              {S("register"), {{0, 1}, {16, 0}, {0, 2}, {32, 0}, {64, 0}}},
+              {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}}},
+              {S("warp"), {{0, 0}, {0, 0}}},
+              {S("block"), {}},
+          },
+          {S("dim0"), S("dim1")}));
+}
+
+TEST_F(DPAStoLinearLayoutTest, BlockScaledScaleOperandWarpBroadcast) {
+  // Preparatory audit for SpatialReuseAnalysis (see
+  // annotate-cc-p1-spatial-reuse.md): the scale-operand branch of
+  // BlockScaledDPAStoLinearLayout must produce a warp-broadcast LinearLayout
+  // (zero warp basis across all output dims). Scales are consumed by the same
+  // DPAS-backed matmul as the A/B operands and benefit from the same
+  // cross-subgroup L1 reuse; a non-zero warp basis here would force
+  // AnnotateCacheControl to keep a use-site scan as a workaround.
+  //
+  // Coverage: opIdx in {3, 4} (scale A, scale B) x MXFP8 (block 16, no
+  // fp4Kpack) / MXFP4 (block 32, fp4Kpack=2) x warp sizes 16 and 32 x 2D and
+  // 3D shapes, mirroring the configurations already asserted in
+  // DPAS_OperandScaleA / DPAS_OperandScaleB above.
+  StringAttr kWarp = S("warp");
+
+  struct Config {
+    SmallVector<int64_t> shape;
+    DpasEncodingAttr dpas;
+    unsigned opIdx;
+    StringRef name;
+  };
+
+  SmallVector<Config> configs = {
+      // 2D, warp size 32, MXFP8, scale A / scale B
+      {{128, 2}, dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 32), 3, "mxfp8-tpw32-A"},
+      {{128, 2}, dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 32), 4, "mxfp8-tpw32-B"},
+      // 2D, warp size 16, MXFP8, scale A / scale B
+      {{128, 2}, dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 16), 3, "mxfp8-tpw16-A"},
+      {{128, 2}, dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 16), 4, "mxfp8-tpw16-B"},
+      // 2D, warp size 32, MXFP4, scale A / scale B
+      {{128, 4},
+       dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 32, std::make_optional(2u)),
+       3,
+       "mxfp4-tpw32-A"},
+      {{128, 4},
+       dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 32, std::make_optional(2u)),
+       4,
+       "mxfp4-tpw32-B"},
+      // 2D, warp size 16, MXFP4, scale A / scale B
+      {{128, 4},
+       dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 16, std::make_optional(2u)),
+       3,
+       "mxfp4-tpw16-A"},
+      {{128, 4},
+       dpas({2, 2}, 8, 8, 16, 4, {4, 2}, 16, std::make_optional(2u)),
+       4,
+       "mxfp4-tpw16-B"},
+      // 3D, warp size 16, MXFP8, scale A
+      {{1, 128, 4},
+       dpas({1, 2, 2}, 8, 8, 16, 4, {1, 4, 2}, 16),
+       3,
+       "mxfp8-3d-A"},
+      // 3D, warp size 16, MXFP4, scale B (mirrors the existing
+      // DPAS_OperandScaleA 3D case shape/dpas, flipped to opIdx=4)
+      {{16, 128, 4},
+       dpas({2, 1, 2}, 8, 8, 16, 4, {1, 4, 2}, 16, std::make_optional(2u)),
+       4,
+       "mxfp4-3d-B"},
+  };
+
+  for (const Config &cfg : configs) {
+    LinearLayout ll =
+        BlockScaledDPAStoLinearLayout(cfg.shape, cfg.dpas, cfg.opIdx);
+    auto outDims = llvm::to_vector(ll.getOutDimNames());
+    EXPECT_TRUE(ll.sublayoutIsZero({kWarp}, outDims))
+        << "config=" << cfg.name.str() << " opIdx=" << cfg.opIdx;
+  }
 }
 
 TEST_F(DPAStoLinearLayoutTest, DPAS_withDPASRepetitions) {

--- a/third_party/intel/unittest/Dialect/TritonIntelGPU/DPAStoLinearLayoutTest.cpp
+++ b/third_party/intel/unittest/Dialect/TritonIntelGPU/DPAStoLinearLayoutTest.cpp
@@ -366,13 +366,12 @@ TEST_F(DPAStoLinearLayoutTest, DPAS_OperandScaleB) {
 }
 
 TEST_F(DPAStoLinearLayoutTest, BlockScaledScaleOperandWarpBroadcast) {
-  // Preparatory audit for SpatialReuseAnalysis (see
-  // annotate-cc-p1-spatial-reuse.md): the scale-operand branch of
-  // BlockScaledDPAStoLinearLayout must produce a warp-broadcast LinearLayout
-  // (zero warp basis across all output dims). Scales are consumed by the same
-  // DPAS-backed matmul as the A/B operands and benefit from the same
-  // cross-subgroup L1 reuse; a non-zero warp basis here would force
-  // AnnotateCacheControl to keep a use-site scan as a workaround.
+  // The scale-operand branch of BlockScaledDPAStoLinearLayout must produce a
+  // warp-broadcast LinearLayout (zero warp basis across all output dims).
+  // Scales are consumed by the same DPAS-backed matmul as the A/B operands
+  // and are reused across every warp that shares K, so any non-zero warp
+  // basis would misrepresent the access pattern and block downstream analyses
+  // that rely on `sublayoutIsZero({warp}, outDims)`.
   //
   // Coverage: opIdx in {3, 4} (scale A, scale B) x MXFP8 (block 16, no
   // fp4Kpack) / MXFP4 (block 32, fp4Kpack=2) x warp sizes 16 and 32 x 2D and
@@ -417,8 +416,8 @@ TEST_F(DPAStoLinearLayoutTest, BlockScaledScaleOperandWarpBroadcast) {
        dpas({1, 2, 2}, 8, 8, 16, 4, {1, 4, 2}, 16),
        3,
        "mxfp8-3d-A"},
-      // 3D, warp size 16, MXFP4, scale B (mirrors the existing
-      // DPAS_OperandScaleA 3D case shape/dpas, flipped to opIdx=4)
+      // 3D, warp size 16, MXFP4, scale B (re-asserts the existing 3D
+      // MXFP4 opIdx=4 case in DPAS_OperandScaleA via sublayoutIsZero)
       {{16, 128, 4},
        dpas({2, 1, 2}, 8, 8, 16, 4, {1, 4, 2}, 16, std::make_optional(2u)),
        4,


### PR DESCRIPTION
The scale-operand branch of BlockScaledDPAStoLinearLayout was using
identity1D for the non-K and batch warp dimensions, claiming different
warps access different scale elements. This is incorrect: scale operands
in MXFP are shared across all warps. Fix by replacing identity1D with
zeros1D so the LinearLayout truthfully reflects warp-broadcast behavior.

Update DPAStoLinearLayoutTest expectations to match the corrected layout
and add a BlockScaledScaleOperandWarpBroadcast test that asserts all
warp bases are zero across all scale configurations.

Fixes #6826

Co-Authored-By: Tiotto, Ettore <ettore.tiotto@intel.com>
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>