### PR TITLE
[TEST] (do not merge) Coverage for f32->f8 RTNE (validates #7153 on Windows CI)

### DIFF
--- a/test/Conversion/intel/fp8_convert.mlir
+++ b/test/Conversion/intel/fp8_convert.mlir
@@ -71,3 +71,34 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return %dst : tensor<32xf16, #blocked>
   }
 }
+
+// -----
+
+// f32 -> f8E4M3FN goes through Fp_to_Fp8_RTNE<Float32Type, ...> which uses
+// `1ULL << (SrcBits - 1)` as the sign-bit mask; with `SrcBits == 32` this
+// must materialize as the i32 constant `0x80000000` (-2147483648 signed).
+// A regression to `1L << 31` would crash on Windows MSVC (LLP64).
+#blocked = #ttg.blocked<{sizePerThread = [16], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.min_sg_size = 16 : i32, ttig.target_arch = "spir64" } {
+  tt.func public @convert_f32_to_f8E4M3FN(%src: tensor<16xf32, #blocked>) -> tensor<16xf8E4M3FN, #blocked> {
+    %dst = tt.fp_to_fp %src, rounding = rtne : tensor<16xf32, #blocked> -> tensor<16xf8E4M3FN, #blocked>
+    // CHECK-LABEL: llvm.func spir_kernelcc @convert_f32_to_f8E4M3FN
+    // CHECK: llvm.mlir.constant(-2147483648 : i32) : i32
+    // CHECK: llvm.intr.nearbyint
+    tt.return %dst : tensor<16xf8E4M3FN, #blocked>
+  }
+}
+
+// -----
+
+// f32 -> f8E5M2 takes the same Fp_to_Fp8_RTNE<Float32Type, ...> path.
+#blocked = #ttg.blocked<{sizePerThread = [16], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.min_sg_size = 16 : i32, ttig.target_arch = "spir64" } {
+  tt.func public @convert_f32_to_f8E5M2(%src: tensor<16xf32, #blocked>) -> tensor<16xf8E5M2, #blocked> {
+    %dst = tt.fp_to_fp %src, rounding = rtne : tensor<16xf32, #blocked> -> tensor<16xf8E5M2, #blocked>
+    // CHECK-LABEL: llvm.func spir_kernelcc @convert_f32_to_f8E5M2
+    // CHECK: llvm.mlir.constant(-2147483648 : i32) : i32
+    // CHECK: llvm.intr.nearbyint
+    tt.return %dst : tensor<16xf8E5M2, #blocked>
+  }
+}


### PR DESCRIPTION
  **Do not merge — validation only.**

  This branch contains only a lit test (no source fix), pushed on top
  of unmodified `main`. Its purpose is to confirm on Windows MSVC CI
  that the test actually catches the bug fixed in #7153.

  ## Test

  Two new `// -----` sections in
  `test/Conversion/intel/fp8_convert.mlir` covering `f32 → f8E4M3FN`
  and `f32 → f8E5M2` RTNE lowering. They drive
  `Fp_to_Fp8_RTNE<Float32Type, ...>` in
  `third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp`,
  which on `main` (without the fix in #7153) reaches a `1L << 31`
  shift that is undefined on Windows MSVC (LLP64, where `long` is 32
  bits).

  ## Expected CI outcome

  When `build-test-windows.yml` is dispatched on this branch, the two
  new test cases should fail with the same crash signature as #5664:

  Assertion failed: llvm::isUIntN(BitWidth, val) &&
    "Value is not an N-bit unsigned value", llvm/ADT/APInt.h:128
  ...
  FileCheck error: '' is empty.

  `triton-opt.exe` aborts before producing any output, so FileCheck
  gets nothing to match against.

## CI run

  Dispatched against this branch:
  https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27193153174


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
