### PR TITLE
Build oneDNN library in case it is downloaded from the web

### DIFF
--- a/benchmarks/cmake/FindoneDNNLibrary.cmake
+++ b/benchmarks/cmake/FindoneDNNLibrary.cmake
@@ -27,6 +27,14 @@ if (NOT oneDNNLibrary_FOUND)
 
     set(oneDNNLibrary_INCLUDE_DIR "${oneDNNLibrary_SOURCE_DIR}/include" CACHE INTERNAL "oneDNNLibrary_SOURCE_DIR")
 
+    # Build oneDNN as a subdirectory so the dnnl target is available.
+    set(DNNL_CPU_RUNTIME "SEQ" CACHE STRING "" FORCE)
+    set(DNNL_GPU_RUNTIME "SYCL" CACHE STRING "" FORCE)
+    set(DNNL_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(DNNL_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(ONEDNN_BUILD_GRAPH OFF CACHE BOOL "" FORCE)
+    add_subdirectory(${oneDNNLibrary_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/oneDNNLibrary-build)
+
     find_package_handle_standard_args(
             oneDNNLibrary
             FOUND_VAR oneDNNLibrary_FOUND

--- a/benchmarks/onednn_kernel/CMakeLists.txt
+++ b/benchmarks/onednn_kernel/CMakeLists.txt
@@ -9,8 +9,8 @@ target_compile_options(onednn_kernel PRIVATE "-fsycl")
 target_compile_options(onednn_kernel PRIVATE "-DDNNL_CPU_RUNTIME=SYCL")
 target_compile_options(onednn_kernel PRIVATE "-DDNNL_GPU_RUNTIME=SYCL")
 
-target_link_options(onednn_kernel PRIVATE ${oneDNN_KERNEL_FLAGS} -ldnnl)
-target_link_libraries(onednn_kernel PUBLIC ${TORCH_LIBRARIES} ${TORCH_PYTHON_LIBRARY})
+target_link_options(onednn_kernel PRIVATE ${oneDNN_KERNEL_FLAGS})
+target_link_libraries(onednn_kernel PUBLIC ${TORCH_LIBRARIES} ${TORCH_PYTHON_LIBRARY} dnnl)
 
 target_include_directories(onednn_kernel PUBLIC "${oneDNNLibrary_INCLUDE_DIR}")
 


### PR DESCRIPTION
This PR makes sure that if oneDNN library is downloaded from the web then it is built and onednn_kernel is then linked with it.