### PR TITLE
[Clang] SpatialReuseAnalysisTest, replace ArrayRef with SmallVector

### DIFF
--- a/third_party/intel/unittest/Analysis/SpatialReuseAnalysisTest.cpp
+++ b/third_party/intel/unittest/Analysis/SpatialReuseAnalysisTest.cpp
@@ -251,7 +251,7 @@ TEST_F(SpatialReuseAnalysisTest, DescriptorLoadOpOverload) {
       RankedTensorType::get({64, 64}, builder->getF32Type(), dotOpEnc);
 
   Type elemTy = builder->getF32Type();
-  ArrayRef<int64_t> shape = {64, 64};
+  SmallVector<int64_t> shape = {64, 64};
   auto descTy =
       TensorDescType::get(shape, elemTy, /*sharedLayout=*/Attribute{});
 
@@ -286,7 +286,7 @@ TEST_F(SpatialReuseAnalysisTest, DescriptorGatherOpOverload) {
       RankedTensorType::get({16, 32}, builder->getF16Type(), blocked);
 
   Type elemTy = builder->getF16Type();
-  ArrayRef<int64_t> descShape = {1024, 1024};
+  SmallVector<int64_t> descShape = {1024, 1024};
   auto descTy =
       TensorDescType::get(descShape, elemTy, /*sharedLayout=*/Attribute{});
   auto indicesXTy = RankedTensorType::get({512}, builder->getI32Type());


### PR DESCRIPTION
`ArrayRef` is a non-owning view and does not store the underlying data. Initializing it with {64, 64} creates a temporary array whose lifetime ends at the end of the full expression, resulting in a dangling reference. Newer Clang versions correctly diagnose this with `-Wdangling`, while GCC accepted it silently. Replacing `ArrayRef` with `SmallVector` provides owned storage and avoids the lifetime issue.

```
  /home/user/workspace/intel-xpu-backend-for-triton/third_party/intel/unittest/Analysis/SpatialReuseAnalysisTest.cpp:254:29: error: array backing local initializer list 'shape' will be destroyed at the end of the full-expression [-Werror,-Wdangling]
    254 |   ArrayRef<int64_t> shape = {64, 64};
        |                             ^~~~~~~~
  /home/user/workspace/intel-xpu-backend-for-triton/third_party/intel/unittest/Analysis/SpatialReuseAnalysisTest.cpp:289:33: error: array backing local initializer list 'descShape' will be destroyed at the end of the full-expression [-Werror,-Wdangling]
    289 |   ArrayRef<int64_t> descShape = {1024, 1024};
        |                                 ^~~~~~~~~~~~
  2 errors generated.
```