### PR TITLE
[CI][Win] Update `intel-sycl-rt` to 2026.0.0 version

### DIFF
--- a/.github/workflows/pip-test-windows.yml
+++ b/.github/workflows/pip-test-windows.yml
@@ -91,7 +91,7 @@ jobs:
           Invoke-BatchFile "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
           cd ${{ env.NEW_WORKSPACE }}
           pip install -r python\requirements.txt
-          pip install -U intel-sycl-rt==2025.3.2
+          pip install -U intel-sycl-rt==2026.0.0
           # `build` can't determine that Ninja is already installed.
           # similar issue: https://github.com/pypa/build/issues/506
           python -m build --wheel --no-isolation --skip-dependency-check


### PR DESCRIPTION
CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27617360030/job/81656594461 (no more sycl issue)