### PR TITLE
[CI] Temporarily remove custom PTI build

### DIFF
--- a/.github/workflows/build-test-reusable.yml
+++ b/.github/workflows/build-test-reusable.yml
@@ -121,10 +121,6 @@ jobs:
             DEBUG=1
             python -m build --wheel --no-isolation && pip install dist/*.whl
 
-      - name: Build PTI
-        run: |
-          ./scripts/install-pti.sh --build-level-zero
-
       - name: Set test-triton command line
         id: test-triton
         run: |
@@ -172,12 +168,6 @@ jobs:
         with:
           name: triton-${{ inputs.python_version }}-${{ inputs.runner_label || inputs.driver_version }}
           path: dist/*.whl
-
-      - name: Upload PTI wheels
-        uses: actions/upload-artifact@v7
-        with:
-          name: pti-${{ inputs.python_version }}-${{ inputs.runner_label || inputs.driver_version }}
-          path: .scripts_cache/pti/dist/*.whl
 
       - name: Upload test reports
         uses: actions/upload-artifact@v7
@@ -239,22 +229,10 @@ jobs:
         with:
           name: triton-${{ inputs.python_version }}-${{ inputs.runner_label || inputs.driver_version }}
 
-      - name: Download PTI wheels
-        uses: actions/download-artifact@v8
-        with:
-          name: pti-${{ inputs.python_version }}-${{ inputs.runner_label || inputs.driver_version }}
-
       - name: Install Triton
         run: |
           pip install triton-*.whl
           python -c 'import triton; print(triton.__version__)'
-
-      - name: Install PTI
-        run: |
-          pip install intel_pti-*.whl
-          PTI_LIBS_DIR=$(python ./scripts/pti_lib.py)
-          ls $PTI_LIBS_DIR
-          echo "LD_LIBRARY_PATH=$PTI_LIBS_DIR:$LD_LIBRARY_PATH" | tee -a $GITHUB_ENV
 
       - name: Report environment details
         timeout-minutes: 1

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -124,16 +124,6 @@ jobs:
           pip install -U pybind11 cmake
           pip install -v '.[build,tests,tutorials]'
 
-      - name: Build && Install PTI
-        run: |
-          .venv\Scripts\activate.ps1
-          Invoke-BatchFile "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
-          cd ${{ env.NEW_WORKSPACE }}
-          bash -c './scripts/install-pti.sh --build-level-zero'
-          $PTI_LIBS_DIR = python ./scripts/pti_lib.py
-          ls $PTI_LIBS_DIR
-          echo "PATH=$PTI_LIBS_DIR;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
       - name: Triton version
         run: |
           .venv\Scripts\activate.ps1

--- a/.github/workflows/pip-test-windows.yml
+++ b/.github/workflows/pip-test-windows.yml
@@ -102,16 +102,6 @@ jobs:
           .venv\Scripts\activate.ps1
           python -c 'import triton; print(triton.__version__)'
 
-      - name: Build && Install PTI
-        run: |
-          .venv\Scripts\activate.ps1
-          Invoke-BatchFile "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
-          cd ${{ env.NEW_WORKSPACE }}
-          bash -c './scripts/install-pti.sh --build-level-zero'
-          $PTI_LIBS_DIR = python ./scripts/pti_lib.py
-          ls $PTI_LIBS_DIR
-          echo "PATH=$PTI_LIBS_DIR;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
       - name: Install test dependencies
         run: |
           .venv\Scripts\activate.ps1

--- a/.github/workflows/pip-test.yml
+++ b/.github/workflows/pip-test.yml
@@ -55,13 +55,6 @@ jobs:
       - name: Install Triton
         uses: ./.github/actions/setup-triton
 
-      - name: Build && Install PTI
-        run: |
-          ./scripts/install-pti.sh --build-level-zero
-          PTI_LIBS_DIR=$(python ./scripts/pti_lib.py)
-          ls $PTI_LIBS_DIR
-          echo "LD_LIBRARY_PATH=$PTI_LIBS_DIR:$LD_LIBRARY_PATH" | tee -a $GITHUB_ENV
-
       - name: Install runtime dependencies
         run: |
           curl -sSLO --retry 10 https://raw.githubusercontent.com/pytorch/pytorch/$(<.github/pins/pytorch.txt)/.github/scripts/generate_binary_build_matrix.py


### PR DESCRIPTION
To simplify switch to oneAPI 2026.0

https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/25854838382 (now it's the tests that fail, not the build)