### PR TITLE
[AMD/NVIDIA] Sync third_party/{amd,nvidia} files with upstream c7391a2

### DIFF
--- a/third_party/amd/include/hipblas_instance.h
+++ b/third_party/amd/include/hipblas_instance.h
@@ -2,21 +2,7 @@
 #define TRITON_HIPBLAS_INSTANCE_H
 
 #include "hipblas_types.h"
-#if defined(_WIN32)
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
-#include <windows.h>
-// tricky one
-// otherwise there may be a compilation error of
-// llvm/TargetParser/TargetParser.h due to a coincidence between the macro name
-// and one of the values in the enum:
-// https://github.com/llvm/llvm-project/blame/bb38b48910967041045997a0c1293ee2ba834196/llvm/include/llvm/TargetParser/TargetParser.h#L166-L170C3
-#ifdef NO_ERROR
-#undef NO_ERROR
-#endif
-#else
 #include <dlfcn.h>
-#endif
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -84,9 +70,6 @@ class HipblasLtInstance {
   hipblasLtMatmulPreference_t preference = NULL;
 
   void loadHipBlasDylib() {
-#if defined(_WIN32)
-    assert(0 && "Not implemented on Windows");
-#else
     if (dylibHandle == nullptr) {
       // First reuse the existing handle
       dylibHandle = dlopen(name, RTLD_NOLOAD);
@@ -133,16 +116,9 @@ class HipblasLtInstance {
                                std::string(name) +
                                "`: " + std::string(dlsym_error));
     }
-#endif
   }
 
-  void unloadHipBlasDylib() {
-#if defined(_WIN32)
-    assert(0 && "Not implemented on Windows");
-#else
-    dlclose(dylibHandle);
-#endif
-  }
+  void unloadHipBlasDylib() { dlclose(dylibHandle); }
 
   void successOrExit(hipblasStatus_t status, const std::string &context = "") {
     if (status != HIPBLAS_STATUS_SUCCESS) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/FuncOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/FuncOpToLLVM.cpp
@@ -11,23 +11,6 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
                    const TargetInfoBase &targetInfo, PatternBenefit benefit)
       : ConvertOpToLLVMPattern(converter, benefit), targetInfo(targetInfo) {}
 
-  static void handleArgPtrDatatype(triton::FuncOp funcOp,
-                                   LLVM::LLVMFuncOp &llvmFuncOp) {
-
-    // The convertion from triton::PointerType to LLVM::LLVMPointerType losts
-    // the pointee datatype information.
-    // This function add back the pointee datatype information to arg attribute.
-    FunctionType fty = funcOp.getFunctionType();
-    for (unsigned i = 0; i < fty.getNumInputs(); ++i) {
-      auto argType = fty.getInput(i);
-      if (auto argPtrType = dyn_cast<triton::PointerType>(argType)) {
-        auto argDType = argPtrType.getPointeeType();
-        llvmFuncOp.setArgAttr(i, "tt.pointee_type",
-                              mlir::TypeAttr::get(argDType));
-      }
-    }
-  }
-
   LogicalResult
   matchAndRewrite(triton::FuncOp funcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/third_party/amd/python/examples/gluon/moe_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/moe_gfx1250.py
@@ -24,7 +24,6 @@ from triton_kernels.numerics_details.mxfp import upcast_from_mxfp, downcast_to_m
 from triton_kernels.swiglu import swiglu_fn, swiglu, PrecisionConfig as SwiGLUPrecisionConfig
 
 from triton_kernels.testing import assert_close
-from triton._internal_testing import is_hip_gfx1250
 
 # Handle imports for both pytest (module context) and direct execution
 try:
@@ -1322,7 +1321,6 @@ def matmul(a, b, bias, a_ragged_metadata: RaggedTensorMetadata | None = None,
     return out_final, k
 
 
-@pytest.mark.xfail(not is_hip_gfx1250(), reason="AMD gfx1250-only example", run=False)
 @pytest.mark.parametrize("m, n, k", [(300, 400, 416), (128, 128, 512)])
 @pytest.mark.parametrize("block_m, block_n, block_k", [(128, 128, 256), (256, 256, 256)])
 @pytest.mark.parametrize("dtype_a, dtype_b", [("float8_e5m2", "mxfloat4_e2m1"), ("float8_e4m3fn", "mxfloat4_e2m1"),

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -2908,7 +2908,7 @@ def test_runtime_tensor_copy_mbarrier(M, N, BLOCK_M, BLOCK_N, NUM_BUFFERS, NUM_W
     assert torch.equal(b_triton, a)
 
 
-@pytest.mark.xfail(not is_hip_gfx1250(), reason="Requires GFX1250", run=False)
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 def test_tdm_load_pred():
 
     @gluon.jit

--- a/third_party/nvidia/CMakeLists.txt
+++ b/third_party/nvidia/CMakeLists.txt
@@ -3,7 +3,6 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 add_subdirectory(include)
 add_subdirectory(lib)
 if(TRITON_BUILD_PYTHON_MODULE)
-  if(NOT WIN32)
   set(GSAN_RUNTIME_SRC "${triton_SOURCE_DIR}/python/triton/experimental/gsan/src/GSanLibrary.cu")
   set(GSAN_RUNTIME_HDRS
     "${triton_SOURCE_DIR}/python/triton/experimental/gsan/src/GSan.h"
@@ -47,13 +46,10 @@ if(TRITON_BUILD_PYTHON_MODULE)
       COMMENT "Building GSan runtime"
       VERBATIM)
   add_custom_target(TritonNVIDIAGSanRuntime ALL DEPENDS "${GSAN_RUNTIME_IR}")
-  endif()
 
   add_triton_plugin(TritonNVIDIA ${CMAKE_CURRENT_SOURCE_DIR}/triton_nvidia.cc LINK_LIBS TritonNVIDIAGPUToLLVM NVGPUToLLVM)
   target_link_libraries(TritonNVIDIA PRIVATE Python3::Module pybind11::headers)
-  if(NOT WIN32)
-    add_dependencies(TritonNVIDIA TritonNVIDIAGSanRuntime)
-  endif()
+  add_dependencies(TritonNVIDIA TritonNVIDIAGSanRuntime)
 endif()
 if(TRITON_BUILD_UT)
   add_subdirectory(unittest)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -535,16 +535,14 @@ class CUDABackend(BaseBackend):
                     with open(flog.name) as log_file:
                         print(log_file.read())
 
-                # Skip deleting on Windows to avoid
-                # PermissionError: [WinError 32] The process cannot access the file because it is being used by another process
-                if os.path.exists(fsrc.name) and os.name != "nt":
+                if os.path.exists(fsrc.name):
                     os.remove(fsrc.name)
-                if os.path.exists(flog.name) and os.name != "nt":
+                if os.path.exists(flog.name):
                     os.remove(flog.name)
             except subprocess.CalledProcessError as e:
                 with open(flog.name) as log_file:
                     log = log_file.read()
-                if os.path.exists(flog.name) and os.name != "nt":
+                if os.path.exists(flog.name):
                     os.remove(flog.name)
 
                 if e.returncode == 255:

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -1,11 +1,5 @@
 #include "cuda.h"
-#if defined(_WIN32)
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
-#include <windows.h>
-#else
 #include <dlfcn.h>
-#endif
 #include <stdalign.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -343,28 +337,6 @@ typedef CUresult (*cuLaunchKernelEx_t)(const CUlaunchConfig *config,
                                        CUfunction f, void **kernelParams,
                                        void **extra);
 
-#if defined(_WIN32)
-#define defineGetFunctionHandle(name, symbolName)                              \
-  static symbolName##_t name() {                                               \
-    /* Open the shared library */                                              \
-    HMODULE handle = LoadLibraryA("nvcuda.dll");                               \
-    if (!handle) {                                                             \
-      PyErr_SetString(PyExc_RuntimeError, "Failed to open nvcuda.dll");        \
-      return NULL;                                                             \
-    }                                                                          \
-    symbolName##_t funcHandle =                                                \
-        (symbolName##_t)GetProcAddress((HMODULE)handle, #symbolName);          \
-    /* Check for errors */                                                     \
-    long err = GetLastError();                                                 \
-    if (err) {                                                                 \
-      PyErr_SetString(PyExc_RuntimeError,                                      \
-                      "Failed to retrieve " #symbolName " from nvcuda.dll");   \
-      FreeLibrary(handle);                                                     \
-      return NULL;                                                             \
-    }                                                                          \
-    return funcHandle;                                                         \
-  }
-#else
 #define defineGetFunctionHandle(name, symbolName)                              \
   static symbolName##_t name() {                                               \
     /* Open the shared library */                                              \
@@ -386,7 +358,6 @@ typedef CUresult (*cuLaunchKernelEx_t)(const CUlaunchConfig *config,
     }                                                                          \
     return funcHandle;                                                         \
   }
-#endif
 
 defineGetFunctionHandle(getCuOccupancyMaxActiveClustersHandle,
                         cuOccupancyMaxActiveClusters);

--- a/third_party/nvidia/include/cublas_instance.h
+++ b/third_party/nvidia/include/cublas_instance.h
@@ -2,13 +2,7 @@
 #define TRITON_CUBLAS_INSTANCE_H
 
 #include "cublas_types.h"
-#if defined(_WIN32)
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
-#include <windows.h>
-#else
 #include <dlfcn.h>
-#endif
 #include <stdexcept>
 #include <string>
 
@@ -71,9 +65,6 @@ private:
   cublasLtMatmulPreference_t preference = NULL;
 
   void loadCublasDylib() {
-#if defined(_WIN32)
-    assert(0 && "Not implemented on Windows");
-#else
     if (dylibHandle == nullptr) {
       // First reuse the existing handle
       dylibHandle = dlopen(name, RTLD_NOLOAD);
@@ -118,16 +109,11 @@ private:
                                std::string(name) +
                                "`: " + std::string(dlsym_error));
     }
-#endif
   }
 
   void unloadCublasDylib() {
-#if defined(_WIN32)
-    assert(0 && "Not implemented on Windows");
-#else
     if (dylibHandle)
       dlclose(dylibHandle);
-#endif
   }
 
   void successOrExit(cublasStatus_t status) {

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -11,13 +11,7 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 #include "llvm/IR/Constants.h"
-#if defined(_WIN32)
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
-#include <windows.h>
-#else
 #include <dlfcn.h>
-#endif
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
@@ -50,14 +44,6 @@ private:
   cuGetErrorString_t cuGetErrorString = nullptr;
 
   template <typename T> T loadSymbol(const char *name) {
-#if defined(_WIN32)
-    auto *symbol = GetProcAddress(static_cast<HMODULE>(dylibHandle), name);
-    if (!symbol) {
-      throw std::runtime_error(
-          "Could not load CUDA driver symbol `" + std::string(name) +
-          "`. Initialize the NVIDIA runtime before using this helper.");
-    }
-#else
     dlerror();
     auto *symbol = dlsym(dylibHandle, name);
     if (const char *error = dlerror()) {
@@ -66,7 +52,6 @@ private:
           "`. Initialize the NVIDIA runtime before using this helper: " +
           std::string(error));
     }
-#endif
     return reinterpret_cast<T>(symbol);
   }
 
@@ -90,21 +75,12 @@ public:
   }
 
   CudaExampleUtils() {
-#if defined(_WIN32)
-    dylibHandle = LoadLibraryA("nvcuda.dll");
-    if (dylibHandle == nullptr) {
-      throw std::runtime_error(
-          "Could not find `nvcuda.dll`. Initialize "
-          "Triton's NVIDIA runtime before using this helper.");
-    }
-#else
     dylibHandle = dlopen("libcuda.so.1", RTLD_NOLOAD | RTLD_LAZY);
     if (dylibHandle == nullptr) {
       throw std::runtime_error(
           "Could not find an already-loaded `libcuda.so.1`. Initialize "
           "Triton's NVIDIA runtime before using this helper.");
     }
-#endif
     cuMemAlloc = loadSymbol<cuMemAlloc_t>("cuMemAlloc_v2");
     cuMemFree = loadSymbol<cuMemFree_t>("cuMemFree_v2");
     cuMemcpyHtoD = loadSymbol<cuMemcpyHtoD_t>("cuMemcpyHtoD_v2");
@@ -115,11 +91,7 @@ public:
 
   ~CudaExampleUtils() {
     if (dylibHandle) {
-#if defined(_WIN32)
-      FreeLibrary(static_cast<HMODULE>(dylibHandle));
-#else
       dlclose(dylibHandle);
-#endif
     }
   }
 


### PR DESCRIPTION
## Summary

Removes stale merge conflict residue in 9 files across `third_party/amd` and `third_party/nvidia`. These files contained code that upstream deleted at or before commit \`c7391a2\` (the last OpenAI Triton commit merged into this repo via #6988). Restores them to be identical to upstream \`c7391a2\`.

### AMD files (4 files, -45 LOC)
| File | Change |
|---|---|
| `third_party/amd/include/hipblas_instance.h` | Remove Windows `#ifdef _WIN32` hipblas guards |
| `third_party/amd/lib/TritonAMDGPUToLLVM/FuncOpToLLVM.cpp` | Remove `handleArgPtrDatatype()` helper |
| `third_party/amd/python/test/test_gluon_gfx1250.py` | Sync `xfail` → `skipif` |
| `third_party/amd/python/examples/gluon/moe_gfx1250.py` | Remove stale import and `xfail` decorator |

### NVIDIA files (5 files, -81 LOC)
| File | Change |
|---|---|
| `third_party/nvidia/include/cublas_instance.h` | Remove Windows `#ifdef _WIN32` cublas guards |
| `third_party/nvidia/backend/driver.c` | Remove Windows `#ifdef _WIN32` CUDA driver guards |
| `third_party/nvidia/triton_nvidia.cc` | Remove Windows `#ifdef _WIN32` dylib loading guards |
| `third_party/nvidia/CMakeLists.txt` | Remove `if(NOT WIN32)` build guards |
| `third_party/nvidia/backend/compiler.py` | Remove `os.name != "nt"` Windows file deletion guards |

## Test plan

- No Intel XPU backend logic is touched — these are pure AMD/NVIDIA files
- Verified: `git diff c7391a203e8f7772b11093e85508d5d7c6a9c665 -- third_party/amd/ third_party/nvidia/` is empty after this change