### PR TITLE
[vLLM] Skip patch step under --no-clean to avoid double-apply

### DIFF
--- a/scripts/vllm/install-vllm.sh
+++ b/scripts/vllm/install-vllm.sh
@@ -283,8 +283,10 @@ if [[ "$prepare_source_only" == false ]]; then
 fi
 
 prepare_source "$VLLM_PROJ" "https://github.com/vllm-project/vllm.git" "${vllm_pinned_commit:-}" "$latest"
-git -C "$VLLM_PROJ" apply "$SCRIPTS_DIR/vllm/vllm-fix.patch"
-python "$SCRIPTS_DIR/vllm/vllm_xpu_patch.py" "$VLLM_PROJ"
+if [[ "$clean" == true ]]; then
+  git -C "$VLLM_PROJ" apply "$SCRIPTS_DIR/vllm/vllm-fix.patch"
+  python "$SCRIPTS_DIR/vllm/vllm_xpu_patch.py" "$VLLM_PROJ"
+fi
 
 if [[ "$build_vllm" == false ]]; then
   if ! command -v gh &>/dev/null; then


### PR DESCRIPTION
The `vllm-fix.patch` and `vllm_xpu_patch.py` steps ran unconditionally after `prepare_source`, so reusing an existing tree with `--no-clean` caused git apply to fail because the patches were already applied. Gating both on `clean=true` matches the documented `--no-clean` behavior of leaving the tree as-is.

---

Don't need to check vLLM bencharks/tests since `--no-clean` is not used by workflows and is mainly for debugging/dev work.