### PR TITLE
[FuseReshape] Reject fusion when stride divisibility cannot be proven

### DIFF
--- a/test/Triton/Intel/FuseReshape/fuse-reshape.mlir
+++ b/test/Triton/Intel/FuseReshape/fuse-reshape.mlir
@@ -61,3 +61,21 @@ tt.func public @fuseLoadWithReshape2(%arg0: tensor<32x256xbf16>, %arg1: !tt.ptr<
 // CHECK:   [[ADD2:%.*]] = arith.addi [[MUL2]], %c32_i32 : i32
 // CHECK:   [[LOAD_A:%.*]] = tt.descriptor_load [[DESC]][[[ADD2]], %c0_i32] : !tt.tensordesc<256x32xbf16> -> tensor<256x32xbf16>
 // CHECK:   tt.dot [[LOAD_A]], {{.*}}, {{.*}}, inputPrecision = tf32 : tensor<256x32xbf16> * tensor<32x256xbf16> -> tensor<256x256xf32>
+
+// -----
+
+// Do not fuse when strides[0] is not provably divisible by strides[1]
+// (e.g., padded strides as in github.com/intel/intel-xpu-backend-for-triton/issues/7030).
+tt.func public @noFusePaddedStrides(%arg0: tensor<16x16xf32>, %arg1: !tt.ptr<f32>, %G: i32, %K: i32, %M: i32, %stride0: i64, %stride1: i64) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32>
+  %0 = tt.make_tensor_descriptor %arg1, [%G, %K, %M], [%stride0, %stride1, %c1_i64] : <f32>, <1x16x16xf32>
+  %1 = tt.descriptor_load %0[%c0_i32, %c0_i32, %c0_i32] : !tt.tensordesc<1x16x16xf32> -> tensor<1x16x16xf32>
+  %2 = tt.reshape %1 : tensor<1x16x16xf32> -> tensor<16x16xf32>
+  %3 = tt.dot %2, %arg0, %cst, inputPrecision = tf32 : tensor<16x16xf32> * tensor<16x16xf32> -> tensor<16x16xf32>
+  tt.return
+}
+// CHECK-LABEL: noFusePaddedStrides
+// CHECK: tt.descriptor_load
+// CHECK: tt.reshape

--- a/third_party/intel/lib/Dialect/Triton/Transforms/FuseReshape.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/FuseReshape.cpp
@@ -1,4 +1,5 @@
 #include "intel/include/Dialect/Triton/Transforms/Passes.h"
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/Utility.h"
 #include "intel/include/Utils/DefUseChain.h"
 #include "intel/include/Utils/Utility.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -6,6 +7,7 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Support/LLVM.h"
@@ -273,7 +275,37 @@ private:
     assert((tensorTy.getRank() == 3 && tensorTy.getDimSize(0) == 1) &&
            "Unexpected tensor type");
 
+    // The fusion collapses dimensions using strides[0] / strides[1]. This is
+    // only valid when strides[0] is an exact multiple of strides[1]. Reject
+    // cases where divisibility cannot be proven (e.g., padded strides).
+    OperandRange strides = makeTensorDescOp->getStrides();
+    if (!isProvablyDivisible(strides[0], strides[1]))
+      return false;
+
     return true;
+  }
+
+  /// Return true if \p numerator is provably divisible by \p denominator.
+  static bool isProvablyDivisible(Value numerator, Value denominator) {
+    // If both are the same value, trivially divisible.
+    if (numerator == denominator)
+      return true;
+
+    // If numerator is defined by arith.muli and one operand is the
+    // denominator, it is divisible.
+    if (auto mulOp = numerator.getDefiningOp<arith::MulIOp>()) {
+      if (mulOp.getLhs() == denominator || mulOp.getRhs() == denominator)
+        return true;
+    }
+
+    // If denominator is a constant, use isDivisible which leverages
+    // tt.divisibility attributes on function arguments and constants.
+    APInt denVal;
+    if (matchPattern(denominator, m_ConstantInt(&denVal)) && !denVal.isZero())
+      return mlir::triton::gpu::intel::isDivisible(numerator,
+                                                   denVal.getZExtValue());
+
+    return false;
   }
 
   // If \p user is not \p sentinel, propagate \p newVal to \p user. Otherwise


### PR DESCRIPTION
The fusion formula collapses dimensions using strides[0] / strides[1]. This is only valid when strides[0] is an exact multiple of strides[1]. When strides are padded (e.g., stride > dim_size * next_stride), the integer division truncates and produces incorrect index calculations.

Add a divisibility check that proves strides[0] % strides[1] == 0 via:
- Identity (same SSA value)
- arith.muli pattern (numerator = X * denominator)
- Constant denominator with isDivisible (leverages tt.divisibility attrs)

Fixes the first problem in #7030.