### PR TITLE
[BlockIO] Use 2D block load for descriptor GEMM with runtime base

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -104,6 +104,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::test::registerTestAMDGPUMembarPass();
   mlir::test::registerTestTritonAMDGPURangeAnalysis();
   mlir::triton::registerConvertTritonToTritonGPUPass();
+  mlir::triton::intel::registerTritonIntelDescriptorVersioning();
   mlir::triton::intel::registerTritonIntelFuseReshape();
   mlir::triton::intel::registerTritonIntelRemoveMasks();
   mlir::triton::intel::registerTritonIntelStrideVersioning();

--- a/test/Triton/Intel/DescriptorVersioning/k-versioning.mlir
+++ b/test/Triton/Intel/DescriptorVersioning/k-versioning.mlir
@@ -1,0 +1,87 @@
+// RUN: triton-opt %s -split-input-file --triton-intel-descriptor-versioning | FileCheck %s
+
+module {
+  // CHECK-LABEL: tt.func public @version_runtime_k
+  tt.func public @version_runtime_k(%base: !tt.ptr<f16>, %cbase: !tt.ptr<f16>, %gm: i32, %gk_ptr: !tt.ptr<i32>, %gn_ptr: !tt.ptr<i32>, %lda: i64, %ldc: i64, %ub: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    // CHECK-DAG: %[[GK:.*]] = tt.load %arg3
+    // CHECK-DAG: %[[GN:.*]] = tt.load %arg4
+    %gk = tt.load %gk_ptr : !tt.ptr<i32>
+    %gn = tt.load %gn_ptr : !tt.ptr<i32>
+
+    // CHECK: %[[ARAW:.*]] = tt.make_tensor_descriptor %arg0, [%arg2, %[[GK]]]
+    // CHECK: %[[ADIV:.*]] = arith.divsi %[[GK]], %[[D0:.*]] :
+    // CHECK: %[[AK:.*]] = arith.muli %[[ADIV]], %[[D0]] :
+    // CHECK: %[[AALIGNED:.*]] = tt.make_tensor_descriptor %arg0, [%arg2, %[[AK]]]
+    // CHECK: %[[CRAW:.*]] = tt.make_tensor_descriptor %arg1, [%arg2, %[[GN]]]
+    // CHECK: %[[CDIV:.*]] = arith.divsi %[[GN]], %[[D1:.*]] :
+    // CHECK: %[[CK:.*]] = arith.muli %[[CDIV]], %[[D1]] :
+    // CHECK: %[[CALIGNED:.*]] = tt.make_tensor_descriptor %arg1, [%arg2, %[[CK]]]
+    %adesc = tt.make_tensor_descriptor %base, [%gm, %gk], [%lda, %c1_i64] : <f16>, <128x64xf16>
+    %cdesc = tt.make_tensor_descriptor %cbase, [%gm, %gn], [%ldc, %c1_i64] : <f16>, <128x128xf16>
+
+    // CHECK: arith.remsi %[[GK]]
+    // CHECK: %[[C0:.*]] = arith.cmpi eq
+    // CHECK: arith.remsi %[[GN]]
+    // CHECK: %[[C1:.*]] = arith.cmpi eq
+    // CHECK: %[[PRED:.*]] = arith.andi
+    // CHECK: scf.if %[[PRED]]
+    // CHECK: scf.while
+    // CHECK: scf.for
+    // CHECK: tt.descriptor_load %[[AALIGNED]]
+    // CHECK: tt.descriptor_store %[[CALIGNED]]
+    // CHECK: else
+    // CHECK: scf.while
+    // CHECK: tt.descriptor_load %[[ARAW]]
+    // CHECK: tt.descriptor_store %[[CRAW]]
+    %r = scf.while (%t = %c0_i32) : (i32) -> i32 {
+      %c = arith.cmpi slt, %t, %ub : i32
+      scf.condition(%c) %t : i32
+    } do {
+    ^bb0(%t: i32):
+      %acc = scf.for %kk = %c0_i32 to %ub step %c1_i32 iter_args(%a = %cst) -> (tensor<128x128xf32>) : i32 {
+        %off = arith.muli %kk, %c64_i32 : i32
+        %ld = tt.descriptor_load %adesc[%c0_i32, %off] : !tt.tensordesc<128x64xf16> -> tensor<128x64xf16>
+        scf.yield %a : tensor<128x128xf32>
+      }
+      %cv = arith.truncf %acc : tensor<128x128xf32> to tensor<128x128xf16>
+      tt.descriptor_store %cdesc[%c0_i32, %c0_i32], %cv : !tt.tensordesc<128x128xf16>, tensor<128x128xf16>
+      %tn = arith.addi %t, %c64_i32 : i32
+      scf.yield %tn : i32
+    }
+    tt.return
+  }
+}
+
+// -----
+
+module {
+  // CHECK-LABEL: tt.func public @constant_k_not_versioned
+  tt.func public @constant_k_not_versioned(%base: !tt.ptr<f16>, %gm: i32, %lda: i64, %ub: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    // CHECK-NOT: scf.if
+    %adesc = tt.make_tensor_descriptor %base, [%gm, %c64_i32], [%lda, %c1_i64] : <f16>, <128x64xf16>
+    %r = scf.while (%t = %c0_i32) : (i32) -> i32 {
+      %c = arith.cmpi slt, %t, %ub : i32
+      scf.condition(%c) %t : i32
+    } do {
+    ^bb0(%t: i32):
+      %acc = scf.for %kk = %c0_i32 to %ub step %c1_i32 iter_args(%a = %cst) -> (tensor<128x128xf32>) : i32 {
+        %off = arith.muli %kk, %c64_i32 : i32
+        %ld = tt.descriptor_load %adesc[%c0_i32, %off] : !tt.tensordesc<128x64xf16> -> tensor<128x64xf16>
+        scf.yield %a : tensor<128x128xf32>
+      }
+      %tn = arith.addi %t, %c64_i32 : i32
+      scf.yield %tn : i32
+    }
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/dot-operands.mlir
+++ b/test/TritonIntelGPU/dot-operands.mlir
@@ -111,3 +111,44 @@ module attributes {ttig.support_2d_block_io, "ttg.num-warps" = 8 : i32, "ttg.thr
     tt.return %d : tensor<64x64xf32, #dpas>
   }
 }
+
+// -----
+
+// COM: trans(descriptor_load) -> dot inside an scf.while must still fuse into a
+// COM: column_major 2D block load (regression guard for the removed scf.while
+// COM: guard in OptimizeDotOperands).
+#brow = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#bcol = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+#dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>
+module attributes {ttig.support_2d_block_io, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: tt.func @fuse_trans_with_descriptor_load_in_while
+  // CHECK: scf.while
+  // CHECK: %[[LD:.*]] = tt.descriptor_load {{.*}} {ttig.block_io = "column_major"} : !tt.tensordesc<64x32xf16> -> tensor<32x64xf16, #[[BCOL:[a-z]+]]>
+  // CHECK-NOT: tt.trans
+  // CHECK: ttg.convert_layout %[[LD]] : tensor<32x64xf16, #[[BCOL]]> -> tensor<32x64xf16, {{.*}}>
+  // CHECK: tt.dot
+  tt.func @fuse_trans_with_descriptor_load_in_while(%ptr: !tt.ptr<f16>, %a: tensor<64x32xf16, #dot0>, %ub: i32) -> tensor<64x64xf32, #dpas> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i32 = arith.constant 32 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c32_i64 = arith.constant 32 : i64
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #dpas>
+    %desc = tt.make_tensor_descriptor %ptr, [%c64_i32, %c32_i32], [%c32_i64, %c1_i64] : <f16>, <64x32xf16>
+    %r:2 = scf.while (%t = %c0_i32, %acc = %cst) : (i32, tensor<64x64xf32, #dpas>) -> (i32, tensor<64x64xf32, #dpas>) {
+      %c = arith.cmpi slt, %t, %ub : i32
+      scf.condition(%c) %t, %acc : i32, tensor<64x64xf32, #dpas>
+    } do {
+    ^bb0(%t: i32, %acc: tensor<64x64xf32, #dpas>):
+      %ld = tt.descriptor_load %desc[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #brow>
+      %tr = tt.trans %ld {order = array<i32: 1, 0>} : tensor<64x32xf16, #brow> -> tensor<32x64xf16, #bcol>
+      %b = ttg.convert_layout %tr : tensor<32x64xf16, #bcol> -> tensor<32x64xf16, #dot1>
+      %d = tt.dot %a, %b, %acc, inputPrecision = tf32 : tensor<64x32xf16, #dot0> * tensor<32x64xf16, #dot1> -> tensor<64x64xf32, #dpas>
+      %tn = arith.addi %t, %c64_i32 : i32
+      scf.yield %tn, %d : i32, tensor<64x64xf32, #dpas>
+    }
+    tt.return %r#1 : tensor<64x64xf32, #dpas>
+  }
+}

--- a/test/TritonIntelGPU/materialize-tensor-descriptor.mlir
+++ b/test/TritonIntelGPU/materialize-tensor-descriptor.mlir
@@ -165,3 +165,35 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     tt.return
   }
 }
+
+// -----
+
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot_a = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func public @materialize_tensor_descriptor_f32_row_length(
+  tt.func public @materialize_tensor_descriptor_f32_row_length(%base: !tt.ptr<f32>, %pitch: i64, %k: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i32 = arith.constant 64 : i32
+    %c119_i32 = arith.constant 119 : i32
+
+    // CHECK: tt.make_tensor_descriptor
+    // CHECK-NEXT: tt.descriptor_load
+    // CHECK-NOT: ttig.block_io = "row_major"
+    %0 = tt.make_tensor_descriptor %base, [%c64_i32, %c119_i32], [%pitch, %c1_i64] : !tt.ptr<f32>, !tt.tensordesc<8x16xf32, #dot_a>
+    %1 = tt.descriptor_load %0[%c0_i32, %c0_i32] : !tt.tensordesc<8x16xf32, #dot_a> -> tensor<8x16xf32, #dot_a>
+
+    // CHECK: tt.make_tensor_descriptor
+    // CHECK-NEXT: tt.descriptor_load
+    // CHECK-NOT: ttig.block_io = "row_major"
+    %2 = tt.make_tensor_descriptor %base, [%c64_i32, %k], [%pitch, %c1_i64] : !tt.ptr<f32>, !tt.tensordesc<8x16xf32, #dot_a>
+    %3 = tt.descriptor_load %2[%c0_i32, %c0_i32] : !tt.tensordesc<8x16xf32, #dot_a> -> tensor<8x16xf32, #dot_a>
+
+    // CHECK: tt.descriptor_load {{.*}} {ttig.block_io = "row_major"{{.*}}}
+    %4 = tt.make_tensor_descriptor %base, [%c64_i32, %c64_i32], [%pitch, %c1_i64] : !tt.ptr<f32>, !tt.tensordesc<8x16xf32, #dot_a>
+    %5 = tt.descriptor_load %4[%c0_i32, %c0_i32] : !tt.tensordesc<8x16xf32, #dot_a> -> tensor<8x16xf32, #dot_a>
+
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/materialize-tensor-descriptor.mlir
+++ b/test/TritonIntelGPU/materialize-tensor-descriptor.mlir
@@ -139,3 +139,29 @@ module attributes {"ttg.num-ctas" = 1 : i32, ttg.target = "xpu", "ttg.num-warps"
     tt.return %a_13 : tensor<256x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
   }
 }
+
+// -----
+
+// COM: Runtime base/pitch with no tt.divisibility hint, so axis-info reports
+// COM: divisibility 1. We trust the 16-byte make_tensor_descriptor contract
+// COM: instead of rejecting, so block_io must still be set (row_major). This is
+// COM: the fast-path unlock that the hinted descriptors above never exercise.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot_a = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func public @materialize_tensor_descriptor_runtime_base(
+  tt.func public @materialize_tensor_descriptor_runtime_base(%base: !tt.ptr<f16>, %pitch: i64) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i32 = arith.constant 32 : i32
+    %c64_i32 = arith.constant 64 : i32
+
+    // CHECK: tt.descriptor_load {{.*}} {ttig.block_io = "row_major"{{.*}}}
+    %0 = tt.make_tensor_descriptor %base, [%c64_i32, %c32_i32], [%pitch, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<64x32xf16, #dot_a>
+    %1 = tt.descriptor_load %0[%c0_i32, %c0_i32] : !tt.tensordesc<64x32xf16, #dot_a> -> tensor<64x32xf16, #dot_a>
+    // CHECK: tt.descriptor_store {{.*}} {ttig.block_io = "row_major"{{.*}}}
+    tt.descriptor_store %0[%c0_i32, %c0_i32], %1 : !tt.tensordesc<64x32xf16, #dot_a>, tensor<64x32xf16, #dot_a>
+
+    tt.return
+  }
+}

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -307,6 +307,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         passes.ttir.add_triton_licm(pm)
         intel.passes.ttir.add_remove_masks(pm)
         intel.passes.ttir.add_stride_versioning(pm)
+        intel.passes.ttir.add_descriptor_versioning(pm)
         intel.passes.ttir.add_fuse_reshape(pm)
         intel.passes.ttir.add_fold_true_cmpi(pm)
         intel.passes.ttir.add_prepare_if_combining(pm)

--- a/third_party/intel/include/Dialect/Triton/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/Triton/Transforms/Passes.td
@@ -110,6 +110,35 @@ def TritonIntelStrideVersioning
   ];
 }
 
+def TritonIntelDescriptorVersioning
+    : Pass<"triton-intel-descriptor-versioning", "mlir::ModuleOp"> {
+  let summary = "Version persistent tensor-descriptor loops on a runtime row length so the 2D-block fast path can fire";
+
+  let description = [{
+    Versions a persistent `scf.while` tile loop on the runtime row length of a
+    tensor descriptor that `MaterializeBlockPointer` must prove divisible by the
+    surface-width granularity (2 for fp16) at compile time to enable the
+    2D-block fast path.
+
+    In grouped GEMM the row length is a runtime `gk = tl.load(...)`, so the gate
+    cannot prove it divisible. Clone the persistent loop under `if (gk % d == 0)`
+    and rewrite the then-branch row length to `(gk / d) * d` (== gk under the
+    predicate, and structurally divisible so the gate fires); the else-branch
+    keeps the runtime `gk` for the correct gather path:
+
+       %a  = tt.make_tensor_descriptor %base, [%gm, %gk], [%lda, 1]
+       %a' = tt.make_tensor_descriptor %base, [%gm, (%gk / 2) * 2], [%lda, 1]
+       if (%gk % 2 == 0) scf.while ... { scf.for ... { ...%a'... } }
+       else              scf.while ... { scf.for ... { ...%a...  } }
+  }];
+
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::scf::SCFDialect",
+    "mlir::triton::TritonDialect"
+  ];
+}
+
 def TritonIntelSimplifySignedArithmetic
     : Pass<"triton-intel-simplify-signed-arithmetic", "mlir::ModuleOp"> {
   let summary = "Simplify signed arithmetic ops by converting to unsigned when operands are non-negative";

--- a/third_party/intel/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_triton_library(TritonIntelTransforms
+  DescriptorVersioning.cpp
   FoldTrueCmpIOp.cpp
   FuseReshape.cpp
   PrepareIfCombining.cpp

--- a/third_party/intel/lib/Dialect/Triton/Transforms/DescriptorVersioning.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/DescriptorVersioning.cpp
@@ -1,0 +1,207 @@
+//===- DescriptorVersioning.cpp - Version descriptor loops ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Runtime row-length versioning for persistent tensor-descriptor loops.
+//
+// Clone a persistent scf.while under `gk % d == 0` so the then-branch can use a
+// row length rewritten to `(gk / d) * d` (== gk under the predicate, and
+// structurally divisible so the 2D-block gate in MaterializeBlockPointer
+// fires), while the else-branch keeps the runtime `gk` for the gather path.
+// `d` is the surface-width granularity (2 for fp16).
+//
+//===----------------------------------------------------------------------===//
+
+#include "intel/include/Dialect/Triton/Transforms/Passes.h"
+#include "intel/include/Utils/Utility.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Support/LLVM.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "triton-intel-descriptor-versioning"
+
+using namespace mlir;
+namespace tt = mlir::triton;
+
+namespace mlir::triton::intel {
+#define GEN_PASS_DEF_TRITONINTELDESCRIPTORVERSIONING
+#include "intel/include/Dialect/Triton/Transforms/Passes.h.inc"
+} // namespace mlir::triton::intel
+
+namespace {
+
+// Marks a versioned (then/else) clone so it isn't versioned again.
+constexpr StringLiteral kVersionedAttr = "ttig.descriptor_k_versioned";
+
+struct DescCandidate {
+  tt::MakeTensorDescOp descOp;
+  Value innerShape;
+  unsigned divisor;
+};
+
+SmallVector<DescCandidate> collectKCandidates(scf::WhileOp whileOp) {
+  llvm::SmallMapVector<Operation *, DescCandidate, 4> candidates;
+  auto consider = [&](Value desc) {
+    std::optional<tt::MakeTensorDescOp> descOp =
+        tt::intel::findMakeTensorDescOp(desc);
+    if (!descOp || candidates.contains(descOp->getOperation()))
+      return;
+    // The descriptor must dominate the while for the rewritten clone to be
+    // valid; in grouped-GEMM it sits just before the while in the same block.
+    if (descOp->getOperation()->getBlock() != whileOp->getBlock() ||
+        !descOp->getOperation()->isBeforeInBlock(whileOp))
+      return;
+
+    Operation::operand_range shape = descOp->getShape();
+    unsigned rank = shape.size();
+    if (rank < 2)
+      return;
+
+    auto descType = cast<tt::TensorDescType>(descOp->getType());
+    unsigned divisor =
+        llvm::divideCeil(32u, descType.getBlockType().getElementTypeBitWidth());
+    if (divisor <= 1)
+      return;
+
+    // Only version a runtime row length; a constant already passes the gate.
+    Value innerShape = shape[rank - 1];
+    if (tt::intel::getFoldedConstantValue(tt::intel::getFinalValue(innerShape)))
+      return;
+
+    candidates.insert({descOp->getOperation(), {*descOp, innerShape, divisor}});
+  };
+
+  whileOp.walk([&](Operation *op) {
+    if (auto load = dyn_cast<tt::DescriptorLoadOp>(op))
+      consider(load.getDesc());
+    else if (auto store = dyn_cast<tt::DescriptorStoreOp>(op))
+      consider(store.getDesc());
+  });
+
+  return llvm::to_vector(llvm::make_second_range(candidates));
+}
+
+void versionWhileForK(scf::WhileOp whileOp,
+                      ArrayRef<DescCandidate> candidates) {
+  Location loc = whileOp.getLoc();
+  OpBuilder builder(whileOp);
+
+  // One predicate term per distinct row length.
+  llvm::MapVector<Value, unsigned> shapeToDivisor;
+  for (const DescCandidate &c : candidates) {
+    auto [it, inserted] = shapeToDivisor.try_emplace(c.innerShape, c.divisor);
+    if (!inserted)
+      it->second = std::max(it->second, c.divisor);
+  }
+
+  Value zero =
+      arith::ConstantOp::create(builder, loc, builder.getI32IntegerAttr(0));
+  Value verCond;
+  for (auto &[innerShape, divisor] : shapeToDivisor) {
+    Value div = arith::ConstantOp::create(builder, loc,
+                                          builder.getI32IntegerAttr(divisor));
+    Value rem = arith::RemSIOp::create(builder, loc, innerShape, div);
+    Value cmp = arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::eq,
+                                      rem, zero);
+    verCond =
+        verCond ? arith::AndIOp::create(builder, loc, verCond, cmp).getResult()
+                : cmp;
+  }
+  assert(verCond && "Expecting at least one versioning condition");
+
+  auto ifOp = scf::IfOp::create(builder, loc, whileOp.getResultTypes(), verCond,
+                                /*withElseRegion=*/true);
+  OpBuilder thenB = ifOp.getThenBodyBuilder();
+  Operation *thenWhile = thenB.clone(*whileOp.getOperation());
+  OpBuilder elseB = ifOp.getElseBodyBuilder();
+  Operation *elseWhile = elseB.clone(*whileOp.getOperation());
+  if (!thenWhile->getResults().empty()) {
+    scf::YieldOp::create(thenB, loc, thenWhile->getResults());
+    scf::YieldOp::create(elseB, loc, elseWhile->getResults());
+  }
+
+  thenWhile->setAttr(kVersionedAttr, builder.getUnitAttr());
+  elseWhile->setAttr(kVersionedAttr, builder.getUnitAttr());
+
+  for (auto [orig, repl] : llvm::zip(whileOp.getResults(), ifOp.getResults()))
+    orig.replaceAllUsesWith(repl);
+
+  for (const DescCandidate &c : candidates) {
+    tt::MakeTensorDescOp descOp = c.descOp;
+    OpBuilder descB(descOp);
+    descB.setInsertionPointAfter(descOp);
+    Value div = arith::ConstantOp::create(descB, loc,
+                                          descB.getI32IntegerAttr(c.divisor));
+    Value divided = arith::DivSIOp::create(descB, loc, c.innerShape, div);
+    Value aligned = arith::MulIOp::create(descB, loc, divided, div);
+
+    auto alignedDesc = cast<tt::MakeTensorDescOp>(descOp->clone());
+    descB.insert(alignedDesc);
+    MutableOperandRange shapeMut = alignedDesc.getShapeMutable();
+    unsigned lastIdx = alignedDesc.getShape().size() - 1;
+    unsigned idx = 0;
+    for (OpOperand &shapeOperand : shapeMut) {
+      if (idx++ == lastIdx) {
+        shapeOperand.set(aligned);
+        break;
+      }
+    }
+
+    // Rewire only the then-clone to the aligned descriptor.
+    descOp.getResult().replaceUsesWithIf(
+        alignedDesc.getResult(), [&](OpOperand &use) {
+          return thenWhile->isProperAncestor(use.getOwner());
+        });
+  }
+
+  whileOp.erase();
+}
+
+struct TritonIntelDescriptorVersioning
+    : tt::intel::impl::TritonIntelDescriptorVersioningBase<
+          TritonIntelDescriptorVersioning> {
+public:
+  using Base::Base;
+
+  void runOnOperation() final {
+    ModuleOp moduleOp = getOperation();
+
+    // Collect first, then transform: versioning erases the whole nest, so only
+    // queue outermost, unversioned loops.
+    SmallVector<scf::WhileOp> whileWorklist;
+    moduleOp.walk([&](scf::WhileOp whileOp) {
+      if (!whileOp->hasAttr(kVersionedAttr) &&
+          !whileOp->getParentOfType<scf::WhileOp>())
+        whileWorklist.push_back(whileOp);
+    });
+    for (scf::WhileOp whileOp : whileWorklist) {
+      SmallVector<DescCandidate> candidates = collectKCandidates(whileOp);
+      if (candidates.empty())
+        continue;
+      LLVM_DEBUG(llvm::dbgs() << "K-versioning scf.while with "
+                              << candidates.size() << " candidate(s)\n");
+      versionWhileForK(whileOp, candidates);
+    }
+
+    LLVM_DEBUG(llvm::dbgs() << "After versioning:\n" << moduleOp << "\n");
+    assert(succeeded(verify(moduleOp)) && "Module verification failed");
+  }
+};
+
+} // namespace

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -890,7 +890,7 @@ private:
     // Analyze the shape of the stride one dimension to ensure it satisfies HW
     // constraints.
     Value baseWidth = tt::intel::getFinalValue(shape[strideOneDimVal]);
-    unsigned divisor = llvm::divideCeil(32, elementWidth);
+    unsigned divisor = std::max(2u, llvm::divideCeil(32u, elementWidth));
     if (!ttgi::isDivisible(baseWidth, divisor)) {
       LLVM_DEBUG({
         llvm::dbgs() << "baseWidth does not satisfies HW constraint: ";

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -46,6 +46,26 @@ static bool isBlockIOForAllLayoutsExplicitlyDisabled() {
          !enableBlockIOForAllLayout.value();
 }
 
+// Check a descriptor base pointer or pitch against an alignment requirement.
+// A constant must be provably divisible. For a runtime value, divisibility 1
+// means the alignment is unknown; we trust the 16-byte make_tensor_descriptor
+// contract rather than reject the 2D block IO path. This silently miscompiles
+// if a caller breaks that contract, so the LDBG traces when we rely on it.
+static bool isDescriptorAligned(tt::intel::ModuleAxisInfoAnalysis &axisInfo,
+                                Value v, unsigned divisor) {
+  if (matchPattern(v, m_Constant()))
+    return ttgi::isDivisible(v, divisor);
+  const tt::AxisInfo *info = axisInfo.getAxisInfo(v);
+  int64_t div = info ? info->getDivisibility(0) : 1;
+  if (div == 1) {
+    LDBG("Divisibility unknown; trusting the 16-byte make_tensor_descriptor "
+         "alignment contract for runtime value (divisor="
+         << divisor << "): " << v);
+    return true;
+  }
+  return div % divisor == 0;
+}
+
 struct TritonIntelGPUMaterializeBlockPointerPass
     : public triton::gpu::intel::impl::
           TritonIntelGPUMaterializeBlockPointerBase<
@@ -153,8 +173,8 @@ private:
     // multiple of OWord(128 bits). All candidates must satisfy this.
     unsigned pitchDivisor = llvm::divideCeil(128, elementWidth);
     if (!llvm::all_of(allDescs, [&](tt::MakeTensorDescOp d) {
-          Value pitch = d.getStrides()[rank - 2];
-          return ttgi::isDivisible(pitch, pitchDivisor);
+          return isDescriptorAligned(axisInfoAnalysis, d.getStrides()[rank - 2],
+                                     pitchDivisor);
         }))
       return;
 
@@ -860,10 +880,10 @@ private:
     // Ensure the base ptr is 4-byte aligned.
     // Note: the HW requires the address to be 64-byte aligned, however we will
     // compensate by imposing restrictions on the offsetX and baseWidth.
-    const tt::AxisInfo *axisInfo = axisInfoAnalysis.getAxisInfo(desc);
-    if (axisInfo->getDivisibility(strideOneDimVal) % 4 != 0) {
-      LDBG("Found non 4 bytes aligned base: "
-           << axisInfo->getDivisibility(strideOneDimVal));
+    if (!llvm::all_of(allDescs, [&](tt::MakeTensorDescOp d) {
+          return isDescriptorAligned(axisInfoAnalysis, d.getBase(), 4);
+        })) {
+      LDBG("Found non 4 bytes aligned base");
       return false;
     }
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/OptimizeDotOperands.cpp
@@ -80,9 +80,6 @@ private:
             ttgi::TritonIntelGPUDialect::getSupport2DBlockIOAttrName()))
       return false;
 
-    if (transOp->getParentOfType<scf::WhileOp>())
-      return false;
-
     if (!transOp->hasOneUse())
       return false;
 

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -64,6 +64,8 @@ void init_triton_intel_passes_ttir(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_remove_masks", intel::createTritonIntelRemoveMasks);
   ADD_PASS_WRAPPER_0("add_stride_versioning",
                      intel::createTritonIntelStrideVersioning);
+  ADD_PASS_WRAPPER_0("add_descriptor_versioning",
+                     intel::createTritonIntelDescriptorVersioning);
   ADD_PASS_WRAPPER_0("add_fuse_reshape", intel::createTritonIntelFuseReshape);
   ADD_PASS_WRAPPER_0("add_simplify_signed_arithmetic",
                      intel::createTritonIntelSimplifySignedArithmetic);


### PR DESCRIPTION
The grouped GEMM tutorial fell back to a scalar gather on PVC instead of using 2D block loads. In the persistent kernel the row length gk is a runtime tl.load, so MaterializeBlockPointer can't prove it's divisible by the surface granularity (2 for fp16) and skips the fast path.

This adds a triton-intel-descriptor-versioning pass that clones the persistent scf.while loop under if (gk % d == 0):
- then-branch: rewrite the row length to (gk / d) * d same value under the predicate, but structurally divisible, so the 2D block load fires.
- else-branch: keep gk and fall back to the gather for odd K.

Also trusts runtime base/pitch against the 16-byte make_tensor_descriptor contract (with a comment + LDBG), and drops the scf.while guard blocking trans(descriptor_load) fusion, with a lit test.

Closes #7214 