### PR TITLE
[CI] Increase timeout from 6 to 10 hours for `auto-update-translator-cid` workflow

### DIFF
--- a/.github/workflows/auto-update-translator-cid.yml
+++ b/.github/workflows/auto-update-translator-cid.yml
@@ -16,6 +16,7 @@ jobs:
       - max1100
       - rolling
       - runner-0.0.22
+    timeout-minutes: 600
     defaults:
       run:
         shell: bash -noprofile --norc -eo pipefail -c "source /opt/intel/oneapi/setvars.sh > /dev/null; source {0}"


### PR DESCRIPTION
To fix: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/25768327871/job/75685831950

New run: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/25801426231 (to check)