### PR TITLE
[CI] Fix wheel installation in "Test with pip" workflow

### DIFF
--- a/.github/actions/install-wheels/action.yml
+++ b/.github/actions/install-wheels/action.yml
@@ -56,7 +56,7 @@ runs:
         mkdir -p ~/wheels
         gh run download ${{ steps.run_id.outputs.run_id }} \
           --repo ${{ inputs.repository }} \
-          --pattern "*-py${{ inputs.python_version }}*" \
+          --pattern "*${{ inputs.wheels_pattern }}py${{ inputs.python_version }}*" \
           --dir ~/wheels
 
     - name: Install wheels
@@ -65,4 +65,4 @@ runs:
         set -x
         shopt -s extglob
         cd ~/wheels/*-py${{ inputs.python_version }}*
-        ${{ inputs.install_cmd }} ${{ inputs.wheels_pattern }}
+        ${{ inputs.install_cmd }} ${{ inputs.wheels_pattern }}.whl

--- a/.github/workflows/pip-test.yml
+++ b/.github/workflows/pip-test.yml
@@ -50,7 +50,7 @@ jobs:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           python_version: ${{ env.PYTHON_VERSION }}
           # transformers package is required for the inductor (e2e) test
-          wheels_pattern: 'torch-*.whl'
+          wheels_pattern: 'torch*'
 
       - name: Install Triton
         uses: ./.github/actions/setup-triton


### PR DESCRIPTION
Broken due to new vllm wheels folder: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27011953641/job/79717462837#step:4:84

CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27018520593 (installation works)