### PR TITLE
[TritonIntelGPU] Anchor transpose convert feeding descriptor store

### DIFF
--- a/test/TritonIntelGPU/RemoveLayoutConversions/tensor_descriptor.mlir
+++ b/test/TritonIntelGPU/RemoveLayoutConversions/tensor_descriptor.mlir
@@ -82,3 +82,50 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32,
     tt.return
   }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+// COM: ============================================================
+// COM: Test 4: Descriptor store PRESERVES an order-changing (transpose)
+// COM: convert_layout. Coalesce inserts a [0,1] -> [1,0] convert so the
+// COM: store is row-major / coalesced; RLC must NOT fold it away (doing
+// COM: so demotes the store to a scalar scatter). GitHub issue #7093.
+// COM: ============================================================
+
+// CHECK-LABEL: @descriptor_store_transpose_convert_preserved
+// CHECK: %[[CVT:.*]] = ttg.convert_layout {{.*}} -> tensor<16x64xf16, #blocked1>
+// CHECK: tt.descriptor_store {{.*}}, %[[CVT]] : !tt.tensordesc<16x64xf16>, tensor<16x64xf16, #blocked1>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  tt.func @descriptor_store_transpose_convert_preserved(%desc: !tt.tensordesc<16x64xf16>, %src: tensor<16x64xf16, #blocked>) {
+    %c0 = arith.constant 0 : i32
+    %cvt = ttg.convert_layout %src : tensor<16x64xf16, #blocked> -> tensor<16x64xf16, #blocked1>
+    tt.descriptor_store %desc[%c0, %c0], %cvt : !tt.tensordesc<16x64xf16>, tensor<16x64xf16, #blocked1>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+// COM: ============================================================
+// COM: Test 5: Descriptor store still FOLDS a same-order convert_layout
+// COM: ([1,0] -> [1,0]). Such a convert is only a re-tiling, not a
+// COM: transpose, so it must not be anchored (cf. issue #4866).
+// COM: ============================================================
+
+// CHECK-LABEL: @descriptor_store_same_order_convert_folded
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.descriptor_store {{.*}}, %arg1 : !tt.tensordesc<16x64xf16>, tensor<16x64xf16, #blocked>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  tt.func @descriptor_store_same_order_convert_folded(%desc: !tt.tensordesc<16x64xf16>, %src: tensor<16x64xf16, #blocked>) {
+    %c0 = arith.constant 0 : i32
+    %cvt = ttg.convert_layout %src : tensor<16x64xf16, #blocked> -> tensor<16x64xf16, #blocked1>
+    tt.descriptor_store %desc[%c0, %c0], %cvt : !tt.tensordesc<16x64xf16>, tensor<16x64xf16, #blocked1>
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/RemoveLayoutConversions/tensor_descriptor.mlir
+++ b/test/TritonIntelGPU/RemoveLayoutConversions/tensor_descriptor.mlir
@@ -129,3 +129,30 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32,
     tt.return
   }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+// COM: ============================================================
+// COM: Test 6: Descriptor store PRESERVES a SAME-order convert whose
+// COM: lane distribution is transposed (threadsPerWarp [16,1] -> [1,16],
+// COM: both order = [1,0]). The `order` attribute is identical on both
+// COM: sides, so an order-based check would wrongly fold; the lane-fast
+// COM: dim differs (0 -> 1), so the convert is a genuine within-subgroup
+// COM: transpose that must be anchored (else the row-major store demotes
+// COM: to a scalar scatter). GitHub issue #7093 (same-order gap).
+// COM: ============================================================
+
+// CHECK-LABEL: @descriptor_store_same_order_lane_transpose_preserved
+// CHECK: %[[CVT:.*]] = ttg.convert_layout {{.*}} -> tensor<16x64xf16, #blocked1>
+// CHECK: tt.descriptor_store {{.*}}, %[[CVT]] : !tt.tensordesc<16x64xf16>, tensor<16x64xf16, #blocked1>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  tt.func @descriptor_store_same_order_lane_transpose_preserved(%desc: !tt.tensordesc<16x64xf16>, %src: tensor<16x64xf16, #blocked>) {
+    %c0 = arith.constant 0 : i32
+    %cvt = ttg.convert_layout %src : tensor<16x64xf16, #blocked> -> tensor<16x64xf16, #blocked1>
+    tt.descriptor_store %desc[%c0, %c0], %cvt : !tt.tensordesc<16x64xf16>, tensor<16x64xf16, #blocked1>
+    tt.return
+  }
+}

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
@@ -57,6 +57,16 @@ extern template BlockIOTileSizeInfo
 getBlockIOTileSize<false>(const LinearLayout &, unsigned, unsigned, AxisInfo *,
                           bool);
 
+/// Return the tensor dimension along which consecutive lanes (the fastest-
+/// varying lane bit) advance in `ll` -- the dimension the hardware vectorizes
+/// for 2D block I/O. This is the dimension getBlockIOTileSize uses to decide
+/// block-I/O vs. scatter (block I/O requires it to equal the memory-contiguous
+/// dimension). Returns std::nullopt when the first lane basis vector is not a
+/// clean single-dimension stride, in which case the layout is not a 2D block
+/// I/O candidate.
+std::optional<unsigned> getLaneFastChangeDim(const LinearLayout &ll,
+                                             MLIRContext *ctx);
+
 /// Get the DPAS operand index from a tensor type's encoding.
 /// The encoding must be DPAS or DotOperand-with-DPAS parent.
 DpasEncodingAttr::OpIdx getOpIdx(RankedTensorType tensorTy);

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -14,6 +14,21 @@ template <typename T> static T product(const std::vector<T> &vec) {
                          std::multiplies<T>());
 }
 
+std::optional<unsigned> getLaneFastChangeDim(const LinearLayout &ll,
+                                             MLIRContext *ctx) {
+  auto kLane = StringAttr::get(ctx, "lane");
+  if (!ll.hasInDim(kLane))
+    return std::nullopt;
+  // First lane basis vector (fastest-varying lane bit). Mirrors the gate in
+  // getBlockIOTileSize<false>: the lane base must move along exactly one tensor
+  // dimension, else the layout is not a clean 2D block-I/O tile.
+  ArrayRef<int32_t> laneBase0 = ll.getBasis(kLane, /*pos=*/0);
+  if (llvm::count_if(laneBase0, [](int32_t x) { return x > 0; }) != 1)
+    return std::nullopt;
+  auto it = llvm::find_if(laneBase0, [](int32_t x) { return x > 0; });
+  return static_cast<unsigned>(std::distance(laneBase0.begin(), it));
+}
+
 // Return the tileHeight, tileWidth, numElemPerPackedVal, vBlocks, row Dim and
 // column Dim.
 template <bool isLoad>

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -355,15 +355,13 @@ bool isLayoutAnchor(Operation *op) {
   //
   // The descriptor-store fast path emits a 2D block write iff consecutive lanes
   // of the store operand's layout advance along the memory-contiguous tensor
-  // dimension (exactly the gate in getBlockIOTileSize<false>:
-  // transpose := laneFastDim != memContiguousDim). Coalesce inserts this
-  // convert to give the store its coalesced (row-major) layout, so dst is
-  // block-write-eligible by construction. Forward propagation from an
-  // (expensive) load would otherwise strip the convert and replace the store
-  // operand with the chain's root layout; if root distributes lanes along a
-  // different dimension than dst, that fold turns the block write into a
-  // scatter (issue #7093). Unlike a store (no result, cannot be anchored), the
-  // convert has a result and can.
+  // dimension. Coalesce inserts this convert to give the store its coalesced
+  // (row-major) layout, so dst is block-write-eligible by construction. Forward
+  // propagation from an (expensive) load would otherwise strip the convert and
+  // replace the store operand with the chain's root layout; if root distributes
+  // lanes along a different dimension than dst, that fold turns the block write
+  // into a scatter (issue #7093). Unlike a store (no result, cannot be
+  // anchored), the convert has a result and can.
   //
   // The lane-fast-dim is compared across the whole convert chain (root source
   // -> store-feeding convert), not on a single convert: the store-feeding

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -18,11 +18,13 @@
 #include "mlir/Transforms/RegionUtils.h"
 
 #include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h"
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h"
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/Utility.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonGPU/Transforms/TritonGPUConversion.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Tools/Sys/GetEnv.h"
@@ -348,19 +350,29 @@ bool isLayoutAnchor(Operation *op) {
   if (auto reshape = dyn_cast<tt::ReshapeOp>(op))
     return reshape.getAllowReorder();
 
-  // Anchor a convert_layout that feeds a descriptor store when the chain of
-  // converts behind it performs a net order change (a transpose).  Coalesce
-  // inserts such a chain to give the store its coalesced (row-major) layout;
-  // without anchoring it, forward propagation from an (expensive) load strips
-  // the chain and demotes the store to a scalar scatter.  Unlike a store (which
-  // has no result and so cannot be anchored), the convert has a result and can.
+  // Anchor a convert_layout that feeds a descriptor store when folding it would
+  // demote the store from a 2D block write to a scalar scatter.
   //
-  // The order change is checked across the whole convert chain (root source ->
-  // store-feeding convert), not on a single convert: the store-feeding convert
-  // is frequently a same-order re-tiling whose transpose lives one convert
-  // upstream.  Gating on the net change keeps a genuine transpose (issue #7093)
-  // while still folding a chain that ends at the same order it started (e.g. a
-  // dot result re-tiled for the store, issue #4866).
+  // The descriptor-store fast path emits a 2D block write iff consecutive lanes
+  // of the store operand's layout advance along the memory-contiguous tensor
+  // dimension (exactly the gate in getBlockIOTileSize<false>:
+  // transpose := laneFastDim != memContiguousDim). Coalesce inserts this
+  // convert to give the store its coalesced (row-major) layout, so dst is
+  // block-write-eligible by construction. Forward propagation from an
+  // (expensive) load would otherwise strip the convert and replace the store
+  // operand with the chain's root layout; if root distributes lanes along a
+  // different dimension than dst, that fold turns the block write into a
+  // scatter (issue #7093). Unlike a store (no result, cannot be anchored), the
+  // convert has a result and can.
+  //
+  // The lane-fast-dim is compared across the whole convert chain (root source
+  // -> store-feeding convert), not on a single convert: the store-feeding
+  // convert is frequently a same-order re-tiling whose lane transpose lives one
+  // convert upstream. Comparing lane-fast-dims (not the `order` attribute)
+  // distinguishes a genuine within-subgroup transpose -- which can keep the
+  // SAME `order` while flipping the lane distribution (#7093) -- from a pure
+  // re-tiling that ends with the same lane-fast-dim it started (e.g. a dot
+  // result re-tiled for the store, issue #4866), which still folds.
   if (auto convertOp = dyn_cast<ttg::ConvertLayoutOp>(op)) {
     bool feedsDescStore =
         llvm::any_of(convertOp.getResult().getUsers(), [](Operation *user) {
@@ -374,12 +386,21 @@ bool isLayoutAnchor(Operation *op) {
       auto rootTy = dyn_cast<RankedTensorType>(root.getType());
       auto dstTy = dyn_cast<RankedTensorType>(convertOp.getType());
       if (rootTy && dstTy) {
-        auto rootBlocked =
-            dyn_cast<ttg::BlockedEncodingAttr>(rootTy.getEncoding());
-        auto dstBlocked =
-            dyn_cast<ttg::BlockedEncodingAttr>(dstTy.getEncoding());
-        if (rootBlocked && dstBlocked)
-          return rootBlocked.getOrder() != dstBlocked.getOrder();
+        // The descriptor-store fast path is a 2D block write iff consecutive
+        // lanes advance along the memory-contiguous tensor dim. Folding this
+        // convert replaces the store operand's layout (dst) with root's; if the
+        // two layouts distribute lanes along different dims, that fold turns a
+        // block write into a scalar scatter. Anchor to prevent it.
+        MLIRContext *ctx = op->getContext();
+        std::optional<unsigned> rootLaneDim =
+            ttgi::getLaneFastChangeDim(ttg::toLinearLayout(rootTy), ctx);
+        std::optional<unsigned> dstLaneDim =
+            ttgi::getLaneFastChangeDim(ttg::toLinearLayout(dstTy), ctx);
+        // Conservative fallback: if either lane base is not a clean single-dim
+        // stride, the store can't be a 2D block write anyway -> nothing to
+        // protect -> don't anchor (fold by default, as before).
+        if (rootLaneDim && dstLaneDim)
+          return *rootLaneDim != *dstLaneDim;
       }
     }
   }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -348,6 +348,42 @@ bool isLayoutAnchor(Operation *op) {
   if (auto reshape = dyn_cast<tt::ReshapeOp>(op))
     return reshape.getAllowReorder();
 
+  // Anchor a convert_layout that feeds a descriptor store when the chain of
+  // converts behind it performs a net order change (a transpose).  Coalesce
+  // inserts such a chain to give the store its coalesced (row-major) layout;
+  // without anchoring it, forward propagation from an (expensive) load strips
+  // the chain and demotes the store to a scalar scatter.  Unlike a store (which
+  // has no result and so cannot be anchored), the convert has a result and can.
+  //
+  // The order change is checked across the whole convert chain (root source ->
+  // store-feeding convert), not on a single convert: the store-feeding convert
+  // is frequently a same-order re-tiling whose transpose lives one convert
+  // upstream.  Gating on the net change keeps a genuine transpose (issue #7093)
+  // while still folding a chain that ends at the same order it started (e.g. a
+  // dot result re-tiled for the store, issue #4866).
+  if (auto convertOp = dyn_cast<ttg::ConvertLayoutOp>(op)) {
+    bool feedsDescStore =
+        llvm::any_of(convertOp.getResult().getUsers(), [](Operation *user) {
+          return isa<tt::DescriptorStoreOp>(user);
+        });
+    if (feedsDescStore) {
+      // Walk up consecutive converts to the root source of the chain.
+      Value root = convertOp.getSrc();
+      while (auto upConvert = root.getDefiningOp<ttg::ConvertLayoutOp>())
+        root = upConvert.getSrc();
+      auto rootTy = dyn_cast<RankedTensorType>(root.getType());
+      auto dstTy = dyn_cast<RankedTensorType>(convertOp.getType());
+      if (rootTy && dstTy) {
+        auto rootBlocked =
+            dyn_cast<ttg::BlockedEncodingAttr>(rootTy.getEncoding());
+        auto dstBlocked =
+            dyn_cast<ttg::BlockedEncodingAttr>(dstTy.getEncoding());
+        if (rootBlocked && dstBlocked)
+          return rootBlocked.getOrder() != dstBlocked.getOrder();
+      }
+    }
+  }
+
   return false;
 }
 


### PR DESCRIPTION
RemoveLayoutConversions anchors load layouts and forward-propagates them through convert_layout ops. For a `tl.make_tensor_descriptor(...).store(...)` permute, this stripped the order-changing convert that Coalesce inserts to give the store its coalesced row-major layout: a store has no result and so cannot defend its layout as an anchor, so propagation from the load anchor (order=[0,1]) folded the transpose convert and demoted the store from a 2D block write to a scalar scatter (~+127% slower on PVC, up to +325%).

Fix: anchor the convert_layout itself when it feeds a descriptor store and its convert chain performs a net order change. Unlike the store, the convert has a result and can be anchored. The order change is checked across the whole chain (root source -> store-feeding convert), not a single convert, so a genuine transpose (#7093) is kept while a same-order re-tiling chain (e.g. a dot result re-tiled for the store, #4866) is still folded.