### PR TITLE
[LowerTo2DBlockLoad] Fix pitch computation for transposed pointer loads

### DIFF
--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/pointer-load.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/pointer-load.mlir
@@ -33,7 +33,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x64x!tt.ptr<f16>, #dot1>
     %3 = tt.addptr %2, %1 : tensor<1x64x!tt.ptr<f16>, #dot1>, tensor<1x64xi32, #dot1>
     %4 = tt.broadcast %3 : tensor<1x64x!tt.ptr<f16>, #dot1> -> tensor<32x64x!tt.ptr<f16>, #dot1>
-    // CHECK: ttig.2d_block_load_from_ptr %4 {column_major} {base_height = 1 : i32, base_pitch = 128 : i32, base_width = 128 : i32}
+    // CHECK: ttig.2d_block_load_from_ptr %4 {column_major} {base_height = 1 : i32, base_pitch = 64 : i32, base_width = 64 : i32}
     %5 = tt.load %4 {ttig.block_io = "column_major"} : tensor<32x64x!tt.ptr<f16>, #dot1>
     tt.return %5 : tensor<32x64xf16, #dot1>
   }
@@ -142,6 +142,36 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     // CHECK-SAME: ttig.one_matrix_per_load
     %5 = tt.load %4 {ttig.block_io = "row_major", ttig.one_matrix_per_load} : tensor<64x32x!tt.ptr<f16>, #dot0>
     tt.return %5 : tensor<64x32xf16, #dot0>
+  }
+}
+
+// -----
+
+// COM: Non-broadcast transposed pointer load. Memory is column-major
+// COM: (contiguous in dim 0), with a valid pitch along dim 1. This exercises
+// COM: the transpose pitch fix: pitch must use colDim (the non-contiguous
+// COM: memory direction) instead of rowDim.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @non_broadcast_column_major
+  tt.func @non_broadcast_column_major(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) -> tensor<32x64xf16, #dot1> {
+    // Build ptr[i, j] = arg0 + i + j * 128  (stride[0]=1, stride[1]=128)
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 1, parent = #dot1}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<32xi32, #ttg.slice<{dim = 1, parent = #dot1}>> -> tensor<32x1xi32, #dot1>
+    %2 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #dot1}>>
+    %3 = tt.expand_dims %2 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #dot1}>> -> tensor<1x64xi32, #dot1>
+    %cst_stride = arith.constant dense<128> : tensor<1x64xi32, #dot1>
+    %4 = arith.muli %3, %cst_stride : tensor<1x64xi32, #dot1>
+    %5 = tt.broadcast %1 : tensor<32x1xi32, #dot1> -> tensor<32x64xi32, #dot1>
+    %6 = tt.broadcast %4 : tensor<1x64xi32, #dot1> -> tensor<32x64xi32, #dot1>
+    %7 = arith.addi %5, %6 : tensor<32x64xi32, #dot1>
+    %8 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<32x64x!tt.ptr<f16>, #dot1>
+    %9 = tt.addptr %8, %7 : tensor<32x64x!tt.ptr<f16>, #dot1>, tensor<32x64xi32, #dot1>
+    // CHECK: ttig.2d_block_load_from_ptr %9 {column_major}
+    // CHECK-SAME: base_pitch = 256
+    %10 = tt.load %9 {ttig.block_io = "column_major"} : tensor<32x64x!tt.ptr<f16>, #dot1>
+    tt.return %10 : tensor<32x64xf16, #dot1>
   }
 }
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -350,6 +350,7 @@ private:
     unsigned rowDim, colDim;
     int tileWidth = -1;
     int tileHeight = -1;
+    bool isTranspose = false;
     if (has1DReshapeStride) {
       // 1D reshape: conventional dims, no tile validation needed.
       rowDim = memoryRowMajor ? rank - 2 : rank - 1;
@@ -372,29 +373,61 @@ private:
       colDim = sizeInfo.colDim;
       tileWidth = sizeInfo.tileWidth;
       tileHeight = sizeInfo.tileHeight;
+      isTranspose = sizeInfo.transpose;
     }
 
+    // For the 2D block load surface, the pitch dimension is always the
+    // non-contiguous memory direction. For transposed loads, rowDim is the
+    // memory-contiguous dim and colDim is non-contiguous, so pitch uses colDim.
+    unsigned pitchDim = isTranspose ? colDim : rowDim;
+
     // Compute pitch from stride analysis or the 1D->2D reshape attribute.
-    int64_t baseWidthBytes = tensorTy.getDimSize(colDim) * elemSizeInBits / 8;
+    // For the HW surface: width is along memory-contiguous direction, height
+    // is along non-contiguous. For transposed loads, rowDim is the contiguous
+    // dim and colDim is non-contiguous, so we swap which dim provides
+    // width/height.
+    unsigned surfaceWidthDim = isTranspose ? rowDim : colDim;
+    unsigned surfaceHeightDim = isTranspose ? colDim : rowDim;
+    int64_t baseWidthBytes =
+        tensorTy.getDimSize(surfaceWidthDim) * elemSizeInBits / 8;
     constexpr int64_t MIN_PITCH = 64;
 
     int64_t pitch;
-    int64_t stride; // stride in elements for the row dimension
+    int64_t stride; // stride in elements for the pitch dimension
     if (has1DReshapeStride) {
       auto strideAttr = op->getAttrOfType<IntegerAttr>(
           ttgi::TritonIntelGPUDialect::getBlockIOStrideAttrName());
       stride = strideAttr.getInt();
       pitch = stride * elemSizeInBits / 8;
     } else {
-      stride = getStride(strideAnalysis, op.getPtr(), rowDim);
-      if (stride < 0) {
-        LDBG("Cannot compute constant stride for load: " << *op);
-        return;
-      }
-      if (stride == 0)
+      // Check if the load is a broadcast: stride=0 along rowDim means all
+      // rows are identical, so we only need height=1 with a dummy pitch.
+      int64_t rowStride = getStride(strideAnalysis, op.getPtr(), rowDim);
+      if (rowStride == 0) {
+        stride = 0;
         pitch = std::max((int64_t)MIN_PITCH, baseWidthBytes);
-      else
+      } else if (!isTranspose) {
+        // Non-transposed: rowDim IS the pitch dimension.
+        stride = rowStride;
+        if (stride < 0) {
+          LDBG("Cannot compute constant stride for load: " << *op);
+          return;
+        }
         pitch = stride * elemSizeInBits / 8;
+      } else {
+        // Transposed non-broadcast: pitch comes from colDim (pitchDim).
+        // Keep stride = rowStride (non-zero) so baseHeight uses full dim.
+        stride = rowStride;
+        int64_t pitchStride = getStride(strideAnalysis, op.getPtr(), pitchDim);
+        if (pitchStride < 0) {
+          LDBG("Cannot compute constant stride for load: " << *op);
+          return;
+        }
+        if (pitchStride == 0)
+          pitch = std::max((int64_t)MIN_PITCH, baseWidthBytes);
+        else
+          pitch = pitchStride * elemSizeInBits / 8;
+      }
     }
 
     // HW requires pitch >= 64 bytes and pitch aligned to 16 bytes.
@@ -423,7 +456,8 @@ private:
     Location loc = op.getLoc();
 
     // Compute constant surface parameters.
-    int64_t baseHeightRows = stride == 0 ? 1 : tensorTy.getDimSize(rowDim);
+    int64_t baseHeightRows =
+        stride == 0 ? 1 : tensorTy.getDimSize(surfaceHeightDim);
 
     auto memLayout = memoryRowMajor ? ttgi::BlockIOMode::RowMajor
                                     : ttgi::BlockIOMode::ColumnMajor;

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -393,40 +393,27 @@ private:
     constexpr int64_t MIN_PITCH = 64;
 
     int64_t pitch;
-    int64_t stride; // stride in elements for the pitch dimension
+    bool isBroadcast = false;
     if (has1DReshapeStride) {
       auto strideAttr = op->getAttrOfType<IntegerAttr>(
           ttgi::TritonIntelGPUDialect::getBlockIOStrideAttrName());
-      stride = strideAttr.getInt();
+      int64_t stride = strideAttr.getInt();
+      isBroadcast = (stride == 0);
       pitch = stride * elemSizeInBits / 8;
     } else {
       // Check if the load is a broadcast: stride=0 along rowDim means all
       // rows are identical, so we only need height=1 with a dummy pitch.
       int64_t rowStride = getStride(strideAnalysis, op.getPtr(), rowDim);
-      if (rowStride == 0) {
-        stride = 0;
+      isBroadcast = (rowStride == 0);
+      if (isBroadcast) {
         pitch = std::max((int64_t)MIN_PITCH, baseWidthBytes);
-      } else if (!isTranspose) {
-        // Non-transposed: rowDim IS the pitch dimension.
-        stride = rowStride;
-        if (stride < 0) {
-          LDBG("Cannot compute constant stride for load: " << *op);
-          return;
-        }
-        pitch = stride * elemSizeInBits / 8;
       } else {
-        // Transposed non-broadcast: pitch comes from colDim (pitchDim).
-        // Keep stride = rowStride (non-zero) so baseHeight uses full dim.
-        stride = rowStride;
         int64_t pitchStride = getStride(strideAnalysis, op.getPtr(), pitchDim);
         if (pitchStride < 0) {
           LDBG("Cannot compute constant stride for load: " << *op);
           return;
         }
-        if (pitchStride == 0)
-          pitch = std::max((int64_t)MIN_PITCH, baseWidthBytes);
-        else
-          pitch = pitchStride * elemSizeInBits / 8;
+        pitch = pitchStride * elemSizeInBits / 8;
       }
     }
 
@@ -436,10 +423,10 @@ private:
       return;
     }
 
-    // For broadcast loads (stride=0), the LLVM lowering's row replication
+    // For broadcast loads, the LLVM lowering's row replication
     // requires tileWidth >= threadsPerWarp or tileWidth * 2 == threadsPerWarp.
     // Reject unsupported configurations.
-    if (stride == 0 && tileHeight > 1 && tileWidth > 0) {
+    if (isBroadcast && tileHeight > 1 && tileWidth > 0) {
       unsigned threadsPerWarp = ttg::TritonGPUDialect::getThreadsPerWarp(
           op->getParentOfType<ModuleOp>());
       if (tileWidth < (int)threadsPerWarp &&
@@ -457,7 +444,7 @@ private:
 
     // Compute constant surface parameters.
     int64_t baseHeightRows =
-        stride == 0 ? 1 : tensorTy.getDimSize(surfaceHeightDim);
+        isBroadcast ? 1 : tensorTy.getDimSize(surfaceHeightDim);
 
     auto memLayout = memoryRowMajor ? ttgi::BlockIOMode::RowMajor
                                     : ttgi::BlockIOMode::ColumnMajor;


### PR DESCRIPTION
For column_major (transposed) pointer loads, three issues are fixed:
1. Pitch must be computed from the non-contiguous memory dimension (colDim for transposed), not the contiguous one (rowDim). Previously, using rowDim gave stride=1, producing an invalid pitch (< 64 bytes).
2. Surface width/height must be swapped for transposed loads: the HW surface width corresponds to the memory-contiguous direction (rowDim for transposed), and height to the non-contiguous direction (colDim).
3. Broadcast detection (stride[rowDim]==0) is tracked separately from the pitch stride to avoid incorrectly setting baseHeight=1 for non-broadcast transposed loads.