### PR TITLE
Use explicit accumulator in `tl.dot` across benchmarks and tutorials

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -39,10 +39,11 @@ You can check if triton is currently available by running one of the [tutorials]
 Basic rules:
 
 1. **Use Tensor Descriptors:** For inputs and outputs of matmul operations (`tl.dot`), use Tensor Descriptors. This utilizes hardware-optimized DPAS operations and 2D block IO HW operations. You can often expect more than 2x performance improvement compared to the basic tensor of pointers approach. Use device side Tensor Descriptors (defined inside a kernel), not host side (defined in CPU code and passed to the kernel).
-2. **Type Annotations:** Use proper type annotations for your kernels. Good type annotations allow for better optimization, but be careful to avoid excessive recompilation.
-3. **Benchmark:** Experiment with the performance of your kernel. You can use `triton.testing.do_bench` for basic benchmarking, as demonstrated in the [tutorials](../python/tutorials/02-fused-softmax.py).
-4. **Tiling and Autotuning:** Pick appropriate tiling for your machine and tensor shapes.
-5. **Grid Dimension Ordering:** On XPU, the first grid dimension changes fastest. Place computation tile indices on `axis=0` and batch/expert indices on higher dimensions to preserve cache locality. Misordering can cost 20% to 2x performance.
+2. **Use explicit accumulator in `tl.dot`:** Always write `accumulator = tl.dot(a, b, accumulator)` instead of `accumulator += tl.dot(a, b)`. The explicit form maps directly to a single DPAS instruction. The `+=` form relies on the compiler's `CombineOps` pass to fold the separate add back into the dot, which can fail (e.g., when the dot result has multiple uses or flows through control flow).
+3. **Type Annotations:** Use proper type annotations for your kernels. Good type annotations allow for better optimization, but be careful to avoid excessive recompilation.
+4. **Benchmark:** Experiment with the performance of your kernel. You can use `triton.testing.do_bench` for basic benchmarking, as demonstrated in the [tutorials](../python/tutorials/02-fused-softmax.py).
+5. **Tiling and Autotuning:** Pick appropriate tiling for your machine and tensor shapes.
+6. **Grid Dimension Ordering:** On XPU, the first grid dimension changes fastest. Place computation tile indices on `axis=0` and batch/expert indices on higher dimensions to preserve cache locality. Misordering can cost 20% to 2x performance.
 
 More details below.
 
@@ -122,7 +123,7 @@ off_k = 0
 for _ in range(0, K, BLOCK_SIZE_K):
     a = a_desc.load([pid_m * BLOCK_SIZE_M, off_k])
     b = b_desc.load([off_k, pid_n * BLOCK_SIZE_N])
-    accumulator += tl.dot(a, b)
+    accumulator = tl.dot(a, b, accumulator)
     off_k += BLOCK_SIZE_K
 ```
 

--- a/benchmarks/triton_kernels_benchmark/flash_attention_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/flash_attention_benchmark.py
@@ -273,14 +273,14 @@ def _attn_bwd_dkdv(dk, dv,  #
         # Compute dV.
         ppT = pT
         ppT = ppT.to(tl.float16)
-        dv += tl.dot(ppT, do)
+        dv = tl.dot(ppT, do, dv)
         # D (= delta) is pre-divided by ds_scale.
         Di = tl.load(D + offs_m)
         # Compute dP and dS.
         dpT = tl.dot(v, tl.trans(do)).to(tl.float32)
         dsT = pT * (dpT - Di[None, :])
         dsT = dsT.to(tl.float16)
-        dk += tl.dot(dsT, tl.trans(qT))
+        dk = tl.dot(dsT, tl.trans(qT), dk)
         # Increment pointers.
         curr_m += step_m
     return dk, dv
@@ -328,7 +328,7 @@ def _attn_bwd_dq(dq, q, K, V,  #
         ds = ds.to(tl.float16)
         # Compute dQ.
         # NOTE: We need to de-scale dq in the end, because kT was pre-scaled.
-        dq += tl.dot(ds, tl.trans(kT))
+        dq = tl.dot(ds, tl.trans(kT), dq)
         # Increment pointers.
         curr_n += step_n
     return dq

--- a/benchmarks/triton_kernels_benchmark/gemm_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_benchmark.py
@@ -90,7 +90,7 @@ def matmul_kernel_with_tensor_descriptors(
             b = b_desc.load([pid_n * BLOCK_SIZE_N, off_k]).T
         else:
             b = b_desc.load([off_k, pid_n * BLOCK_SIZE_N])
-        accumulator += tl.dot(a, b)
+        accumulator = tl.dot(a, b, accumulator)
         off_k += BLOCK_SIZE_K
     c = accumulator.to(tl.float32)
 
@@ -184,7 +184,7 @@ def matmul_kernel_with_tensor_descriptors_batched(
             b = b_desc.load([pid_n * BLOCK_SIZE_N, off_k]).T
         else:
             b = b_desc.load([off_k, pid_n * BLOCK_SIZE_N])
-        accumulator += tl.dot(a, b)
+        accumulator = tl.dot(a, b, accumulator)
         off_k += BLOCK_SIZE_K
     c = accumulator.to(tl.float32)
 

--- a/benchmarks/triton_kernels_benchmark/gemm_block_ptr_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_block_ptr_benchmark.py
@@ -55,7 +55,7 @@ def matmul_kernel_with_block_pointers(
     for _ in range(0, K, BLOCK_SIZE_K):
         a = tl.load(a_block_ptr, boundary_check=(0, 1))
         b = tl.load(b_block_ptr, boundary_check=(0, 1))
-        accumulator += tl.dot(a, b)
+        accumulator = tl.dot(a, b, accumulator)
         a_block_ptr = tl.advance(a_block_ptr, (0, BLOCK_SIZE_K))
         b_block_ptr = tl.advance(b_block_ptr, (BLOCK_SIZE_K, 0))
     c = accumulator.to(tl.float32)
@@ -110,7 +110,7 @@ def matmul_kernel_with_block_pointers_batched(
     for _ in range(0, K, BLOCK_SIZE_K):
         a = tl.load(a_block_ptr, boundary_check=(0, 1))
         b = tl.load(b_block_ptr, boundary_check=(0, 1))
-        accumulator += tl.dot(a, b)
+        accumulator = tl.dot(a, b, accumulator)
         a_block_ptr = tl.advance(a_block_ptr, (0, BLOCK_SIZE_K))
         b_block_ptr = tl.advance(b_block_ptr, (BLOCK_SIZE_K, 0))
     c = accumulator.to(tl.float32)

--- a/benchmarks/triton_kernels_benchmark/gemm_postop_addmatrix_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_postop_addmatrix_benchmark.py
@@ -89,7 +89,7 @@ def matmul_kernel_with_tensor_descriptors(
     for _ in range(0, K, BLOCK_SIZE_K):
         a = a_desc.load([pid_m * BLOCK_SIZE_M, off_k])
         b = b_desc.load([off_k, pid_n * BLOCK_SIZE_N])
-        accumulator += tl.dot(a, b)
+        accumulator = tl.dot(a, b, accumulator)
         off_k += BLOCK_SIZE_K
 
     d_desc = tl.make_tensor_descriptor(base=d_ptr, shape=(M, N), strides=(stride_dm, stride_dn),
@@ -165,7 +165,7 @@ def matmul_kernel_with_tensor_descriptors_batched(
     for _ in range(0, K, BLOCK_SIZE_K):
         a = a_desc.load([pid_m * BLOCK_SIZE_M, off_k])
         b = b_desc.load([off_k, pid_n * BLOCK_SIZE_N])
-        accumulator += tl.dot(a, b)
+        accumulator = tl.dot(a, b, accumulator)
         off_k += BLOCK_SIZE_K
 
     offset_d = bid.to(tl.int64) * stride_dz

--- a/benchmarks/triton_kernels_benchmark/gemm_postop_gelu_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_postop_gelu_benchmark.py
@@ -85,7 +85,7 @@ def matmul_kernel_with_tensor_descriptors(
     for _ in range(0, K, BLOCK_SIZE_K):
         a = a_desc.load([pid_m * BLOCK_SIZE_M, off_k])
         b = b_desc.load([off_k, pid_n * BLOCK_SIZE_N])
-        accumulator += tl.dot(a, b)
+        accumulator = tl.dot(a, b, accumulator)
         off_k += BLOCK_SIZE_K
     c = gelu(accumulator)
 
@@ -155,7 +155,7 @@ def matmul_kernel_with_tensor_descriptors_batched(
     for _ in range(0, K, BLOCK_SIZE_K):
         a = a_desc.load([pid_m * BLOCK_SIZE_M, off_k])
         b = b_desc.load([off_k, pid_n * BLOCK_SIZE_N])
-        accumulator += tl.dot(a, b)
+        accumulator = tl.dot(a, b, accumulator)
         off_k += BLOCK_SIZE_K
     c = gelu(accumulator)
 

--- a/benchmarks/triton_kernels_benchmark/gemm_preop_exp_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_preop_exp_benchmark.py
@@ -70,7 +70,7 @@ def matmul_kernel_with_tensor_descriptors(
         a = tl.math.exp(a)
         a = a.to(tl.bfloat16)
         b = b_desc.load([off_k, pid_n * BLOCK_SIZE_N])
-        accumulator += tl.dot(a, b)
+        accumulator = tl.dot(a, b, accumulator)
         off_k += BLOCK_SIZE_K
     c = accumulator.to(tl.float32)
 
@@ -143,7 +143,7 @@ def matmul_kernel_with_tensor_descriptors_batched(
         a = tl.math.exp(a)
         a = a.to(tl.bfloat16)
         b = b_desc.load([off_k, pid_n * BLOCK_SIZE_N])
-        accumulator += tl.dot(a, b)
+        accumulator = tl.dot(a, b, accumulator)
         off_k += BLOCK_SIZE_K
     c = accumulator.to(tl.float32)
 

--- a/benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_splitk_benchmark.py
@@ -52,7 +52,7 @@ def _kernel(A, B, C,  #
     for _ in range(0, K, BLOCK_K * SPLIT_K):
         a = a_desc.load([pid_m * BLOCK_M, off_k])
         b = b_desc.load([off_k, pid_n * BLOCK_N])
-        acc += tl.dot(a, b, out_dtype=acc_dtype)
+        acc = tl.dot(a, b, acc, out_dtype=acc_dtype)
         off_k += BLOCK_K * SPLIT_K
     acc = acc.to(C.dtype.element_ty)
 

--- a/benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_streamk_benchmark.py
@@ -78,7 +78,7 @@ def mac_loop(
     for _ in range(start_iter, end_iter):
         a = a_desc.load([pid_m * BLOCK_SIZE_M, off_k])
         b = b_desc.load([off_k, pid_n * BLOCK_SIZE_N])
-        acc += tl.dot(a, b)
+        acc = tl.dot(a, b, acc)
         off_k += BLOCK_SIZE_K
 
     if remain_iters == 0 and end_iter % iters_per_tile == 0:
@@ -174,7 +174,7 @@ def full_tiles(
     for _ in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
         a = a_desc.load([pid_m * BLOCK_SIZE_M, off_k])
         b = b_desc.load([off_k, pid_n * BLOCK_SIZE_N])
-        acc += tl.dot(a, b)
+        acc = tl.dot(a, b, acc)
         off_k += BLOCK_SIZE_K
 
     c_desc = tl.make_tensor_descriptor(base=c_ptr, shape=(M, N), strides=(stride_cm, stride_cn),

--- a/benchmarks/triton_kernels_benchmark/vllm/batched_moe/batched_moe.patch
+++ b/benchmarks/triton_kernels_benchmark/vllm/batched_moe/batched_moe.patch
@@ -51,7 +51,8 @@ index 8bbbab3e5..8daefc5bb 100644
              accumulator = tl.dot(a, b.to(compute_type), acc=accumulator)
 @@ -135,10 +132,6 @@ def moe_mmk(
          else:
-             accumulator += tl.dot(a, b)
+-            accumulator += tl.dot(a, b)
++            accumulator = tl.dot(a, b, accumulator)
  
 -        # Advance the ptrs to the next K block.
 -        a_ptrs += BLOCK_K * stride_ak

--- a/benchmarks/triton_kernels_benchmark/vllm/fused_moe/fused_moe.patch
+++ b/benchmarks/triton_kernels_benchmark/vllm/fused_moe/fused_moe.patch
@@ -81,13 +81,15 @@ diff --git a/vllm/model_executor/layers/fused_moe/fused_moe.py b/vllm/model_exec
          if use_int8_w8a16:
              accumulator = tl.dot(a, b.to(compute_type), acc=accumulator)
 @@ -528,9 +531,6 @@
-                     accumulator += tl.dot(a, b)
+-                    accumulator += tl.dot(a, b)
++                    accumulator = tl.dot(a, b, accumulator)
          else:
-             accumulator += tl.dot(a, b)
+-            accumulator += tl.dot(a, b)
++            accumulator = tl.dot(a, b, accumulator)
 -        # Advance the ptrs to the next K block.
 -        a_ptrs += BLOCK_SIZE_K * stride_ak
 -        b_ptrs += BLOCK_SIZE_K * stride_bk
-
+ 
      # Dequantization for supported quantization schemes:
      #   - int8_w8a16
 @@ -800,6 +800,7 @@

--- a/benchmarks/triton_kernels_benchmark/vllm/unified_attention/unified_attention.patch
+++ b/benchmarks/triton_kernels_benchmark/vllm/unified_attention/unified_attention.patch
@@ -1,8 +1,7 @@
 diff --git a/vllm/v1/attention/ops/triton_unified_attention.py b/vllm/v1/attention/ops/triton_unified_attention.py
-index 0ffe85054..8471906ab 100644
 --- a/vllm/v1/attention/ops/triton_unified_attention.py
 +++ b/vllm/v1/attention/ops/triton_unified_attention.py
-@@ -279,6 +279,9 @@ def kernel_unified_attention(
+@@ -279,6 +279,9 @@
      USE_TD_QO: tl.constexpr = False,
      Q_IS_FP8: tl.constexpr = False,
  ):
@@ -12,7 +11,7 @@ index 0ffe85054..8471906ab 100644
      # Per-(token, head) scale caches: used iff KV_QUANT_MODE in {2, 3}.
      USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = (KV_QUANT_MODE >= 2) and (
          KV_QUANT_MODE <= 3
-@@ -540,13 +543,8 @@ def kernel_unified_attention(
+@@ -540,19 +543,14 @@
          M, L, P, alpha = softmax_step(S, M, L)
          acc = acc * alpha[:, None]
  
@@ -28,7 +27,15 @@ index 0ffe85054..8471906ab 100644
          if USE_PER_TOKEN_HEAD_SCALES:
              # Per-token-head quant: apply v_scale to P instead of V.
              P_v = (P * v_token_head_scales[None, :]).to(V.dtype)
-@@ -872,12 +870,16 @@ def unified_attention(
+-            acc += tl.dot(P_v, V)
++            acc = tl.dot(P_v, V, acc)
+         else:
+-            acc += tl.dot(P.to(V.dtype), V)
++            acc = tl.dot(P.to(V.dtype), V, acc)
+ 
+     # ---- Epilogue ---------------------------------------------------------
+     if IS_3D:
+@@ -872,12 +870,16 @@
      elif sliding_window_val <= 0:
          chunk_lookback = -1
  
@@ -51,7 +58,7 @@ index 0ffe85054..8471906ab 100644
  
      # USE_TD requires BLOCK_SIZE % TILE_SIZE == 0 (enforced by a
      # ``tl.static_assert`` in the kernel).  The default prefill tile
-@@ -928,18 +930,11 @@ def unified_attention(
+@@ -928,18 +930,11 @@
      # Launch the 2D kernel if
      # 1. No intermediate tiled softmax buffers for the 3D kernel have been allocated, or
      # 2. The batch includes at least one prefill request, or
@@ -75,7 +82,7 @@ index 0ffe85054..8471906ab 100644
  
      # The kernel signature is the same for 2D and 3D — only the launch
      # grid + a handful of constexpr toggles differ.  Per-token-head scale
-@@ -960,6 +955,30 @@ def unified_attention(
+@@ -960,6 +955,30 @@
          v_scale_ptr = None
      # 3D needs real segm tensors; 2D never touches them.  Pass ``None`` in
      # 2D mode so Triton can skip materialising these pointer arguments.

--- a/python/tutorials/03a-matrix-multiplication-tensor-descriptor.py
+++ b/python/tutorials/03a-matrix-multiplication-tensor-descriptor.py
@@ -81,7 +81,7 @@ direct knowledge of the memory access pattern, enabling it to emit optimal hardw
 #     for _ in range(0, K, BLOCK_SIZE_K):
 #         a = a_desc.load([pid_m * BLOCK_SIZE_M, off_k])
 #         b = b_desc.load([off_k, pid_n * BLOCK_SIZE_N])
-#         accumulator += tl.dot(a, b)
+#         accumulator = tl.dot(a, b, accumulator)
 #         off_k += BLOCK_SIZE_K
 
 # %%
@@ -169,7 +169,7 @@ def matmul_kernel_with_tensor_descriptors(
         a = a_desc.load([pid_m * BLOCK_SIZE_M, off_k])
         b = b_desc.load([off_k, pid_n * BLOCK_SIZE_N])
         # We accumulate along the K dimension.
-        accumulator += tl.dot(a, b, out_dtype=ACCUMULATOR_DTYPE)
+        accumulator = tl.dot(a, b, accumulator, out_dtype=ACCUMULATOR_DTYPE)
         # Advance the K offset for the next iteration.
         # See above `Iterating over K` section for details.
         off_k += BLOCK_SIZE_K
@@ -252,7 +252,7 @@ def matmul_kernel_with_tensor_descriptors_batched(
         a = a_desc.load([pid_m * BLOCK_SIZE_M, off_k])
         b = b_desc.load([off_k, pid_n * BLOCK_SIZE_N])
         # We accumulate along the K dimension.
-        accumulator += tl.dot(a, b, out_dtype=ACCUMULATOR_DTYPE)
+        accumulator = tl.dot(a, b, accumulator, out_dtype=ACCUMULATOR_DTYPE)
         # Advance the K offset for the next iteration.
         # See above `Iterating over K` section for details.
         off_k += BLOCK_SIZE_K


### PR DESCRIPTION
Pass the accumulator directly as the third argument to `tl.dot` instead of using `+=` to ensure the operation maps to a single DPAS instruction without relying on the `CombineOps` pass to fold a separate add.