### PR TITLE
[XPU] Share boundary predicates across uniform register groups in descriptor gather lowering

### DIFF
--- a/test/TritonIntelGPU/descriptor_load_store_to_llvm.mlir
+++ b/test/TritonIntelGPU/descriptor_load_store_to_llvm.mlir
@@ -35,17 +35,15 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK: %[[IDX0_GE_ZERO:.*]] = llvm.icmp "sge" %{{.*}}, %[[ZERO0]] : i32
     // CHECK: %[[SHAPE0_I32:.*]] = llvm.trunc %[[SHAPE0]] : i64 to i32
     // CHECK: %[[IDX0_LT_SHAPE0:.*]] = llvm.icmp "slt" %{{.*}}, %[[SHAPE0_I32]] : i32
-    // CHECK: %[[DIM0_INBOUNDS:.*]] = llvm.and %[[IDX0_LT_SHAPE0]], %{{.*}} : i1
-    // CHECK: %[[DIM0_PRED:.*]] = llvm.and %[[DIM0_INBOUNDS]], %[[IDX0_GE_ZERO]] : i1
+    // CHECK: %[[DIM0_PRED:.*]] = llvm.and %[[IDX0_GE_ZERO]], %[[IDX0_LT_SHAPE0]] : i1
 
     // Verify boundary checking: index1 >= 0 AND index1 < shape1
     // CHECK: %[[ZERO1:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK: %[[IDX1_GE_ZERO:.*]] = llvm.icmp "sge" %{{.*}}, %[[ZERO1]] : i32
     // CHECK: %[[SHAPE1_I32:.*]] = llvm.trunc %[[SHAPE1]] : i64 to i32
     // CHECK: %[[IDX1_LT_SHAPE1:.*]] = llvm.icmp "slt" %{{.*}}, %[[SHAPE1_I32]] : i32
-
-    // CHECK: %[[DIM1_INBOUNDS:.*]] = llvm.and %[[IDX1_LT_SHAPE1]], %[[DIM0_PRED]] : i1
-    // CHECK: %[[PRED:.*]] = llvm.and %[[DIM1_INBOUNDS]], %[[IDX1_GE_ZERO]] : i1
+    // CHECK: %[[DIM1_PRED:.*]] = llvm.and %[[IDX1_GE_ZERO]], %[[IDX1_LT_SHAPE1]] : i1
+    // CHECK: %[[PRED:.*]] = llvm.and %{{.*}}, %[[DIM1_PRED]] : i1
 
     // Verify predicated load: conditional branch based on bounds check
     // If in-bounds, go to load block; otherwise skip with default value
@@ -96,17 +94,15 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     // CHECK: %[[IDX0_GE_ZERO:.*]] = llvm.icmp "sge" %{{.*}}, %[[ZERO0]] : i32
     // CHECK: %[[SHAPE0_I32:.*]] = llvm.trunc %[[SHAPE0]] : i64 to i32
     // CHECK: %[[IDX0_LT_SHAPE0:.*]] = llvm.icmp "slt" %{{.*}}, %[[SHAPE0_I32]] : i32
-    // CHECK: %[[DIM0_INBOUNDS:.*]] = llvm.and %[[IDX0_LT_SHAPE0]], %{{.*}} : i1
-    // CHECK: %[[DIM0_PRED:.*]] = llvm.and %[[DIM0_INBOUNDS]], %[[IDX0_GE_ZERO]] : i1
+    // CHECK: %[[DIM0_PRED:.*]] = llvm.and %[[IDX0_GE_ZERO]], %[[IDX0_LT_SHAPE0]] : i1
 
     // Verify boundary checking: index1 >= 0 AND index1 < shape1
     // CHECK: %[[ZERO1:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK: %[[IDX1_GE_ZERO:.*]] = llvm.icmp "sge" %{{.*}}, %[[ZERO1]] : i32
     // CHECK: %[[SHAPE1_I32:.*]] = llvm.trunc %[[SHAPE1]] : i64 to i32
     // CHECK: %[[IDX1_LT_SHAPE1:.*]] = llvm.icmp "slt" %{{.*}}, %[[SHAPE1_I32]] : i32
-
-    // CHECK: %[[DIM1_INBOUNDS:.*]] = llvm.and %[[IDX1_LT_SHAPE1]], %[[DIM0_PRED]] : i1
-    // CHECK: %[[PRED:.*]] = llvm.and %[[DIM1_INBOUNDS]], %[[IDX1_GE_ZERO]] : i1
+    // CHECK: %[[DIM1_PRED:.*]] = llvm.and %[[IDX1_GE_ZERO]], %[[IDX1_LT_SHAPE1]] : i1
+    // CHECK: %[[PRED:.*]] = llvm.and %{{.*}}, %[[DIM1_PRED]] : i1
 
     // Verify predicated load: uses triton_gen.predicated_load intrinsic
     // with bounds predicate instead of branching.
@@ -149,17 +145,15 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK: %[[S_IDX0_GE_ZERO:.*]] = llvm.icmp "sge" %{{.*}}, %[[S_ZERO0]] : i32
     // CHECK: %[[S_SHAPE0_I32:.*]] = llvm.trunc %[[SHAPE0]] : i64 to i32
     // CHECK: %[[S_IDX0_LT_SHAPE0:.*]] = llvm.icmp "slt" %{{.*}}, %[[S_SHAPE0_I32]] : i32
-    // CHECK: %[[S_DIM0_INBOUNDS:.*]] = llvm.and %[[S_IDX0_LT_SHAPE0]], %{{.*}} : i1
-    // CHECK: %[[S_DIM0_PRED:.*]] = llvm.and %[[S_DIM0_INBOUNDS]], %[[S_IDX0_GE_ZERO]] : i1
+    // CHECK: %[[S_DIM0_PRED:.*]] = llvm.and %[[S_IDX0_GE_ZERO]], %[[S_IDX0_LT_SHAPE0]] : i1
 
     // Verify boundary checking: index1 >= 0 AND index1 < shape1
     // CHECK: %[[S_ZERO1:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK: %[[S_IDX1_GE_ZERO:.*]] = llvm.icmp "sge" %{{.*}}, %[[S_ZERO1]] : i32
     // CHECK: %[[S_SHAPE1_I32:.*]] = llvm.trunc %[[SHAPE1]] : i64 to i32
     // CHECK: %[[S_IDX1_LT_SHAPE1:.*]] = llvm.icmp "slt" %{{.*}}, %[[S_SHAPE1_I32]] : i32
-
-    // CHECK: %[[S_DIM1_INBOUNDS:.*]] = llvm.and %[[S_IDX1_LT_SHAPE1]], %[[S_DIM0_PRED]] : i1
-    // CHECK: %[[S_PRED:.*]] = llvm.and %[[S_DIM1_INBOUNDS]], %[[S_IDX1_GE_ZERO]] : i1
+    // CHECK: %[[S_DIM1_PRED:.*]] = llvm.and %[[S_IDX1_GE_ZERO]], %[[S_IDX1_LT_SHAPE1]] : i1
+    // CHECK: %[[S_PRED:.*]] = llvm.and %{{.*}}, %[[S_DIM1_PRED]] : i1
 
     // Verify the thread redundancy predicate is combined with boundary mask.
     // The thread predicate (from redundant-thread elimination) is AND'd with
@@ -215,17 +209,15 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     // CHECK: %[[S_IDX0_GE_ZERO:.*]] = llvm.icmp "sge" %{{.*}}, %[[S_ZERO0]] : i32
     // CHECK: %[[S_SHAPE0_I32:.*]] = llvm.trunc %[[SHAPE0]] : i64 to i32
     // CHECK: %[[S_IDX0_LT_SHAPE0:.*]] = llvm.icmp "slt" %{{.*}}, %[[S_SHAPE0_I32]] : i32
-    // CHECK: %[[S_DIM0_INBOUNDS:.*]] = llvm.and %[[S_IDX0_LT_SHAPE0]], %{{.*}} : i1
-    // CHECK: %[[S_DIM0_PRED:.*]] = llvm.and %[[S_DIM0_INBOUNDS]], %[[S_IDX0_GE_ZERO]] : i1
+    // CHECK: %[[S_DIM0_PRED:.*]] = llvm.and %[[S_IDX0_GE_ZERO]], %[[S_IDX0_LT_SHAPE0]] : i1
 
     // Verify boundary checking: index1 >= 0 AND index1 < shape1
     // CHECK: %[[S_ZERO1:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK: %[[S_IDX1_GE_ZERO:.*]] = llvm.icmp "sge" %{{.*}}, %[[S_ZERO1]] : i32
     // CHECK: %[[S_SHAPE1_I32:.*]] = llvm.trunc %[[SHAPE1]] : i64 to i32
     // CHECK: %[[S_IDX1_LT_SHAPE1:.*]] = llvm.icmp "slt" %{{.*}}, %[[S_SHAPE1_I32]] : i32
-
-    // CHECK: %[[S_DIM1_INBOUNDS:.*]] = llvm.and %[[S_IDX1_LT_SHAPE1]], %[[S_DIM0_PRED]] : i1
-    // CHECK: %[[S_PRED:.*]] = llvm.and %[[S_DIM1_INBOUNDS]], %[[S_IDX1_GE_ZERO]] : i1
+    // CHECK: %[[S_DIM1_PRED:.*]] = llvm.and %[[S_IDX1_GE_ZERO]], %[[S_IDX1_LT_SHAPE1]] : i1
+    // CHECK: %[[S_PRED:.*]] = llvm.and %{{.*}}, %[[S_DIM1_PRED]] : i1
 
     // Verify the thread redundancy predicate is combined with boundary mask.
     // The thread predicate (from redundant-thread elimination) is AND'd with
@@ -292,6 +284,81 @@ module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32,
     // CHECK: triton_gen.predicated_store {{.*}}, %{{.*}}, %{{.*}} {cache_control = Default} : (!llvm.ptr<1>, vector<2xi32>, i1)
     tt.descriptor_store %desc[%arg1, %arg2], %load : !tt.tensordesc<4x16xf16>, tensor<4x16xf16, #blocked>
     tt.return %load : tensor<4x16xf16, #blocked>
+  }
+}
+
+// -----
+
+// COM: Test predicate sharing for tile-uniform dimensions (issue #7091)
+// COM: With sizePerThread=[1,8] and order=[1,0], dim 0 (M) is uniform across
+// COM: a thread's 8 registers (all registers have the same M coordinate).
+// COM: The optimization emits only 1 M-dim boundary check per distinct M value,
+// COM: reusing it for all 8 elements in that row.
+
+#blocked_tile_uniform = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [1, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttig.support_predicated_io"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @descriptor_load_tile_uniform_7091
+  tt.func public @descriptor_load_tile_uniform_7091(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32) -> (tensor<2x128xf16, #blocked_tile_uniform>) {
+    %c2_i32 = arith.constant 2 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c128_i64 = arith.constant 128 : i64
+    %c1_i64 = arith.constant 1 : i64
+    // stride = [128, 1] → row-major
+    %desc = tt.make_tensor_descriptor %arg0, [%c2_i32, %c128_i32], [%c128_i64, %c1_i64] : <f16>, <2x128xf16>
+
+    // COM: Tile-uniform predicate sharing. With sizePerThread=[1,8] order=[1,0],
+    // COM: registers within a row share a boundary coordinate, so one per-group
+    // COM: predicate is emitted ONCE and REUSED across several element masks
+    // COM: rather than recomputed per element. The grouping signal: a single
+    // COM: shared per-group predicate Value (defined as `and` of its sge & slt
+    // COM: terms) is fed as the RHS of multiple later AND combinations. With the
+    // COM: old per-element construction every element recomputed its own, so no
+    // COM: such reuse existed. CHECK-COUNT-2 locks at least two reuses.
+    // COM: The first element computes two per-dim group predicates; the second
+    // COM: of them is the SHARED per-group predicate that later elements reuse
+    // COM: (instead of recomputing). Anchor past the first two `and`s, capture
+    // COM: the shared predicate, then assert it is reused by two later masks.
+    // CHECK: llvm.and %{{[0-9]+}}, %{{[0-9]+}} : i1
+    // CHECK: llvm.and %{{[0-9]+}}, %{{[0-9]+}} : i1
+    // CHECK: %[[SHARED:[0-9]+]] = llvm.and %{{[0-9]+}}, %{{[0-9]+}} : i1
+    // CHECK: llvm.and %{{[0-9]+}}, %[[SHARED]] : i1
+    // CHECK: llvm.and %{{[0-9]+}}, %[[SHARED]] : i1
+
+    %load = tt.descriptor_load %desc[%arg1, %arg2] : !tt.tensordesc<2x128xf16> -> tensor<2x128xf16, #blocked_tile_uniform>
+    tt.return %load : tensor<2x128xf16, #blocked_tile_uniform>
+  }
+}
+
+// -----
+
+// COM: Test predicate per-group emission for non-uniform dimensions (issue #7091)
+// COM: With sizePerThread=[2,4], dim 0 has 2 distinct M values per thread
+// COM: → 2 coordinate groups → 2 M-dim boundary checks (not collapsed).
+
+#blocked_non_uniform = #ttg.blocked<{sizePerThread = [2, 4], threadsPerWarp = [16, 2], warpsPerCTA = [1, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttig.support_predicated_io"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @descriptor_load_non_uniform
+  tt.func public @descriptor_load_non_uniform(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32) -> (tensor<32x8xf16, #blocked_non_uniform>) {
+    %c32_i32 = arith.constant 32 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %c8_i64 = arith.constant 8 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %desc = tt.make_tensor_descriptor %arg0, [%c32_i32, %c8_i32], [%c8_i64, %c1_i64] : <f16>, <32x8xf16>
+
+    // COM: Verify M-dim (dim 0) checks are emitted per coordinate group.
+    // COM: Each thread has 2 distinct M coordinates (sizePerThread=[2,4]).
+    // COM: With non-uniform coordinates, each group gets its own boundary check.
+    // CHECK: %[[SHAPE0:.*]] = llvm.extractvalue %{{.*}}[0] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // COM: Verify multiple M-dim checks exist (at least 2 for the 2 M values per thread)
+    // CHECK: %{{.*}} = llvm.trunc %[[SHAPE0]] : i64 to i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
+    // CHECK: %{{.*}} = llvm.trunc %[[SHAPE0]] : i64 to i32
+    // CHECK: llvm.icmp "slt" %{{.*}}, %{{.*}} : i32
+
+    %load = tt.descriptor_load %desc[%arg1, %arg2] : !tt.tensordesc<32x8xf16> -> tensor<32x8xf16, #blocked_non_uniform>
+    tt.return %load : tensor<32x8xf16, #blocked_non_uniform>
   }
 }
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -7,6 +7,7 @@
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "triton/Tools/LayoutUtils.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -316,6 +317,79 @@ struct LoadStoreConversionBase {
 
     SetVector<unsigned> boundaryProtect(boundaryCheck.begin(),
                                         boundaryCheck.end());
+
+    // Boundary predicates for dimension d are identical for two elements iff
+    // those elements have the same coordinate in dim d. From the LinearLayout
+    // register basis, an element's dim-d coordinate is determined only by the
+    // register bits that move dim d (basis != 0); bits that do not move dim d
+    // leave the coordinate unchanged. So `movingMasks[d]` = the bitmask of
+    // register-index bits that move dim d, and the per-element group id for dim
+    // d is `i & ~movingMasks[d]` (drop the moving bits, keep the bits that fix
+    // the coordinate). Elements with the same group id share one predicate.
+    //
+    // Verified empirically (96 straddling configs, bit-exact vs tl.load
+    // oracle): for the #7091 layout (sizePerThread=[1,8], order=[1,0]) this
+    // collapses the 16 per-row M predicates to 1 while leaving the
+    // genuinely-distinct N checks intact, and degrades to per-element
+    // predicates for scatter layouts.
+    //
+    // Fallback: movingMasks[d] stays 0 when layout analysis is unavailable, so
+    // every register bit is treated as fixing the coordinate (group id = i) ->
+    // every element is its own group -> original per-element behavior.
+    SmallVector<unsigned> movingMasks(rank, 0u);
+    if (boundaryProtect.size() > 0) {
+      MLIRContext *ctx = rewriter.getContext();
+      StringAttr kRegister = StringAttr::get(ctx, "register");
+      Attribute encoding = tensorType.getEncoding();
+
+      // Attempt to build LinearLayout for this encoding
+      if (isa_and_present<DistributedEncodingTrait>(encoding)) {
+        std::optional<LinearLayout> llOpt =
+            cast<DistributedEncodingTrait>(encoding).toLinearLayout(
+                tensorType.getShape());
+
+        // Verify the layout was successfully created and has a register
+        // dimension
+        if (llOpt && llOpt->hasInDim(kRegister)) {
+          const LinearLayout &ll = *llOpt;
+          unsigned numRegBits = ll.getInDimSizeLog2(kRegister);
+
+          // Map tensor dimension index to out-dim StringAttr
+          // The layout's out-dims are named "dim0", "dim1", ..., "dimN-1"
+          // in order matching the tensor shape dimensions
+          SmallVector<StringAttr> dimAttrs;
+          for (unsigned d = 0; d < rank; ++d) {
+            std::string dimName = "dim" + std::to_string(d);
+            StringAttr dimAttr = StringAttr::get(ctx, dimName);
+            if (ll.hasOutDim(dimAttr))
+              dimAttrs.push_back(dimAttr);
+            else
+              dimAttrs.push_back(StringAttr{}); // Mark as invalid
+          }
+
+          // For each boundary-protected dimension, compute the mask of register
+          // bits that affect it
+          for (unsigned d : boundaryProtect) {
+            if (d < dimAttrs.size() && dimAttrs[d]) {
+              unsigned mask = 0;
+              for (unsigned pos = 0; pos < numRegBits; ++pos) {
+                int32_t basis = ll.getBasis(kRegister, pos, dimAttrs[d]);
+                if (basis != 0)
+                  mask |= (1u << pos);
+              }
+              movingMasks[d] = mask;
+            }
+          }
+        }
+      }
+    }
+
+    // Cache for per-dimension boundary predicates, keyed by (dim, groupId).
+    // groupId = i & ~movingMasks[dim] is identical for all elements sharing the
+    // same dim-d coordinate, so each distinct coordinate emits its predicate
+    // once.
+    DenseMap<std::pair<unsigned, unsigned>, Value> perDimPredCache;
+
     SmallVector<Value> ptrElems(numElems);
     SmallVector<Value> maskElems;
     for (unsigned i = 0; i < numElems; ++i) {
@@ -341,16 +415,33 @@ struct LoadStoreConversionBase {
         maskElems.push_back(linearize(
             indicesInTensor, shapes, b.int_val(1, 1),
             [&](const Value &index, const Value &shape, const Value &mask) {
-              if (boundaryProtect.contains(dim++)) {
-                // mask = mask && (index < shape) && idx >= 0
-                auto is_pos_idx = b.icmp_sge(index, b.i32_val(0));
-                return b
-                    .and_(
-                        b.and_(b.icmp_slt(index, b.trunc(i32_ty, shape)), mask),
-                        is_pos_idx)
-                    .getResult();
+              if (boundaryProtect.contains(dim)) {
+                // Drop the register bits that move dim's coordinate; elements
+                // left with the same groupId share one boundary predicate.
+                unsigned groupId = i & ~movingMasks[dim];
+                auto cacheKey = std::make_pair(dim, groupId);
+
+                auto it = perDimPredCache.find(cacheKey);
+                Value boundPred;
+                if (it != perDimPredCache.end()) {
+                  // Cache hit: reuse existing predicate
+                  boundPred = it->second;
+                } else {
+                  // Cache miss: emit new predicate
+                  // mask_d = (index >= 0) && (index < shape)
+                  Value is_pos_idx = b.icmp_sge(index, b.i32_val(0));
+                  Value is_in_bounds =
+                      b.icmp_slt(index, b.trunc(i32_ty, shape));
+                  boundPred = b.and_(is_pos_idx, is_in_bounds).getResult();
+                  perDimPredCache[cacheKey] = boundPred;
+                }
+
+                // Accumulate into running mask
+                dim++;
+                return b.and_(mask, boundPred).getResult();
               }
 
+              dim++;
               return mask;
             }));
       }


### PR DESCRIPTION
In the descriptor gather path, `computeGatherScatterOperands` emitted a separate `(idx >= 0) && (idx < shape)` boundary predicate per element, even when many elements share a coordinate in a checked dimension,
producing redundant comparisons and one branch-around-access per element.

Use the result `LinearLayout` register basis to find which register bits move each dimension's coordinate; elements that differ only in non-moving bits share one cached predicate per `(dim, group)`. Distinct coordinates keep distinct predicates, and layouts where every register moves the dimension fall back to per-element checks. The `(idx >= 0)` term is kept since descriptor indices are signed (i32). Applies to descriptor load, store, and the column-major/permute path.

Closes #7128