### PR TITLE
Fix RemoveMasks map poisoning on multi-mask ops

### DIFF
--- a/test/Triton/Intel/RemoveMasks/regressions.mlir
+++ b/test/Triton/Intel/RemoveMasks/regressions.mlir
@@ -19,4 +19,47 @@ module {
     }
     tt.return
   }
+
+  // -----
+
+  // COM: Regression test for issue #6871.
+  // COM: Ensure arith.select with AlwaysFalse condition and AlwaysTrue true-value folds to false-value, not true-value.
+  // CHECK-LABEL: issue_6871
+  tt.func public @issue_6871(%arg0: tensor<32x!tt.ptr<f32>>) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c0 = arith.constant dense<0> : tensor<32xi32>
+    %c64 = arith.constant dense<64> : tensor<32xi32>
+    %cst_false = arith.constant dense<false> : tensor<32xi1>
+    %cst_zero = arith.constant dense<0.000000e+00> : tensor<32xf32>
+    %range = tt.make_range {start = 0 : i32, end = 32 : i32} : tensor<32xi32>
+    // CHECK: [[CST_FALSE:%.+]] = arith.constant dense<false> : tensor<32xi1>
+
+    %result = scf.for %iv = %c0_i32 to %c32_i32 step %c1_i32 iter_args(%carry = %cst_false) -> (tensor<32xi1>) : i32 {
+      // Offsets = IV (scalar splatted) + make_range [0, 32)
+      %iv_splat = tt.splat %iv : i32 -> tensor<32xi32>
+      %offsets = arith.addi %iv_splat, %range : tensor<32xi32>
+
+      // mask_true: offsets < 64 → AlwaysTrue for IV in [0, 32)
+      %mask_true = arith.cmpi slt, %offsets, %c64 : tensor<32xi32>
+
+      // mask_false: offsets < 0 → AlwaysFalse for IV in [0, 32)
+      %mask_false = arith.cmpi slt, %offsets, %c0 : tensor<32xi32>
+
+      // Load with mask_true (always true, should be optimized to unmasked)
+      %loaded = tt.load %arg0, %mask_true, %cst_zero : tensor<32x!tt.ptr<f32>>
+
+      // Select with mask_false as condition, mask_true as true-value, cst_false as false-value
+      // Since mask_false is AlwaysFalse, this MUST fold to cst_false, NOT mask_true
+      %selected = arith.select %mask_false, %mask_true, %cst_false : tensor<32xi1>, tensor<32xi1>
+
+      scf.yield %selected : tensor<32xi1>
+    }
+    // COM: mask_true is AlwaysTrue, so the load is rewritten without a mask.
+    // CHECK: tt.load %arg0 :
+    // CHECK: scf.yield [[CST_FALSE]] : tensor<32xi1>
+
+    tt.return
+  }
 }

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RemoveMasks.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RemoveMasks.cpp
@@ -169,7 +169,8 @@ public:
   virtual ~MaskValidatorBase() = default;
 
   // Check whether the given mask is valid.
-  virtual bool isValidMask(scf::ForOp &forOp, Value mask) const = 0;
+  virtual bool isValidMask(scf::ForOp &forOp, Value mask,
+                           Operation *op) const = 0;
 
   // Create the loop versioning condition based on the mask.
   virtual Value getVersioningCond(scf::ForOp &forOp, Value mask) const = 0;
@@ -183,11 +184,11 @@ public:
   RemovableMaskValidator(DataFlowSolver *solver)
       : MaskValidatorBase(), solver(solver) {}
 
-  virtual bool isValidMask(scf::ForOp &forOp, Value mask) const {
+  virtual bool isValidMask(scf::ForOp &forOp, Value mask, Operation *op) const {
     MaskClassification cls = classify(forOp, mask);
     if (cls == MaskClassification::Unknown)
       return false;
-    registerMaskValue(mask, cls == MaskClassification::AlwaysTrue);
+    registerMaskValue(op, cls == MaskClassification::AlwaysTrue);
     return true;
   }
 
@@ -203,10 +204,12 @@ public:
   }
 
 private:
-  // Record the final mask value for all users of `mask`.
-  void registerMaskValue(Value mask, bool maskVal) const {
-    for (Operation *user : mask.getUsers())
-      opToMaskValue.insert({user, maskVal});
+  // Record the final mask value for the given masked operation.
+  // Fixes #6871: each operation must record only its own mask, not the masks of
+  // its other users (which would poison the map for ops consuming two masks,
+  // e.g. an arith.select using one mask as condition and another as true-value).
+  void registerMaskValue(Operation *op, bool maskVal) const {
+    opToMaskValue.insert({op, maskVal});
   }
 
   // Dispatch on the mask's defining op: `arith.andi` is combined recursively,
@@ -310,7 +313,7 @@ public:
   };
 
   // Check whether the mask is equivalent to the form: `END-1 < N-i*END`.
-  virtual bool isValidMask(scf::ForOp &forOp, Value mask) const {
+  virtual bool isValidMask(scf::ForOp &forOp, Value mask, Operation *op) const {
     Value finalVal = tt::intel::getFinalValue(mask);
     assert(finalVal && "Expecting a valid mask");
 
@@ -456,7 +459,8 @@ private:
   // Assuming the mask is equivalent to the form: `END < N-i*END`, returns a
   // structure containing `N` and `END`.
   MaskInfo getMaskInfo(scf::ForOp &forOp, Value mask) const {
-    assert(isValidMask(forOp, mask) && "Expecting a valid mask");
+    assert(isValidMask(forOp, mask, /*op=*/nullptr) &&
+           "Expecting a valid mask");
 
     Value finalMask = tt::intel::getFinalValue(mask);
     auto cmpOp = cast<arith::CmpIOp>(finalMask.getDefiningOp());
@@ -474,7 +478,7 @@ public:
   //   - N < M (with i1 data type)
   //   - [0..END] < splat(N)
   //   - splat(N) < [0..END]
-  virtual bool isValidMask(scf::ForOp &forOp, Value mask) const {
+  virtual bool isValidMask(scf::ForOp &forOp, Value mask, Operation *op) const {
     Value finalVal = tt::intel::getFinalValue(mask);
     assert(finalVal && "Expecting a valid mask");
 
@@ -520,7 +524,7 @@ public:
   } // namespace
 
   virtual Value getVersioningCond(scf::ForOp &forOp, Value mask) const {
-    assert(isValidMask(forOp, mask) && "Invalid mask");
+    assert(isValidMask(forOp, mask, /*op=*/nullptr) && "Invalid mask");
 
     OpBuilder builder(forOp);
     Location loc = forOp.getLoc();
@@ -576,7 +580,7 @@ public:
     auto collectMaskedOps = [&](auto ops, MaskedOperations &maskedOps) {
       for (Operation *op : ops) {
         Value mask = getMask(op);
-        if (mask && maskValidator.isValidMask(forOp, mask)) {
+        if (mask && maskValidator.isValidMask(forOp, mask, op)) {
           maskedOps.insert(op);
           LLVM_DEBUG(llvm::dbgs()
                      << maskValidator.getName()

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RemoveMasks.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RemoveMasks.cpp
@@ -207,7 +207,8 @@ private:
   // Record the final mask value for the given masked operation.
   // Fixes #6871: each operation must record only its own mask, not the masks of
   // its other users (which would poison the map for ops consuming two masks,
-  // e.g. an arith.select using one mask as condition and another as true-value).
+  // e.g. an arith.select using one mask as condition and another as
+  // true-value).
   void registerMaskValue(Operation *op, bool maskVal) const {
     opToMaskValue.insert({op, maskVal});
   }


### PR DESCRIPTION
`registerMaskValue` iterated over all users of a mask Value, tagging each in `opToMaskValue` via std::map::insert (a no-op on an existing key). An `arith.select` using one mask as its condition and another as its true-value got its entry written from the wrong mask by the load processed earlier, so `dropMask` folded the select to the wrong operand.

Thread the specific masked Operation pointer through `isValidMask` so each op records only its own mask. Add a regression test.

Closes #6871

