### PR TITLE
[vLLM] Remove cuda Stream pattern from vllm_xpu_patch.py

### DIFF
--- a/scripts/vllm/vllm_xpu_patch.py
+++ b/scripts/vllm/vllm_xpu_patch.py
@@ -104,16 +104,6 @@ def _find_cuda_patterns(source: str) -> list[dict]:
                 "col": node.col_offset,
             })
 
-        # torch.cuda.Stream() calls
-        if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "Stream"
-                and isinstance(node.func.value, ast.Attribute) and node.func.value.attr == "cuda"
-                and isinstance(node.func.value.value, ast.Name) and node.func.value.value.id == "torch"):
-            patterns.append({
-                "type": "cuda_stream",
-                "line": node.lineno,
-                "col": node.col_offset,
-            })
-
         # torch.cuda.get_device_capability() calls
         if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
                 and node.func.attr == "get_device_capability" and isinstance(node.func.value, ast.Attribute)
@@ -189,10 +179,6 @@ def _apply_patches(source: str, patterns: list[dict]) -> str:
                 r"torch.manual_seed(\1)",
                 line,
             )
-
-        elif ptype == "cuda_stream":
-            # Replace torch.cuda.Stream() with torch.xpu.Stream()
-            lines[line_idx] = line.replace("torch.cuda.Stream()", "torch.xpu.Stream()")
 
         elif ptype == "cuda_get_device_capability":
             # Replace torch.cuda.get_device_capability() with torch.xpu.get_device_capability()


### PR DESCRIPTION
This patch removes the `torch.cuda.Stream()` ->  `torch.xpu.Stream()` replacement in `vllm_xpu_patch.py`. 

The replacement seems high risk and removing it does not make any vLLM benchmarks or tests fail.

---

vLLM benchmarks: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27152372606
vLLM benchmarks BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27152383861
vLLM tests: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27152402417
vLLM tests BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27173656467

No impact on vLLM benchmarks performance.