### PR TITLE
[CI] Enable TRITON_EXT_ENABLED for Triton builds

### DIFF
--- a/.github/actions/setup-triton/action.yml
+++ b/.github/actions/setup-triton/action.yml
@@ -115,6 +115,8 @@ runs:
 
     - name: Build Triton
       shell: bash
+      env:
+        TRITON_EXT_ENABLED: ON
       run: |
         pip install -r python/requirements.txt
         ${{ inputs.command }}


### PR DESCRIPTION
This PR enables `TRITON_EXT_ENABLED` for all Triton builds. This matches the behaviour of upstream `wheels.yml` (https://github.com/triton-lang/triton/pull/9935).

Part of #6970.

---

nightly wheels: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27436483910