### PR TITLE
[AxisInfo] Fix signed division AxisInfo bug and revert PyTorch workaround

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -444,11 +444,27 @@ private:
     // the minimal constancy is gcd(d_lhs, d_rhs).
     // Since gcd(d_lhs, d_rhs) maybe > len(lhs),
     // we need to use another gcd to get the actual constancy.
+    //
+    // NOTE: This only holds when the division rounds consistently in one
+    // direction. For signed division (DivSIOp), truncation toward zero means
+    // the constancy pattern breaks at the zero crossing:
+    //   sdiv([-2, -1, 0, 1], 2) = [-1, 0, 0, 0]  (not pairwise constant)
+    // For signed division, we can still apply this optimization when the
+    // contiguous window is guaranteed not to cross zero. This is the case
+    // when divisibility >= contiguity: the window starts at k*div and has
+    // length cont <= div, so it stays within [k*div, (k+1)*div - 1] which
+    // never spans zero.
     if (AxisInfoVisitor::isContiguousDim(lhs, shape, dim) &&
         AxisInfoVisitor::isConstantDim(rhs, shape, dim)) {
-      constancy = std::max(constancy,
-                           gcd(lhs.getContiguity(dim), lhs.getDivisibility(dim),
-                               rhs.getDivisibility(dim)));
+      if constexpr (!std::is_same_v<OpTy, arith::DivSIOp>) {
+        constancy = std::max(constancy, gcd(lhs.getContiguity(dim),
+                                            lhs.getDivisibility(dim),
+                                            rhs.getDivisibility(dim)));
+      } else if (lhs.getDivisibility(dim) >= lhs.getContiguity(dim)) {
+        constancy = std::max(constancy, gcd(lhs.getContiguity(dim),
+                                            lhs.getDivisibility(dim),
+                                            rhs.getDivisibility(dim)));
+      }
     }
     return constancy;
   }
@@ -506,10 +522,22 @@ private:
     // The minimal contiguity is gcd(d_lhs, d_rhs).
     // Since gcd(d_lhs, d_rhs) maybe > len(lhs),
     // we need to use another gcd to get the actual contiguity.
+    //
+    // NOTE: For signed remainder (RemSIOp), the contiguity pattern breaks
+    // at the zero crossing because srem produces negative results for
+    // negative dividends: srem([-2, -1, 0, 1], 2) = [0, -1, 0, 1]
+    // For signed remainder, we can still apply this optimization when the
+    // contiguous window is guaranteed not to cross zero (divisibility >=
+    // contiguity ensures the window stays within one sign region).
     if (AxisInfoVisitor::isContiguousDim(lhs, shape, dim) &&
         AxisInfoVisitor::isConstantDim(rhs, shape, dim)) {
-      contiguity = gcd(lhs.getContiguity(dim), lhs.getDivisibility(dim),
-                       rhs.getDivisibility(dim));
+      if constexpr (!std::is_same_v<OpTy, arith::RemSIOp>) {
+        contiguity = gcd(lhs.getContiguity(dim), lhs.getDivisibility(dim),
+                         rhs.getDivisibility(dim));
+      } else if (lhs.getDivisibility(dim) >= lhs.getContiguity(dim)) {
+        contiguity = gcd(lhs.getContiguity(dim), lhs.getDivisibility(dim),
+                         rhs.getDivisibility(dim));
+      }
     }
     return contiguity;
   }

--- a/scripts/patch-pytorch.sh
+++ b/scripts/patch-pytorch.sh
@@ -35,3 +35,4 @@ apply_patch() {
 echo "Applying PyTorch patches in $REPO_ROOT"
 
 # put your patch applies here
+apply_patch patch/175168-revert.patch

--- a/scripts/patch/175168-revert.patch
+++ b/scripts/patch/175168-revert.patch
@@ -1,0 +1,40 @@
+diff --git a/torch/_inductor/codegen/triton.py b/torch/_inductor/codegen/triton.py
+index 959ff25..3d1db5f 100644
+--- a/torch/_inductor/codegen/triton.py
++++ b/torch/_inductor/codegen/triton.py
+@@ -2016,30 +2016,11 @@ class TritonOverrides(OpOverrides):
+     @staticmethod
+     def floordiv(a, b):
+         # See the comment in lowering.div_mode. a and b are integer type.
+-        # Notice that // in triton behaves as truncdiv instead of floordiv.
+-        #
+-        # We avoid feeding negative values into Triton's // operator because
+-        # Triton's AxisInfo analysis incorrectly deduplicates signed division
+-        # results for contiguous inputs (triton-lang/triton#XXXX). Instead we
+-        # use bitwise complement (~) to make the dividend non-negative:
+-        #   floor_div(a, b) = ~(~a // b) when a < 0, a // b when a >= 0
+-        # For negative b we negate both operands first.
+-        zero = ops.constant(0, torch.int32)
+-        one = ops.constant(1, torch.int32)
+-        # Guard against integer division by zero before the division to
+-        # avoid undefined behavior (LLVM may optimize away a post-division
+-        # check assuming UB doesn't happen). Replace b with 1 when b is 0
+-        # so the division is safe, then select 0 as the final result.
+-        b_zero = ops.eq(b, zero)
+-        b = ops.where(b_zero, one, b)
+-        b_neg = ops.lt(b, zero)
+-        a = ops.where(b_neg, ops.sub(zero, a), a)
+-        b = ops.where(b_neg, ops.sub(zero, b), b)
+-        a_neg = ops.lt(a, zero)
+-        a = ops.where(a_neg, ops.bitwise_not(a), a)
+-        quot = ops.truncdiv(a, b)
+-        quot = ops.where(a_neg, ops.bitwise_not(quot), quot)
+-        return ops.where(b_zero, zero, quot)
++        # Similar to div_floor_kernel_cuda in pytorch core.
++        # Notice that // in triton behaves as truncdiv instead of floordiv
++        quot = f"{a} // {b}"
++        rem = f"{a} % {b}"
++        return f"tl.where(({a} < 0) != ({b} < 0), tl.where({rem} != 0, {quot} - 1, {quot}), {quot})"
+
+     @staticmethod
+     # pyrefly: ignore [bad-override]

--- a/test/Analysis/intel/test-axis-info.mlir
+++ b/test/Analysis/intel/test-axis-info.mlir
@@ -160,6 +160,10 @@ tt.func @div() {
   %10 = tt.make_range {end = 8320 : i32, start = 8192 : i32} : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [64], constant_value = <none>
   %11 = arith.divsi %10, %4 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [128], divisibility = [32], constancy = [1], constant_value = <none>
+  %12 = tt.make_range {end = 160 : i32, start = 32 : i32} : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %13 = arith.divsi %12, %4 : tensor<128xi32>
   tt.return
 }
 

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -266,7 +266,7 @@ tt.func @rem() {
   %13 = arith.remsi %0, %12 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %14 = arith.remsi %12, %0 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [32], divisibility = [32], constancy = [1], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [32], constancy = [1], constant_value = <none>}}
   %15 = arith.remsi %12, %4 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %16 = arith.remsi %4, %12 : tensor<128xi32>


### PR DESCRIPTION
Fix AxisInfo incorrectly computing constancy for `DivSIOp` and contiguity for `RemSIOp`. The optimization breaks at zero crossings: `sdiv([-2,-1,0,1], 2) = [-1,0,0,0]` is not pairwise constant.

Instead of unconditionally disabling the optimization for signed ops, apply it when `divisibility >= contiguity`. This guarantees the contiguous window cannot span zero, preserving performance for typical GPU patterns (`make_range + block offset`) while correctly rejecting cases where negative values may cross zero.

Revert the PyTorch inductor `floordiv` workaround (pytorch/pytorch#175168) since the root cause is now fixed.

Fixes #6376