### PR TITLE
[Win][Build] Exclude `*.ilk` artifacts from wheel

### DIFF
--- a/.github/workflows/wheels-triton.yml
+++ b/.github/workflows/wheels-triton.yml
@@ -1,4 +1,4 @@
-name: Triton wheels
+name: Triton wheels for Windows
 
 on:
   workflow_dispatch:
@@ -69,7 +69,7 @@ jobs:
           Invoke-BatchFile "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
 
           $env:CIBW_BUILD_VERBOSITY = "1"
-          $env:CIBW_SKIP = "cp{35,36,37}-*"
+          $env:CIBW_SKIP = "cp{35,36,37,38,39}-*"
           $env:CIBW_BUILD = "cp" + "${{ matrix.python}}".replace(".", "") + "*-win_amd64"
           $env:CIBW_CACHE_PATH = "${{ env.NEW_WORKSPACE }}/cibw"
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,3 +18,5 @@ include python/test-requirements.txt
 global-exclude __pycache__
 global-exclude __pycache__/*
 global-exclude *.py[cod]
+global-exclude *.pdb
+global-exclude *.ilk

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,5 +18,3 @@ include python/test-requirements.txt
 global-exclude __pycache__
 global-exclude __pycache__/*
 global-exclude *.py[cod]
-global-exclude *.pdb
-global-exclude *.ilk

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
 from setuptools.command.egg_info import egg_info
 from setuptools.command.install import install
+from setuptools.command.install_lib import install_lib
 from setuptools.command.sdist import sdist
 
 from dataclasses import dataclass
@@ -387,6 +388,18 @@ class CMakeBuild(build_ext):
         subprocess.check_call(["cmake", "--build", ".", "--target", "mlir-doc"], cwd=cmake_dir)
 
 
+class InstallLib(install_lib):
+
+    def run(self):
+        super().run()
+
+        if os.name == "nt":
+            # Make sure that Triton wheel for Windows does not include any unnecessary files.
+            for ext in (".ilk", ):
+                for f in Path(self.install_dir).rglob(f"*{ext}"):
+                    f.unlink()
+
+
 backends = [*BackendInstaller.copy(["intel", "nvidia", "amd"]), *BackendInstaller.copy_externals()]
 
 
@@ -606,13 +619,12 @@ setup(
         "__pycache__",
         "__pycache__/*",
         "*.py[cod]",
-        "*.pdb",
-        "*.ilk",
     ]},
     ext_modules=[CMakeExtension("triton", "triton/_C/")],
     cmdclass={
         "bdist_wheel": plugin_bdist_wheel,
         "build_ext": CMakeBuild,
+        "install_lib": InstallLib,
         "build_py": CMakeBuildPy,
         "clean": CMakeClean,
         "develop": plugin_develop,

--- a/setup.py
+++ b/setup.py
@@ -606,6 +606,8 @@ setup(
         "__pycache__",
         "__pycache__/*",
         "*.py[cod]",
+        "*.pdb",
+        "*.ilk",
     ]},
     ext_modules=[CMakeExtension("triton", "triton/_C/")],
     cmdclass={


### PR DESCRIPTION
For example: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27206970898/job/80325259881#step:9:2054

I decided to leave `.pdb` files, since the wheel is built with debug symbols for Linux.

Relates to https://github.com/intel/intel-xpu-backend-for-triton/issues/6970