### PR TITLE
[BlockIO] Enable 2D block load for runtime row strides

### DIFF
--- a/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
+++ b/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
@@ -74,8 +74,9 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x32x!tt.ptr<f16>, #dot0>
     %3 = tt.addptr %2, %1 : tensor<1x32x!tt.ptr<f16>, #dot0>, tensor<1x32xi32, #dot0>
     %4 = tt.broadcast %3 : tensor<1x32x!tt.ptr<f16>, #dot0> -> tensor<64x32x!tt.ptr<f16>, #dot0>
+    %pitch = arith.constant 64 : i32
     // CHECK-COUNT-2: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 2, transpose = false, vnni_transform = false, cache_control = Default}
-    %5 = ttig.2d_block_load_from_ptr %4 {row_major} {base_height = 1 : i32, base_pitch = 64 : i32, base_width = 64 : i32} : (tensor<64x32x!tt.ptr<f16>, #dot0>) -> tensor<64x32xf16, #dot0>
+    %5 = ttig.2d_block_load_from_ptr %4, %pitch {row_major} {base_height = 1 : i32, base_width = 64 : i32} : (tensor<64x32x!tt.ptr<f16>, #dot0>, i32) -> tensor<64x32xf16, #dot0>
     tt.return
   }
 }
@@ -96,10 +97,11 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x32x!tt.ptr<f16>, #dot0>
     %3 = tt.addptr %2, %1 : tensor<1x32x!tt.ptr<f16>, #dot0>, tensor<1x32xi32, #dot0>
     %4 = tt.broadcast %3 : tensor<1x32x!tt.ptr<f16>, #dot0> -> tensor<64x32x!tt.ptr<f16>, #dot0>
+    %pitch = arith.constant 64 : i32
     // CHECK: llvm.select {{.*}} : i1, i32
     // CHECK: triton_gen.2Dblockload
     // CHECK: llvm.select
-    %5 = ttig.2d_block_load_from_ptr %4, %true, %cst {row_major} {base_height = 8 : i32, base_pitch = 64 : i32, base_width = 64 : i32} : (tensor<64x32x!tt.ptr<f16>, #dot0>, tensor<64x32xi1, #dot0>, tensor<64x32xf16, #dot0>) -> tensor<64x32xf16, #dot0>
+    %5 = ttig.2d_block_load_from_ptr %4, %pitch, %true, %cst {row_major} {base_height = 8 : i32, base_width = 64 : i32} : (tensor<64x32x!tt.ptr<f16>, #dot0>, i32, tensor<64x32xi1, #dot0>, tensor<64x32xf16, #dot0>) -> tensor<64x32xf16, #dot0>
     tt.return
   }
 }
@@ -118,9 +120,10 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x32x!tt.ptr<f16>, #dot0>
     %3 = tt.addptr %2, %1 : tensor<1x32x!tt.ptr<f16>, #dot0>, tensor<1x32xi32, #dot0>
     %4 = tt.broadcast %3 : tensor<1x32x!tt.ptr<f16>, #dot0> -> tensor<64x32x!tt.ptr<f16>, #dot0>
+    %pitch = arith.constant 64 : i32
     // CHECK: triton_gen.2Dblockload
     // CHECK: llvm.shufflevector
-    %5 = ttig.2d_block_load_from_ptr %4 {row_major} {base_height = 1 : i32, base_pitch = 64 : i32, base_width = 64 : i32} : (tensor<64x32x!tt.ptr<f16>, #dot0>) -> tensor<64x32xf16, #dot0>
+    %5 = ttig.2d_block_load_from_ptr %4, %pitch {row_major} {base_height = 1 : i32, base_width = 64 : i32} : (tensor<64x32x!tt.ptr<f16>, #dot0>, i32) -> tensor<64x32xf16, #dot0>
     tt.return
   }
 }
@@ -139,8 +142,9 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x16x!tt.ptr<f16>, #blocked>
     %3 = tt.addptr %2, %1 : tensor<1x16x!tt.ptr<f16>, #blocked>, tensor<1x16xi32, #blocked>
     %4 = tt.broadcast %3 : tensor<1x16x!tt.ptr<f16>, #blocked> -> tensor<64x16x!tt.ptr<f16>, #blocked>
+    %pitch = arith.constant 128 : i32
     // CHECK: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 1, transpose = false, vnni_transform = false, cache_control = Default}
-    %5 = ttig.2d_block_load_from_ptr %4 {row_major} {base_height = 64 : i32, base_pitch = 128 : i32, base_width = 32 : i32, ttig.block_io_stride = 64 : i64} : (tensor<64x16x!tt.ptr<f16>, #blocked>) -> tensor<64x16xf16, #blocked>
+    %5 = ttig.2d_block_load_from_ptr %4, %pitch {row_major} {base_height = 64 : i32, base_width = 32 : i32, ttig.block_io_stride = 64 : i64} : (tensor<64x16x!tt.ptr<f16>, #blocked>, i32) -> tensor<64x16xf16, #blocked>
     tt.return
   }
 }

--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/pointer-load.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/pointer-load.mlir
@@ -13,7 +13,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x32x!tt.ptr<f16>, #dot0>
     %3 = tt.addptr %2, %1 : tensor<1x32x!tt.ptr<f16>, #dot0>, tensor<1x32xi32, #dot0>
     %4 = tt.broadcast %3 : tensor<1x32x!tt.ptr<f16>, #dot0> -> tensor<64x32x!tt.ptr<f16>, #dot0>
-    // CHECK: ttig.2d_block_load_from_ptr %4 {row_major} {base_height = 1 : i32, base_pitch = 64 : i32, base_width = 64 : i32}
+    // CHECK: %[[P:.*]] = arith.constant 64 : i32
+    // CHECK: ttig.2d_block_load_from_ptr %4, %[[P]] {row_major} {base_height = 1 : i32, base_width = 64 : i32}
     %5 = tt.load %4 {ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f16>, #dot0>
     tt.return %5 : tensor<64x32xf16, #dot0>
   }
@@ -33,7 +34,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x64x!tt.ptr<f16>, #dot1>
     %3 = tt.addptr %2, %1 : tensor<1x64x!tt.ptr<f16>, #dot1>, tensor<1x64xi32, #dot1>
     %4 = tt.broadcast %3 : tensor<1x64x!tt.ptr<f16>, #dot1> -> tensor<32x64x!tt.ptr<f16>, #dot1>
-    // CHECK: ttig.2d_block_load_from_ptr %4 {column_major} {base_height = 1 : i32, base_pitch = 64 : i32, base_width = 64 : i32}
+    // CHECK: %[[P:.*]] = arith.constant 64 : i32
+    // CHECK: ttig.2d_block_load_from_ptr %4, %[[P]] {column_major} {base_height = 1 : i32, base_width = 64 : i32}
     %5 = tt.load %4 {ttig.block_io = "column_major"} : tensor<32x64x!tt.ptr<f16>, #dot1>
     tt.return %5 : tensor<32x64xf16, #dot1>
   }
@@ -102,7 +104,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x32x!tt.ptr<f16>, #dot0>
     %3 = tt.addptr %2, %1 : tensor<1x32x!tt.ptr<f16>, #dot0>, tensor<1x32xi32, #dot0>
     %4 = tt.broadcast %3 : tensor<1x32x!tt.ptr<f16>, #dot0> -> tensor<64x32x!tt.ptr<f16>, #dot0>
-    // CHECK: ttig.2d_block_load_from_ptr %4 {row_major} {base_height = 64 : i32, base_pitch = 512 : i32, base_width = 64 : i32, ttig.block_io_stride = 256 : i64}
+    // CHECK: %[[P:.*]] = arith.constant 512 : i32
+    // CHECK: ttig.2d_block_load_from_ptr %4, %[[P]] {row_major} {base_height = 64 : i32, base_width = 64 : i32, ttig.block_io_stride = 256 : i64}
     %5 = tt.load %4 {ttig.block_io = "row_major", ttig.block_io_stride = 256 : i64} : tensor<64x32x!tt.ptr<f16>, #dot0>
     tt.return %5 : tensor<64x32xf16, #dot0>
   }
@@ -168,10 +171,77 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %7 = arith.addi %5, %6 : tensor<32x64xi32, #dot1>
     %8 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<32x64x!tt.ptr<f16>, #dot1>
     %9 = tt.addptr %8, %7 : tensor<32x64x!tt.ptr<f16>, #dot1>, tensor<32x64xi32, #dot1>
-    // CHECK: ttig.2d_block_load_from_ptr %9 {column_major}
-    // CHECK-SAME: base_pitch = 256
+    // CHECK: %[[P:.*]] = arith.constant 256 : i32
+    // CHECK: ttig.2d_block_load_from_ptr %9, %[[P]] {column_major}
     %10 = tt.load %9 {ttig.block_io = "column_major"} : tensor<32x64x!tt.ptr<f16>, #dot1>
     tt.return %10 : tensor<32x64xf16, #dot1>
+  }
+}
+
+// -----
+
+// COM: Row-major pointer load whose row stride (`lda`) is a runtime scalar,
+// COM: as in grouped GEMM. StrideAnalysis cannot fold it to a constant, but it
+// COM: recovers the SSA value, so the pass feeds `lda * elemSize` as the pitch
+// COM: operand (rather than a materialized arith.constant).
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @runtime_row_stride
+  tt.func @runtime_row_stride(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %lda: i32 {tt.divisibility = 16 : i32}) -> tensor<64x32xf16, #dot0> {
+    // Build ptr[i, j] = arg0 + i * lda + j  (row-major, runtime row stride lda).
+    %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #dot0}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #dot0}>> -> tensor<64x1xi32, #dot0>
+    %lda_splat = tt.splat %lda : i32 -> tensor<64x1xi32, #dot0>
+    %row = arith.muli %1, %lda_splat : tensor<64x1xi32, #dot0>
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #dot0}>>
+    %3 = tt.expand_dims %2 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #dot0}>> -> tensor<1x32xi32, #dot0>
+    %rowb = tt.broadcast %row : tensor<64x1xi32, #dot0> -> tensor<64x32xi32, #dot0>
+    %colb = tt.broadcast %3 : tensor<1x32xi32, #dot0> -> tensor<64x32xi32, #dot0>
+    %off = arith.addi %rowb, %colb : tensor<64x32xi32, #dot0>
+    %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x32x!tt.ptr<f16>, #dot0>
+    %ptr = tt.addptr %base, %off : tensor<64x32x!tt.ptr<f16>, #dot0>, tensor<64x32xi32, #dot0>
+    // CHECK: %[[C2:.*]] = arith.constant 2 : i32
+    // CHECK: %[[PITCH:.*]] = arith.muli %{{.*}}, %[[C2]] : i32
+    // CHECK: ttig.2d_block_load_from_ptr %{{.*}}, %[[PITCH]] {row_major} {base_height = 8 : i32, base_width = 32 : i32}
+    %5 = tt.load %ptr {ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f16>, #dot0>
+    tt.return %5 : tensor<64x32xf16, #dot0>
+  }
+}
+
+// -----
+
+// COM: Grouped GEMM advances the pointer inside the K-loop, so the load sees a
+// COM: loop-carried iter-arg. The runtime stride (`lda`) is loop-invariant, so
+// COM: the dataflow fixpoint still recovers it and the in-loop load lowers to a
+// COM: block load with the runtime pitch operand.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @loop_carried_runtime_stride
+  tt.func @loop_carried_runtime_stride(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %lda: i32 {tt.divisibility = 16 : i32}, %lb: index, %ub: index, %step: index) -> tensor<64x32xf16, #dot0> {
+    %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #dot0}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #dot0}>> -> tensor<64x1xi32, #dot0>
+    %lda_splat = tt.splat %lda : i32 -> tensor<64x1xi32, #dot0>
+    %row = arith.muli %1, %lda_splat : tensor<64x1xi32, #dot0>
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #dot0}>>
+    %3 = tt.expand_dims %2 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #dot0}>> -> tensor<1x32xi32, #dot0>
+    %rowb = tt.broadcast %row : tensor<64x1xi32, #dot0> -> tensor<64x32xi32, #dot0>
+    %colb = tt.broadcast %3 : tensor<1x32xi32, #dot0> -> tensor<64x32xi32, #dot0>
+    %off = arith.addi %rowb, %colb : tensor<64x32xi32, #dot0>
+    %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x32x!tt.ptr<f16>, #dot0>
+    %ptr0 = tt.addptr %base, %off : tensor<64x32x!tt.ptr<f16>, #dot0>, tensor<64x32xi32, #dot0>
+    %cst32 = arith.constant dense<32> : tensor<64x32xi32, #dot0>
+    // CHECK: scf.for
+    // CHECK: %[[PITCH:.*]] = arith.muli %{{.*}}, %{{.*}} : i32
+    // CHECK: ttig.2d_block_load_from_ptr %{{.*}}, %[[PITCH]] {row_major}
+    %res = scf.for %i = %lb to %ub step %step iter_args(%p = %ptr0) -> (tensor<64x32x!tt.ptr<f16>, #dot0>) {
+      %ld = tt.load %p {ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f16>, #dot0>
+      %pn = tt.addptr %p, %cst32 : tensor<64x32x!tt.ptr<f16>, #dot0>, tensor<64x32xi32, #dot0>
+      scf.yield %pn : tensor<64x32x!tt.ptr<f16>, #dot0>
+    }
+    %final = tt.load %res {ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f16>, #dot0>
+    tt.return %final : tensor<64x32xf16, #dot0>
   }
 }
 

--- a/test/TritonIntelGPU/prefetch-to-llvm.mlir
+++ b/test/TritonIntelGPU/prefetch-to-llvm.mlir
@@ -95,3 +95,47 @@ module attributes {ttig.min_sg_size = 16 : i32, ttig.support_2d_block_io, ttig.t
     tt.return
   }
 }
+
+// -----
+
+// COM: Prefetch of a tensor-of-pointers whose row stride (`lda`) is a runtime
+// COM: scalar, as in grouped GEMM. The pitch can't be a compile-time constant,
+// COM: so the lowering recovers the runtime stride and materializes
+// COM: pitch = lda * elemSize, then feeds it to the HW 2D block prefetch.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [2, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_runtime_stride
+  tt.func public @prefetch_runtime_stride(%arg0: !tt.ptr<f16>, %lda: i32 {tt.divisibility = 16 : i32}) {
+    %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>}>> -> tensor<64x1xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %lda_splat = tt.splat %lda : i32 -> tensor<64x1xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %3 = arith.muli %1, %lda_splat : tensor<64x1xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %4 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>}>> -> tensor<1x32xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %6 = tt.broadcast %3 : tensor<64x1xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>> -> tensor<64x32xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %7 = tt.broadcast %5 : tensor<1x32xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>> -> tensor<64x32xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %8 = arith.addi %6, %7 : tensor<64x32xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %9 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x32x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %tp = tt.addptr %9, %8 : tensor<64x32x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>, tensor<64x32xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    // CHECK: %[[PITCH:.*]] = llvm.mul %arg1, %{{.*}} : i32
+    // CHECK: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %[[PITCH]],
+    ttig.prefetch %tp {cache = 1 : i32, evict = 1 : i32, isVolatile = false, ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Prefetch of a tensor-of-pointers whose stride is neither a compile-time
+// COM: constant nor a recoverable runtime value (the pointer tensor is a bare
+// COM: function argument). The lowering must cleanly bail to a no-op rather
+// COM: than emit a malformed prefetch.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [2, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_unknown_stride
+  // CHECK-NOT: triton_gen.2Dblockprefetch
+  tt.func public @prefetch_unknown_stride(%arg0: tensor<64x32x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>) {
+    ttig.prefetch %arg0 {cache = 1 : i32, evict = 1 : i32, isVolatile = false, ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/tritonintelgpu-invalid.mlir
+++ b/test/TritonIntelGPU/tritonintelgpu-invalid.mlir
@@ -114,9 +114,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
-  tt.func @ttig.2d_block_load_from_ptr.rank1(%ptr: tensor<32x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #dot0}>>) -> tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>> {
+  tt.func @ttig.2d_block_load_from_ptr.rank1(%ptr: tensor<32x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #dot0}>>, %pitch: i32) -> tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>> {
     // expected-error @below {{'ttig.2d_block_load_from_ptr' op result tensor must have rank >= 2, got 1}}
-    %0 = ttig.2d_block_load_from_ptr %ptr {row_major} {base_width = 64 : i32, base_height = 8 : i32, base_pitch = 256 : i32} : (tensor<32x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #dot0}>>) -> (tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>>)
+    %0 = ttig.2d_block_load_from_ptr %ptr, %pitch {row_major} {base_width = 64 : i32, base_height = 8 : i32} : (tensor<32x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #dot0}>>, i32) -> (tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>>)
     tt.return %0 : tensor<32xf16, #ttg.slice<{dim = 0, parent = #dot0}>>
   }
 }
@@ -128,9 +128,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
-  tt.func @ttig.2d_block_load_from_ptr.mask_without_other(%ptr: tensor<64x32x!tt.ptr<f16>, #dot0>, %mask: tensor<64x32xi1, #dot0>) -> tensor<64x32xf16, #dot0> {
+  tt.func @ttig.2d_block_load_from_ptr.mask_without_other(%ptr: tensor<64x32x!tt.ptr<f16>, #dot0>, %mask: tensor<64x32xi1, #dot0>, %pitch: i32) -> tensor<64x32xf16, #dot0> {
     // expected-error @below {{'ttig.2d_block_load_from_ptr' op 'other' must be present when 'mask' is present}}
-    %0 = "ttig.2d_block_load_from_ptr"(%ptr, %mask) <{base_width = 64 : i32, base_height = 8 : i32, base_pitch = 256 : i32, memory_layout = 0 : i32, operandSegmentSizes = array<i32: 1, 1, 0>}> : (tensor<64x32x!tt.ptr<f16>, #dot0>, tensor<64x32xi1, #dot0>) -> tensor<64x32xf16, #dot0>
+    %0 = "ttig.2d_block_load_from_ptr"(%ptr, %pitch, %mask) <{base_width = 64 : i32, base_height = 8 : i32, memory_layout = 0 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 0>}> : (tensor<64x32x!tt.ptr<f16>, #dot0>, i32, tensor<64x32xi1, #dot0>) -> tensor<64x32xf16, #dot0>
     tt.return %0 : tensor<64x32xf16, #dot0>
   }
 }

--- a/test/TritonIntelGPU/tritonintelgpu.mlir
+++ b/test/TritonIntelGPU/tritonintelgpu.mlir
@@ -47,17 +47,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
-  tt.func @ttig.2d_block_load_from_ptr(%ptr: tensor<64x32x!tt.ptr<f16>, #dot0>) -> tensor<64x32xf16, #dot0> {
+  tt.func @ttig.2d_block_load_from_ptr(%ptr: tensor<64x32x!tt.ptr<f16>, #dot0>, %pitch: i32) -> tensor<64x32xf16, #dot0> {
     // CHECK-LABEL: @ttig.2d_block_load_from_ptr
-    // CHECK: ttig.2d_block_load_from_ptr %arg0 {row_major} {base_height = 8 : i32, base_pitch = 256 : i32, base_width = 64 : i32}
-    %0 = ttig.2d_block_load_from_ptr %ptr {row_major} {base_width = 64 : i32, base_height = 8 : i32, base_pitch = 256 : i32} : (tensor<64x32x!tt.ptr<f16>, #dot0>) -> (tensor<64x32xf16, #dot0>)
+    // CHECK: ttig.2d_block_load_from_ptr %arg0, %arg1 {row_major} {base_height = 8 : i32, base_width = 64 : i32}
+    %0 = ttig.2d_block_load_from_ptr %ptr, %pitch {row_major} {base_width = 64 : i32, base_height = 8 : i32} : (tensor<64x32x!tt.ptr<f16>, #dot0>, i32) -> (tensor<64x32xf16, #dot0>)
     tt.return %0 : tensor<64x32xf16, #dot0>
   }
 
-  tt.func @ttig.2d_block_load_from_ptr_with_mask(%ptr: tensor<64x32x!tt.ptr<f16>, #dot0>, %mask: tensor<64x32xi1, #dot0>, %other: tensor<64x32xf16, #dot0>) -> tensor<64x32xf16, #dot0> {
+  tt.func @ttig.2d_block_load_from_ptr_with_mask(%ptr: tensor<64x32x!tt.ptr<f16>, #dot0>, %mask: tensor<64x32xi1, #dot0>, %other: tensor<64x32xf16, #dot0>, %pitch: i32) -> tensor<64x32xf16, #dot0> {
     // CHECK-LABEL: @ttig.2d_block_load_from_ptr_with_mask
-    // CHECK: ttig.2d_block_load_from_ptr %arg0, %arg1, %arg2 {row_major} {base_height = 8 : i32, base_pitch = 256 : i32, base_width = 64 : i32}
-    %0 = ttig.2d_block_load_from_ptr %ptr, %mask, %other {row_major} {base_width = 64 : i32, base_height = 8 : i32, base_pitch = 256 : i32} : (tensor<64x32x!tt.ptr<f16>, #dot0>, tensor<64x32xi1, #dot0>, tensor<64x32xf16, #dot0>) -> (tensor<64x32xf16, #dot0>)
+    // CHECK: ttig.2d_block_load_from_ptr %arg0, %arg3, %arg1, %arg2 {row_major} {base_height = 8 : i32, base_width = 64 : i32}
+    %0 = ttig.2d_block_load_from_ptr %ptr, %pitch, %mask, %other {row_major} {base_width = 64 : i32, base_height = 8 : i32} : (tensor<64x32x!tt.ptr<f16>, #dot0>, i32, tensor<64x32xi1, #dot0>, tensor<64x32xf16, #dot0>) -> (tensor<64x32xf16, #dot0>)
     tt.return %0 : tensor<64x32xf16, #dot0>
   }
 }

--- a/third_party/intel/include/Analysis/StrideInfo.h
+++ b/third_party/intel/include/Analysis/StrideInfo.h
@@ -31,12 +31,20 @@ class ModuleAxisInfoAnalysis;
 class StrideInfo {
 public:
   using DimVectorT = SmallVector<int64_t>;
+  /// One entry per axis: the SSA value behind a runtime stride (see
+  /// `getStrideValue`), or null where there isn't one.
+  using StrideValueVectorT = SmallVector<Value>;
 
   StrideInfo() = default;
   explicit StrideInfo(ArrayRef<int64_t> stride) : stride(stride) {}
   StrideInfo(DimVectorT spatial,
              DenseMap<LoopLikeOpInterface, DimVectorT> ivStrides)
       : stride(std::move(spatial)), ivStrides(std::move(ivStrides)) {}
+  StrideInfo(DimVectorT spatial,
+             DenseMap<LoopLikeOpInterface, DimVectorT> ivStrides,
+             StrideValueVectorT strideValues)
+      : stride(std::move(spatial)), ivStrides(std::move(ivStrides)),
+        strideValues(canonicalizeStrideValues(std::move(strideValues))) {}
 
   /// Spatial stride along `dim`: how many elements apart consecutive lanes
   /// along that tensor axis are within a single loaded tile.  Values follow
@@ -47,10 +55,32 @@ public:
   /// Full per-axis spatial-stride vector.  Size matches `getRank()`.
   const DimVectorT &getStride() const { return stride; }
 
+  /// The SSA value behind a runtime stride along `dim`, or null if there is
+  /// none. Set only when the constant stride is unknown (`getStride(dim) < 0`)
+  /// but the value can still be named, so a consumer can use it instead of
+  /// digging through the IR.
+  Value getStrideValue(size_t dim) const {
+    return dim < strideValues.size() ? strideValues[dim] : Value();
+  }
+
+  /// Full per-axis symbolic-stride vector.  Either empty (no symbolic source
+  /// for any axis) or exactly `getRank()`-sized.
+  const StrideValueVectorT &getStrideValues() const { return strideValues; }
+
   unsigned getRank() const { return stride.size(); }
 
   bool operator==(const StrideInfo &other) const {
-    return stride == other.stride && ivStrides == other.ivStrides;
+    return stride == other.stride && ivStrides == other.ivStrides &&
+           strideValues == other.strideValues;
+  }
+
+  /// Collapse an all-null vector to empty, so "no runtime stride" compares
+  /// equal regardless of rank (keeps the lattice equality well-behaved).
+  static StrideValueVectorT
+  canonicalizeStrideValues(StrideValueVectorT strideValues) {
+    if (llvm::all_of(strideValues, [](Value v) { return !v; }))
+      return {};
+    return strideValues;
   }
 
   static StrideInfo getPessimisticValueState(Value value);
@@ -90,6 +120,7 @@ public:
 private:
   DimVectorT stride;                                   // spatial
   DenseMap<LoopLikeOpInterface, DimVectorT> ivStrides; // per-loop IV
+  StrideValueVectorT strideValues; // symbolic spatial-stride source per axis
 };
 
 using StrideInfoMapT = DenseMap<Value, StrideInfo>;

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -277,22 +277,27 @@ def TTIG_Subgroup2DBlockLoadFromPtrOp : TTIG_Op<"2d_block_load_from_ptr", [
     `ptr[i,j] = base + i*row_stride + j*elem_size` for a constant `base`
     and known `row_stride`. Creating this op from a ptr tensor that does not
     satisfy this precondition produces undefined behavior at lowering.
+
+    `base_pitch` (row stride in bytes) is a runtime `i32` operand, matching
+    `ttig.2d_block_load` and `triton_gen.2Dblockload`. A compile-time pitch is
+    just an `arith.constant`; a runtime one (e.g. grouped-GEMM `lda`) is the
+    computed SSA value.
   }];
 
   let arguments = (ins
     Arg<TT_PtrLike, "tensor of pointers to the memory surface",
         [MemRead<GlobalMemory>]>:$ptr,
+    I32:$base_pitch,
     Optional<TT_BoolLike>:$mask,
     Optional<TT_Type>:$other,
     I32Attr:$base_width,
     I32Attr:$base_height,
-    I32Attr:$base_pitch,
     TTIG_BlockIOMode:$memory_layout
   );
 
   let results = (outs TT_Tensor:$result);
   let assemblyFormat = [{
-    $ptr (`,` $mask^ `,` $other)?
+    $ptr `,` $base_pitch (`,` $mask^ `,` $other)?
     ` ` `{` $memory_layout `}`
     attr-dict `:` functional-type(operands, results)
   }];

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
@@ -2,6 +2,7 @@
 #define TRITONINTELGPU_TRANSFORMS_BLOCKIOUTILS_H
 
 #include "intel/include/Dialect/TritonIntelGPU/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Support/LogicalResult.h"
 #include "triton/Analysis/AxisInfo.h"
@@ -10,6 +11,10 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include <optional>
+
+namespace mlir::triton::intel {
+class ModuleStrideAnalysis;
+} // namespace mlir::triton::intel
 
 namespace mlir::triton::gpu::intel {
 
@@ -138,6 +143,14 @@ bool isBlockIOEligible(OpTy loadOp, RankedTensorType tensorTy) {
 /// encoding. Higher values indicate more HW cost. Used for cost modeling in
 /// RemoveLayoutConversions. Returns a comparable scalar (not cycle-accurate).
 unsigned estimateLoadHWCost(RankedTensorType type, Operation *loadOp);
+
+/// Runtime stride value along `dim`; null if none.
+Value getRuntimeStrideValue(triton::intel::ModuleStrideAnalysis &strideAnalysis,
+                            Value ptr, unsigned dim);
+
+/// Build `stride * elemSizeInBytes` as an i32; null for non-integer stride.
+Value materializePitchBytes(OpBuilder &builder, Location loc, Value stride,
+                            unsigned elemSizeInBytes);
 
 } // namespace mlir::triton::gpu::intel
 

--- a/third_party/intel/lib/Analysis/StrideInfo.cpp
+++ b/third_party/intel/lib/Analysis/StrideInfo.cpp
@@ -108,7 +108,24 @@ StrideInfo StrideInfo::join(const StrideInfo &lhs, const StrideInfo &rhs) {
         joinColumn(l ? ArrayRef<int64_t>(*l) : ArrayRef<int64_t>(zeros),
                    r ? ArrayRef<int64_t>(*r) : ArrayRef<int64_t>(zeros)));
   }
-  return StrideInfo(std::move(spatial), std::move(ivStrides));
+
+  // Runtime stride value: keep it on an axis only when both sides agree on
+  // the same SSA value, otherwise drop to null (same idea as the join of
+  // AxisInfo::constantValue).
+  StrideValueVectorT strideValues;
+  const StrideValueVectorT &lv = lhs.getStrideValues();
+  const StrideValueVectorT &rv = rhs.getStrideValues();
+  if (!lv.empty() || !rv.empty()) {
+    strideValues.resize(lhs.getRank());
+    for (unsigned d = 0, rank = lhs.getRank(); d < rank; ++d) {
+      Value a = d < lv.size() ? lv[d] : Value();
+      Value b = d < rv.size() ? rv[d] : Value();
+      strideValues[d] = (a && a == b) ? a : Value();
+    }
+  }
+
+  return StrideInfo(std::move(spatial), std::move(ivStrides),
+                    std::move(strideValues));
 }
 
 int64_t StrideInfo::getIVStride(LoopLikeOpInterface loop, size_t dim) const {
@@ -174,6 +191,19 @@ void StrideInfo::print(raw_ostream &os) const {
     }
     os << "}";
   }
+  if (!strideValues.empty()) {
+    os << ", stride_values = {";
+    bool first = true;
+    for (unsigned d = 0, rank = strideValues.size(); d < rank; ++d) {
+      if (!strideValues[d])
+        continue;
+      if (!first)
+        os << ", ";
+      first = false;
+      os << d << ": " << strideValues[d];
+    }
+    os << "}";
+  }
 }
 
 using AxisInfoLookupFn = std::function<AxisInfo *(Value)>;
@@ -222,6 +252,12 @@ public:
 
   void setAxisInfoLookup(AxisInfoLookupFn fn) {
     axisInfoLookup = std::move(fn);
+  }
+
+  /// Public wrapper over `getConstantValue` so free helpers can reuse the
+  /// same constant detection.
+  std::optional<int64_t> getConstantValueForStride(Value v) const {
+    return getConstantValue(v);
   }
 
 protected:
@@ -306,7 +342,14 @@ public:
       const StrideInfo::DimVectorT *rCol = rc ? rc : (rhs ? &zeros : nullptr);
       maybeStoreIVStride(ivStrides, loop, applyOne(op, lCol, rCol));
     }
-    return StrideInfo(std::move(spatial), std::move(ivStrides));
+
+    // Runtime stride value (spatial axes only). The default hook returns
+    // nothing; a visitor opts in only where the value is safe to name.
+    StrideInfo::StrideValueVectorT strideValues =
+        applyStrideValues(op, lhs, rhs, spatial);
+
+    return StrideInfo(std::move(spatial), std::move(ivStrides),
+                      std::move(strideValues));
   }
 
 protected:
@@ -318,6 +361,16 @@ protected:
   virtual StrideInfo::DimVectorT
   applyOne(OpTy op, const StrideInfo::DimVectorT &lhs,
            const StrideInfo::DimVectorT *rhs) const = 0;
+
+  /// Subclass hook: name the runtime stride value for each spatial axis of
+  /// the result (`resultSpatial` is the already-computed integer column).
+  /// Defaults to "none"; a visitor overrides only when a bare SSA scalar
+  /// really is the element stride.
+  virtual StrideInfo::StrideValueVectorT
+  applyStrideValues(OpTy op, const StrideInfo &lhs, const StrideInfo *rhs,
+                    const StrideInfo::DimVectorT &resultSpatial) const {
+    return {};
+  }
 };
 
 class StrideInfoVisitorList {
@@ -421,6 +474,30 @@ public:
 template <typename OpTy>
 class AddSubStrideVisitor final : public StrideArithVisitor<OpTy> {
 protected:
+  StrideInfo::StrideValueVectorT applyStrideValues(
+      OpTy op, const StrideInfo &lhs, const StrideInfo *rhs,
+      const StrideInfo::DimVectorT &resultSpatial) const override {
+    // `a + b` (or addptr): the result stride is the sum, so a single value
+    // names it only when one side carries the runtime stride and the other
+    // adds nothing (stride 0). If both sides name a value we cannot keep it,
+    // since `s + s` is `2*s`. Subtraction keeps only the left side's value.
+    if (!rhs)
+      return {};
+    unsigned rank = lhs.getRank();
+    StrideInfo::StrideValueVectorT values(rank);
+    for (unsigned d = 0; d < rank; ++d) {
+      Value ls = lhs.getStrideValue(d);
+      Value rs = rhs->getStrideValue(d);
+      if (ls && lhs.getStride(d) < 0 && rhs->getStride(d) == 0) {
+        values[d] = ls;
+      } else if constexpr (!std::is_same_v<OpTy, arith::SubIOp>) {
+        if (rs && rhs->getStride(d) < 0 && lhs.getStride(d) == 0)
+          values[d] = rs;
+      }
+    }
+    return values;
+  }
+
   StrideInfo::DimVectorT
   applyOne(OpTy op, const StrideInfo::DimVectorT &lhs,
            const StrideInfo::DimVectorT *rhs) const override {
@@ -440,8 +517,49 @@ protected:
   }
 };
 
+/// Look through int casts and a splat; return the splatted scalar if it's a
+/// runtime (non-constant) value, else null.
+static Value getNonConstSplatScalar(Value v, const StrideInfoVisitor &visitor) {
+  while (Operation *def = v.getDefiningOp()) {
+    if (isa<arith::ExtSIOp, arith::ExtUIOp, arith::TruncIOp,
+            arith::IndexCastOp>(def)) {
+      v = def->getOperand(0);
+      continue;
+    }
+    break;
+  }
+  auto splat = v.getDefiningOp<triton::SplatOp>();
+  if (!splat)
+    return {};
+  Value scalar = splat.getSrc();
+  if (visitor.getConstantValueForStride(scalar))
+    return {};
+  return scalar;
+}
+
 class MulIOpStrideVisitor final : public StrideArithVisitor<arith::MulIOp> {
 protected:
+  StrideInfo::StrideValueVectorT applyStrideValues(
+      arith::MulIOp op, const StrideInfo &lhs, const StrideInfo *rhs,
+      const StrideInfo::DimVectorT &resultSpatial) const override {
+    // `index * splat(s)`: when one side steps by exactly 1, the per-element
+    // stride is exactly the scalar `s`, so we can name it. Any other step
+    // would make the stride `c * s`, which is not a single value, so we skip.
+    if (!rhs)
+      return {};
+    unsigned rank = lhs.getRank();
+    StrideInfo::StrideValueVectorT values(rank);
+    Value rhsScalar = getNonConstSplatScalar(op.getRhs(), *this);
+    Value lhsScalar = getNonConstSplatScalar(op.getLhs(), *this);
+    for (unsigned d = 0; d < rank; ++d) {
+      if (lhs.getStride(d) == 1 && rhsScalar)
+        values[d] = rhsScalar;
+      else if (rhs->getStride(d) == 1 && lhsScalar)
+        values[d] = lhsScalar;
+    }
+    return values;
+  }
+
   StrideInfo::DimVectorT
   applyOne(arith::MulIOp op, const StrideInfo::DimVectorT &lhs,
            const StrideInfo::DimVectorT *rhs) const override {
@@ -613,6 +731,18 @@ protected:
     stride.insert(stride.begin() + op.getAxis(), 0);
     return stride;
   }
+
+  StrideInfo::StrideValueVectorT
+  applyStrideValues(triton::ExpandDimsOp op, const StrideInfo &lhs,
+                    const StrideInfo *,
+                    const StrideInfo::DimVectorT &) const override {
+    const StrideInfo::StrideValueVectorT &src = lhs.getStrideValues();
+    if (src.empty())
+      return {};
+    StrideInfo::StrideValueVectorT values(src.begin(), src.end());
+    values.insert(values.begin() + op.getAxis(), Value());
+    return values;
+  }
 };
 
 class BroadcastOpStrideVisitor final
@@ -626,6 +756,21 @@ protected:
     // already 0 in the operand column, so a verbatim copy is correct for
     // every column (spatial + every IV column).
     return lhs;
+  }
+
+  StrideInfo::StrideValueVectorT applyStrideValues(
+      triton::BroadcastOp op, const StrideInfo &lhs, const StrideInfo *,
+      const StrideInfo::DimVectorT &resultSpatial) const override {
+    // A broadcast axis becomes uniform (stride 0), so its runtime stride no
+    // longer means anything: drop it there and pass the other axes through.
+    const StrideInfo::StrideValueVectorT &src = lhs.getStrideValues();
+    if (src.empty())
+      return {};
+    StrideInfo::StrideValueVectorT values(src.begin(), src.end());
+    for (unsigned d = 0, e = values.size(); d < e; ++d)
+      if (d < resultSpatial.size() && resultSpatial[d] == 0)
+        values[d] = Value();
+    return values;
   }
 };
 
@@ -641,6 +786,20 @@ protected:
     for (unsigned d = 0, rank = lhs.size(); d < rank; ++d)
       stride.push_back(lhs[order[d]]);
     return stride;
+  }
+
+  StrideInfo::StrideValueVectorT
+  applyStrideValues(triton::TransOp op, const StrideInfo &lhs,
+                    const StrideInfo *,
+                    const StrideInfo::DimVectorT &) const override {
+    const StrideInfo::StrideValueVectorT &src = lhs.getStrideValues();
+    if (src.empty())
+      return {};
+    ArrayRef<int32_t> order = op.getOrder();
+    StrideInfo::StrideValueVectorT values(src.size());
+    for (unsigned d = 0, rank = src.size(); d < rank; ++d)
+      values[d] = src[order[d]];
+    return values;
   }
 };
 
@@ -775,7 +934,8 @@ public:
             newStride[d] = 1;
           }
         }
-        curr = StrideInfo(std::move(newStride), curr.getIVStrides());
+        curr = StrideInfo(std::move(newStride), curr.getIVStrides(),
+                          curr.getStrideValues());
       }
     }
     for (auto *result : results)

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -4031,10 +4031,9 @@ struct Subgroup2DBlockLoadFromPtrOpConversion
       }
     }
 
-    // Surface parameters from op attributes.
     Value baseWidth = b.i32_val(op.getBaseWidth() * cfg.vBlocks);
     Value baseHeight = b.i32_val(op.getBaseHeight());
-    Value pitch = b.i32_val(op.getBasePitch());
+    Value pitch = adaptor.getBasePitch();
 
     unsigned blockColIdx = cfg.isTransposeRequired ? cfg.rowDim : cfg.colDim;
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -694,7 +694,8 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
     return triton::gpu::intel::getDpasLayout(tensorTy);
   }
 
-  // Returns the pitch (stride in bytes) for a regular pointer.
+  // Pitch (row stride in bytes) for a regular pointer, or null when it is not
+  // a usable compile-time constant. Prefetch falls back to getRuntimePitch().
   Value getPitch(ConversionPatternRewriter &rewriter, Value ptr,
                  unsigned elemSizeInBits, unsigned dim) const {
     Location loc = ptr.getLoc();
@@ -713,8 +714,31 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
       return b.i32_val(pitch);
     }
     assert(stride == -1 && "invalid stride < 0");
-
     return nullptr;
+  }
+
+  // Recover a runtime pitch when the constant stride is unknown: build
+  // pitch = runtime_stride * elemSizeInBytes, like the 2D block load does.
+  // Returns null if there is no runtime stride or the row is too narrow.
+  //
+  // A runtime pitch cannot be range-checked at compile time and the verifier
+  // only checks constant pitches, so we reuse the load path guards: the
+  // 16-byte alignment is proven by MaterializeBlockPointer, and the
+  // full_row >= 64 check below covers the minimum. Only prefetch uses this;
+  // the store path still needs a constant pitch.
+  Value getRuntimePitch(ConversionPatternRewriter &rewriter, Value ptr,
+                        unsigned elemSizeInBits, unsigned dim,
+                        int64_t fullRowElems) const {
+    Location loc = ptr.getLoc();
+
+    constexpr int64_t MIN_PITCH = 64;
+    if (fullRowElems * elemSizeInBits / 8 < MIN_PITCH)
+      return nullptr;
+
+    Value lda = getRuntimeStrideValue(strideAnalysis, ptr, dim);
+    if (!lda)
+      return nullptr;
+    return materializePitchBytes(rewriter, loc, lda, elemSizeInBits / 8);
   }
 
   /// Configuration produced by configureDPASLoadTypes().
@@ -1492,8 +1516,16 @@ struct PrefetchOpConversion
         masks[offset] = maskElems[i];
     }
 
+    unsigned pitchDim = memoryRowMajor ? 0 : 1;
     Value rowStrideInBytes =
-        getPitch(rewriter, op.getPtr(), elemSizeInBits, memoryRowMajor ? 0 : 1);
+        getPitch(rewriter, op.getPtr(), elemSizeInBits, pitchDim);
+    if (!rowStrideInBytes) {
+      // No constant pitch: a prefetch may use a runtime stride. The full row
+      // width is the contiguous tensor dimension.
+      int64_t fullRowElems = tensorShape[memoryRowMajor ? rank - 1 : rank - 2];
+      rowStrideInBytes = getRuntimePitch(rewriter, op.getPtr(), elemSizeInBits,
+                                         pitchDim, fullRowElems);
+    }
     if (!rowStrideInBytes)
       return failure();
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -1,6 +1,8 @@
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h"
+#include "intel/include/Analysis/StrideInfo.h"
 #include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/Utility.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -10,6 +12,32 @@
 #include <numeric>
 
 namespace mlir::triton::gpu::intel {
+
+Value getRuntimeStrideValue(triton::intel::ModuleStrideAnalysis &strideAnalysis,
+                            Value ptr, unsigned dim) {
+  if (triton::intel::StrideInfo *info = strideAnalysis.getStrideInfo(ptr))
+    return info->getStrideValue(dim);
+  return {};
+}
+
+Value materializePitchBytes(OpBuilder &builder, Location loc, Value stride,
+                            unsigned elemSizeInBytes) {
+  Type i32Ty = builder.getI32Type();
+  Value strideI32 = stride;
+  if (stride.getType().isIndex()) {
+    strideI32 = arith::IndexCastOp::create(builder, loc, i32Ty, stride);
+  } else if (auto intTy = dyn_cast<IntegerType>(stride.getType())) {
+    if (intTy.getWidth() < 32)
+      strideI32 = arith::ExtSIOp::create(builder, loc, i32Ty, stride);
+    else if (intTy.getWidth() > 32)
+      strideI32 = arith::TruncIOp::create(builder, loc, i32Ty, stride);
+  } else {
+    return {};
+  }
+  Value elemSizeV = arith::ConstantOp::create(
+      builder, loc, builder.getI32IntegerAttr(elemSizeInBytes));
+  return arith::MulIOp::create(builder, loc, strideI32, elemSizeV);
+}
 
 template <typename T> static T product(const std::vector<T> &vec) {
   return std::accumulate(vec.begin(), vec.end(), static_cast<T>(1),

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -64,8 +64,8 @@ static int64_t getStride(tt::intel::ModuleStrideAnalysis &strideAnalysis,
   return -1;
 }
 
-/// Create a zero-valued splat for the given tensor type. Used when a mask is
-/// present but no explicit 'other' value was provided by the user.
+/// Zero splat for tensorTy, used as the default `other` for a masked load
+/// when the user did not pass one.
 static Value createZeroSplat(OpBuilder &builder, Location loc,
                              RankedTensorType tensorTy) {
   Type elemType = tensorTy.getElementType();
@@ -373,7 +373,10 @@ private:
     // descriptor (see `triton_gen.2Dblockload` verifier in TritonGENOps.cpp).
     constexpr int64_t MAX_PITCH = int64_t(1) << 24;
 
-    int64_t pitch;
+    // Pitch is either a compile-time constant or a runtime SSA value,
+    // never both.
+    int64_t pitch = -1;
+    Value pitchValue;
     bool isBroadcast = false;
     if (has1DReshapeStride) {
       auto strideAttr = op->getAttrOfType<IntegerAttr>(
@@ -382,8 +385,8 @@ private:
       isBroadcast = (stride == 0);
       pitch = stride * elemSizeInBits / 8;
     } else {
-      // Check if the load is a broadcast: stride=0 along rowDim means all
-      // rows are identical, so we only need height=1 with a dummy pitch.
+      // stride=0 along rowDim means every row is the same: treat it as a
+      // broadcast and load height=1 with a dummy pitch.
       int64_t rowStride = getStride(strideAnalysis, op.getPtr(), rowDim);
       isBroadcast = (rowStride == 0);
     }
@@ -401,18 +404,46 @@ private:
       } else {
         int64_t pitchStride = getStride(strideAnalysis, op.getPtr(), pitchDim);
         if (pitchStride < 0) {
-          LDBG("Cannot compute constant stride for load: " << *op);
-          return;
+          // No constant stride: use the runtime stride that StrideAnalysis
+          // recovered. MaterializeBlockPointer already checked its 16-byte
+          // alignment.
+          Value lda = ttgi::getRuntimeStrideValue(strideAnalysis, op.getPtr(),
+                                                  pitchDim);
+          if (!lda) {
+            LDBG("No runtime stride source for load: " << *op);
+            return;
+          }
+          OpBuilder bld(op);
+          pitchValue = ttgi::materializePitchBytes(bld, op.getLoc(), lda,
+                                                   elemSizeInBits / 8);
+          if (!pitchValue) {
+            LDBG("Unsupported lda type: " << lda.getType());
+            return;
+          }
+        } else {
+          pitch = pitchStride * elemSizeInBits / 8;
         }
-        pitch = pitchStride * elemSizeInBits / 8;
       }
     }
 
-    // HW requires pitch >= 64 bytes, aligned to 16 bytes, and encoded in
-    // 24 bits.
-    if (pitch < MIN_PITCH || (pitch % 16) != 0 || pitch > MAX_PITCH) {
-      LDBG("Invalid pitch " << pitch << " for load: " << *op);
-      return;
+    // The HW needs pitch >= 64 bytes, a multiple of 16, and within 24 bits.
+    // For a constant pitch we just check it. For a runtime pitch we can't,
+    // so we rely on the checks already done: MaterializeBlockPointer proved
+    // the stride is 16-byte aligned, `lda >= K` keeps pitch >= the row width,
+    // and the row-width check below covers the 64-byte minimum.
+    if (!pitchValue) {
+      if (pitch < MIN_PITCH || (pitch % 16) != 0 || pitch > MAX_PITCH) {
+        LDBG("Invalid pitch " << pitch << " for load: " << *op);
+        return;
+      }
+    } else {
+      int64_t fullRowBytes =
+          tensorTy.getDimSize(surfaceWidthDim) * elemSizeInBits / 8;
+      if (fullRowBytes < MIN_PITCH) {
+        LDBG("Runtime pitch: full row width " << fullRowBytes << " < "
+                                              << MIN_PITCH << " bytes");
+        return;
+      }
     }
 
     // For broadcast loads, the LLVM lowering's row replication
@@ -453,11 +484,18 @@ private:
     if (mask && !other)
       other = createZeroSplat(builder, loc, tensorTy);
 
+    // Pitch is a single i32 operand: the runtime value when we have one, an
+    // arith.constant otherwise (the lowering and asserts treat both the same).
+    Value pitchOperand =
+        pitchValue
+            ? pitchValue
+            : arith::ConstantOp::create(
+                  builder, loc,
+                  builder.getI32IntegerAttr(static_cast<int32_t>(pitch)));
     auto blockPtrLoadOp = ttgi::Subgroup2DBlockLoadFromPtrOp::create(
-        builder, loc, op.getType(), op.getPtr(), mask, other,
+        builder, loc, op.getType(), op.getPtr(), pitchOperand, mask, other,
         builder.getI32IntegerAttr(baseWidthBytes),
         builder.getI32IntegerAttr(baseHeightRows),
-        builder.getI32IntegerAttr(pitch),
         ttgi::BlockIOModeAttr::get(builder.getContext(), memLayout));
 
     // Propagate attributes if present.

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -253,20 +253,20 @@ private:
         return false;
       }
 
-      // Value -1 is used to represent the unknown stride.
+      // Runtime stride (-1) is OK if AxisInfo proves 16-byte alignment.
       int64_t otherDimStride =
           strideInfo ? strideInfo->getStride(otherDim) : -1;
-      if (otherDimStride < 0) {
-        LDBG("Found unknown stride: " << otherDimStride);
-        return false;
-      }
-
-      // Surface pitch is required to be 16 bytes aligned.
       Type elemTy =
           cast<tt::PointerType>(tensorTy.getElementType()).getPointeeType();
       unsigned elemSizeInBytes = elemTy.getIntOrFloatBitWidth() / 8;
-      if ((otherDimStride * elemSizeInBytes) % 16 != 0) {
-        LDBG("Found Non 16 bytes aligned stride: " << otherDimStride);
+      if (otherDimStride >= 0) {
+        if ((otherDimStride * elemSizeInBytes) % 16 != 0) {
+          LDBG("Non 16-byte aligned stride: " << otherDimStride);
+          return false;
+        }
+      } else if (axisInfo.getDivisibility(otherDim) % 16 != 0) {
+        LDBG("Runtime stride: divisibility "
+             << axisInfo.getDivisibility(otherDim) << " < 16 bytes");
         return false;
       }
 

--- a/third_party/intel/unittest/Analysis/StrideInfoTest.cpp
+++ b/third_party/intel/unittest/Analysis/StrideInfoTest.cpp
@@ -435,4 +435,71 @@ TEST_F(StrideInfoTest, SpatialSplatConstant) {
   EXPECT_EQ(info->getIVStride(forOp, 0), 0);
 }
 
+// Test 11: Symbolic stride channel. muli(make_range, splat(lda)) names `lda`
+// as the runtime stride source along the varying axis, while a constant
+// multiplier yields no symbolic source.
+TEST_F(StrideInfoTest, SymbolicStrideValueFromRuntimeScalar) {
+  ModuleOp module = buildModule();
+  func::FuncOp funcOp = buildFunc(module);
+
+  // Add a runtime i32 `lda` argument.
+  Block *block = &funcOp.getBody().front();
+  Type i32Ty = builder->getI32Type();
+  FunctionType newFuncType =
+      builder->getFunctionType({i32Ty}, funcOp.getFunctionType().getResults());
+  funcOp.setType(newFuncType);
+  BlockArgument lda = block->addArgument(i32Ty, builder->getUnknownLoc());
+
+  builder->setInsertionPointToStart(block);
+  Location loc = builder->getUnknownLoc();
+
+  // make_range : tensor<64xi32> (spatial stride 1 along dim 0)
+  auto encoding = makeBlocked({1}, {16}, {4}, {0});
+  auto rangeTy = RankedTensorType::get({64}, i32Ty, encoding);
+  auto rangeOp = MakeRangeOp::create(*builder, loc, rangeTy, 0, 64);
+
+  // splat(lda) : tensor<64xi32> and the product range * splat(lda).
+  auto ldaSplat = SplatOp::create(*builder, loc, rangeTy, lda);
+  auto mulOp = arith::MulIOp::create(*builder, loc, rangeOp, ldaSplat);
+
+  func::ReturnOp::create(*builder, loc);
+
+  mlir::triton::intel::ModuleAxisInfoAnalysis axisInfo(module);
+  ModuleStrideAnalysis strideAnalysis(module, axisInfo);
+
+  StrideInfo *info = strideAnalysis.getStrideInfo(mulOp);
+  ASSERT_NE(info, nullptr);
+  // The constant stride is unknown (-1: runtime), but the symbolic source is
+  // exactly the `lda` argument.
+  EXPECT_EQ(info->getStride(0), -1);
+  EXPECT_EQ(info->getStrideValue(0), Value(lda));
+}
+
+// Test 12: A constant multiplier produces a known stride and NO symbolic
+// source (the constant path is preferred and getStrideValue stays null).
+TEST_F(StrideInfoTest, ConstantStrideHasNoSymbolicValue) {
+  ModuleOp module = buildModule();
+  func::FuncOp funcOp = buildFunc(module);
+  builder->setInsertionPointToStart(&funcOp.getBody().front());
+
+  Location loc = builder->getUnknownLoc();
+  Type i32Ty = builder->getI32Type();
+
+  auto encoding = makeBlocked({1}, {16}, {4}, {0});
+  auto rangeTy = RankedTensorType::get({64}, i32Ty, encoding);
+  auto rangeOp = MakeRangeOp::create(*builder, loc, rangeTy, 0, 64);
+  auto c128 = arith::ConstantOp::create(
+      *builder, loc,
+      SplatElementsAttr::get(rangeTy, builder->getI32IntegerAttr(128)));
+  auto mulOp = arith::MulIOp::create(*builder, loc, rangeOp, c128);
+
+  mlir::triton::intel::ModuleAxisInfoAnalysis axisInfo(module);
+  ModuleStrideAnalysis strideAnalysis(module, axisInfo);
+
+  StrideInfo *info = strideAnalysis.getStrideInfo(mulOp);
+  ASSERT_NE(info, nullptr);
+  EXPECT_EQ(info->getStride(0), 128);
+  EXPECT_EQ(info->getStrideValue(0), Value());
+}
+
 } // namespace


### PR DESCRIPTION
Root cause
The 2D block load needs a row pitch (byte stride between rows). The hardware accepts that pitch at runtime, but our IR only had a compile-time attribute slot for it, so any pitch not known at compile time was reported as unknown.

In grouped GEMM the leading dimension (lda) is a runtime value (each sub-matrix has its own size, loaded from memory in the kernel). So the stride analysis returned -1 ("unknown"), MaterializeBlockPointer fell back to slow per-element gather/scatter emitting zero 2D block loads.

Fix
Compute the pitch from the runtime lda and pass it to Matrix2DBlockLoadOp as an operand instead of an attribute.
  1. ttig.2d_block_load_from_ptr - add an optional base_pitch_dyn operand alongside the existing compile-time base_pitch attribute. Compile-time users are
  unchanged.
  2. MaterializeBlockPointer -  stop on an unknown stride when AxisInfo proves it is 16-byte aligned.
  3. StrideInfo / StrideAnalysis - track the value behind a runtime stride (forward dataflow) and expose it via getStrideValue().
  4. LowerTo2DBlockLoad - ask the analysis for the runtime stride, materialize pitch = lda * elemSize, and route it through the new operand, the lowering picks base_pitch_dyn when present.

Closes #6861