### PR TITLE
Fix for e2e-windows.yml workflow after 895e7cf3

### DIFF
--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Install transformers package
         if: inputs.suite == 'all' || inputs.suite == 'huggingface'
         run: |
-          cd pytorch
+          cd /c/pytorch
           pip install -r .ci/docker/ci_commit_pins/huggingface-requirements.txt
 
       - name: Install torchvision package

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -169,6 +169,7 @@ jobs:
 
       - name: Install transformers package
         if: inputs.suite == 'all' || inputs.suite == 'huggingface'
+        shell: bash
         run: |
           cd /c/pytorch
           pip install -r .ci/docker/ci_commit_pins/huggingface-requirements.txt


### PR DESCRIPTION
E2E windows: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/26089484103 (to check)