### PR TITLE
[FuseReshape] Gate on `ttig.block_io` attribute presence

### DIFF
--- a/test/Triton/Intel/FuseReshape/fuse-reshape.mlir
+++ b/test/Triton/Intel/FuseReshape/fuse-reshape.mlir
@@ -11,7 +11,7 @@ tt.func public @fuseLoadWithReshape1(%arg0: tensor<256x32xbf16>, %arg1: !tt.ptr<
   %c1024_i64 = arith.constant 1024 : i64
   %cst = arith.constant dense<0.000000e+00> : tensor<256x256xf32>
   %0 = tt.make_tensor_descriptor %arg1, [%c1_i32, %c64_i32, %c1024_i32], [%c1024_i64, %c4_i64, %c1_i64] : <bf16>, <1x32x256xbf16>
-  %3 = tt.descriptor_load %0[%c2_i32, %c1_i32, %c0_i32]  : !tt.tensordesc<1x32x256xbf16> -> tensor<1x32x256xbf16>
+  %3 = tt.descriptor_load %0[%c2_i32, %c1_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<1x32x256xbf16> -> tensor<1x32x256xbf16>
   %4 = tt.reshape %3 : tensor<1x32x256xbf16> -> tensor<32x256xbf16>
   %5 = tt.dot %arg0, %4, %cst, inputPrecision = tf32 : tensor<256x32xbf16> * tensor<32x256xbf16> -> tensor<256x256xf32>
   tt.return
@@ -25,7 +25,7 @@ tt.func public @fuseLoadWithReshape1(%arg0: tensor<256x32xbf16>, %arg1: !tt.ptr<
 // CHECK: [[DESC:%.*]] = tt.make_tensor_descriptor %arg1, [[[ADD1]], %c1024_i32], [%c4_i64, %c1_i64] : <bf16>, <32x256xbf16>
 // CHECK: [[MUL2:%.*]] = arith.muli %c2_i32, [[TRUNC]] : i32
 // CHECK: [[ADD2:%.*]] = arith.addi [[MUL2]], %c1_i32 : i32
-// CHECK: [[LOAD_B:%.*]] = tt.descriptor_load [[DESC]][[[ADD2]], %c0_i32] : !tt.tensordesc<32x256xbf16> -> tensor<32x256xbf16>
+// CHECK: [[LOAD_B:%.*]] = tt.descriptor_load [[DESC]][[[ADD2]], %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<32x256xbf16> -> tensor<32x256xbf16>
 // CHECK: tt.dot {{.*}}, [[LOAD_B]], {{.*}}, inputPrecision = tf32 : tensor<256x32xbf16> * tensor<32x256xbf16> -> tensor<256x256xf32>
 
 // -----
@@ -41,7 +41,7 @@ tt.func public @fuseLoadWithReshape2(%arg0: tensor<32x256xbf16>, %arg1: !tt.ptr<
   %cst = arith.constant dense<0.000000e+00> : tensor<256x256xf32>
   %0 = tt.make_tensor_descriptor %arg1, [%c512_i32, %c1024_i32, %c32_i32], [%c1024_i64, %c1_i64, %c512_i64]: <bf16>, <1x256x32xbf16>
   %res:2 = scf.for %arg3 = %c0_i32 to %c1024_i32 step %c32_i32 iter_args(%arg4 = %cst, %arg5 = %c0_i32) -> (tensor<256x256xf32>, i32) : i32 {
-    %1 = tt.descriptor_load %0[%c32_i32, %c32_i32, %c0_i32] : !tt.tensordesc<1x256x32xbf16> -> tensor<1x256x32xbf16>
+    %1 = tt.descriptor_load %0[%c32_i32, %c32_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<1x256x32xbf16> -> tensor<1x256x32xbf16>
     %2 = tt.reshape %1 : tensor<1x256x32xbf16> -> tensor<256x32xbf16>
     %4 = tt.dot %2, %arg0, %arg4, inputPrecision = tf32 : tensor<256x32xbf16> * tensor<32x256xbf16> -> tensor<256x256xf32>
     %5 = arith.addi %arg5, %c32_i32 : i32
@@ -59,5 +59,5 @@ tt.func public @fuseLoadWithReshape2(%arg0: tensor<32x256xbf16>, %arg1: !tt.ptr<
 // CHECK: scf.for
 // CHECK:   [[MUL2:%.*]] = arith.muli %c32_i32, [[TRUNC]] : i32
 // CHECK:   [[ADD2:%.*]] = arith.addi [[MUL2]], %c32_i32 : i32
-// CHECK:   [[LOAD_A:%.*]] = tt.descriptor_load [[DESC]][[[ADD2]], %c0_i32] : !tt.tensordesc<256x32xbf16> -> tensor<256x32xbf16>
+// CHECK:   [[LOAD_A:%.*]] = tt.descriptor_load [[DESC]][[[ADD2]], %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<256x32xbf16> -> tensor<256x32xbf16>
 // CHECK:   tt.dot [[LOAD_A]], {{.*}}, {{.*}}, inputPrecision = tf32 : tensor<256x32xbf16> * tensor<32x256xbf16> -> tensor<256x256xf32>

--- a/test/Triton/Intel/FuseReshape/invalid.mlir
+++ b/test/Triton/Intel/FuseReshape/invalid.mlir
@@ -1,0 +1,21 @@
+// RUN: triton-opt %s -split-input-file -triton-intel-fuse-reshape | FileCheck %s
+
+// CHECK-LABEL: noFuseWithoutBlockIO
+// CHECK: tt.descriptor_load
+// CHECK: tt.reshape
+tt.func public @noFuseWithoutBlockIO(%arg0: tensor<256x32xbf16>, %arg1: !tt.ptr<bf16>) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c2_i32 = arith.constant 2 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %c4_i64 = arith.constant 4 : i64
+  %c64_i32 = arith.constant 64 : i32
+  %c1024_i32 = arith.constant 1024 : i32
+  %c1024_i64 = arith.constant 1024 : i64
+  %cst = arith.constant dense<0.000000e+00> : tensor<256x256xf32>
+  %0 = tt.make_tensor_descriptor %arg1, [%c1_i32, %c64_i32, %c1024_i32], [%c1024_i64, %c4_i64, %c1_i64] : <bf16>, <1x32x256xbf16>
+  %3 = tt.descriptor_load %0[%c2_i32, %c1_i32, %c0_i32] : !tt.tensordesc<1x32x256xbf16> -> tensor<1x32x256xbf16>
+  %4 = tt.reshape %3 : tensor<1x32x256xbf16> -> tensor<32x256xbf16>
+  %5 = tt.dot %arg0, %4, %cst, inputPrecision = tf32 : tensor<256x32xbf16> * tensor<32x256xbf16> -> tensor<256x256xf32>
+  tt.return
+}

--- a/test/TritonIntelGPU/dot-operands.mlir
+++ b/test/TritonIntelGPU/dot-operands.mlir
@@ -82,3 +82,31 @@ module attributes {ttig.support_2d_block_io, "ttg.num-warps" = 8 : i32, "ttg.thr
     tt.return %d : tensor<64x64xf32, #dpas>
   }
 }
+
+// -----
+
+#brow = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#bcol = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+#dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>
+module attributes {ttig.support_2d_block_io, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: tt.func @do_not_fuse_rank_reducing_descriptor_load
+  // CHECK: tt.descriptor_load {{.*}} {ttig.block_io = "row_major"}
+  // CHECK: tt.trans
+  tt.func @do_not_fuse_rank_reducing_descriptor_load(%ptr: !tt.ptr<f16>, %a: tensor<64x32xf16, #dot0>) -> tensor<64x64xf32, #dpas> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i32 = arith.constant 32 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c32_i64 = arith.constant 32 : i64
+    %c = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #dpas>
+    %desc = tt.make_tensor_descriptor %ptr, [%c1_i32, %c64_i32, %c32_i32], [%c32_i64, %c32_i64, %c1_i64] : <f16>, <1x64x32xf16>
+    %ld = tt.descriptor_load %desc[%c0_i32, %c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<1x64x32xf16> -> tensor<64x32xf16, #brow>
+    %tr = tt.trans %ld {order = array<i32: 1, 0>} : tensor<64x32xf16, #brow> -> tensor<32x64xf16, #bcol>
+    %b = ttg.convert_layout %tr : tensor<32x64xf16, #bcol> -> tensor<32x64xf16, #dot1>
+    %d = tt.dot %a, %b, %c, inputPrecision = tf32 : tensor<64x32xf16, #dot0> * tensor<32x64xf16, #dot1> -> tensor<64x64xf32, #dpas>
+    tt.return %d : tensor<64x64xf32, #dpas>
+  }
+}

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -297,7 +297,6 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         passes.ttir.add_triton_licm(pm)
         intel.passes.ttir.add_remove_masks(pm)
         intel.passes.ttir.add_stride_versioning(pm)
-        intel.passes.ttir.add_fuse_reshape(pm)
         intel.passes.ttir.add_fold_true_cmpi(pm)
         intel.passes.ttir.add_prepare_if_combining(pm)
         passes.common.add_canonicalizer(pm)
@@ -343,6 +342,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
 
         intel.passes.ttgpuir.add_accelerate_matmul(pm)
         intel.passes.ttgpuir.add_materialize_block_pointer(pm)
+        intel.passes.ttir.add_fuse_reshape(pm)
         intel.passes.ttgpuir.add_remove_layout_conversions(pm)
         intel.passes.ttgpuir.add_optimize_dot_operands(pm)
         intel.passes.ttgpuir.add_hoist_layout_conversions(pm, opt.grf_mode)

--- a/third_party/intel/lib/Dialect/Triton/Transforms/FuseReshape.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/FuseReshape.cpp
@@ -184,9 +184,8 @@ private:
         builder, loc, arith::MulIOp::create(builder, loc, offsets[0], trunc),
         newOffsets[newOutermostDimIdx]);
 
-    auto resType = cast<tt::TensorDescType>(newDesc.getType()).getBlockType();
     auto newDescLoadOp = tt::DescriptorLoadOp::create(
-        builder, descLoadOp.getLoc(), resType, newDesc, newOffsets,
+        builder, descLoadOp.getLoc(), reshapeOp.getType(), newDesc, newOffsets,
         descLoadOp.getCache(), descLoadOp.getEvict());
     newDescLoadOp->setAttrs(descLoadOp->getAttrs());
 

--- a/third_party/intel/lib/Dialect/Triton/Transforms/FuseReshape.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/FuseReshape.cpp
@@ -1,4 +1,5 @@
 #include "intel/include/Dialect/Triton/Transforms/Passes.h"
+#include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
 #include "intel/include/Utils/DefUseChain.h"
 #include "intel/include/Utils/Utility.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -20,6 +21,7 @@
 
 using namespace mlir;
 namespace tt = mlir::triton;
+namespace ttgi = mlir::triton::gpu::intel;
 
 namespace mlir::triton::intel {
 #define GEN_PASS_DEF_TRITONINTELFUSERESHAPE
@@ -261,6 +263,9 @@ private:
 
   bool isCandidate(tt::DescriptorLoadOp descLoadOp) const {
     if (!descLoadOp->hasOneUse())
+      return false;
+
+    if (!descLoadOp->getAttr(ttgi::TritonIntelGPUDialect::getBlockIOAttrName()))
       return false;
 
     std::optional<tt::MakeTensorDescOp> makeTensorDescOp =

--- a/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
@@ -103,7 +103,14 @@ private:
     if (!descLoadOp || !descLoadOp->hasOneUse())
       return false;
 
-    if (cast<RankedTensorType>(descLoadOp.getType()).getRank() < 2)
+    auto resultRank = cast<RankedTensorType>(descLoadOp.getType()).getRank();
+    if (resultRank < 2)
+      return false;
+
+    // Reject rank-reducing descriptor loads where the descriptor block type
+    // rank differs from the result rank (the fuse logic assumes they match).
+    auto descType = cast<tt::TensorDescType>(descLoadOp.getDesc().getType());
+    if (descType.getBlockType().getRank() != resultRank)
       return false;
 
     // Validate that the transpose only swaps the innermost 2 dimensions


### PR DESCRIPTION
Only fuse reshape with descriptor loads that carry the block_io attribute, ensuring the transform is limited to loads destined for 2D block I/O lowering. The fusion is unnecessary when 2D block load cannot be used, and this also works around the first issue encountered in #7030.