### PR TITLE
[vLLM] Remove mamba tests from skiplist that pass after vllm pin update

### DIFF
--- a/scripts/skiplist/default/vllm_mamba.txt
+++ b/scripts/skiplist/default/vllm_mamba.txt
@@ -1,8 +1,0 @@
-# Multi GPU
-tests/kernels/mamba/test_mamba_mixer2.py::test_mixer2_gated_norm_multi_gpu[dtype0-hidden_size_n_groups0-128-8]
-tests/kernels/mamba/test_mamba_mixer2.py::test_mixer2_gated_norm_multi_gpu[dtype0-hidden_size_n_groups1-128-8]
-tests/kernels/mamba/test_mamba_mixer2.py::test_mixer2_gated_norm_multi_gpu[dtype0-hidden_size_n_groups2-128-8]
-
-# Other
-tests/kernels/mamba/test_mamba_ssm.py::test_selective_scan
-tests/kernels/mamba/test_mamba_ssm.py::test_selective_scan_varlen

--- a/scripts/skiplist/default/vllm_mamba.txt
+++ b/scripts/skiplist/default/vllm_mamba.txt
@@ -1,0 +1,4 @@
+# Multi GPU
+tests/kernels/mamba/test_mamba_mixer2.py::test_mixer2_gated_norm_multi_gpu[dtype0-hidden_size_n_groups0-128-8]
+tests/kernels/mamba/test_mamba_mixer2.py::test_mixer2_gated_norm_multi_gpu[dtype0-hidden_size_n_groups1-128-8]
+tests/kernels/mamba/test_mamba_mixer2.py::test_mixer2_gated_norm_multi_gpu[dtype0-hidden_size_n_groups2-128-8]

--- a/scripts/skiplist/xe2/vllm_mamba.txt
+++ b/scripts/skiplist/xe2/vllm_mamba.txt
@@ -1,8 +1,0 @@
-# Multi GPU
-tests/kernels/mamba/test_mamba_mixer2.py::test_mixer2_gated_norm_multi_gpu[dtype0-hidden_size_n_groups0-128-8]
-tests/kernels/mamba/test_mamba_mixer2.py::test_mixer2_gated_norm_multi_gpu[dtype0-hidden_size_n_groups1-128-8]
-tests/kernels/mamba/test_mamba_mixer2.py::test_mixer2_gated_norm_multi_gpu[dtype0-hidden_size_n_groups2-128-8]
-
-# Other
-tests/kernels/mamba/test_mamba_ssm.py::test_selective_scan
-tests/kernels/mamba/test_mamba_ssm.py::test_selective_scan_varlen

--- a/scripts/skiplist/xe2/vllm_mamba.txt
+++ b/scripts/skiplist/xe2/vllm_mamba.txt
@@ -1,0 +1,4 @@
+# Multi GPU
+tests/kernels/mamba/test_mamba_mixer2.py::test_mixer2_gated_norm_multi_gpu[dtype0-hidden_size_n_groups0-128-8]
+tests/kernels/mamba/test_mamba_mixer2.py::test_mixer2_gated_norm_multi_gpu[dtype0-hidden_size_n_groups1-128-8]
+tests/kernels/mamba/test_mamba_mixer2.py::test_mixer2_gated_norm_multi_gpu[dtype0-hidden_size_n_groups2-128-8]


### PR DESCRIPTION
These mamba tests now no longer fail when removed from the skiplist after the vllm pin update commit (7d5743e18):

```
tests/kernels/mamba/test_mamba_ssm.py::test_selective_scan
tests/kernels/mamba/test_mamba_ssm.py::test_selective_scan_varlen
```

An upstream vLLM commit has adapted the mamba tests to be compatible with XPU. These tests in particular are all intentionally getting pytest skipped because the selective_scan_fn is backed by the CUDA-only `ops.selective_scan_fwd`.

PVC tests: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27359642468
BMG tests: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27366383748

Relates to #6589