### PR TITLE
Fix OSTYPE to support cygwin

### DIFF
--- a/scripts/capture-hw-details.sh
+++ b/scripts/capture-hw-details.sh
@@ -19,7 +19,7 @@ for arg in "$@"; do
 done
 
 function libigc_version {
-    if [[ $OSTYPE = msys ]]; then
+    if [[ $OSTYPE = msys || $OSTYPE = cygwin ]]; then
         pwsh -Command '
             $igc = @(Get-Process -Name dwm -Module | Where-Object ModuleName -eq 'igc64.dll').FileVersionInfo.FileVersion | Sort-Object -Unique
             if ($igc.Count -gt 1) {
@@ -43,7 +43,7 @@ function libigc_version {
 }
 
 function level_zero_version {
-    if [[ $OSTYPE = msys ]]; then
+    if [[ $OSTYPE = msys || $OSTYPE = cygwin ]]; then
         powershell -Command "(Get-Item C:\Windows\system32\ze_loader.dll).VersionInfo.ProductVersion"
         return
     fi
@@ -57,7 +57,7 @@ function level_zero_version {
 }
 
 function agama_version {
-    if [[ $OSTYPE = msys ]]; then
+    if [[ $OSTYPE = msys || $OSTYPE = cygwin ]]; then
         powershell -Command '(Get-WmiObject Win32_VideoController | where {$_.VideoProcessor -like "*Intel*" }).DriverVersion'
         return
     fi

--- a/scripts/install-pti.sh
+++ b/scripts/install-pti.sh
@@ -43,7 +43,7 @@ function build_level_zero {
   LEVEL_ZERO_VERSION=1.24.2
   LEVEL_ZERO_SHA256=b77e6e28623134ee4e99e2321c127b554bdd5bfa3e80064922eba293041c6c52
 
-  if [[ $OSTYPE = msys ]]; then
+  if [[ $OSTYPE = msys || $OSTYPE = cygwin ]]; then
     pwsh -Command \
       "Invoke-WebRequest -Uri 'https://github.com/oneapi-src/level-zero/archive/refs/tags/v${LEVEL_ZERO_VERSION}.tar.gz' -OutFile 'v${LEVEL_ZERO_VERSION}.tar.gz'"
     ls . -alh
@@ -70,7 +70,7 @@ function build_level_zero {
   cmake --build . --config Release --parallel "$(nproc)"
   cmake --build . --config Release --target install
   export LEVELZERO_INCLUDE_DIR="$L0_INSTALL_PATH/include"
-  if [[ $OSTYPE = msys ]]; then
+  if [[ $OSTYPE = msys || $OSTYPE = cygwin ]]; then
     export LEVELZERO_LIBRARY="$L0_INSTALL_PATH/lib/ze_loader.lib"
   else
     export LEVELZERO_LIBRARY="$L0_INSTALL_PATH/lib/libze_loader.so"

--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -99,7 +99,7 @@ done
 
 if [ "$VENV" = true ]; then
   echo "**** Activate virtual environment *****"
-  if [[ $OSTYPE = msys ]]; then
+  if [[ $OSTYPE = msys || $OSTYPE = cygwin ]]; then
     source .venv/Scripts/activate
   else
     source .venv/bin/activate
@@ -209,7 +209,7 @@ function pytorch_wheel_exists {
   PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
   PYTORCH_VERSION=$(<$PYTORCH_PROJ/version.txt)
   PYTORCH_COMMIT=${PYTORCH_PINNED_COMMIT:-main}
-  if [[ $OSTYPE = msys ]]; then
+  if [[ $OSTYPE = msys || $OSTYPE = cygwin ]]; then
     PYTORCH_OS=win
     PYTORCH_ARCH="amd64"
   else
@@ -288,7 +288,7 @@ function build_pytorch {
   pip install 'cmake<4.0.0'
   pip install -r requirements.txt
   pip install cmake ninja
-  if [[ $OSTYPE = msys ]]; then
+  if [[ $OSTYPE = msys || $OSTYPE = cygwin ]]; then
     # Another way (but we don't use conda): conda install -c conda-forge libuv=1.40.0
     # Ref https://github.com/pytorch/pytorch/blob/8c2e45008282cf5202b72a0ecb0c2951438abeea/.ci/pytorch/windows/setup_build.bat#L23
     # This is an artifact (around 330kb) that PyTorch uses, however it may not be very good to use here.

--- a/scripts/pytest-utils.sh
+++ b/scripts/pytest-utils.sh
@@ -139,7 +139,7 @@ capture_runtime_env() {
 
 ensure_spirv_dis() {
     # Does not work on Windows
-    if [[ $OSTYPE = msys ]]; then
+    if [[ $OSTYPE = msys || $OSTYPE = cygwin ]]; then
         return
     fi
     export PATH="$HOME/.local/bin:$PATH"

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -415,7 +415,7 @@ if [ "$TEST_DEFAULT" = true ]; then
 fi
 
 if [ "$VENV" = true ]; then
-  if [[ $OSTYPE = msys ]]; then
+  if [[ $OSTYPE = msys || $OSTYPE = cygwin ]]; then
     source .venv/Scripts/activate
   else
     source .venv/bin/activate

--- a/scripts/vllm/install-vllm.sh
+++ b/scripts/vllm/install-vllm.sh
@@ -56,7 +56,7 @@ done
 
 if [ "$VENV" = true ]; then
   echo "**** Activating virtual environment ****"
-  if [[ $OSTYPE = msys ]]; then
+  if [[ $OSTYPE = msys || $OSTYPE = cygwin ]]; then
     source .venv/Scripts/activate
   else
     source .venv/bin/activate


### PR DESCRIPTION
> According to https://www.msys2.org/news/, `Bash has recently been changed to report "$OSTYPE" as "cygwin" instead of "msys"`.
> So install-pti.sh is entering the wrong branch because it expects OSTYPE == "msys" currently.  

 _Originally posted by @exolyr in [#6817](https://github.com/intel/intel-xpu-backend-for-triton/issues/6817#issuecomment-4374056061)_

Test run: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/25344321853/job/74309419221
Closes #6817 