### PR TITLE
[MaterializeBlockPointer] Skip block IO when surface pitch exceeds 24-bit hardware limit 

### DIFF
--- a/python/test/unit/intel/test_regressions.py
+++ b/python/test/unit/intel/test_regressions.py
@@ -1914,3 +1914,59 @@ module {
     module, function, n_regs, n_spills, n_max_threads = driver.active.utils.load_binary(
         kernel.name, kernel.kernel, kernel.metadata.shared, kernel.metadata.build_flags,
         not kernel.metadata.generate_native_code, device)
+
+
+def test_regression_7022(device, tmp_path: pathlib.Path):
+    ir = """
+module {
+  tt.func public @triton_per_fused__softmax__softmax_backward_data__to_copy_add_native_dropout_backward_sum_view_12(%in_ptr0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %in_ptr1: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %in_ptr2: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %in_ptr3: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %out_ptr0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %xnumel: i32 {tt.divisibility = 16 : i32}, %r0_numel: i32) attributes {noinline = false} {
+    %cst = arith.constant dense<12582912> : tensor<1x8xi32>
+    %c8_i32 = arith.constant 8 : i32
+    %xoffset = tt.get_program_id x : i32
+    %xoffset_0 = arith.muli %xoffset, %c8_i32 : i32
+    %xindex = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %xindex_1 = tt.expand_dims %xindex {axis = 1 : i32} : tensor<8xi32> -> tensor<8x1xi32>
+    %xindex_2 = tt.splat %xoffset_0 : i32 -> tensor<8x1xi32>
+    %xindex_3 = arith.addi %xindex_2, %xindex_1 : tensor<8x1xi32>
+    %r0_index = tt.expand_dims %xindex {axis = 0 : i32} : tensor<8xi32> -> tensor<1x8xi32>
+    %tmp0 = arith.muli %r0_index, %cst : tensor<1x8xi32>
+    %tmp0_4 = tt.broadcast %xindex_3 : tensor<8x1xi32> -> tensor<8x8xi32>
+    %tmp0_5 = tt.broadcast %tmp0 : tensor<1x8xi32> -> tensor<8x8xi32>
+    %tmp0_6 = arith.addi %tmp0_4, %tmp0_5 : tensor<8x8xi32>
+    %tmp0_7 = tt.splat %in_ptr0 : !tt.ptr<bf16> -> tensor<8x8x!tt.ptr<bf16>>
+    %tmp0_8 = tt.addptr %tmp0_7, %tmp0_6 : tensor<8x8x!tt.ptr<bf16>>, tensor<8x8xi32>
+    %tmp0_9 = tt.load %tmp0_8 : tensor<8x8x!tt.ptr<bf16>>
+    %tmp0_10 = arith.extf %tmp0_9 : tensor<8x8xbf16> to tensor<8x8xf32>
+    %tmp1 = tt.splat %in_ptr1 : !tt.ptr<bf16> -> tensor<8x8x!tt.ptr<bf16>>
+    %tmp1_11 = tt.addptr %tmp1, %tmp0_6 : tensor<8x8x!tt.ptr<bf16>>, tensor<8x8xi32>
+    %tmp1_12 = tt.load %tmp1_11 : tensor<8x8x!tt.ptr<bf16>>
+    %tmp1_13 = arith.extf %tmp1_12 : tensor<8x8xbf16> to tensor<8x8xf32>
+    %tmp3 = tt.splat %in_ptr2 : !tt.ptr<bf16> -> tensor<8x8x!tt.ptr<bf16>>
+    %tmp3_14 = tt.addptr %tmp3, %tmp0_6 : tensor<8x8x!tt.ptr<bf16>>, tensor<8x8xi32>
+    %tmp3_15 = tt.load %tmp3_14 : tensor<8x8x!tt.ptr<bf16>>
+    %tmp3_16 = arith.extf %tmp3_15 : tensor<8x8xbf16> to tensor<8x8xf32>
+    %tmp5 = tt.splat %in_ptr3 : !tt.ptr<bf16> -> tensor<8x8x!tt.ptr<bf16>>
+    %tmp5_17 = tt.addptr %tmp5, %tmp0_6 : tensor<8x8x!tt.ptr<bf16>>, tensor<8x8xi32>
+    %tmp5_18 = tt.load %tmp5_17 : tensor<8x8x!tt.ptr<bf16>>
+    %tmp5_19 = arith.extf %tmp5_18 : tensor<8x8xbf16> to tensor<8x8xf32>
+    %tmp2 = arith.addf %tmp0_10, %tmp1_13 : tensor<8x8xf32>
+    %tmp4 = arith.addf %tmp2, %tmp3_16 : tensor<8x8xf32>
+    %tmp6 = arith.addf %tmp4, %tmp5_19 : tensor<8x8xf32>
+    %tmp10 = "tt.reduce"(%tmp6) <{axis = 1 : i32}> ({
+    ^bb0(%tmp10_21: f32, %tmp10_22: f32):
+      %tmp10_23 = arith.addf %tmp10_21, %tmp10_22 : f32
+      tt.reduce.return %tmp10_23 : f32
+    }) : (tensor<8x8xf32>) -> tensor<8xf32>
+    %tmp10_20 = tt.expand_dims %tmp10 {axis = 1 : i32} : tensor<8xf32> -> tensor<8x1xf32>
+    %0 = tt.splat %out_ptr0 : !tt.ptr<bf16> -> tensor<8x1x!tt.ptr<bf16>>
+    %1 = tt.addptr %0, %xindex_3 : tensor<8x1x!tt.ptr<bf16>>, tensor<8x1xi32>
+    %2 = arith.truncf %tmp10_20 : tensor<8x1xf32> to tensor<8x1xbf16>
+    tt.store %1, %2 : tensor<8x1x!tt.ptr<bf16>>
+    tt.return
+  }
+}
+    """
+
+    temp_file = tmp_path / "test_regression_7022.ttir"
+    temp_file.write_text(ir)
+    triton.compile(str(temp_file))

--- a/test/TritonIntelGPU/tensor-pointer-load-pitch-limit.mlir
+++ b/test/TritonIntelGPU/tensor-pointer-load-pitch-limit.mlir
@@ -1,0 +1,57 @@
+// RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s
+
+// COM: Regression test for issue #7022 (T5 training warmup failure).
+// COM:
+// COM: Inductor's hf_T5 / hf_T5_base softmax-backward kernel produces a
+// COM: column-major tensor-of-pointers load whose column stride is 12_582_912
+// COM: bf16 elements -> 25_165_824 byte pitch -> 0x1800000 (25 bits), exceeding
+// COM: the 24-bit limit on the `triton_gen.2Dblockload` `base_pitch` operand
+// COM: (verifier in TritonGENOps.cpp). Lowering must refuse to emit a 2D block
+// COM: load in this case and fall back to the scalar/vectorized path; otherwise
+// COM: PassManager::run fails in `make_llir`.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 2], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 32 : i32, ttig.min_sg_size = 16 : i32, ttig.support_2d_block_io, ttig.support_bfloat16_conversion, ttig.support_subgroup_matrix_multiply_accumulate, ttig.target_arch = "spir64"} {
+  // CHECK-LABEL: @col_pitch_exceeds_24bit_limit
+  tt.func public @col_pitch_exceeds_24bit_limit(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}) {
+    %row = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %row_exp = tt.expand_dims %row {axis = 1 : i32} : tensor<8xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<8x1xi32, #blocked>
+    %col = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %col_exp = tt.expand_dims %col {axis = 0 : i32} : tensor<8xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x8xi32, #blocked>
+    %col_stride = arith.constant dense<12582912> : tensor<1x8xi32, #blocked>
+    %col_off = arith.muli %col_exp, %col_stride : tensor<1x8xi32, #blocked>
+    %row_bc = tt.broadcast %row_exp : tensor<8x1xi32, #blocked> -> tensor<8x8xi32, #blocked>
+    %col_bc = tt.broadcast %col_off : tensor<1x8xi32, #blocked> -> tensor<8x8xi32, #blocked>
+    %offsets = arith.addi %row_bc, %col_bc : tensor<8x8xi32, #blocked>
+    %ptrs_splat = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<8x8x!tt.ptr<bf16>, #blocked>
+    %ptrs = tt.addptr %ptrs_splat, %offsets : tensor<8x8x!tt.ptr<bf16>, #blocked>, tensor<8x8xi32, #blocked>
+    // CHECK-NOT: triton_gen.2Dblockload
+    tt.load %ptrs {ttig.block_io = "column_major"} : tensor<8x8x!tt.ptr<bf16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Boundary case: column stride 8_388_608 bf16 elements -> 16_777_216 byte
+// COM: pitch == (1 << 24) -- still within hardware limit, must lower to a
+// COM: triton_gen.2Dblockload as before.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 2], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 32 : i32, ttig.min_sg_size = 16 : i32, ttig.support_2d_block_io, ttig.support_bfloat16_conversion, ttig.support_subgroup_matrix_multiply_accumulate, ttig.target_arch = "spir64"} {
+  // CHECK-LABEL: @col_pitch_at_24bit_limit
+  tt.func public @col_pitch_at_24bit_limit(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}) {
+    %row = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %row_exp = tt.expand_dims %row {axis = 1 : i32} : tensor<8xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<8x1xi32, #blocked>
+    %col = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %col_exp = tt.expand_dims %col {axis = 0 : i32} : tensor<8xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x8xi32, #blocked>
+    %col_stride = arith.constant dense<8388608> : tensor<1x8xi32, #blocked>
+    %col_off = arith.muli %col_exp, %col_stride : tensor<1x8xi32, #blocked>
+    %row_bc = tt.broadcast %row_exp : tensor<8x1xi32, #blocked> -> tensor<8x8xi32, #blocked>
+    %col_bc = tt.broadcast %col_off : tensor<1x8xi32, #blocked> -> tensor<8x8xi32, #blocked>
+    %offsets = arith.addi %row_bc, %col_bc : tensor<8x8xi32, #blocked>
+    %ptrs_splat = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<8x8x!tt.ptr<bf16>, #blocked>
+    %ptrs = tt.addptr %ptrs_splat, %offsets : tensor<8x8x!tt.ptr<bf16>, #blocked>, tensor<8x8xi32, #blocked>
+    // CHECK: triton_gen.2Dblockload
+    tt.load %ptrs {ttig.block_io = "column_major"} : tensor<8x8x!tt.ptr<bf16>, #blocked>
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -709,8 +709,12 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
       return b.i32_val(MIN_PITCH);
 
     if (stride > 0) {
-      unsigned pitch = (unsigned)stride * elemSizeInBits / 8;
-      if (pitch < MIN_PITCH)
+      // Surface pitch is encoded in 24 bits in the 2D block IO message
+      // descriptor (see `triton_gen.2Dblockload` / `2Dblockstore` verifier in
+      // TritonGENOps.cpp). A constant pitch above this limit is unsupported.
+      constexpr int64_t MAX_PITCH = int64_t(1) << 24;
+      int64_t pitch = int64_t(stride) * elemSizeInBits / 8;
+      if (pitch < MIN_PITCH || pitch > MAX_PITCH)
         return nullptr; // unsupported pitch
       return b.i32_val(pitch);
     }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -267,17 +267,6 @@ private:
         return false;
       }
 
-      // Hardware 2D block IO encodes the surface pitch in 24 bits, so a
-      // pitch >= (1 << 24) bytes cannot be expressed. Tagging such a load
-      // as block-IO would later fail verification of triton_gen.2Dblockload
-      // ("4th operand (base pitch) should be <= 24 bits"). Bail out so the
-      // load falls back to the regular vectorized lowering.
-      if (otherDimStride * elemSizeInBytes > (int64_t(1) << 24)) {
-        LDBG("Pitch exceeds 24-bit hardware limit: "
-             << (otherDimStride * elemSizeInBytes));
-        return false;
-      }
-
       // Base pointer can be compensate by the offset and base width, where they
       // each has restriction that it has to be 4 bytes aligned.
       if (axisInfo.getDivisibility(fastChangeDim) % 4 != 0) {

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -267,6 +267,17 @@ private:
         return false;
       }
 
+      // Hardware 2D block IO encodes the surface pitch in 24 bits, so a
+      // pitch >= (1 << 24) bytes cannot be expressed. Tagging such a load
+      // as block-IO would later fail verification of triton_gen.2Dblockload
+      // ("4th operand (base pitch) should be <= 24 bits"). Bail out so the
+      // load falls back to the regular vectorized lowering.
+      if (otherDimStride * elemSizeInBytes > (int64_t(1) << 24)) {
+        LDBG("Pitch exceeds 24-bit hardware limit: "
+             << (otherDimStride * elemSizeInBytes));
+        return false;
+      }
+
       // Base pointer can be compensate by the offset and base width, where they
       // each has restriction that it has to be 4 bytes aligned.
       if (axisInfo.getDivisibility(fastChangeDim) % 4 != 0) {


### PR DESCRIPTION
Adresses #7022.

`getPitch()` in `LoadStoreOpToLLVM.cpp` now returns `nullptr` when the surface
pitch exceeds the 24-bit hardware limit, mirroring the existing `MIN_PITCH`
guard. The existing `if (!pitch) return failure();` at the call site falls
back to the regular vectorized lowering, avoiding the verifier crash in
`make_llir` ("4th operand (base pitch) should be <= 24 bits").

actual error:

```
cat /tmp/repro.log
loading model: 0it [00:05, ?it/s]
xpu  train hf_T5_base
/tmp/torchinductor_root/tmp3vhp19vn/id/cidrz572k4jmk5ofsybkrz3acpryhgvtcs5il6kihb4tygmmpfes.py:34:12: error: 'triton_gen.2Dblockload' op 4th operand (base pitch) should be <= 24 bits
    tmp0 = tl.load(in_ptr0 + (x0 + 12582912*r0_1), r0_mask, other=0.0)
```

validated on release/3.7.2 tip + this change, that the failing cases reported in #7022 pass