### PR TITLE
[LowerTo2DBlockLoad] Allow rank-3 pointer loads with batch dimensions

### DIFF
--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/pointer-load.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/pointer-load.mlir
@@ -110,6 +110,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 
 // -----
 
+// COM: Rank-3 pointer load where getBlockIOTileSize assigns rowDim to a batch
+// COM: dimension (dim 0). The pass must still convert it — the downstream
+// COM: lowering handles batch dims by folding them into the base pointer.
+#linear = #ttg.linear<{register = [[1, 0, 0], [2, 0, 0], [0, 0, 16], [0, 0, 32], [0, 0, 64]], lane = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8]], warp = [[0, 0, 0]], block = []}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @rank3_batch_dim_load
+  tt.func @rank3_batch_dim_load(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) -> tensor<4x1x128xf16, #linear> {
+    %0 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<4x1x128x!tt.ptr<f16>, #linear>
+    // CHECK: ttig.2d_block_load_from_ptr
+    %1 = tt.load %0 {ttig.block_io = "row_major"} : tensor<4x1x128x!tt.ptr<f16>, #linear>
+    tt.return %1 : tensor<4x1x128xf16, #linear>
+  }
+}
+
+// -----
+
 // COM: Pointer load with ttig.one_matrix_per_load attribute. The pass must
 // COM: propagate this attribute to the resulting ttig.2d_block_load_from_ptr.
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -487,15 +487,6 @@ bool validate2DBlockLoadTile(const LinearLayout &ll, unsigned memContiguousDim,
   if (!sizeInfo.isValid())
     return false;
 
-  // The 2D block I/O tile must use only the inner 2 dims. Reject if
-  // rowDim or colDim falls in a batch dimension.
-  unsigned rank = ll.getNumOutDims();
-  if (rank > 2) {
-    int innerDimStart = static_cast<int>(rank - 2);
-    if (sizeInfo.rowDim < innerDimStart || sizeInfo.colDim < innerDimStart)
-      return false;
-  }
-
   unsigned packedElemSizeInBits = elemSizeInBits * sizeInfo.numElemPerPackedVal;
   if (!check2DBlockAddressPayloadRestriction(packedElemSizeInBits,
                                              sizeInfo.tileWidth))

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -201,6 +201,19 @@ private:
       return;
     }
 
+    // For descriptor loads, the 2D block I/O tile must use only the inner 2
+    // dims. Reject if rowDim or colDim falls in a batch dimension.
+    if (rank > 2) {
+      auto sizeInfo = ttgi::getBlockIOTileSize<true>(
+          llEncoding, contiguousDim, elemSizeInBits,
+          /*maskAxisInfo=*/nullptr, oneMatrixPerLoadForBT);
+      int innerDimStart = static_cast<int>(rank - 2);
+      if (sizeInfo.rowDim < innerDimStart || sizeInfo.colDim < innerDimStart) {
+        LDBG("Batch dim in tile for descriptor load: " << *op);
+        return;
+      }
+    }
+
     OpBuilder builder(op);
     Location loc = op.getLoc();
     Type i32Ty = builder.getI32Type();


### PR DESCRIPTION
The batch dimension check in `validate2DBlockLoadTile` rejected rank-3 pointer loads where `getBlockIOTileSize` assigns `rowDim` to a batch dim (dim < rank-2). This blocked flex attention's split-KV decode kernel which loads Q as `tensor<4x1x128xf16, #linear>`.

Move the batch dim restriction to `convertDescriptorLoadOp` only (where descriptors genuinely require inner-2-dim tiles). For pointer loads, the downstream `Subgroup2DBlockLoadFromPtrOpConversion` handles batch dims by folding them into the base pointer via GEP.