### PR TITLE
Remove the reshape fuse pass in pipeline

### DIFF
--- a/python/test/unit/intel/test_block_tdesc.py
+++ b/python/test/unit/intel/test_block_tdesc.py
@@ -3,6 +3,7 @@ import torch
 import pathlib
 
 import triton
+import triton.language as tl
 from triton._internal_testing import is_xpu
 
 
@@ -130,3 +131,110 @@ def test_tdesc_load_zero_padding(M, N, dtype_str, device, tmp_path: pathlib.Path
     expected[:, N - 1] = 0
 
     assert torch.equal(x, expected)
+
+
+@triton.jit
+def grouped_mm_tma_kernel_nonk(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    G,
+    M,
+    N,
+    K,
+    stride_ag,
+    stride_ak,
+    stride_am,
+    stride_bg,
+    stride_bk,
+    stride_bn,
+    stride_cg,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Non-K-major: A desc [G,K,M], B desc [G,K,N], MMA: dot(a.T, b)."""
+    a_desc = tl.make_tensor_descriptor(
+        a_ptr,
+        shape=[G, K, M],
+        strides=[stride_ag, stride_ak, stride_am],
+        block_shape=[1, BLOCK_K, BLOCK_M],
+    )
+    b_desc = tl.make_tensor_descriptor(
+        b_ptr,
+        shape=[G, K, N],
+        strides=[stride_bg, stride_bk, stride_bn],
+        block_shape=[1, BLOCK_K, BLOCK_N],
+    )
+
+    for g in tl.range(G):
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        for k in range(0, K, BLOCK_K):
+            a = a_desc.load([g, k, 0])
+            # tl.device_print(" A1:", a)
+            a = a.reshape(BLOCK_K, BLOCK_M)
+            # tl.device_print(" A2:", a)
+            # a = a_desc.load([g, k, 0])
+            # a = tl.permute(a, (0, 2, 1)).reshape(BLOCK_M, BLOCK_K)
+            b = b_desc.load([g, k, 0]).reshape(BLOCK_K, BLOCK_N)
+            acc += tl.dot(a.T, b)
+
+        c = acc.to(tl.bfloat16)
+        offs_m = tl.arange(0, BLOCK_M)
+        offs_n = tl.arange(0, BLOCK_N)
+        c_base = c_ptr + g * stride_cg
+        c_ptrs = c_base + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+        mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+        tl.store(c_ptrs, c, mask=mask)
+
+
+@pytest.mark.skipif(not is_xpu(), reason="Tensor descriptor tests are specific to the XPU backend")
+def test_tma_correctness(device):
+    torch.manual_seed(42)
+    dtype = torch.float32
+
+    # Parameters from the failing test case
+    G, M, N, K = 2, 3, 7, 13
+    M_padded = 8
+    N_padded = 8
+    BLOCK_M, BLOCK_N, BLOCK_K = 16, 16, 16
+    grid = (1, )
+
+    # A: created as randn(G, K, M_padded).transpose(-2,-1)[:,:M,:]
+    # → shape [G, M, K], stride (K*M_padded, 1, M_padded) - M is innermost
+    A2_full = torch.randn(G, K, M_padded, dtype=dtype, device=device)
+    A2 = A2_full.transpose(-2, -1)[:, :M, :]  # shape (5,3,13), stride (K*M_padded, 1, M_padded)=(104, 1, 8)
+
+    B2_full = torch.randn(G, K, N_padded, dtype=dtype, device=device)
+    B2_view = B2_full.transpose(-2, -1)[:, :N, :]  # shape (5,7,13), stride (104, 1, 8)
+    mat_b = B2_view.transpose(-2, -1)  # shape (5,13,7), stride (104, 8, 1)
+
+    # Reference: A2 @ mat_b for each group
+    ref2 = torch.bmm(A2, mat_b)
+
+    C2_tma = torch.zeros(G, M, N, dtype=dtype, device=device)
+    # Pass strides for [G, K, M] order for A and [G, K, N] order for B
+    grouped_mm_tma_kernel_nonk[grid](
+        A2,
+        mat_b,
+        C2_tma,
+        G,
+        M,
+        N,
+        K,
+        A2.stride(0),
+        A2.stride(2),
+        A2.stride(1),  # stride_G, stride_K(=8), stride_M(=1)
+        mat_b.stride(0),
+        mat_b.stride(1),
+        mat_b.stride(2),  # stride_G, stride_K(=8), stride_N(=1)
+        C2_tma.stride(0),
+        C2_tma.stride(1),
+        C2_tma.stride(2),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+    )
+    torch.testing.assert_close(ref2, C2_tma, atol=1e-5, rtol=1e-5)

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -297,7 +297,6 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         passes.ttir.add_triton_licm(pm)
         intel.passes.ttir.add_remove_masks(pm)
         intel.passes.ttir.add_stride_versioning(pm)
-        intel.passes.ttir.add_fuse_reshape(pm)
         intel.passes.ttir.add_fold_true_cmpi(pm)
         intel.passes.ttir.add_prepare_if_combining(pm)
         passes.common.add_canonicalizer(pm)

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -294,7 +294,13 @@ struct LoadStoreConversionBase {
       std::optional<PaddingOption> padding = std::nullopt) const {
 
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    size_t rank = tensorType.getRank();
+    assert(offsets.size() == shapes.size() &&
+           offsets.size() == strides.size() &&
+           "invalid length of offsets, shapes and strides");
+    size_t tensorRank = tensorType.getRank();
+    size_t pointerRank = offsets.size();
+    assert(pointerRank >= tensorRank &&
+           "descriptor rank must be >= result/source tensor rank");
     const unsigned numElems = getTotalElemsPerThread(tensorType);
 
     // Get the LLVM values for indices in block
@@ -320,9 +326,13 @@ struct LoadStoreConversionBase {
     SmallVector<Value> maskElems;
     for (unsigned i = 0; i < numElems; ++i) {
       SmallVector<Value> index = indices[i];
-      SmallVector<Value> indicesInTensor(rank);
-      for (unsigned j = 0; j < rank; ++j)
-        indicesInTensor[j] = b.add(index[j], offsets[j]);
+      SmallVector<Value> indicesInTensor(pointerRank);
+      for (unsigned j = 0; j < pointerRank - tensorRank; ++j) {
+        indicesInTensor[j] = offsets[j];
+      }
+      for (unsigned j = 0; j < tensorRank; ++j)
+        indicesInTensor[j + (pointerRank - tensorRank)] =
+            b.add(index[j], offsets[j + (pointerRank - tensorRank)]);
 
       // Get the LLVM values for pointers
       Value offset = linearize(
@@ -399,25 +409,19 @@ struct LoadStoreConversionBase {
 
     DescriptorFields desc =
         unpackDescriptor(descriptorStruct, descriptorRank, loc, rewriter);
-    const size_t rank = tensorType.getRank();
-    assert(descriptorRank >= rank &&
-           "descriptor rank must be >= result/source tensor rank");
-    const size_t rankDelta = descriptorRank - rank;
 
     SmallVector<Value> offsets;
-    offsets.reserve(rank);
-    if (indices.size() == descriptorRank) {
-      for (size_t i = 0; i < rank; ++i)
-        offsets.push_back(indices[i + rankDelta]);
-    } else {
-      assert(indices.size() == rank && "unexpected descriptor indices rank");
-      offsets.append(indices.begin(), indices.end());
-    }
+    offsets.reserve(descriptorRank);
+    assert(indices.size() == descriptorRank &&
+           "unexpected descriptor indices rank");
+    for (size_t i = 0; i < descriptorRank; ++i)
+      offsets.push_back(indices[i]);
 
-    SmallVector<Value> mappedShapes(rank), mappedStrides(rank);
-    for (size_t i = 0; i < rank; ++i) {
-      mappedShapes[i] = desc.shapes[i + rankDelta];
-      mappedStrides[i] = desc.strides[i + rankDelta];
+    SmallVector<Value> mappedShapes(descriptorRank),
+        mappedStrides(descriptorRank);
+    for (size_t i = 0; i < descriptorRank; ++i) {
+      mappedShapes[i] = desc.shapes[i];
+      mappedStrides[i] = desc.strides[i];
     }
 
     return computeGatherScatterOperands(loc, desc.base, offsets, mappedShapes,
@@ -2167,6 +2171,15 @@ struct DescriptorLoadOpConversion
     auto descType = cast<triton::TensorDescType>(op.getDesc().getType());
     RankedTensorType descTensorType = descType.getBlockType();
     size_t descRank = descTensorType.getRank();
+
+    // Only supports the rank reduce of [1, 1, M, N] to [M, N].
+    auto descBlockShape = descTensorType.getShape();
+    const size_t rankDelta = descRank - resultRank;
+    for (int i = 0; i < rankDelta; ++i) {
+      if (descBlockShape[i] != 1)
+        llvm_unreachable("unsupported reduce rank in desc load");
+    }
+
     auto blockIOAttr = op->getAttrOfType<StringAttr>(
         TritonIntelGPUDialect::getBlockIOAttrName());
     bool permuteDescDim =
@@ -2184,8 +2197,10 @@ struct DescriptorLoadOpConversion
 
     // Boundary check all dimensions — tensor descriptors always encode shape
     // bounds and don't have a user-facing boundaryCheck attribute.
-    SmallVector<int32_t> allDims(resultRank);
-    for (size_t i = 0; i < resultRank; ++i)
+    // auto descType = cast<triton::TensorDescType>(op.getDesc().getType());
+    RankedTensorType tensorType = descType.getBlockType();
+    SmallVector<int32_t> allDims(descRank);
+    for (size_t i = 0; i < descRank; ++i)
       allDims[i] = static_cast<int32_t>(i);
 
     // Reuse the shared gather/scatter operand computation.
@@ -2215,11 +2230,10 @@ struct DescriptorLoadOpConversion
       std::swap(permOffsets[descRank - 2], permOffsets[descRank - 1]);
       SmallVector<Value> mappedShapes(resultRank), mappedStrides(resultRank),
           mappedOffsets(resultRank);
-      const size_t rankDelta = descRank - resultRank;
-      for (size_t i = 0; i < resultRank; ++i) {
-        mappedShapes[i] = permShapes[i + rankDelta];
-        mappedStrides[i] = permStrides[i + rankDelta];
-        mappedOffsets[i] = permOffsets[i + rankDelta];
+      for (size_t i = 0; i < descRank; ++i) {
+        mappedShapes[i] = permShapes[i];
+        mappedStrides[i] = permStrides[i];
+        mappedOffsets[i] = permOffsets[i];
       }
       std::tie(ptrElems, maskElems, otherElems) = computeGatherScatterOperands(
           loc, desc.base, mappedOffsets, mappedShapes, mappedStrides,
@@ -2380,6 +2394,7 @@ struct DescriptorStoreOpConversion
 
     // Get value type information
     auto valueTy = cast<RankedTensorType>(op.getSrc().getType());
+    size_t resultRank = valueTy.getRank();
     Type valueElemTy = typeConverter->convertType(valueTy.getElementType());
     unsigned numElems = getTotalElemsPerThread(valueTy);
 
@@ -2391,10 +2406,18 @@ struct DescriptorStoreOpConversion
     assertDescriptorInnerShapeCompatible(op, descTensorType.getShape(),
                                          valueTy.getShape());
 
+    // Only supports the rank reduce of [1, 1, M, N] to [M, N].
+    auto descBlockShape = descTensorType.getShape();
+    const size_t rankDelta = descRank - resultRank;
+    for (int i = 0; i < rankDelta; ++i) {
+      if (descBlockShape[i] != 1)
+        llvm_unreachable("unsupported reduce rank in desc load");
+    }
+
     // Boundary check all dimensions — tensor descriptors always encode shape
     // bounds and don't have a user-facing boundaryCheck attribute.
-    SmallVector<int32_t> allDims(valueTy.getRank());
-    for (size_t i = 0; i < valueTy.getRank(); ++i)
+    SmallVector<int32_t> allDims(descRank);
+    for (size_t i = 0; i < descRank; ++i)
       allDims[i] = static_cast<int32_t>(i);
 
     // Reuse the shared gather/scatter operand computation.


### PR DESCRIPTION
Remove the reshape fuse pass in pipeline which has bug on boundary check and non-divisible stride cases.

We plan to optimize the rank >=3 TDESC memory accessing in TTGIR -> LLVM lowering. So it is no need to enhance to improve the reshape fusing for complicating boundary check and non-divisible stride.
