### PR TITLE
[TritonIntelGPU][NFC] Share 2D block store tile validation

### DIFF
--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
@@ -98,6 +98,22 @@ bool validate2DBlockLoadTile(const LinearLayout &ll, unsigned memContiguousDim,
                              bool oneMatrixPerLoadForBT = false,
                              AxisInfo *maskAxisInfo = nullptr);
 
+/// Validate that a store with the given encoding and element size can be
+/// lowered to 2D block I/O, applying the constraints the store lowering
+/// enforces: a valid tile shape, the HW address payload restriction, no
+/// transpose, and a single v-block. On success returns true and writes the
+/// validated tile geometry (with vBlocks forced to 1) into \p sizeInfoOut; on
+/// failure returns false and leaves \p sizeInfoOut unspecified.
+///
+/// This is the single source of truth for 2D block store eligibility, shared
+/// by the store lowering patterns in LoadStoreOpToLLVM.cpp so their tile
+/// validation cannot drift.
+bool validate2DBlockStoreTile(const LinearLayout &ll, unsigned memContiguousDim,
+                              unsigned elemSizeInBits,
+                              RankedTensorType tensorType,
+                              AxisInfo *maskAxisInfo,
+                              BlockIOTileSizeInfo &sizeInfoOut);
+
 } // namespace mlir::triton::gpu::intel
 
 #endif // TRITONINTELGPU_TRANSFORMS_BLOCKIOUTILS_H

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2531,26 +2531,18 @@ struct DescriptorStoreOpToBlockIOConversion
     // propagated here.
     AxisInfo *maskAxisInfo = nullptr;
 
-    BlockIOTileSizeInfo sizeInfo = getBlockIOTileSize<false /*store*/>(
-        llEncoding.value(), contiguousDim, elemSizeInBits, maskAxisInfo,
-        /*oneMatrixPerLoadForBT=*/false);
-    if (!sizeInfo.isValid())
+    // Validate the store tile through the shared helper: it computes the tile
+    // geometry, enforces the HW address payload restriction, rejects transpose,
+    // and forces vBlocks to 1.
+    BlockIOTileSizeInfo sizeInfo = BlockIOTileSizeInfo::unknown();
+    if (!validate2DBlockStoreTile(llEncoding.value(), contiguousDim,
+                                  elemSizeInBits, tensorType, maskAxisInfo,
+                                  sizeInfo))
       return failure();
 
     auto [tileHeight, tileWidth, numPackedVals, vBlocks, rowDim, colDim,
           isTransposeRequired, regPackedBases] = std::move(sizeInfo);
-
     unsigned packedElemSizeInBits = elemSizeInBits * numPackedVals;
-    if (!check2DBlockAddressPayloadRestriction(packedElemSizeInBits, tileWidth))
-      return failure();
-
-    // Limit vBlock to 1 for stores.
-    vBlocks = 1;
-
-    if (isTransposeRequired) {
-      // 2D Block store doesn't support transpose.
-      return failure();
-    }
 
     Location loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -2791,29 +2783,28 @@ struct StoreOpToBlockIOConversion
                                      /*vBlocks=*/1, /*rowDim=*/0,
                                      /*colDim=*/rank - 1, /*transpose=*/false,
                                      std::move(regPackBases));
+      // The reshape path bypasses getBlockIOTileSize (and thus
+      // validate2DBlockStoreTile), so apply the HW address payload restriction
+      // here; vBlocks and transpose are already fixed (1 / false) above.
+      if (!sizeInfo.isValid())
+        return failure();
+      if (!check2DBlockAddressPayloadRestriction(
+              elemSizeInBits * sizeInfo.numElemPerPackedVal,
+              sizeInfo.tileWidth))
+        return failure();
     } else {
-      sizeInfo = getBlockIOTileSize<false /*store*/>(
-          llEncoding.value(), contiguousDim, elemSizeInBits, maskAxisInfo,
-          /*oneMatrixPerLoadForBT=*/false);
+      // Validate through the shared helper (the single source of truth for 2D
+      // block store eligibility): tile geometry, HW address payload
+      // restriction, no transpose, vBlocks forced to 1.
+      if (!validate2DBlockStoreTile(llEncoding.value(), contiguousDim,
+                                    elemSizeInBits, tensorType, maskAxisInfo,
+                                    sizeInfo))
+        return failure();
     }
-
-    if (!sizeInfo.isValid())
-      return failure();
 
     auto [tileHeight, tileWidth, numPackedVals, vBlocks, rowDim, colDim,
           isTransposeRequired, regPackedBases] = std::move(sizeInfo);
-
     unsigned packedElemSizeInBits = elemSizeInBits * numPackedVals;
-    if (!check2DBlockAddressPayloadRestriction(packedElemSizeInBits, tileWidth))
-      return failure();
-
-    // Limit vBlock to 1
-    vBlocks = 1;
-
-    if (isTransposeRequired) {
-      // 2D Block store doesn't support transpose.
-      return failure();
-    }
 
     Location loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -560,4 +560,35 @@ bool validate2DBlockLoadTile(const LinearLayout &ll, unsigned memContiguousDim,
   return true;
 }
 
+bool validate2DBlockStoreTile(const LinearLayout &ll, unsigned memContiguousDim,
+                              unsigned elemSizeInBits,
+                              RankedTensorType tensorType,
+                              AxisInfo *maskAxisInfo,
+                              BlockIOTileSizeInfo &sizeInfoOut) {
+  // Compute the store tile geometry and reject configurations the 2D block
+  // store cannot express. This mirrors the checks the store lowering applies;
+  // keeping them here (rather than duplicated inline in each store lowering
+  // pattern) makes this the single source of truth for store eligibility.
+  BlockIOTileSizeInfo sizeInfo = getBlockIOTileSize</*isLoad=*/false>(
+      ll, memContiguousDim, elemSizeInBits, maskAxisInfo,
+      /*oneMatrixPerLoadForBT=*/false);
+  if (!sizeInfo.isValid())
+    return false;
+
+  unsigned packedElemSizeInBits = elemSizeInBits * sizeInfo.numElemPerPackedVal;
+  if (!check2DBlockAddressPayloadRestriction(packedElemSizeInBits,
+                                             sizeInfo.tileWidth))
+    return false;
+
+  // 2D block store does not support transpose.
+  if (sizeInfo.transpose)
+    return false;
+
+  // The store always issues a single v-block per message.
+  sizeInfo.vBlocks = 1;
+
+  sizeInfoOut = sizeInfo;
+  return true;
+}
+
 } // namespace mlir::triton::gpu::intel


### PR DESCRIPTION
NFC refactor: the 2D block **store** tile validation was duplicated inline in both store lowering patterns in `LoadStoreOpToLLVM.cpp` — `DescriptorStoreOpToBlockIOConversion` and `StoreOpToBlockIOConversion`. Each copy ran the same sequence: `getBlockIOTileSize<false>`, the HW address payload restriction, transpose rejection, and `vBlocks = 1`.

This factors that sequence into a single `validate2DBlockStoreTile` helper in `BlockIOUtils` — the symmetric counterpart to the existing `validate2DBlockLoadTile` — and routes both lowering patterns through it, so their store-eligibility logic is one source of truth and cannot drift.
