### PR TITLE
Fix float32 reduction accuracy regression in ReduceOpToLLVM

### DIFF
--- a/test/TritonIntelGPU/reduce-thread-fold-order.mlir
+++ b/test/TritonIntelGPU/reduce-thread-fold-order.mlir
@@ -1,0 +1,49 @@
+// RUN: triton-opt %s --split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s
+
+// COM: Verify that f32 within-thread reduction uses tree reduction (parallel pairs)
+// COM: while f16 uses left-fold (sequential accumulation) to preserve low-precision
+// COM: accuracy. See issue #6904 and PR #6667.
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 32 : i32, ttig.min_sg_size = 32 : i32} {
+  // CHECK-LABEL: reduce_f32_tree
+  tt.func @reduce_f32_tree(%f : tensor<128xf32, #blocked>) -> f32 {
+    // 4 registers per thread, tree reduce: (r0+r1), (r2+r3), then combine
+    // CHECK: llvm.extractvalue {{.*}}[0]
+    // CHECK: llvm.extractvalue {{.*}}[1]
+    // CHECK: llvm.extractvalue {{.*}}[2]
+    // CHECK: llvm.extractvalue {{.*}}[3]
+    // CHECK: [[A:%.*]] = llvm.fadd %{{.*}}, %{{.*}} : f32
+    // CHECK: [[B:%.*]] = llvm.fadd %{{.*}}, %{{.*}} : f32
+    // CHECK: llvm.fadd [[A]], [[B]] : f32
+    %g = "tt.reduce" (%f) ({
+    ^bb0(%arg0: f32, %arg1: f32):
+      %add = arith.addf %arg0, %arg1 : f32
+      tt.reduce.return %add : f32
+    }) {axis = 0 : i32} : (tensor<128xf32, #blocked>) -> f32
+    tt.return %g : f32
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 32 : i32, ttig.min_sg_size = 32 : i32} {
+  // CHECK-LABEL: reduce_f16_left_fold
+  tt.func @reduce_f16_left_fold(%f : tensor<128xf16, #blocked>) -> f16 {
+    // 4 registers per thread, left fold: r0+r1 -> +r2 -> +r3 (sequential chain)
+    // CHECK: llvm.extractvalue {{.*}}[0]
+    // CHECK: llvm.extractvalue {{.*}}[1]
+    // CHECK: llvm.extractvalue {{.*}}[2]
+    // CHECK: llvm.extractvalue {{.*}}[3]
+    // CHECK: [[S0:%.*]] = llvm.fadd %{{.*}}, %{{.*}} : f16
+    // CHECK: [[S1:%.*]] = llvm.fadd [[S0]], %{{.*}} : f16
+    // CHECK: llvm.fadd [[S1]], %{{.*}} : f16
+    %g = "tt.reduce" (%f) ({
+    ^bb0(%arg0: f16, %arg1: f16):
+      %add = arith.addf %arg0, %arg1 : f16
+      tt.reduce.return %add : f16
+    }) {axis = 0 : i32} : (tensor<128xf16, #blocked>) -> f16
+    tt.return %g : f16
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ReduceOpToLLVM.cpp
@@ -327,12 +327,19 @@ private:
         vectorCombineRegion ? *vectorCombineRegion : op.getCombineOp();
 
     Operation &combinerOp = combineRegion.front().front();
-
-#if !TRITON_INTEL_REDUCE_USE_LEFT_FOLD_THREAD_REDUCE
     unsigned arity = targetInfo.getReductionTreeArity(&combinerOp);
-#endif
 
-    // Perform a tree reduction
+    // Use a deterministic left fold for sub-32-bit float types to avoid
+    // extra reassociation error in low-precision reductions (fp16/bf16).
+    // For float32 and wider float types, use a tree reduction which
+    // matches the upstream accumulation order and avoids tolerance
+    // regressions in float32 reduction accuracy tests.
+    // Non-float types keep left fold (integer addition is associative,
+    // so the reduction order does not affect the result).
+    bool useLeftFold =
+        TRITON_INTEL_REDUCE_USE_LEFT_FOLD_THREAD_REDUCE &&
+        !(isa<FloatType>(elemTy) && elemTy.getIntOrFloatBitWidth() >= 32);
+
     unsigned numOperands = accs.size();
     SmallVector<SmallVector<Value>> reduced(numOperands);
     unsigned regs = accs.front().size();
@@ -347,17 +354,15 @@ private:
         vals.push_back(std::move(cur));
       }
 
-#if TRITON_INTEL_REDUCE_USE_LEFT_FOLD_THREAD_REDUCE
-      // Use a deterministic left fold to avoid extra reassociation error in
-      // low-precision reductions.
-      SmallVector<Value> acc = vals.front();
-      for (unsigned i = 1; i < vals.size(); ++i) {
-        accumulate(loc, rewriter, combineRegion, acc, vals[i]);
+      SmallVector<Value> acc;
+      if (useLeftFold) {
+        acc = vals.front();
+        for (unsigned i = 1; i < vals.size(); ++i) {
+          accumulate(loc, rewriter, combineRegion, acc, vals[i]);
+        }
+      } else {
+        acc = treeReduce(loc, rewriter, combineRegion, std::move(vals), arity);
       }
-#else
-      auto acc =
-          treeReduce(loc, rewriter, combineRegion, std::move(vals), arity);
-#endif
       for (unsigned opIdx = 0; opIdx < numOperands; ++opIdx) {
         reduced[opIdx].push_back(acc[opIdx]);
       }


### PR DESCRIPTION
PR #6667 (commits 9960fa5fb, a792fe7a2) introduced an Intel-specific ReduceOp lowering path to work around TIMM model accuracy issues caused by the upstream tree reduction combine order. That change unconditionally replaced tree reduction with left-fold accumulation in reduceWithinThreads via TRITON_INTEL_REDUCE_USE_LEFT_FOLD_THREAD_REDUCE.

While left fold improves accuracy for low-precision types (fp16/bf16) by providing deterministic accumulation order, it changes the float32 accumulation order enough to produce ~1.5e-6 relative error for sums of ~2048 elements. This exceeds PyTorch's default assertEqual tolerance of 1.3e-6, causing test_fuse_mix_order_reductions_combo_kernels to fail and blocking the Triton XPU pin update in PyTorch.

Fix: make left fold conditional on element bitwidth < 32. Sub-32-bit types still use left fold (preserving the TIMM fix). Float32 and wider types use tree reduction (matching upstream behavior).

Fixes: #6904
