### PR TITLE
Allow benchmarks to run as pytest tests

### DIFF
--- a/benchmarks/tests/benchmark_helpers.py
+++ b/benchmarks/tests/benchmark_helpers.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import fields
+
+from triton_kernels_benchmark.benchmark_testing import BenchmarkConfigRunResult
+from triton_kernels_benchmark.configs.benchmark_config_templates import CONFIGS
+
+
+def make_cfg(template, providers: list[str] | None = None) -> BenchmarkConfigRunResult:
+    template_kwargs = {f.name: getattr(template, f.name) for f in fields(template) if f.name != "providers_filter"}
+    return BenchmarkConfigRunResult(**template_kwargs, providers_filter=providers, shape_pattern=None)
+
+
+def template_for(config_key: str):
+    for template in CONFIGS:
+        if template.key == config_key:
+            return template
+    raise KeyError(f"No benchmark template with key {config_key!r}")

--- a/benchmarks/tests/conftest.py
+++ b/benchmarks/tests/conftest.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+import pytest
+
+from benchmark_helpers import make_cfg, template_for
+from triton_kernels_benchmark.benchmark_testing import (
+    BenchmarkCategory,
+    MarkArgs,
+)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("triton-benchmarks")
+    group.addoption(
+        "--reports",
+        default="",
+        help="Directory to write benchmark report artifacts.",
+    )
+    group.addoption(
+        "--tag",
+        default="",
+        help="Tag propagated to build_report.",
+    )
+    group.addoption(
+        "--n-runs",
+        type=int,
+        default=1,
+        dest="n_runs",
+        help="Number of re-runs per test case.",
+    )
+    group.addoption(
+        "--benchmark-brief",
+        action="store_true",
+        dest="benchmark_brief",
+        help="Print only mean values without min, max, CV.",
+    )
+    group.addoption(
+        "--benchmark-eff",
+        action="store_true",
+        dest="benchmark_eff",
+        help="Print HW utilization using gpu_info.json.",
+    )
+    group.addoption(
+        "--describe-only",
+        action="store_true",
+        dest="describe_only",
+        help="Describe each (benchmark, shape, provider) without executing the kernel.",
+    )
+
+
+@pytest.fixture(scope="session")
+def benchmark_reports_dir(request: pytest.FixtureRequest) -> Path | None:
+    value = request.config.getoption("--reports")
+    return Path(value) if value else None
+
+
+@pytest.fixture(scope="session")
+def benchmark_describe_only(request: pytest.FixtureRequest) -> bool:
+    return bool(request.config.getoption("describe_only"))
+
+
+@pytest.fixture(scope="session")
+def benchmark_mark_args(request: pytest.FixtureRequest, benchmark_reports_dir: Path | None,  # pylint: disable=redefined-outer-name
+                        ) -> MarkArgs:
+    return MarkArgs(
+        reports=str(benchmark_reports_dir) if benchmark_reports_dir else "",
+        n_runs=request.config.getoption("n_runs"),
+        brief=request.config.getoption("benchmark_brief"),
+        eff=request.config.getoption("benchmark_eff"),
+    )
+
+
+_PARTS_SUBDIR = "_parts"
+
+
+def _iter_case_dirs(parts_dir: Path) -> Iterable[tuple[str, Path]]:
+    """Yield (config_key, case_dir) for each per-test subdir under _parts/."""
+    if not parts_dir.is_dir():
+        return
+    for case_dir in sorted(parts_dir.iterdir()):
+        if not case_dir.is_dir():
+            continue
+        # Directory names follow "<config>__<shape>__<provider>".
+        config_key = case_dir.name.split("__", 1)[0]
+        yield config_key, case_dir
+
+
+def _aggregate_reports(reports: Path, tag: str) -> None:
+    parts_dir = reports / _PARTS_SUBDIR
+    if not parts_dir.is_dir():
+        return
+
+    # Group per-test subdirs by config_key.
+    dirs_by_config: dict[str, list[Path]] = {}
+    for config_key, case_dir in _iter_case_dirs(parts_dir):
+        dirs_by_config.setdefault(config_key, []).append(case_dir)
+
+    for config_key, case_dirs in dirs_by_config.items():
+        providers = list({d.name.rsplit("__", 1)[-1] for d in case_dirs})
+        cfg = make_cfg(template_for(config_key), providers=providers)
+        merged_name = f"{cfg.plot_name}.csv"
+        frames: list[pd.DataFrame] = []
+        for case_dir in case_dirs:
+            csv_path = case_dir / merged_name
+            if not csv_path.is_file():
+                continue
+            df = pd.read_csv(csv_path)
+            if df.empty:
+                continue
+            frames.append(df)
+        if not frames:
+            continue
+        combined = pd.concat(frames, axis=0, ignore_index=True)
+        combined.to_csv(reports / merged_name, index=False)
+        cfg.res_df_list = [combined]
+        cfg.build_report(reports_folder=str(reports), tag=tag)
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    if hasattr(session.config, "workerinput"):
+        return
+    reports = session.config.getoption("--reports")
+    if not reports:
+        return
+    parts_dir = Path(reports) / _PARTS_SUBDIR
+    if parts_dir.is_dir():
+        shutil.rmtree(parts_dir)
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:  # pylint: disable=unused-argument
+    # xdist workers have a `workerinput` attribute on their config; only the
+    # controller (or a non-xdist run) should aggregate once all tests are done.
+    if hasattr(session.config, "workerinput"):
+        return
+    reports = session.config.getoption("--reports")
+    if not reports:
+        return
+    tag = session.config.getoption("--tag")
+    _aggregate_reports(Path(reports), tag)
+
+
+# Expose BenchmarkCategory so tests can reference the full category set symbolically.
+ALL_CATEGORIES = {cat.value for cat in BenchmarkCategory}

--- a/benchmarks/tests/test_benchmarks.py
+++ b/benchmarks/tests/test_benchmarks.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from typing import List, Tuple
+
+import pytest
+
+from benchmark_helpers import make_cfg
+from triton_kernels_benchmark.benchmark_shapes_parser import ShapePatternParser
+from triton_kernels_benchmark.benchmark_testing import (
+    BenchmarkCategory,
+    MarkArgs,
+)
+from triton_kernels_benchmark.benchmark_utils import BenchmarkConfigs
+from triton_kernels_benchmark.configs.benchmark_config_templates import CONFIGS
+
+
+def _collect_cases() -> List[Tuple[str, str, str]]:
+    cases: List[Tuple[str, str, str]] = []
+    for template in CONFIGS:
+        probe = make_cfg(template)
+        for shape in probe.supported_shapes:
+            shape_str = str(shape)
+            for provider_key in probe.supported_providers:
+                cases.append((template.key, shape_str, provider_key))
+    return cases
+
+
+CASES = _collect_cases()
+ALL_CATEGORIES = {cat.value for cat in BenchmarkCategory}
+
+
+@pytest.mark.parametrize(("config_key", "shape", "provider"), CASES)
+def test_benchmarks(
+    config_key: str,
+    shape: str,
+    provider: str,
+    benchmark_mark_args: MarkArgs,
+    benchmark_reports_dir: Path | None,
+    benchmark_describe_only: bool,
+) -> None:
+    configs = BenchmarkConfigs._get_configs(  # pylint: disable=protected-access
+        configs_filter={config_key},
+        categories_filter=ALL_CATEGORIES,
+        providers_filter=[provider],
+        shape_pattern=ShapePatternParser(shape),
+    )
+    assert len(configs) == 1, f"expected exactly one config for {config_key!r}, got {len(configs)}"
+    cfg = configs[0]
+
+    if benchmark_describe_only:
+        assert cfg.selected_shapes, f"shape {shape} did not resolve for {config_key}"
+        assert cfg.selected_providers, f"provider {provider} not supported by {config_key}"
+        # Mirror the `triton-benchmarks describe` output (benchmark_utils.py:72).
+        print(str(cfg))
+        return
+
+    args = benchmark_mark_args
+    if benchmark_reports_dir is not None:
+        # Mark.run writes a fixed "{plot_name}.csv"; each xdist worker gets its own
+        # subdir to avoid clobbering peers. pytest_sessionfinish (conftest.py) merges
+        # these into the consolidated reports the CLI produces.
+        per_test_dir = benchmark_reports_dir / "_parts" / f"{config_key}__{shape}__{provider}"
+        per_test_dir.mkdir(parents=True, exist_ok=True)
+        args = dataclasses.replace(args, reports=str(per_test_dir))
+
+    cfg.run(args)

--- a/benchmarks/triton_kernels_benchmark/benchmark_testing.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_testing.py
@@ -273,7 +273,10 @@ def do_bench_proton(fn, n_warmup=25, n_repeat=100, grad_to_none=None, quantiles=
             if sync_submitting:
                 synchronize()
 
-    proton.start()
+    # Use a pid-suffixed profile name so parallel workers (e.g. pytest-xdist)
+    # don't clobber each other's ./proton.hatchet output.
+    profile_name = f"proton-{os.getpid()}"
+    proton.start(profile_name)
     # Benchmark
     for idx in range(n_repeat):
         # we don't want `fn` to accumulate gradient values
@@ -292,8 +295,10 @@ def do_bench_proton(fn, n_warmup=25, n_repeat=100, grad_to_none=None, quantiles=
     # Record clocks
     synchronize()
     proton.finalize()
-    with open("./proton.hatchet", encoding="utf-8") as f:
+    hatchet_path = f"./{profile_name}.hatchet"
+    with open(hatchet_path, encoding="utf-8") as f:
         data = json.load(f)
+    os.remove(hatchet_path)
 
     profiling_func_filter = filter(
         lambda x: x["frame"]["name"].startswith("__profile_kernel_of_func"


### PR DESCRIPTION
This makes it possible to run benchmarks in parallel using pytest-xdist

It is now possible to run benchmarks like this:

### Parallel run
```bash
source ./scripts/capture-hw-details.sh
cd benchmarks
pytest -vvv -s -n 2 --reports softmax_reports --tag softmax_tag -k 'softmax and triton'
```
### Single config run
```bash
source ./scripts/capture-hw-details.sh
cd benchmarks
pytest -vvv -s --reports softmax_256_report --tag softmax_tag 'tests/test_benchmarks.py::test_benchmarks[softmax-[256]-triton]'
```
### Get all configs
```bash
source ./scripts/capture-hw-details.sh
cd benchmarks
pytest --collect-only tests/test_benchmarks.py
```
### Describe all configs
```bash
source ./scripts/capture-hw-details.sh
cd benchmarks
pytest -vvv -s --describe-only tests/test_benchmarks.py
```