### PR TITLE
[vLLM] Remove test from linear attn skiplist after vllm pin update

### DIFF
--- a/scripts/skiplist/default/vllm_linear_attn.txt
+++ b/scripts/skiplist/default/vllm_linear_attn.txt
@@ -1,2 +1,0 @@
-# Skip tests using get_device_capability
-tests/kernels/attention/test_lightning_attn.py::test_lightning_attention_reference

--- a/scripts/skiplist/xe2/vllm_linear_attn.txt
+++ b/scripts/skiplist/xe2/vllm_linear_attn.txt
@@ -1,2 +1,0 @@
-# Skip tests using get_device_capability
-tests/kernels/attention/test_lightning_attn.py::test_lightning_attention_reference


### PR DESCRIPTION
This PR removes the single test from the linear attn skiplist:

```tests/kernels/attention/test_lightning_attn.py::test_lightning_attention_reference```

The test now passes after the vllm pin update commit (7d5743e18). An upstream vLLM commit has adapted the lightning_attn tests to be compatible with XPU.

PVC tests: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27358273241
BMG tests: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27358305134

Closes #6594