### PR TITLE
Remove LowerTo2DBlockLoad pass from pipeline

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -390,7 +390,6 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
 
-        intel.passes.ttgpuir.add_lower_to_2d_block_load(pm)
         passes.convert.add_scf_to_cf(pm)
         passes.gluon.add_inliner(pm)
         passes.convert.add_index_to_llvmir(pm)

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2169,6 +2169,343 @@ public:
   }
 };
 
+struct DescriptorLoadOpToBlockIOConversion
+    : public ConvertTritonGPUOpToLLVMPattern<triton::DescriptorLoadOp>,
+      public BlockIOConversionBase {
+  using ConvertTritonGPUOpToLLVMPattern<
+      triton::DescriptorLoadOp>::ConvertTritonGPUOpToLLVMPattern;
+
+  DescriptorLoadOpToBlockIOConversion(
+      LLVMTypeConverter &converter, const triton::intel::TargetInfo &targetInfo,
+      const triton::intel::ModuleAxisInfoAnalysis &axisAnalysisPass,
+      triton::intel::ModuleStrideAnalysis &strideAnalysis,
+      PatternBenefit benefit)
+      : ConvertTritonGPUOpToLLVMPattern<triton::DescriptorLoadOp>(converter,
+                                                                  benefit),
+        BlockIOConversionBase(targetInfo, axisAnalysisPass, strideAnalysis) {}
+
+  LogicalResult
+  matchAndRewrite(triton::DescriptorLoadOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!isDescriptorBlockIOCandidate(op))
+      return failure();
+
+    // Get padding from the propagated attribute (set by
+    // MaterializeBlockPointer).
+    PaddingOption padding = PaddingOption::PAD_ZERO;
+    if (auto paddingAttr = op->getAttrOfType<triton::PaddingOptionAttr>(
+            TritonIntelGPUDialect::getDescPaddingAttrName()))
+      padding = paddingAttr.getValue();
+
+    // Result type and encoding setup.
+    Type resultType = op.getType();
+    auto tensorType = cast<RankedTensorType>(resultType);
+    Attribute encoding = tensorType.getEncoding();
+    std::optional<LinearLayout> llEncoding =
+        cast<DistributedEncodingTrait>(encoding).toLinearLayout(
+            tensorType.getShape());
+    assert(llEncoding.has_value() &&
+           "unexpected failure when getting linear layout");
+
+    // Read memory layout from block_io attribute (set by
+    // MaterializeBlockPointer; column_major set by
+    // FuseTransWithDescriptorLoad).
+    StringRef blockIOName = TritonIntelGPUDialect::getBlockIOAttrName();
+    StringAttr blockIOAttr = op->getAttrOfType<StringAttr>(blockIOName);
+    assert(
+        blockIOAttr &&
+        "block_io attribute required; checked by isDescriptorBlockIOCandidate");
+    const unsigned rank = tensorType.getRank();
+    auto descType = cast<triton::TensorDescType>(op.getDesc().getType());
+    const unsigned descRank = descType.getBlockType().getRank();
+    assert(descRank >= rank &&
+           "descriptor rank must be >= result rank for descriptor load");
+    const unsigned rankDelta = descRank - rank;
+    auto mapResultDimToDescDim = [rankDelta](unsigned dim) {
+      return dim + rankDelta;
+    };
+    auto mode = symbolizeBlockIOMode(blockIOAttr.getValue());
+    // The ColumnMajor mode means the descriptor load needs to permute
+    // the last 2 dim to align the load result type.
+    bool permuteDescDim = mode && *mode == BlockIOMode::ColumnMajor;
+    assertDescriptorInnerShapeCompatible(op, descType.getBlockType().getShape(),
+                                         tensorType.getShape(), permuteDescDim);
+    // For the permuted case, the tensor descriptor's dimension space needs to
+    // be aligned with the result type. Specifically, the (rank - 1) dimension
+    // of the tensor descriptor is mapped to the (rank - 2) dimension of the
+    // result type when permuted. Note: The getBlockIOTileSize function expects
+    // the input dimension based on the result type, not the tensor descriptor
+    // type.
+    unsigned contiguousDim = !permuteDescDim ? rank - 1 : rank - 2;
+
+    Type eltTy = getTypeConverter()->convertType(tensorType.getElementType());
+    unsigned elemSizeInBits = eltTy.getIntOrFloatBitWidth();
+
+    // Tile size computation (no mask for descriptors).
+    // FIXME: Remove once IGC can split large 2D block loads.
+    std::optional<bool> oneMatrixPerLoadForBT =
+        mlir::triton::tools::isEnvValueBool(mlir::triton::tools::getStrEnv(
+            "TRITON_INTEL_ONE_MATRIX_PER_LOAD_BT"));
+    if (!oneMatrixPerLoadForBT.has_value())
+      oneMatrixPerLoadForBT =
+          op->hasAttr(triton::gpu::intel::TritonIntelGPUDialect::
+                          getOneMatrixPerLoadAttrName());
+    BlockIOTileSizeInfo sizeInfo = getBlockIOTileSize<true /*load*/>(
+        llEncoding.value(), contiguousDim, elemSizeInBits,
+        /*maskAxisInfo=*/nullptr, *oneMatrixPerLoadForBT);
+    if (!sizeInfo.isValid())
+      return failure();
+
+    // For descriptor loads, the 2D block I/O tile must use only the inner 2
+    // dims. Reject if rowDim or colDim falls in a batch dimension.
+    int innerDimStart = static_cast<int>(rank - 2);
+    if (sizeInfo.rowDim < innerDimStart || sizeInfo.colDim < innerDimStart)
+      return failure();
+
+    int tileHeight = sizeInfo.tileHeight;
+    int tileWidth = sizeInfo.tileWidth;
+    int numPackedVals = sizeInfo.numElemPerPackedVal;
+    int vBlocks = sizeInfo.vBlocks;
+    int rowDim = sizeInfo.rowDim;
+    int colDim = sizeInfo.colDim;
+    bool isTransposeRequired = sizeInfo.transpose;
+    std::optional<SetVector<unsigned>> regPackedBases =
+        std::move(sizeInfo.regPackedBases);
+
+    unsigned packedElemSizeInBits = elemSizeInBits * numPackedVals;
+    if (!check2DBlockAddressPayloadRestriction(packedElemSizeInBits, tileWidth))
+      return failure();
+
+    // 2D block load supports 64 bytes per row at most.
+    constexpr int MAX_WIDTH = 64;
+    unsigned totalBytesPerRowPerMatrix = tileWidth * packedElemSizeInBits / 8;
+    if (totalBytesPerRowPerMatrix > MAX_WIDTH)
+      return failure();
+
+    Location loc = op.getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    MLIRContext *ctx = rewriter.getContext();
+
+    unsigned threadsPerWarp =
+        TritonGPUDialect::getThreadsPerWarp(op->getParentOfType<ModuleOp>());
+
+    StringAttr kRegister = S("register");
+    StringAttr kLane = S("lane");
+    StringAttr kWarp = S("warp");
+    StringAttr kBlock = S("block");
+    assert(regPackedBases.has_value() &&
+           "invalid register bases for packing elems.");
+    std::vector<std::vector<int>> bases(regPackedBases->size());
+    llvm::transform(*regPackedBases, bases.begin(),
+                    [&](int base) { return std::vector<int>{base}; });
+    LinearLayout regMapping({{kRegister, bases}},
+                            {{kRegister, llEncoding->getInDimSize(kRegister)}},
+                            /*requireSurjective=*/true);
+
+    // Unpack descriptor struct: { shape[rank], stride[rank], base }.
+    DescriptorFields desc =
+        unpackDescriptor(adaptor.getDesc(), descRank, loc, rewriter);
+
+    const unsigned descRowDim = mapResultDimToDescDim(rowDim);
+    const unsigned descColDim = mapResultDimToDescDim(colDim);
+
+    if (permuteDescDim) {
+      std::swap(desc.shapes[descRank - 2], desc.shapes[descRank - 1]);
+      std::swap(desc.strides[descRank - 2], desc.strides[descRank - 1]);
+    }
+
+    // column_major descriptor loads must always produce transposed block I/O
+    // (contiguousDim = rank-2 forces transpose in getBlockIOTileSize). If this
+    // invariant breaks, the surface parameters below would be incorrect because
+    // they index the already-swapped shapes/strides via isTransposeRequired.
+    assert((!permuteDescDim || isTransposeRequired) &&
+           "column_major descriptor load expects transposed block I/O");
+
+    Value elemBytes = b.i32_val(elemSizeInBits / 8);
+    Value surfaceWidth = b.trunc(
+        i32_ty, desc.shapes[isTransposeRequired ? descRowDim : descColDim]);
+    Value surfaceHeight = b.trunc(
+        i32_ty, desc.shapes[isTransposeRequired ? descColDim : descRowDim]);
+    Value baseWidth = b.mul(surfaceWidth, elemBytes);
+    Value baseHeight = surfaceHeight;
+    Value pitch = b.mul(
+        b.trunc(i32_ty,
+                desc.strides[isTransposeRequired ? descColDim : descRowDim]),
+        elemBytes);
+
+    // Base offsets from descriptor load indices.
+    // Indices are in descriptor dimension space. When column_major, the result
+    // type dimensions are transposed relative to the descriptor, so we swap
+    // the indices to align with the result type coordinate system used by
+    // the LinearLayout offsets.
+    SmallVector<Value> descIndices(adaptor.getIndices().begin(),
+                                   adaptor.getIndices().end());
+    assert(descIndices.size() == descRank &&
+           "descriptor index count must match descriptor rank");
+    if (permuteDescDim) {
+      // Only swap the inner 2 dims; batch dims stay in place.
+      std::swap(descIndices[descRank - 2], descIndices[descRank - 1]);
+    }
+
+    // Replicate base pointer for all tiles.
+    unsigned numElems = getTotalElemsPerThread(resultType);
+
+    int64_t numElemsPerLoad = mlir::ceil(
+        tileHeight * tileWidth * numPackedVals * vBlocks, (int)threadsPerWarp);
+    unsigned numValuesPerLoad = mlir::ceil((int)numElemsPerLoad, numPackedVals);
+    Type packedType = IntegerType::get(ctx, packedElemSizeInBits);
+    Type load2DGenXType = LLVM::getVectorType(packedType, numValuesPerLoad);
+    Type unpackedType = LLVM::getVectorType(eltTy, numElemsPerLoad);
+
+    auto dpasCfg = configureDPASLoadTypes(
+        tensorType, eltTy, packedType, load2DGenXType, unpackedType,
+        elemSizeInBits, numPackedVals, threadsPerWarp, tileHeight, tileWidth,
+        vBlocks, numElemsPerLoad, numValuesPerLoad, isTransposeRequired, ctx);
+    Type packedDPASOperandType = dpasCfg.packedDPASOperandType;
+    unpackedType = dpasCfg.unpackedType;
+    load2DGenXType = dpasCfg.load2DGenXType;
+    packedType = dpasCfg.packedType;
+    bool useVNNIFormat = dpasCfg.useVNNIFormat;
+    tileHeight = dpasCfg.tileHeight;
+    tileWidth = dpasCfg.tileWidth;
+    vBlocks = dpasCfg.vBlocks;
+    numElemsPerLoad = dpasCfg.numElemsPerLoad;
+    numValuesPerLoad = dpasCfg.numValuesPerLoad;
+
+    LinearLayout shuffleMapping =
+        LinearLayout::identity1D(numElemsPerLoad, kRegister, kRegister);
+    if (isTransposeRequired) {
+      auto result = computeTransposeShuffleMapping(
+          tensorType, regMapping, numElemsPerLoad, numPackedVals, tileHeight,
+          threadsPerWarp, /*hasDPASOperandType=*/!!packedDPASOperandType, ctx);
+      if (failed(result))
+        return failure();
+      shuffleMapping = *result;
+    }
+
+    Value warpId = arith::IndexCastOp::create(
+        rewriter, loc, i32_ty,
+        mlir::gpu::SubgroupIdOp::create(rewriter, loc,
+                                        /*upperBound=*/nullptr));
+
+    // Dimension mapping for offsets.
+    // When transpose is required, the row/col assignment to X/Y swaps:
+    //   X (block load column offset) maps to the fast-changing dimension.
+    //   Y (block load row offset) maps to the slow-changing dimension.
+    unsigned blockColIdx = isTransposeRequired ? rowDim : colDim;
+    unsigned blockRowIdx = isTransposeRequired ? colDim : rowDim;
+
+    // FIXME: This is a workaround for suboptimal instruction scheduling.
+    // Remove once IGC handles the or-expression reassociation correctly
+    // (see https://github.com/intel/intel-xpu-backend-for-triton/issues/6540).
+    //
+    // Pre-apply 64-byte alignment compensation to the base pointer and column
+    // offset when the descriptor column index is non-zero. This bakes the
+    // alignment adjustment into the column index BEFORE per-tile layout offsets
+    // are added, ensuring LLVM builds tile 1's x-coordinate as
+    // (tile0_x + delta) rather than (descIndex + delta) + misalign. Without
+    // this, LLVM's CSE factors out (descIndex + delta) as a common
+    // subexpression shared across different operand loads, producing a
+    // suboptimal instruction schedule.
+    unsigned descBlockColIdx =
+        mapResultDimToDescDim(isTransposeRequired ? rowDim : colDim);
+    std::optional<int64_t> descColConst =
+        mlir::triton::intel::getFoldedConstantValue(
+            descIndices[descBlockColIdx]);
+    if (!descColConst || *descColConst != 0) {
+      constexpr int64_t ALIGNMENT_MASK = 0x3f;
+      Value baseAddr = b.ptrtoint(int_ty(64), desc.base);
+      Value alignedBaseAddr = b.and_(baseAddr, b.i64_val(~ALIGNMENT_MASK));
+      desc.base = b.inttoptr(ptr_ty(ctx, 1), alignedBaseAddr);
+      Value offsetInBytes =
+          b.trunc(i32_ty, b.and_(baseAddr, b.i64_val(ALIGNMENT_MASK)));
+      Value misalignElems = b.udiv(offsetInBytes, elemBytes);
+      baseWidth = b.add(baseWidth, offsetInBytes);
+      descIndices[descBlockColIdx] =
+          b.add(descIndices[descBlockColIdx], misalignElems);
+    }
+
+    // Build NaN masks for PAD_NAN descriptors. The 2D block load hardware
+    // zero-pads OOB accesses; for NaN padding we post-select NaN values.
+    SmallVector<Value> nanMaskElems;
+    if (padding == PaddingOption::PAD_NAN) {
+      // Map descriptor shapes/indices to result dimension space.
+      SmallVector<Value> resultOffsets(rank), resultShapes(rank);
+      for (unsigned i = 0; i < rank; ++i) {
+        unsigned descDim = mapResultDimToDescDim(i);
+        resultOffsets[i] = descIndices[descDim];
+        resultShapes[i] = desc.shapes[descDim];
+      }
+      nanMaskElems =
+          buildNaNMasks(loc, resultOffsets, resultShapes, tensorType, rewriter);
+    }
+
+    SmallVector<Value> unpackedLoadedVals(numElems);
+    for (size_t elemIdx = 0; elemIdx < numElems; elemIdx += numElemsPerLoad) {
+      unsigned registerIdx = regMapping.apply({{kRegister, elemIdx}})[0].second;
+
+      auto offsets = applyLinearLayout(loc, rewriter, *llEncoding,
+                                       {{kRegister, b.i32_val(registerIdx)},
+                                        {kLane, b.i32_val(0)},
+                                        {kWarp, warpId},
+                                        {kBlock, b.i32_val(0)}});
+
+      Value addrElem = desc.base;
+      Value offsetX, offsetY;
+      Value adjustedBaseWidth = baseWidth;
+      Value adjustedBaseHeight = baseHeight;
+
+      // Compute per-tile offsets: descriptor indices + linear layout offsets.
+      // Boundary check is always enabled for descriptors.
+      for (auto [dim, offsetPair] : llvm::enumerate(offsets)) {
+        unsigned descDim = mapResultDimToDescDim(dim);
+        Value adjustedOffset = b.add(descIndices[descDim], offsetPair.second);
+        if (dim == blockRowIdx)
+          offsetY = adjustedOffset;
+        else if (dim == blockColIdx)
+          offsetX = adjustedOffset;
+        else {
+          // Batch dimensions: fold into base pointer via GEP.
+          Value pred; // Unused for descriptors (boundary checking is built-in).
+          adjustOtherDimension(adjustedOffset, addrElem, pred, eltTy,
+                               desc.strides, desc.shapes, dim,
+                               /*hasBoundaryCheck=*/false, loc, rewriter, b);
+        }
+      }
+
+      assert(numPackedVals > 0 && "numPackedVals should be greater than zero.");
+      Value ret = TritonGEN::Matrix2DBlockLoadOp::create(
+          rewriter, loc, load2DGenXType,
+          /*ptr*/ addrElem,
+          /*base_width*/ adjustedBaseWidth,
+          /*base_height*/ adjustedBaseHeight,
+          /*base_pitch*/ pitch,
+          /*x*/ b.udiv(offsetX, b.i32_val(numPackedVals)),
+          /*y*/ offsetY,
+          /*elem_size_in_bits*/ packedElemSizeInBits,
+          /*tile_width*/ tileWidth,
+          /*tile_height*/ tileHeight,
+          /*v_blocks*/ vBlocks,
+          /*transpose*/ isTransposeRequired,
+          /*vnni_transform*/ !isTransposeRequired && useVNNIFormat);
+
+      unpackBlockLoadResult(ret, unpackedLoadedVals, elemIdx, regMapping,
+                            shuffleMapping, packedDPASOperandType, unpackedType,
+                            numValuesPerLoad, numPackedVals,
+                            /*pred=*/Value(), /*otherElems=*/{}, nanMaskElems,
+                            loc, rewriter, ctx);
+    }
+
+    auto typeConverter = getTypeConverter();
+    Type llvmResultStructTy = typeConverter->convertType(op.getType());
+    Value resultStruct = packLLElements(loc, typeConverter, unpackedLoadedVals,
+                                        rewriter, llvmResultStructTy);
+    rewriter.replaceOp(op, {resultStruct});
+
+    return success();
+  }
+};
+
 struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
                           public LoadStoreConversionBase {
   using ConvertOpToLLVMPattern<triton::LoadOp>::ConvertOpToLLVMPattern;
@@ -4133,6 +4470,7 @@ void mlir::triton::intel::populateLoadStoreOpToLLVMPatterns(
       typeConverter, targetInfo, axisInfoAnalysis, strideAnalysis, benefit);
   // BlockIO is more efficient than gather load or scatter store.
   patterns.add<LoadOpToBlockIOConversion, StoreOpToBlockIOConversion,
+               DescriptorLoadOpToBlockIOConversion,
                DescriptorStoreOpToBlockIOConversion>(
       typeConverter, targetInfo, axisInfoAnalysis, strideAnalysis,
       benefit.getBenefit() + 2);


### PR DESCRIPTION
vLLM benchmarks: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/25404576400

Fixes #6848