### PR TITLE
[vLLM] Increase timeout for setup stage of vLLM tests workflow

### DIFF
--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on:
       - linux
       - ${{ inputs.runner_label || 'max1550' }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     defaults:
       run:
         shell: bash -noprofile --norc -eo pipefail -c "source /opt/intel/oneapi/setvars.sh > /dev/null; source {0}"


### PR DESCRIPTION
The vLLM tests repo needs to increase the timeout for the setup stage. If the pytorch setup action misses in the cache, we must build it from source. A source build of pytorch takes longer than 60 minutes. I'm doubling the timeout to be conservative.

Example failing run due to timeout: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/26758258052/job/78954760906