### PR TITLE
Gate FP8E4M3FN→BF16 fmul converter on bf16 arithmetic support

### DIFF
--- a/test/Conversion/intel/fp8e4m3_to_bf16_fma.mlir
+++ b/test/Conversion/intel/fp8e4m3_to_bf16_fma.mlir
@@ -1,19 +1,47 @@
 // RUN: triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm --canonicalize | FileCheck %s
 
+// COM: Non-LTS driver path: fast fmul BF16 converter. Module has ttig.support_bfloat16_arithmetic,
+// COM: so the gate selects the i16-mask + fmul bf16 path (2^120 multiplier, no integer table).
 #blocked = #ttg.blocked<{sizePerThread = [16], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.min_sg_size = 16 : i32, ttig.target_arch = "spir64" } {
-  tt.func public @convert_fp8e4m3_to_bf16(%src: tensor<16xf8E4M3FN, #blocked>) -> tensor<16xbf16, #blocked> {
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.min_sg_size = 16 : i32, ttig.target_arch = "spir64", ttig.support_bfloat16_arithmetic } {
+  // CHECK-LABEL: @convert_fp8e4m3_to_bf16_fmul
+  tt.func public @convert_fp8e4m3_to_bf16_fmul(%src: tensor<16xf8E4M3FN, #blocked>) -> tensor<16xbf16, #blocked> {
     %dst = tt.fp_to_fp %src : tensor<16xf8E4M3FN, #blocked> -> tensor<16xbf16, #blocked>
     // CHECK-DAG: llvm.mlir.constant(2032 : i16) : i16
     // CHECK-DAG: llvm.mlir.constant(4 : i16) : i16
+    // CHECK-DAG: llvm.mlir.constant(1.329230e+36 : bf16) : bf16
     // CHECK: llvm.trunc {{.*}} : i32 to i16
     // CHECK: llvm.lshr {{.*}} : i16
     // CHECK: llvm.and {{.*}} : i16
     // CHECK: llvm.fmul {{.*}} : bf16
-    // CHECK-NOT: llvm.and {{.*}}133169152
-    // CHECK-NOT: llvm.add {{.*}}1006632960
-    // CHECK-NOT: llvm.extractelement {{.*}}<i32 0, i32 989855744
-    // CHECK-NOT: llvm.icmp{{.*}}eq{{.*}}0xf800000
+    // CHECK-NOT: llvm.mlir.constant(260046848 : i32)
+    // CHECK-NOT: llvm.mlir.constant(1006632960 : i32)
+    // CHECK-NOT: llvm.mlir.constant(989855744 : i32)
+    // CHECK-NOT: llvm.extractelement {{.*}}vector<8xi32>
+    // CHECK-NOT: llvm.icmp "eq"
     tt.return %dst : tensor<16xbf16, #blocked>
+  }
+}
+
+// -----
+
+// COM: LTS driver path: pure-integer table-lookup converter. Module lacks ttig.support_bfloat16_arithmetic,
+// COM: so the gate selects the fallback (subnormal detection + 8-element table + rebias add, no bf16 fmul).
+#blocked1 = #ttg.blocked<{sizePerThread = [16], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.min_sg_size = 16 : i32, ttig.target_arch = "spir64" } {
+  // CHECK-LABEL: @convert_fp8e4m3_to_bf16_table
+  tt.func public @convert_fp8e4m3_to_bf16_table(%src: tensor<16xf8E4M3FN, #blocked1>) -> tensor<16xbf16, #blocked1> {
+    %dst = tt.fp_to_fp %src : tensor<16xf8E4M3FN, #blocked1> -> tensor<16xbf16, #blocked1>
+    // CHECK-DAG: llvm.mlir.constant(260046848 : i32)
+    // CHECK-DAG: llvm.mlir.constant(1006632960 : i32)
+    // CHECK-DAG: llvm.mlir.constant(989855744 : i32)
+    // CHECK: llvm.icmp "eq" {{.*}} : i32
+    // CHECK: llvm.extractelement {{.*}}vector<8xi32>
+    // CHECK: llvm.add {{.*}} : i32
+    // CHECK-NOT: llvm.mlir.constant(2032 : i16)
+    // CHECK-NOT: llvm.mlir.constant(4 : i16)
+    // CHECK-NOT: llvm.mlir.constant(1.329230e+36 : bf16)
+    // CHECK-NOT: llvm.fmul
+    tt.return %dst : tensor<16xbf16, #blocked1>
   }
 }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -502,6 +502,108 @@ static SmallVector<Value> Fp_to_Fp8_RTNE(Location loc,
   return {b.select(isNan, b.i8_val(DST_NAN), b.trunc(i8_ty, val))};
 }
 
+static SmallVector<Value>
+Fp8E4M3Nv_to_Bf16Table(Location loc, ConversionPatternRewriter &rewriter,
+                       const SmallVector<Value> &v) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  auto fp8x4VecTy = vec_ty(i8_ty, 4);
+  Value a0 = b.undef(fp8x4VecTy);
+  a0 = b.insert_element(fp8x4VecTy, a0, b.int_val(8, 0), b.i32_val(0));
+  a0 = b.insert_element(fp8x4VecTy, a0, v[0], b.i32_val(1));
+  a0 = b.insert_element(fp8x4VecTy, a0, b.int_val(8, 0), b.i32_val(2));
+  a0 = b.insert_element(fp8x4VecTy, a0, v[1], b.i32_val(3));
+  a0 = b.bitcast(a0, i32_ty);
+
+  Value a1 = b.undef(fp8x4VecTy);
+  a1 = b.insert_element(fp8x4VecTy, a1, b.int_val(8, 0), b.i32_val(0));
+  a1 = b.insert_element(fp8x4VecTy, a1, v[2], b.i32_val(1));
+  a1 = b.insert_element(fp8x4VecTy, a1, b.int_val(8, 0), b.i32_val(2));
+  a1 = b.insert_element(fp8x4VecTy, a1, v[3], b.i32_val(3));
+  a1 = b.bitcast(a1, i32_ty);
+
+  Value b0 = b.and_(i32_ty, a0, b.i32_val(0x7fff7fff));
+  Value b1 = b.and_(i32_ty, a1, b.i32_val(0x7fff7fff));
+  b0 = b.lshr(i32_ty, b0, b.i32_val(4));
+  b1 = b.lshr(i32_ty, b1, b.i32_val(4));
+
+  Value c0 = b.and_(i32_ty, b0, b.i32_val(0xffff0000));
+  Value c1 = b.shl(i32_ty, b0, b.i32_val(16));
+  Value c2 = b.and_(i32_ty, b1, b.i32_val(0xffff0000));
+  Value c3 = b.shl(i32_ty, b1, b.i32_val(16));
+
+  // Check if the exponent is zero, i.e. subnormal number.
+  // fp8e4 has a bias of 7
+  // depending on the significand value normalization goes like:
+  //  [000] -> 0x0
+  //  [001] -> exp=127-9, sig=0x0
+  //  [010] -> exp=127-8, sig=0x0
+  //  [011] -> exp=127-8, sig=b1000...
+  //  [100] -> exp=127-7, sig=0x0
+  //  [101] -> exp=127-7, sig=b0100...
+  //  [110] -> exp=127-7, sig=b1000...
+  //  [111] -> exp=127-7, sig=b1100...
+  Value cmp0 = b.icmp_eq(b.and_(c0, b.i32_val(0xf800000)), b.i32_val(0));
+  Value cmp1 = b.icmp_eq(b.and_(c1, b.i32_val(0xf800000)), b.i32_val(0));
+  Value cmp2 = b.icmp_eq(b.and_(c2, b.i32_val(0xf800000)), b.i32_val(0));
+  Value cmp3 = b.icmp_eq(b.and_(c3, b.i32_val(0xf800000)), b.i32_val(0));
+
+  auto i32x8VecTy = vec_ty(i32_ty, 8);
+  Value predefined = b.undef(i32x8VecTy);
+  predefined =
+      b.insert_element(i32x8VecTy, predefined, b.i32_val(0x0), b.i32_val(0));
+  predefined = b.insert_element(i32x8VecTy, predefined, b.i32_val(0x3B000000),
+                                b.i32_val(1));
+  predefined = b.insert_element(i32x8VecTy, predefined, b.i32_val(0x3B800000),
+                                b.i32_val(2));
+  predefined = b.insert_element(i32x8VecTy, predefined, b.i32_val(0x3BC00000),
+                                b.i32_val(3));
+  predefined = b.insert_element(i32x8VecTy, predefined, b.i32_val(0x3C000000),
+                                b.i32_val(4));
+  predefined = b.insert_element(i32x8VecTy, predefined, b.i32_val(0x3C200000),
+                                b.i32_val(5));
+  predefined = b.insert_element(i32x8VecTy, predefined, b.i32_val(0x3C400000),
+                                b.i32_val(6));
+  predefined = b.insert_element(i32x8VecTy, predefined, b.i32_val(0x3C600000),
+                                b.i32_val(7));
+
+  Value predef_idx0 = b.lshr(b.and_(c0, b.i32_val(7 << 20)), b.i32_val(20));
+  Value predef_idx1 = b.lshr(b.and_(c1, b.i32_val(7 << 20)), b.i32_val(20));
+  Value predef_idx2 = b.lshr(b.and_(c2, b.i32_val(7 << 20)), b.i32_val(20));
+  Value predef_idx3 = b.lshr(b.and_(c3, b.i32_val(7 << 20)), b.i32_val(20));
+
+  Value normalized0 = b.extract_element(i32_ty, predefined, predef_idx0);
+  Value normalized1 = b.extract_element(i32_ty, predefined, predef_idx1);
+  Value normalized2 = b.extract_element(i32_ty, predefined, predef_idx2);
+  Value normalized3 = b.extract_element(i32_ty, predefined, predef_idx3);
+
+  Value d0 = b.add(i32_ty, c0, b.i32_val(0x3c000000));
+  Value d1 = b.add(i32_ty, c1, b.i32_val(0x3c000000));
+  Value d2 = b.add(i32_ty, c2, b.i32_val(0x3c000000));
+  Value d3 = b.add(i32_ty, c3, b.i32_val(0x3c000000));
+
+  Value res0 = b.select(cmp0, normalized0, d0);
+  Value res1 = b.select(cmp1, normalized1, d1);
+  Value res2 = b.select(cmp2, normalized2, d2);
+  Value res3 = b.select(cmp3, normalized3, d3);
+
+  Value f0 = b.or_(i32_ty, res0, b.lshr(i32_ty, res1, b.i32_val(16)));
+  Value f1 = b.or_(i32_ty, res2, b.lshr(i32_ty, res3, b.i32_val(16)));
+
+  Value sign0 = b.and_(i32_ty, a0, b.i32_val(0x80008000));
+  Value sign1 = b.and_(i32_ty, a1, b.i32_val(0x80008000));
+
+  auto bf16x2VecTy = vec_ty(bf16_ty, 2);
+  Value bf16x2Vec0 = b.or_(i32_ty, sign0, f0);
+  Value bf16x2Vec1 = b.or_(i32_ty, sign1, f1);
+  bf16x2Vec0 = b.bitcast(bf16x2Vec0, bf16x2VecTy);
+  bf16x2Vec1 = b.bitcast(bf16x2Vec1, bf16x2VecTy);
+
+  return {b.extract_element(bf16_ty, bf16x2Vec0, b.i32_val(0)),
+          b.extract_element(bf16_ty, bf16x2Vec0, b.i32_val(1)),
+          b.extract_element(bf16_ty, bf16x2Vec1, b.i32_val(0)),
+          b.extract_element(bf16_ty, bf16x2Vec1, b.i32_val(1))};
+}
+
 static SmallVector<Value> Fp8E4M3Nv_to_Bf16(Location loc,
                                             ConversionPatternRewriter &rewriter,
                                             const SmallVector<Value> &v) {
@@ -521,7 +623,10 @@ static SmallVector<Value> Fp8E4M3Nv_to_Bf16(Location loc,
   a1 = b.insert_element(fp8x4VecTy, a1, v[3], b.i32_val(3));
   a1 = b.bitcast(a1, i32_ty);
 
-  // FP8E4M3FN -> BF16 via single fmul rebias.
+  // FP8E4M3FN -> BF16 via single fmul rebias. This path requires native bf16
+  // arithmetic support and is selected only when
+  // ttig.support_bfloat16_arithmetic is present (non-LTS drivers);
+  // Fp8E4M3Nv_to_Bf16Table provides the LTS fallback.
   //
   // Algorithm (per pack `a` holding 2 FP8 bytes in upper half of each i16 lane,
   // i.e. byte i sits in bits [15:8] of i16 lane i):
@@ -742,6 +847,8 @@ template <typename Ty> Type toType(TritonLLVMIRRewriter &b) {
 
 constexpr const auto SUPPORT_F8_CONV =
     triton::gpu::intel::TritonIntelGPUDialect::getSupportF8ConversionAttrName;
+constexpr const auto SUPPORT_BF16_ARITH = triton::gpu::intel::
+    TritonIntelGPUDialect::getSupportBFloat16ArithmeticAttrName;
 constexpr const char BUILTIN_HFTOHF8[] =
     "__builtin_spirv_ClampConvertFP16ToE4M3INTEL";
 constexpr const char BUILTIN_HFTOBF8[] =
@@ -972,7 +1079,10 @@ struct FpToFpOpConversion
               {Fp_to_Fp8_RTNE<Float16Type, Float8E5M2Type>, 1}}},
             // F8 -> BF16
             {{F8E5M2TyID, BF16TyID, undefRounding}, {Fp8E5M2_to_Bf16, 4}},
-            {{F8E4M3TyID, BF16TyID, undefRounding}, {Fp8E4M3Nv_to_Bf16, 4}},
+            {{F8E4M3TyID, BF16TyID, undefRounding},
+             {HasAttr<SUPPORT_BF16_ARITH>,
+              {Fp8E4M3Nv_to_Bf16, 4},
+              {Fp8E4M3Nv_to_Bf16Table, 4}}},
             // BF16 -> F8
             {{BF16TyID, F8E5M2TyID, RoundingMode::RTZ}, {Bf16_to_Fp8E5M2, 4}},
             {{BF16TyID, F8E5M2TyID, RoundingMode::RTNE},


### PR DESCRIPTION
Closes #7077

## Problem

PR #7040 replaced the FP8E4M3FN→BF16 converter with a single `fmul bf16` rebias. That multiply requires **native bf16 arithmetic**, which LTS drivers do not have. On the LTS CI matrix ([run](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/26832966793/job/79120695491#step:13:3814)) the converter produced wrong results for **254/256** byte values (e.g. `byte=0x01 expected=0x3b00 actual=0x2b80`). Reported by @anmyachev.

Root cause: `ttig.support_bfloat16_arithmetic` is set only for non-LTS drivers, and the `arith-emulate-unsupported-floats` pass runs in TTGIR — before the `fmul` is created during elementwise lowering — so it never lowers this multiply. A raw `fmul bf16` then reaches IGC on a driver without native bf16 arithmetic.

## Fix

Gate the converter on the `ttig.support_bfloat16_arithmetic` module attribute using the existing `ConverterSelector`/`HasAttr<>` mechanism already used for the F8↔F16 converters:

```cpp
{{F8E4M3TyID, BF16TyID, undefRounding},
 {HasAttr<SUPPORT_BF16_ARITH>,
  {Fp8E4M3Nv_to_Bf16, 4},        // non-LTS: fast fmul rebias (PR #7040)
  {Fp8E4M3Nv_to_Bf16Table, 4}}}, // LTS: integer table-lookup fallback
```

- **Non-LTS** (attribute present): keep the fast `fmul` rebias path from #7040.
- **LTS** (attribute absent): fall back to `Fp8E4M3Nv_to_Bf16Table`, the pure-integer table-lookup converter that shipped before #7040 (no bf16 arithmetic — byte-identical to the previous implementation).

`Fp8E5M2_to_Bf16` is already pure-integer and is unaffected.

## Testing

- **lit** `test/Conversion/intel/fp8e4m3_to_bf16_fma.mlir`: split into two `-split-input-file` sections — a non-LTS section (attribute present) asserting the `fmul`/i16-mask path, and an LTS section (attribute absent) asserting the integer table-lookup path and forbidding `llvm.fmul`. Verified against locally-built `triton-opt`: non-LTS emits 16 `fmul`, LTS emits 0.
- **pytest** `python/test/unit/intel/test_fp8e4m3_to_bf16.py`: unchanged and passes 256/256 bit-exact on PVC (non-LTS). Both paths reproduce the same ground-truth bit pattern, so no update was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)