### PR TITLE
Fix test_device_assert_barrier crash on BMG with --forked (#6819)

### DIFF
--- a/python/test/unit/test_debug.py
+++ b/python/test/unit/test_debug.py
@@ -45,19 +45,19 @@ def test_device_assert(cond, mask, opt_flag, env_var, jit_flag, device):
 
 
 @pytest.mark.forked
-def test_device_assert_barrier(monkeypatch, device):
-    monkeypatch.setenv("TRITON_DEBUG", "1")
-    triton.knobs.refresh_knobs()
-    tensor = torch.zeros([16], dtype=torch.int32, device=device)
+def test_device_assert_barrier(device):
+    """Subprocess solution to handle XPU SIGABRT from device_assert infrastructure.
+    See: https://github.com/pytorch/pytorch/issues/142135"""
+    kernel_file = os.path.join(os.path.dirname(__file__), "test_debug_kernels.py")
 
-    @triton.jit
-    def _kernel(in_ptr0):
-        xindex = tl.arange(0, 8)
-        tmp0 = tl.load(in_ptr0 + xindex)
-        tl.device_assert(tmp0 < 1)
+    env = os.environ.copy()
+    env["TRITON_DEBUG"] = "1"
 
-    _kernel[(1, )](tensor)
-    getattr(torch, device).synchronize()
+    result = subprocess.run([sys.executable, kernel_file, "device_assert_barrier", device], capture_output=True,
+                            text=True, env=env)
+
+    assert result.returncode == 0, (f"Expected success but got exit code {result.returncode}. "
+                                    f"stdout: {result.stdout}, stderr: {result.stderr}")
 
 
 @pytest.mark.parametrize("cond", [False, True])

--- a/python/test/unit/test_debug_kernels.py
+++ b/python/test/unit/test_debug_kernels.py
@@ -33,6 +33,18 @@ def run_device_assert_kernel(cond, mask, opt_flag, jit_flag, device):
     return _run_and_catch(lambda: _kernel[(1, )](cond, mask, **kwargs), device)
 
 
+def run_device_assert_barrier_kernel(device):
+    tensor = torch.zeros([16], dtype=torch.int32, device=device)
+
+    @triton.jit
+    def _kernel(in_ptr0):
+        xindex = tl.arange(0, 8)
+        tmp0 = tl.load(in_ptr0 + xindex)
+        tl.device_assert(tmp0 < 1)
+
+    return _run_and_catch(lambda: _kernel[(1, )](tensor), device)
+
+
 @triton.jit
 def _kernel_add(X, Y, Z):
     tl.store(Z, tl.load(X) + tl.load(Y))
@@ -73,6 +85,12 @@ if __name__ == "__main__":
         device = sys.argv[6]
         triton.knobs.refresh_knobs()
         exit_code = run_device_assert_kernel(cond, mask, opt_flag, jit_flag, device)
+        sys.exit(exit_code)
+
+    elif test_type == "device_assert_barrier":
+        device = sys.argv[2]
+        triton.knobs.refresh_knobs()
+        exit_code = run_device_assert_barrier_kernel(device)
         sys.exit(exit_code)
 
     elif test_type == "overflow":


### PR DESCRIPTION
Convert test_device_assert_barrier to subprocess isolation, matching the existing test_device_assert pattern. Under CI conditions (Python 3.10 & pytest-forked & xdist -n8), the test crashes with SIGABRT because os.fork() inherits corrupted Level Zero GPU state from the xdist worker. Running the kernel in a subprocess avoids inherited GPU handles entirely.

Fixes: #6819

