### PR TITLE
[LowerTo2DBlockLoad] Check mask axis info before converting loads

### DIFF
--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/invalid.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/invalid.mlir
@@ -1,5 +1,40 @@
 // RUN: triton-opt %s -split-input-file --tritonintelgpu-lower-to-2d-block-load | FileCheck %s --implicit-check-not=ttig.2d_block_load_from_ptr --implicit-check-not=ttig.2d_block_load
 
+// COM: Descriptor load without ttig.block_io attribute should NOT be converted
+// COM: to ttig.2d_block_load — it must remain as tt.descriptor_load.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @descriptor_load_no_block_io
+  tt.func @descriptor_load_no_block_io(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64) -> tensor<64x32xf16, #dot0> {
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
+    // CHECK: tt.descriptor_load
+    %0 = tt.descriptor_load %desc[%c0_i32, %c0_i32] : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #dot0>
+    tt.return %0 : tensor<64x32xf16, #dot0>
+  }
+}
+
+// -----
+
+// COM: Module without support_2d_block_io attribute should skip the pass entirely.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: tt.func @no_2d_block_support
+  tt.func @no_2d_block_support(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64) -> tensor<64x32xf16, #dot0> {
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
+    // CHECK: tt.descriptor_load
+    %0 = tt.descriptor_load %desc[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #dot0>
+    tt.return %0 : tensor<64x32xf16, #dot0>
+  }
+}
+
+// -----
+
 // COM: Pointer-based load from a function arg has unknown stride, so it
 // COM: cannot be converted (stride analysis returns -1). Stays as tt.load.
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
@@ -29,25 +64,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 
 // -----
 
-
-// COM: Descriptor load without ttig.block_io attribute should NOT be converted
-// COM: to ttig.2d_block_load — it must remain as tt.descriptor_load.
-#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
-#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
-  // CHECK-LABEL: tt.func @descriptor_load_no_block_io
-  tt.func @descriptor_load_no_block_io(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64) -> tensor<64x32xf16, #dot0> {
-    %c1_i64 = arith.constant 1 : i64
-    %c0_i32 = arith.constant 0 : i32
-    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
-    // CHECK: tt.descriptor_load
-    %0 = tt.descriptor_load %desc[%c0_i32, %c0_i32] : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #dot0>
-    tt.return %0 : tensor<64x32xf16, #dot0>
-  }
-}
-
-// -----
-
 // COM: Pointer load with invalid pitch (< 64 bytes). The stride of 16 f16
 // COM: elements gives pitch = 32 bytes, which is below the HW minimum of 64.
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
@@ -68,17 +84,35 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 
 // -----
 
-// COM: Module without support_2d_block_io attribute should skip the pass entirely.
+// COM: Masked pointer load where the mask has non-trivial axis info that
+// COM: constrains the tile size below what is valid for 2D block I/O.
+// COM: The mask is derived from a comparison with a runtime bound, giving
+// COM: constancy=1 in the fast-change dimension, which makes the tile invalid.
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  // CHECK-LABEL: tt.func @no_2d_block_support
-  tt.func @no_2d_block_support(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64) -> tensor<64x32xf16, #dot0> {
-    %c1_i64 = arith.constant 1 : i64
-    %c0_i32 = arith.constant 0 : i32
-    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
-    // CHECK: tt.descriptor_load
-    %0 = tt.descriptor_load %desc[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #dot0>
-    tt.return %0 : tensor<64x32xf16, #dot0>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @masked_load_non_power_of_2_constancy
+  tt.func @masked_load_non_power_of_2_constancy(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32) -> tensor<64x32xf16, #dot0> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x32xf16, #dot0>
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #dot0}>>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #dot0}>> -> tensor<1x32xi32, #dot0>
+    %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x32x!tt.ptr<f16>, #dot0>
+    %3 = tt.addptr %2, %1 : tensor<1x32x!tt.ptr<f16>, #dot0>, tensor<1x32xi32, #dot0>
+    %4 = tt.broadcast %3 : tensor<1x32x!tt.ptr<f16>, #dot0> -> tensor<64x32x!tt.ptr<f16>, #dot0>
+    // Mask with non-trivial constancy: compare range against runtime bound.
+    // The mask has constancy=1 along the fast-change dim because each element
+    // is independently compared against %arg2.
+    %5 = tt.splat %arg2 : i32 -> tensor<1x32xi32, #dot0>
+    %6 = arith.cmpi slt, %1, %5 : tensor<1x32xi32, #dot0>
+    %7 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #dot0}>>
+    %8 = tt.expand_dims %7 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #dot0}>> -> tensor<64x1xi32, #dot0>
+    %9 = tt.splat %arg1 : i32 -> tensor<64x1xi32, #dot0>
+    %10 = arith.cmpi slt, %8, %9 : tensor<64x1xi32, #dot0>
+    %11 = tt.broadcast %6 : tensor<1x32xi1, #dot0> -> tensor<64x32xi1, #dot0>
+    %12 = tt.broadcast %10 : tensor<64x1xi1, #dot0> -> tensor<64x32xi1, #dot0>
+    %mask = arith.andi %11, %12 : tensor<64x32xi1, #dot0>
+    // CHECK: tt.load
+    %13 = tt.load %4, %mask, %cst {ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f16>, #dot0>
+    tt.return %13 : tensor<64x32xf16, #dot0>
   }
 }

--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/pointer-load.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/pointer-load.mlir
@@ -42,21 +42,20 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 // -----
 
 // COM: Masked pointer load with both mask and other. Both are forwarded
-// COM: to the ttig.2d_block_load_from_ptr op.
+// COM: to the ttig.2d_block_load_from_ptr op. The mask is a constant true
+// COM: (uniform constancy) which satisfies the 2D block I/O tile constraints.
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
   // CHECK-LABEL: tt.func @masked_pointer_load_with_other
-  tt.func @masked_pointer_load_with_other(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: i32) -> tensor<64x32xf16, #dot0> {
+  tt.func @masked_pointer_load_with_other(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: i1) -> tensor<64x32xf16, #dot0> {
     %cst = arith.constant dense<0.000000e+00> : tensor<64x32xf16, #dot0>
     %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #dot0}>>
     %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #dot0}>> -> tensor<1x32xi32, #dot0>
     %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x32x!tt.ptr<f16>, #dot0>
     %3 = tt.addptr %2, %1 : tensor<1x32x!tt.ptr<f16>, #dot0>, tensor<1x32xi32, #dot0>
     %4 = tt.broadcast %3 : tensor<1x32x!tt.ptr<f16>, #dot0> -> tensor<64x32x!tt.ptr<f16>, #dot0>
-    %5 = tt.splat %arg1 : i32 -> tensor<1x32xi32, #dot0>
-    %6 = arith.cmpi slt, %5, %1 : tensor<1x32xi32, #dot0>
-    %mask = tt.broadcast %6 : tensor<1x32xi1, #dot0> -> tensor<64x32xi1, #dot0>
+    %mask = tt.splat %arg1 : i1 -> tensor<64x32xi1, #dot0>
     // CHECK: ttig.2d_block_load_from_ptr
     %7 = tt.load %4, %mask, %cst {ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f16>, #dot0>
     tt.return %7 : tensor<64x32xf16, #dot0>
@@ -67,20 +66,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 
 // COM: Masked pointer load WITHOUT an explicit 'other' value. The pass must
 // COM: synthesize a zero splat so the verifier constraint (other required when
-// COM: mask is present) is satisfied.
+// COM: mask is present) is satisfied. The mask is a uniform splat which has
+// COM: sufficient constancy for 2D block I/O.
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
   // CHECK-LABEL: tt.func @masked_pointer_load_no_other
-  tt.func @masked_pointer_load_no_other(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: i32) -> tensor<64x32xf16, #dot0> {
+  tt.func @masked_pointer_load_no_other(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: i1) -> tensor<64x32xf16, #dot0> {
     %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #dot0}>>
     %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #dot0}>> -> tensor<1x32xi32, #dot0>
     %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x32x!tt.ptr<f16>, #dot0>
     %3 = tt.addptr %2, %1 : tensor<1x32x!tt.ptr<f16>, #dot0>, tensor<1x32xi32, #dot0>
     %4 = tt.broadcast %3 : tensor<1x32x!tt.ptr<f16>, #dot0> -> tensor<64x32x!tt.ptr<f16>, #dot0>
-    %5 = tt.splat %arg1 : i32 -> tensor<1x32xi32, #dot0>
-    %6 = arith.cmpi slt, %5, %1 : tensor<1x32xi32, #dot0>
-    %mask = tt.broadcast %6 : tensor<1x32xi1, #dot0> -> tensor<64x32xi1, #dot0>
+    %mask = tt.splat %arg1 : i1 -> tensor<64x32xi1, #dot0>
     // CHECK: %[[ZERO_CST:.*]] = arith.constant 0.000000e+00 : f16
     // CHECK: %[[ZERO_SPLAT:.*]] = tt.splat %[[ZERO_CST]]
     // CHECK: ttig.2d_block_load_from_ptr

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
@@ -84,7 +84,8 @@ bool check2DBlockAddressPayloadRestriction(unsigned packedElemSizeInBits,
 /// inner-dim constraints, and transpose shuffle mapping. Returns true if valid.
 bool validate2DBlockLoadTile(const LinearLayout &ll, unsigned memContiguousDim,
                              unsigned elemSizeInBits,
-                             RankedTensorType tensorType);
+                             RankedTensorType tensorType,
+                             AxisInfo *maskAxisInfo = nullptr);
 
 } // namespace mlir::triton::gpu::intel
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -479,12 +479,12 @@ FailureOr<LinearLayout> computeTransposeShuffleMapping(
 
 bool validate2DBlockLoadTile(const LinearLayout &ll, unsigned memContiguousDim,
                              unsigned elemSizeInBits,
-                             RankedTensorType tensorType) {
-  // Descriptor loads have no mask, so maskAxisInfo is nullptr.
+                             RankedTensorType tensorType,
+                             AxisInfo *maskAxisInfo) {
   // oneMatrixPerLoadForBT is not needed for validation — it only limits
   // transpose tile expansion, which doesn't affect basic validity.
   auto sizeInfo = getBlockIOTileSize<true>(ll, memContiguousDim, elemSizeInBits,
-                                           /*maskAxisInfo=*/nullptr,
+                                           maskAxisInfo,
                                            /*oneMatrixPerLoadForBT=*/false);
   if (!sizeInfo.isValid())
     return false;

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -130,7 +130,7 @@ public:
     SmallVector<tt::LoadOp> loadOps;
     mod.walk([&](tt::LoadOp op) { loadOps.push_back(op); });
     for (auto op : loadOps)
-      convertLoadOp(op, strideAnalysis);
+      convertLoadOp(op, strideAnalysis, axisInfoAnalysis);
   }
 
 private:
@@ -282,7 +282,8 @@ private:
 
   /// Convert a tt.load to ttig.2d_block_load_from_ptr.
   void convertLoadOp(tt::LoadOp op,
-                     tt::intel::ModuleStrideAnalysis &strideAnalysis) {
+                     tt::intel::ModuleStrideAnalysis &strideAnalysis,
+                     tt::intel::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
     if (!isBlockIOEligible(op))
       return;
 
@@ -293,6 +294,12 @@ private:
 
     bool memoryRowMajor = isMemoryRowMajor(op);
     unsigned contiguousDim = memoryRowMajor ? rank - 1 : rank - 2;
+
+    // Retrieve mask axis info to validate tile constraints consistently
+    // with the downstream LLVM lowering.
+    tt::AxisInfo *maskAxisInfo = nullptr;
+    if (op.getMask())
+      maskAxisInfo = axisInfoAnalysis.getAxisInfo(op.getMask());
 
     // For 1D->2D reshape loads, skip tile validation and use the stride
     // attribute directly for pitch.
@@ -313,12 +320,13 @@ private:
           cast<ttg::DistributedEncodingTrait>(encoding).toLinearLayout(
               tensorTy.getShape());
       if (!ttgi::validate2DBlockLoadTile(llEncoding, contiguousDim,
-                                         elemSizeInBits, tensorTy)) {
+                                         elemSizeInBits, tensorTy,
+                                         maskAxisInfo)) {
         LDBG("Tile validation failed for load: " << *op);
         return;
       }
       auto sizeInfo = ttgi::getBlockIOTileSize<true>(
-          llEncoding, contiguousDim, elemSizeInBits, /*maskAxisInfo=*/nullptr,
+          llEncoding, contiguousDim, elemSizeInBits, maskAxisInfo,
           /*oneMatrixPerLoadForBT=*/false);
       rowDim = sizeInfo.rowDim;
       colDim = sizeInfo.colDim;


### PR DESCRIPTION
The pass was ignoring mask constraints when deciding whether a tt.load can be lowered to ttig.2d_block_load_from_ptr. The downstream LLVM lowering (ConvertTritonIntelGPUToLLVM) validates mask constancy via getBlockIOTileSize and rejects loads whose mask constancy is incompatible with the 2D block I/O tile shape. This mismatch caused PassManager::run failures for masked reduction kernels (e.g. Liger-Kernel DYT benchmark).