### PR TITLE
[Analysis] Extend StrideInfo with per-loop IV stride

### DIFF
--- a/third_party/intel/include/Analysis/StrideInfo.h
+++ b/third_party/intel/include/Analysis/StrideInfo.h
@@ -1,6 +1,7 @@
 #ifndef TRITON_INTEL_ANALYSIS_STRIDEINFO_H
 #define TRITON_INTEL_ANALYSIS_STRIDEINFO_H
 
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "triton/Analysis/Utility.h"
 
 namespace mlir::triton::intel {
@@ -9,32 +10,64 @@ class ModuleAxisInfoAnalysis;
 
 /// Per-dimension stride tracked by StrideAnalysis.
 ///   -1 = unknown, 0 = broadcast/constant, >0 = known stride.
+///
+/// In addition to the spatial stride (how elements within a single loaded
+/// tile vary across tensor axes), StrideInfo also tracks a per-loop
+/// *temporal* stride — how a value's address shifts between successive
+/// iterations of a given `LoopLikeOpInterface`.  The IV-stride table is
+/// keyed by the enclosing loop op; an absent entry is semantically
+/// equivalent to an all-zero vector (i.e. the value does not depend on
+/// that loop's IV).
 class StrideInfo {
 public:
   using DimVectorT = SmallVector<int64_t>;
 
   StrideInfo() = default;
   explicit StrideInfo(ArrayRef<int64_t> stride) : stride(stride) {}
+  StrideInfo(DimVectorT spatial,
+             DenseMap<LoopLikeOpInterface, DimVectorT> ivStrides)
+      : stride(std::move(spatial)), ivStrides(std::move(ivStrides)) {}
 
+  /// Spatial stride along `dim`: how many elements apart consecutive lanes
+  /// along that tensor axis are within a single loaded tile.  Values follow
+  /// the lattice convention: -1 = unknown, 0 = broadcast/constant along the
+  /// axis, >0 = known element-count stride.
   int64_t getStride(size_t dim) const { return stride[dim]; }
+
+  /// Full per-axis spatial-stride vector.  Size matches `getRank()`.
   const DimVectorT &getStride() const { return stride; }
+
   unsigned getRank() const { return stride.size(); }
 
   bool operator==(const StrideInfo &other) const {
-    return stride == other.stride;
+    return stride == other.stride && ivStrides == other.ivStrides;
   }
 
   static StrideInfo getPessimisticValueState(Value value);
   static StrideInfo join(const StrideInfo &lhs, const StrideInfo &rhs);
 
-  void print(raw_ostream &os) const {
-    os << "stride = [";
-    llvm::interleaveComma(stride, os);
-    os << "]";
+  void print(raw_ostream &os) const;
+
+  /// Temporal stride of this value along `dim` with respect to `loop`'s IV.
+  /// Returns 0 when `loop` is not tracked for this value (the consumer
+  /// interprets "not tracked" as "does not depend on this loop's IV", which
+  /// is correct for values defined outside the loop and is the conservative
+  /// answer for values we have not yet propagated into).
+  int64_t getIVStride(LoopLikeOpInterface loop, size_t dim) const;
+
+  /// Full per-axis vector for `loop`.  Returns `nullptr` when `loop` has no
+  /// entry (treated as all-zero by consumers).
+  const DimVectorT *getIVStride(LoopLikeOpInterface loop) const;
+
+  /// Enumerate the loops with tracked IV-stride columns.  Used by visitors
+  /// to fold over both operands' loop sets.
+  const DenseMap<LoopLikeOpInterface, DimVectorT> &getIVStrides() const {
+    return ivStrides;
   }
 
 private:
-  DimVectorT stride;
+  DimVectorT stride;                                   // spatial
+  DenseMap<LoopLikeOpInterface, DimVectorT> ivStrides; // per-loop IV
 };
 
 using StrideInfoMapT = DenseMap<Value, StrideInfo>;

--- a/third_party/intel/include/Analysis/StrideInfo.h
+++ b/third_party/intel/include/Analysis/StrideInfo.h
@@ -15,9 +15,10 @@ class ModuleAxisInfoAnalysis;
 /// tile vary across tensor axes), StrideInfo also tracks a per-loop
 /// *temporal* stride — how a value's address shifts per **unit of IV
 /// increase** of a given `LoopLikeOpInterface`.  The IV-stride table is
-/// keyed by the enclosing loop op; an absent entry is semantically
-/// equivalent to an all-zero vector (i.e. the value does not depend on
-/// that loop's IV).
+/// keyed by the enclosing loop op.  **An absent entry is the canonical
+/// and only encoding of "value does not depend on this loop's IV"** —
+/// all-zero vectors are never stored.  A present entry is guaranteed to
+/// carry at least one non-zero dimension.
 ///
 /// NOTE on units: `getIVStride()` reports the delta per unit of IV, not
 /// per iteration.  To obtain the per-iteration address delta, multiply
@@ -65,8 +66,9 @@ public:
   /// we have not yet propagated into).
   int64_t getIVStride(LoopLikeOpInterface loop, size_t dim) const;
 
-  /// Full per-axis IV-unit stride vector for `loop`.  Returns `nullptr`
-  /// when `loop` has no entry (treated as all-zero by consumers).
+  /// Full per-axis IV-unit stride vector for `loop`.  Returns `nullptr` iff
+  /// the value does not depend on `loop`'s IV.  A non-null result is
+  /// guaranteed to have at least one non-zero dimension (asserted).
   const DimVectorT *getIVStride(LoopLikeOpInterface loop) const;
 
   /// Per-iteration address delta along `dim` with respect to `loop`.

--- a/third_party/intel/include/Analysis/StrideInfo.h
+++ b/third_party/intel/include/Analysis/StrideInfo.h
@@ -13,11 +13,20 @@ class ModuleAxisInfoAnalysis;
 ///
 /// In addition to the spatial stride (how elements within a single loaded
 /// tile vary across tensor axes), StrideInfo also tracks a per-loop
-/// *temporal* stride — how a value's address shifts between successive
-/// iterations of a given `LoopLikeOpInterface`.  The IV-stride table is
+/// *temporal* stride — how a value's address shifts per **unit of IV
+/// increase** of a given `LoopLikeOpInterface`.  The IV-stride table is
 /// keyed by the enclosing loop op; an absent entry is semantically
 /// equivalent to an all-zero vector (i.e. the value does not depend on
 /// that loop's IV).
+///
+/// NOTE on units: `getIVStride()` reports the delta per unit of IV, not
+/// per iteration.  To obtain the per-iteration address delta, multiply
+/// by the enclosing loop's step (when constant) — use
+/// `getPerIterationIVStride()`, which folds this in and returns
+/// `std::nullopt` for dynamic-step loops.  The native-unit convention
+/// keeps the column meaningful even when the step is not a compile-time
+/// constant, and mirrors the spatial column (which is also in native
+/// element units).
 class StrideInfo {
 public:
   using DimVectorT = SmallVector<int64_t>;
@@ -48,16 +57,27 @@ public:
 
   void print(raw_ostream &os) const;
 
-  /// Temporal stride of this value along `dim` with respect to `loop`'s IV.
-  /// Returns 0 when `loop` is not tracked for this value (the consumer
-  /// interprets "not tracked" as "does not depend on this loop's IV", which
-  /// is correct for values defined outside the loop and is the conservative
-  /// answer for values we have not yet propagated into).
+  /// Temporal stride of this value along `dim` with respect to `loop`'s IV,
+  /// in IV units (delta per unit of IV increase).  Returns 0 when `loop` is
+  /// not tracked for this value (the consumer interprets "not tracked" as
+  /// "does not depend on this loop's IV", which is correct for values
+  /// defined outside the loop and is the conservative answer for values
+  /// we have not yet propagated into).
   int64_t getIVStride(LoopLikeOpInterface loop, size_t dim) const;
 
-  /// Full per-axis vector for `loop`.  Returns `nullptr` when `loop` has no
-  /// entry (treated as all-zero by consumers).
+  /// Full per-axis IV-unit stride vector for `loop`.  Returns `nullptr`
+  /// when `loop` has no entry (treated as all-zero by consumers).
   const DimVectorT *getIVStride(LoopLikeOpInterface loop) const;
+
+  /// Per-iteration address delta along `dim` with respect to `loop`.
+  /// Equivalent to `getIVStride(loop, dim) * loop.step` when the step is
+  /// a compile-time constant.  Returns `std::nullopt` when the step is
+  /// dynamic, when the underlying IV-unit stride is unknown (-1), or when
+  /// the constant-step multiplication would overflow `int64_t`.  Callers
+  /// that need a concrete per-iteration delta should use this helper
+  /// instead of multiplying by the step manually.
+  std::optional<int64_t> getPerIterationIVStride(LoopLikeOpInterface loop,
+                                                 size_t dim) const;
 
   /// Enumerate the loops with tracked IV-stride columns.  Used by visitors
   /// to fold over both operands' loop sets.

--- a/third_party/intel/lib/Analysis/StrideInfo.cpp
+++ b/third_party/intel/lib/Analysis/StrideInfo.cpp
@@ -8,6 +8,7 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/MathExtras.h"
 
 #include <numeric>
 
@@ -104,6 +105,31 @@ StrideInfo::getIVStride(LoopLikeOpInterface loop) const {
   if (it == ivStrides.end())
     return nullptr;
   return &it->second;
+}
+
+std::optional<int64_t>
+StrideInfo::getPerIterationIVStride(LoopLikeOpInterface loop,
+                                    size_t dim) const {
+  int64_t ivUnitStride = getIVStride(loop, dim);
+  if (ivUnitStride < 0)
+    return std::nullopt;
+  // Only scf.for exposes a constant-step query today; scf.while does not
+  // have a single step to fold in and is deferred (see StrideAnalysis).
+  auto forOp = dyn_cast<scf::ForOp>(loop.getOperation());
+  if (!forOp)
+    return std::nullopt;
+  std::optional<APInt> step = forOp.getConstantStep();
+  if (!step.has_value())
+    return std::nullopt;
+  // Guard against overflow when the step doesn't fit in int64_t or the
+  // product would wrap.
+  if (step->getSignificantBits() > 64)
+    return std::nullopt;
+  int64_t stepVal = step->getSExtValue();
+  int64_t product;
+  if (llvm::MulOverflow(ivUnitStride, stepVal, product))
+    return std::nullopt;
+  return product;
 }
 
 void StrideInfo::print(raw_ostream &os) const {

--- a/third_party/intel/lib/Analysis/StrideInfo.cpp
+++ b/third_party/intel/lib/Analysis/StrideInfo.cpp
@@ -6,6 +6,7 @@
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Debug.h"
 
 #include <numeric>
@@ -16,6 +17,24 @@
 
 namespace mlir::triton::intel {
 
+/// Per-axis join for a single stride column, using the "agree or -1" rule.
+/// A -1 on either side propagates to -1.  This is the same rule the
+/// existing spatial-stride `join` has always used, factored out so both
+/// the spatial and IV columns share one implementation.
+static StrideInfo::DimVectorT joinColumn(ArrayRef<int64_t> lhs,
+                                         ArrayRef<int64_t> rhs) {
+  assert(lhs.size() == rhs.size() && "Mismatched column ranks");
+  StrideInfo::DimVectorT result;
+  result.reserve(lhs.size());
+  for (unsigned d = 0, rank = lhs.size(); d < rank; ++d) {
+    if (lhs[d] == rhs[d])
+      result.push_back(lhs[d]);
+    else
+      result.push_back(-1);
+  }
+  return result;
+}
+
 // StrideInfo static methods
 StrideInfo StrideInfo::getPessimisticValueState(Value value) {
   unsigned rank = 1;
@@ -25,23 +44,84 @@ StrideInfo StrideInfo::getPessimisticValueState(Value value) {
   if (auto descTy = dyn_cast<triton::TensorDescInterface>(ty))
     rank = descTy.getBlockType().getRank();
 
+  // Leave `ivStrides` empty: "no entry" is interpreted as all-zero by
+  // consumers, which is correct for values defined outside every loop.
+  // Values defined *inside* a loop whose defining op hits the pessimistic
+  // path receive pessimism for the IV columns via subsequent arithmetic
+  // visitors (which propagate -1 through the per-column Template Method).
   return StrideInfo(DimVectorT(rank, -1));
 }
 
 StrideInfo StrideInfo::join(const StrideInfo &lhs, const StrideInfo &rhs) {
-  if (lhs.getRank() == 0)
+  if (lhs.getRank() == 0) {
+    assert(lhs.getIVStrides().empty() &&
+           "rank-0 StrideInfo should not carry IV-stride entries");
     return rhs;
-  if (rhs.getRank() == 0)
-    return lhs;
-  assert(lhs.getRank() == rhs.getRank() && "Mismatched ranks");
-  DimVectorT result;
-  for (unsigned d = 0; d < lhs.getRank(); ++d) {
-    if (lhs.stride[d] == rhs.stride[d])
-      result.push_back(lhs.stride[d]);
-    else
-      result.push_back(-1);
   }
-  return StrideInfo(std::move(result));
+  if (rhs.getRank() == 0) {
+    assert(rhs.getIVStrides().empty() &&
+           "rank-0 StrideInfo should not carry IV-stride entries");
+    return lhs;
+  }
+  assert(lhs.getRank() == rhs.getRank() && "Mismatched ranks");
+
+  DimVectorT spatial = joinColumn(lhs.stride, rhs.stride);
+
+  // Union the set of tracked loops.  A missing entry is treated as an
+  // all-zero vector of the shared rank, so: {zero,zero}->zero,
+  // {known,zero}->zero (disagrees -> -1), {known,known}-> agree-or-(-1).
+  llvm::SmallSetVector<LoopLikeOpInterface, 4> allLoops;
+  for (LoopLikeOpInterface loop : llvm::make_first_range(lhs.ivStrides))
+    allLoops.insert(loop);
+  for (LoopLikeOpInterface loop : llvm::make_first_range(rhs.ivStrides))
+    allLoops.insert(loop);
+  DimVectorT zeros(lhs.getRank(), 0);
+  DenseMap<LoopLikeOpInterface, DimVectorT> ivStrides;
+  for (LoopLikeOpInterface loop : allLoops) {
+    const DimVectorT *l = lhs.getIVStride(loop);
+    const DimVectorT *r = rhs.getIVStride(loop);
+    ivStrides[loop] =
+        joinColumn(l ? ArrayRef<int64_t>(*l) : ArrayRef<int64_t>(zeros),
+                   r ? ArrayRef<int64_t>(*r) : ArrayRef<int64_t>(zeros));
+  }
+  return StrideInfo(std::move(spatial), std::move(ivStrides));
+}
+
+int64_t StrideInfo::getIVStride(LoopLikeOpInterface loop, size_t dim) const {
+  DenseMap<LoopLikeOpInterface, DimVectorT>::const_iterator it =
+      ivStrides.find(loop);
+  if (it == ivStrides.end())
+    return 0;
+  return it->second[dim];
+}
+
+const StrideInfo::DimVectorT *
+StrideInfo::getIVStride(LoopLikeOpInterface loop) const {
+  DenseMap<LoopLikeOpInterface, DimVectorT>::const_iterator it =
+      ivStrides.find(loop);
+  if (it == ivStrides.end())
+    return nullptr;
+  return &it->second;
+}
+
+void StrideInfo::print(raw_ostream &os) const {
+  os << "stride = [";
+  llvm::interleaveComma(stride, os);
+  os << "]";
+  if (!ivStrides.empty()) {
+    os << ", iv_strides = {";
+    bool first = true;
+    for (const std::pair<LoopLikeOpInterface, DimVectorT> &kv : ivStrides) {
+      if (!first)
+        os << ", ";
+      first = false;
+      os << kv.first->getName() << "@" << static_cast<const void *>(&*kv.first)
+         << ": [";
+      llvm::interleaveComma(kv.second, os);
+      os << "]";
+    }
+    os << "}";
+  }
 }
 
 using AxisInfoLookupFn = std::function<AxisInfo *(Value)>;
@@ -121,6 +201,73 @@ public:
       ArrayRef<const dataflow::Lattice<StrideInfo> *> operands) const = 0;
 };
 
+/// Template Method base for arithmetic visitors that treat the spatial
+/// column and every per-loop IV column the same way.  Subclasses override
+/// one per-column hook (`applyOne`); the base class walks every column
+/// (spatial + union of IV columns from all operand lattices) and assembles
+/// the resulting StrideInfo.
+///
+/// - Binary arithmetic visitors (AddI, SubI, AddPtr, MulI, DivI, RemI)
+///   receive `rhs` as a pointer to the right-hand-side column.
+/// - Unary / shape-transform visitors (Splat, ExpandDims, Broadcast, Trans)
+///   receive `rhs == nullptr` and should ignore it.
+///
+/// Leaf / pessimistic visitors that do not perform per-column arithmetic
+/// (LoadOp, DescriptorLoadOp, PoisonOp, MakeRangeOp, ConstantOp,
+/// MakeTensorDescOp) do **not** use this base — they subclass
+/// StrideInfoVisitorImpl directly and produce a full StrideInfo by hand.
+///
+/// MAINTAINER NOTE: When adding a new arithmetic visitor, prefer
+/// `StrideArithVisitor` over `StrideInfoVisitorImpl`.  The base iterates
+/// every stride column for you, so you cannot forget to propagate an
+/// IV column.  This is the single source of truth for per-axis stride
+/// arithmetic.
+template <typename OpTy>
+class StrideArithVisitor : public StrideInfoVisitorImpl<OpTy> {
+public:
+  StrideInfo getStrideInfo(
+      OpTy op,
+      ArrayRef<const dataflow::Lattice<StrideInfo> *> operands) const final {
+    assert(!operands.empty() && "Arithmetic visitor requires >= 1 operand");
+    const StrideInfo &lhs = operands[0]->getValue();
+    const StrideInfo *rhs =
+        operands.size() > 1 ? &operands[1]->getValue() : nullptr;
+
+    StrideInfo::DimVectorT spatial =
+        applyOne(op, lhs.getStride(), rhs ? &rhs->getStride() : nullptr);
+
+    // Every IV column present in either operand.
+    llvm::SmallSetVector<LoopLikeOpInterface, 4> allLoops;
+    for (LoopLikeOpInterface loop : llvm::make_first_range(lhs.getIVStrides()))
+      allLoops.insert(loop);
+    if (rhs)
+      for (LoopLikeOpInterface loop :
+           llvm::make_first_range(rhs->getIVStrides()))
+        allLoops.insert(loop);
+
+    StrideInfo::DimVectorT zeros(lhs.getRank(), 0);
+    DenseMap<LoopLikeOpInterface, StrideInfo::DimVectorT> ivStrides;
+    for (LoopLikeOpInterface loop : allLoops) {
+      const StrideInfo::DimVectorT *lc = lhs.getIVStride(loop);
+      const StrideInfo::DimVectorT *rc = rhs ? rhs->getIVStride(loop) : nullptr;
+      const StrideInfo::DimVectorT &lCol = lc ? *lc : zeros;
+      const StrideInfo::DimVectorT *rCol = rc ? rc : (rhs ? &zeros : nullptr);
+      ivStrides[loop] = applyOne(op, lCol, rCol);
+    }
+    return StrideInfo(std::move(spatial), std::move(ivStrides));
+  }
+
+protected:
+  /// Subclass hook — compute the result of `op` for one stride column.
+  /// For binary ops, `rhs` is non-null and points at the right-hand-side
+  /// column (either the operand's actual column or a zero vector of the
+  /// correct rank when that side has no entry for this loop).  For
+  /// unary/shape-transform ops, `rhs` is `nullptr`.
+  virtual StrideInfo::DimVectorT
+  applyOne(OpTy op, const StrideInfo::DimVectorT &lhs,
+           const StrideInfo::DimVectorT *rhs) const = 0;
+};
+
 class StrideInfoVisitorList {
 public:
   template <typename... Ts, typename = std::enable_if_t<sizeof...(Ts) != 0>>
@@ -146,7 +293,9 @@ private:
   std::vector<std::unique_ptr<StrideInfoVisitor>> visitors;
 };
 
-// PassThrough: stride passes from operand 0
+// PassThrough: stride passes from operand 0.  Returning `operands[0]->
+// getValue()` verbatim correctly carries both the spatial column and the
+// full IV-stride map to the result.
 template <typename OpTy,
           typename =
               std::enable_if_t<OpTy::template hasTrait<OpTrait::OneOperand>()>>
@@ -218,117 +367,117 @@ public:
 };
 
 template <typename OpTy>
-class AddSubStrideVisitor final : public StrideInfoVisitorImpl<OpTy> {
-public:
-  StrideInfo getStrideInfo(
-      OpTy op,
-      ArrayRef<const dataflow::Lattice<StrideInfo> *> operands) const override {
-    const auto &lhs = operands[0]->getValue();
-    const auto &rhs = operands[1]->getValue();
-    auto rank = lhs.getRank();
+class AddSubStrideVisitor final : public StrideArithVisitor<OpTy> {
+protected:
+  StrideInfo::DimVectorT
+  applyOne(OpTy op, const StrideInfo::DimVectorT &lhs,
+           const StrideInfo::DimVectorT *rhs) const override {
+    assert(rhs && "AddSubStrideVisitor requires two operand columns");
     StrideInfo::DimVectorT stride;
-    for (unsigned d = 0; d < rank; ++d) {
-      if (lhs.getStride(d) < 0 || rhs.getStride(d) < 0) {
+    stride.reserve(lhs.size());
+    for (unsigned d = 0, rank = lhs.size(); d < rank; ++d) {
+      if (lhs[d] < 0 || (*rhs)[d] < 0) {
         stride.push_back(-1);
       } else if constexpr (std::is_same_v<OpTy, arith::SubIOp>) {
-        stride.push_back(
-            std::max(lhs.getStride(d) - rhs.getStride(d), int64_t(-1)));
+        stride.push_back(std::max(lhs[d] - (*rhs)[d], int64_t(-1)));
       } else {
-        stride.push_back(lhs.getStride(d) + rhs.getStride(d));
+        stride.push_back(lhs[d] + (*rhs)[d]);
       }
     }
-    return StrideInfo(std::move(stride));
+    return stride;
   }
 };
 
-class MulIOpStrideVisitor final : public StrideInfoVisitorImpl<arith::MulIOp> {
-public:
-  StrideInfo getStrideInfo(
-      arith::MulIOp op,
-      ArrayRef<const dataflow::Lattice<StrideInfo> *> operands) const override {
-    const auto &lhs = operands[0]->getValue();
-    const auto &rhs = operands[1]->getValue();
-    auto rank = lhs.getRank();
+class MulIOpStrideVisitor final : public StrideArithVisitor<arith::MulIOp> {
+protected:
+  StrideInfo::DimVectorT
+  applyOne(arith::MulIOp op, const StrideInfo::DimVectorT &lhs,
+           const StrideInfo::DimVectorT *rhs) const override {
+    assert(rhs && "MulIOpStrideVisitor requires two operand columns");
+
+    // Constant detection is an op-level property — it depends on the
+    // defining op of the raw Value, not on the per-column stride.
+    // Call through to the inherited StrideInfoVisitor::getConstantValue().
+    std::optional<int64_t> lhsConst = getConstantValue(op.getLhs());
+    std::optional<int64_t> rhsConst = getConstantValue(op.getRhs());
+
     StrideInfo::DimVectorT stride;
-
-    auto lhsConst = this->getConstantValue(op.getLhs());
-    auto rhsConst = this->getConstantValue(op.getRhs());
-
-    for (unsigned d = 0; d < rank; ++d) {
-      if (lhs.getStride(d) > 0 && rhsConst.has_value()) {
-        int64_t product = lhs.getStride(d) * rhsConst.value();
+    stride.reserve(lhs.size());
+    for (unsigned d = 0, rank = lhs.size(); d < rank; ++d) {
+      if (lhs[d] > 0 && rhsConst.has_value()) {
+        int64_t product = lhs[d] * rhsConst.value();
         stride.push_back(product >= 0 ? product : -1);
-      } else if (rhs.getStride(d) > 0 && lhsConst.has_value()) {
-        int64_t product = lhsConst.value() * rhs.getStride(d);
+      } else if ((*rhs)[d] > 0 && lhsConst.has_value()) {
+        int64_t product = lhsConst.value() * (*rhs)[d];
         stride.push_back(product >= 0 ? product : -1);
       } else {
-        auto strideZero = [&](const StrideInfo &si, Value v) {
-          return this->getConstantValue(v).has_value() ||
-                 si.getStride(d) == 0 || !isa<TensorType>(op.getType());
+        auto strideZero = [&](int64_t col, Value v) {
+          return getConstantValue(v).has_value() || col == 0 ||
+                 !isa<TensorType>(op.getType());
         };
-        if (strideZero(lhs, op.getLhs()) && strideZero(rhs, op.getRhs()))
+        if (strideZero(lhs[d], op.getLhs()) &&
+            strideZero((*rhs)[d], op.getRhs()))
           stride.push_back(0);
         else
           stride.push_back(-1);
       }
     }
-    return StrideInfo(std::move(stride));
+    return stride;
   }
 };
 
 template <typename OpTy>
-class DivOpStrideVisitor final : public StrideInfoVisitorImpl<OpTy> {
-public:
-  StrideInfo getStrideInfo(
-      OpTy op,
-      ArrayRef<const dataflow::Lattice<StrideInfo> *> operands) const override {
-    const auto &lhs = operands[0]->getValue();
-    const auto &rhs = operands[1]->getValue();
-    auto rank = lhs.getRank();
+class DivOpStrideVisitor final : public StrideArithVisitor<OpTy> {
+protected:
+  StrideInfo::DimVectorT
+  applyOne(OpTy op, const StrideInfo::DimVectorT &lhs,
+           const StrideInfo::DimVectorT *rhs) const override {
+    // `rhs` column is unused here — RHS-constant detection is an op-level
+    // property (we read the defining op via `getConstantValue`).  It must
+    // still be non-null because this is a binary-arithmetic visitor.
+    assert(rhs && "DivOpStrideVisitor requires two operand columns");
+
+    std::optional<int64_t> rhsConst = this->getConstantValue(op.getRhs());
+
     StrideInfo::DimVectorT stride;
-
-    auto rhsConst = this->getConstantValue(op.getRhs());
-
-    for (unsigned d = 0; d < rank; ++d) {
-      if (lhs.getStride(d) > 0 && rhsConst.has_value() &&
-          rhsConst.value() > 0 && lhs.getStride(d) % rhsConst.value() == 0)
-        stride.push_back(lhs.getStride(d) / rhsConst.value());
-      else if (lhs.getStride(d) == 0 && rhsConst.has_value() &&
-               rhsConst.value() != 0)
+    stride.reserve(lhs.size());
+    for (unsigned d = 0, rank = lhs.size(); d < rank; ++d) {
+      if (lhs[d] > 0 && rhsConst.has_value() && rhsConst.value() > 0 &&
+          lhs[d] % rhsConst.value() == 0)
+        stride.push_back(lhs[d] / rhsConst.value());
+      else if (lhs[d] == 0 && rhsConst.has_value() && rhsConst.value() != 0)
         stride.push_back(0);
       else
         stride.push_back(-1);
     }
-    return StrideInfo(std::move(stride));
+    return stride;
   }
 };
 
 template <typename OpTy>
-class RemOpStrideVisitor final : public StrideInfoVisitorImpl<OpTy> {
-public:
-  StrideInfo getStrideInfo(
-      OpTy op,
-      ArrayRef<const dataflow::Lattice<StrideInfo> *> operands) const override {
-    const auto &lhs = operands[0]->getValue();
-    const auto &rhs = operands[1]->getValue();
-    auto rank = lhs.getRank();
+class RemOpStrideVisitor final : public StrideArithVisitor<OpTy> {
+protected:
+  StrideInfo::DimVectorT
+  applyOne(OpTy op, const StrideInfo::DimVectorT &lhs,
+           const StrideInfo::DimVectorT *rhs) const override {
+    assert(rhs && "RemOpStrideVisitor requires two operand columns");
+
+    std::optional<int64_t> rhsConst = this->getConstantValue(op.getRhs());
+
     StrideInfo::DimVectorT stride;
-
-    auto rhsConst = this->getConstantValue(op.getRhs());
-
-    for (unsigned d = 0; d < rank; ++d) {
-      if (lhs.getStride(d) == 0 && rhs.getStride(d) == 0) {
+    stride.reserve(lhs.size());
+    for (unsigned d = 0, rank = lhs.size(); d < rank; ++d) {
+      if (lhs[d] == 0 && (*rhs)[d] == 0) {
         // Both sides are uniform/constant — result is uniform.
         stride.push_back(0);
-      } else if (lhs.getStride(d) > 0 && rhsConst.has_value() &&
-                 rhsConst.value() > 0) {
+      } else if (lhs[d] > 0 && rhsConst.has_value() && rhsConst.value() > 0) {
         // Stride preserved when range span doesn't cross a modulus boundary.
         // Effective period is gcd(divisibility, modulus) when AxisInfo is
         // available; falls back to modulus otherwise.
         auto resTy = dyn_cast<RankedTensorType>(op.getType());
         if (resTy) {
           int64_t dimSize = resTy.getDimSize(d);
-          int64_t maxVal = lhs.getStride(d) * (dimSize - 1);
+          int64_t maxVal = lhs[d] * (dimSize - 1);
           int64_t modulus = rhsConst.value();
           int64_t g = modulus; // fallback when no AxisInfo
           if (auto *ai = this->axisInfoLookup(op.getLhs())) {
@@ -336,7 +485,7 @@ public:
             g = std::gcd(divisibility, modulus);
           }
           if (maxVal < g)
-            stride.push_back(lhs.getStride(d));
+            stride.push_back(lhs[d]);
           else
             stride.push_back(-1);
         } else {
@@ -346,10 +495,26 @@ public:
         stride.push_back(-1);
       }
     }
-    return StrideInfo(std::move(stride));
+    return stride;
   }
 };
 
+/// SplatOp: a splat takes a scalar and produces a tensor where every
+/// element equals the scalar.  The two stride columns answer different
+/// questions and therefore must be computed independently:
+///
+/// - **Spatial stride** of the result is 0 along every axis, because
+///   neighbouring tensor elements within a single loop iteration are
+///   identical.  This is independent of the scalar's spatial stride.
+/// - **IV stride** of the result equals the scalar's IV stride,
+///   broadcast across every tensor axis.  If the scalar advances by N
+///   per iteration, every element of the splat tensor advances by N
+///   per iteration.  This is the key case for recognising the 1-D
+///   streaming pattern `tt.addptr(splat(base), splat(muli(iv, N)))`.
+///
+/// Because the spatial and IV columns require different logic, `SplatOp`
+/// does not use `StrideArithVisitor`; it overrides `getStrideInfo`
+/// directly and handles both columns by hand.
 class SplatOpStrideVisitor final
     : public StrideInfoVisitorImpl<triton::SplatOp> {
 public:
@@ -357,7 +522,21 @@ public:
       triton::SplatOp op,
       ArrayRef<const dataflow::Lattice<StrideInfo> *> operands) const override {
     TensorType retTy = cast<TensorType>(*op->result_type_begin());
-    return StrideInfo(StrideInfo::DimVectorT(retTy.getRank(), 0));
+    unsigned resRank = retTy.getRank();
+
+    const StrideInfo &scalar = operands[0]->getValue();
+    DenseMap<LoopLikeOpInterface, StrideInfo::DimVectorT> ivStrides;
+    for (const std::pair<LoopLikeOpInterface, StrideInfo::DimVectorT> &kv :
+         scalar.getIVStrides()) {
+      // The scalar's IV column is rank-1 (scalars have rank 1 in this
+      // analysis, because getRank() treats scalars as 1-element vectors).
+      // Broadcast the scalar's single IV-stride value across every
+      // axis of the result tensor.
+      assert(!kv.second.empty() && "scalar IV-stride column is empty");
+      int64_t ivVal = kv.second.front();
+      ivStrides[kv.first] = StrideInfo::DimVectorT(resRank, ivVal);
+    }
+    return StrideInfo(StrideInfo::DimVectorT(resRank, 0), std::move(ivStrides));
   }
 };
 
@@ -371,41 +550,44 @@ public:
 };
 
 class ExpandDimsOpStrideVisitor final
-    : public StrideInfoVisitorImpl<triton::ExpandDimsOp> {
-public:
-  StrideInfo getStrideInfo(
-      triton::ExpandDimsOp op,
-      ArrayRef<const dataflow::Lattice<StrideInfo> *> operands) const override {
-    auto opStride = operands[0]->getValue().getStride();
-    StrideInfo::DimVectorT stride(opStride.begin(), opStride.end());
+    : public StrideArithVisitor<triton::ExpandDimsOp> {
+protected:
+  StrideInfo::DimVectorT
+  applyOne(triton::ExpandDimsOp op, const StrideInfo::DimVectorT &lhs,
+           const StrideInfo::DimVectorT *rhs) const override {
+    assert(!rhs && "ExpandDimsOpStrideVisitor is unary");
+    StrideInfo::DimVectorT stride(lhs.begin(), lhs.end());
     stride.insert(stride.begin() + op.getAxis(), 0);
-    return StrideInfo(std::move(stride));
+    return stride;
   }
 };
 
 class BroadcastOpStrideVisitor final
-    : public StrideInfoVisitorImpl<triton::BroadcastOp> {
-public:
-  StrideInfo getStrideInfo(
-      triton::BroadcastOp op,
-      ArrayRef<const dataflow::Lattice<StrideInfo> *> operands) const override {
-    return operands[0]->getValue();
+    : public StrideArithVisitor<triton::BroadcastOp> {
+protected:
+  StrideInfo::DimVectorT
+  applyOne(triton::BroadcastOp, const StrideInfo::DimVectorT &lhs,
+           const StrideInfo::DimVectorT *rhs) const override {
+    assert(!rhs && "BroadcastOpStrideVisitor is unary");
+    // Broadcast preserves rank and per-axis values; broadcast axes are
+    // already 0 in the operand column, so a verbatim copy is correct for
+    // every column (spatial + every IV column).
+    return lhs;
   }
 };
 
-class TransOpStrideVisitor final
-    : public StrideInfoVisitorImpl<triton::TransOp> {
-public:
-  StrideInfo getStrideInfo(
-      triton::TransOp op,
-      ArrayRef<const dataflow::Lattice<StrideInfo> *> operands) const override {
-    const auto &srcInfo = operands[0]->getValue();
+class TransOpStrideVisitor final : public StrideArithVisitor<triton::TransOp> {
+protected:
+  StrideInfo::DimVectorT
+  applyOne(triton::TransOp op, const StrideInfo::DimVectorT &lhs,
+           const StrideInfo::DimVectorT *rhs) const override {
+    assert(!rhs && "TransOpStrideVisitor is unary");
     auto order = op.getOrder();
     StrideInfo::DimVectorT stride;
-    for (unsigned d = 0; d < srcInfo.getRank(); ++d) {
-      stride.push_back(srcInfo.getStride(order[d]));
-    }
-    return StrideInfo(std::move(stride));
+    stride.reserve(lhs.size());
+    for (unsigned d = 0, rank = lhs.size(); d < rank; ++d)
+      stride.push_back(lhs[order[d]]);
+    return stride;
   }
 };
 
@@ -417,7 +599,7 @@ public:
       ArrayRef<const dataflow::Lattice<StrideInfo> *> operands) const override {
     StrideInfo::DimVectorT result;
     for (Value s : op.getStrides()) {
-      auto val = this->getConstantValue(s);
+      std::optional<int64_t> val = getConstantValue(s);
       result.push_back(val.has_value() ? val.value() : -1);
     }
     return StrideInfo(std::move(result));
@@ -454,10 +636,19 @@ private:
       ValueRange /*nonSuccessorInputs*/,
       ArrayRef<dataflow::Lattice<StrideInfo> *> argLattices) override {
     if (auto forOp = dyn_cast<scf::ForOp>(op)) {
-      // Induction variable has stride 0 (scalar).
-      auto iv = StrideInfo(StrideInfo::DimVectorT{0});
+      // Induction variable has spatial stride 0 (scalar) and IV stride 1
+      // w.r.t. its own loop's IV; no entries for any other loop
+      // (implicitly treated as all-zero by downstream consumers).
+      DenseMap<LoopLikeOpInterface, StrideInfo::DimVectorT> ivStrides;
+      ivStrides[cast<LoopLikeOpInterface>(op)] = StrideInfo::DimVectorT{1};
+      StrideInfo iv(StrideInfo::DimVectorT{0}, std::move(ivStrides));
       (void)argLattices[0]->join(iv);
     } else {
+      // scf.while IV-stride seeding is intentionally deferred.  Its
+      // before-region args are control-flow-fed from the init operands, which
+      // bypasses this hook.  Handling it requires overriding the solver's
+      // region-successor propagation; that is out of scope here and will be
+      // revisited when a consumer (PR-B TemporalReuseAnalysis) needs it.
       setAllToEntryStates(argLattices);
     }
   }
@@ -514,20 +705,21 @@ public:
       setAllToEntryStates(results);
       return success();
     }
-    // Override stride from tt.contiguity hint.
+    // Override stride from tt.contiguity hint.  Build a fresh StrideInfo
+    // carrying the patched spatial column and the IV-stride map verbatim.
     if (auto contiguityAttr = op->getDiscardableAttr("tt.contiguity")) {
       if (auto resTy = dyn_cast<RankedTensorType>(op->getResult(0).getType())) {
         AxisInfo::DimVectorT hintContiguity;
         AxisInfo::initDimVectorFromHint(contiguityAttr, &hintContiguity);
-        const auto &stride = curr.getStride();
-        StrideInfo::DimVectorT newStride(stride.begin(), stride.end());
+        StrideInfo::DimVectorT newStride(curr.getStride().begin(),
+                                         curr.getStride().end());
         for (unsigned d = 0; d < curr.getRank() && d < hintContiguity.size();
              ++d) {
           if (newStride[d] < 0 && hintContiguity[d] >= resTy.getDimSize(d)) {
             newStride[d] = 1;
           }
         }
-        curr = StrideInfo(std::move(newStride));
+        curr = StrideInfo(std::move(newStride), curr.getIVStrides());
       }
     }
     for (auto *result : results)

--- a/third_party/intel/lib/Analysis/StrideInfo.cpp
+++ b/third_party/intel/lib/Analysis/StrideInfo.cpp
@@ -68,8 +68,10 @@ StrideInfo StrideInfo::join(const StrideInfo &lhs, const StrideInfo &rhs) {
   DimVectorT spatial = joinColumn(lhs.stride, rhs.stride);
 
   // Union the set of tracked loops.  A missing entry is treated as an
-  // all-zero vector of the shared rank, so: {zero,zero}->zero,
-  // {known,zero}->zero (disagrees -> -1), {known,known}-> agree-or-(-1).
+  // all-zero vector of the shared rank, then joined with `joinColumn`'s
+  // "agree-or-(-1)" rule.  Concretely, per dimension: {0,0} -> 0;
+  // {k,0} or {0,k} -> 0 if k == 0 else -1; {k1,k2} -> k1 if k1 == k2
+  // else -1.
   llvm::SmallSetVector<LoopLikeOpInterface, 4> allLoops;
   for (LoopLikeOpInterface loop : llvm::make_first_range(lhs.ivStrides))
     allLoops.insert(loop);

--- a/third_party/intel/lib/Analysis/StrideInfo.cpp
+++ b/third_party/intel/lib/Analysis/StrideInfo.cpp
@@ -73,6 +73,13 @@ StrideInfo StrideInfo::join(const StrideInfo &lhs, const StrideInfo &rhs) {
   // "agree-or-(-1)" rule.  Concretely, per dimension: {0,0} -> 0;
   // {k,0} or {0,k} -> 0 if k == 0 else -1; {k1,k2} -> k1 if k1 == k2
   // else -1.
+  //
+  // Note: when one incoming path is loop-variant (stride k != 0) and
+  // the other is loop-invariant (absent entry, treated as 0), the
+  // merged column is -1 for that loop.  This is not pessimism hiding a
+  // better answer — across iterations of the loop the value genuinely
+  // advances by k on some paths and by 0 on others, so no single stride
+  // describes it.  The lattice's -1 ("unknown") is the correct answer.
   llvm::SmallSetVector<LoopLikeOpInterface, 4> allLoops;
   for (LoopLikeOpInterface loop : llvm::make_first_range(lhs.ivStrides))
     allLoops.insert(loop);

--- a/third_party/intel/lib/Analysis/StrideInfo.cpp
+++ b/third_party/intel/lib/Analysis/StrideInfo.cpp
@@ -36,6 +36,19 @@ static StrideInfo::DimVectorT joinColumn(ArrayRef<int64_t> lhs,
   return result;
 }
 
+// Insert `vec` into `ivStrides[loop]` only if it carries meaningful
+// information — i.e. at least one non-zero dimension.  An all-zero vector
+// is semantically equivalent to an absent entry (see StrideInfo class
+// docstring), and is never stored.  All sites that insert into `ivStrides`
+// must go through this helper so the canonical-form invariant holds.
+static void maybeStoreIVStride(
+    DenseMap<LoopLikeOpInterface, StrideInfo::DimVectorT> &ivStrides,
+    LoopLikeOpInterface loop, StrideInfo::DimVectorT vec) {
+  if (llvm::all_of(vec, [](int64_t v) { return v == 0; }))
+    return;
+  ivStrides[loop] = std::move(vec);
+}
+
 // StrideInfo static methods
 StrideInfo StrideInfo::getPessimisticValueState(Value value) {
   unsigned rank = 1;
@@ -90,9 +103,10 @@ StrideInfo StrideInfo::join(const StrideInfo &lhs, const StrideInfo &rhs) {
   for (LoopLikeOpInterface loop : allLoops) {
     const DimVectorT *l = lhs.getIVStride(loop);
     const DimVectorT *r = rhs.getIVStride(loop);
-    ivStrides[loop] =
+    maybeStoreIVStride(
+        ivStrides, loop,
         joinColumn(l ? ArrayRef<int64_t>(*l) : ArrayRef<int64_t>(zeros),
-                   r ? ArrayRef<int64_t>(*r) : ArrayRef<int64_t>(zeros));
+                   r ? ArrayRef<int64_t>(*r) : ArrayRef<int64_t>(zeros)));
   }
   return StrideInfo(std::move(spatial), std::move(ivStrides));
 }
@@ -111,6 +125,8 @@ StrideInfo::getIVStride(LoopLikeOpInterface loop) const {
       ivStrides.find(loop);
   if (it == ivStrides.end())
     return nullptr;
+  assert(!llvm::all_of(it->second, [](int64_t v) { return v == 0; }) &&
+         "ivStrides invariant violated: stored entry is all-zero");
   return &it->second;
 }
 
@@ -150,8 +166,9 @@ void StrideInfo::print(raw_ostream &os) const {
       if (!first)
         os << ", ";
       first = false;
-      os << kv.first->getName() << "@" << static_cast<const void *>(&*kv.first)
-         << ": [";
+      os << kv.first->getName() << "@";
+      kv.first->getLoc().print(os);
+      os << ": [";
       llvm::interleaveComma(kv.second, os);
       os << "]";
     }
@@ -287,7 +304,7 @@ public:
       const StrideInfo::DimVectorT *rc = rhs ? rhs->getIVStride(loop) : nullptr;
       const StrideInfo::DimVectorT &lCol = lc ? *lc : zeros;
       const StrideInfo::DimVectorT *rCol = rc ? rc : (rhs ? &zeros : nullptr);
-      ivStrides[loop] = applyOne(op, lCol, rCol);
+      maybeStoreIVStride(ivStrides, loop, applyOne(op, lCol, rCol));
     }
     return StrideInfo(std::move(spatial), std::move(ivStrides));
   }
@@ -569,7 +586,8 @@ public:
       // axis of the result tensor.
       assert(kv.second.size() == 1 && "scalar should have rank-1 IV stride");
       int64_t ivVal = kv.second.front();
-      ivStrides[kv.first] = StrideInfo::DimVectorT(resRank, ivVal);
+      maybeStoreIVStride(ivStrides, kv.first,
+                         StrideInfo::DimVectorT(resRank, ivVal));
     }
     return StrideInfo(StrideInfo::DimVectorT(resRank, 0), std::move(ivStrides));
   }
@@ -675,7 +693,8 @@ private:
       // w.r.t. its own loop's IV; no entries for any other loop
       // (implicitly treated as all-zero by downstream consumers).
       DenseMap<LoopLikeOpInterface, StrideInfo::DimVectorT> ivStrides;
-      ivStrides[cast<LoopLikeOpInterface>(op)] = StrideInfo::DimVectorT{1};
+      maybeStoreIVStride(ivStrides, cast<LoopLikeOpInterface>(op),
+                         StrideInfo::DimVectorT{1});
       StrideInfo iv(StrideInfo::DimVectorT{0}, std::move(ivStrides));
       (void)argLattices[0]->join(iv);
     } else {

--- a/third_party/intel/lib/Analysis/StrideInfo.cpp
+++ b/third_party/intel/lib/Analysis/StrideInfo.cpp
@@ -560,7 +560,7 @@ public:
       // analysis, because getRank() treats scalars as 1-element vectors).
       // Broadcast the scalar's single IV-stride value across every
       // axis of the result tensor.
-      assert(!kv.second.empty() && "scalar IV-stride column is empty");
+      assert(kv.second.size() == 1 && "scalar should have rank-1 IV stride");
       int64_t ivVal = kv.second.front();
       ivStrides[kv.first] = StrideInfo::DimVectorT(resRank, ivVal);
     }

--- a/third_party/intel/unittest/Analysis/CMakeLists.txt
+++ b/third_party/intel/unittest/Analysis/CMakeLists.txt
@@ -20,3 +20,26 @@ add_triton_ut(
 if(NOT WIN32)
   target_compile_options(DPASAnalysis PRIVATE -Wno-deprecated-declarations)
 endif()
+
+add_triton_ut(
+  NAME StrideInfo
+  SRCS StrideInfoTest.cpp
+  LIBS
+    TritonAnalysis
+    TritonGPUIR
+    TritonGPUTransforms
+    TritonIR
+    TritonIntelAnalysis
+    TritonIntelGPUIR
+    TritonIntelGPUTransforms
+    TritonNvidiaGPUIR
+    TritonNvidiaGPUTransforms
+    MLIRArithDialect
+    MLIRFuncDialect
+    MLIRSCFDialect
+)
+
+# Suppress deprecation warnings for OpBuilder::create<> API
+if(NOT WIN32)
+  target_compile_options(StrideInfo PRIVATE -Wno-deprecated-declarations)
+endif()

--- a/third_party/intel/unittest/Analysis/StrideInfoTest.cpp
+++ b/third_party/intel/unittest/Analysis/StrideInfoTest.cpp
@@ -43,7 +43,9 @@ public:
     auto funcOp =
         func::FuncOp::create(builder->getUnknownLoc(), name, funcType);
     module.push_back(funcOp);
-    funcOp.addEntryBlock();
+    Block *entry = funcOp.addEntryBlock();
+    builder->setInsertionPointToEnd(entry);
+    func::ReturnOp::create(*builder, builder->getUnknownLoc());
     return funcOp;
   }
 
@@ -336,7 +338,7 @@ TEST_F(StrideInfoTest, NestedLoopsInnerIVOuterValue) {
 // PR-B (TemporalReuseAnalysis) will revisit scf.while when a consumer
 // actually exercises it.
 
-// Test 9: Spatial stride regression — tt.make_range
+// Test 8: Spatial stride regression — tt.make_range
 TEST_F(StrideInfoTest, SpatialRangeStrideOne) {
   ModuleOp module = buildModule();
   func::FuncOp funcOp = buildFunc(module);
@@ -371,7 +373,7 @@ TEST_F(StrideInfoTest, SpatialRangeStrideOne) {
   }
 }
 
-// Test 10: Spatial stride regression — tt.splat(const)
+// Test 9: Spatial stride regression — tt.splat(const)
 TEST_F(StrideInfoTest, SpatialSplatConstant) {
   ModuleOp module = buildModule();
   func::FuncOp funcOp = buildFunc(module);

--- a/third_party/intel/unittest/Analysis/StrideInfoTest.cpp
+++ b/third_party/intel/unittest/Analysis/StrideInfoTest.cpp
@@ -291,7 +291,39 @@ TEST_F(StrideInfoTest, OneDimStreamingAddPtr) {
   EXPECT_EQ(info->getStride(0), 0);
 }
 
-// Test 7: Nested loops — inner IV queried for outer-only-dependent value
+// Test 7: step > 1 — IV-unit stride is independent of loop step; per-iteration
+// stride folds in the step via getPerIterationIVStride().
+TEST_F(StrideInfoTest, StepGreaterThanOne) {
+  ModuleOp module = buildModule();
+  func::FuncOp funcOp = buildFunc(module);
+  builder->setInsertionPointToStart(&funcOp.getBody().front());
+
+  Location loc = builder->getUnknownLoc();
+
+  // scf.for %iv = 0 to 100 step 4 { %off = muli(%iv, 32) }
+  auto forOp = buildScfFor(*builder, 0, 100, 4);
+  Value iv = forOp.getInductionVar();
+  auto c32 = arith::ConstantIndexOp::create(*builder, loc, 32);
+  auto mulOp = arith::MulIOp::create(*builder, loc, iv, c32);
+
+  scf::YieldOp::create(*builder, loc);
+
+  mlir::triton::intel::ModuleAxisInfoAnalysis axisInfo(module);
+  ModuleStrideAnalysis strideAnalysis(module, axisInfo);
+
+  StrideInfo *info = strideAnalysis.getStrideInfo(mulOp);
+  ASSERT_NE(info, nullptr);
+
+  // IV-unit stride: delta per unit of IV increase = 32.
+  EXPECT_EQ(info->getIVStride(forOp, 0), 32);
+
+  // Per-iteration stride: delta per loop iteration = 32 * 4 = 128.
+  std::optional<int64_t> perIter = info->getPerIterationIVStride(forOp, 0);
+  ASSERT_TRUE(perIter.has_value());
+  EXPECT_EQ(*perIter, 128);
+}
+
+// Test 8: Nested loops — inner IV queried for outer-only-dependent value
 TEST_F(StrideInfoTest, NestedLoopsInnerIVOuterValue) {
   ModuleOp module = buildModule();
   func::FuncOp funcOp = buildFunc(module);
@@ -338,7 +370,7 @@ TEST_F(StrideInfoTest, NestedLoopsInnerIVOuterValue) {
 // PR-B (TemporalReuseAnalysis) will revisit scf.while when a consumer
 // actually exercises it.
 
-// Test 8: Spatial stride regression — tt.make_range
+// Test 9: Spatial stride regression — tt.make_range
 TEST_F(StrideInfoTest, SpatialRangeStrideOne) {
   ModuleOp module = buildModule();
   func::FuncOp funcOp = buildFunc(module);
@@ -373,7 +405,7 @@ TEST_F(StrideInfoTest, SpatialRangeStrideOne) {
   }
 }
 
-// Test 9: Spatial stride regression — tt.splat(const)
+// Test 10: Spatial stride regression — tt.splat(const)
 TEST_F(StrideInfoTest, SpatialSplatConstant) {
   ModuleOp module = buildModule();
   func::FuncOp funcOp = buildFunc(module);

--- a/third_party/intel/unittest/Analysis/StrideInfoTest.cpp
+++ b/third_party/intel/unittest/Analysis/StrideInfoTest.cpp
@@ -106,12 +106,9 @@ TEST_F(StrideInfoTest, ConstantScalarIVStrideZero) {
   StrideInfo *info = strideAnalysis.getStrideInfo(constOp);
   ASSERT_NE(info, nullptr);
 
-  // IV stride should be 0 or nullptr (both acceptable per plan)
-  const auto *ivStrideVec = info->getIVStride(forOp);
-  if (ivStrideVec != nullptr) {
-    EXPECT_EQ((*ivStrideVec)[0], 0);
-  }
-  // Also check getIVStride(loop, dim) returns 0
+  // Canonical form: constants produce no IV-stride entry.
+  EXPECT_EQ(info->getIVStride(forOp), nullptr);
+  // Scalar getter collapses absent entry to 0.
   EXPECT_EQ(info->getIVStride(forOp, 0), 0);
 }
 
@@ -398,11 +395,8 @@ TEST_F(StrideInfoTest, SpatialRangeStrideOne) {
   // Spatial stride should be 1
   EXPECT_EQ(info->getStride(0), 1);
 
-  // IV stride should be 0 or nullptr (not loop-dependent)
-  const auto *ivStrideVec = info->getIVStride(forOp);
-  if (ivStrideVec != nullptr) {
-    EXPECT_EQ((*ivStrideVec)[0], 0);
-  }
+  // Canonical form: MakeRangeOp has no loop dependence → no IV-stride entry.
+  EXPECT_EQ(info->getIVStride(forOp), nullptr);
 }
 
 // Test 10: Spatial stride regression — tt.splat(const)

--- a/third_party/intel/unittest/Analysis/StrideInfoTest.cpp
+++ b/third_party/intel/unittest/Analysis/StrideInfoTest.cpp
@@ -1,0 +1,410 @@
+#include "intel/include/Analysis/StrideInfo.h"
+#include "intel/include/Analysis/AxisInfoExt.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include <gtest/gtest.h>
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::gpu;
+using namespace mlir::triton::intel;
+
+namespace {
+
+class StrideInfoTest : public ::testing::Test {
+public:
+  void SetUp() override {
+    ctx.getOrLoadDialect<arith::ArithDialect>();
+    ctx.getOrLoadDialect<func::FuncDialect>();
+    ctx.getOrLoadDialect<scf::SCFDialect>();
+    ctx.getOrLoadDialect<TritonDialect>();
+    ctx.getOrLoadDialect<TritonGPUDialect>();
+    builder = std::make_unique<OpBuilder>(&ctx);
+  }
+
+  ModuleOp buildModule() {
+    Location loc = builder->getUnknownLoc();
+    auto module = ModuleOp::create(loc);
+    module->setAttr(AttrNumWarpsName, builder->getI32IntegerAttr(4));
+    module->setAttr(AttrNumThreadsPerWarp, builder->getI32IntegerAttr(16));
+    return module;
+  }
+
+  func::FuncOp buildFunc(ModuleOp module, StringRef name = "test_func") {
+    OpBuilder::InsertionGuard guard(*builder);
+    builder->setInsertionPointToEnd(module.getBody());
+    FunctionType funcType = builder->getFunctionType({}, {});
+    auto funcOp =
+        func::FuncOp::create(builder->getUnknownLoc(), name, funcType);
+    module.push_back(funcOp);
+    funcOp.addEntryBlock();
+    return funcOp;
+  }
+
+  scf::ForOp buildScfFor(OpBuilder &b, int64_t lowerBound, int64_t upperBound,
+                         int64_t step) {
+    Location loc = b.getUnknownLoc();
+    auto lb = arith::ConstantIndexOp::create(b, loc, lowerBound);
+    auto ub = arith::ConstantIndexOp::create(b, loc, upperBound);
+    auto stepOp = arith::ConstantIndexOp::create(b, loc, step);
+    auto forOp = scf::ForOp::create(b, loc, lb, ub, stepOp);
+    b.setInsertionPointToStart(forOp.getBody());
+    return forOp;
+  }
+
+  BlockedEncodingAttr makeBlocked(ArrayRef<unsigned> sizePerThread,
+                                  ArrayRef<unsigned> threadsPerWarp,
+                                  ArrayRef<unsigned> warpsPerCTA,
+                                  ArrayRef<unsigned> order) {
+    auto cgaLayout = CGAEncodingAttr::get1CTALayout(&ctx, order.size());
+    return BlockedEncodingAttr::get(&ctx, sizePerThread, threadsPerWarp,
+                                    warpsPerCTA, order, cgaLayout);
+  }
+
+  BlockArgument addPtrArg(func::FuncOp funcOp, Type elemTy,
+                          unsigned addressSpace = 1) {
+    Block *block = &funcOp.getBody().front();
+    auto ptrTy = PointerType::get(elemTy, addressSpace);
+    FunctionType newFuncType = builder->getFunctionType(
+        {ptrTy}, funcOp.getFunctionType().getResults());
+    funcOp.setType(newFuncType);
+    return block->addArgument(ptrTy, builder->getUnknownLoc());
+  }
+
+protected:
+  MLIRContext ctx;
+  std::unique_ptr<OpBuilder> builder;
+};
+
+// Test 1: Constant scalar has IV stride 0 for any loop
+TEST_F(StrideInfoTest, ConstantScalarIVStrideZero) {
+  ModuleOp module = buildModule();
+  func::FuncOp funcOp = buildFunc(module);
+  builder->setInsertionPointToStart(&funcOp.getBody().front());
+
+  // Build a constant
+  Location loc = builder->getUnknownLoc();
+  auto constOp =
+      arith::ConstantIntOp::create(*builder, loc, builder->getI64Type(), 42);
+
+  // Build a dummy loop
+  auto forOp = buildScfFor(*builder, 0, 10, 1);
+  scf::YieldOp::create(*builder, loc);
+
+  // Run analysis
+  mlir::triton::intel::ModuleAxisInfoAnalysis axisInfo(module);
+  ModuleStrideAnalysis strideAnalysis(module, axisInfo);
+
+  StrideInfo *info = strideAnalysis.getStrideInfo(constOp);
+  ASSERT_NE(info, nullptr);
+
+  // IV stride should be 0 or nullptr (both acceptable per plan)
+  const auto *ivStrideVec = info->getIVStride(forOp);
+  if (ivStrideVec != nullptr) {
+    EXPECT_EQ((*ivStrideVec)[0], 0);
+  }
+  // Also check getIVStride(loop, dim) returns 0
+  EXPECT_EQ(info->getIVStride(forOp, 0), 0);
+}
+
+// Test 2: Loop IV has stride 1 w.r.t. its own loop, 0 w.r.t. other loop
+TEST_F(StrideInfoTest, LoopIVOwnLoop) {
+  ModuleOp module = buildModule();
+  func::FuncOp funcOp = buildFunc(module);
+  builder->setInsertionPointToStart(&funcOp.getBody().front());
+
+  Location loc = builder->getUnknownLoc();
+
+  // Build first loop
+  auto forOp1 = buildScfFor(*builder, 0, 10, 1);
+  Value iv1 = forOp1.getInductionVar();
+  scf::YieldOp::create(*builder, loc);
+
+  // Build second independent loop
+  builder->setInsertionPointAfter(forOp1);
+  auto forOp2 = buildScfFor(*builder, 0, 10, 1);
+  scf::YieldOp::create(*builder, loc);
+
+  // Run analysis
+  mlir::triton::intel::ModuleAxisInfoAnalysis axisInfo(module);
+  ModuleStrideAnalysis strideAnalysis(module, axisInfo);
+
+  StrideInfo *info = strideAnalysis.getStrideInfo(iv1);
+  ASSERT_NE(info, nullptr);
+
+  // IV stride w.r.t. its own loop should be 1
+  EXPECT_EQ(info->getIVStride(forOp1, 0), 1);
+
+  // IV stride w.r.t. unrelated loop should be 0
+  EXPECT_EQ(info->getIVStride(forOp2, 0), 0);
+}
+
+// Test 3: arith.muli(iv, 128) → IV stride 128
+TEST_F(StrideInfoTest, MulIVByConstant) {
+  ModuleOp module = buildModule();
+  func::FuncOp funcOp = buildFunc(module);
+  builder->setInsertionPointToStart(&funcOp.getBody().front());
+
+  Location loc = builder->getUnknownLoc();
+
+  auto forOp = buildScfFor(*builder, 0, 10, 1);
+  Value iv = forOp.getInductionVar();
+
+  // iv * 128 — iv is index-typed, so use ConstantIndexOp for the multiplier.
+  auto c128 = arith::ConstantIndexOp::create(*builder, loc, 128);
+  auto mulOp = arith::MulIOp::create(*builder, loc, iv, c128);
+
+  scf::YieldOp::create(*builder, loc);
+
+  // Run analysis
+  mlir::triton::intel::ModuleAxisInfoAnalysis axisInfo(module);
+  ModuleStrideAnalysis strideAnalysis(module, axisInfo);
+
+  StrideInfo *info = strideAnalysis.getStrideInfo(mulOp);
+  ASSERT_NE(info, nullptr);
+
+  EXPECT_EQ(info->getIVStride(forOp, 0), 128);
+}
+
+// Test 4: arith.addi(iv, const) → IV stride 1
+TEST_F(StrideInfoTest, AddIVConstant) {
+  ModuleOp module = buildModule();
+  func::FuncOp funcOp = buildFunc(module);
+  builder->setInsertionPointToStart(&funcOp.getBody().front());
+
+  Location loc = builder->getUnknownLoc();
+
+  auto forOp = buildScfFor(*builder, 0, 10, 1);
+  Value iv = forOp.getInductionVar();
+
+  // iv + 5 — iv is index-typed.
+  auto c5 = arith::ConstantIndexOp::create(*builder, loc, 5);
+  auto addOp = arith::AddIOp::create(*builder, loc, iv, c5);
+
+  scf::YieldOp::create(*builder, loc);
+
+  // Run analysis
+  mlir::triton::intel::ModuleAxisInfoAnalysis axisInfo(module);
+  ModuleStrideAnalysis strideAnalysis(module, axisInfo);
+
+  StrideInfo *info = strideAnalysis.getStrideInfo(addOp);
+  ASSERT_NE(info, nullptr);
+
+  EXPECT_EQ(info->getIVStride(forOp, 0), 1);
+}
+
+// Test 5: tt.splat(muli(iv, 128)) → IV stride [128]
+TEST_F(StrideInfoTest, SplatMulIV) {
+  ModuleOp module = buildModule();
+  func::FuncOp funcOp = buildFunc(module);
+  builder->setInsertionPointToStart(&funcOp.getBody().front());
+
+  Location loc = builder->getUnknownLoc();
+
+  auto forOp = buildScfFor(*builder, 0, 10, 1);
+  Value iv = forOp.getInductionVar();
+
+  // iv * 128 — iv is index-typed; cast the product to i64 before splatting.
+  auto c128 = arith::ConstantIndexOp::create(*builder, loc, 128);
+  auto mulOp = arith::MulIOp::create(*builder, loc, iv, c128);
+  Type i64Ty = builder->getI64Type();
+  auto mulI64 = arith::IndexCastOp::create(*builder, loc, i64Ty, mulOp);
+
+  // splat to tensor<128xi64>
+  auto encoding = makeBlocked({1}, {16}, {4}, {0});
+  auto tensorTy = RankedTensorType::get({128}, i64Ty, encoding);
+  auto splatOp = SplatOp::create(*builder, loc, tensorTy, mulI64);
+
+  scf::YieldOp::create(*builder, loc);
+
+  // Run analysis
+  mlir::triton::intel::ModuleAxisInfoAnalysis axisInfo(module);
+  ModuleStrideAnalysis strideAnalysis(module, axisInfo);
+
+  StrideInfo *info = strideAnalysis.getStrideInfo(splatOp);
+  ASSERT_NE(info, nullptr);
+  EXPECT_EQ(info->getRank(), 1u);
+
+  // IV stride should be [128] for dim 0
+  EXPECT_EQ(info->getIVStride(forOp, 0), 128);
+}
+
+// Test 6: 1-D streaming case: addptr(splat(base), splat(muli(iv, 128)))
+TEST_F(StrideInfoTest, OneDimStreamingAddPtr) {
+  ModuleOp module = buildModule();
+  func::FuncOp funcOp = buildFunc(module);
+
+  // Add a pointer argument
+  Type f16Ty = builder->getF16Type();
+  BlockArgument basePtr = addPtrArg(funcOp, f16Ty);
+
+  builder->setInsertionPointToStart(&funcOp.getBody().front());
+  Location loc = builder->getUnknownLoc();
+
+  auto forOp = buildScfFor(*builder, 0, 10, 1);
+  Value iv = forOp.getInductionVar();
+
+  // iv * 128 — iv is index-typed; cast the product to i64 for the offset splat.
+  auto c128 = arith::ConstantIndexOp::create(*builder, loc, 128);
+  auto mulOp = arith::MulIOp::create(*builder, loc, iv, c128);
+  Type i64Ty = builder->getI64Type();
+  auto mulI64 = arith::IndexCastOp::create(*builder, loc, i64Ty, mulOp);
+
+  // Create tensor<128x!tt.ptr<f16>> type
+  auto encoding = makeBlocked({1}, {16}, {4}, {0});
+  auto ptrTy = PointerType::get(f16Ty, 1);
+  auto tensorPtrTy = RankedTensorType::get({128}, ptrTy, encoding);
+
+  // splat(base_ptr)
+  auto baseSplat = SplatOp::create(*builder, loc, tensorPtrTy, basePtr);
+
+  // splat(muli(iv, 128))
+  auto tensorI64Ty = RankedTensorType::get({128}, i64Ty, encoding);
+  auto offsetSplat = SplatOp::create(*builder, loc, tensorI64Ty, mulI64);
+
+  // addptr
+  auto addPtrOp =
+      AddPtrOp::create(*builder, loc, tensorPtrTy, baseSplat, offsetSplat);
+
+  scf::YieldOp::create(*builder, loc);
+
+  // Run analysis
+  mlir::triton::intel::ModuleAxisInfoAnalysis axisInfo(module);
+  ModuleStrideAnalysis strideAnalysis(module, axisInfo);
+
+  StrideInfo *info = strideAnalysis.getStrideInfo(addPtrOp);
+  ASSERT_NE(info, nullptr);
+  EXPECT_EQ(info->getRank(), 1u);
+
+  // IV stride should be 128 (streaming access)
+  EXPECT_EQ(info->getIVStride(forOp, 0), 128);
+
+  // Spatial stride should be 0 (base is splatted)
+  EXPECT_EQ(info->getStride(0), 0);
+}
+
+// Test 7: Nested loops — inner IV queried for outer-only-dependent value
+TEST_F(StrideInfoTest, NestedLoopsInnerIVOuterValue) {
+  ModuleOp module = buildModule();
+  func::FuncOp funcOp = buildFunc(module);
+  builder->setInsertionPointToStart(&funcOp.getBody().front());
+
+  Location loc = builder->getUnknownLoc();
+
+  // Outer loop
+  auto outerForOp = buildScfFor(*builder, 0, 10, 1);
+  Value outerIV = outerForOp.getInductionVar();
+
+  // outerIV * 16 — outerIV is index-typed.
+  auto c16 = arith::ConstantIndexOp::create(*builder, loc, 16);
+  auto mulOp = arith::MulIOp::create(*builder, loc, outerIV, c16);
+
+  // Inner loop
+  auto innerForOp = buildScfFor(*builder, 0, 5, 1);
+  scf::YieldOp::create(*builder, loc);
+
+  // Close outer loop
+  builder->setInsertionPointAfter(innerForOp);
+  scf::YieldOp::create(*builder, loc);
+
+  // Run analysis
+  mlir::triton::intel::ModuleAxisInfoAnalysis axisInfo(module);
+  ModuleStrideAnalysis strideAnalysis(module, axisInfo);
+
+  StrideInfo *info = strideAnalysis.getStrideInfo(mulOp);
+  ASSERT_NE(info, nullptr);
+
+  // Query w.r.t. inner loop: should be 0 (outer-IV-derived, doesn't change in
+  // inner)
+  EXPECT_EQ(info->getIVStride(innerForOp, 0), 0);
+
+  // Query w.r.t. outer loop: should be 16
+  EXPECT_EQ(info->getIVStride(outerForOp, 0), 16);
+}
+
+// scf.while IV-stride seeding is intentionally deferred: its before-region
+// args are control-flow-fed from the init operands, which bypasses the
+// `visitNonControlFlowArguments` hook used to seed the scf.for IV column.
+// Handling it requires overriding the solver's region-successor propagation,
+// which is out of scope for the streaming-pattern regression this PR targets.
+// PR-B (TemporalReuseAnalysis) will revisit scf.while when a consumer
+// actually exercises it.
+
+// Test 9: Spatial stride regression — tt.make_range
+TEST_F(StrideInfoTest, SpatialRangeStrideOne) {
+  ModuleOp module = buildModule();
+  func::FuncOp funcOp = buildFunc(module);
+  builder->setInsertionPointToStart(&funcOp.getBody().front());
+
+  Location loc = builder->getUnknownLoc();
+
+  // tt.make_range {start=0, end=128} : tensor<128xi32>
+  auto encoding = makeBlocked({1}, {16}, {4}, {0});
+  auto tensorTy = RankedTensorType::get({128}, builder->getI32Type(), encoding);
+  auto rangeOp = MakeRangeOp::create(*builder, loc, tensorTy, 0, 128);
+
+  // Build a dummy loop to test IV stride is empty/zero
+  auto forOp = buildScfFor(*builder, 0, 10, 1);
+  scf::YieldOp::create(*builder, loc);
+
+  // Run analysis
+  mlir::triton::intel::ModuleAxisInfoAnalysis axisInfo(module);
+  ModuleStrideAnalysis strideAnalysis(module, axisInfo);
+
+  StrideInfo *info = strideAnalysis.getStrideInfo(rangeOp);
+  ASSERT_NE(info, nullptr);
+  EXPECT_EQ(info->getRank(), 1u);
+
+  // Spatial stride should be 1
+  EXPECT_EQ(info->getStride(0), 1);
+
+  // IV stride should be 0 or nullptr (not loop-dependent)
+  const auto *ivStrideVec = info->getIVStride(forOp);
+  if (ivStrideVec != nullptr) {
+    EXPECT_EQ((*ivStrideVec)[0], 0);
+  }
+}
+
+// Test 10: Spatial stride regression — tt.splat(const)
+TEST_F(StrideInfoTest, SpatialSplatConstant) {
+  ModuleOp module = buildModule();
+  func::FuncOp funcOp = buildFunc(module);
+  builder->setInsertionPointToStart(&funcOp.getBody().front());
+
+  Location loc = builder->getUnknownLoc();
+
+  // Constant
+  auto c0 =
+      arith::ConstantIntOp::create(*builder, loc, builder->getI32Type(), 0);
+
+  // tt.splat(c0) : tensor<128xi32>
+  auto encoding = makeBlocked({1}, {16}, {4}, {0});
+  auto tensorTy = RankedTensorType::get({128}, builder->getI32Type(), encoding);
+  auto splatOp = SplatOp::create(*builder, loc, tensorTy, c0);
+
+  // Build a dummy loop
+  auto forOp = buildScfFor(*builder, 0, 10, 1);
+  scf::YieldOp::create(*builder, loc);
+
+  // Run analysis
+  mlir::triton::intel::ModuleAxisInfoAnalysis axisInfo(module);
+  ModuleStrideAnalysis strideAnalysis(module, axisInfo);
+
+  StrideInfo *info = strideAnalysis.getStrideInfo(splatOp);
+  ASSERT_NE(info, nullptr);
+  EXPECT_EQ(info->getRank(), 1u);
+
+  // Spatial stride should be 0 (splat)
+  EXPECT_EQ(info->getStride(0), 0);
+
+  // IV stride should be 0 (constant value)
+  EXPECT_EQ(info->getIVStride(forOp, 0), 0);
+}
+
+} // namespace


### PR DESCRIPTION
Closes #6857.

Spatial stride can't distinguish a loop-invariant pointer from a 1-D streaming pointer — both have spatial stride `[0]`. Add a second column to `StrideInfo`: a per-loop IV-stride map keyed by `LoopLikeOpInterface`, recording how a value's address shifts across iterations of each enclosing loop.

Arithmetic visitors share one Template Method (`StrideArithVisitor`) so they can't forget to propagate a column; splat is bespoke (spatial 0, IV value broadcast). `scf.for` seeds IV-stride 1 on its own loop; `scf.while` is deferred to the first consumer.

Existing `getStride()` callers are unaffected.