### PR TITLE
[RemoveLayoutConversions] Split cleanup phase; tolerate SCF non-convergence (#10132)

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -2162,7 +2162,7 @@ public:
     scf::ForOp::getCanonicalizationPatterns(scfCleanup, context);
     scf::IfOp::getCanonicalizationPatterns(scfCleanup, context);
     if (applyPatternsGreedily(m, std::move(scfCleanup)).failed()) {
-      LLVM_DEBUG(DBGS() << "scf cleanup did not converge\n");
+      LDBG("scf cleanup did not converge");
     }
     LLVM_DEBUG({
       DBGS() << "Module after final cleanups:\n";

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -2148,13 +2148,21 @@ public:
 
     // 5. Apply clean up patterns to remove dead convert and dead code generated
     // by the previous transformations.
-    RewritePatternSet cleanUpPatterns2(context);
-    scf::ForOp::getCanonicalizationPatterns(cleanUpPatterns2, context);
-    scf::IfOp::getCanonicalizationPatterns(cleanUpPatterns2, context);
-    ttg::ConvertLayoutOp::getCanonicalizationPatterns(cleanUpPatterns2,
-                                                      context);
-    if (applyPatternsGreedily(m, std::move(cleanUpPatterns2)).failed()) {
+    // ConvertLayoutOp canonicalization must converge.
+    RewritePatternSet convertCleanup(context);
+    ttg::ConvertLayoutOp::getCanonicalizationPatterns(convertCleanup, context);
+    if (applyPatternsGreedily(m, std::move(convertCleanup)).failed()) {
       signalPassFailure();
+    }
+
+    // scf canonicalization is best-effort: deeply unrolled scf.if regions
+    // carrying tensor values can drive the greedy rewriter to non-convergence
+    // (see upstream PR #10132 / pytorch/pytorch#180908).
+    RewritePatternSet scfCleanup(context);
+    scf::ForOp::getCanonicalizationPatterns(scfCleanup, context);
+    scf::IfOp::getCanonicalizationPatterns(scfCleanup, context);
+    if (applyPatternsGreedily(m, std::move(scfCleanup)).failed()) {
+      LLVM_DEBUG(DBGS() << "scf cleanup did not converge\n");
     }
     LLVM_DEBUG({
       DBGS() << "Module after final cleanups:\n";


### PR DESCRIPTION
Port of upstream PR [#10132](https://github.com/triton-lang/triton/pull/10132) (commit `ca21b1b95`) to the Intel XPU `RemoveLayoutConversions` fork.

The Intel fork combined `scf::ForOp` + `scf::IfOp` + `ttg::ConvertLayoutOp` canonicalization into a single must-converge `applyPatternsGreedily` call. On deeply-unrolled `scf.if` ladders carrying tensor values (e.g. vLLM `_penalties_kernel`, [pytorch/pytorch#180908](https://github.com/pytorch/pytorch/issues/180908)), the greedy rewriter hit its iteration cap before convergence and triggered `signalPassFailure()`, crashing compilation.

This change splits the cleanup into two sequential phases matching upstream:

- **`ConvertLayoutOp` canonicalization — must converge** (correctness contract; still calls `signalPassFailure()` on non-convergence).
- **`scf::ForOp` + `scf::IfOp` canonicalization — best-effort.** Non-convergence is now logged via `LDBG` instead of triggering `signalPassFailure()`.