### PR TITLE
[LLVMIR] Widen sub-byte bit ops forbidden by SPV_INTEL_int4 (#6927)

### DIFF
--- a/bin/triton-llvm-opt.cpp
+++ b/bin/triton-llvm-opt.cpp
@@ -53,6 +53,15 @@ static cl::opt<bool> ExpandSaddOverflow(
     llvm::cl::desc("expand llvm.sadd.with.overflow into plain arithmetic"),
     cl::init(false));
 
+static cl::opt<bool> ExpandSubByteBitReverse(
+    "expand-subbyte-bitreverse",
+    llvm::cl::desc("rewrite sub-byte llvm.bitreverse.iN via an i32 bitreverse"),
+    cl::init(false));
+
+static cl::opt<bool> ExpandSubByteBitwiseAnd(
+    "expand-subbyte-bitwise-and",
+    llvm::cl::desc("widen sub-byte `and iN` through i32"), cl::init(false));
+
 namespace {
 static std::function<Error(Module *)> makeOptimizingPipeline() {
   return [](Module *m) -> Error {
@@ -72,6 +81,10 @@ static std::function<Error(Module *)> makeOptimizingPipeline() {
     ModulePassManager mpm;
     if (ExpandSaddOverflow)
       mpm.addPass(ExpandSaddWithOverflowPass());
+    if (ExpandSubByteBitReverse)
+      mpm.addPass(ExpandSubByteBitReversePass());
+    if (ExpandSubByteBitwiseAnd)
+      mpm.addPass(ExpandSubByteBitwiseAndPass());
     llvm::FunctionPassManager fpm;
     if (BreakStructPhiNodes)
       fpm.addPass(BreakStructPhiNodesPass());

--- a/scripts/skiplist/default/vllm_mamba.txt
+++ b/scripts/skiplist/default/vllm_mamba.txt
@@ -8,13 +8,3 @@ tests/kernels/mamba/test_causal_conv1d.py::test_causal_conv1d_varlen
 tests/kernels/mamba/test_mamba_ssm.py::test_selective_scan
 tests/kernels/mamba/test_mamba_ssm.py::test_selective_scan_varlen
 tests/kernels/mamba/test_mamba_ssm.py::test_selective_state_update
-
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/6713
-tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-5-16-itype1]
-tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-5-32-itype1]
-tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-8-16-itype1]
-tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-8-32-itype1]
-tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-32-16-itype1]
-tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-32-32-itype1]
-tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-128-16-itype1]
-tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-128-32-itype1]

--- a/test/LLVMIR/expand-subbyte-bitreverse.ll
+++ b/test/LLVMIR/expand-subbyte-bitreverse.ll
@@ -1,0 +1,60 @@
+; RUN: triton-llvm-opt -expand-subbyte-bitreverse %s | FileCheck %s
+
+; CHECK-LABEL: @bitrev_i4
+define i4 @bitrev_i4(i4 %x) {
+; CHECK-NOT: call i4 @llvm.bitreverse.i4
+; CHECK:     [[ZEXT:%.*]] = zext i4 %x to i32
+; CHECK:     [[REV:%.*]]  = call i32 @llvm.bitreverse.i32(i32 [[ZEXT]])
+; CHECK:     [[SHR:%.*]]  = lshr i32 [[REV]], 28
+; CHECK:     [[RES:%.*]]  = trunc i32 [[SHR]] to i4
+; CHECK:     ret i4 [[RES]]
+  %r = call i4 @llvm.bitreverse.i4(i4 %x)
+  ret i4 %r
+}
+
+; CHECK-LABEL: @bitrev_i3
+define i3 @bitrev_i3(i3 %x) {
+; CHECK-NOT: call i3 @llvm.bitreverse.i3
+; CHECK:     [[ZEXT:%.*]] = zext i3 %x to i32
+; CHECK:     [[REV:%.*]]  = call i32 @llvm.bitreverse.i32(i32 [[ZEXT]])
+; CHECK:     [[SHR:%.*]]  = lshr i32 [[REV]], 29
+; CHECK:     [[RES:%.*]]  = trunc i32 [[SHR]] to i3
+; CHECK:     ret i3 [[RES]]
+  %r = call i3 @llvm.bitreverse.i3(i3 %x)
+  ret i3 %r
+}
+
+; Ensure >=8-bit widths are not touched.
+; CHECK-LABEL: @bitrev_i8
+define i8 @bitrev_i8(i8 %x) {
+; CHECK: call i8 @llvm.bitreverse.i8(i8 %x)
+  %r = call i8 @llvm.bitreverse.i8(i8 %x)
+  ret i8 %r
+}
+
+; CHECK-LABEL: @bitrev_i32
+define i32 @bitrev_i32(i32 %x) {
+; CHECK: call i32 @llvm.bitreverse.i32(i32 %x)
+  %r = call i32 @llvm.bitreverse.i32(i32 %x)
+  ret i32 %r
+}
+
+; Vector of sub-byte integers is widened element-wise via <K x i32>.
+; CHECK-LABEL: @bitrev_v4i4
+define <4 x i4> @bitrev_v4i4(<4 x i4> %x) {
+; CHECK-NOT: call <4 x i4> @llvm.bitreverse.v4i4
+; CHECK:     [[ZEXT:%.*]] = zext <4 x i4> %x to <4 x i32>
+; CHECK:     [[REV:%.*]]  = call <4 x i32> @llvm.bitreverse.v4i32(<4 x i32> [[ZEXT]])
+; CHECK:     [[SHR:%.*]]  = lshr <4 x i32> [[REV]], {{.*}}
+; CHECK:     [[RES:%.*]]  = trunc <4 x i32> [[SHR]] to <4 x i4>
+; CHECK:     ret <4 x i4> [[RES]]
+  %r = call <4 x i4> @llvm.bitreverse.v4i4(<4 x i4> %x)
+  ret <4 x i4> %r
+}
+
+declare i3  @llvm.bitreverse.i3(i3)
+declare i4  @llvm.bitreverse.i4(i4)
+declare i8  @llvm.bitreverse.i8(i8)
+declare i32 @llvm.bitreverse.i32(i32)
+declare <4 x i4>  @llvm.bitreverse.v4i4(<4 x i4>)
+declare <4 x i32> @llvm.bitreverse.v4i32(<4 x i32>)

--- a/test/LLVMIR/expand-subbyte-bitwise-and.ll
+++ b/test/LLVMIR/expand-subbyte-bitwise-and.ll
@@ -1,0 +1,46 @@
+; RUN: triton-llvm-opt -expand-subbyte-bitwise-and %s | FileCheck %s
+
+; CHECK-LABEL: @and_i4
+define i4 @and_i4(i4 %a, i4 %b) {
+; CHECK-NOT: and i4
+; CHECK:     [[A32:%.*]] = zext i4 %a to i32
+; CHECK:     [[B32:%.*]] = zext i4 %b to i32
+; CHECK:     [[R32:%.*]] = and i32 [[A32]], [[B32]]
+; CHECK:     [[RES:%.*]] = trunc i32 [[R32]] to i4
+; CHECK:     ret i4 [[RES]]
+  %r = and i4 %a, %b
+  ret i4 %r
+}
+
+; CHECK-LABEL: @and_i3
+define i3 @and_i3(i3 %a, i3 %b) {
+; CHECK-NOT: and i3
+; CHECK:     [[A32:%.*]] = zext i3 %a to i32
+; CHECK:     [[B32:%.*]] = zext i3 %b to i32
+; CHECK:     [[R32:%.*]] = and i32 [[A32]], [[B32]]
+; CHECK:     [[RES:%.*]] = trunc i32 [[R32]] to i3
+; CHECK:     ret i3 [[RES]]
+  %r = and i3 %a, %b
+  ret i3 %r
+}
+
+; >=8-bit `and` is not touched.
+; CHECK-LABEL: @and_i8
+define i8 @and_i8(i8 %a, i8 %b) {
+; CHECK: and i8 %a, %b
+  %r = and i8 %a, %b
+  ret i8 %r
+}
+
+; Vector sub-byte `and` is widened element-wise via <K x i32>.
+; CHECK-LABEL: @and_v4i4
+define <4 x i4> @and_v4i4(<4 x i4> %a, <4 x i4> %b) {
+; CHECK-NOT: and <4 x i4>
+; CHECK:     [[A32:%.*]] = zext <4 x i4> %a to <4 x i32>
+; CHECK:     [[B32:%.*]] = zext <4 x i4> %b to <4 x i32>
+; CHECK:     [[R32:%.*]] = and <4 x i32> [[A32]], [[B32]]
+; CHECK:     [[RES:%.*]] = trunc <4 x i32> [[R32]] to <4 x i4>
+; CHECK:     ret <4 x i4> [[RES]]
+  %r = and <4 x i4> %a, %b
+  ret <4 x i4> %r
+}

--- a/third_party/intel/lib/Target/LLVMIR/LLVMPasses.h
+++ b/third_party/intel/lib/Target/LLVMIR/LLVMPasses.h
@@ -13,4 +13,16 @@ struct ExpandSaddWithOverflowPass : PassInfoMixin<ExpandSaddWithOverflowPass> {
   static StringRef name() { return "ExpandSaddWithOverflowPass"; }
 };
 
+struct ExpandSubByteBitReversePass
+    : PassInfoMixin<ExpandSubByteBitReversePass> {
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  static StringRef name() { return "ExpandSubByteBitReversePass"; }
+};
+
+struct ExpandSubByteBitwiseAndPass
+    : PassInfoMixin<ExpandSubByteBitwiseAndPass> {
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  static StringRef name() { return "ExpandSubByteBitwiseAndPass"; }
+};
+
 } // namespace llvm

--- a/third_party/intel/lib/Target/LLVMIR/PostProcess.cpp
+++ b/third_party/intel/lib/Target/LLVMIR/PostProcess.cpp
@@ -1,6 +1,7 @@
 #include "third_party/intel/include/Target/LLVMIR/PostProcess.h"
 #include "third_party/intel/lib/Target/LLVMIR/LLVMPasses.h"
 
+#include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/Module.h"
@@ -64,6 +65,89 @@ void expandSaddWithOverflow(Module &module) {
   }
 }
 
+// Returns the sub-byte (N<8) integer element type of `t` (scalar IntegerType
+// or FixedVectorType of integers), or nullptr otherwise.
+static IntegerType *getSubByteIntElement(Type *t) {
+  if (auto *intTy = dyn_cast<IntegerType>(t))
+    return intTy->getBitWidth() < 8 ? intTy : nullptr;
+  if (auto *vecTy = dyn_cast<FixedVectorType>(t))
+    if (auto *intTy = dyn_cast<IntegerType>(vecTy->getElementType()))
+      return intTy->getBitWidth() < 8 ? intTy : nullptr;
+  return nullptr;
+}
+
+// Returns an i32 type matching the shape of `narrowTy`: scalar i32 for a
+// scalar narrow type, <K x i32> for <K x iN>.
+static Type *getWideTypeForNarrow(Type *narrowTy, IRBuilder<> &builder) {
+  Type *i32ElemTy = builder.getInt32Ty();
+  if (auto *vecTy = dyn_cast<FixedVectorType>(narrowTy))
+    return FixedVectorType::get(i32ElemTy, vecTy->getNumElements());
+  return i32ElemTy;
+}
+
+// SPV_INTEL_int4 does not permit OpBitReverse on sub-byte OpTypeInt. Widen
+// via i32 bitreverse (supported by SPV_KHR_bit_instructions):
+//   zext iN -> i32; bitreverse.i32; lshr (32-N); trunc i32 -> iN
+// Handles scalar iN and <K x iN> vectors uniformly.
+void expandSubByteBitReverse(Module &module) {
+  SmallVector<CallInst *> calls;
+
+  for (auto &func : module)
+    for (auto &block : func)
+      for (auto &inst : block)
+        if (auto *call = dyn_cast<CallInst>(&inst))
+          if (auto *callee = call->getCalledFunction())
+            if (callee->getIntrinsicID() == Intrinsic::bitreverse)
+              if (getSubByteIntElement(call->getType()))
+                calls.push_back(call);
+
+  for (CallInst *call : calls) {
+    IRBuilder<> builder(call);
+    Type *narrowTy = call->getType();
+    unsigned narrowBits = getSubByteIntElement(narrowTy)->getBitWidth();
+    Type *wideTy = getWideTypeForNarrow(narrowTy, builder);
+
+    Value *zext = builder.CreateZExt(call->getArgOperand(0), wideTy);
+    Value *rev32 = builder.CreateIntrinsic(Intrinsic::bitreverse, {wideTy},
+                                           {zext}, /*FMFSource=*/nullptr);
+    Value *shr =
+        builder.CreateLShr(rev32, ConstantInt::get(wideTy, 32 - narrowBits));
+    Value *result = builder.CreateTrunc(shr, narrowTy);
+
+    call->replaceAllUsesWith(result);
+    call->eraseFromParent();
+  }
+}
+
+// SPV_INTEL_int4 does not permit OpBitwiseAnd on sub-byte OpTypeInt. Widen
+// through i32:
+//   zext iN -> i32 (both operands); and i32; trunc i32 -> iN
+// Handles scalar iN and <K x iN> vectors uniformly.
+void expandSubByteBitwiseAnd(Module &module) {
+  SmallVector<BinaryOperator *> ands;
+
+  for (auto &func : module)
+    for (auto &block : func)
+      for (auto &inst : block)
+        if (inst.getOpcode() == Instruction::And)
+          if (getSubByteIntElement(inst.getType()))
+            ands.push_back(cast<BinaryOperator>(&inst));
+
+  for (BinaryOperator *op : ands) {
+    IRBuilder<> builder(op);
+    Type *narrowTy = op->getType();
+    Type *wideTy = getWideTypeForNarrow(narrowTy, builder);
+
+    Value *a32 = builder.CreateZExt(op->getOperand(0), wideTy);
+    Value *b32 = builder.CreateZExt(op->getOperand(1), wideTy);
+    Value *r32 = builder.CreateAnd(a32, b32);
+    Value *result = builder.CreateTrunc(r32, narrowTy);
+
+    op->replaceAllUsesWith(result);
+    op->eraseFromParent();
+  }
+}
+
 void postProcessLLVMIR(llvm::Module &mod) {
   // __devicelib_assert_fail must be a declaration so that
   // IGC can replace it with a runtime assert function.
@@ -79,6 +163,10 @@ void postProcessLLVMIR(llvm::Module &mod) {
   // Pre-expand llvm.sadd.with.overflow.* so the SPIR-V translator never
   // links in the {iN, i1} emulation function that triggers the IGC bug.
   expandSaddWithOverflow(mod);
+
+  // Widen sub-byte bit ops forbidden by SPV_INTEL_int4.
+  expandSubByteBitReverse(mod);
+  expandSubByteBitwiseAnd(mod);
 }
 
 } // namespace mlir::triton::intel
@@ -86,5 +174,17 @@ void postProcessLLVMIR(llvm::Module &mod) {
 PreservedAnalyses ExpandSaddWithOverflowPass::run(Module &M,
                                                   ModuleAnalysisManager &) {
   mlir::triton::intel::expandSaddWithOverflow(M);
+  return PreservedAnalyses::none();
+}
+
+PreservedAnalyses ExpandSubByteBitReversePass::run(Module &M,
+                                                   ModuleAnalysisManager &) {
+  mlir::triton::intel::expandSubByteBitReverse(M);
+  return PreservedAnalyses::none();
+}
+
+PreservedAnalyses ExpandSubByteBitwiseAndPass::run(Module &M,
+                                                   ModuleAnalysisManager &) {
+  mlir::triton::intel::expandSubByteBitwiseAnd(M);
   return PreservedAnalyses::none();
 }


### PR DESCRIPTION
**Problem**
SPV_INTEL_int4 permits OpTypeInt 4 only with a restricted set of ops. Bitwise and bit-manipulation ops are not on that list. IGC SIGFPEs during ocloc compile when it encounters OpBitReverse or OpBitwiseAnd on OpTypeInt N<8.

Triton does not emit sub-byte ops directly, LLVM's -O3 produces them from small swizzled-SLM index computations.

  **Fix**
Two post-process LLVM-IR passes run after -O3 and before SPIR-V translation.
- expandSubByteBitReverse : llvm.bitreverse.iN (N<8) -> zext iN -> i32; bitreverse.i32; lshr (32-N); trunc i32 -> iN
- expandSubByteBitwiseAnd : and iN (N<8) -> zext iN -> i32 (both operands); and i32; trunc i32 -> iN

Closes #6713

and also fix this issue #6138

---------


(cherry picked from commit ad5c9757756c6c1341c82e1e891363149a74f192)