### PR TITLE
[TritonIntelGPU] Add ttig.extract_desc op for runtime descriptor field extraction

### DIFF
--- a/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
+++ b/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
@@ -144,3 +144,18 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     tt.return
   }
 }
+
+// -----
+
+// COM: Test that ttig.extract_base_ptr lowers to llvm.extractvalue from the
+// COM: descriptor struct (base pointer is the last element).
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: @extract_base_ptr
+  tt.func public @extract_base_ptr(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64) {
+    %c1_i64 = arith.constant 1 : i64
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
+    // CHECK: llvm.extractvalue {{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    %0 = ttig.extract_base_ptr %desc : <64x32xf16> -> <f16>
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
+++ b/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
@@ -147,15 +147,19 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
 
 // -----
 
-// COM: Test that ttig.extract_base_ptr lowers to llvm.extractvalue from the
-// COM: descriptor struct (base pointer is the last element).
+// COM: Test that ttig.extract_desc lowers to llvm.extractvalue from the
+// COM: descriptor struct at the given index.
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
-  // CHECK-LABEL: @extract_base_ptr
-  tt.func public @extract_base_ptr(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64) {
+  // CHECK-LABEL: @extract_desc_fields
+  tt.func public @extract_desc_fields(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64) {
     %c1_i64 = arith.constant 1 : i64
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
+    // CHECK: llvm.extractvalue {{.*}}[0] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    %0 = ttig.extract_desc %desc[0] : <64x32xf16> -> i64
+    // CHECK: llvm.extractvalue {{.*}}[2] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    %1 = ttig.extract_desc %desc[2] : <64x32xf16> -> i64
     // CHECK: llvm.extractvalue {{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
-    %0 = ttig.extract_base_ptr %desc : <64x32xf16> -> <f16>
+    %2 = ttig.extract_desc %desc[4] : <64x32xf16> -> !tt.ptr<f16>
     tt.return
   }
 }

--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
@@ -10,12 +10,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %c1_i64 = arith.constant 1 : i64
     %c0_i32 = arith.constant 0 : i32
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
-    // CHECK-DAG: %[[ELEM_BYTES:.*]] = arith.constant 2 : i32
-    // CHECK-DAG: %[[ZERO:.*]] = arith.constant 0 : i32
-    // CHECK: %[[BW:.*]] = arith.muli %arg2, %[[ELEM_BYTES]]
+    // CHECK: %[[BASE:.*]] = ttig.extract_base_ptr
+    // CHECK: %[[BW:.*]] = arith.muli %arg2, %{{.*}}
     // CHECK: %[[ST:.*]] = arith.trunci %arg3
-    // CHECK: %[[BP:.*]] = arith.muli %[[ST]], %[[ELEM_BYTES]]
-    // CHECK: ttig.2d_block_load %arg0, %[[BW]], %arg1, %[[BP]][%[[ZERO]], %[[ZERO]]] {row_major}
+    // CHECK: %[[BP:.*]] = arith.muli %[[ST]], %{{.*}}
+    // CHECK: ttig.2d_block_load %[[BASE]], %[[BW]], %arg1, %[[BP]][%c0_i32, %c0_i32] {row_major}
     %0 = tt.descriptor_load %desc[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #dot0>
     tt.return %0 : tensor<64x32xf16, #dot0>
   }
@@ -35,12 +34,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %c1_i64 = arith.constant 1 : i64
     %c0_i32 = arith.constant 0 : i32
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
-    // CHECK-DAG: %[[ELEM_BYTES:.*]] = arith.constant 2 : i32
-    // CHECK-DAG: %[[ZERO:.*]] = arith.constant 0 : i32
-    // CHECK: %[[BW:.*]] = arith.muli %arg2, %[[ELEM_BYTES]]
+    // CHECK: %[[BASE:.*]] = ttig.extract_base_ptr
+    // CHECK: %[[BW:.*]] = arith.muli %arg2, %{{.*}}
     // CHECK: %[[ST:.*]] = arith.trunci %arg3
-    // CHECK: %[[BP:.*]] = arith.muli %[[ST]], %[[ELEM_BYTES]]
-    // CHECK: ttig.2d_block_load %arg0, %[[BW]], %arg1, %[[BP]][%[[ZERO]], %[[ZERO]]] {column_major}
+    // CHECK: %[[BP:.*]] = arith.muli %[[ST]], %{{.*}}
+    // CHECK: ttig.2d_block_load %[[BASE]], %[[BW]], %arg1, %[[BP]][%c0_i32, %c0_i32] {column_major}
     %0 = tt.descriptor_load %desc[%c0_i32, %c0_i32] {ttig.block_io = "column_major"} : !tt.tensordesc<64x32xf16> -> tensor<32x64xf16, #dot1>
     tt.return %0 : tensor<32x64xf16, #dot1>
   }
@@ -79,9 +77,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %c1_i64 = arith.constant 1 : i64
     %c0_i32 = arith.constant 0 : i32
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2, %arg3], [%arg4, %arg5, %c1_i64] : <f16>, <2x64x32xf16>
+    // CHECK: %[[BASE:.*]] = ttig.extract_base_ptr %{{.*}}
     // CHECK: %[[BATCH_EXT:.*]] = arith.extsi %arg6 : i32 to i64
     // CHECK: %[[BATCH_OFF:.*]] = arith.muli %[[BATCH_EXT]], %arg4
-    // CHECK: %[[ADJ_PTR:.*]] = tt.addptr %arg0, %[[BATCH_OFF]]
+    // CHECK: %[[ADJ_PTR:.*]] = tt.addptr %[[BASE]], %[[BATCH_OFF]]
     // CHECK: ttig.2d_block_load %[[ADJ_PTR]]
     %0 = tt.descriptor_load %desc[%batch_idx, %c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<2x64x32xf16> -> tensor<2x64x32xf16, #dot0>
     tt.return %0 : tensor<2x64x32xf16, #dot0>
@@ -102,9 +101,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %c1_i64 = arith.constant 1 : i64
     %c0_i32 = arith.constant 0 : i32
     %desc = tt.make_tensor_descriptor %arg0, [%c1_i32, %arg1, %arg2], [%arg3, %c1_i64, %c1_i64] : <f16>, <1x64x32xf16>
+    // CHECK: %[[BASE:.*]] = ttig.extract_base_ptr %{{.*}}
     // CHECK: %[[BATCH_EXT:.*]] = arith.extsi %arg4 : i32 to i64
     // CHECK: %[[BATCH_OFF:.*]] = arith.muli %[[BATCH_EXT]], %arg3
-    // CHECK: %[[ADJ_PTR:.*]] = tt.addptr %arg0, %[[BATCH_OFF]]
+    // CHECK: %[[ADJ_PTR:.*]] = tt.addptr %[[BASE]], %[[BATCH_OFF]]
     // CHECK: ttig.2d_block_load %[[ADJ_PTR]]
     %0 = tt.descriptor_load %desc[%batch_idx, %c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<1x64x32xf16> -> tensor<64x32xf16, #dot0>
     tt.return %0 : tensor<64x32xf16, #dot0>

--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
@@ -10,11 +10,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %c1_i64 = arith.constant 1 : i64
     %c0_i32 = arith.constant 0 : i32
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
-    // CHECK: %[[BASE:.*]] = ttig.extract_base_ptr
-    // CHECK: %[[BW:.*]] = arith.muli %arg2, %{{.*}}
-    // CHECK: %[[ST:.*]] = arith.trunci %arg3
-    // CHECK: %[[BP:.*]] = arith.muli %[[ST]], %{{.*}}
-    // CHECK: ttig.2d_block_load %[[BASE]], %[[BW]], %arg1, %[[BP]][%c0_i32, %c0_i32] {row_major}
+    // CHECK: ttig.extract_desc
+    // CHECK: %[[ELEM_BYTES:.*]] = arith.constant 2 : i32
+    // CHECK: %[[WIDTH:.*]] = arith.trunci %{{.*}} : i64 to i32
+    // CHECK: %[[BW:.*]] = arith.muli %[[WIDTH]], %[[ELEM_BYTES]]
+    // CHECK: %[[HEIGHT:.*]] = arith.trunci %{{.*}} : i64 to i32
+    // CHECK: %[[STRIDE:.*]] = arith.trunci %{{.*}} : i64 to i32
+    // CHECK: %[[BP:.*]] = arith.muli %[[STRIDE]], %[[ELEM_BYTES]]
+    // CHECK: ttig.2d_block_load %{{.*}}, %[[BW]], %[[HEIGHT]], %[[BP]][%{{.*}}, %{{.*}}] {row_major}
     %0 = tt.descriptor_load %desc[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #dot0>
     tt.return %0 : tensor<64x32xf16, #dot0>
   }
@@ -34,11 +37,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %c1_i64 = arith.constant 1 : i64
     %c0_i32 = arith.constant 0 : i32
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
-    // CHECK: %[[BASE:.*]] = ttig.extract_base_ptr
-    // CHECK: %[[BW:.*]] = arith.muli %arg2, %{{.*}}
-    // CHECK: %[[ST:.*]] = arith.trunci %arg3
-    // CHECK: %[[BP:.*]] = arith.muli %[[ST]], %{{.*}}
-    // CHECK: ttig.2d_block_load %[[BASE]], %[[BW]], %arg1, %[[BP]][%c0_i32, %c0_i32] {column_major}
+    // CHECK: ttig.extract_desc
+    // CHECK: %[[ELEM_BYTES:.*]] = arith.constant 2 : i32
+    // CHECK: %[[WIDTH:.*]] = arith.trunci %{{.*}} : i64 to i32
+    // CHECK: %[[BW:.*]] = arith.muli %[[WIDTH]], %[[ELEM_BYTES]]
+    // CHECK: %[[HEIGHT:.*]] = arith.trunci %{{.*}} : i64 to i32
+    // CHECK: %[[STRIDE:.*]] = arith.trunci %{{.*}} : i64 to i32
+    // CHECK: %[[BP:.*]] = arith.muli %[[STRIDE]], %[[ELEM_BYTES]]
+    // CHECK: ttig.2d_block_load %{{.*}}, %[[BW]], %[[HEIGHT]], %[[BP]][%{{.*}}, %{{.*}}] {column_major}
     %0 = tt.descriptor_load %desc[%c0_i32, %c0_i32] {ttig.block_io = "column_major"} : !tt.tensordesc<64x32xf16> -> tensor<32x64xf16, #dot1>
     tt.return %0 : tensor<32x64xf16, #dot1>
   }
@@ -77,10 +83,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %c1_i64 = arith.constant 1 : i64
     %c0_i32 = arith.constant 0 : i32
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2, %arg3], [%arg4, %arg5, %c1_i64] : <f16>, <2x64x32xf16>
-    // CHECK: %[[BASE:.*]] = ttig.extract_base_ptr %{{.*}}
+    // CHECK: ttig.extract_desc
+    // CHECK: ttig.extract_desc
     // CHECK: %[[BATCH_EXT:.*]] = arith.extsi %arg6 : i32 to i64
-    // CHECK: %[[BATCH_OFF:.*]] = arith.muli %[[BATCH_EXT]], %arg4
-    // CHECK: %[[ADJ_PTR:.*]] = tt.addptr %[[BASE]], %[[BATCH_OFF]]
+    // CHECK: %[[BATCH_OFF:.*]] = arith.muli %[[BATCH_EXT]], %{{.*}}
+    // CHECK: %[[ADJ_PTR:.*]] = tt.addptr %{{.*}}, %[[BATCH_OFF]]
     // CHECK: ttig.2d_block_load %[[ADJ_PTR]]
     %0 = tt.descriptor_load %desc[%batch_idx, %c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<2x64x32xf16> -> tensor<2x64x32xf16, #dot0>
     tt.return %0 : tensor<2x64x32xf16, #dot0>
@@ -101,12 +108,46 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %c1_i64 = arith.constant 1 : i64
     %c0_i32 = arith.constant 0 : i32
     %desc = tt.make_tensor_descriptor %arg0, [%c1_i32, %arg1, %arg2], [%arg3, %c1_i64, %c1_i64] : <f16>, <1x64x32xf16>
-    // CHECK: %[[BASE:.*]] = ttig.extract_base_ptr %{{.*}}
+    // CHECK: ttig.extract_desc
+    // CHECK: ttig.extract_desc
     // CHECK: %[[BATCH_EXT:.*]] = arith.extsi %arg4 : i32 to i64
-    // CHECK: %[[BATCH_OFF:.*]] = arith.muli %[[BATCH_EXT]], %arg3
-    // CHECK: %[[ADJ_PTR:.*]] = tt.addptr %[[BASE]], %[[BATCH_OFF]]
+    // CHECK: %[[BATCH_OFF:.*]] = arith.muli %[[BATCH_EXT]], %{{.*}}
+    // CHECK: %[[ADJ_PTR:.*]] = tt.addptr %{{.*}}, %[[BATCH_OFF]]
     // CHECK: ttig.2d_block_load %[[ADJ_PTR]]
     %0 = tt.descriptor_load %desc[%batch_idx, %c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<1x64x32xf16> -> tensor<64x32xf16, #dot0>
     tt.return %0 : tensor<64x32xf16, #dot0>
+  }
+}
+
+// -----
+
+// COM: Loop-carried descriptor: the descriptor is rebuilt each iteration with
+// COM: an advanced base pointer. The pass must use ttig.extract_desc on the
+// COM: loop-body descriptor value (%arg5), NOT the pre-loop MakeTensorDescOp.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @descriptor_load_loop_carried
+  tt.func @descriptor_load_loop_carried(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64, %N: i32) -> tensor<64x32xf16, #dot0> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c16_i64 = arith.constant 16 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %desc_init = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
+    // The extract_desc must be on %arg5 (the loop-carried descriptor),
+    // not on %desc_init. (%arg5 is the induction var, %arg6 is the iter_arg).
+    // CHECK: scf.for
+    // CHECK: ttig.extract_desc %arg6
+    // CHECK: ttig.2d_block_load
+    %result = scf.for %i = %c0_i32 to %N step %c1_i32 iter_args(%desc = %desc_init) -> (!tt.tensordesc<64x32xf16>) : i32 {
+      %load = tt.descriptor_load %desc[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #dot0>
+      // Advance: rebuild descriptor with a new base pointer.
+      %new_base = tt.addptr %arg0, %c16_i64 : !tt.ptr<f16>, i64
+      %new_desc = tt.make_tensor_descriptor %new_base, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
+      scf.yield %new_desc : !tt.tensordesc<64x32xf16>
+    }
+    // Load from the final descriptor outside the loop.
+    %final_load = tt.descriptor_load %result[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #dot0>
+    tt.return %final_load : tensor<64x32xf16, #dot0>
   }
 }

--- a/test/TritonIntelGPU/descriptor-load-block-2d.mlir
+++ b/test/TritonIntelGPU/descriptor-load-block-2d.mlir
@@ -82,7 +82,7 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
 
     // Verify base pointer alignment: ptr & ~0x3f (clear lower 6 bits).
-    // CHECK: %[[ADDR:.*]] = llvm.ptrtoint %arg0 : !llvm.ptr<1> to i64
+    // CHECK: %[[ADDR:.*]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<1> to i64
     // CHECK: %[[ALIGNED_ADDR:.*]] = llvm.and %[[ADDR]], {{.*}} : i64
     // CHECK: %[[ALIGNED_PTR:.*]] = llvm.inttoptr %[[ALIGNED_ADDR]] : i64 to !llvm.ptr<1>
 
@@ -122,10 +122,11 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     // The base pointer should be passed directly to the 2D block load
     // (alignment handled later by computeAlignedBasePtrWidthAndOffset in
     // TritonGEN lowering). No llvm.inttoptr (alignment) should appear
-    // between the base pointer and the 2D block loads.
+    // between the base extraction and the 2D block loads.
+    // CHECK: %[[BASE:.*]] = llvm.extractvalue {{.*}}[4]
     // CHECK-NOT: llvm.inttoptr
-    // CHECK: triton_gen.2Dblockload %arg0
-    // CHECK: triton_gen.2Dblockload %arg0
+    // CHECK: triton_gen.2Dblockload %[[BASE]]
+    // CHECK: triton_gen.2Dblockload %[[BASE]]
     %load = tt.descriptor_load %desc[%arg4, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #dot0_noalign>
     tt.return
   }

--- a/test/TritonIntelGPU/tritonintelgpu.mlir
+++ b/test/TritonIntelGPU/tritonintelgpu.mlir
@@ -75,9 +75,11 @@ tt.func @ttig.descriptor_prefetch(%desc: !tt.tensordesc<256x32xf16>, %x: i32, %y
 
 // -----
 
-tt.func @ttig.extract_base_ptr(%arg0: !tt.tensordesc<64x32xf16>) {
-  // CHECK-LABEL: @ttig.extract_base_ptr
-  // CHECK: ttig.extract_base_ptr %arg0 : <64x32xf16> -> <f16>
-  %0 = ttig.extract_base_ptr %arg0 : <64x32xf16> -> <f16>
+tt.func @ttig.extract_desc(%arg0: !tt.tensordesc<64x32xf16>) {
+  // CHECK-LABEL: @ttig.extract_desc
+  // CHECK: ttig.extract_desc %arg0[0] : <64x32xf16> -> i64
+  %0 = ttig.extract_desc %arg0[0] : <64x32xf16> -> i64
+  // CHECK: ttig.extract_desc %arg0[4] : <64x32xf16> -> !tt.ptr<f16>
+  %1 = ttig.extract_desc %arg0[4] : <64x32xf16> -> !tt.ptr<f16>
   tt.return
 }

--- a/test/TritonIntelGPU/tritonintelgpu.mlir
+++ b/test/TritonIntelGPU/tritonintelgpu.mlir
@@ -72,3 +72,12 @@ tt.func @ttig.descriptor_prefetch(%desc: !tt.tensordesc<256x32xf16>, %x: i32, %y
   ttig.descriptor_prefetch %desc[%x, %y] : !tt.tensordesc<256x32xf16>
   tt.return
 }
+
+// -----
+
+tt.func @ttig.extract_base_ptr(%arg0: !tt.tensordesc<64x32xf16>) {
+  // CHECK-LABEL: @ttig.extract_base_ptr
+  // CHECK: ttig.extract_base_ptr %arg0 : <64x32xf16> -> <f16>
+  %0 = ttig.extract_base_ptr %arg0 : <64x32xf16> -> <f16>
+  tt.return
+}

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -186,19 +186,24 @@ def TTIG_SubGroupTransposeOp
 }
 
 
-def TTIG_ExtractBasePtrOp : TTIG_Op<"extract_base_ptr", [Pure]> {
-  let summary = "Extract the base pointer from a tensor descriptor";
+def TTIG_ExtractDescOp : TTIG_Op<"extract_desc", [Pure]> {
+  let summary = "Extract a field from a tensor descriptor struct";
   let description = [{
-    Extracts the base pointer from a tensor descriptor value. This allows
-    the LowerTo2DBlockLoad pass to obtain the runtime base pointer from
-    loop-carried descriptors without statically tracing to the defining
+    Extracts a field from a tensor descriptor by struct index. The descriptor
+    struct layout is { shapes[rank], strides[rank], base_ptr }:
+      - index 0..rank-1: shapes (i64)
+      - index rank..2*rank-1: strides (i64)
+      - index 2*rank: base pointer (tt.ptr)
+
+    This allows the LowerTo2DBlockLoad pass to obtain runtime field values
+    from loop-carried descriptors without statically tracing to the defining
     MakeTensorDescOp.
   }];
 
-  let arguments = (ins TT_TensorDescType:$desc);
-  let results = (outs TT_Ptr:$result);
+  let arguments = (ins TT_TensorDescType:$desc, I32Attr:$index);
+  let results = (outs AnyType:$result);
 
-  let assemblyFormat = "$desc attr-dict `:` type($desc) `->` type($result)";
+  let assemblyFormat = "$desc `[` $index `]` attr-dict `:` type($desc) `->` type($result)";
 }
 
 def TTIG_Subgroup2DBlockLoadOp : TTIG_Op<"2d_block_load"> {

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -186,6 +186,21 @@ def TTIG_SubGroupTransposeOp
 }
 
 
+def TTIG_ExtractBasePtrOp : TTIG_Op<"extract_base_ptr", [Pure]> {
+  let summary = "Extract the base pointer from a tensor descriptor";
+  let description = [{
+    Extracts the base pointer from a tensor descriptor value. This allows
+    the LowerTo2DBlockLoad pass to obtain the runtime base pointer from
+    loop-carried descriptors without statically tracing to the defining
+    MakeTensorDescOp.
+  }];
+
+  let arguments = (ins TT_TensorDescType:$desc);
+  let results = (outs TT_Ptr:$result);
+
+  let assemblyFormat = "$desc attr-dict `:` type($desc) `->` type($result)";
+}
+
 def TTIG_Subgroup2DBlockLoadOp : TTIG_Op<"2d_block_load"> {
   let summary = "2D block load from a descriptor-based surface";
   let description = [{

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -4196,6 +4196,29 @@ struct AtomicRMWOpConversion
   }
 };
 
+struct ExtractBasePtrOpConversion
+    : public ConvertOpToLLVMPattern<triton::gpu::intel::ExtractBasePtrOp> {
+  using ConvertOpToLLVMPattern<
+      triton::gpu::intel::ExtractBasePtrOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::gpu::intel::ExtractBasePtrOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // The descriptor struct layout is: { shapes[rank], strides[rank], base }.
+    // The base pointer is the last element.
+    auto descType = cast<triton::TensorDescType>(op.getDesc().getType());
+    unsigned rank = descType.getBlockType().getRank();
+    unsigned basePtrIdx = 2 * rank; // after shapes and strides
+
+    Value basePtr = LLVM::ExtractValueOp::create(
+        rewriter, op.getLoc(),
+        LLVM::LLVMPointerType::get(rewriter.getContext(), 1), adaptor.getDesc(),
+        basePtrIdx);
+    rewriter.replaceOp(op, basePtr);
+    return success();
+  }
+};
+
 struct Subgroup2DBlockLoadOpConversion
     : public ConvertTritonGPUOpToLLVMPattern<
           triton::gpu::intel::Subgroup2DBlockLoadOp>,
@@ -4767,7 +4790,8 @@ void mlir::triton::intel::populateLoadStoreOpToLLVMPatterns(
                DescriptorStoreOpToBlockIOConversion>(
       typeConverter, targetInfo, axisInfoAnalysis, strideAnalysis,
       benefit.getBenefit() + 2);
-  // TTIG 2D block load (from LowerTo2DBlockLoad TTGIR pass).
+  // TTIG ops from LowerTo2DBlockLoad TTGIR pass.
+  patterns.add<ExtractBasePtrOpConversion>(typeConverter, benefit);
   patterns.add<Subgroup2DBlockLoadOpConversion,
                Subgroup2DBlockLoadFromPtrOpConversion>(
       typeConverter, targetInfo, axisInfoAnalysis, strideAnalysis, benefit);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -4196,25 +4196,21 @@ struct AtomicRMWOpConversion
   }
 };
 
-struct ExtractBasePtrOpConversion
-    : public ConvertOpToLLVMPattern<triton::gpu::intel::ExtractBasePtrOp> {
+struct ExtractDescOpConversion
+    : public ConvertOpToLLVMPattern<triton::gpu::intel::ExtractDescOp> {
   using ConvertOpToLLVMPattern<
-      triton::gpu::intel::ExtractBasePtrOp>::ConvertOpToLLVMPattern;
+      triton::gpu::intel::ExtractDescOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(triton::gpu::intel::ExtractBasePtrOp op, OpAdaptor adaptor,
+  matchAndRewrite(triton::gpu::intel::ExtractDescOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // The descriptor struct layout is: { shapes[rank], strides[rank], base }.
-    // The base pointer is the last element.
-    auto descType = cast<triton::TensorDescType>(op.getDesc().getType());
-    unsigned rank = descType.getBlockType().getRank();
-    unsigned basePtrIdx = 2 * rank; // after shapes and strides
-
-    Value basePtr = LLVM::ExtractValueOp::create(
-        rewriter, op.getLoc(),
-        LLVM::LLVMPointerType::get(rewriter.getContext(), 1), adaptor.getDesc(),
-        basePtrIdx);
-    rewriter.replaceOp(op, basePtr);
+    // Struct layout: { shapes[rank], strides[rank], base_ptr }.
+    // The index attribute directly gives the struct field position.
+    unsigned idx = op.getIndex();
+    Type resultTy = getTypeConverter()->convertType(op.getResult().getType());
+    Value result = LLVM::ExtractValueOp::create(rewriter, op.getLoc(), resultTy,
+                                                adaptor.getDesc(), idx);
+    rewriter.replaceOp(op, result);
     return success();
   }
 };
@@ -4791,7 +4787,7 @@ void mlir::triton::intel::populateLoadStoreOpToLLVMPatterns(
       typeConverter, targetInfo, axisInfoAnalysis, strideAnalysis,
       benefit.getBenefit() + 2);
   // TTIG ops from LowerTo2DBlockLoad TTGIR pass.
-  patterns.add<ExtractBasePtrOpConversion>(typeConverter, benefit);
+  patterns.add<ExtractDescOpConversion>(typeConverter, benefit);
   patterns.add<Subgroup2DBlockLoadOpConversion,
                Subgroup2DBlockLoadFromPtrOpConversion>(
       typeConverter, targetInfo, axisInfoAnalysis, strideAnalysis, benefit);

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -181,15 +181,22 @@ private:
     auto memLayout = memoryRowMajor ? ttgi::BlockIOMode::RowMajor
                                     : ttgi::BlockIOMode::ColumnMajor;
 
-    // Extract the runtime base pointer from the descriptor value. This
-    // correctly handles loop-carried descriptors where the base pointer
-    // changes per iteration (e.g., via tt.make_tensor_descriptor inside
-    // the loop with an advanced pointer).
-    Value basePtr = ttgi::ExtractBasePtrOp::create(
-        builder, loc, makeTensorDescOp->getBase().getType(), desc);
-    // Shapes and strides are loop-invariant — use from MakeTensorDescOp.
-    Operation::operand_range shapes = makeTensorDescOp->getShape();
-    Operation::operand_range strides = makeTensorDescOp->getStrides();
+    // Extract all surface parameters from the runtime descriptor value.
+    // This correctly handles loop-carried descriptors where fields change
+    // per iteration. Struct layout: { shapes[rank], strides[rank], base_ptr }.
+    Type i64Ty = builder.getI64Type();
+    Type ptrType =
+        tt::PointerType::get(descType.getBlockType().getElementType(), 1);
+    SmallVector<Value> shapes(descRank);
+    SmallVector<Value> strides(descRank);
+    for (unsigned d = 0; d < descRank; ++d) {
+      shapes[d] = ttgi::ExtractDescOp::create(builder, loc, i64Ty, desc,
+                                              builder.getI32IntegerAttr(d));
+      strides[d] = ttgi::ExtractDescOp::create(
+          builder, loc, i64Ty, desc, builder.getI32IntegerAttr(descRank + d));
+    }
+    Value basePtr = ttgi::ExtractDescOp::create(
+        builder, loc, ptrType, desc, builder.getI32IntegerAttr(2 * descRank));
     SmallVector<Value> indices(op.getIndices().begin(), op.getIndices().end());
     assert(indices.size() == descRank &&
            "descriptor index count must match descriptor rank");

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -181,12 +181,13 @@ private:
     auto memLayout = memoryRowMajor ? ttgi::BlockIOMode::RowMajor
                                     : ttgi::BlockIOMode::ColumnMajor;
 
-    // Extract surface parameters from MakeTensorDescOp.
-    // The surface parameters describe the physical memory layout and are the
-    // SAME regardless of row_major/column_major. The memory_layout attribute
-    // tells the LLVM lowering to set contiguousDim, which triggers the
-    // transpose flag in the HW instruction via getBlockIOTileSize.
-    Value basePtr = makeTensorDescOp->getBase();
+    // Extract the runtime base pointer from the descriptor value. This
+    // correctly handles loop-carried descriptors where the base pointer
+    // changes per iteration (e.g., via tt.make_tensor_descriptor inside
+    // the loop with an advanced pointer).
+    Value basePtr = ttgi::ExtractBasePtrOp::create(
+        builder, loc, makeTensorDescOp->getBase().getType(), desc);
+    // Shapes and strides are loop-invariant — use from MakeTensorDescOp.
     Operation::operand_range shapes = makeTensorDescOp->getShape();
     Operation::operand_range strides = makeTensorDescOp->getStrides();
     SmallVector<Value> indices(op.getIndices().begin(), op.getIndices().end());


### PR DESCRIPTION
Add a new `ttig.extract_desc` op that extracts the fields from a tensor descriptor value at runtime. This fixes a correctness bug where `LowerTo2DBlockLoad` used `findDefiningOpOfType<MakeTensorDescOp>` which traced through loop block arguments to find the initial `MakeTensorDescOp` outside the loop, missing descriptors created inside the loop with an advanced base pointer.

The new op lowers to `llvm.extractvalue` on the descriptor struct. This ensures the correct per-iteration fields are used for loop-carried descriptors.