### PR TITLE
Rewrite `findDefiningOpOfType` as worklist-based `findAllMakeTensorDescOps`

### DIFF
--- a/test/Triton/rewrite-tensor-descriptor-loop-carried.mlir
+++ b/test/Triton/rewrite-tensor-descriptor-loop-carried.mlir
@@ -1,0 +1,59 @@
+// RUN: env TRITON_INTEL_DISABLE_DESCRIPTOR_GATHER_SCATTER_REWRITE=1 triton-opt %s --triton-intel-rewrite-tensor-descriptor-to-pointer --split-input-file | FileCheck %s
+
+// Test that scf.for carrying tensor descriptors with candidate MakeTensorDescOps
+// is NOT converted to pointer-based operations. The descriptor load/store and the
+// loop should remain in tensor descriptor form.
+
+module {
+  // CHECK-LABEL: tt.func @for_loop_carried_desc
+  tt.func @for_loop_carried_desc(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %M: i32 {tt.divisibility = 16 : i32}, %N: i32 {tt.divisibility = 16 : i32}) -> tensor<8x128xf32> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %stride = arith.extsi %N : i32 to i64
+    %desc = tt.make_tensor_descriptor %arg0, [%M, %N], [%stride, %c1_i64] : !tt.ptr<f32>, !tt.tensordesc<8x128xf32>
+    // CHECK: tt.make_tensor_descriptor
+    // CHECK: scf.for
+    %result:2 = scf.for %iv = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%iter_desc = %desc, %acc = %c0_i32) -> (!tt.tensordesc<8x128xf32>, i32) : i32 {
+      // CHECK: tt.descriptor_load
+      %ld = tt.descriptor_load %iter_desc[%c0_i32, %acc] : !tt.tensordesc<8x128xf32> -> tensor<8x128xf32>
+      tt.descriptor_store %iter_desc[%c0_i32, %acc], %ld : !tt.tensordesc<8x128xf32>, tensor<8x128xf32>
+      %next = arith.addi %acc, %c1_i32 : i32
+      scf.yield %iter_desc, %next : !tt.tensordesc<8x128xf32>, i32
+    }
+    %final = tt.descriptor_load %result#0[%c0_i32, %c0_i32] : !tt.tensordesc<8x128xf32> -> tensor<8x128xf32>
+    tt.return %final : tensor<8x128xf32>
+  }
+}
+
+// -----
+
+// Test that scf.for with loop-carried descriptor reassigned inside the loop
+// (two MakeTensorDescOps) preserves tensor descriptor form.
+
+module {
+  // CHECK-LABEL: tt.func @for_loop_carried_reassigned_desc
+  tt.func @for_loop_carried_reassigned_desc(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %M: i32 {tt.divisibility = 16 : i32}, %N: i32 {tt.divisibility = 16 : i32}, %cond: i1) -> tensor<8x128xf32> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %stride = arith.extsi %N : i32 to i64
+    %desc_outer = tt.make_tensor_descriptor %arg0, [%M, %N], [%stride, %c1_i64] : !tt.ptr<f32>, !tt.tensordesc<8x128xf32>
+    // CHECK: tt.make_tensor_descriptor
+    // CHECK: scf.for
+    %result:2 = scf.for %iv = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%iter_desc = %desc_outer, %acc = %c0_i32) -> (!tt.tensordesc<8x128xf32>, i32) : i32 {
+      // CHECK: tt.descriptor_load
+      %ld = tt.descriptor_load %iter_desc[%c0_i32, %acc] : !tt.tensordesc<8x128xf32> -> tensor<8x128xf32>
+      tt.descriptor_store %iter_desc[%c0_i32, %acc], %ld : !tt.tensordesc<8x128xf32>, tensor<8x128xf32>
+      // CHECK: tt.make_tensor_descriptor
+      %desc_inner = tt.make_tensor_descriptor %arg0, [%M, %N], [%stride, %c1_i64] : !tt.ptr<f32>, !tt.tensordesc<8x128xf32>
+      %new_desc = arith.select %cond, %desc_inner, %iter_desc : !tt.tensordesc<8x128xf32>
+      %next = arith.addi %acc, %c1_i32 : i32
+      scf.yield %new_desc, %next : !tt.tensordesc<8x128xf32>, i32
+    }
+    %final = tt.descriptor_load %result#0[%c0_i32, %c0_i32] : !tt.tensordesc<8x128xf32> -> tensor<8x128xf32>
+    tt.return %final : tensor<8x128xf32>
+  }
+}

--- a/test/TritonIntelGPU/find-defining-op-loops.mlir
+++ b/test/TritonIntelGPU/find-defining-op-loops.mlir
@@ -1,0 +1,77 @@
+// RUN: triton-opt %s -split-input-file --tritonintelgpu-materialize-block-pointer | FileCheck %s
+
+// COM: scf.for with pass-through yield (descriptor unchanged across iterations).
+// COM: findAllMakeTensorDescOps should resolve to the unique MakeTensorDescOp.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot_a = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @for_passthrough_yield
+  tt.func @for_passthrough_yield(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %pitch: i64 {tt.divisibility = 16 : i32}) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i32 = arith.constant 64 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %desc = tt.make_tensor_descriptor %arg0, [%c64_i32, %c32_i32], [%pitch, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<64x32xf16, #dot_a>
+    %result = scf.for %iv = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%iter_desc = %desc) -> (!tt.tensordesc<64x32xf16, #dot_a>) : i32 {
+      // CHECK: tt.descriptor_load {{.*}} {ttig.block_io = "row_major"{{.*}}}
+      %ld = tt.descriptor_load %iter_desc[%c0_i32, %c0_i32] : !tt.tensordesc<64x32xf16, #dot_a> -> tensor<64x32xf16, #dot_a>
+      scf.yield %iter_desc : !tt.tensordesc<64x32xf16, #dot_a>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// COM: scf.for where the yield provides a different MakeTensorDescOp with compatible
+// COM: alignment properties. All candidates satisfy constraints, so block_io is set.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot_a = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @for_multiple_compatible_descs
+  tt.func @for_multiple_compatible_descs(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %pitch: i64 {tt.divisibility = 16 : i32}) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i32 = arith.constant 64 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %desc1 = tt.make_tensor_descriptor %arg0, [%c64_i32, %c32_i32], [%pitch, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<64x32xf16, #dot_a>
+    %desc2 = tt.make_tensor_descriptor %arg1, [%c64_i32, %c32_i32], [%pitch, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<64x32xf16, #dot_a>
+    %result = scf.for %iv = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%iter_desc = %desc1) -> (!tt.tensordesc<64x32xf16, #dot_a>) : i32 {
+      // CHECK: tt.descriptor_load {{.*}} {ttig.block_io = "row_major"{{.*}}}
+      %ld = tt.descriptor_load %iter_desc[%c0_i32, %c0_i32] : !tt.tensordesc<64x32xf16, #dot_a> -> tensor<64x32xf16, #dot_a>
+      scf.yield %desc2 : !tt.tensordesc<64x32xf16, #dot_a>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// COM: scf.for where the yield provides a MakeTensorDescOp with incompatible
+// COM: pitch (not divisible by 128/elementWidth). block_io should NOT be set.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot_a = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @for_incompatible_pitch
+  tt.func @for_incompatible_pitch(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %pitch_good: i64 {tt.divisibility = 16 : i32}, %pitch_bad: i64 {tt.divisibility = 3 : i32}) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i32 = arith.constant 64 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %desc1 = tt.make_tensor_descriptor %arg0, [%c64_i32, %c32_i32], [%pitch_good, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<64x32xf16, #dot_a>
+    %desc2 = tt.make_tensor_descriptor %arg1, [%c64_i32, %c32_i32], [%pitch_bad, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<64x32xf16, #dot_a>
+    %result = scf.for %iv = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%iter_desc = %desc1) -> (!tt.tensordesc<64x32xf16, #dot_a>) : i32 {
+      // CHECK: tt.descriptor_load
+      // CHECK-NOT: ttig.block_io
+      %ld = tt.descriptor_load %iter_desc[%c0_i32, %c0_i32] : !tt.tensordesc<64x32xf16, #dot_a> -> tensor<64x32xf16, #dot_a>
+      scf.yield %desc2 : !tt.tensordesc<64x32xf16, #dot_a>
+    }
+    tt.return
+  }
+}

--- a/third_party/intel/include/Analysis/AliasAnalysis.h
+++ b/third_party/intel/include/Analysis/AliasAnalysis.h
@@ -26,7 +26,7 @@ namespace mlir::triton::intel {
 ///   - "Modeled" ops with known pointer resolution:
 ///     `tt.load/store/atomic_rmw/atomic_cas` and the five
 ///     `tt.descriptor_*` ops (base resolved through
-///     `findDefiningOpOfType<MakeTensorDescOp>`).
+///     `findAllMakeTensorDescOps`).
 ///   - Any other op implementing `MemoryEffectOpInterface` with at
 ///     least one `MemoryEffects::Read` or `MemoryEffects::Write`
 ///     effect. For these, the pointer is the first pointer-like

--- a/third_party/intel/include/Utils/Utility.h
+++ b/third_party/intel/include/Utils/Utility.h
@@ -1,16 +1,11 @@
 #ifndef TRITON_INTEL_UTILS_UTILITY_H
 #define TRITON_INTEL_UTILS_UTILITY_H
 
-#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Value.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
 namespace mlir {
-namespace triton {
-class MakeTensorDescOp;
-} // namespace triton
-
 class FunctionOpInterface;
 class LoopLikeOpInterface;
 } // namespace mlir
@@ -38,83 +33,15 @@ Value getFinalValue(Value value);
 // Erase the operations in \p operations.
 void eraseOperations(SmallPtrSetImpl<Operation *> &operations);
 
-// Find the defining operation of type `OpTy` for the given value.
-// Note: traverses block arguments and loop yields, etc...
-template <typename OpTy, typename = std::enable_if<std::is_same<
-                             OpTy, triton::MakeTensorDescOp>::value>>
-std::optional<OpTy> findDefiningOpOfType(Value val) {
-  if (auto arg = dyn_cast<BlockArgument>(val)) {
-    Operation *parentOp = arg.getParentBlock()->getParentOp();
-    if (!parentOp || isa<FunctionOpInterface>(parentOp))
-      return std::nullopt;
+// Find all MakeTensorDescOps reachable from the given value.
+// Traverses block arguments, loop yields, if/select branches, etc.
+// Returns a deduplicated list of all reachable ops, or an empty list if any
+// path leads to an untraceable value (e.g., function call, unknown op).
+SmallVector<triton::MakeTensorDescOp> findAllMakeTensorDescOps(Value val);
 
-    Value loopArg;
-    if (auto forOp = dyn_cast<scf::ForOp>(parentOp))
-      loopArg = forOp.getInitArgs()[arg.getArgNumber() - 1];
-    else if (auto whileOp = dyn_cast<scf::WhileOp>(parentOp))
-      loopArg = whileOp.getInits()[arg.getArgNumber()];
-    else
-      llvm_unreachable("Unexpected parent operator");
-
-    return findDefiningOpOfType<OpTy>(loopArg);
-  }
-
-  if (auto poisonOp = val.getDefiningOp<ub::PoisonOp>())
-    return std::nullopt;
-  if (auto callOp = val.getDefiningOp<triton::CallOp>())
-    return std::nullopt;
-  if (auto makePtrOp = val.getDefiningOp<OpTy>())
-    return makePtrOp;
-  if (auto opRes = dyn_cast<OpResult>(val)) {
-    Operation *defOp = opRes.getOwner();
-    if (auto loopOp = dyn_cast<LoopLikeOpInterface>(defOp))
-      return findDefiningOpOfType<OpTy>(
-          loopOp.getYieldedValues()[opRes.getResultNumber()]);
-    if (auto ifOp = dyn_cast<scf::IfOp>(defOp)) {
-      // Give up if the 2 possible definitions aren't the same.
-      Region &thenRgn = ifOp.getThenRegion();
-      Region &elseRgn = ifOp.getElseRegion();
-      if (thenRgn.empty() || elseRgn.empty())
-        return std::nullopt;
-      assert(thenRgn.hasOneBlock() && elseRgn.hasOneBlock() &&
-             "Expecting single blocks on both the 'then' and 'else' regions");
-      auto thenYieldOp =
-               cast<scf::YieldOp>(thenRgn.getBlocks().front().getTerminator()),
-           elseYieldOp =
-               cast<scf::YieldOp>(elseRgn.getBlocks().front().getTerminator());
-      Value thenVal = thenYieldOp->getOperand(opRes.getResultNumber()),
-            elseVal = elseYieldOp->getOperand(opRes.getResultNumber());
-      std::optional<OpTy> thenDef = findDefiningOpOfType<OpTy>(thenVal),
-                          elseDef = findDefiningOpOfType<OpTy>(elseVal);
-      if (!thenDef || !elseDef || *thenDef != *elseDef)
-        return std::nullopt;
-      return thenDef;
-    }
-    if (auto selectOp = dyn_cast<arith::SelectOp>(defOp)) {
-      // Give up if the 2 possible definitions aren't the same.
-      Value trueVal = selectOp.getTrueValue(),
-            falseVal = selectOp.getFalseValue();
-      std::optional<OpTy> trueDef = findDefiningOpOfType<OpTy>(trueVal),
-                          falseDef = findDefiningOpOfType<OpTy>(falseVal);
-      if (!trueDef || !falseDef || *trueDef != *falseDef)
-        return std::nullopt;
-      return trueDef;
-    }
-    if (auto castOp = dyn_cast<mlir::UnrealizedConversionCastOp>(defOp)) {
-      // Follow through unrealized conversion casts inserted by the type
-      // conversion framework (e.g. applyPartialConversion remapping of
-      // function arguments).
-      if (castOp.getInputs().size() == 1)
-        return findDefiningOpOfType<OpTy>(castOp.getInputs()[0]);
-      return std::nullopt;
-    }
-
-    llvm::errs() << "defOp: " << *defOp << "\n";
-    assert(false && "unhandled operation");
-  }
-
-  return std::nullopt;
-}
+// Find the unique MakeTensorDescOp for the given value.
+// Returns the op only if all reachable paths lead to the same one.
+std::optional<triton::MakeTensorDescOp> findMakeTensorDescOp(Value val);
 
 } // namespace mlir::triton::intel
 

--- a/third_party/intel/include/Utils/Utility.h
+++ b/third_party/intel/include/Utils/Utility.h
@@ -5,6 +5,8 @@
 #include "mlir/IR/Value.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
+#include <optional>
+
 namespace mlir {
 class FunctionOpInterface;
 class LoopLikeOpInterface;

--- a/third_party/intel/lib/Analysis/AliasAnalysis.cpp
+++ b/third_party/intel/lib/Analysis/AliasAnalysis.cpp
@@ -97,16 +97,11 @@ static Value getMemOpPointer(Operation *op) {
             tt::DescriptorScatterOp, tt::DescriptorReduceOp>(
           [](auto op) -> Value {
             Value desc = op.getDesc();
-            // TODO(#6862): once the worklist-based findAllMakeTensorDescOps
-            // lands, iterate all reachable MakeTensorDescOps and union their
-            // base pointers, degrading to Unknown on any irresolvable base.
-            // The single-op resolution here may pick a stale init-args
-            // descriptor for loop-carried descs.
-            if (std::optional<tt::MakeTensorDescOp> makeDesc =
-                    findDefiningOpOfType<tt::MakeTensorDescOp>(desc))
-              return makeDesc->getBase();
-            // Couldn't resolve to a MakeTensorDescOp — keep the op alive
-            // by returning the descriptor itself as an opaque sentinel.
+            auto allDescs = tt::intel::findAllMakeTensorDescOps(desc);
+            if (allDescs.size() == 1)
+              return allDescs[0].getBase();
+            // Couldn't resolve to a unique MakeTensorDescOp — keep the op
+            // alive by returning the descriptor itself as an opaque sentinel.
             return desc;
           })
       .Default([](Operation *op) -> Value {

--- a/third_party/intel/lib/Dialect/Triton/Transforms/FuseReshape.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/FuseReshape.cpp
@@ -56,8 +56,7 @@ public:
         llvm::TypeSwitch<Operation *>(srcOp)
             .Case<tt::DescriptorLoadOp>([&](auto descLoadOp) {
               auto makeTensorDescOp =
-                  *tt::intel::findDefiningOpOfType<tt::MakeTensorDescOp>(
-                      descLoadOp.getDesc());
+                  *tt::intel::findMakeTensorDescOp(descLoadOp.getDesc());
               manager.createChains(makeTensorDescOp, reshapeOp);
             })
             .Default([](Operation *) {});
@@ -265,8 +264,7 @@ private:
       return false;
 
     std::optional<tt::MakeTensorDescOp> makeTensorDescOp =
-        tt::intel::findDefiningOpOfType<tt::MakeTensorDescOp>(
-            descLoadOp.getDesc());
+        tt::intel::findMakeTensorDescOp(descLoadOp.getDesc());
     if (!makeTensorDescOp)
       return false;
 

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
@@ -1122,26 +1122,37 @@ class TritonRewriteTensorDescriptorToPointerPass
       candidateMakeTensorDescOps.remove(op);
 
     mlir::ConversionTarget target(getContext());
-    target.addDynamicallyLegalDialect<
-        mlir::arith::ArithDialect, mlir::scf::SCFDialect,
-        mlir::triton::TritonDialect>([&](mlir::Operation *op) {
-      if (!hasATensorDescriptorType(op->getOperandTypes()) &&
-          !hasATensorDescriptorType(op->getResultTypes()))
-        return true;
+    target.addDynamicallyLegalDialect<mlir::arith::ArithDialect,
+                                      mlir::scf::SCFDialect,
+                                      mlir::triton::TritonDialect>(
+        [&](mlir::Operation *op) {
+          if (!hasATensorDescriptorType(op->getOperandTypes()) &&
+              !hasATensorDescriptorType(op->getResultTypes()))
+            return true;
 
-      return TypeSwitch<Operation *, bool>(op)
-          .Case<triton::MakeTensorDescOp>(
-              [&](auto op) { return candidateMakeTensorDescOps.contains(op); })
-          .Case<triton::DescriptorLoadOp, triton::DescriptorStoreOp>(
-              [&](auto op) {
-                auto allDescs =
-                    triton::intel::findAllMakeTensorDescOps(op.getDesc());
-                return !allDescs.empty() && llvm::all_of(allDescs, [&](auto d) {
-                  return candidateMakeTensorDescOps.contains(d);
-                });
+          // Check if all tensor descriptor values in the op trace back to
+          // candidate MakeTensorDescOps.
+          auto allDescValuesAreCandidate = [&](Operation *op) {
+            for (Value operand : op->getOperands()) {
+              if (!isa<triton::TensorDescType>(operand.getType()))
+                continue;
+              auto allDescs = triton::intel::findAllMakeTensorDescOps(operand);
+              if (allDescs.empty())
+                return false;
+              if (!llvm::all_of(allDescs, [&](auto d) {
+                    return candidateMakeTensorDescOps.contains(d);
+                  }))
+                return false;
+            }
+            return true;
+          };
+
+          return TypeSwitch<Operation *, bool>(op)
+              .Case<triton::MakeTensorDescOp>([&](auto op) {
+                return candidateMakeTensorDescOps.contains(op);
               })
-          .Default([](auto) { return false; });
-    });
+              .Default([&](auto *op) { return allDescValuesAreCandidate(op); });
+        });
     target.addDynamicallyLegalOp<triton::FuncOp>([](triton::FuncOp funcOp) {
       return !hasATensorDescriptorType(funcOp.getFunctionType().getInputs()) &&
              !hasATensorDescriptorType(funcOp.getFunctionType().getResults());

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
@@ -1104,21 +1104,16 @@ class TritonRewriteTensorDescriptorToPointerPass
         unhandledMakeTensorDescOps;
     op->walk([&](Operation *op) {
       TypeSwitch<Operation *>(op)
-          .Case<triton::DescriptorLoadOp,
-                triton::DescriptorStoreOp>([&](auto op) {
-            auto makeTensorDescOp =
-                triton::intel::findDefiningOpOfType<triton::MakeTensorDescOp>(
-                    op.getDesc());
-            if (makeTensorDescOp.has_value())
-              candidateMakeTensorDescOps.insert(*makeTensorDescOp);
-          })
+          .Case<triton::DescriptorLoadOp, triton::DescriptorStoreOp>(
+              [&](auto op) {
+                for (auto d :
+                     triton::intel::findAllMakeTensorDescOps(op.getDesc()))
+                  candidateMakeTensorDescOps.insert(d);
+              })
           .Case<triton::DescriptorGatherOp, triton::DescriptorScatterOp,
                 triton::DescriptorReduceOp>([&](auto op) {
-            auto makeTensorDescOp =
-                triton::intel::findDefiningOpOfType<triton::MakeTensorDescOp>(
-                    op.getDesc());
-            if (makeTensorDescOp.has_value())
-              unhandledMakeTensorDescOps.insert(*makeTensorDescOp);
+            for (auto d : triton::intel::findAllMakeTensorDescOps(op.getDesc()))
+              unhandledMakeTensorDescOps.insert(d);
           })
           .Default([](auto) {});
       return WalkResult::advance();
@@ -1137,14 +1132,14 @@ class TritonRewriteTensorDescriptorToPointerPass
       return TypeSwitch<Operation *, bool>(op)
           .Case<triton::MakeTensorDescOp>(
               [&](auto op) { return candidateMakeTensorDescOps.contains(op); })
-          .Case<triton::DescriptorLoadOp,
-                triton::DescriptorStoreOp>([&](auto op) {
-            auto makeTensorDescOp =
-                triton::intel::findDefiningOpOfType<triton::MakeTensorDescOp>(
-                    op.getDesc());
-            return makeTensorDescOp.has_value() &&
-                   candidateMakeTensorDescOps.contains(*makeTensorDescOp);
-          })
+          .Case<triton::DescriptorLoadOp, triton::DescriptorStoreOp>(
+              [&](auto op) {
+                auto allDescs =
+                    triton::intel::findAllMakeTensorDescOps(op.getDesc());
+                return !allDescs.empty() && llvm::all_of(allDescs, [&](auto d) {
+                  return candidateMakeTensorDescOps.contains(d);
+                });
+              })
           .Default([](auto) { return false; });
     });
     target.addDynamicallyLegalOp<triton::FuncOp>([](triton::FuncOp funcOp) {

--- a/third_party/intel/lib/Dialect/Triton/Transforms/StrideVersioning.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/StrideVersioning.cpp
@@ -47,7 +47,7 @@ public:
 private:
   bool isCandidate(tt::DescriptorLoadOp loadOp) const {
     std::optional<tt::MakeTensorDescOp> makeTensorDescOp =
-        tt::intel::findDefiningOpOfType<tt::MakeTensorDescOp>(loadOp.getDesc());
+        tt::intel::findMakeTensorDescOp(loadOp.getDesc());
     if (!makeTensorDescOp)
       return false;
 
@@ -252,8 +252,7 @@ private:
       SmallVectorImpl<Operation *> &selectedOps,
       std::unordered_map<Operation *, Value> &selectedOpToStride) const {
     auto makeTensorDescOp =
-        *tt::intel::findDefiningOpOfType<tt::MakeTensorDescOp>(
-            descLoadOp.getDesc());
+        *tt::intel::findMakeTensorDescOp(descLoadOp.getDesc());
 
     OperandRange strides = makeTensorDescOp.getStrides();
     for (Value stride : llvm::reverse(strides)) {

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -143,12 +143,21 @@ private:
     unsigned rank = tensorTy.getRank();
     unsigned elemSizeInBits = tensorTy.getElementTypeBitWidth();
 
-    // Find the MakeTensorDescOp that created the descriptor.
+    // Find all MakeTensorDescOps that could define this descriptor.
     Value desc = op.getDesc();
-    std::optional<tt::MakeTensorDescOp> makeTensorDescOp =
-        tt::intel::findDefiningOpOfType<tt::MakeTensorDescOp>(desc);
-    if (!makeTensorDescOp) {
+    SmallVector<tt::MakeTensorDescOp> allDescs =
+        tt::intel::findAllMakeTensorDescOps(desc);
+    if (allDescs.empty()) {
       LDBG("Could not find MakeTensorDescOp for: " << *op);
+      return;
+    }
+
+    // All candidates must have the same padding.
+    tt::PaddingOption padding = allDescs[0].getPadding();
+    if (!llvm::all_of(allDescs, [&](tt::MakeTensorDescOp d) {
+          return d.getPadding() == padding;
+        })) {
+      LDBG("Inconsistent padding across descriptor candidates for: " << *op);
       return;
     }
 
@@ -252,7 +261,7 @@ private:
     Value offsetY = indices[descRank - 2];
 
     // Determine padding mode from the descriptor.
-    bool padNan = makeTensorDescOp->getPadding() == tt::PaddingOption::PAD_NAN;
+    bool padNan = padding == tt::PaddingOption::PAD_NAN;
     UnitAttr padNanAttr = padNan ? builder.getUnitAttr() : UnitAttr();
 
     auto blockLoadOp = ttgi::Subgroup2DBlockLoadOp::create(

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -96,12 +96,20 @@ private:
     tt::MakeTensorDescOp makeTensorDescOp = allDescs[0];
     LDBG("Make tensor desc op: " << makeTensorDescOp);
 
+    // All candidates must have the same padding.
+    tt::PaddingOption padding = makeTensorDescOp.getPadding();
+    if (!llvm::all_of(allDescs, [&](tt::MakeTensorDescOp d) {
+          return d.getPadding() == padding;
+        })) {
+      LDBG("Inconsistent padding across candidates");
+      return;
+    }
+
     // Propagate padding from MakeTensorDescOp unconditionally so the LLVM
     // lowering can read it even after MakeTensorDescOp has been converted
     // in the same applyPartialConversion phase.
-    op->setAttr(
-        ttgi::TritonIntelGPUDialect::getDescPaddingAttrName(),
-        tt::PaddingOptionAttr::get(context, makeTensorDescOp.getPadding()));
+    op->setAttr(ttgi::TritonIntelGPUDialect::getDescPaddingAttrName(),
+                tt::PaddingOptionAttr::get(context, padding));
 
     Operation::operand_range shape = makeTensorDescOp.getShape();
     unsigned rank = shape.size();
@@ -871,6 +879,14 @@ private:
 
     tt::MakeTensorDescOp makeTensorDescOp = allDescs[0];
     Operation::operand_range shape = makeTensorDescOp.getShape();
+    // All candidates must have the same shape operands.
+    if (!llvm::all_of(allDescs, [&](tt::MakeTensorDescOp d) {
+          return d.getShape() == shape;
+        })) {
+      LDBG("Inconsistent shape across descriptor candidates");
+      return false;
+    }
+
     unsigned rank = shape.size();
     if (rank == 1)
       return false;

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -85,15 +85,15 @@ private:
     LDBG("Considering descriptor op: " << *op);
 
     Value desc = op.getDesc();
-    // Find the make tensor desc operation that created the descriptor.
-    std::optional<tt::MakeTensorDescOp> defOp =
-        tt::intel::findDefiningOpOfType<tt::MakeTensorDescOp>(desc);
-    if (!defOp) {
-      LDBG("Could not find make tensor desc op for: " << *op);
+    // Find all MakeTensorDescOps that could define this descriptor.
+    SmallVector<tt::MakeTensorDescOp> allDescs =
+        tt::intel::findAllMakeTensorDescOps(desc);
+    if (allDescs.empty()) {
+      LDBG("Could not find any make tensor desc op for: " << *op);
       return;
     }
 
-    tt::MakeTensorDescOp makeTensorDescOp = *defOp;
+    tt::MakeTensorDescOp makeTensorDescOp = allDescs[0];
     LDBG("Make tensor desc op: " << makeTensorDescOp);
 
     // Propagate padding from MakeTensorDescOp unconditionally so the LLVM
@@ -127,10 +127,12 @@ private:
            "Tensor descriptor must have stride=1 in last dimension");
 
     // Across Intel platforms, the strictest pitch restriction is to be a
-    // multiple of OWord(128 bits).
-    Value pitch = strides[rank - 2];
-    LDBG("Pitch: " << pitch);
-    if (!ttgi::isDivisible(pitch, llvm::divideCeil(128, elementWidth)))
+    // multiple of OWord(128 bits). All candidates must satisfy this.
+    unsigned pitchDivisor = llvm::divideCeil(128, elementWidth);
+    if (!llvm::all_of(allDescs, [&](tt::MakeTensorDescOp d) {
+          Value pitch = d.getStrides()[rank - 2];
+          return ttgi::isDivisible(pitch, pitchDivisor);
+        }))
       return;
 
     std::optional<ttg::DotOperandEncodingAttr> dotLayout = getDotLayout(op);
@@ -861,12 +863,13 @@ private:
       OpType op, tt::intel::ModuleAxisInfoAnalysis &axisInfoAnalysis) const {
     Value desc = op.getDesc();
 
-    // Find the make tensor desc operation that created the descriptor for the
-    // load/store operation.
-    std::optional<tt::MakeTensorDescOp> defOp =
-        tt::intel::findDefiningOpOfType<tt::MakeTensorDescOp>(desc);
-    assert(defOp && "Expected a make tensor desc op.");
-    tt::MakeTensorDescOp makeTensorDescOp = *defOp;
+    // Find all MakeTensorDescOps that could define this descriptor.
+    SmallVector<tt::MakeTensorDescOp> allDescs =
+        tt::intel::findAllMakeTensorDescOps(desc);
+    if (allDescs.empty())
+      return false;
+
+    tt::MakeTensorDescOp makeTensorDescOp = allDescs[0];
     Operation::operand_range shape = makeTensorDescOp.getShape();
     unsigned rank = shape.size();
     if (rank == 1)

--- a/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
@@ -124,10 +124,9 @@ private:
     }
 
     // Must be able to find the defining MakeTensorDescOp.
-    auto makeTensorDescOp =
-        tt::intel::findDefiningOpOfType<tt::MakeTensorDescOp>(
-            descLoadOp.getDesc());
-    if (!makeTensorDescOp.has_value())
+    SmallVector<tt::MakeTensorDescOp> allDescs =
+        tt::intel::findAllMakeTensorDescOps(descLoadOp.getDesc());
+    if (allDescs.empty())
       return false;
 
     // Only fuse if the descriptor load carries block_io = "row_major", which

--- a/third_party/intel/lib/Utils/Utility.cpp
+++ b/third_party/intel/lib/Utils/Utility.cpp
@@ -7,6 +7,7 @@
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include <optional>
 
@@ -236,6 +237,9 @@ SmallVector<tt::MakeTensorDescOp> findAllMakeTensorDescOps(Value val) {
         return {};
 
       if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
+        // The induction variable (argNumber == 0) is not traceable.
+        if (arg == forOp.getInductionVar())
+          return {};
         unsigned idx = arg.getArgNumber() - 1;
         worklist.push_back(forOp.getInitArgs()[idx]);
         auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
@@ -298,8 +302,9 @@ SmallVector<tt::MakeTensorDescOp> findAllMakeTensorDescOps(Value val) {
         continue;
       }
       if (auto castOp = dyn_cast<UnrealizedConversionCastOp>(defOp)) {
-        if (castOp.getInputs().size() == 1)
-          worklist.push_back(castOp.getInputs()[0]);
+        if (castOp.getInputs().size() != 1)
+          return {};
+        worklist.push_back(castOp.getInputs()[0]);
         continue;
       }
       // Unknown op producing this value — cannot trace through.

--- a/third_party/intel/lib/Utils/Utility.cpp
+++ b/third_party/intel/lib/Utils/Utility.cpp
@@ -3,9 +3,11 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include <optional>
 
 using namespace mlir;
@@ -215,6 +217,104 @@ void eraseOperations(SmallPtrSetImpl<Operation *> &operations) {
       continue;
     op->erase();
   }
+}
+
+SmallVector<tt::MakeTensorDescOp> findAllMakeTensorDescOps(Value val) {
+  llvm::SmallSetVector<tt::MakeTensorDescOp, 4> results;
+  SmallPtrSet<Value, 8> visited;
+  SmallVector<Value, 8> worklist;
+  worklist.push_back(val);
+
+  while (!worklist.empty()) {
+    Value cur = worklist.pop_back_val();
+    if (!visited.insert(cur).second)
+      continue;
+
+    if (auto arg = dyn_cast<BlockArgument>(cur)) {
+      Operation *parentOp = arg.getParentBlock()->getParentOp();
+      if (!parentOp || isa<FunctionOpInterface>(parentOp))
+        return {};
+
+      if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
+        unsigned idx = arg.getArgNumber() - 1;
+        worklist.push_back(forOp.getInitArgs()[idx]);
+        auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+        worklist.push_back(yieldOp->getOperand(idx));
+        continue;
+      }
+      if (auto whileOp = dyn_cast<scf::WhileOp>(parentOp)) {
+        unsigned idx = arg.getArgNumber();
+        Block *beforeBlock = &whileOp.getBefore().front();
+        Block *afterBlock = &whileOp.getAfter().front();
+        auto condOp = cast<scf::ConditionOp>(beforeBlock->getTerminator());
+        auto afterYieldOp = cast<scf::YieldOp>(afterBlock->getTerminator());
+
+        if (arg.getParentBlock() == beforeBlock) {
+          worklist.push_back(whileOp.getInits()[idx]);
+          worklist.push_back(afterYieldOp->getOperand(idx));
+        } else {
+          worklist.push_back(condOp.getArgs()[idx]);
+        }
+        continue;
+      }
+      // Unknown parent op — cannot trace through.
+      return {};
+    }
+
+    // PoisonOp is an uninitialized placeholder (e.g., in pipelined loops).
+    // It is not a valid definition but does not invalidate other results.
+    if (cur.getDefiningOp<ub::PoisonOp>())
+      continue;
+    if (cur.getDefiningOp<tt::CallOp>())
+      return {};
+    if (auto makeDescOp = cur.getDefiningOp<tt::MakeTensorDescOp>()) {
+      results.insert(makeDescOp);
+      continue;
+    }
+    if (auto opRes = dyn_cast<OpResult>(cur)) {
+      Operation *defOp = opRes.getOwner();
+      if (auto loopOp = dyn_cast<LoopLikeOpInterface>(defOp)) {
+        worklist.push_back(loopOp.getYieldedValues()[opRes.getResultNumber()]);
+        continue;
+      }
+      if (auto ifOp = dyn_cast<scf::IfOp>(defOp)) {
+        Region &thenRgn = ifOp.getThenRegion();
+        Region &elseRgn = ifOp.getElseRegion();
+        if (!thenRgn.empty()) {
+          auto thenYieldOp =
+              cast<scf::YieldOp>(thenRgn.getBlocks().front().getTerminator());
+          worklist.push_back(thenYieldOp->getOperand(opRes.getResultNumber()));
+        }
+        if (!elseRgn.empty()) {
+          auto elseYieldOp =
+              cast<scf::YieldOp>(elseRgn.getBlocks().front().getTerminator());
+          worklist.push_back(elseYieldOp->getOperand(opRes.getResultNumber()));
+        }
+        continue;
+      }
+      if (auto selectOp = dyn_cast<arith::SelectOp>(defOp)) {
+        worklist.push_back(selectOp.getTrueValue());
+        worklist.push_back(selectOp.getFalseValue());
+        continue;
+      }
+      if (auto castOp = dyn_cast<UnrealizedConversionCastOp>(defOp)) {
+        if (castOp.getInputs().size() == 1)
+          worklist.push_back(castOp.getInputs()[0]);
+        continue;
+      }
+      // Unknown op producing this value — cannot trace through.
+      return {};
+    }
+  }
+
+  return results.takeVector();
+}
+
+std::optional<tt::MakeTensorDescOp> findMakeTensorDescOp(Value val) {
+  SmallVector<tt::MakeTensorDescOp> all = findAllMakeTensorDescOps(val);
+  if (all.size() == 1)
+    return all[0];
+  return std::nullopt;
 }
 
 } // namespace mlir::triton::intel

--- a/third_party/intel/unittest/Analysis/AliasAnalysisTest.cpp
+++ b/third_party/intel/unittest/Analysis/AliasAnalysisTest.cpp
@@ -473,7 +473,7 @@ TEST_F(AliasAnalysisTest, DescriptorLoadAndRawLoadSameBase) {
 TEST_F(AliasAnalysisTest, DescriptorLoadThroughSCFForIterArg) {
   // When a descriptor flows through scf.for iter_args, the
   // tt.descriptor_load's getDesc() is a block argument, not a direct
-  // MakeTensorDescOp result. findDefiningOpOfType<> must trace through the
+  // MakeTensorDescOp result. findAllMakeTensorDescOps must trace through the
   // iter_arg back to the original descriptor so the op is not dropped and
   // its base pointer is resolved correctly.
   auto module = createModule();
@@ -713,7 +713,7 @@ TEST_F(AliasAnalysisTest, OpaqueDescriptorPropagatesUnknown) {
                                                 ValueRange{c128, c64},
                                                 ValueRange{c64_i64, c1});
 
-  // Opaque descriptor via arith.select (not recognized by findDefiningOpOfType)
+  // Opaque descriptor via arith.select (multiple candidates, no unique result)
   auto opaqueDesc =
       arith::SelectOp::create(*builder, loc, condition, descA, descB);
 


### PR DESCRIPTION
Replace the recursive `findDefiningOpOfType` template with a robust worklist-based implementation that collects all reachable `MakeTensorDescOps`.