### PR TITLE
Make load_binary and library linking backend-agnostic for NVIDIA compatibility

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -489,14 +489,20 @@ class CompiledKernel:
         if knobs.runtime.kernel_load_start_hook is not None:
             knobs.runtime.kernel_load_start_hook(self.module, self.function, self.name, self.metadata_group, self.hash)
         # TODO: n_regs, n_spills should be metadata generated when calling `ptxas`
-        self.module, self.function, self.n_regs, self.n_spills, self.n_max_threads = driver.active.utils.load_binary(
-            self.name, self.kernel, self.metadata.shared, self.metadata.build_flags,
-            not self.metadata.generate_native_code, device)
-        # PyTorch could use the updated build flags in load binary.
-        if hasattr(driver.active.utils, "get_last_selected_build_flags"):
-            new_build_flags = driver.active.utils.get_last_selected_build_flags()
-            if new_build_flags != self.metadata.build_flags:
-                self.metadata = self.metadata._replace(build_flags=new_build_flags)
+        # `build_flags`/`generate_native_code` are Intel/XPU-specific metadata fields.
+        # Backends that don't define them (e.g. NVIDIA/CUDA) use the plain load_binary signature.
+        if hasattr(self.metadata, "build_flags"):
+            self.module, self.function, self.n_regs, self.n_spills, self.n_max_threads = driver.active.utils.load_binary(
+                self.name, self.kernel, self.metadata.shared, self.metadata.build_flags,
+                not self.metadata.generate_native_code, device)
+            # PyTorch could use the updated build flags in load binary.
+            if hasattr(driver.active.utils, "get_last_selected_build_flags"):
+                new_build_flags = driver.active.utils.get_last_selected_build_flags()
+                if new_build_flags != self.metadata.build_flags:
+                    self.metadata = self.metadata._replace(build_flags=new_build_flags)
+        else:
+            self.module, self.function, self.n_regs, self.n_spills, self.n_max_threads = driver.active.utils.load_binary(
+                self.name, self.kernel, self.metadata.shared, device)
 
         if hasattr(self.metadata, "threads_per_warp"):
             warp_size = self.metadata.threads_per_warp

--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -45,7 +45,7 @@ def _cc_cmd(cc, src, out, include_dirs, library_dirs, libraries):
             cc_cmd += ["-fPIC"]
         else:
             cc_cmd += ["-Wno-deprecated-declarations"]
-        cc_cmd += [f'-l{lib}' for lib in libraries]
+        cc_cmd += [_library_flag(lib) for lib in libraries]
         cc_cmd += [f"-L{dir}" for dir in library_dirs]
         cc_cmd += [f"-I{dir}" for dir in include_dirs]
         cc_cmd += ["-o", out]


### PR DESCRIPTION
The shared compiler/runtime layer assumed Intel/XPU-specific metadata, which broke non-XPU backends.
- compiler.py: guard the XPU `load_binary` path behind `hasattr(self.metadata, "build_flags")`. Backends without `build_flags`/`generate_native_code` (NVIDIA/AMD) now fall back to the plain `load_binary(name, kernel, shared, device)` signature.
- build.py: use `_library_flag(lib)` instead of hardcoded `-l{lib}` so full-path `.so`/`.a` libraries link correctly across backends.