### PR TITLE
[LowerTo2DBlockLoad] Pass oneMatrixPerLoadForBT to tile validation

### DIFF
--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
@@ -151,3 +151,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     tt.return %final_load : tensor<64x32xf16, #dot0>
   }
 }
+
+// -----
+
+// COM: Descriptor load with ttig.one_matrix_per_load attribute. The pass must
+// COM: read and propagate this attribute to the resulting ttig.2d_block_load op.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @descriptor_load_one_matrix_per_load
+  tt.func @descriptor_load_one_matrix_per_load(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64) -> tensor<32x64xf16, #dot1> {
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
+    // CHECK: ttig.2d_block_load
+    // CHECK-SAME: {column_major}
+    // CHECK-SAME: ttig.one_matrix_per_load
+    %0 = tt.descriptor_load %desc[%c0_i32, %c0_i32] {ttig.block_io = "column_major", ttig.one_matrix_per_load} : !tt.tensordesc<64x32xf16> -> tensor<32x64xf16, #dot1>
+    tt.return %0 : tensor<32x64xf16, #dot1>
+  }
+}

--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/pointer-load.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/pointer-load.mlir
@@ -107,3 +107,46 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     tt.return %5 : tensor<64x32xf16, #dot0>
   }
 }
+
+// -----
+
+// COM: Pointer load with ttig.one_matrix_per_load attribute. The pass must
+// COM: propagate this attribute to the resulting ttig.2d_block_load_from_ptr.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @pointer_load_one_matrix_per_load
+  tt.func @pointer_load_one_matrix_per_load(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) -> tensor<64x32xf16, #dot0> {
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #dot0}>>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #dot0}>> -> tensor<1x32xi32, #dot0>
+    %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x32x!tt.ptr<f16>, #dot0>
+    %3 = tt.addptr %2, %1 : tensor<1x32x!tt.ptr<f16>, #dot0>, tensor<1x32xi32, #dot0>
+    %4 = tt.broadcast %3 : tensor<1x32x!tt.ptr<f16>, #dot0> -> tensor<64x32x!tt.ptr<f16>, #dot0>
+    // CHECK: ttig.2d_block_load_from_ptr
+    // CHECK-SAME: ttig.one_matrix_per_load
+    %5 = tt.load %4 {ttig.block_io = "row_major", ttig.one_matrix_per_load} : tensor<64x32x!tt.ptr<f16>, #dot0>
+    tt.return %5 : tensor<64x32xf16, #dot0>
+  }
+}
+
+// -----
+
+// COM: Env var TRITON_INTEL_ONE_MATRIX_PER_LOAD_BT=1 forces the attribute on
+// COM: all loads, even those without it originally.
+// RUN: env TRITON_INTEL_ONE_MATRIX_PER_LOAD_BT=1 triton-opt %s -split-input-file --tritonintelgpu-lower-to-2d-block-load | FileCheck %s --check-prefix=ENV-CHECK
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // ENV-CHECK-LABEL: tt.func @pointer_load_env_override
+  tt.func @pointer_load_env_override(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) -> tensor<64x32xf16, #dot0> {
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #dot0}>>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #dot0}>> -> tensor<1x32xi32, #dot0>
+    %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x32x!tt.ptr<f16>, #dot0>
+    %3 = tt.addptr %2, %1 : tensor<1x32x!tt.ptr<f16>, #dot0>, tensor<1x32xi32, #dot0>
+    %4 = tt.broadcast %3 : tensor<1x32x!tt.ptr<f16>, #dot0> -> tensor<64x32x!tt.ptr<f16>, #dot0>
+    // ENV-CHECK: ttig.2d_block_load_from_ptr
+    // ENV-CHECK-SAME: ttig.one_matrix_per_load
+    %5 = tt.load %4 {ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f16>, #dot0>
+    tt.return %5 : tensor<64x32xf16, #dot0>
+  }
+}

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
@@ -85,6 +85,7 @@ bool check2DBlockAddressPayloadRestriction(unsigned packedElemSizeInBits,
 bool validate2DBlockLoadTile(const LinearLayout &ll, unsigned memContiguousDim,
                              unsigned elemSizeInBits,
                              RankedTensorType tensorType,
+                             bool oneMatrixPerLoadForBT = false,
                              AxisInfo *maskAxisInfo = nullptr);
 
 } // namespace mlir::triton::gpu::intel

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1829,14 +1829,9 @@ public:
     if (!isBlockIOCandidate(op))
       return failure();
 
-    // FIXME: Remove once IGC can split large 2D block loads.
-    std::optional<bool> oneMatrixPerLoadForBT =
-        mlir::triton::tools::isEnvValueBool(mlir::triton::tools::getStrEnv(
-            "TRITON_INTEL_ONE_MATRIX_PER_LOAD_BT"));
-    if (!oneMatrixPerLoadForBT.has_value())
-      oneMatrixPerLoadForBT =
-          op->hasAttr(triton::gpu::intel::TritonIntelGPUDialect::
-                          getOneMatrixPerLoadAttrName());
+    bool oneMatrixPerLoadForBT =
+        op->hasAttr(triton::gpu::intel::TritonIntelGPUDialect::
+                        getOneMatrixPerLoadAttrName());
 
     // Get the max tile shape supported by the layout.
     Type resultType = op.getType();
@@ -1885,7 +1880,7 @@ public:
     } else {
       sizeInfo = getBlockIOTileSize<true /*load*/>(
           llEncoding.value(), contiguousDim, elemSizeInBits, maskAxisInfo,
-          oneMatrixPerLoadForBT.has_value() ? *oneMatrixPerLoadForBT : false);
+          oneMatrixPerLoadForBT);
     }
     if (!sizeInfo.isValid())
       return failure();
@@ -2243,16 +2238,12 @@ struct DescriptorLoadOpToBlockIOConversion
 
     // Tile size computation (no mask for descriptors).
     // FIXME: Remove once IGC can split large 2D block loads.
-    std::optional<bool> oneMatrixPerLoadForBT =
-        mlir::triton::tools::isEnvValueBool(mlir::triton::tools::getStrEnv(
-            "TRITON_INTEL_ONE_MATRIX_PER_LOAD_BT"));
-    if (!oneMatrixPerLoadForBT.has_value())
-      oneMatrixPerLoadForBT =
-          op->hasAttr(triton::gpu::intel::TritonIntelGPUDialect::
-                          getOneMatrixPerLoadAttrName());
+    bool oneMatrixPerLoadForBT =
+        op->hasAttr(triton::gpu::intel::TritonIntelGPUDialect::
+                        getOneMatrixPerLoadAttrName());
     BlockIOTileSizeInfo sizeInfo = getBlockIOTileSize<true /*load*/>(
         llEncoding.value(), contiguousDim, elemSizeInBits,
-        /*maskAxisInfo=*/nullptr, *oneMatrixPerLoadForBT);
+        /*maskAxisInfo=*/nullptr, oneMatrixPerLoadForBT);
     if (!sizeInfo.isValid())
       return failure();
 
@@ -4254,15 +4245,11 @@ struct Subgroup2DBlockLoadOpConversion
 
     // Tile size computation.
     // FIXME: Remove once IGC can split large 2D block loads.
-    std::optional<bool> oneMatrixPerLoadForBT =
-        mlir::triton::tools::isEnvValueBool(mlir::triton::tools::getStrEnv(
-            "TRITON_INTEL_ONE_MATRIX_PER_LOAD_BT"));
-    if (!oneMatrixPerLoadForBT.has_value())
-      oneMatrixPerLoadForBT =
-          op->hasAttr(TritonIntelGPUDialect::getOneMatrixPerLoadAttrName());
+    bool oneMatrixPerLoadForBT =
+        op->hasAttr(TritonIntelGPUDialect::getOneMatrixPerLoadAttrName());
     BlockIOTileSizeInfo sizeInfo = getBlockIOTileSize<true /*load*/>(
         llEncoding.value(), contiguousDim, elemSizeInBits,
-        /*maskAxisInfo=*/nullptr, *oneMatrixPerLoadForBT);
+        /*maskAxisInfo=*/nullptr, oneMatrixPerLoadForBT);
     assert(sizeInfo.isValid() && "expected valid tile size");
 
     int tileHeight = sizeInfo.tileHeight;
@@ -4518,12 +4505,8 @@ struct Subgroup2DBlockLoadFromPtrOpConversion
 
     // Tile size computation.
     // FIXME: Remove once IGC can split large 2D block loads.
-    std::optional<bool> oneMatrixPerLoadForBT =
-        mlir::triton::tools::isEnvValueBool(mlir::triton::tools::getStrEnv(
-            "TRITON_INTEL_ONE_MATRIX_PER_LOAD_BT"));
-    if (!oneMatrixPerLoadForBT.has_value())
-      oneMatrixPerLoadForBT =
-          op->hasAttr(TritonIntelGPUDialect::getOneMatrixPerLoadAttrName());
+    bool oneMatrixPerLoadForBT =
+        op->hasAttr(TritonIntelGPUDialect::getOneMatrixPerLoadAttrName());
 
     AxisInfo *maskAxisInfo = nullptr;
     if (op.getMask())
@@ -4552,9 +4535,9 @@ struct Subgroup2DBlockLoadFromPtrOpConversion
                                      /*colDim=*/rank - 1, /*transpose=*/false,
                                      std::move(regPackBases));
     } else {
-      sizeInfo = getBlockIOTileSize<true>(
-          *llEncoding, contiguousDim, elemSizeInBits, maskAxisInfo,
-          oneMatrixPerLoadForBT.has_value() ? *oneMatrixPerLoadForBT : false);
+      sizeInfo =
+          getBlockIOTileSize<true>(*llEncoding, contiguousDim, elemSizeInBits,
+                                   maskAxisInfo, oneMatrixPerLoadForBT);
     }
     if (!sizeInfo.isValid())
       return failure();

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -480,12 +480,10 @@ FailureOr<LinearLayout> computeTransposeShuffleMapping(
 bool validate2DBlockLoadTile(const LinearLayout &ll, unsigned memContiguousDim,
                              unsigned elemSizeInBits,
                              RankedTensorType tensorType,
+                             bool oneMatrixPerLoadForBT,
                              AxisInfo *maskAxisInfo) {
-  // oneMatrixPerLoadForBT is not needed for validation — it only limits
-  // transpose tile expansion, which doesn't affect basic validity.
   auto sizeInfo = getBlockIOTileSize<true>(ll, memContiguousDim, elemSizeInBits,
-                                           maskAxisInfo,
-                                           /*oneMatrixPerLoadForBT=*/false);
+                                           maskAxisInfo, oneMatrixPerLoadForBT);
   if (!sizeInfo.isValid())
     return false;
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -119,6 +119,24 @@ public:
             ttgi::TritonIntelGPUDialect::getSupport2DBlockIOAttrName()))
       return;
 
+    // FIXME: Remove once IGC can split large 2D block loads.
+    // Read the env var once and materialize it as an attribute on the ops
+    // so downstream passes only need to check the attribute.
+    std::optional<bool> envOneMatrixPerLoad = tt::tools::isEnvValueBool(
+        tt::tools::getStrEnv("TRITON_INTEL_ONE_MATRIX_PER_LOAD_BT"));
+    if (envOneMatrixPerLoad.has_value()) {
+      StringRef attrName =
+          ttgi::TritonIntelGPUDialect::getOneMatrixPerLoadAttrName();
+      mod.walk([&](Operation *op) {
+        if (!isa<tt::LoadOp, tt::DescriptorLoadOp>(op))
+          return;
+        if (*envOneMatrixPerLoad)
+          op->setAttr(attrName, UnitAttr::get(mod.getContext()));
+        else
+          op->removeAttr(attrName);
+      });
+    }
+
     tt::intel::ModuleAxisInfoAnalysis axisInfoAnalysis(mod);
     tt::intel::ModuleStrideAnalysis strideAnalysis(mod, axisInfoAnalysis);
 
@@ -168,13 +186,17 @@ private:
     bool memoryRowMajor = isMemoryRowMajor(op);
 
     // Validate that tile computation will succeed during LLVM lowering.
+    bool oneMatrixPerLoadForBT =
+        op->hasAttr(ttgi::TritonIntelGPUDialect::getOneMatrixPerLoadAttrName());
+
     unsigned contiguousDim = memoryRowMajor ? rank - 1 : rank - 2;
     Attribute encoding = tensorTy.getEncoding();
     LinearLayout llEncoding =
         cast<ttg::DistributedEncodingTrait>(encoding).toLinearLayout(
             tensorTy.getShape());
     if (!ttgi::validate2DBlockLoadTile(llEncoding, contiguousDim,
-                                       elemSizeInBits, tensorTy)) {
+                                       elemSizeInBits, tensorTy,
+                                       oneMatrixPerLoadForBT)) {
       LDBG("Tile validation failed for descriptor load: " << *op);
       return;
     }
@@ -270,7 +292,7 @@ private:
         ttgi::BlockIOModeAttr::get(builder.getContext(), memLayout));
 
     // Propagate one_matrix_per_load attribute if present.
-    if (op->hasAttr(ttgi::TritonIntelGPUDialect::getOneMatrixPerLoadAttrName()))
+    if (oneMatrixPerLoadForBT)
       blockLoadOp->setAttr(
           ttgi::TritonIntelGPUDialect::getOneMatrixPerLoadAttrName(),
           builder.getUnitAttr());
@@ -294,6 +316,9 @@ private:
 
     bool memoryRowMajor = isMemoryRowMajor(op);
     unsigned contiguousDim = memoryRowMajor ? rank - 1 : rank - 2;
+
+    bool oneMatrixPerLoadForBT =
+        op->hasAttr(ttgi::TritonIntelGPUDialect::getOneMatrixPerLoadAttrName());
 
     // Retrieve mask axis info to validate tile constraints consistently
     // with the downstream LLVM lowering.
@@ -323,13 +348,13 @@ private:
               tensorTy.getShape());
       if (!ttgi::validate2DBlockLoadTile(llEncoding, contiguousDim,
                                          elemSizeInBits, tensorTy,
-                                         maskAxisInfo)) {
+                                         oneMatrixPerLoadForBT, maskAxisInfo)) {
         LDBG("Tile validation failed for load: " << *op);
         return;
       }
       auto sizeInfo = ttgi::getBlockIOTileSize<true>(
           llEncoding, contiguousDim, elemSizeInBits, maskAxisInfo,
-          /*oneMatrixPerLoadForBT=*/false);
+          oneMatrixPerLoadForBT);
       rowDim = sizeInfo.rowDim;
       colDim = sizeInfo.colDim;
       tileWidth = sizeInfo.tileWidth;
@@ -405,12 +430,14 @@ private:
         ttgi::BlockIOModeAttr::get(builder.getContext(), memLayout));
 
     // Propagate attributes if present.
-    for (StringRef attrName :
-         {ttgi::TritonIntelGPUDialect::getOneMatrixPerLoadAttrName(),
-          ttgi::TritonIntelGPUDialect::getBlockIOStrideAttrName()}) {
-      if (auto attr = op->getAttr(attrName))
-        blockPtrLoadOp->setAttr(attrName, attr);
-    }
+    if (oneMatrixPerLoadForBT)
+      blockPtrLoadOp->setAttr(
+          ttgi::TritonIntelGPUDialect::getOneMatrixPerLoadAttrName(),
+          builder.getUnitAttr());
+    if (auto attr = op->getAttr(
+            ttgi::TritonIntelGPUDialect::getBlockIOStrideAttrName()))
+      blockPtrLoadOp->setAttr(
+          ttgi::TritonIntelGPUDialect::getBlockIOStrideAttrName(), attr);
 
     op.replaceAllUsesWith(blockPtrLoadOp.getResult());
     op.erase();


### PR DESCRIPTION
The LowerTo2DBlockLoad pass was rejecting loads that the downstream LLVM lowering (LoadOpToBlockIOConversion/DescriptorLoadOpToBlockIOConversion) would accept. The root cause: validate2DBlockLoadTile always used oneMatrixPerLoadForBT=false, producing a larger transposed tile that failed the shuffle mapping check. The LLVM lowering read the actual ttig.one_matrix_per_load attribute (set by AccelerateMatmul for shared dot operands like K in flex attention), getting a smaller valid tile.