### PR TITLE
  Fix #5665: use perf_counter_ns for compile timing

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -196,8 +196,10 @@ def filter_traceback(e: BaseException):
 class CompileTimer:
 
     def __init__(self) -> None:
-        # #5665: use perf_counter_ns instead of time.time(). Windows time.time()
-        # has ~16ms resolution, rounding sub-ms stages (store_results) to 0.
+        # #5665:
+        #   - time.time() ticks every 15.6ms on Windows
+        #   - store_results returns ~us, so every value below 15600us will not be counted.
+        #   - perf_counter_ns ticks every ~100ns, fine enough to see us-scale durations.
         self.start: int = time.perf_counter_ns()
         self.ir_initialization_end: int | None = None
         self.lowering_stage_ends: list[tuple[str, int]] = []

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -196,28 +196,30 @@ def filter_traceback(e: BaseException):
 class CompileTimer:
 
     def __init__(self) -> None:
-        self.start: float = time.time()
-        self.ir_initialization_end: float | None = None
-        self.lowering_stage_ends: list[tuple[str, float]] = []
-        self.store_results_end: float | None = None
+        # #5665: use perf_counter_ns instead of time.time(). Windows time.time()
+        # has ~16ms resolution, rounding sub-ms stages (store_results) to 0.
+        self.start: int = time.perf_counter_ns()
+        self.ir_initialization_end: int | None = None
+        self.lowering_stage_ends: list[tuple[str, int]] = []
+        self.store_results_end: int | None = None
 
     def finished_ir_initialization(self) -> None:
-        self.ir_initialization_end = time.time()
+        self.ir_initialization_end = time.perf_counter_ns()
 
     def stage_finished(self, stage_name: str) -> None:
-        self.lowering_stage_ends.append((stage_name, time.time()))
+        self.lowering_stage_ends.append((stage_name, time.perf_counter_ns()))
 
     def end(self) -> knobs.CompileTimes:
-        timestamp = time.time()
+        timestamp = time.perf_counter_ns()
         if self.ir_initialization_end is None:
             self.ir_initialization_end = timestamp
         else:
             self.store_results_end = timestamp
 
-        def delta(start: float, end: float | None) -> int:
+        def delta(start: int, end: int | None) -> int:
             if end is None:
                 return 0
-            return int((end - start) * 1000000)
+            return (end - start) // 1000
 
         lowering_stage_durations = []
         stage_start = self.ir_initialization_end


### PR DESCRIPTION
  time.time() has ~16ms resolution on Windows, which rounds sub-millisecond
  compilation stages (e.g. store_results) to 0 and breaks
  test_compilation_listener::test_compile_stats with `assert 0 > 0`.

  Switch CompileTimer to time.perf_counter_ns(). Update field types from
  float to int and the delta() helper to convert ns->us via integer
  division. The CompileTimes API still returns microseconds; only internal
  storage units changed.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x ] This PR does not need a test because `This PR only changes the method of time sampling`.

- Select one of the following.
  - [x ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
