### PR TITLE
[LowerTo2DBlockLoad] Reject broadcast loads with incompatible tile width

### DIFF
--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/invalid.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/invalid.mlir
@@ -116,3 +116,27 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     tt.return %13 : tensor<64x32xf16, #dot0>
   }
 }
+
+// -----
+
+// COM: Broadcast load (stride=0) where the tile width is incompatible with
+// COM: threadsPerWarp for the row replication logic. tileWidth=1 with
+// COM: threadsPerWarp=32 does not satisfy tileWidth*2 == threadsPerWarp.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 8], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @broadcast_load_incompatible_tile_width
+  tt.func @broadcast_load_incompatible_tile_width(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32) {
+    %cst = arith.constant dense<4096> : tensor<1x1024xi32, #blocked>
+    %0 = tt.get_program_id x : i32
+    %1 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %2 = tt.expand_dims %1 {axis = 0 : i32} : tensor<1024xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x1024xi32, #blocked>
+    %3 = arith.muli %2, %cst : tensor<1x1024xi32, #blocked>
+    %4 = tt.splat %0 : i32 -> tensor<1x1024xi32, #blocked>
+    %5 = arith.addi %4, %3 : tensor<1x1024xi32, #blocked>
+    %6 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1x1024x!tt.ptr<f32>, #blocked>
+    %7 = tt.addptr %6, %5 : tensor<1x1024x!tt.ptr<f32>, #blocked>, tensor<1x1024xi32, #blocked>
+    // CHECK: tt.load
+    %8 = tt.load %7 {ttig.block_io = "column_major"} : tensor<1x1024x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -310,6 +310,8 @@ private:
     // encoding. These may differ from the conventional rank-2/rank-1 for
     // rank > 2 tensors.
     unsigned rowDim, colDim;
+    int tileWidth = -1;
+    int tileHeight = -1;
     if (has1DReshapeStride) {
       // 1D reshape: conventional dims, no tile validation needed.
       rowDim = memoryRowMajor ? rank - 2 : rank - 1;
@@ -330,6 +332,8 @@ private:
           /*oneMatrixPerLoadForBT=*/false);
       rowDim = sizeInfo.rowDim;
       colDim = sizeInfo.colDim;
+      tileWidth = sizeInfo.tileWidth;
+      tileHeight = sizeInfo.tileHeight;
     }
 
     // Compute pitch from stride analysis or the 1D->2D reshape attribute.
@@ -359,6 +363,22 @@ private:
     if (pitch < MIN_PITCH || (pitch % 16) != 0) {
       LDBG("Invalid pitch " << pitch << " for load: " << *op);
       return;
+    }
+
+    // For broadcast loads (stride=0), the LLVM lowering's row replication
+    // requires tileWidth >= threadsPerWarp or tileWidth * 2 == threadsPerWarp.
+    // Reject unsupported configurations.
+    if (stride == 0 && tileHeight > 1 && tileWidth > 0) {
+      unsigned threadsPerWarp = ttg::TritonGPUDialect::getThreadsPerWarp(
+          op->getParentOfType<ModuleOp>());
+      if (tileWidth < (int)threadsPerWarp &&
+          (unsigned)tileWidth * 2 != threadsPerWarp) {
+        LDBG("Broadcast load tile width " << tileWidth
+                                          << " incompatible with "
+                                             "threadsPerWarp "
+                                          << threadsPerWarp << " for: " << *op);
+        return;
+      }
     }
 
     OpBuilder builder(op);


### PR DESCRIPTION
For broadcast loads (stride=0), the LLVM lowering's row replication requires `tileWidth >= threadsPerWarp` or `tileWidth * 2 == threadsPerWarp`. Reject configurations that violate this constraint to prevent assertion failures in `ConvertTritonIntelGPUToLLVM`.