### PR TITLE
Fix issue in TDESC load/store lowering for reduced rank.

### DIFF
--- a/python/test/unit/intel/test_block_tdesc.py
+++ b/python/test/unit/intel/test_block_tdesc.py
@@ -130,3 +130,56 @@ def test_tdesc_load_zero_padding(M, N, dtype_str, device, tmp_path: pathlib.Path
     expected[:, N - 1] = 0
 
     assert torch.equal(x, expected)
+
+
+@pytest.mark.parametrize("M, N", [[64, 32], [32, 16], [16, 16]])
+@pytest.mark.parametrize("dtype_str", ["float32", "float16", "int8"])
+@pytest.mark.skipif(not is_xpu(), reason="Tensor descriptor tests are specific to the XPU backend")
+def test_tdesc_rank_reducing_load_store(M, N, dtype_str, device, tmp_path: pathlib.Path):
+    num_warps = 4
+    threads_per_warp = 32
+
+    ty = {"float32": "f32", "float16": "f16", "int8": "i8"}[dtype_str]
+    mn = M * N
+
+    ir = f"""
+    #blocked = #ttg.blocked<{{sizePerThread = [1, 1], threadsPerWarp = [1, {threads_per_warp}], warpsPerCTA = [1, {num_warps}], order = [1, 0]}}>
+    module attributes {{ttg.target = "xpu", "ttg.num-warps" = {num_warps} : i32, "ttg.threads-per-warp" = {threads_per_warp} : i32}} {{
+        tt.func public @descriptor_rank_reduce_load_store(%arg0: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}) {{
+            %c1_i32 = arith.constant 1 : i32
+            %c0_i32 = arith.constant 0 : i32
+            %cM_i32 = arith.constant {M} : i32
+            %cN_i32 = arith.constant {N} : i32
+            %c1_i64 = arith.constant 1 : i64
+            %cN_i64 = arith.constant {N} : i64
+            %cMN_i64 = arith.constant {mn} : i64
+
+            // 4D descriptor reduced to a 2D tensor: leading singleton dimensions
+            // use stride M*N so their zero offsets keep the same contiguous view.
+            %src_desc = tt.make_tensor_descriptor %arg0, [%c1_i32, %c1_i32, %cM_i32, %cN_i32], [%cMN_i64, %cMN_i64, %cN_i64, %c1_i64]
+                        : !tt.ptr<{ty}>, !tt.tensordesc<1x1x{M}x{N}x{ty}>
+            %data = tt.descriptor_load %src_desc [%c0_i32, %c0_i32, %c0_i32, %c0_i32]
+                    : !tt.tensordesc<1x1x{M}x{N}x{ty}> -> tensor<{M}x{N}x{ty}, #blocked>
+
+            %dst_desc = tt.make_tensor_descriptor %arg1, [%c1_i32, %c1_i32, %cM_i32, %cN_i32], [%cMN_i64, %cMN_i64, %cN_i64, %c1_i64]
+                        : !tt.ptr<{ty}>, !tt.tensordesc<1x1x{M}x{N}x{ty}>
+            tt.descriptor_store %dst_desc [%c0_i32, %c0_i32, %c0_i32, %c0_i32], %data
+                                : !tt.tensordesc<1x1x{M}x{N}x{ty}>, tensor<{M}x{N}x{ty}, #blocked>
+            tt.return
+        }}
+    }}
+    """
+
+    torch_dtype = getattr(torch, dtype_str)
+    if torch_dtype.is_floating_point:
+        a = torch.randn((M, N), dtype=torch_dtype, device=device)
+    else:
+        a = torch.randint(low=-127, high=128, size=(M, N), dtype=torch_dtype, device=device)
+
+    x = torch.empty_like(a)
+    temp_file = tmp_path / "test_tdesc_rank_reducing_load_store.ttgir"
+    temp_file.write_text(ir)
+    kernel = triton.compile(str(temp_file))
+
+    kernel[(1, 1, 1)](a, x)
+    assert torch.equal(a, x)

--- a/test/TritonIntelGPU/descriptor_load_store_to_llvm.mlir
+++ b/test/TritonIntelGPU/descriptor_load_store_to_llvm.mlir
@@ -321,3 +321,75 @@ module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32,
     tt.return %load : tensor<4x16xf16, #blocked>
   }
 }
+
+// -----
+
+// Test rank reduction from a 4D descriptor (1x1x4x4) to a 2D tensor (4x4):
+// lowering must keep boundary checks for all descriptor dimensions, including
+// the leading reduced singleton dimensions.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [1, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_predicated_io"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @rank_reducing_load
+  tt.func public @rank_reducing_load(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32) -> (tensor<4x4xf32, #blocked>) {
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %desc = tt.make_tensor_descriptor %arg0, [%c1_i32, %c1_i32, %c4_i32, %c4_i32], [%c16_i64, %c16_i64, %c4_i64, %c1_i64] : <f32>, <1x1x4x4xf32>
+
+    // CHECK: %[[DESC:.*]] = llvm.insertvalue %{{.*}}, %{{.*}}[8] : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[SHAPE0:.*]] = llvm.extractvalue %[[DESC]][0] : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[SHAPE1:.*]] = llvm.extractvalue %[[DESC]][1] : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[SHAPE2:.*]] = llvm.extractvalue %[[DESC]][2] : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[SHAPE3:.*]] = llvm.extractvalue %[[DESC]][3] : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[SHAPE0_I32:.*]] = llvm.trunc %[[SHAPE0]] : i64 to i32
+    // CHECK-DAG: %[[SHAPE1_I32:.*]] = llvm.trunc %[[SHAPE1]] : i64 to i32
+    // CHECK-DAG: %[[SHAPE2_I32:.*]] = llvm.trunc %[[SHAPE2]] : i64 to i32
+    // CHECK-DAG: %[[SHAPE3_I32:.*]] = llvm.trunc %[[SHAPE3]] : i64 to i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %[[SHAPE0_I32]] : i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %[[SHAPE1_I32]] : i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %[[SHAPE2_I32]] : i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %[[SHAPE3_I32]] : i32
+    %load = tt.descriptor_load %desc[%arg1, %arg2, %arg3, %arg4] : !tt.tensordesc<1x1x4x4xf32> -> tensor<4x4xf32, #blocked>
+    tt.return %load : tensor<4x4xf32, #blocked>
+  }
+}
+
+// -----
+
+// Test rank reduction from a 4D descriptor (1x1x4x4) to a 2D tensor (4x4):
+// store lowering must keep boundary checks for all descriptor dimensions,
+// including the leading reduced singleton dimensions.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [1, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_predicated_io"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @rank_reducing_store
+  tt.func public @rank_reducing_store(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: tensor<4x4xf32, #blocked>) {
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %desc = tt.make_tensor_descriptor %arg0, [%c1_i32, %c1_i32, %c4_i32, %c4_i32], [%c16_i64, %c16_i64, %c4_i64, %c1_i64] : <f32>, <1x1x4x4xf32>
+
+    // CHECK: %[[DESC:.*]] = llvm.insertvalue %{{.*}}, %{{.*}}[8] : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[SHAPE0:.*]] = llvm.extractvalue %[[DESC]][0] : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[SHAPE1:.*]] = llvm.extractvalue %[[DESC]][1] : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[SHAPE2:.*]] = llvm.extractvalue %[[DESC]][2] : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[SHAPE3:.*]] = llvm.extractvalue %[[DESC]][3] : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[SHAPE0_I32:.*]] = llvm.trunc %[[SHAPE0]] : i64 to i32
+    // CHECK-DAG: %[[SHAPE1_I32:.*]] = llvm.trunc %[[SHAPE1]] : i64 to i32
+    // CHECK-DAG: %[[SHAPE2_I32:.*]] = llvm.trunc %[[SHAPE2]] : i64 to i32
+    // CHECK-DAG: %[[SHAPE3_I32:.*]] = llvm.trunc %[[SHAPE3]] : i64 to i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %[[SHAPE0_I32]] : i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %[[SHAPE1_I32]] : i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %[[SHAPE2_I32]] : i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %[[SHAPE3_I32]] : i32
+    tt.descriptor_store %desc[%arg1, %arg2, %arg3, %arg4], %arg5 : !tt.tensordesc<1x1x4x4xf32>, tensor<4x4xf32, #blocked>
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/descriptor_load_store_to_llvm.mlir
+++ b/test/TritonIntelGPU/descriptor_load_store_to_llvm.mlir
@@ -349,10 +349,10 @@ module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32,
     // CHECK-DAG: %[[SHAPE1_I32:.*]] = llvm.trunc %[[SHAPE1]] : i64 to i32
     // CHECK-DAG: %[[SHAPE2_I32:.*]] = llvm.trunc %[[SHAPE2]] : i64 to i32
     // CHECK-DAG: %[[SHAPE3_I32:.*]] = llvm.trunc %[[SHAPE3]] : i64 to i32
-    // CHECK: llvm.icmp "slt" %{{.*}}, %[[SHAPE0_I32]] : i32
-    // CHECK: llvm.icmp "slt" %{{.*}}, %[[SHAPE1_I32]] : i32
-    // CHECK: llvm.icmp "slt" %{{.*}}, %[[SHAPE2_I32]] : i32
-    // CHECK: llvm.icmp "slt" %{{.*}}, %[[SHAPE3_I32]] : i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
     %load = tt.descriptor_load %desc[%arg1, %arg2, %arg3, %arg4] : !tt.tensordesc<1x1x4x4xf32> -> tensor<4x4xf32, #blocked>
     tt.return %load : tensor<4x4xf32, #blocked>
   }
@@ -385,10 +385,10 @@ module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32,
     // CHECK-DAG: %[[SHAPE1_I32:.*]] = llvm.trunc %[[SHAPE1]] : i64 to i32
     // CHECK-DAG: %[[SHAPE2_I32:.*]] = llvm.trunc %[[SHAPE2]] : i64 to i32
     // CHECK-DAG: %[[SHAPE3_I32:.*]] = llvm.trunc %[[SHAPE3]] : i64 to i32
-    // CHECK: llvm.icmp "slt" %{{.*}}, %[[SHAPE0_I32]] : i32
-    // CHECK: llvm.icmp "slt" %{{.*}}, %[[SHAPE1_I32]] : i32
-    // CHECK: llvm.icmp "slt" %{{.*}}, %[[SHAPE2_I32]] : i32
-    // CHECK: llvm.icmp "slt" %{{.*}}, %[[SHAPE3_I32]] : i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
     tt.descriptor_store %desc[%arg1, %arg2, %arg3, %arg4], %arg5 : !tt.tensordesc<1x1x4x4xf32>, tensor<4x4xf32, #blocked>
     tt.return
   }

--- a/test/TritonIntelGPU/descriptor_load_store_to_llvm.mlir
+++ b/test/TritonIntelGPU/descriptor_load_store_to_llvm.mlir
@@ -331,7 +331,12 @@ module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32,
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [1, 1], order = [1, 0]}>
 
 module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_predicated_io"} {
-  // CHECK-LABEL: llvm.func spir_kernelcc @rank_reducing_load
+  // CHECK-LABEL:   llvm.func spir_kernelcc @rank_reducing_load(
+  // CHECK-SAME:      %[[ARG0:.*]]: !llvm.ptr<1> {tt.pointee_type = f32},
+  // CHECK-SAME:      %[[OFFSET0:[^:]+]]: i32,
+  // CHECK-SAME:      %[[OFFSET1:[^:]+]]: i32,
+  // CHECK-SAME:      %[[OFFSET2:[^:]+]]: i32,
+  // CHECK-SAME:      %[[OFFSET3:[^:]+]]: i32,
   tt.func public @rank_reducing_load(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32) -> (tensor<4x4xf32, #blocked>) {
     %c1_i32 = arith.constant 1 : i32
     %c4_i32 = arith.constant 4 : i32
@@ -345,14 +350,18 @@ module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32,
     // CHECK-DAG: %[[SHAPE1:.*]] = llvm.extractvalue %[[DESC]][1] : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64, ptr<1>)>
     // CHECK-DAG: %[[SHAPE2:.*]] = llvm.extractvalue %[[DESC]][2] : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64, ptr<1>)>
     // CHECK-DAG: %[[SHAPE3:.*]] = llvm.extractvalue %[[DESC]][3] : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64, ptr<1>)>
+
+    // CHECK-DAG: %[[LINEAR_OFF2:.*]] = llvm.add {{.*}}, %[[OFFSET2]] : i32
+    // CHECK-DAG: %[[LINEAR_OFF3:.*]] = llvm.add {{.*}}, %[[OFFSET3]] : i32
+
     // CHECK-DAG: %[[SHAPE0_I32:.*]] = llvm.trunc %[[SHAPE0]] : i64 to i32
+    // CHECK-DAG: %[[BOUNDRY_CHECK0:.*]] = llvm.icmp "slt" %[[OFFSET0]], %[[SHAPE0_I32]] : i32
     // CHECK-DAG: %[[SHAPE1_I32:.*]] = llvm.trunc %[[SHAPE1]] : i64 to i32
+    // CHECK-DAG: %[[BOUNDRY_CHECK1:.*]] = llvm.icmp "slt" %[[OFFSET1]], %[[SHAPE1_I32]] : i32
     // CHECK-DAG: %[[SHAPE2_I32:.*]] = llvm.trunc %[[SHAPE2]] : i64 to i32
+    // CHECK-DAG: %[[BOUNDRY_CHECK2:.*]] = llvm.icmp "slt" %[[LINEAR_OFF2]], %[[SHAPE2_I32]] : i32
     // CHECK-DAG: %[[SHAPE3_I32:.*]] = llvm.trunc %[[SHAPE3]] : i64 to i32
-    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
-    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
-    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
-    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
+    // CHECK-DAG: %[[BOUNDRY_CHECK3:.*]] = llvm.icmp "slt" %[[LINEAR_OFF3]], %[[SHAPE3_I32]] : i32
     %load = tt.descriptor_load %desc[%arg1, %arg2, %arg3, %arg4] : !tt.tensordesc<1x1x4x4xf32> -> tensor<4x4xf32, #blocked>
     tt.return %load : tensor<4x4xf32, #blocked>
   }
@@ -367,7 +376,12 @@ module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32,
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [1, 1], order = [1, 0]}>
 
 module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_predicated_io"} {
-  // CHECK-LABEL: llvm.func spir_kernelcc @rank_reducing_store
+  // CHECK-LABEL:   llvm.func spir_kernelcc @rank_reducing_store(
+  // CHECK-SAME:      %[[ARG0:.*]]: !llvm.ptr<1> {tt.pointee_type = f32},
+  // CHECK-SAME:      %[[OFFSET0:[^:]+]]: i32,
+  // CHECK-SAME:      %[[OFFSET1:[^:]+]]: i32,
+  // CHECK-SAME:      %[[OFFSET2:[^:]+]]: i32,
+  // CHECK-SAME:      %[[OFFSET3:[^:]+]]: i32,
   tt.func public @rank_reducing_store(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: tensor<4x4xf32, #blocked>) {
     %c1_i32 = arith.constant 1 : i32
     %c4_i32 = arith.constant 4 : i32
@@ -381,14 +395,18 @@ module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32,
     // CHECK-DAG: %[[SHAPE1:.*]] = llvm.extractvalue %[[DESC]][1] : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64, ptr<1>)>
     // CHECK-DAG: %[[SHAPE2:.*]] = llvm.extractvalue %[[DESC]][2] : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64, ptr<1>)>
     // CHECK-DAG: %[[SHAPE3:.*]] = llvm.extractvalue %[[DESC]][3] : !llvm.struct<(i64, i64, i64, i64, i64, i64, i64, i64, ptr<1>)>
+
+    // CHECK-DAG: %[[LINEAR_OFF2:.*]] = llvm.add {{.*}}, %[[OFFSET2]] : i32
+    // CHECK-DAG: %[[LINEAR_OFF3:.*]] = llvm.add {{.*}}, %[[OFFSET3]] : i32
+
     // CHECK-DAG: %[[SHAPE0_I32:.*]] = llvm.trunc %[[SHAPE0]] : i64 to i32
+    // CHECK-DAG: %[[BOUNDRY_CHECK0:.*]] = llvm.icmp "slt" %[[OFFSET0]], %[[SHAPE0_I32]] : i32
     // CHECK-DAG: %[[SHAPE1_I32:.*]] = llvm.trunc %[[SHAPE1]] : i64 to i32
+    // CHECK-DAG: %[[BOUNDRY_CHECK1:.*]] = llvm.icmp "slt" %[[OFFSET1]], %[[SHAPE1_I32]] : i32
     // CHECK-DAG: %[[SHAPE2_I32:.*]] = llvm.trunc %[[SHAPE2]] : i64 to i32
+    // CHECK-DAG: %[[BOUNDRY_CHECK2:.*]] = llvm.icmp "slt" %[[LINEAR_OFF2]], %[[SHAPE2_I32]] : i32
     // CHECK-DAG: %[[SHAPE3_I32:.*]] = llvm.trunc %[[SHAPE3]] : i64 to i32
-    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
-    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
-    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
-    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
+    // CHECK-DAG: %[[BOUNDRY_CHECK3:.*]] = llvm.icmp "slt" %[[LINEAR_OFF3]], %[[SHAPE3_I32]] : i32
     tt.descriptor_store %desc[%arg1, %arg2, %arg3, %arg4], %arg5 : !tt.tensordesc<1x1x4x4xf32>, tensor<4x4xf32, #blocked>
     tt.return
   }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2123,7 +2123,6 @@ struct DescriptorLoadOpConversion
 
     // Get result type information
     auto resultType = cast<RankedTensorType>(op.getType());
-    size_t resultRank = resultType.getRank();
     Type valueElemTy = typeConverter->convertType(resultType.getElementType());
     unsigned numElems = getTotalElemsPerThread(resultType);
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -254,7 +254,13 @@ struct LoadStoreConversionBase {
       std::optional<PaddingOption> padding = std::nullopt) const {
 
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    size_t rank = tensorType.getRank();
+    assert(offsets.size() == shapes.size() &&
+           offsets.size() == strides.size() &&
+           "invalid length of offsets, shapes and strides");
+    size_t tensorRank = tensorType.getRank();
+    size_t pointerRank = offsets.size();
+    assert(pointerRank >= tensorRank &&
+           "descriptor rank must be >= result/source tensor rank");
     const unsigned numElems = getTotalElemsPerThread(tensorType);
 
     // Get the LLVM values for indices in block
@@ -280,9 +286,13 @@ struct LoadStoreConversionBase {
     SmallVector<Value> maskElems;
     for (unsigned i = 0; i < numElems; ++i) {
       SmallVector<Value> index = indices[i];
-      SmallVector<Value> indicesInTensor(rank);
-      for (unsigned j = 0; j < rank; ++j)
-        indicesInTensor[j] = b.add(index[j], offsets[j]);
+      SmallVector<Value> indicesInTensor(pointerRank);
+      for (unsigned j = 0; j < pointerRank - tensorRank; ++j) {
+        indicesInTensor[j] = offsets[j];
+      }
+      for (unsigned j = 0; j < tensorRank; ++j)
+        indicesInTensor[j + (pointerRank - tensorRank)] =
+            b.add(index[j], offsets[j + (pointerRank - tensorRank)]);
 
       // Get the LLVM values for pointers
       Value offset = linearize(
@@ -359,25 +369,19 @@ struct LoadStoreConversionBase {
 
     DescriptorFields desc =
         unpackDescriptor(descriptorStruct, descriptorRank, loc, rewriter);
-    const size_t rank = tensorType.getRank();
-    assert(descriptorRank >= rank &&
-           "descriptor rank must be >= result/source tensor rank");
-    const size_t rankDelta = descriptorRank - rank;
 
     SmallVector<Value> offsets;
-    offsets.reserve(rank);
-    if (indices.size() == descriptorRank) {
-      for (size_t i = 0; i < rank; ++i)
-        offsets.push_back(indices[i + rankDelta]);
-    } else {
-      assert(indices.size() == rank && "unexpected descriptor indices rank");
-      offsets.append(indices.begin(), indices.end());
-    }
+    offsets.reserve(descriptorRank);
+    assert(indices.size() == descriptorRank &&
+           "unexpected descriptor indices rank");
+    for (size_t i = 0; i < descriptorRank; ++i)
+      offsets.push_back(indices[i]);
 
-    SmallVector<Value> mappedShapes(rank), mappedStrides(rank);
-    for (size_t i = 0; i < rank; ++i) {
-      mappedShapes[i] = desc.shapes[i + rankDelta];
-      mappedStrides[i] = desc.strides[i + rankDelta];
+    SmallVector<Value> mappedShapes(descriptorRank),
+        mappedStrides(descriptorRank);
+    for (size_t i = 0; i < descriptorRank; ++i) {
+      mappedShapes[i] = desc.shapes[i];
+      mappedStrides[i] = desc.strides[i];
     }
 
     return computeGatherScatterOperands(loc, desc.base, offsets, mappedShapes,
@@ -2144,8 +2148,10 @@ struct DescriptorLoadOpConversion
 
     // Boundary check all dimensions — tensor descriptors always encode shape
     // bounds and don't have a user-facing boundaryCheck attribute.
-    SmallVector<int32_t> allDims(resultRank);
-    for (size_t i = 0; i < resultRank; ++i)
+    // auto descType = cast<triton::TensorDescType>(op.getDesc().getType());
+    RankedTensorType tensorType = descType.getBlockType();
+    SmallVector<int32_t> allDims(descRank);
+    for (size_t i = 0; i < descRank; ++i)
       allDims[i] = static_cast<int32_t>(i);
 
     // Reuse the shared gather/scatter operand computation.
@@ -2175,11 +2181,10 @@ struct DescriptorLoadOpConversion
       std::swap(permOffsets[descRank - 2], permOffsets[descRank - 1]);
       SmallVector<Value> mappedShapes(resultRank), mappedStrides(resultRank),
           mappedOffsets(resultRank);
-      const size_t rankDelta = descRank - resultRank;
-      for (size_t i = 0; i < resultRank; ++i) {
-        mappedShapes[i] = permShapes[i + rankDelta];
-        mappedStrides[i] = permStrides[i + rankDelta];
-        mappedOffsets[i] = permOffsets[i + rankDelta];
+      for (size_t i = 0; i < descRank; ++i) {
+        mappedShapes[i] = permShapes[i];
+        mappedStrides[i] = permStrides[i];
+        mappedOffsets[i] = permOffsets[i];
       }
       std::tie(ptrElems, maskElems, otherElems) = computeGatherScatterOperands(
           loc, desc.base, mappedOffsets, mappedShapes, mappedStrides,
@@ -2353,8 +2358,8 @@ struct DescriptorStoreOpConversion
 
     // Boundary check all dimensions — tensor descriptors always encode shape
     // bounds and don't have a user-facing boundaryCheck attribute.
-    SmallVector<int32_t> allDims(valueTy.getRank());
-    for (size_t i = 0; i < valueTy.getRank(); ++i)
+    SmallVector<int32_t> allDims(descRank);
+    for (size_t i = 0; i < descRank; ++i)
       allDims[i] = static_cast<int32_t>(i);
 
     // Reuse the shared gather/scatter operand computation.

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2148,8 +2148,6 @@ struct DescriptorLoadOpConversion
 
     // Boundary check all dimensions — tensor descriptors always encode shape
     // bounds and don't have a user-facing boundaryCheck attribute.
-    // auto descType = cast<triton::TensorDescType>(op.getDesc().getType());
-    RankedTensorType tensorType = descType.getBlockType();
     SmallVector<int32_t> allDims(descRank);
     for (size_t i = 0; i < descRank; ++i)
       allDims[i] = static_cast<int32_t>(i);
@@ -2179,8 +2177,8 @@ struct DescriptorLoadOpConversion
       std::swap(permShapes[descRank - 2], permShapes[descRank - 1]);
       std::swap(permStrides[descRank - 2], permStrides[descRank - 1]);
       std::swap(permOffsets[descRank - 2], permOffsets[descRank - 1]);
-      SmallVector<Value> mappedShapes(resultRank), mappedStrides(resultRank),
-          mappedOffsets(resultRank);
+      SmallVector<Value> mappedShapes(descRank), mappedStrides(descRank),
+          mappedOffsets(descRank);
       for (size_t i = 0; i < descRank; ++i) {
         mappedShapes[i] = permShapes[i];
         mappedStrides[i] = permStrides[i];


### PR DESCRIPTION
This PR fixes tensor-descriptor (TDESC) load/store lowering when the descriptor rank is larger than the result/source tensor rank (rank-reduction), ensuring pointer arithmetic and boundary checks account for the full descriptor rank (including leading singleton dims).

Changes:

1. Update gather/scatter operand computation to support descriptorRank >= tensorRank by aligning tensor indices into the trailing descriptor dimensions.
2. Adjust descriptor unpack/mapping so offsets/shapes/strides are handled at descriptor-rank granularity for correct linearization and masking.
3. Add MLIR + Python unit tests covering 4D-descriptor → 2D-tensor rank reduction for both load and store.