### PR TITLE
Fix for e2e-windows.yml workflow after 895e7cf3 (#6964)

### DIFF
--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -169,8 +169,9 @@ jobs:
 
       - name: Install transformers package
         if: inputs.suite == 'all' || inputs.suite == 'huggingface'
+        shell: bash
         run: |
-          cd pytorch
+          cd /c/pytorch
           pip install -r .ci/docker/ci_commit_pins/huggingface-requirements.txt
 
       - name: Install torchvision package


### PR DESCRIPTION
E2E windows:
https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/26089484103 (to check)

(cherry picked from commit bdfc36b17806c76db86b05e091d6d88127b506c1)