### PR TITLE
[AMD] Sync third_party/amd files with upstream c7391a2

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/FuncOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/FuncOpToLLVM.cpp
@@ -11,23 +11,6 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
                    const TargetInfoBase &targetInfo, PatternBenefit benefit)
       : ConvertOpToLLVMPattern(converter, benefit), targetInfo(targetInfo) {}
 
-  static void handleArgPtrDatatype(triton::FuncOp funcOp,
-                                   LLVM::LLVMFuncOp &llvmFuncOp) {
-
-    // The convertion from triton::PointerType to LLVM::LLVMPointerType losts
-    // the pointee datatype information.
-    // This function add back the pointee datatype information to arg attribute.
-    FunctionType fty = funcOp.getFunctionType();
-    for (unsigned i = 0; i < fty.getNumInputs(); ++i) {
-      auto argType = fty.getInput(i);
-      if (auto argPtrType = dyn_cast<triton::PointerType>(argType)) {
-        auto argDType = argPtrType.getPointeeType();
-        llvmFuncOp.setArgAttr(i, "tt.pointee_type",
-                              mlir::TypeAttr::get(argDType));
-      }
-    }
-  }
-
   LogicalResult
   matchAndRewrite(triton::FuncOp funcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/third_party/amd/python/examples/gluon/moe_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/moe_gfx1250.py
@@ -24,7 +24,6 @@ from triton_kernels.numerics_details.mxfp import upcast_from_mxfp, downcast_to_m
 from triton_kernels.swiglu import swiglu_fn, swiglu, PrecisionConfig as SwiGLUPrecisionConfig
 
 from triton_kernels.testing import assert_close
-from triton._internal_testing import is_hip_gfx1250
 
 # Handle imports for both pytest (module context) and direct execution
 try:
@@ -1322,7 +1321,6 @@ def matmul(a, b, bias, a_ragged_metadata: RaggedTensorMetadata | None = None,
     return out_final, k
 
 
-@pytest.mark.xfail(not is_hip_gfx1250(), reason="AMD gfx1250-only example", run=False)
 @pytest.mark.parametrize("m, n, k", [(300, 400, 416), (128, 128, 512)])
 @pytest.mark.parametrize("block_m, block_n, block_k", [(128, 128, 256), (256, 256, 256)])
 @pytest.mark.parametrize("dtype_a, dtype_b", [("float8_e5m2", "mxfloat4_e2m1"), ("float8_e4m3fn", "mxfloat4_e2m1"),

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -2908,7 +2908,7 @@ def test_runtime_tensor_copy_mbarrier(M, N, BLOCK_M, BLOCK_N, NUM_BUFFERS, NUM_W
     assert torch.equal(b_triton, a)
 
 
-@pytest.mark.xfail(not is_hip_gfx1250(), reason="Requires GFX1250", run=False)
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 def test_tdm_load_pred():
 
     @gluon.jit


### PR DESCRIPTION
Removes stale merge conflict residue in 3 `third_party/amd` files. These files contained code that upstream deleted at or before commit `c7391a2` (the last OpenAI Triton commit merged into this repo via #6988): `handleArgPtrDatatype` helper in `FuncOpToLLVM.cpp`, and stale `xfail`/import in two gfx1250 files.