### PR TITLE
[TTGIR] Rewrite AnnotateCacheControl on top of ReuseAnalysis + AliasAnalysis

### DIFF
--- a/test/TritonIntelGPU/annotate-cache-control.mlir
+++ b/test/TritonIntelGPU/annotate-cache-control.mlir
@@ -42,20 +42,24 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
 // -----
 
 // COM: Test c — load with #blocked encoding that is converted to #dot_a and
-// COM: consumed by tt.dot GETS .cg. The blocked load issues non-overlapping
-// COM: subgroup addresses (no cross-subgroup L1 reuse to preserve); the
-// COM: layout conversion to dot operand happens in registers after the load.
+// COM: consumed by tt.dot. warpsPerCTA = [1, 4]: warps tile only dim 1, so
+// COM: every warp reads the SAME rows on dim 0. SpatialReuseAnalysis (P1)
+// COM: structurally detects dim 0's zero warp basis and reports
+// COM: cross-subgroup reuse: the load is correctly left with the default
+// COM: cache modifier. The %b load has a dot-operand encoding (dim K
+// COM: warp-broadcast), also correctly skipped.
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [1, 4], order = [1, 0]}>
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 1], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot_a = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
 #dot_b = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  // CHECK-LABEL: @blocked_to_dot_via_convert_gets_cg
-  tt.func public @blocked_to_dot_via_convert_gets_cg(%aptr: tensor<32x32x!tt.ptr<f16>, #blocked>,
-                                                     %bptr: tensor<32x32x!tt.ptr<f16>, #dot_b>,
-                                                     %c: tensor<32x32xf32, #dpas>) -> tensor<32x32xf32, #dpas> {
-    // CHECK: tt.load {{.*}} cacheModifier = cg
+  // CHECK-LABEL: @blocked_to_dot_via_convert_warp_broadcast
+  tt.func public @blocked_to_dot_via_convert_warp_broadcast(%aptr: tensor<32x32x!tt.ptr<f16>, #blocked>,
+                                                            %bptr: tensor<32x32x!tt.ptr<f16>, #dot_b>,
+                                                            %c: tensor<32x32xf32, #dpas>) -> tensor<32x32xf32, #dpas> {
+    // CHECK: tt.load
+    // CHECK-NOT: cacheModifier = cg
     %a_blk = tt.load %aptr : tensor<32x32x!tt.ptr<f16>, #blocked>
     %a = ttg.convert_layout %a_blk : tensor<32x32xf16, #blocked> -> tensor<32x32xf16, #dot_a>
     // CHECK: tt.load
@@ -473,5 +477,109 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK-NOT: cacheModifier = cg
     %0 = tt.load %p : tensor<16x!tt.ptr<f16>, #slice_1d>
     tt.return
+  }
+}
+
+// -----
+
+// COM: Test u — KV-cache decode regression guard (#6809). Pointer is defined
+// COM: outside the scf.for: TemporalReuseAnalysis reports Invariant → reuse on
+// COM: the enclosing loop. Load must NOT get .cg even though it is read-only
+// COM: and does not feed a dot.
+
+#blocked1d = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [16], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: @kv_cache_decode_loop_invariant
+  tt.func public @kv_cache_decode_loop_invariant(%kv: tensor<32x!tt.ptr<f32>, #blocked1d>,
+                                                 %out: tensor<32x!tt.ptr<f32>, #blocked1d>,
+                                                 %lb: i32, %ub: i32, %step: i32) {
+    scf.for %q = %lb to %ub step %step : i32 {
+      // CHECK: tt.load
+      // CHECK-NOT: cacheModifier = cg
+      %v = tt.load %kv : tensor<32x!tt.ptr<f32>, #blocked1d>
+      tt.store %out, %v : tensor<32x!tt.ptr<f32>, #blocked1d>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Test w — pure streaming in a loop: the pointer advances by exactly
+// COM: the tile extent (32) per iteration, so successive tiles are disjoint.
+// COM: TemporalReuseAnalysis reports Streaming on the enclosing loop → no
+// COM: temporal reuse. Load gets .cg.
+
+#blocked1d = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [16], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: @streaming_loop_gets_cg
+  tt.func public @streaming_loop_gets_cg(%in: !tt.ptr<f32>,
+                                         %out: !tt.ptr<f32>,
+                                         %lb: i32, %ub: i32) {
+    %c32 = arith.constant 32 : i32
+    %r = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #blocked1d>
+    %s = tt.splat %in : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>, #blocked1d>
+    %sout = tt.splat %out : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>, #blocked1d>
+    %p0 = tt.addptr %s, %r : tensor<32x!tt.ptr<f32>, #blocked1d>, tensor<32xi32, #blocked1d>
+    %po0 = tt.addptr %sout, %r : tensor<32x!tt.ptr<f32>, #blocked1d>, tensor<32xi32, #blocked1d>
+    scf.for %i = %lb to %ub step %c32 : i32 {
+      %iv = tt.splat %i : i32 -> tensor<32xi32, #blocked1d>
+      %pp = tt.addptr %p0, %iv : tensor<32x!tt.ptr<f32>, #blocked1d>, tensor<32xi32, #blocked1d>
+      %poo = tt.addptr %po0, %iv : tensor<32x!tt.ptr<f32>, #blocked1d>, tensor<32xi32, #blocked1d>
+      // CHECK: tt.load {{.*}} cacheModifier = cg
+      %v = tt.load %pp : tensor<32x!tt.ptr<f32>, #blocked1d>
+      tt.store %poo, %v : tensor<32x!tt.ptr<f32>, #blocked1d>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Test x — two read-only loads of the same arg at different offsets:
+// COM: they alias each other (per AliasAnalysisTest TwoLoadsSameArgDifferentOffsets)
+// COM: but no peer has a write effect, so `aliasesWritingPeer` returns false
+// COM: for both. Both loads get .cg.
+
+#blocked1d = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [16], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: @two_readonly_loads_same_arg
+  tt.func public @two_readonly_loads_same_arg(%X: tensor<32x!tt.ptr<f32>, #blocked1d>,
+                                              %off0: tensor<32xi32, #blocked1d>,
+                                              %off1: tensor<32xi32, #blocked1d>)
+      -> (tensor<32xf32, #blocked1d>, tensor<32xf32, #blocked1d>) {
+    %p0 = tt.addptr %X, %off0 : tensor<32x!tt.ptr<f32>, #blocked1d>, tensor<32xi32, #blocked1d>
+    %p1 = tt.addptr %X, %off1 : tensor<32x!tt.ptr<f32>, #blocked1d>, tensor<32xi32, #blocked1d>
+    // CHECK: tt.load {{.*}} cacheModifier = cg
+    %a = tt.load %p0 : tensor<32x!tt.ptr<f32>, #blocked1d>
+    // CHECK: tt.load {{.*}} cacheModifier = cg
+    %b = tt.load %p1 : tensor<32x!tt.ptr<f32>, #blocked1d>
+    tt.return %a, %b : tensor<32xf32, #blocked1d>, tensor<32xf32, #blocked1d>
+  }
+}
+
+// -----
+
+// COM: Test y — scale-operand LinearEncodingAttr load. Regression guard for
+// COM: deletion of the use-site `tt.dot_scaled` scan in the old pass: after
+// COM: deletion, the ONLY mechanism that keeps `.cg` off the scale load is
+// COM: SpatialReuseAnalysis structurally catching the scale encoding's
+// COM: warp-invariant basis (zero warp dim in the LinearLayout). If this test
+// COM: ever regresses, `BlockScaledDPAStoLinearLayout`'s warp basis for the
+// COM: scale encoding is wrong — not the pass.
+// COM:
+// COM: The `warp = [[0, 0], [0, 0]]` basis below encodes "every warp reads
+// COM: the same coordinates": P1 reports cross-subgroup reuse and the load
+// COM: is left with the default cache modifier.
+
+#ll_scale = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4]], lane = [[1, 0], [2, 0], [4, 0], [8, 0]], warp = [[0, 0], [0, 0]], block = []}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: @scale_encoding_load_unchanged
+  tt.func public @scale_encoding_load_unchanged(%sptr: tensor<16x8x!tt.ptr<i8>, #ll_scale>)
+      -> tensor<16x8xi8, #ll_scale> {
+    // CHECK: tt.load
+    // CHECK-NOT: cacheModifier = cg
+    %s = tt.load %sptr : tensor<16x8x!tt.ptr<i8>, #ll_scale>
+    tt.return %s : tensor<16x8xi8, #ll_scale>
   }
 }

--- a/third_party/intel/include/Analysis/AliasAnalysis.h
+++ b/third_party/intel/include/Analysis/AliasAnalysis.h
@@ -74,6 +74,27 @@ public:
   llvm::ArrayRef<mlir::Operation *>
   getAliasingMemOps(triton::DescriptorLoadOp loadOp) const;
 
+  /// Three-state classification of a pointer's origin. The enum makes
+  /// `Unknown` vs `NotTracked` impossible to conflate at the call site.
+  enum class PointerRootKind { Known, Unknown, NotTracked };
+
+  /// Root-query result for a pointer.
+  struct PointerRootsResult {
+    PointerRootKind kind;
+    /// Populated only when `kind == Known`.
+    llvm::SmallVector<mlir::Value> roots;
+  };
+
+  /// Returns the root set for `ptr`, distinguishing Known / Unknown /
+  /// NotTracked. `Known` means the dataflow solver resolved the pointer to a
+  /// non-empty set of entry-block pointer arguments. `Unknown` means the
+  /// solver marked the pointer's origin opaque (e.g., `arith.select` fallback).
+  /// `NotTracked` means the pointer was never seeded in the solver (it is not
+  /// a memory-effect op operand). `Unknown` and `NotTracked` are both
+  /// conservative: a caller that wants "is this pointer known?" should pattern
+  /// match on `kind == Known`.
+  PointerRootsResult getPointerRoots(mlir::Value ptr) const;
+
 private:
   /// Returns true if the snapshots for pointers `a` and `b` may alias.
   /// Either snapshot being `unknown` (opaque origin or missing from the map)

--- a/third_party/intel/lib/Analysis/AliasAnalysis.cpp
+++ b/third_party/intel/lib/Analysis/AliasAnalysis.cpp
@@ -398,6 +398,25 @@ bool AliasAnalysis::mayAlias(Value a, Value b) const {
   return false;
 }
 
+AliasAnalysis::PointerRootsResult
+AliasAnalysis::getPointerRoots(Value ptr) const {
+  PointerRootsResult result;
+  auto it = pointerRoots.find(ptr);
+  if (it == pointerRoots.end()) {
+    result.kind = PointerRootKind::NotTracked;
+    return result;
+  }
+  if (it->second.unknown) {
+    result.kind = PointerRootKind::Unknown;
+    return result;
+  }
+  result.kind = PointerRootKind::Known;
+  result.roots.reserve(it->second.roots.size());
+  for (Value v : it->second.roots)
+    result.roots.push_back(v);
+  return result;
+}
+
 ArrayRef<Operation *>
 AliasAnalysis::getAliasingMemOps(tt::LoadOp loadOp) const {
   return getAliasingMemOps(loadOp.getOperation());

--- a/third_party/intel/lib/TritonIntelGPUTransforms/AnnotateCacheControl.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/AnnotateCacheControl.cpp
@@ -1,13 +1,18 @@
+#include "intel/include/Analysis/AliasAnalysis.h"
+#include "intel/include/Analysis/AxisInfoExt.h"
+#include "intel/include/Analysis/ReuseAnalysis.h"
+#include "intel/include/Analysis/StrideInfo.h"
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
-#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace tt = mlir::triton;
-namespace ttg = mlir::triton::gpu;
+namespace tti = mlir::triton::intel;
 
 namespace mlir::triton::gpu::intel {
 
@@ -16,15 +21,21 @@ namespace mlir::triton::gpu::intel {
 
 namespace {
 
-// Propagates a use of `v` through structured control flow, inserting any
-// downstream values that may transitively carry data from `v` into `worklist`.
-// Returns true if the caller should skip the default fallback (i.e. the use
-// was already handled here). Handles scf.for (init -> iter_arg, result),
-// scf.if (yield -> result), and scf.while (init -> before-region arg,
-// condition -> after-region arg + while result, after-region yield ->
-// before-region arg).
-static bool propagateThroughSCF(OpOperand &use,
-                                llvm::SetVector<Value> &worklist) {
+using AliasKind = tti::AliasAnalysis::PointerRootKind;
+using RootsResult = tti::AliasAnalysis::PointerRootsResult;
+
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
+
+/// Propagates a use of `v` through structured control flow, inserting any
+/// downstream values that may transitively carry data from `v` into `worklist`.
+/// Returns true if the caller should skip the default fallback (i.e. the use
+/// was already handled here). Handles scf.for (init -> iter_arg, result),
+/// scf.if (yield -> result), and scf.while (init -> before-region arg,
+/// condition -> after-region arg + while result, after-region yield ->
+/// before-region arg).
+static bool propagateThroughSCF(OpOperand &use, SetVector<Value> &worklist) {
   Operation *user = use.getOwner();
 
   if (auto forOp = dyn_cast<scf::ForOp>(user)) {
@@ -81,174 +92,169 @@ static bool propagateThroughSCF(OpOperand &use,
   return false;
 }
 
-// Returns true when `.cg` annotation should be suppressed on `loadOp` because
-// the HW access pattern implied by the load's result encoding already yields
-// cross-subgroup L1 reuse. Replaces an older forward-dataflow heuristic
-// (see PR #6723 review).
-static bool skipForL1Reuse(tt::LoadOp loadOp) {
-  auto tensorTy = dyn_cast<RankedTensorType>(loadOp.getType());
-  if (!tensorTy)
+/// True if `arg` is an entry-block block-argument of some FunctionOpInterface.
+static bool isEntryBlockFuncArg(Value v) {
+  auto arg = dyn_cast<BlockArgument>(v);
+  if (!arg)
     return false;
-  Attribute enc = tensorTy.getEncoding();
-  if (!enc)
+  Block *owner = arg.getOwner();
+  if (!owner)
     return false;
+  auto funcOp = dyn_cast_or_null<FunctionOpInterface>(owner->getParentOp());
+  if (!funcOp)
+    return false;
+  Region &body = funcOp.getFunctionBody();
+  return !body.empty() && owner == &body.front();
+}
 
-  // Unwrap SliceEncodingAttr chain (may be nested).
-  while (auto sliceEnc = dyn_cast<ttg::SliceEncodingAttr>(enc))
-    enc = sliceEnc.getParent();
+/// Returns true iff `ptr`'s origin is opaque (Unknown) or was never seeded
+/// by the alias analysis (NotTracked). Both cases are conservatively treated
+/// as "origin unresolved" by callers — we cannot prove the pointer is safe
+/// for L1 bypass in the presence of an unknown root.
+static bool ptrRootsUnknown(Value ptr, const tti::AliasAnalysis &alias) {
+  return alias.getPointerRoots(ptr).kind != AliasKind::Known;
+}
 
-  // DotOperandEncodingAttr whose parent is a DPAS/MMA-family encoding
-  // (DpasEncodingAttr and Subgroup2DBlockEncodingAttr both implement
-  // MmaEncodingTrait).
-  if (auto dotEnc = dyn_cast<ttg::DotOperandEncodingAttr>(enc))
-    if (isa<ttg::MmaEncodingTrait>(dotEnc.getParent()))
-      return true;
+/// Returns true iff every root of `ptr` is an entry-block function argument.
+/// Used by the atomic-policy gate. `Unknown` / `NotTracked` return false —
+/// the caller (`ptrRootsUnknown` gate) handles those separately.
+static bool isPointerArgRooted(Value ptr, const tti::AliasAnalysis &alias) {
+  RootsResult result = alias.getPointerRoots(ptr);
+  if (result.kind != AliasKind::Known || result.roots.empty())
+    return false;
+  return llvm::all_of(result.roots, isEntryBlockFuncArg);
+}
 
-  // Scale operand of tt.dot_scaled: scales are consumed by the same
-  // DPAS-backed matmul as the A/B operands and benefit from the same
-  // cross-subgroup L1 reuse, so `.cg` would defeat that. The
-  // LinearEncodingAttr built by BlockScaledDPAStoLinearLayout has no
-  // signature we can match by attribute, so use a use-site check instead.
-  // A single-hop walk suffices because AccelerateMatmul materialises the
-  // scale encoding immediately before the tt.dot_scaled consumer — no
-  // scf.for / convert_layout sits between them at this pass position.
-  for (OpOperand &use : loadOp.getResult().getUses()) {
-    if (auto ds = dyn_cast<tt::DotScaledOp>(use.getOwner()))
-      if (use.get() == ds.getAScale() || use.get() == ds.getBScale())
+/// Returns true iff `op` is a write-effect memory op with respect to the
+/// cache-control policy: any `tt.store`, `tt.atomic_*`, their descriptor
+/// counterparts, or any op implementing `MemoryEffectOpInterface` with a
+/// `MemoryEffects::Write` effect.
+static bool hasWriteEffect(Operation *op) {
+  if (isa<tt::StoreOp, tt::AtomicRMWOp, tt::AtomicCASOp, tt::DescriptorStoreOp,
+          tt::DescriptorScatterOp, tt::DescriptorReduceOp>(op))
+    return true;
+  if (auto effectOp = dyn_cast<MemoryEffectOpInterface>(op)) {
+    SmallVector<MemoryEffects::EffectInstance> effects;
+    effectOp.getEffects(effects);
+    for (const auto &effect : effects)
+      if (isa<MemoryEffects::Write>(effect.getEffect()))
         return true;
   }
-
   return false;
 }
 
-// Tracks kernel-argument pointers where `.cg` annotation is suppressed to
-// preserve L1 locality for loads that may benefit from L1 reuse.
-struct FuncSkipInfo {
-  llvm::DenseSet<BlockArgument> skipArgs;
-  bool hasAtomic = false;
-};
-
-// Walks the pointer SSA chain backward and collects all entry-block
-// BlockArguments of `func` that `ptr` may resolve to. Returns true iff every
-// path in the SSA chain bottomed out at a known handled op. Returns false if
-// any path hit an unknown producer — the caller should skip annotation.
-static bool collectRoots(Value ptr, tt::FuncOp func,
-                         llvm::SmallVectorImpl<BlockArgument> &roots,
-                         llvm::DenseSet<Value> &visited) {
-  if (!ptr)
-    return false;
-  if (!visited.insert(ptr).second)
-    return true;
-
-  Block &entryBlock = func.getBody().front();
-
-  if (auto blockArg = dyn_cast<BlockArgument>(ptr)) {
-    if (blockArg.getOwner() == &entryBlock) {
-      roots.push_back(blockArg);
+/// Returns true iff `load` has at least one aliasing peer with a write effect.
+/// Read-only peers (e.g. a second `tt.load` of the same arg) are not a reason
+/// to suppress `.cg`: see AliasAnalysisTest.cpp TwoLoadsSameArgDifferentOffsets
+/// — read-only loads from the same arg alias each other and `.cg` is still
+/// correct for both.
+static bool aliasesWritingPeer(tt::LoadOp load,
+                               const tti::AliasAnalysis &alias) {
+  for (Operation *peer : alias.getAliasingMemOps(load))
+    if (hasWriteEffect(peer))
       return true;
-    }
-    // Region iter_arg of an scf.for: follow matching init + yield operands.
-    if (auto forOp = dyn_cast<scf::ForOp>(blockArg.getOwner()->getParentOp())) {
-      unsigned argIdx = blockArg.getArgNumber();
-      // argIdx 0 is the induction variable; iter_args start at 1.
-      if (argIdx == 0)
-        return false;
-      unsigned iterIdx = argIdx - 1;
-      if (iterIdx >= forOp.getInitArgs().size())
-        return false;
-      bool resolved =
-          collectRoots(forOp.getInitArgs()[iterIdx], func, roots, visited);
-      auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
-      if (iterIdx < yieldOp.getNumOperands())
-        resolved &=
-            collectRoots(yieldOp.getOperand(iterIdx), func, roots, visited);
-      else
-        resolved = false;
-      return resolved;
-    }
-    return false;
-  }
-
-  Operation *defOp = ptr.getDefiningOp();
-  if (!defOp)
-    return false;
-
-  // Pointer arithmetic / shape/layout reshuffling: follow operand 0.
-  if (isa<tt::AddPtrOp, tt::SplatOp, tt::BroadcastOp, tt::BitcastOp,
-          tt::ExpandDimsOp, tt::ReshapeOp, tt::TransOp, ttg::ConvertLayoutOp>(
-          defOp)) {
-    return collectRoots(defOp->getOperand(0), func, roots, visited);
-  }
-
-  // scf.for result: forward to matching init and yield operands.
-  if (auto forOp = dyn_cast<scf::ForOp>(defOp)) {
-    auto result = cast<OpResult>(ptr);
-    unsigned iterIdx = result.getResultNumber();
-    bool resolved = true;
-    if (iterIdx < forOp.getInitArgs().size())
-      resolved &=
-          collectRoots(forOp.getInitArgs()[iterIdx], func, roots, visited);
-    else
-      resolved = false;
-    auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
-    if (iterIdx < yieldOp.getNumOperands())
-      resolved &=
-          collectRoots(yieldOp.getOperand(iterIdx), func, roots, visited);
-    else
-      resolved = false;
-    return resolved;
-  }
-
-  // scf.if result: follow both branches.
-  if (auto ifOp = dyn_cast<scf::IfOp>(defOp)) {
-    auto result = cast<OpResult>(ptr);
-    unsigned idx = result.getResultNumber();
-    bool resolved = true;
-    for (Region *region : {&ifOp.getThenRegion(), &ifOp.getElseRegion()}) {
-      if (region->empty())
-        continue;
-      auto yieldOp = cast<scf::YieldOp>(region->front().getTerminator());
-      if (idx < yieldOp.getNumOperands())
-        resolved &= collectRoots(yieldOp.getOperand(idx), func, roots, visited);
-      else
-        resolved = false;
-    }
-    return resolved;
-  }
-
-  // Unknown producer: signal incomplete resolution to the caller.
   return false;
 }
 
-// Returns true if `.cg` annotation should be skipped for a load at `ptr`:
-// (a) the pointer SSA chain could not be fully resolved to entry-block function
-// arguments, OR (b) any resolved root is in `skipArgs`.
-static bool shouldSkipLoad(Value ptr, tt::FuncOp func,
-                           const llvm::DenseSet<BlockArgument> &skipArgs) {
-  llvm::SmallVector<BlockArgument, 4> roots;
-  llvm::DenseSet<Value> visited;
-  bool resolved = collectRoots(ptr, func, roots, visited);
-  if (!resolved)
+/// Returns true iff the function contains any atomic memory op.
+static bool funcContainsAtomic(tt::FuncOp func) {
+  auto result = func.walk([&](Operation *op) {
+    if (isa<tt::AtomicRMWOp, tt::AtomicCASOp>(op))
+      return WalkResult::interrupt();
+    return WalkResult::advance();
+  });
+  return result.wasInterrupted();
+}
+
+/// Computes the set of entry-block pointer arguments on which `.cg` annotation
+/// must be suppressed to preserve L1 locality:
+///   - read-write args (loaded AND stored within the same function), OR
+///   - if any store's pointer origin is unresolved, all pointer args, OR
+///   - if the function contains atomics, all pointer args.
+static SetVector<BlockArgument>
+computeSkippedArgs(tt::FuncOp func, const tti::AliasAnalysis &alias,
+                   bool hasAtomic) {
+  SetVector<BlockArgument> skipped;
+  DenseSet<BlockArgument> loadedArgs;
+  DenseSet<BlockArgument> storedArgs;
+  bool hasUnresolvedStore = false;
+
+  auto collectRootArgs = [&](Value ptr, DenseSet<BlockArgument> &sink) -> bool {
+    RootsResult result = alias.getPointerRoots(ptr);
+    if (result.kind != AliasKind::Known)
+      return false;
+    for (Value r : result.roots)
+      if (auto arg = dyn_cast<BlockArgument>(r);
+          arg && isEntryBlockFuncArg(arg))
+        sink.insert(arg);
     return true;
-  for (BlockArgument arg : roots) {
-    if (skipArgs.contains(arg))
-      return true;
+  };
+
+  func.walk([&](Operation *op) {
+    if (auto loadOp = dyn_cast<tt::LoadOp>(op))
+      collectRootArgs(loadOp.getPtr(), loadedArgs);
+    else if (auto storeOp = dyn_cast<tt::StoreOp>(op)) {
+      if (!collectRootArgs(storeOp.getPtr(), storedArgs))
+        hasUnresolvedStore = true;
+    }
+  });
+
+  // Read-write args are always excluded.
+  for (BlockArgument arg : loadedArgs)
+    if (storedArgs.contains(arg))
+      skipped.insert(arg);
+
+  // Atomic kernels and unresolved-store functions: exclude every pointer-typed
+  // entry-block arg. The rationale matches the original pass:
+  //   - atomic kernels often mix matmul operand loads with streaming loads
+  //     and we cannot distinguish them;
+  //   - unresolved stores mean we cannot prove which args are written.
+  if (hasAtomic || hasUnresolvedStore) {
+    for (BlockArgument arg : func.getBody().front().getArguments()) {
+      Type argTy = arg.getType();
+      if (isa<tt::PointerType>(argTy)) {
+        skipped.insert(arg);
+      } else if (auto tensorTy = dyn_cast<RankedTensorType>(argTy)) {
+        if (isa<tt::PointerType>(tensorTy.getElementType()))
+          skipped.insert(arg);
+      }
+    }
   }
+
+  return skipped;
+}
+
+/// Returns true iff the store's pointer origin is unknown OR any of its
+/// roots intersects the `skipped` arg set.
+static bool storePtrIsSkipped(Value storePtr, const tti::AliasAnalysis &alias,
+                              const SetVector<BlockArgument> &skipped) {
+  RootsResult result = alias.getPointerRoots(storePtr);
+  if (result.kind != AliasKind::Known)
+    return true;
+  for (Value r : result.roots)
+    if (auto arg = dyn_cast<BlockArgument>(r); arg && skipped.contains(arg))
+      return true;
   return false;
 }
 
-// Returns true if any transitive forward user of `root` is a `tt.store` whose
-// destination pointer resolves to an arg in `skipArgs`. This catches the
-// pattern where the loaded value is reduced into a read-write accumulator
-// buffer even though the load's own pointer is read-only.
-// Walks through scf.for/scf.if/scf.while.
-static bool
-valueFlowsToSkippedStore(Value root, tt::FuncOp func,
-                         const llvm::DenseSet<BlockArgument> &skipArgs) {
-  if (skipArgs.empty())
+/// Returns true iff any transitive forward user of `root` is a `tt.store`
+/// whose destination pointer root-intersects `skipped` (or is unknown). This
+/// catches the pattern where the loaded value is reduced into a read-write
+/// accumulator buffer even though the load's own pointer is read-only.
+/// Walks through scf.for/scf.if/scf.while via `propagateThroughSCF`.
+///
+/// This filter is retained because the alias analysis (P3) cannot replace it:
+/// the filter tracks data flow, not pointer aliasing. See
+/// `annotate-cc-rewrite.md` §"What stays and why" — tests m, p, r have the
+/// pattern `load %X; ...; store %DW, derived_from_load` where `%X` and `%DW`
+/// are distinct args with disjoint root sets.
+static bool valueFlowsToSkippedStore(Value root,
+                                     const tti::AliasAnalysis &alias,
+                                     const SetVector<BlockArgument> &skipped) {
+  if (skipped.empty())
     return false;
 
-  llvm::SetVector<Value> worklist;
+  SetVector<Value> worklist;
   worklist.insert(root);
 
   for (unsigned i = 0; i < worklist.size(); ++i) {
@@ -261,7 +267,7 @@ valueFlowsToSkippedStore(Value root, tt::FuncOp func,
         // pointer or mask operand, it's irrelevant to where the loaded *data*
         // ends up.
         if (use.get() == storeOp.getValue() &&
-            shouldSkipLoad(storeOp.getPtr(), func, skipArgs))
+            storePtrIsSkipped(storeOp.getPtr(), alias, skipped))
           return true;
         continue;
       }
@@ -278,69 +284,20 @@ valueFlowsToSkippedStore(Value root, tt::FuncOp func,
   return false;
 }
 
-// Scans `func` once to determine which entry-block pointer arguments should
-// have `.cg` annotation suppressed. `.cg` (L1UC_L3C) on loads is always
-// coherence-safe because it reads from the shared L3 rather than the
-// incoherent per-core L1. These filters preserve L1 locality for loads that
-// may benefit from L1 reuse (e.g. matmul operand loads in complex kernels):
-//   - read-write args (loaded AND stored within the same function), OR
-//   - if the function contains any atomic op, every pointer-typed entry-block
-//     arg is excluded (atomic kernels often mix matmul operand loads with
-//     streaming loads; excluding all args avoids regressing matmul operand
-//     L1 reuse), OR
-//   - if any store's pointer could not be resolved to known roots (so we
-//     cannot tell which args are actually written), treat every pointer-typed
-//     entry-block arg as potentially read-write.
-static FuncSkipInfo computeSkipArgs(tt::FuncOp func) {
-  FuncSkipInfo info;
-  llvm::DenseSet<BlockArgument> loadedArgs;
-  llvm::DenseSet<BlockArgument> storedArgs;
-  bool hasUnresolvedStore = false;
+//===----------------------------------------------------------------------===//
+// Per-function context
+//===----------------------------------------------------------------------===//
 
-  auto collectFor = [&](Value ptr,
-                        llvm::DenseSet<BlockArgument> &sink) -> bool {
-    llvm::SmallVector<BlockArgument, 4> roots;
-    llvm::DenseSet<Value> visited;
-    bool resolved = collectRoots(ptr, func, roots, visited);
-    for (BlockArgument arg : roots)
-      sink.insert(arg);
-    return resolved;
-  };
+struct FuncContext {
+  ReuseAnalysis reuse;
+  std::unique_ptr<tti::AliasAnalysis> alias;
+  bool hasAtomic;
+  SetVector<BlockArgument> skipped;
+};
 
-  func.walk([&](Operation *op) {
-    if (auto loadOp = dyn_cast<tt::LoadOp>(op))
-      collectFor(loadOp.getPtr(), loadedArgs);
-    else if (auto storeOp = dyn_cast<tt::StoreOp>(op)) {
-      if (!collectFor(storeOp.getPtr(), storedArgs))
-        hasUnresolvedStore = true;
-    } else if (isa<tt::AtomicRMWOp, tt::AtomicCASOp>(op))
-      info.hasAtomic = true;
-  });
-
-  // Read-write args are always excluded.
-  for (BlockArgument arg : loadedArgs) {
-    if (storedArgs.contains(arg))
-      info.skipArgs.insert(arg);
-  }
-  // If the function has any atomic, exclude every pointer-typed entry-block
-  // arg — atomic kernels often mix matmul operand loads with streaming loads
-  // and we cannot distinguish them; excluding all args preserves L1 reuse.
-  // Likewise, if any store has an unresolved pointer, we can't prove which
-  // args are written; treat every pointer arg as potentially RW.
-  if (info.hasAtomic || hasUnresolvedStore) {
-    for (BlockArgument arg : func.getBody().front().getArguments()) {
-      Type argTy = arg.getType();
-      if (isa<tt::PointerType>(argTy))
-        info.skipArgs.insert(arg);
-      else if (auto tensorTy = dyn_cast<RankedTensorType>(argTy)) {
-        if (isa<tt::PointerType>(tensorTy.getElementType()))
-          info.skipArgs.insert(arg);
-      }
-    }
-  }
-
-  return info;
-}
+//===----------------------------------------------------------------------===//
+// Pass
+//===----------------------------------------------------------------------===//
 
 struct AnnotateCacheControlPass
     : public impl::TritonIntelGPUAnnotateCacheControlBase<
@@ -350,28 +307,29 @@ struct AnnotateCacheControlPass
 
   void runOnOperation() final {
     ModuleOp moduleOp = getOperation();
+    // ModuleStrideAnalysis requires a ModuleAxisInfoAnalysis& (StrideInfo.h).
+    tti::ModuleAxisInfoAnalysis axisInfo(moduleOp);
+    tti::ModuleStrideAnalysis strideAnalysis(moduleOp, axisInfo);
     bool changed = false;
 
     moduleOp.walk([&](tt::FuncOp func) {
       if (func.getBody().empty())
         return;
 
-      FuncSkipInfo info = computeSkipArgs(func);
+      auto alias = std::make_unique<tti::AliasAnalysis>(func);
+      bool hasAtomic = funcContainsAtomic(func);
+      SetVector<BlockArgument> skipped =
+          computeSkippedArgs(func, *alias, hasAtomic);
+      FuncContext ctx{
+          ReuseAnalysis(moduleOp, strideAnalysis),
+          std::move(alias),
+          hasAtomic,
+          std::move(skipped),
+      };
 
-      func.walk([&](tt::LoadOp loadOp) {
-        if (loadOp.getCache() != tt::CacheModifier::NONE)
-          return;
-        if (!isa<RankedTensorType>(loadOp.getType()))
-          return;
-        if (skipForL1Reuse(loadOp))
-          return;
-        if (shouldSkipLoad(loadOp.getPtr(), func, info.skipArgs))
-          return;
-        if (valueFlowsToSkippedStore(loadOp.getResult(), func, info.skipArgs))
-          return;
-        loadOp.setCacheAttr(tt::CacheModifierAttr::get(loadOp.getContext(),
-                                                       tt::CacheModifier::CG));
-        changed = true;
+      func.walk([&](tt::LoadOp load) {
+        if (tryAnnotate(load, ctx))
+          changed = true;
       });
     });
 
@@ -383,6 +341,50 @@ struct AnnotateCacheControlPass
 
     if (!changed)
       markAllAnalysesPreserved();
+  }
+
+private:
+  static bool tryAnnotate(tt::LoadOp load, FuncContext &ctx) {
+    // Gate 1: user override — never overwrite an explicitly-set cache modifier.
+    if (load.getCache() != tt::CacheModifier::NONE)
+      return false;
+
+    // Gate 2: scalar loads don't get encoding-based annotation.
+    auto loadTy = dyn_cast<RankedTensorType>(load.getType());
+    if (!loadTy)
+      return false;
+
+    // Gate 3: reuse analysis (P1 OR P2). Only consult when an encoding is
+    // present. Without an encoding, SpatialReuseAnalysis is conservative
+    // (reuse = true), which would incorrectly suppress `.cg` on bare
+    // tensor<Nx!tt.ptr<T>> loads (test f).
+    if (loadTy.getEncoding() && ctx.reuse.anyReuse(load))
+      return false;
+
+    // Gate 4: atomic policy — in atomic kernels, any load whose pointer roots
+    // to an entry-block pointer arg is suppressed (cost-model policy — see
+    // the pass description in Passes.td).
+    if (ctx.hasAtomic && isPointerArgRooted(load.getPtr(), *ctx.alias))
+      return false;
+
+    // Gate 5: unresolved pointer origin — conservative skip.
+    if (ptrRootsUnknown(load.getPtr(), *ctx.alias))
+      return false;
+
+    // Gate 6: alias analysis — suppress only on aliasing with a write peer.
+    // Two read-only loads of the same arg are fine; both can keep `.cg`.
+    if (aliasesWritingPeer(load, *ctx.alias))
+      return false;
+
+    // Gate 7: forward data-flow into a store on an excluded arg. Retained
+    // verbatim — alias analysis cannot replace it (see §"What stays and why"
+    // in annotate-cc-rewrite.md).
+    if (valueFlowsToSkippedStore(load.getResult(), *ctx.alias, ctx.skipped))
+      return false;
+
+    load.setCacheAttr(
+        tt::CacheModifierAttr::get(load.getContext(), tt::CacheModifier::CG));
+    return true;
   }
 };
 

--- a/third_party/intel/unittest/Analysis/AliasAnalysisTest.cpp
+++ b/third_party/intel/unittest/Analysis/AliasAnalysisTest.cpp
@@ -733,4 +733,122 @@ TEST_F(AliasAnalysisTest, OpaqueDescriptorPropagatesUnknown) {
               ::testing::Contains(loadA.getOperation()));
 }
 
+// ===----------------------------------------------------------------------===//
+// Test PointerRoots accessor
+// ===----------------------------------------------------------------------===//
+
+using ::mlir::triton::intel::AliasAnalysis;
+
+TEST_F(AliasAnalysisTest, PointerRootsKnownViaAddPtr) {
+  auto module = createModule();
+  auto ptrType = getPtrType(builder->getF16Type());
+  auto funcOp = createFunctionWithReturn(module, "test_func", {ptrType});
+  auto loc = builder->getUnknownLoc();
+  auto arg0 = funcOp.getArgument(0);
+
+  auto i32Type = builder->getI32Type();
+  auto off = arith::ConstantOp::create(*builder, loc, i32Type,
+                                       builder->getI32IntegerAttr(16));
+  auto ptr = triton::AddPtrOp::create(*builder, loc, ptrType, arg0, off);
+  auto load = makeLoad(ptr);
+
+  AliasAnalysis analysis(funcOp);
+  auto result = analysis.getPointerRoots(load.getPtr());
+  EXPECT_EQ(result.kind, AliasAnalysis::PointerRootKind::Known);
+  EXPECT_THAT(result.roots, ::testing::ElementsAre(arg0));
+}
+
+TEST_F(AliasAnalysisTest, PointerRootsKnownViaSplat) {
+  auto module = createModule();
+  auto ptrType = getPtrType(builder->getF16Type());
+  auto funcOp = createFunctionWithReturn(module, "test_func", {ptrType});
+  auto loc = builder->getUnknownLoc();
+  auto arg0 = funcOp.getArgument(0);
+
+  auto splatType = RankedTensorType::get({16}, ptrType);
+  auto splat = triton::SplatOp::create(*builder, loc, splatType, arg0);
+  auto load = makeLoad(splat);
+
+  AliasAnalysis analysis(funcOp);
+  auto result = analysis.getPointerRoots(load.getPtr());
+  EXPECT_EQ(result.kind, AliasAnalysis::PointerRootKind::Known);
+  EXPECT_THAT(result.roots, ::testing::ElementsAre(arg0));
+}
+
+TEST_F(AliasAnalysisTest, PointerRootsUnknownViaArithSelect) {
+  auto module = createModule();
+  auto ptrType = getPtrType(builder->getF16Type());
+  auto funcOp = createFunctionWithReturn(
+      module, "test_func", {ptrType, ptrType, builder->getI1Type()});
+  auto loc = builder->getUnknownLoc();
+  auto arg0 = funcOp.getArgument(0);
+  auto arg1 = funcOp.getArgument(1);
+  auto cond = funcOp.getArgument(2);
+
+  // arith.select on pointers: opaque producer — must be Unknown.
+  auto sel = arith::SelectOp::create(*builder, loc, cond, arg0, arg1);
+  auto load = makeLoad(sel.getResult());
+
+  AliasAnalysis analysis(funcOp);
+  auto result = analysis.getPointerRoots(load.getPtr());
+  EXPECT_EQ(result.kind, AliasAnalysis::PointerRootKind::Unknown);
+  EXPECT_TRUE(result.roots.empty());
+}
+
+TEST_F(AliasAnalysisTest, PointerRootsNotTrackedForNonMemOpPointer) {
+  auto module = createModule();
+  auto ptrType = getPtrType(builder->getF16Type());
+  auto funcOp = createFunctionWithReturn(module, "test_func", {ptrType});
+  auto loc = builder->getUnknownLoc();
+  auto arg0 = funcOp.getArgument(0);
+
+  // Build a pointer value that is never used by a tracked memory op. The
+  // analysis only seeds the pointerRoots map from collected mem-op pointers,
+  // so this value is NotTracked.
+  auto i32Type = builder->getI32Type();
+  auto off = arith::ConstantOp::create(*builder, loc, i32Type,
+                                       builder->getI32IntegerAttr(4));
+  auto ptr = triton::AddPtrOp::create(*builder, loc, ptrType, arg0, off);
+  // No load/store consumes `ptr`.
+
+  AliasAnalysis analysis(funcOp);
+  auto result = analysis.getPointerRoots(ptr.getResult());
+  EXPECT_EQ(result.kind, AliasAnalysis::PointerRootKind::NotTracked);
+  EXPECT_TRUE(result.roots.empty());
+}
+
+TEST_F(AliasAnalysisTest, PointerRootsKnownThroughScfForIterArg) {
+  auto module = createModule();
+  auto ptrType = getPtrType(builder->getF16Type());
+  auto funcOp = createFunctionWithReturn(module, "test_func", {ptrType});
+  auto loc = builder->getUnknownLoc();
+  auto arg0 = funcOp.getArgument(0);
+
+  auto i32Type = builder->getI32Type();
+  auto lb = arith::ConstantOp::create(*builder, loc, i32Type,
+                                      builder->getI32IntegerAttr(0));
+  auto ub = arith::ConstantOp::create(*builder, loc, i32Type,
+                                      builder->getI32IntegerAttr(4));
+  auto step = arith::ConstantOp::create(*builder, loc, i32Type,
+                                        builder->getI32IntegerAttr(1));
+
+  auto forOp =
+      scf::ForOp::create(*builder, loc, lb, ub, step, ValueRange{arg0});
+
+  {
+    OpBuilder::InsertionGuard guard(*builder);
+    builder->setInsertionPointToStart(forOp.getBody());
+    auto iter = forOp.getRegionIterArg(0);
+    auto load = makeLoad(iter);
+    (void)load;
+    scf::YieldOp::create(*builder, loc, ValueRange{iter});
+  }
+
+  AliasAnalysis analysis(funcOp);
+  auto iter = forOp.getRegionIterArg(0);
+  auto result = analysis.getPointerRoots(iter);
+  EXPECT_EQ(result.kind, AliasAnalysis::PointerRootKind::Known);
+  EXPECT_THAT(result.roots, ::testing::ElementsAre(arg0));
+}
+
 } // namespace


### PR DESCRIPTION
Rewrites `tritonintelgpu-annotate-cache-control` on top of the three analyses (`SpatialReuseAnalysis` #6827,  `TemporalReuseAnalysis` #6858/#6860,  `AliasAnalysis` #6822). 