### PR TITLE
Suppress false 'No junit xml files' warnings for tutorial benchmark subdirs (#6355)

### DIFF
--- a/scripts/triton_utils/src/triton_utils/pass_rate_utils.py
+++ b/scripts/triton_utils/src/triton_utils/pass_rate_utils.py
@@ -459,8 +459,10 @@ class TestReport:
         if len(all_paths) == 0:
             raise ValueError(f"No junit xml found in the reports folder {search_folder}")
 
+        is_tutorial_report = (search_folder_path / "tutorials.xml").is_file()
         empty_subfolders = [
             folder for folder in search_folder_path.iterdir() if folder.is_dir() and not any(folder.glob("*.xml"))
+            and not (is_tutorial_report and re.match(r"\d{2}[a-z]?-", folder.name) and any(folder.glob("*.csv")))
         ]
         if len(empty_subfolders) > 0:
             print(

--- a/scripts/triton_utils/test/test_triton_utils.py
+++ b/scripts/triton_utils/test/test_triton_utils.py
@@ -443,6 +443,51 @@ def test_report_directory_layout(  # pylint: disable=R0913, R0914, R0917
         assert 'WARNING: No junit xml files' in std_err
 
 
+def test_tutorial_benchmark_dirs_do_not_warn(capsys, tmp_path):
+    (tmp_path / 'tutorials.xml').write_text(
+        TESTS_WITH_DIFFERENT_STATUSES['language.xml'], encoding='utf-8')
+    for name in ('01-vector-add', '02-fused-softmax', '03a-matrix-multiplication-tensor-descriptor'):
+        d = tmp_path / name
+        d.mkdir()
+        (d / f'{name}-performance.csv').write_text('col1,col2\n1,2\n', encoding='utf-8')
+    broken = tmp_path / 'broken-report'
+    broken.mkdir()
+    (broken / 'warnings.json').write_text('{}', encoding='utf-8')
+    config = triton_utils.Config(action='pass_rate', reports=str(tmp_path))
+    triton_utils.PassRateActionRunner(config)()
+    _, std_err = capsys.readouterr()
+    assert '01-vector-add' not in std_err
+    assert '02-fused-softmax' not in std_err
+    assert '03a-matrix-multiplication-tensor-descriptor' not in std_err
+    assert 'WARNING: No junit xml files' in std_err
+    assert 'broken-report' in std_err
+
+
+def test_tutorial_dir_without_csv_still_warns(capsys, tmp_path):
+    (tmp_path / 'tutorials.xml').write_text(
+        TESTS_WITH_DIFFERENT_STATUSES['language.xml'], encoding='utf-8')
+    d = tmp_path / '03a-matrix-multiplication-tensor-descriptor'
+    d.mkdir()
+    config = triton_utils.Config(action='pass_rate', reports=str(tmp_path))
+    triton_utils.PassRateActionRunner(config)()
+    _, std_err = capsys.readouterr()
+    assert 'WARNING: No junit xml files' in std_err
+    assert '03a-matrix-multiplication-tensor-descriptor' in std_err
+
+
+def test_csv_dirs_without_tutorials_xml_still_warn(capsys, tmp_path):
+    (tmp_path / 'language.xml').write_text(
+        TESTS_WITH_DIFFERENT_STATUSES['language.xml'], encoding='utf-8')
+    d = tmp_path / '01-vector-add'
+    d.mkdir()
+    (d / '01-vector-add-performance.csv').write_text('col1,col2\n1,2\n', encoding='utf-8')
+    config = triton_utils.Config(action='pass_rate', reports=str(tmp_path))
+    triton_utils.PassRateActionRunner(config)()
+    _, std_err = capsys.readouterr()
+    assert 'WARNING: No junit xml files' in std_err
+    assert '01-vector-add' in std_err
+
+
 @pytest.mark.parametrize(
     ('layout', 'exclude_subdir_patterns', 'include_subdir_patterns', 'passed', 'skipped', 'xfailed', 'failed'),
     [


### PR DESCRIPTION
Tutorial tests write per-tutorial benchmark CSVs into numbered subdirs
(e.g. 01-vector-add/, 03a-matrix-multiplication-tensor-descriptor/) that
legitimately contain no JUnit XML. Skip the warning only when tutorials.xml
exists in the report root, the subdir name matches the tutorial naming
pattern, and the subdir contains CSV files.