### PR TITLE
[vLLM] Increase timeout of setup in vLLM tests to 3 hours

### DIFF
--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on:
       - linux
       - ${{ inputs.runner_label || 'max1550' }}
-    timeout-minutes: 120
+    timeout-minutes: 180
     defaults:
       run:
         shell: bash -noprofile --norc -eo pipefail -c "source /opt/intel/oneapi/setvars.sh > /dev/null; source {0}"


### PR DESCRIPTION
I recently increased the setup timeout to 2 hours in https://github.com/intel/intel-xpu-backend-for-triton/pull/7067. However, building PyTorch (cache miss on wheel) and Triton from source may take more than 2 hours. Let's increase the timeout for the setup job to 3 hours.

Example of a run that was cancelled with the 2 hour setup timeout: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/26805316923/attempts/1 