### PR TITLE
Use upstream loop.stage/loop.cluster annotations to drive XPU prefetch op placement

### DIFF
--- a/test/TritonIntelGPU/loop-pipeline-annotation-driven.mlir
+++ b/test/TritonIntelGPU/loop-pipeline-annotation-driven.mlir
@@ -1,0 +1,87 @@
+// RUN: triton-opt %s -split-input-file -tritonintelgpu-pipeline=num-stages=3 | FileCheck %s --check-prefix=DEFAULT
+// RUN: env TRITON_INTEL_ANNOTATE_LATENCIES=1 triton-opt %s -split-input-file -tritongpu-assign-latencies=num-stages=3 -tritongpu-schedule-loops -tritonintelgpu-pipeline=num-stages=3 | FileCheck %s --check-prefix=ANNOTATED
+
+// COM: Verifies that Intel's matmul pipeliner produces structurally identical
+// COM: results whether or not upstream annotation passes run first. The test
+// COM: uses a rank-3 GEMM with descriptor_load ops (matching the existing
+// COM: upstream-latency-annotation.mlir test) and asserts:
+// COM:   - Same prefetch op count (4 hoisted, 2 in-loop)
+// COM:   - Same scf.for iter-arg count
+// COM:   - Same in-loop op ordering (prefetch → load → dot)
+// COM:   - DEFAULT: Prefetch ops do NOT carry loop.stage/loop.cluster attributes
+// COM:   - ANNOTATED: Prefetch ops DO carry loop.stage=0 and loop.cluster (copied from source load)
+// COM:   - ANNOTATED: Load ops DO carry loop.stage/loop.cluster (set by upstream)
+
+#blocked3d = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 4], warpsPerCTA = [1, 2, 4], order = [2, 1, 0]}>
+#blocked2d = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 4], warpsPerCTA = [2, 4], order = [1, 0]}>
+#mma = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [2, 4], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>
+
+module attributes {ttig.support_subgroup_matrix_multiply_accumulate, ttig.support_2d_block_io, ttig.target_arch = "spir64", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32} {
+  tt.func public @gemm_pipeline_structural_equivalence(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32, %arg6: i32 {tt.divisibility = 16 : i32}) {
+    // DEFAULT-LABEL: tt.func public @gemm_pipeline_structural_equivalence
+    // ANNOTATED-LABEL: tt.func public @gemm_pipeline_structural_equivalence
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %0 = arith.extsi %arg6 : i32 to i64
+
+    %descA = tt.make_tensor_descriptor %arg0, [%arg3, %arg3, %arg6], [%0, %0, %c1_i64] : <f16>, <1x128x64xf16>
+    %descB = tt.make_tensor_descriptor %arg1, [%arg3, %arg6, %arg6], [%0, %0, %c1_i64] : <f16>, <1x64x256xf16>
+
+    // COM: Structural invariants verified by both DEFAULT and ANNOTATED prefixes:
+    // COM:   - 4 hoisted prefetches before loop (2 per stage × 2 stages)
+    // COM:   - 2 prefetches inside loop body
+    // COM:   - 2 loads inside loop body
+    // COM:   - 1 dot inside loop body
+    // COM:   - Loop has 3 iter-args (acc, next_koff, current_koff)
+
+    // COM: DEFAULT path: verify op counts and ordering. Without annotations,
+    // COM: prefetches do NOT carry loop.stage/loop.cluster.
+    // DEFAULT-COUNT-4: ttig.descriptor_prefetch
+    // DEFAULT-NOT: ttig.descriptor_prefetch{{.*}}loop.stage
+    // DEFAULT-NOT: ttig.descriptor_prefetch{{.*}}loop.cluster
+    // DEFAULT: scf.for {{.*}} iter_args({{.*}}) -> (tensor<128x256xf32, #{{.*}}>, i32, i32)
+    // DEFAULT-COUNT-2: ttig.descriptor_prefetch
+    // DEFAULT-NOT: ttig.descriptor_prefetch{{.*}}loop.stage
+    // DEFAULT-NOT: ttig.descriptor_prefetch{{.*}}loop.cluster
+    // DEFAULT: tt.descriptor_load
+    // DEFAULT: tt.descriptor_load
+    // DEFAULT: tt.reshape
+    // DEFAULT: ttg.convert_layout
+    // DEFAULT: tt.reshape
+    // DEFAULT: ttg.convert_layout
+    // DEFAULT: tt.dot
+    // COM: Catch extra prefetches beyond the expected 4+2 (legacy hardcoded).
+    // DEFAULT-NOT: ttig.descriptor_prefetch
+
+    // COM: ANNOTATED path: verify op counts and ordering. Hoisted and in-loop
+    // COM: prefetches carry loop.cluster and loop.stage = 0.
+    // ANNOTATED-COUNT-4: ttig.descriptor_prefetch {{.*}}loop.cluster = {{[0-9]+}} : i32, loop.stage = 0 : i32
+    // ANNOTATED: scf.for {{.*}} iter_args({{.*}}) -> (tensor<128x256xf32, #{{.*}}>, i32, i32)
+    // ANNOTATED-COUNT-2: ttig.descriptor_prefetch {{.*}}loop.cluster = {{[0-9]+}} : i32, loop.stage = 0 : i32
+    // ANNOTATED: tt.descriptor_load {{.*}}loop.stage = {{[0-9]+}} : i32{{.*}}ttig.block_io
+    // ANNOTATED: tt.descriptor_load {{.*}}loop.stage = {{[0-9]+}} : i32{{.*}}ttig.block_io
+    // ANNOTATED: tt.reshape {{.*}}loop.stage
+    // ANNOTATED: ttg.convert_layout {{.*}}loop.stage
+    // ANNOTATED: tt.reshape {{.*}}loop.stage
+    // ANNOTATED: ttg.convert_layout {{.*}}loop.stage
+    // ANNOTATED: tt.dot {{.*}}loop.stage
+    // COM: Catch extra prefetches beyond the expected 4+2 (annotation-driven).
+    // ANNOTATED-NOT: ttig.descriptor_prefetch
+
+    %result:2 = scf.for %k = %c0_i32 to %c64_i32 step %c1_i32 iter_args(%acc = %cst, %koff = %c0_i32) -> (tensor<128x256xf32, #mma>, i32) : i32 {
+      %a3d = tt.descriptor_load %descA[%c0_i32, %c0_i32, %koff] {ttig.block_io = "row_major"} : !tt.tensordesc<1x128x64xf16> -> tensor<1x128x64xf16, #blocked3d>
+      %a2d = tt.reshape %a3d : tensor<1x128x64xf16, #blocked3d> -> tensor<128x64xf16, #blocked2d>
+      %a = ttg.convert_layout %a2d : tensor<128x64xf16, #blocked2d> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+      %b3d = tt.descriptor_load %descB[%c0_i32, %koff, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<1x64x256xf16> -> tensor<1x64x256xf16, #blocked3d>
+      %b2d = tt.reshape %b3d : tensor<1x64x256xf16, #blocked3d> -> tensor<64x256xf16, #blocked2d>
+      %b = ttg.convert_layout %b2d : tensor<64x256xf16, #blocked2d> -> tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+      %d = tt.dot %a, %b, %acc, inputPrecision = tf32 : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x256xf32, #mma>
+      %next_koff = arith.addi %koff, %c1_i32 : i32
+      scf.yield %d, %next_koff : tensor<128x256xf32, #mma>, i32
+    }
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/loop-pipeline.mlir
+++ b/test/TritonIntelGPU/loop-pipeline.mlir
@@ -1,4 +1,10 @@
 // RUN: triton-opt %s -split-input-file -tritonintelgpu-pipeline="num-stages=3" | FileCheck %s
+// COM: Behavior-preservation cross-check: when upstream `tritongpu-assign-latencies` and
+// COM: `tritongpu-schedule-loops` annotate the IR before Intel's pipeline pass and the
+// COM: opt-in env var is on, every CHECK line in this file must still match. This proves
+// COM: that the annotation-validated path does not regress prefetch insertion (count,
+// COM: kind, ordering) on real GEMM and FlashAttention-shaped loops.
+// RUN: env TRITON_INTEL_ANNOTATE_LATENCIES=1 triton-opt %s -split-input-file -tritongpu-assign-latencies=num-stages=3 -tritongpu-schedule-loops -tritonintelgpu-pipeline="num-stages=3" | FileCheck %s
 
 // CHECK: #[[$BLOCK_0:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 2], order = [1, 0]}>
 // CHECK: #[[$BLOCK_1:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [1, 4], order = [1, 0]}>

--- a/test/TritonIntelGPU/upstream-latency-annotation.mlir
+++ b/test/TritonIntelGPU/upstream-latency-annotation.mlir
@@ -1,0 +1,60 @@
+// RUN: triton-opt %s -split-input-file -tritongpu-assign-latencies=num-stages=3 -tritongpu-schedule-loops | FileCheck %s --check-prefix=ANNOTATE
+// RUN: triton-opt %s -split-input-file -tritongpu-assign-latencies=num-stages=3 -tritongpu-schedule-loops -tritonintelgpu-pipeline=num-stages=3 | FileCheck %s --check-prefix=PIPELINE
+
+// COM: Verifies that the upstream `tritongpu-assign-latencies` and
+// COM: `tritongpu-schedule-loops` passes annotate Intel TTGIR (ANNOTATE prefix)
+// COM: and that Intel's pipeline pass produces a structurally equivalent result
+// COM: when fed the annotated IR (PIPELINE prefix). The kernel uses
+// COM: `tt.descriptor_load` because the upstream `AssignLoadLatencies` skips
+// COM: regular `tt.load` ops whose effective access width is < 32 bits, which
+// COM: is the case for f16 loads through a blocked layout with sizePerThread=1.
+
+#blocked3d = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 4], warpsPerCTA = [1, 2, 4], order = [2, 1, 0]}>
+#blocked2d = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 4], warpsPerCTA = [2, 4], order = [1, 0]}>
+#mma = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [2, 4], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>
+
+module attributes {ttig.support_subgroup_matrix_multiply_accumulate, ttig.support_2d_block_io, ttig.target_arch = "spir64", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32} {
+  tt.func public @rank3_descriptor_pipeline(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32, %arg6: i32 {tt.divisibility = 16 : i32}) {
+    // ANNOTATE-LABEL: tt.func public @rank3_descriptor_pipeline
+    // PIPELINE-LABEL: tt.func public @rank3_descriptor_pipeline
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %0 = arith.extsi %arg6 : i32 to i64
+
+    %descA = tt.make_tensor_descriptor %arg0, [%arg3, %arg3, %arg6], [%0, %0, %c1_i64] : <f16>, <1x128x64xf16>
+    %descB = tt.make_tensor_descriptor %arg1, [%arg3, %arg6, %arg6], [%0, %0, %c1_i64] : <f16>, <1x64x256xf16>
+
+    // COM: Upstream passes attach scheduling attributes to the loop and ops.
+    // ANNOTATE: scf.for
+    // ANNOTATE: tt.descriptor_load {{.*}}loop.cluster = {{[0-9]+}} : i32, loop.stage = {{[0-9]+}} : i32
+    // ANNOTATE: tt.descriptor_load {{.*}}loop.cluster = {{[0-9]+}} : i32, loop.stage = {{[0-9]+}} : i32
+    // ANNOTATE: tt.dot
+    // ANNOTATE: tt.scheduled_max_stage = {{[0-9]+}} : i32
+
+    // COM: Intel pipeline pass produces 4 hoisted prefetches (2 per stage, 2 stages)
+    // COM: and maintains prefetch-load-dot ordering inside the loop.
+    // PIPELINE-COUNT-4: ttig.descriptor_prefetch
+    // PIPELINE: scf.for
+    // PIPELINE: ttig.descriptor_prefetch
+    // PIPELINE: ttig.descriptor_prefetch
+    // PIPELINE: tt.descriptor_load
+    // PIPELINE: tt.descriptor_load
+    // PIPELINE: tt.dot
+
+    %result:2 = scf.for %k = %c0_i32 to %c64_i32 step %c1_i32 iter_args(%acc = %cst, %koff = %c0_i32) -> (tensor<128x256xf32, #mma>, i32) : i32 {
+      %a3d = tt.descriptor_load %descA[%c0_i32, %c0_i32, %koff] {ttig.block_io = "row_major"} : !tt.tensordesc<1x128x64xf16> -> tensor<1x128x64xf16, #blocked3d>
+      %a2d = tt.reshape %a3d : tensor<1x128x64xf16, #blocked3d> -> tensor<128x64xf16, #blocked2d>
+      %a = ttg.convert_layout %a2d : tensor<128x64xf16, #blocked2d> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+      %b3d = tt.descriptor_load %descB[%c0_i32, %koff, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<1x64x256xf16> -> tensor<1x64x256xf16, #blocked3d>
+      %b2d = tt.reshape %b3d : tensor<1x64x256xf16, #blocked3d> -> tensor<64x256xf16, #blocked2d>
+      %b = ttg.convert_layout %b2d : tensor<64x256xf16, #blocked2d> -> tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+      %d = tt.dot %a, %b, %acc, inputPrecision = tf32 : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x256xf32, #mma>
+      %next_koff = arith.addi %koff, %c1_i32 : i32
+      scf.yield %d, %next_koff : tensor<128x256xf32, #mma>, i32
+    }
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/upstream-latency-annotation.mlir
+++ b/test/TritonIntelGPU/upstream-latency-annotation.mlir
@@ -1,5 +1,5 @@
 // RUN: triton-opt %s -split-input-file -tritongpu-assign-latencies=num-stages=3 -tritongpu-schedule-loops | FileCheck %s --check-prefix=ANNOTATE
-// RUN: triton-opt %s -split-input-file -tritongpu-assign-latencies=num-stages=3 -tritongpu-schedule-loops -tritonintelgpu-pipeline=num-stages=3 | FileCheck %s --check-prefix=PIPELINE
+// RUN: env TRITON_INTEL_ANNOTATE_LATENCIES=1 triton-opt %s -split-input-file -tritongpu-assign-latencies=num-stages=3 -tritongpu-schedule-loops -tritonintelgpu-pipeline=num-stages=3 | FileCheck %s --check-prefix=PIPELINE
 
 // COM: Verifies that the upstream `tritongpu-assign-latencies` and
 // COM: `tritongpu-schedule-loops` passes annotate Intel TTGIR (ANNOTATE prefix)
@@ -34,15 +34,19 @@ module attributes {ttig.support_subgroup_matrix_multiply_accumulate, ttig.suppor
     // ANNOTATE: tt.dot
     // ANNOTATE: tt.scheduled_max_stage = {{[0-9]+}} : i32
 
-    // COM: Intel pipeline pass produces 4 hoisted prefetches (2 per stage, 2 stages)
-    // COM: and maintains prefetch-load-dot ordering inside the loop.
-    // PIPELINE-COUNT-4: ttig.descriptor_prefetch
+    // COM: Intel pipeline pass produces exactly 4 hoisted prefetches (2 per stage, 2 stages)
+    // COM: and exactly 2 in-loop prefetches, all carrying loop.stage = 0 and loop.cluster
+    // COM: copied from the source load. PIPELINE-COUNT enforces the exact prefetch count;
+    // COM: the per-line PIPELINE checks then verify each carries the expected attrs.
+    // PIPELINE-COUNT-4: ttig.descriptor_prefetch {{.*}}loop.cluster = {{[0-9]+}} : i32, loop.stage = 0 : i32
     // PIPELINE: scf.for
-    // PIPELINE: ttig.descriptor_prefetch
-    // PIPELINE: ttig.descriptor_prefetch
+    // PIPELINE-COUNT-2: ttig.descriptor_prefetch {{.*}}loop.cluster = {{[0-9]+}} : i32, loop.stage = 0 : i32
     // PIPELINE: tt.descriptor_load
     // PIPELINE: tt.descriptor_load
     // PIPELINE: tt.dot
+    // COM: Catch any extra prefetches beyond the 4+2 expected. CHECK-NOT applies between
+    // COM: the previous match and the next, so this guards everything from tt.dot to EOF.
+    // PIPELINE-NOT: ttig.descriptor_prefetch
 
     %result:2 = scf.for %k = %c0_i32 to %c64_i32 step %c1_i32 iter_args(%acc = %cst, %koff = %c0_i32) -> (tensor<128x256xf32, #mma>, i32) : i32 {
       %a3d = tt.descriptor_load %descA[%c0_i32, %c0_i32, %koff] {ttig.block_io = "row_major"} : !tt.tensordesc<1x128x64xf16> -> tensor<1x128x64xf16, #blocked3d>

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -338,6 +338,9 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         intel.passes.ttgpuir.add_remove_layout_conversions(pm)
         intel.passes.ttgpuir.add_optimize_dot_operands(pm)
         intel.passes.ttgpuir.add_hoist_layout_conversions(pm, opt.grf_mode)
+        if os.environ.get("TRITON_INTEL_ANNOTATE_LATENCIES", "0") == "1":
+            passes.ttgpuir.add_assign_latencies(pm, opt.num_stages)
+            passes.ttgpuir.add_schedule_loops(pm)
         intel.passes.ttgpuir.add_pipeline(pm, opt.num_stages, opt.use_barrier)
 
         if (opt.reduce_variable_liveness):

--- a/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
@@ -30,6 +30,7 @@ add_triton_library(TritonIntelGPUTransforms
   TritonIR
   TritonGENIR
   TritonGPUIR
+  TritonGPUTransforms
   TritonIntelGPUIR
   TritonIntelUtils
 )

--- a/third_party/intel/lib/TritonIntelGPUTransforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -7,10 +7,14 @@
 #include "triton/Analysis/AxisInfo.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Schedule.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/MathExtras.h"
+#include <cstdlib>
+#include <cstring>
 #include <limits>
 
 #define DEBUG_TYPE "tritonintelgpu-pipeline"
@@ -112,6 +116,61 @@ collectPrefetchCandidates(scf::ForOp forOp, int numStages) {
   return candidates;
 }
 
+/// Return true iff upstream loop scheduling annotations are present on \p forOp
+/// and cover every prefetch candidate, so Intel's pipeliner can validate the
+/// upstream contract. The check is observational: callers do not branch on it
+/// today, but a `false` return signals that we cannot rely on the annotations
+/// being a faithful description of the candidate set.
+///
+/// All of the following must hold:
+///   1. The opt-in env var TRITON_INTEL_ANNOTATE_LATENCIES is "1" (matching
+///      the activation in third_party/intel/backend/compiler.py).
+///   2. tt::CoarseSchedule::deSerialize succeeds, which requires
+///      `tt.scheduled_max_stage` on the for-op.
+///   3. Every candidate carries `loop.stage`. The only sanctioned exception is
+///      the Xe3P+ elementwise carve-out (loads that do not feed a dot), which
+///      upstream cannot annotate because the upstream scheduler keys on dot
+///      operands -- see collectPrefetchCandidates.
+static bool annotationsAreUsable(scf::ForOp forOp,
+                                 ArrayRef<PrefetchCandidate> candidates) {
+  // (1) Env-var gate. Read with std::getenv to match compiler.py's
+  // `os.environ.get(...) == "1"` semantics and avoid the assertIsRecognized
+  // allowlist in mlir::triton::tools::getBoolEnv.
+  const char *envVal = std::getenv("TRITON_INTEL_ANNOTATE_LATENCIES");
+  if (!envVal || std::strcmp(envVal, "1") != 0) {
+    LDBG(
+        "annotationsAreUsable: env-off (TRITON_INTEL_ANNOTATE_LATENCIES != 1)");
+    return false;
+  }
+
+  // (2) `tt.scheduled_max_stage` must be on the for-op. deSerialize returns
+  // failure() when the attr is absent.
+  tt::CoarseSchedule upstream;
+  if (failed(upstream.deSerialize(forOp, /*normalizeClusterId=*/true))) {
+    LDBG("annotationsAreUsable: no tt.scheduled_max_stage on for-op");
+    return false;
+  }
+
+  // (3) Each candidate must carry loop.stage, except the Xe3P+ elementwise
+  // carve-out (a candidate that does not feed a dot, on a module that supports
+  // 256B prefetch -- see collectPrefetchCandidates lines 100-110).
+  ModuleOp moduleOp = forOp->getParentOfType<ModuleOp>();
+  bool enableElementwisePrefetch = moduleOp->hasAttr(
+      ttgi::TritonIntelGPUDialect::getSupportPrefetch256BAttrName());
+  for (const PrefetchCandidate &c : candidates) {
+    if (c.op->hasAttr(tt::kLoopStageAttrName))
+      continue;
+    bool isElementwiseCarveOut =
+        enableElementwisePrefetch && !PrefetchCandidate::feedsDot(c.op);
+    if (isElementwiseCarveOut)
+      continue;
+    LDBG("annotationsAreUsable: candidate without loop.stage: " << *c.op);
+    return false;
+  }
+
+  return true;
+}
+
 } // namespace
 
 /// Replace the ForOp's yield with a new one with the given operands appended.
@@ -164,7 +223,8 @@ static ttg::DotOperandEncodingAttr allTransitiveUsesHaveDotEncoding(Value val) {
 }
 
 /// Create a prefetch operation for the given load operation.
-static void createPrefetchOp(scf::ForOp &forOp, tt::LoadOp loadOp) {
+static void createPrefetchOp(scf::ForOp &forOp, tt::LoadOp loadOp,
+                             bool useAnnotations) {
   OpBuilder builder(forOp);
   builder.setInsertionPoint(loadOp);
   auto prefetchOp = ttgi::PrefetchOp::create(
@@ -174,10 +234,41 @@ static void createPrefetchOp(scf::ForOp &forOp, tt::LoadOp loadOp) {
   // inherit attributes from the load operation
   auto attrs = loadOp->getAttrDictionary();
   prefetchOp->setAttrs(attrs);
+  // Drop upstream scheduling attrs that may have been attached by
+  // `tritongpu-assign-latencies` / `tritongpu-schedule-loops`. The Intel
+  // pipeliner owns scheduling for prefetch ops and would otherwise produce
+  // self-inconsistent IR (legacy stage assignment + upstream stage attr).
+  // `tt.latency` was already consumed by the upstream passes.
+  prefetchOp->removeAttr(tt::kLoopStageAttrName);
+  prefetchOp->removeAttr(tt::kLoopClusterAttrName);
+
+  // When the upstream annotation contract is in effect, copy the source
+  // load's `loop.stage` / `loop.cluster` onto the new prefetch op so that
+  // `createSchedule` can read the upstream-picked stage instead of the
+  // hardcoded legacy value (0). The load itself still carries the attrs;
+  // the strip above only cleared the dictionary copy on the prefetch op.
+  if (useAnnotations) {
+    if (Attribute s = loadOp->getAttr(tt::kLoopStageAttrName)) {
+      prefetchOp->setAttr(tt::kLoopStageAttrName, s);
+      // Warn if upstream picked a non-zero stage (the legacy hardcoded
+      // value is 0; any other value means this PR shifts the prefetch
+      // off the legacy stage).
+      if (auto stageAttr = dyn_cast<IntegerAttr>(s)) {
+        int upstreamStage = stageAttr.getInt();
+        if (upstreamStage != 0)
+          LDBG("annotation-driven prefetch deviates from legacy stage 0: "
+               "stage="
+               << upstreamStage << " for load=" << *loadOp);
+      }
+    }
+    if (Attribute c = loadOp->getAttr(tt::kLoopClusterAttrName))
+      prefetchOp->setAttr(tt::kLoopClusterAttrName, c);
+  }
 }
 
 /// Create a prefetch operation for the given load operation.
-static void createPrefetchOp(scf::ForOp &forOp, tt::DescriptorLoadOp loadOp) {
+static void createPrefetchOp(scf::ForOp &forOp, tt::DescriptorLoadOp loadOp,
+                             bool useAnnotations) {
   OpBuilder builder(forOp);
   builder.setInsertionPoint(loadOp);
   auto prefetchOp = ttgi::DescriptorPrefetchOp::create(
@@ -187,16 +278,37 @@ static void createPrefetchOp(scf::ForOp &forOp, tt::DescriptorLoadOp loadOp) {
   // inherit attributes from the load operation
   auto attrs = loadOp->getAttrDictionary();
   prefetchOp->setAttrs(attrs);
+  // See the LoadOp overload above for the rationale.
+  prefetchOp->removeAttr(tt::kLoopStageAttrName);
+  prefetchOp->removeAttr(tt::kLoopClusterAttrName);
+
+  // See the LoadOp overload above for the rationale.
+  if (useAnnotations) {
+    if (Attribute s = loadOp->getAttr(tt::kLoopStageAttrName)) {
+      prefetchOp->setAttr(tt::kLoopStageAttrName, s);
+      if (auto stageAttr = dyn_cast<IntegerAttr>(s)) {
+        int upstreamStage = stageAttr.getInt();
+        if (upstreamStage != 0)
+          LDBG("annotation-driven prefetch deviates from legacy stage 0: "
+               "stage="
+               << upstreamStage << " for load=" << *loadOp);
+      }
+    }
+    if (Attribute c = loadOp->getAttr(tt::kLoopClusterAttrName))
+      prefetchOp->setAttr(tt::kLoopClusterAttrName, c);
+  }
 }
 
 /// Create prefetch operations for the given load candidates.
 static void createPrefetchOps(scf::ForOp &forOp,
-                              ArrayRef<PrefetchCandidate> candidates) {
+                              ArrayRef<PrefetchCandidate> candidates,
+                              bool useAnnotations) {
   assert(!candidates.empty() && "Expecting at least one candidate");
   for (const PrefetchCandidate &candidate : candidates) {
     TypeSwitch<Operation *>(candidate.op)
-        .Case<tt::LoadOp, tt::DescriptorLoadOp>(
-            [&](auto loadOp) { createPrefetchOp(forOp, loadOp); })
+        .Case<tt::LoadOp, tt::DescriptorLoadOp>([&](auto loadOp) {
+          createPrefetchOp(forOp, loadOp, useAnnotations);
+        })
         .Default([](Operation *op) {
           llvm_unreachable("Unsupported load operation type");
         });
@@ -326,8 +438,22 @@ createSchedule(scf::ForOp forOp, int numStages) {
          [&](Operation *op) { return stage1deps.count(op); });
 
   // Then Schedule stage 0.
-  addOps(forOp, 0, schedule,
-         [&](Operation *op) { return prefetchAndDeps.count(op); });
+  // Prefetch ops: stage from `loop.stage` attr (set by `createPrefetchOp`
+  // when `useAnnotations` is true) or 0 (legacy hardcoded value, also the
+  // value upstream picks for direct-feed-to-dot loads in 3-stage matmul
+  // loops). Non-prefetch members of `prefetchAndDeps` (the backward
+  // dependencies) stay at stage 0.
+  for (Operation &op : forOp.getBody()->without_terminator()) {
+    if (!prefetchAndDeps.count(&op))
+      continue;
+    unsigned stage = 0;
+    if (isa<ttgi::PrefetchOp, ttgi::DescriptorPrefetchOp>(&op)) {
+      if (auto stageAttr =
+              op.getAttrOfType<IntegerAttr>(tt::kLoopStageAttrName))
+        stage = stageAttr.getInt();
+    }
+    schedule.emplace_back(&op, stage);
+  }
 
   // Schedule stage `numStage - 1` first.
   // Finally schedule the dot ops in stage `numStage - 1` so that they get
@@ -378,8 +504,15 @@ bool ttgi::preProcessLoopAndGetSchedule(scf::ForOp &forOp, int numStages,
            << " in " << numStages << " stages\n";
   });
 
+  // When the upstream annotation pipeline has run and covers every
+  // candidate, drive the prefetch op's stage from upstream's
+  // `loop.stage` / `loop.cluster` attrs instead of hardcoding stage 0.
+  // Other ops keep the stages Intel picks today.
+  bool useAnnotations = annotationsAreUsable(forOp, candidates);
+  LDBG("Pipeline path: " << (useAnnotations ? "annotation-driven" : "legacy"));
+
   // 2. Create the prefetching operations for the loads collected.
-  createPrefetchOps(forOp, candidates);
+  createPrefetchOps(forOp, candidates, useAnnotations);
 
   // 3. Create the final schedule for the kernel loop. This will dictate the
   // stages and order of operations to the pipeline expander.
@@ -393,7 +526,10 @@ bool ttgi::preProcessLoopAndGetSchedule(scf::ForOp &forOp, int numStages,
         s = std::move(schedule);
       };
   options.peelEpilogue = false;
-  options.predicateFn = predicateOp;
+  // Qualify with `::` so unqualified lookup doesn't pick up
+  // `mlir::triton::predicateOp` (a different overload declared in
+  // PipeliningUtility.h that would crash on `ttig.descriptor_prefetch`).
+  options.predicateFn = ::predicateOp;
   options.supportDynamicLoops = true;
   options.annotateFn = [](Operation *op,
                           mlir::scf::PipeliningOption::PipelinerPart part,


### PR DESCRIPTION
This PR makes the upstream `loop.stage`/`loop.cluster` annotations load-bearing for prefetch op placement.

When `TRITON_INTEL_ANNOTATE_LATENCIES=1`, each new prefetch op now explicitly inherits `loop.stage` and `loop.cluster` from its source load, and `createSchedule` reads the prefetch's `loop.stage` instead of hardcoding `0`. On today's kernels upstream assigns `loop.stage = 0` to descriptor loads, so scheduled IR is identical to legacy — the change is in the *source* of the decision, not the result. Future increments can move other op categories to upstream stages one at a time without throwing this away.

Also fixes a pre-existing pipeliner crash (`ttig.descriptor_prefetch` op pipeliner doesn't know how to predicate this op) caused by `options.predicateFn = predicateOp` silently binding to `mlir::triton::predicateOp` via `using namespace mlir;`. Fixed by qualifying as `::predicateOp`. Links `TritonGPUTransforms` in `LINK_LIBS PUBLIC` (was `DEPENDS` only) so `CoarseSchedule` symbols resolve at link time.