### PR TITLE
Fix missing test name in skiplist for test_03a_matrix_multiplication_tensor_descriptor

### DIFF
--- a/scripts/skiplist/a770/tutorials.txt
+++ b/scripts/skiplist/a770/tutorials.txt
@@ -1,4 +1,4 @@
-python/test/tutorials/test_tutorials.py::test_03a_matrix-multiplication_tensor_descriptor
+python/test/tutorials/test_tutorials.py::test_03a_matrix_multiplication_tensor_descriptor
 python/test/tutorials/test_tutorials.py::test_06_fused_attention[default]
 python/test/tutorials/test_tutorials.py::test_06_fused_attention[fp8_only]
 python/test/tutorials/test_tutorials.py::test_06_fused_attention[skip_fp8]

--- a/scripts/skiplist/arl-h/tutorials.txt
+++ b/scripts/skiplist/arl-h/tutorials.txt
@@ -1,5 +1,5 @@
 python/test/tutorials/test_tutorials.py::test_03_matrix_multiplication
-python/test/tutorials/test_tutorials.py::test_03a_matrix-multiplication_tensor_descriptor
+python/test/tutorials/test_tutorials.py::test_03a_matrix_multiplication_tensor_descriptor
 python/test/tutorials/test_tutorials.py::test_06_fused_attention[default]
 python/test/tutorials/test_tutorials.py::test_06_fused_attention[fp8_only]
 python/test/tutorials/test_tutorials.py::test_06_fused_attention[skip_fp8]

--- a/scripts/skiplist/arl-s/tutorials.txt
+++ b/scripts/skiplist/arl-s/tutorials.txt
@@ -1,5 +1,5 @@
 python/test/tutorials/test_tutorials.py::test_03_matrix_multiplication
-python/test/tutorials/test_tutorials.py::test_03a_matrix-multiplication_tensor_descriptor
+python/test/tutorials/test_tutorials.py::test_03a_matrix_multiplication_tensor_descriptor
 python/test/tutorials/test_tutorials.py::test_06_fused_attention[default]
 python/test/tutorials/test_tutorials.py::test_06_fused_attention[fp8_only]
 python/test/tutorials/test_tutorials.py::test_06_fused_attention[skip_fp8]

--- a/scripts/skiplist/mtl/tutorials.txt
+++ b/scripts/skiplist/mtl/tutorials.txt
@@ -1,6 +1,6 @@
 python/test/tutorials/test_tutorials.py::test_02_fused_softmax
 python/test/tutorials/test_tutorials.py::test_03_matrix_multiplication
-python/test/tutorials/test_tutorials.py::test_03a_matrix-multiplication_tensor_descriptor
+python/test/tutorials/test_tutorials.py::test_03a_matrix_multiplication_tensor_descriptor
 python/test/tutorials/test_tutorials.py::test_06_fused_attention[default]
 python/test/tutorials/test_tutorials.py::test_06_fused_attention[fp8_only]
 python/test/tutorials/test_tutorials.py::test_06_fused_attention[skip_fp8]


### PR DESCRIPTION
 Fix typo in 4 skiplist files where the test name used "-" instead of "_"