### PR TITLE
Fix reduce-rank load in Materialize block pointer pass.

### DIFF
--- a/test/TritonIntelGPU/materialize-tensor-descriptor.mlir
+++ b/test/TritonIntelGPU/materialize-tensor-descriptor.mlir
@@ -120,3 +120,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, ttg.target = "xpu", "ttg.num-warps"
     tt.return
   }
 }
+
+// -----
+
+// COM: rank-reducing 3D descriptor load.
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 16], warpsPerCTA = [8, 4], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 4], warpsPerCTA = [32, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, ttg.target = "xpu", "ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func public @materialize_tensor_descriptor(
+  tt.func public @materialize_tensor_descriptor(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %pitch: i64 {tt.divisibility = 16 : i32}) ->  tensor<256x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>  {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+
+    %a_desc_2 = tt.make_tensor_descriptor %arg0, [%c0_i32, %c0_i32, %c0_i32], [%pitch, %pitch, %c1_i64] : <f16>, <1x256x32xf16>
+    // CHECK: tt.descriptor_load {{.*}} {ttig.block_io = "row_major"{{.*}}}
+    %a_11 = tt.descriptor_load %a_desc_2[%c0_i32, %c0_i32, %c0_i32] : !tt.tensordesc<1x256x32xf16> -> tensor<256x32xf16, #blocked1>
+    %a_13 = ttg.convert_layout %a_11 : tensor<256x32xf16, #blocked1> -> tensor<256x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    tt.return %a_13 : tensor<256x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -825,53 +825,6 @@ private:
   template <typename OpType,
             typename = std::enable_if_t<llvm::is_one_of<
                 OpType, tt::DescriptorLoadOp, tt::DescriptorStoreOp>::value>>
-  std::optional<ttg::DotOperandEncodingAttr> getDotLayout(OpType op) const {
-    // Get the tensor type from the operation's result (load) or value (store)
-    Type resultType;
-    if constexpr (std::is_same_v<OpType, tt::DescriptorLoadOp>) {
-      resultType = op.getResult().getType();
-    } else {
-      resultType = op.getSrc().getType();
-    }
-    RankedTensorType tensorType = ttgi::getRankedTensorType(resultType);
-    if (!tensorType)
-      return std::nullopt;
-
-    auto dotLayout = ttgi::getDotEncoding(tensorType);
-    if (dotLayout)
-      return dotLayout;
-
-    auto allUsersAreConvertOps = [](Operation::user_range users) {
-      return llvm::all_of(users, [](Operation *user) {
-        return isa<ttg::ConvertLayoutOp>(user);
-      });
-    };
-
-    auto allUserHaveIdenticalLayout = [](Operation::user_range users) {
-      Attribute firstUserLayout =
-          cast<ttg::ConvertLayoutOp>(*users.begin()).getType().getEncoding();
-      return llvm::all_of(users, [&firstUserLayout](Operation *user) {
-        return firstUserLayout ==
-               cast<ttg::ConvertLayoutOp>(user).getType().getEncoding();
-      });
-    };
-
-    Operation::user_range users = op->getUsers();
-    if (!users.empty() && allUsersAreConvertOps(users) &&
-        allUserHaveIdenticalLayout(users)) {
-      Attribute firstUserLayout =
-          cast<ttg::ConvertLayoutOp>(*users.begin()).getType().getEncoding();
-      if (isa<ttg::DotOperandEncodingAttr>(firstUserLayout))
-        return dyn_cast<ttg::DotOperandEncodingAttr>(firstUserLayout);
-      return std::nullopt;
-    }
-
-    return std::nullopt;
-  }
-
-  template <typename OpType,
-            typename = std::enable_if_t<llvm::is_one_of<
-                OpType, tt::DescriptorLoadOp, tt::DescriptorStoreOp>::value>>
   bool satisfies2DBlockReadAlignment(
       OpType op, tt::intel::ModuleAxisInfoAnalysis &axisInfoAnalysis) const {
     Value desc = op.getDesc();

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -157,27 +157,6 @@ private:
         }))
       return;
 
-    std::optional<ttg::DotOperandEncodingAttr> dotLayout = getDotLayout(op);
-    if (dotLayout) {
-      // Check if the load is being used by a tt.dot operation, and if so is
-      // this the first operand and is it a transposed row major matrix. If
-      // so, skip the block descriptor attribute as performance is worse than
-      // if we remove the tensor descriptor.
-      LDBG("dotLayout: " << *dotLayout);
-      auto opIdx =
-          static_cast<ttgi::DpasEncodingAttr::OpIdx>(dotLayout->getOpIdx());
-      auto dotOrder = tt::gpu::getThreadOrder(tensorType);
-      // Row-major means the last dim (rank-1) is the fastest-varying, i.e.,
-      // it appears first in the thread order vector.
-      const bool valueRowMajor =
-          (dotOrder[0] == rank - 1 && dotOrder[1] == rank - 2);
-      if (opIdx == ttgi::DpasEncodingAttr::OpIdx::OperandA && !valueRowMajor) {
-        LDBG("Skipping block descriptor attribute for transposed A matrix in "
-             "dot operation");
-        return;
-      }
-    }
-
     // Tensor descriptors are always row major.
     op->setAttr(ttgi::TritonIntelGPUDialect::getBlockIOAttrName(),
                 StringAttr::get(context, "row_major"));


### PR DESCRIPTION
The removed code is implemented for old block pointer API which support non-1 stride in the inner most dim.

The transpose load fusing is now supported by the transposing fusing pass.

Remove the old code which may fail to mark the row major TDESC which supported by 2D block hardware.