### PR TITLE
[BACKEND] Trigger 256-GRF retry when zebin is degenerate (LTS2 IGC silent failure) (#6958)

### DIFF
--- a/python/test/unit/intel/test_extract_spill_size.py
+++ b/python/test/unit/intel/test_extract_spill_size.py
@@ -2,11 +2,18 @@
 
 Regression coverage for https://github.com/intel/intel-xpu-backend-for-triton/issues/6901:
 a missing `.ze_info` section must not raise; it must warn and return 0.
+
+Regression coverage for https://github.com/intel/intel-xpu-backend-for-triton/issues/6941:
+a degenerate zebin (no `.text.<kernel>` and no `.symtab`) must be raised as
+`IntelGPUError` so the existing 256-GRF retry path catches it.
 """
 import struct
 import warnings
 
+import pytest
+
 from triton.backends.intel.compiler import extract_spill_size_from_zebin
+from triton.runtime.errors import IntelGPUError
 
 
 def _build_elf64(sections):
@@ -82,7 +89,7 @@ def _write_elf(tmp_path, sections):
 
 
 def test_missing_ze_info_warns_and_returns_zero(tmp_path):
-    zebin = _write_elf(tmp_path, [(".text", b"\x00\x00\x00\x00")])
+    zebin = _write_elf(tmp_path, [(".text.kernel", b"\x00\x00\x00\x00"), (".symtab", b"\x00")])
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
@@ -91,6 +98,13 @@ def test_missing_ze_info_warns_and_returns_zero(tmp_path):
     assert result == 0
     assert any(".ze_info" in str(w.message) for w in caught), \
         f"expected a warning mentioning .ze_info, got: {[str(w.message) for w in caught]}"
+
+
+def test_degenerate_zebin_raises(tmp_path):
+    zebin = _write_elf(tmp_path, [(".note.intelgt.compat", b"\x00")])
+
+    with pytest.raises(IntelGPUError):
+        extract_spill_size_from_zebin(zebin)
 
 
 def test_ze_info_with_spill_size_returns_value(tmp_path):

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -82,6 +82,16 @@ def extract_spill_size_from_zebin(file):
         elf = ELFFile(f)
         zeinfo = elf.get_section_by_name(".ze_info")
         if zeinfo is None:
+            has_text = any(s.name.startswith('.text.') for s in elf.iter_sections())
+            has_symtab = elf.get_section_by_name('.symtab') is not None
+            if not has_text or not has_symtab:
+                # IGC can exit 0 on PTSS overflow yet emit a degenerate zebin.
+                # Observed on LTS2 line; rolling libigc instead
+                # exits non-zero. Raise so the existing 256-GRF retry path
+                # in make_zebin catches it, matching the rolling code path.
+                raise IntelGPUError('Degenerate zebin: missing .text/.symtab. '
+                                    'IGC likely failed (e.g. PTSS overflow) without '
+                                    'reporting a non-zero exit code.')
             warnings.warn(
                 'Section .ze_info not found in zebin; cannot extract spill_size. '
                 'Auto-GRF mode selection will be skipped for this kernel.',
@@ -526,11 +536,13 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
                         # re-run with double GRF mode
                         ocloc_cmd[-1] = metadata["build_flags"] + shader_dump_opt
                         subprocess.check_output(ocloc_cmd, stderr=subprocess.STDOUT, text=True)
-            except subprocess.CalledProcessError as e:
+            except (subprocess.CalledProcessError, IntelGPUError) as e:
                 # If GRF mode was not explicitly set, retry with large GRF mode
                 # before giving up. This handles cases where the default GRF mode
                 # doesn't provide enough registers (e.g., scratch space exceeds
-                # HW PTSS limit).
+                # HW PTSS limit). Also covers degenerate zebin (no .text/.symtab)
+                # detected by extract_spill_size_from_zebin (LTS2 IGC silent
+                # PTSS overflow).
                 retry_succeeded = False
                 if options.grf_mode == 'default' and \
                         "-cl-intel-256-GRF-per-thread" not in metadata.get("build_flags", ""):
@@ -544,6 +556,8 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
                         pass
 
                 if not retry_succeeded:
+                    if isinstance(e, IntelGPUError):
+                        raise
                     if e.returncode == 255:
                         error = 'Internal Triton ZEBIN codegen error'
                     elif e.returncode == 128 + signal.SIGSEGV:


### PR DESCRIPTION
On LTS2, IGC silently exits 0 on PTSS overflow and emits a degenerate zebin (no .text/.symtab/.ze_info); on rolling, it returns non-zero so Triton's existing 256-GRF retry kicks in. This patch detects the degenerate output in extract_spill_size_from_zebin and re-raises as CalledProcessError, routing it through the same retry path. Verified locally on LTS2:
TritonBlockPointerTestGPU::test_2d_reduction_multi_kernel_xpu (#6941) goes from FAIL 0x78000011 to PASS.

(cherry picked from commit 665881805bc1d5f6df305e075d3668d5e52743d9)