### PR TITLE
[AOT launcher] Bind global/profile scratch kernel args

### DIFF
--- a/third_party/intel/tools/intel/compile.cpp
+++ b/third_party/intel/tools/intel/compile.cpp
@@ -164,6 +164,11 @@ int32_t {kernel_name}(sycl::queue &stream, {signature}) {{
         set_argument(cgh, idx, type, params[idx]);
         idx++;
     }}
+    // Set scratch memory arguments (global_scratch, profile_scratch). These are
+    // appended to params[] by the AOT compiler but are not part of the arg_types
+    // list, so they must be bound explicitly here (mirrors the JIT launcher in driver.c).
+    set_scalar_arg<void *>(cgh, num_params - 2, params[num_params - 2]);
+    set_scalar_arg<void *>(cgh, num_params - 1, params[num_params - 1]);
     if (static_cast<bool>({shared})) {{
         using share_mem_t = sycl::local_accessor<int8_t, 1>;
         share_mem_t local_buffer = share_mem_t({shared}, cgh);


### PR DESCRIPTION
AOT launcher never bound kernel's `global_scratch`/`profile_scratch` arguments that was leading to `UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX` (SIGABRT 6) 

Fix is about porting that to AOT `compile.cpp` - same mechanism is already being used in JIT [`driver.c`](https://github.com/intel/intel-xpu-backend-for-triton/blob/main/third_party/intel/backend/driver.c#L1054)