### PR TITLE
[IntegerRangeAnalysis] Fix `std::optional<bool>` misuse in `getTripCount` causing incorrect cmpi folding (#6922)

### DIFF
--- a/test/Analysis/intel/test-range-analysis.mlir
+++ b/test/Analysis/intel/test-range-analysis.mlir
@@ -1284,7 +1284,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     ttg.local_store %16, %18 : tensor<32x128xf16, #blocked> -> !ttg.memdesc<32x128xf16, #shared1, #smem, mutable>
     // expected-remark@+1 {{unsigned : [0, 18446744073709551615] signed : [-9223372036854775808, 9223372036854775807]}}
     %19 = arith.subi %arg1, %arg2 : index
-    // expected-remark@+1 {{inferred total trip count: 0}}
+    // expected-remark@+1 {{inferred total trip count: 1025}}
     %20:6 = scf.for %arg5 = %arg0 to %19 step %arg2 iter_args(%arg6 = %4, %arg7 = %9, %arg8 = %cst_2, %arg9 = %c0_i32, %arg10 = %17, %arg11 = %18) -> (tensor<128x32x!tt.ptr<f16>, #blocked1>, tensor<32x128x!tt.ptr<f16>, #blocked>, tensor<128x128xf32, #mma>, i32, !ttg.memdesc<128x32xf16, #shared, #smem, mutable>, !ttg.memdesc<32x128xf16, #shared1, #smem, mutable>) {
       %33 = tt.addptr %arg6, %cst_1 : tensor<128x32x!tt.ptr<f16>, #blocked1>, tensor<128x32xi32, #blocked1>
       %34 = tt.addptr %arg7, %cst_0 : tensor<32x128x!tt.ptr<f16>, #blocked>, tensor<32x128xi32, #blocked>
@@ -1297,7 +1297,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
       %40 = tt.dot %36, %39, %arg8 : tensor<128x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<32x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x128xf32, #mma>
       %41 = arith.addi %arg9, %c1_i32 : i32
       %42 = arith.cmpi slt, %41, %c1_i32 : i32
-      // expected-remark@+1 {{unsigned : [0, 0] signed : [0, 0]}}
+      // expected-remark@+1 {{unsigned : [0, 4294967295] signed : [-2147483648, 2147483647]}}
       %43 = arith.select %42, %41, %c0_i32 : i32
       %44 = ttg.memdesc_index %10[%43] : !ttg.memdesc<1x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
       ttg.local_store %35, %44 : tensor<128x32xf16, #blocked1> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
@@ -1514,7 +1514,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %16 = tt.addptr %15, %14 : tensor<32x1x!tt.ptr<f32>, #blocked2>, tensor<32x1xi32, #blocked2>
     %17 = tt.broadcast %16 : tensor<32x1x!tt.ptr<f32>, #blocked2> -> tensor<32x128x!tt.ptr<f32>, #blocked2>
     %18 = ttg.convert_layout %17 : tensor<32x128x!tt.ptr<f32>, #blocked2> -> tensor<32x128x!tt.ptr<f32>, #blocked3>
-    // expected-remark@+1 {{inferred total trip count: 16711680}}
+    // expected-remark@+1 {{inferred total trip count: 16777215}}
     %19 = scf.for %arg3 = %1 to %8 step %2 iter_args(%arg4 = %cst) -> (tensor<32xf32, #blocked>)  : i32 {
       // expected-remark@+1 {{unsigned : [0, 2147483392] signed : [0, 2147483392]}}
       %26 = arith.muli %arg3, %c128_i32 : i32

--- a/test/Triton/Intel/fold-true-cmpi.mlir
+++ b/test/Triton/Intel/fold-true-cmpi.mlir
@@ -145,3 +145,35 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 // CHECK:           %[[TRUE:.*]] = arith.constant dense<true> : tensor<32xi1>
 // CHECK:           tt.return %[[TRUE]] : tensor<32xi1>
 // CHECK:         }
+
+// -----
+
+// Comparisons between loop-carried accumulators and loaded values must NOT be
+// folded. The accumulator starts at INT64_MAX but gets updated each iteration,
+// so "accumulator < loaded_value" is not always false despite the initial value.
+// This is a regression test for a bug where getTripCount returned 0 due to
+// std::optional<bool> misuse, preventing iter_arg range propagation.
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @loop_carried_cmpi_not_folded(%arg0: !tt.ptr<i64>, %lb: i32, %ub: i32) -> tensor<32xi64> {
+    %c32 = arith.constant 32 : i32
+    %cst_max = arith.constant dense<9223372036854775807> : tensor<32xi64>
+    %cst_zero = arith.constant dense<0> : tensor<32xi64>
+    %range = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %ptr_splat = tt.splat %arg0 : !tt.ptr<i64> -> tensor<32x!tt.ptr<i64>>
+    %result = scf.for %iv = %lb to %ub step %c32 iter_args(%acc = %cst_max) -> (tensor<32xi64>) : i32 {
+      %iv_splat = tt.splat %iv : i32 -> tensor<32xi32>
+      %offsets = arith.addi %iv_splat, %range : tensor<32xi32>
+      %ptrs = tt.addptr %ptr_splat, %offsets : tensor<32x!tt.ptr<i64>>, tensor<32xi32>
+      %loaded = tt.load %ptrs : tensor<32x!tt.ptr<i64>>
+      %cmp = arith.cmpi slt, %acc, %loaded : tensor<32xi64>
+      %new_acc = arith.select %cmp, %acc, %loaded : tensor<32xi1>, tensor<32xi64>
+      scf.yield %new_acc : tensor<32xi64>
+    }
+    tt.return %result : tensor<32xi64>
+  }
+}
+
+// CHECK-LABEL:   tt.func @loop_carried_cmpi_not_folded
+// CHECK:           scf.for
+// CHECK:             arith.cmpi slt
+// CHECK:           tt.return

--- a/third_party/intel/lib/Analysis/Range.cpp
+++ b/third_party/intel/lib/Analysis/Range.cpp
@@ -328,8 +328,7 @@ IntegerRangeAnalysis::getTripCount(LoopLikeOpInterface loop) const {
   const unsigned width = ConstantIntRanges::getStorageBitwidth(iv->getType());
 
   auto getLoopRangeInfo = [&](std::optional<OpFoldResult> loopBound,
-                              Block *block,
-                              std::optional<bool> getUpper = std::nullopt,
+                              Block *block, bool getUpper,
                               std::optional<APInt> defaultVal = std::nullopt) {
     if (loopBound) {
       if (auto attr = dyn_cast<Attribute>(*loopBound)) {
@@ -366,7 +365,8 @@ IntegerRangeAnalysis::getTripCount(LoopLikeOpInterface loop) const {
   // We can assume step is 1 if no range information as that gives us the upper
   // bound of the number of iterations.
   APInt stepValDefault = {width, 1, /*isSigned=*/true};
-  APInt stepVal = getLoopRangeInfo(step, block, std::nullopt, stepValDefault);
+  APInt stepVal =
+      getLoopRangeInfo(step, block, /*getUpper=*/false, stepValDefault);
 
   if (stepVal.isNegative())
     std::swap(min, max);


### PR DESCRIPTION
std::optional<bool> in boolean context tests has-value, not the value itself. So getUpper=false was truthy, causing both loop bounds to return smax() and yielding trip count 0. This prevented loop-carried value propagation, leaving iter_args at their initial values (e.g. INT64_MAX), which made comparisons inside reduction loops appear provably false.

Fixes #6918

---------


(cherry picked from commit c21c26d43171097a5b6682f7f129d1a07a4831a5)