### PR TITLE
Use `-cl-fp32-correctly-rounded-divide-sqrt` for LTS

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -306,6 +306,11 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         passes.common.add_symbol_dce(pm)
         passes.ttir.add_loop_unroll(pm)
         pm.run(mod, 'make_ttir')
+
+        driver_version = metadata["target"].arch.get("driver_version")
+        if cls.is_lts(driver_version) and intel.has_precise_divide_sqrt(mod):
+            metadata["build_flags"] = "-cl-fp32-correctly-rounded-divide-sqrt"
+
         return mod
 
     @classmethod
@@ -317,6 +322,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         module_opts = intel.passes.ttgpuir.AnnotateModuleOptions()
         cls.annotate_module(module_opts, properties, opt)
         module_opts.is_lts = cls.is_lts(metadata["target"].arch.get("driver_version"))
+        module_opts.use_cl_rounded_divide_sqrt = (module_opts.is_lts and intel.has_precise_divide_sqrt(mod))
         intel.passes.ttgpuir.add_triton_annotate_module(pm, module_opts)
         pm.run(mod, 'annotate_module')
 

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
@@ -129,6 +129,14 @@ def TritonIntelGPU_Dialect : Dialect {
       return "ttig.support_rounded_divide_sqrt";
     }
 
+    /// Get the name of the attribute used to indicate that the
+    /// -cl-fp32-correctly-rounded-divide-sqrt build flag will be applied,
+    /// i.e. the kernel runs on an LTS driver and contains only precise
+    /// div/sqrt ops (no regular arith::DivFOp or math::SqrtOp).
+    static constexpr llvm::StringRef getUseClRoundedDivideSqrtAttrName() {
+      return "ttig.use_cl_rounded_divide_sqrt";
+    }
+
     /// FIXME: Remove once IGC can split large 2D block loads.
     /// Get the name of the attribute used to indicate that a load operation
     /// should use 'one matrix per load'.

--- a/third_party/intel/include/TritonAnnotateModule/Passes.td
+++ b/third_party/intel/include/TritonAnnotateModule/Passes.td
@@ -59,7 +59,9 @@ def TritonAnnotateModule: Pass<"triton-annotate-module", "mlir::ModuleOp"> {
     Option<"support256bLoadStore", "support-256b-load-store", "bool", /*default*/"false",
            "whether 256-bit per-thread elementwise load/store is supported">,
     Option<"supportRoundedDivideSqrt", "support-rounded-divide-sqrt", "bool", /*default*/"false",
-           "whether rounded divide and sqrt operations are available">
+           "whether rounded divide and sqrt operations are available">,
+    Option<"useClRoundedDivideSqrt", "use-cl-rounded-divide-sqrt", "bool", /*default*/"false",
+           "whether to emit plain LLVM div/sqrt ops relying on the -cl-fp32-correctly-rounded-divide-sqrt build flag">
   ];
 }
 

--- a/third_party/intel/lib/TritonAnnotateModule/TritonAnnotateModule.cpp
+++ b/third_party/intel/lib/TritonAnnotateModule/TritonAnnotateModule.cpp
@@ -91,6 +91,11 @@ struct TritonAnnotateModule
           ttgi::TritonIntelGPUDialect::getSupportRoundedDivideSqrtAttrName(),
           builder.getUnitAttr());
 
+    if (useClRoundedDivideSqrt)
+      mod->setAttr(
+          ttgi::TritonIntelGPUDialect::getUseClRoundedDivideSqrtAttrName(),
+          builder.getUnitAttr());
+
     if (isLTS)
       mod->setAttr(ttgi::TritonIntelGPUDialect::getIsLTSAttrName(),
                    builder.getUnitAttr());

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1344,6 +1344,15 @@ struct PreciseSqrtOpConversion
       return {callOp.getResult()};
     }
 
+    // Rely on `-cl-fp32-correctly-rounded-divide-sqrt` for precise sqrt on
+    // LTS drivers when no regular div/sqrt ops are present.
+    if (mlir::LLVM::intel::hasModuleAttr(
+            op, intel::TritonIntelGPUDialect::
+                    getUseClRoundedDivideSqrtAttrName())) {
+      return {LLVM::SqrtOp::create(rewriter, loc, elemTy, operandsRanges[0],
+                                   adaptor.getAttributes().getValue())};
+    }
+
     // Fallback: use type-appropriate __imf_sqrt*_rn builtin.
     StringRef fnName = elemTy.isF32() ? "__imf_sqrtf_rn" : "__imf_sqrt_rn";
     SmallVector<Type> argTypes(ValueRange(operandsRanges[0]).getTypes());
@@ -1378,6 +1387,15 @@ struct PreciseDivFOpConversion
           rewriter, fnName, elemTy, operandTypes, operandsRanges[0],
           /*paramAttrs=*/{}, intel::noUnwindWillReturnAttrs);
       return {callOp.getResult()};
+    }
+
+    // Rely on `-cl-fp32-correctly-rounded-divide-sqrt` for precise division
+    // on LTS drivers when no regular div/sqrt ops are present.
+    if (mlir::LLVM::intel::hasModuleAttr(
+            op, intel::TritonIntelGPUDialect::
+                    getUseClRoundedDivideSqrtAttrName())) {
+      return {LLVM::FDivOp::create(rewriter, loc, elemTy, operandsRanges[0][0],
+                                   operandsRanges[0][1])};
     }
 
     // Fallback: use type-appropriate __imf_*div_rn builtin.

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -1,4 +1,6 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Pass/PassManager.h"
 #include "passes.h"
 
@@ -133,6 +135,9 @@ void init_triton_intel_passes_ttgpuir(py::module &&m) {
       .def_readwrite(
           "support_rounded_divide_sqrt",
           &gpu::intel::TritonAnnotateModuleOptions::supportRoundedDivideSqrt)
+      .def_readwrite(
+          "use_cl_rounded_divide_sqrt",
+          &gpu::intel::TritonAnnotateModuleOptions::useClRoundedDivideSqrt)
       .def_readwrite("threads_per_warp",
                      &gpu::intel::TritonAnnotateModuleOptions::threadsPerWarp)
       .def_readwrite("target_arch",
@@ -328,6 +333,16 @@ void init_triton_intel(py::module &&m) {
   m.def("get_threads_per_warp", [](mlir::ModuleOp &mod) -> py::object {
     auto ret = mlir::triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
     return py::int_(ret);
+  });
+
+  m.def("has_precise_divide_sqrt", [](mlir::ModuleOp &mod) -> bool {
+    using namespace mlir;
+    WalkResult result = mod.walk([&](Operation *op) {
+      if (isa<mlir::triton::PreciseDivFOp, mlir::triton::PreciseSqrtOp>(op))
+        return WalkResult::interrupt();
+      return WalkResult::advance();
+    });
+    return result.wasInterrupted();
   });
 
   // FIXME: This is for internal experimentation. In the end we will need a


### PR DESCRIPTION
Relates to #6992


https://github.com/intel/intel-xpu-backend-for-triton/issues/6261 works with these changes (tested original E2E model)

Inductor: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/26450746158 (to check)