### PR TITLE
[OptimizeDotOperands] Fix crash on rank-reducing descriptor loads

### DIFF
--- a/test/TritonIntelGPU/dot-operands.mlir
+++ b/test/TritonIntelGPU/dot-operands.mlir
@@ -82,3 +82,31 @@ module attributes {ttig.support_2d_block_io, "ttg.num-warps" = 8 : i32, "ttg.thr
     tt.return %d : tensor<64x64xf32, #dpas>
   }
 }
+
+// -----
+
+#brow = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#bcol = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+#dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>
+module attributes {ttig.support_2d_block_io, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: tt.func @do_not_fuse_rank_reducing_descriptor_load
+  // CHECK: tt.descriptor_load {{.*}} {ttig.block_io = "row_major"}
+  // CHECK: tt.trans
+  tt.func @do_not_fuse_rank_reducing_descriptor_load(%ptr: !tt.ptr<f16>, %a: tensor<64x32xf16, #dot0>) -> tensor<64x64xf32, #dpas> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i32 = arith.constant 32 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c32_i64 = arith.constant 32 : i64
+    %c = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #dpas>
+    %desc = tt.make_tensor_descriptor %ptr, [%c1_i32, %c64_i32, %c32_i32], [%c32_i64, %c32_i64, %c1_i64] : <f16>, <1x64x32xf16>
+    %ld = tt.descriptor_load %desc[%c0_i32, %c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<1x64x32xf16> -> tensor<64x32xf16, #brow>
+    %tr = tt.trans %ld {order = array<i32: 1, 0>} : tensor<64x32xf16, #brow> -> tensor<32x64xf16, #bcol>
+    %b = ttg.convert_layout %tr : tensor<32x64xf16, #bcol> -> tensor<32x64xf16, #dot1>
+    %d = tt.dot %a, %b, %c, inputPrecision = tf32 : tensor<64x32xf16, #dot0> * tensor<32x64xf16, #dot1> -> tensor<64x64xf32, #dpas>
+    tt.return %d : tensor<64x64xf32, #dpas>
+  }
+}

--- a/test/TritonIntelGPU/dot-operands.mlir
+++ b/test/TritonIntelGPU/dot-operands.mlir
@@ -91,10 +91,11 @@ module attributes {ttig.support_2d_block_io, "ttg.num-warps" = 8 : i32, "ttg.thr
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
 #dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>
 module attributes {ttig.support_2d_block_io, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  // CHECK-LABEL: tt.func @do_not_fuse_rank_reducing_descriptor_load
-  // CHECK: tt.descriptor_load {{.*}} {ttig.block_io = "row_major"}
-  // CHECK: tt.trans
-  tt.func @do_not_fuse_rank_reducing_descriptor_load(%ptr: !tt.ptr<f16>, %a: tensor<64x32xf16, #dot0>) -> tensor<64x64xf32, #dpas> {
+  // CHECK-LABEL: tt.func @fuse_rank_reducing_descriptor_load
+  // CHECK-NOT: tt.trans
+  // CHECK: %[[LD:.*]] = tt.descriptor_load {{.*}} {ttig.block_io = "column_major"} : !tt.tensordesc<1x64x32xf16> -> tensor<32x64xf16, #[[BCOL:[a-z]+]]>
+  // CHECK: ttg.convert_layout %[[LD]] : tensor<32x64xf16, #[[BCOL]]> -> tensor<32x64xf16, {{.*}}>
+  tt.func @fuse_rank_reducing_descriptor_load(%ptr: !tt.ptr<f16>, %a: tensor<64x32xf16, #dot0>) -> tensor<64x64xf32, #dpas> {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
     %c1_i64 = arith.constant 1 : i64

--- a/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
@@ -103,7 +103,14 @@ private:
     if (!descLoadOp || !descLoadOp->hasOneUse())
       return false;
 
-    if (cast<RankedTensorType>(descLoadOp.getType()).getRank() < 2)
+    auto resultRank = cast<RankedTensorType>(descLoadOp.getType()).getRank();
+    if (resultRank < 2)
+      return false;
+
+    // Reject rank-reducing descriptor loads where the descriptor block type
+    // rank differs from the result rank (the fuse logic assumes they match).
+    auto descType = cast<tt::TensorDescType>(descLoadOp.getDesc().getType());
+    if (descType.getBlockType().getRank() != resultRank)
       return false;
 
     // Validate that the transpose only swaps the innermost 2 dimensions

--- a/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
@@ -107,12 +107,6 @@ private:
     if (resultRank < 2)
       return false;
 
-    // Reject rank-reducing descriptor loads where the descriptor block type
-    // rank differs from the result rank (the fuse logic assumes they match).
-    auto descType = cast<tt::TensorDescType>(descLoadOp.getDesc().getType());
-    if (descType.getBlockType().getRank() != resultRank)
-      return false;
-
     // Validate that the transpose only swaps the innermost 2 dimensions
     // (identity on outer dims). block_io = "column_major" in the lowering
     // only handles this inner-2-dim swap.
@@ -155,9 +149,10 @@ private:
 
     // Keep the original descriptor — do NOT reverse it.
     // The descriptor is always row-major (stride-1 on last dim).
-    auto descType = cast<tt::TensorDescType>(descLoadOp.getDesc().getType());
-    RankedTensorType blockType = descType.getBlockType();
-    ArrayRef<int64_t> origShape = blockType.getShape();
+    // Use the result type shape (not the descriptor block type shape) to handle
+    // rank-reducing descriptor loads where block type rank > result rank.
+    auto resultType = cast<RankedTensorType>(descLoadOp.getType());
+    ArrayRef<int64_t> origShape = resultType.getShape();
     ArrayRef<int> perm = transOp.getOrder();
     SmallVector<int64_t> transposedShape(origShape.size());
     for (unsigned i = 0; i < origShape.size(); ++i)


### PR DESCRIPTION
Fix the FuseTransWithDescriptorLoad optimization to correctly handle rank-reducing descriptor loads (e.g., !tt.tensordesc<1x64x32xf16> -> tensor<64x32xf16>).

Previously, fuse() derived the original shape from the descriptor's block type, which has a different rank than the result in rank-reducing cases. This caused out-of-bounds access on the transpose order array.

The fix uses the descriptor load's result type shape instead, which already accounts for rank reduction. This means rank-reducing loads are now correctly fused (transpose eliminated, block_io set to column_major) rather than crashing.