### PR TITLE
[XPU] Add fast-math-gated FP reassociation to open dot-scale hoists

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -111,6 +111,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::intel::registerTritonRewriteTensorDescriptorToPointer();
   mlir::triton::intel::registerTritonIntelGPUFoldTrueCmpI();
   mlir::triton::intel::registerTritonIntelGPUPrepareIfCombining();
+  mlir::triton::intel::registerTritonIntelReassociateDotScale();
   mlir::triton::registerRelayoutTritonGPUPass();
   mlir::triton::gpu::registerAllocateSharedMemoryPass();
   mlir::triton::gpu::registerTritonGPUAllocateWarpGroups();

--- a/test/Triton/Intel/ReassociateDotScale/reassociate-and-hoist.mlir
+++ b/test/Triton/Intel/ReassociateDotScale/reassociate-and-hoist.mlir
@@ -1,0 +1,77 @@
+// RUN: triton-opt %s -triton-intel-reassociate-dot-scale=fast-math=true -triton-licm | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// COMBINED HOIST CHECK — verify the reassociation enables LICM
+//===----------------------------------------------------------------------===//
+
+module {
+  // COM: After reassociation, the scaled operand should be hoisted above the loop
+  // COM: Original: scale * dot(A_inv, B_var) inside loop
+  // COM: After reassoc: dot(scale*A_inv, B_var) — the scale*A_inv is loop-invariant
+  // COM: After LICM: scale*A_inv hoisted above loop, dot inside loop uses the hoisted value
+  // CHECK-LABEL: tt.func public @hoist_after_reassociate
+  tt.func public @hoist_after_reassociate(%a_inv: tensor<128x64xbf16>, %b_ptr: !tt.ptr<bf16>, %scale_scalar: f32, %lb: i32, %ub: i32, %step: i32) -> tensor<128x128xf32> {
+    %c64 = arith.constant 64 : i32
+    %zero_acc = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %zero_acc) -> (tensor<128x128xf32>) : i32 {
+      %b_offset = arith.muli %iv, %c64 : i32
+      %b_ptr_off = tt.addptr %b_ptr, %b_offset : !tt.ptr<bf16>, i32
+      %b_ptr_splat = tt.splat %b_ptr_off : !tt.ptr<bf16> -> tensor<64x128x!tt.ptr<bf16>>
+      %b_var = tt.load %b_ptr_splat : tensor<64x128x!tt.ptr<bf16>>
+
+      %dot_res = tt.dot %a_inv, %b_var, %zero_acc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %scale_splat = tt.splat %scale_scalar : f32 -> tensor<128x128xf32>
+      %scaled_dot = arith.mulf %scale_splat, %dot_res : tensor<128x128xf32>
+
+      %acc_new = arith.addf %acc, %scaled_dot : tensor<128x128xf32>
+      scf.yield %acc_new : tensor<128x128xf32>
+    }
+    tt.return %result : tensor<128x128xf32>
+  }
+
+  // COM: The scaled operand computation should appear BEFORE the scf.for
+  // CHECK: %[[SCALE_SPLAT:.*]] = tt.splat %{{.*}} : f32 -> tensor<128x64xf32>
+  // CHECK: %[[A_EXT:.*]] = arith.extf %{{.*}} : tensor<128x64xbf16> to tensor<128x64xf32>
+  // CHECK: %[[SCALED_EXT:.*]] = arith.mulf %[[A_EXT]], %[[SCALE_SPLAT]] fastmath<reassoc> : tensor<128x64xf32>
+  // CHECK: %[[SCALED_A:.*]] = arith.truncf %[[SCALED_EXT]] : tensor<128x64xf32> to tensor<128x64xbf16>
+  // CHECK: %[[RESULT:.*]] = scf.for
+  // CHECK: %[[B_LOAD:.*]] = tt.load
+  // CHECK: %[[DOT:.*]] = tt.dot %[[SCALED_A]], %[[B_LOAD]]
+  // CHECK: arith.addf {{.*}}, %[[DOT]]
+}
+
+// -----
+
+module {
+  // COM: Same test with B invariant instead of A
+  // CHECK-LABEL: tt.func public @hoist_after_reassociate_b
+  tt.func public @hoist_after_reassociate_b(%a_ptr: !tt.ptr<bf16>, %b_inv: tensor<64x128xbf16>, %scale_scalar: f32, %lb: i32, %ub: i32, %step: i32) -> tensor<128x128xf32> {
+    %c64 = arith.constant 64 : i32
+    %zero_acc = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %zero_acc) -> (tensor<128x128xf32>) : i32 {
+      %a_offset = arith.muli %iv, %c64 : i32
+      %a_ptr_off = tt.addptr %a_ptr, %a_offset : !tt.ptr<bf16>, i32
+      %a_ptr_splat = tt.splat %a_ptr_off : !tt.ptr<bf16> -> tensor<128x64x!tt.ptr<bf16>>
+      %a_var = tt.load %a_ptr_splat : tensor<128x64x!tt.ptr<bf16>>
+
+      %dot_res = tt.dot %a_var, %b_inv, %zero_acc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %scale_splat = tt.splat %scale_scalar : f32 -> tensor<128x128xf32>
+      %scaled_dot = arith.mulf %dot_res, %scale_splat : tensor<128x128xf32>
+
+      %acc_new = arith.addf %acc, %scaled_dot : tensor<128x128xf32>
+      scf.yield %acc_new : tensor<128x128xf32>
+    }
+    tt.return %result : tensor<128x128xf32>
+  }
+
+  // CHECK: %[[SCALE_SPLAT:.*]] = tt.splat %{{.*}} : f32 -> tensor<64x128xf32>
+  // CHECK: %[[B_EXT:.*]] = arith.extf %{{.*}} : tensor<64x128xbf16> to tensor<64x128xf32>
+  // CHECK: %[[SCALED_EXT:.*]] = arith.mulf %[[B_EXT]], %[[SCALE_SPLAT]] fastmath<reassoc> : tensor<64x128xf32>
+  // CHECK: %[[SCALED_B:.*]] = arith.truncf %[[SCALED_EXT]] : tensor<64x128xf32> to tensor<64x128xbf16>
+  // CHECK: %[[RESULT:.*]] = scf.for
+  // CHECK: %[[A_LOAD:.*]] = tt.load
+  // CHECK: %[[DOT:.*]] = tt.dot %[[A_LOAD]], %[[SCALED_B]]
+  // CHECK: arith.addf {{.*}}, %[[DOT]]
+}

--- a/test/Triton/Intel/ReassociateDotScale/reassociate-dot-scale.mlir
+++ b/test/Triton/Intel/ReassociateDotScale/reassociate-dot-scale.mlir
@@ -159,6 +159,48 @@ module {
   // CHECK: %[[NEW_DOT:.*]] = tt.dot %[[SCALED_A]], %[[B_LOAD]]
 }
 
+// -----
+
+module {
+  // COM: Scale narrower than the dot operand. The scale tensor (and dot result)
+  // COM: are f16 while the operands are f32, so the scale is extended up to the
+  // COM: f32 compute type (lossless) before the multiply. The compute type
+  // COM: matches the f32 operand, so no operand extf and no product truncf are
+  // COM: emitted — only the scale scalar is extended.
+  // CHECK-LABEL: tt.func public @scale_narrower_than_operand
+  tt.func public @scale_narrower_than_operand(%a_inv: tensor<128x64xf32>, %b_ptr: !tt.ptr<f32>, %scale_scalar: f16, %lb: i32, %ub: i32, %step: i32) -> tensor<128x128xf16> {
+    %c64 = arith.constant 64 : i32
+    %zero_acc = arith.constant dense<0.000000e+00> : tensor<128x128xf16>
+
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %zero_acc) -> (tensor<128x128xf16>) : i32 {
+      %b_offset = arith.muli %iv, %c64 : i32
+      %b_ptr_off = tt.addptr %b_ptr, %b_offset : !tt.ptr<f32>, i32
+      %b_ptr_splat = tt.splat %b_ptr_off : !tt.ptr<f32> -> tensor<64x128x!tt.ptr<f32>>
+      %b_var = tt.load %b_ptr_splat : tensor<64x128x!tt.ptr<f32>>
+
+      %dot_res = tt.dot %a_inv, %b_var, %zero_acc, inputPrecision = tf32 : tensor<128x64xf32> * tensor<64x128xf32> -> tensor<128x128xf16>
+      %scale_splat = tt.splat %scale_scalar : f16 -> tensor<128x128xf16>
+      %scaled_dot = arith.mulf %scale_splat, %dot_res : tensor<128x128xf16>
+
+      %acc_new = arith.addf %acc, %scaled_dot : tensor<128x128xf16>
+      scf.yield %acc_new : tensor<128x128xf16>
+    }
+    tt.return %result : tensor<128x128xf16>
+  }
+
+  // CHECK: scf.for
+  // CHECK: %[[B_LOAD:.*]] = tt.load
+  // COM: Scale scalar extended f16 -> f32 before the splat (compute in f32)
+  // CHECK: %[[SCALE_EXT:.*]] = arith.extf %{{.*}} : f16 to f32
+  // CHECK: %[[SCALE_SPLAT:.*]] = tt.splat %[[SCALE_EXT]] : f32 -> tensor<128x64xf32>
+  // COM: No extf on the operand — it is already f32
+  // CHECK-NOT: arith.extf %{{.*}} : tensor
+  // CHECK: %[[SCALED_A:.*]] = arith.mulf %{{.*}}, %[[SCALE_SPLAT]] fastmath<reassoc> : tensor<128x64xf32>
+  // COM: No truncf — compute type matches the f32 operand type
+  // CHECK-NOT: arith.truncf
+  // CHECK: %[[NEW_DOT:.*]] = tt.dot %[[SCALED_A]], %[[B_LOAD]]
+}
+
 //===----------------------------------------------------------------------===//
 // NEGATIVE TESTS — must NOT rewrite (IR structure preserved)
 //===----------------------------------------------------------------------===//

--- a/test/Triton/Intel/ReassociateDotScale/reassociate-dot-scale.mlir
+++ b/test/Triton/Intel/ReassociateDotScale/reassociate-dot-scale.mlir
@@ -1,0 +1,390 @@
+// RUN: triton-opt %s -split-input-file -triton-intel-reassociate-dot-scale=fast-math=true | FileCheck %s
+// RUN: triton-opt %s -split-input-file -triton-intel-reassociate-dot-scale=fast-math=false | FileCheck %s --check-prefix=NOFAST
+
+//===----------------------------------------------------------------------===//
+// POSITIVE TESTS — fast-math=true must rewrite
+//===----------------------------------------------------------------------===//
+
+// -----
+
+module {
+  // COM: Basic case — bf16 operands, f32 scale via tt.splat, A loop-invariant, B loop-variant
+  // COM: Expect: splat scale to A's shape → extf A to f32 → mulf <reassoc> → truncf back to bf16 → new tt.dot
+  // CHECK-LABEL: tt.func public @scale_invariant_a
+  tt.func public @scale_invariant_a(%a_inv: tensor<128x64xbf16>, %b_ptr: !tt.ptr<bf16>, %scale_scalar: f32, %lb: i32, %ub: i32, %step: i32) -> tensor<128x128xf32> {
+    %c0 = arith.constant 0 : i32
+    %c64 = arith.constant 64 : i32
+    %zero_acc = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+
+    // COM: Loop — A is invariant (defined before loop), B is variant (loaded inside)
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %zero_acc) -> (tensor<128x128xf32>) : i32 {
+      %b_offset = arith.muli %iv, %c64 : i32
+      %b_ptr_off = tt.addptr %b_ptr, %b_offset : !tt.ptr<bf16>, i32
+      %b_ptr_splat = tt.splat %b_ptr_off : !tt.ptr<bf16> -> tensor<64x128x!tt.ptr<bf16>>
+      %b_var = tt.load %b_ptr_splat : tensor<64x128x!tt.ptr<bf16>>
+
+      // COM: Original pattern: dot result used by mulf with scale
+      %dot_res = tt.dot %a_inv, %b_var, %zero_acc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %scale_splat = tt.splat %scale_scalar : f32 -> tensor<128x128xf32>
+      %scaled_dot = arith.mulf %scale_splat, %dot_res : tensor<128x128xf32>
+
+      %acc_new = arith.addf %acc, %scaled_dot : tensor<128x128xf32>
+      scf.yield %acc_new : tensor<128x128xf32>
+    }
+    tt.return %result : tensor<128x128xf32>
+  }
+
+  // CHECK: scf.for
+  // CHECK: %[[B_LOAD:.*]] = tt.load
+  // COM: The scale should be splatted to A's shape in compute type (f32)
+  // CHECK: %[[SCALE_SPLAT:.*]] = tt.splat %{{.*}} : f32 -> tensor<128x64xf32>
+  // COM: Extend A from bf16 to f32
+  // CHECK: %[[A_EXT:.*]] = arith.extf %{{.*}} : tensor<128x64xbf16> to tensor<128x64xf32>
+  // COM: Multiply with reassoc flag
+  // CHECK: %[[SCALED_EXT:.*]] = arith.mulf %[[A_EXT]], %[[SCALE_SPLAT]] fastmath<reassoc> : tensor<128x64xf32>
+  // COM: Truncate back to bf16
+  // CHECK: %[[SCALED_A:.*]] = arith.truncf %[[SCALED_EXT]] : tensor<128x64xf32> to tensor<128x64xbf16>
+  // COM: New dot with scaled A operand
+  // CHECK: %[[NEW_DOT:.*]] = tt.dot %[[SCALED_A]], %[[B_LOAD]], {{.*}} : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+  // COM: Original mulf consuming dot should be GONE — new dot directly replaces it
+  // CHECK-NOT: arith.mulf {{.*}}, %{{.*dot.*}}
+  // CHECK: arith.addf {{.*}}, %[[NEW_DOT]]
+}
+
+// -----
+
+module {
+  // COM: Symmetric case — B loop-invariant, A loop-variant → scale pulled into B
+  // CHECK-LABEL: tt.func public @scale_invariant_b
+  tt.func public @scale_invariant_b(%a_ptr: !tt.ptr<bf16>, %b_inv: tensor<64x128xbf16>, %scale_scalar: f32, %lb: i32, %ub: i32, %step: i32) -> tensor<128x128xf32> {
+    %c64 = arith.constant 64 : i32
+    %zero_acc = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %zero_acc) -> (tensor<128x128xf32>) : i32 {
+      %a_offset = arith.muli %iv, %c64 : i32
+      %a_ptr_off = tt.addptr %a_ptr, %a_offset : !tt.ptr<bf16>, i32
+      %a_ptr_splat = tt.splat %a_ptr_off : !tt.ptr<bf16> -> tensor<128x64x!tt.ptr<bf16>>
+      %a_var = tt.load %a_ptr_splat : tensor<128x64x!tt.ptr<bf16>>
+
+      %dot_res = tt.dot %a_var, %b_inv, %zero_acc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %scale_splat = tt.splat %scale_scalar : f32 -> tensor<128x128xf32>
+      %scaled_dot = arith.mulf %dot_res, %scale_splat : tensor<128x128xf32>
+
+      %acc_new = arith.addf %acc, %scaled_dot : tensor<128x128xf32>
+      scf.yield %acc_new : tensor<128x128xf32>
+    }
+    tt.return %result : tensor<128x128xf32>
+  }
+
+  // CHECK: scf.for
+  // CHECK: %[[A_LOAD:.*]] = tt.load
+  // COM: Scale splatted to B's shape
+  // CHECK: %[[SCALE_SPLAT:.*]] = tt.splat %{{.*}} : f32 -> tensor<64x128xf32>
+  // CHECK: %[[B_EXT:.*]] = arith.extf %{{.*}} : tensor<64x128xbf16> to tensor<64x128xf32>
+  // CHECK: %[[SCALED_EXT:.*]] = arith.mulf %[[B_EXT]], %[[SCALE_SPLAT]] fastmath<reassoc> : tensor<64x128xf32>
+  // CHECK: %[[SCALED_B:.*]] = arith.truncf %[[SCALED_EXT]] : tensor<64x128xf32> to tensor<64x128xbf16>
+  // CHECK: %[[NEW_DOT:.*]] = tt.dot %[[A_LOAD]], %[[SCALED_B]], {{.*}} : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+  // CHECK-NOT: arith.mulf {{.*}}, %{{.*dot.*}}
+  // CHECK: arith.addf {{.*}}, %[[NEW_DOT]]
+}
+
+// -----
+
+module {
+  // COM: Scale via arith.constant dense<X> instead of tt.splat — still rewrites
+  // CHECK-LABEL: tt.func public @scale_constant_splat
+  tt.func public @scale_constant_splat(%a_inv: tensor<128x64xbf16>, %b_ptr: !tt.ptr<bf16>, %lb: i32, %ub: i32, %step: i32) -> tensor<128x128xf32> {
+    %c64 = arith.constant 64 : i32
+    %zero_acc = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %scale_splat = arith.constant dense<2.0> : tensor<128x128xf32>
+
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %zero_acc) -> (tensor<128x128xf32>) : i32 {
+      %b_offset = arith.muli %iv, %c64 : i32
+      %b_ptr_off = tt.addptr %b_ptr, %b_offset : !tt.ptr<bf16>, i32
+      %b_ptr_splat = tt.splat %b_ptr_off : !tt.ptr<bf16> -> tensor<64x128x!tt.ptr<bf16>>
+      %b_var = tt.load %b_ptr_splat : tensor<64x128x!tt.ptr<bf16>>
+
+      %dot_res = tt.dot %a_inv, %b_var, %zero_acc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %scaled_dot = arith.mulf %scale_splat, %dot_res : tensor<128x128xf32>
+
+      %acc_new = arith.addf %acc, %scaled_dot : tensor<128x128xf32>
+      scf.yield %acc_new : tensor<128x128xf32>
+    }
+    tt.return %result : tensor<128x128xf32>
+  }
+
+  // COM: Constant splat hoisted outside loop before scf.for
+  // CHECK: %[[SCALE_CONST:.*]] = arith.constant dense<2.000000e+00> : tensor<128x64xf32>
+  // CHECK: scf.for
+  // CHECK: %[[B_LOAD:.*]] = tt.load
+  // CHECK: %[[A_EXT:.*]] = arith.extf
+  // CHECK: %[[SCALED_EXT:.*]] = arith.mulf %[[A_EXT]], %[[SCALE_CONST]] fastmath<reassoc>
+  // CHECK: %[[SCALED_A:.*]] = arith.truncf %[[SCALED_EXT]]
+  // CHECK: %[[NEW_DOT:.*]] = tt.dot %[[SCALED_A]], %[[B_LOAD]]
+}
+
+// -----
+
+module {
+  // COM: Operands already f32 (scale also f32) — NO extf/truncf emitted
+  // CHECK-LABEL: tt.func public @scale_no_type_conversion
+  tt.func public @scale_no_type_conversion(%a_inv: tensor<128x64xf32>, %b_ptr: !tt.ptr<f32>, %scale_scalar: f32, %lb: i32, %ub: i32, %step: i32) -> tensor<128x128xf32> {
+    %c64 = arith.constant 64 : i32
+    %zero_acc = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %zero_acc) -> (tensor<128x128xf32>) : i32 {
+      %b_offset = arith.muli %iv, %c64 : i32
+      %b_ptr_off = tt.addptr %b_ptr, %b_offset : !tt.ptr<f32>, i32
+      %b_ptr_splat = tt.splat %b_ptr_off : !tt.ptr<f32> -> tensor<64x128x!tt.ptr<f32>>
+      %b_var = tt.load %b_ptr_splat : tensor<64x128x!tt.ptr<f32>>
+
+      %dot_res = tt.dot %a_inv, %b_var, %zero_acc, inputPrecision = tf32 : tensor<128x64xf32> * tensor<64x128xf32> -> tensor<128x128xf32>
+      %scale_splat = tt.splat %scale_scalar : f32 -> tensor<128x128xf32>
+      %scaled_dot = arith.mulf %scale_splat, %dot_res : tensor<128x128xf32>
+
+      %acc_new = arith.addf %acc, %scaled_dot : tensor<128x128xf32>
+      scf.yield %acc_new : tensor<128x128xf32>
+    }
+    tt.return %result : tensor<128x128xf32>
+  }
+
+  // CHECK: scf.for
+  // CHECK: %[[B_LOAD:.*]] = tt.load
+  // CHECK: %[[SCALE_SPLAT:.*]] = tt.splat %{{.*}} : f32 -> tensor<128x64xf32>
+  // COM: No extf — operand already f32
+  // CHECK-NOT: arith.extf
+  // CHECK: %[[SCALED_A:.*]] = arith.mulf %{{.*}}, %[[SCALE_SPLAT]] fastmath<reassoc> : tensor<128x64xf32>
+  // COM: No truncf — no type widening
+  // CHECK-NOT: arith.truncf
+  // CHECK: %[[NEW_DOT:.*]] = tt.dot %[[SCALED_A]], %[[B_LOAD]]
+}
+
+//===----------------------------------------------------------------------===//
+// NEGATIVE TESTS — must NOT rewrite (IR structure preserved)
+//===----------------------------------------------------------------------===//
+
+// -----
+
+module {
+  // COM: fast-math=false — pass is no-op
+  // NOFAST-LABEL: tt.func public @no_rewrite_fast_math_disabled
+  tt.func public @no_rewrite_fast_math_disabled(%a_inv: tensor<128x64xbf16>, %b_ptr: !tt.ptr<bf16>, %scale_scalar: f32, %lb: i32, %ub: i32, %step: i32) -> tensor<128x128xf32> {
+    %c64 = arith.constant 64 : i32
+    %zero_acc = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %zero_acc) -> (tensor<128x128xf32>) : i32 {
+      %b_offset = arith.muli %iv, %c64 : i32
+      %b_ptr_off = tt.addptr %b_ptr, %b_offset : !tt.ptr<bf16>, i32
+      %b_ptr_splat = tt.splat %b_ptr_off : !tt.ptr<bf16> -> tensor<64x128x!tt.ptr<bf16>>
+      %b_var = tt.load %b_ptr_splat : tensor<64x128x!tt.ptr<bf16>>
+
+      %dot_res = tt.dot %a_inv, %b_var, %zero_acc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %scale_splat = tt.splat %scale_scalar : f32 -> tensor<128x128xf32>
+      %scaled_dot = arith.mulf %scale_splat, %dot_res : tensor<128x128xf32>
+
+      %acc_new = arith.addf %acc, %scaled_dot : tensor<128x128xf32>
+      scf.yield %acc_new : tensor<128x128xf32>
+    }
+    tt.return %result : tensor<128x128xf32>
+  }
+
+  // NOFAST: scf.for
+  // NOFAST: %[[DOT:.*]] = tt.dot
+  // NOFAST: %[[SCALE_SPLAT:.*]] = tt.splat
+  // NOFAST: %[[SCALED_DOT:.*]] = arith.mulf %[[SCALE_SPLAT]], %[[DOT]]
+  // NOFAST: arith.addf {{.*}}, %[[SCALED_DOT]]
+}
+
+// -----
+
+module {
+  // COM: Nonzero accumulator — no rewrite
+  // CHECK-LABEL: tt.func public @no_rewrite_nonzero_acc
+  tt.func public @no_rewrite_nonzero_acc(%a_inv: tensor<128x64xbf16>, %b_ptr: !tt.ptr<bf16>, %scale_scalar: f32, %lb: i32, %ub: i32, %step: i32) -> tensor<128x128xf32> {
+    %c64 = arith.constant 64 : i32
+    %zero_acc = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %nonzero_acc = arith.constant dense<1.000000e+00> : tensor<128x128xf32>
+
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %zero_acc) -> (tensor<128x128xf32>) : i32 {
+      %b_offset = arith.muli %iv, %c64 : i32
+      %b_ptr_off = tt.addptr %b_ptr, %b_offset : !tt.ptr<bf16>, i32
+      %b_ptr_splat = tt.splat %b_ptr_off : !tt.ptr<bf16> -> tensor<64x128x!tt.ptr<bf16>>
+      %b_var = tt.load %b_ptr_splat : tensor<64x128x!tt.ptr<bf16>>
+
+      // COM: accumulator is nonzero constant
+      %dot_res = tt.dot %a_inv, %b_var, %nonzero_acc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %scale_splat = tt.splat %scale_scalar : f32 -> tensor<128x128xf32>
+      %scaled_dot = arith.mulf %scale_splat, %dot_res : tensor<128x128xf32>
+
+      %acc_new = arith.addf %acc, %scaled_dot : tensor<128x128xf32>
+      scf.yield %acc_new : tensor<128x128xf32>
+    }
+    tt.return %result : tensor<128x128xf32>
+  }
+
+  // CHECK: scf.for
+  // CHECK: %[[DOT:.*]] = tt.dot {{.*}}, {{.*}}, %{{.*}}
+  // CHECK: %[[SCALE_SPLAT:.*]] = tt.splat
+  // CHECK: %[[SCALED_DOT:.*]] = arith.mulf %[[SCALE_SPLAT]], %[[DOT]]
+  // CHECK: arith.addf {{.*}}, %[[SCALED_DOT]]
+  // COM: No scaled operand (no mulf with reassoc flag), no new dot with pre-scaled input
+  // CHECK-NOT: arith.mulf {{.*}} fastmath<reassoc>
+}
+
+// -----
+
+module {
+  // COM: Dot result has TWO uses — no rewrite
+  // CHECK-LABEL: tt.func public @no_rewrite_dot_two_uses
+  tt.func public @no_rewrite_dot_two_uses(%a_inv: tensor<128x64xbf16>, %b_ptr: !tt.ptr<bf16>, %scale_scalar: f32, %lb: i32, %ub: i32, %step: i32) -> tensor<128x128xf32> {
+    %c64 = arith.constant 64 : i32
+    %zero_acc = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %zero_acc) -> (tensor<128x128xf32>) : i32 {
+      %b_offset = arith.muli %iv, %c64 : i32
+      %b_ptr_off = tt.addptr %b_ptr, %b_offset : !tt.ptr<bf16>, i32
+      %b_ptr_splat = tt.splat %b_ptr_off : !tt.ptr<bf16> -> tensor<64x128x!tt.ptr<bf16>>
+      %b_var = tt.load %b_ptr_splat : tensor<64x128x!tt.ptr<bf16>>
+
+      %dot_res = tt.dot %a_inv, %b_var, %zero_acc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %scale_splat = tt.splat %scale_scalar : f32 -> tensor<128x128xf32>
+      %scaled_dot = arith.mulf %scale_splat, %dot_res : tensor<128x128xf32>
+
+      // COM: Second use of dot_res
+      %acc_tmp = arith.addf %acc, %dot_res : tensor<128x128xf32>
+      %acc_new = arith.addf %acc_tmp, %scaled_dot : tensor<128x128xf32>
+      scf.yield %acc_new : tensor<128x128xf32>
+    }
+    tt.return %result : tensor<128x128xf32>
+  }
+
+  // CHECK: scf.for
+  // CHECK: %[[DOT:.*]] = tt.dot
+  // CHECK: %[[SCALE_SPLAT:.*]] = tt.splat
+  // CHECK: %[[SCALED_DOT:.*]] = arith.mulf %[[SCALE_SPLAT]], %[[DOT]]
+  // CHECK: arith.addf {{.*}}, %[[DOT]]
+  // CHECK: arith.addf {{.*}}, %[[SCALED_DOT]]
+  // COM: Original structure preserved
+  // CHECK-NOT: arith.mulf {{.*}} fastmath<reassoc>
+}
+
+// -----
+
+module {
+  // COM: Both operands loop-invariant (whole dot is invariant) — no rewrite
+  // CHECK-LABEL: tt.func public @no_rewrite_both_invariant
+  tt.func public @no_rewrite_both_invariant(%a_inv: tensor<128x64xbf16>, %b_inv: tensor<64x128xbf16>, %scale_scalar: f32, %lb: i32, %ub: i32, %step: i32) -> tensor<128x128xf32> {
+    %zero_acc = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %zero_acc) -> (tensor<128x128xf32>) : i32 {
+      %dot_res = tt.dot %a_inv, %b_inv, %zero_acc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %scale_splat = tt.splat %scale_scalar : f32 -> tensor<128x128xf32>
+      %scaled_dot = arith.mulf %scale_splat, %dot_res : tensor<128x128xf32>
+
+      %acc_new = arith.addf %acc, %scaled_dot : tensor<128x128xf32>
+      scf.yield %acc_new : tensor<128x128xf32>
+    }
+    tt.return %result : tensor<128x128xf32>
+  }
+
+  // CHECK: scf.for
+  // CHECK: %[[DOT:.*]] = tt.dot
+  // CHECK: %[[SCALE_SPLAT:.*]] = tt.splat
+  // CHECK: arith.mulf %[[SCALE_SPLAT]], %[[DOT]]
+  // CHECK-NOT: arith.mulf {{.*}} fastmath<reassoc>
+}
+
+// -----
+
+module {
+  // COM: Both operands loop-variant — no rewrite
+  // CHECK-LABEL: tt.func public @no_rewrite_both_variant
+  tt.func public @no_rewrite_both_variant(%a_ptr: !tt.ptr<bf16>, %b_ptr: !tt.ptr<bf16>, %scale_scalar: f32, %lb: i32, %ub: i32, %step: i32) -> tensor<128x128xf32> {
+    %c64 = arith.constant 64 : i32
+    %zero_acc = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %zero_acc) -> (tensor<128x128xf32>) : i32 {
+      %a_offset = arith.muli %iv, %c64 : i32
+      %a_ptr_off = tt.addptr %a_ptr, %a_offset : !tt.ptr<bf16>, i32
+      %a_ptr_splat = tt.splat %a_ptr_off : !tt.ptr<bf16> -> tensor<128x64x!tt.ptr<bf16>>
+      %a_var = tt.load %a_ptr_splat : tensor<128x64x!tt.ptr<bf16>>
+
+      %b_offset = arith.muli %iv, %c64 : i32
+      %b_ptr_off = tt.addptr %b_ptr, %b_offset : !tt.ptr<bf16>, i32
+      %b_ptr_splat = tt.splat %b_ptr_off : !tt.ptr<bf16> -> tensor<64x128x!tt.ptr<bf16>>
+      %b_var = tt.load %b_ptr_splat : tensor<64x128x!tt.ptr<bf16>>
+
+      %dot_res = tt.dot %a_var, %b_var, %zero_acc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %scale_splat = tt.splat %scale_scalar : f32 -> tensor<128x128xf32>
+      %scaled_dot = arith.mulf %scale_splat, %dot_res : tensor<128x128xf32>
+
+      %acc_new = arith.addf %acc, %scaled_dot : tensor<128x128xf32>
+      scf.yield %acc_new : tensor<128x128xf32>
+    }
+    tt.return %result : tensor<128x128xf32>
+  }
+
+  // CHECK: scf.for
+  // CHECK: %[[A_LOAD:.*]] = tt.load
+  // CHECK: %[[B_LOAD:.*]] = tt.load
+  // CHECK: %[[DOT:.*]] = tt.dot %[[A_LOAD]], %[[B_LOAD]]
+  // CHECK: %[[SCALE_SPLAT:.*]] = tt.splat
+  // CHECK: arith.mulf %[[SCALE_SPLAT]], %[[DOT]]
+  // CHECK-NOT: arith.mulf {{.*}} fastmath<reassoc>
+}
+
+// -----
+
+module {
+  // COM: Dot NOT inside any loop — no rewrite
+  // CHECK-LABEL: tt.func public @no_rewrite_no_loop
+  tt.func public @no_rewrite_no_loop(%a: tensor<128x64xbf16>, %b: tensor<64x128xbf16>, %scale_scalar: f32) -> tensor<128x128xf32> {
+    %zero_acc = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+
+    %dot_res = tt.dot %a, %b, %zero_acc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+    %scale_splat = tt.splat %scale_scalar : f32 -> tensor<128x128xf32>
+    %scaled_dot = arith.mulf %scale_splat, %dot_res : tensor<128x128xf32>
+
+    tt.return %scaled_dot : tensor<128x128xf32>
+  }
+
+  // CHECK: %[[DOT:.*]] = tt.dot
+  // CHECK: %[[SCALE_SPLAT:.*]] = tt.splat
+  // CHECK: %[[SCALED_DOT:.*]] = arith.mulf %[[SCALE_SPLAT]], %[[DOT]]
+  // CHECK: tt.return %[[SCALED_DOT]]
+  // CHECK-NOT: arith.mulf {{.*}} fastmath<reassoc>
+}
+
+// -----
+
+module {
+  // COM: Non-uniform scale (a loaded tensor, not a scalar splat/constant) — no
+  // COM: rewrite. This is the out-of-scope per-token-head scale case: the scale
+  // COM: is not a uniform scalar broadcast so it cannot be pulled into an operand.
+  // CHECK-LABEL: tt.func public @no_rewrite_non_uniform_scale
+  tt.func public @no_rewrite_non_uniform_scale(%a_inv: tensor<128x64xbf16>, %b_ptr: !tt.ptr<bf16>, %scale_ptr: !tt.ptr<f32>, %lb: i32, %ub: i32, %step: i32) -> tensor<128x128xf32> {
+    %c64 = arith.constant 64 : i32
+    %zero_acc = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %scale_splat = tt.splat %scale_ptr : !tt.ptr<f32> -> tensor<128x128x!tt.ptr<f32>>
+    %scale_non_uniform = tt.load %scale_splat : tensor<128x128x!tt.ptr<f32>>
+
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %zero_acc) -> (tensor<128x128xf32>) : i32 {
+      %b_offset = arith.muli %iv, %c64 : i32
+      %b_ptr_off = tt.addptr %b_ptr, %b_offset : !tt.ptr<bf16>, i32
+      %b_ptr_splat = tt.splat %b_ptr_off : !tt.ptr<bf16> -> tensor<64x128x!tt.ptr<bf16>>
+      %b_var = tt.load %b_ptr_splat : tensor<64x128x!tt.ptr<bf16>>
+
+      %dot_res = tt.dot %a_inv, %b_var, %zero_acc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %scaled_dot = arith.mulf %scale_non_uniform, %dot_res : tensor<128x128xf32>
+
+      %acc_new = arith.addf %acc, %scaled_dot : tensor<128x128xf32>
+      scf.yield %acc_new : tensor<128x128xf32>
+    }
+    tt.return %result : tensor<128x128xf32>
+  }
+
+  // CHECK: scf.for
+  // CHECK: %[[DOT:.*]] = tt.dot %{{.*}}, %{{.*}}
+  // CHECK: arith.mulf %{{.*}}, %[[DOT]]
+  // CHECK-NOT: arith.mulf {{.*}} fastmath<reassoc>
+}

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -294,6 +294,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         passes.common.add_inliner(pm)
         intel.passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)
         passes.common.add_cse(pm)
+        intel.passes.ttir.add_reassociate_dot_scale(pm, knobs.intel.fast_math)
         passes.ttir.add_triton_licm(pm)
         intel.passes.ttir.add_remove_masks(pm)
         intel.passes.ttir.add_stride_versioning(pm)

--- a/third_party/intel/include/Dialect/Triton/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/Triton/Transforms/Passes.td
@@ -159,4 +159,31 @@ def TritonIntelGPUPrepareIfCombining
   let dependentDialects = ["mlir::scf::SCFDialect"];
 }
 
+def TritonIntelReassociateDotScale
+    : Pass<"triton-intel-reassociate-dot-scale", "mlir::ModuleOp"> {
+  let summary = "Reassociate a scalar scale across a dot to enable hoisting";
+  let description = [{
+    Rewrites `scale * tt.dot(a, b, 0)` into `tt.dot(scale * a, b, 0)` (or scaling
+    `b` instead), when `scale` is a uniform scalar broadcast. This is a
+    floating-point reassociation that changes rounding, so it only fires when
+    fast-math is enabled. The rewrite is applied only when it exposes a loop
+    invariant code motion opportunity: the dot must be inside a loop, the dot
+    itself loop-variant, the scalar and the chosen operand loop-invariant, and
+    the other operand loop-variant. After the rewrite the scaled operand is
+    hoisted out of the loop by `triton-licm`.
+
+    The transformation requires a zero accumulator: the algebra
+    `c * (a @ b) = (c * a) @ b` only holds when the dot accumulator is zero.
+  }];
+  let options = [
+    Option<"fastMath", "fast-math", "bool", /*default*/"false",
+           "enable the fast-math-gated reassociation">,
+  ];
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::scf::SCFDialect",
+    "mlir::triton::TritonDialect"
+  ];
+}
+
 #endif // TRITON_DIALECT_TRITON_INTEL_TRANSFORMS_PASSES

--- a/third_party/intel/include/Dialect/Triton/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/Triton/Transforms/Passes.td
@@ -174,6 +174,11 @@ def TritonIntelReassociateDotScale
 
     The transformation requires a zero accumulator: the algebra
     `c * (a @ b) = (c * a) @ b` only holds when the dot accumulator is zero.
+
+    The rewrite is floating-point only by design. The reassociation is
+    algebraically valid for integer dots, but scaling a narrow integer DPAS
+    operand (i8/u8/i4) overflows, and widening it to avoid overflow defeats the
+    integer DPAS lowering this rewrite is meant to preserve.
   }];
   let options = [
     Option<"fastMath", "fast-math", "bool", /*default*/"false",

--- a/third_party/intel/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_triton_library(TritonIntelTransforms
   FoldTrueCmpIOp.cpp
   FuseReshape.cpp
   PrepareIfCombining.cpp
+  ReassociateDotScale.cpp
   RemoveMasks.cpp
   RewriteTensorDescriptorToPointer.cpp
   SimplifySignedArithmetic.cpp

--- a/third_party/intel/lib/Dialect/Triton/Transforms/ReassociateDotScale.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/ReassociateDotScale.cpp
@@ -136,13 +136,17 @@ public:
           dotOp, "both operands variant (no hoisting opportunity)");
     }
 
-    // Step 6: Compute-type safety
+    // Step 6: Select the compute type. The scale multiply is performed in the
+    // wider of the scale and target element types so it is always lossless,
+    // then the result is converted back to the target type. A narrower scale is
+    // extended up to the target type (exact); a wider scale instead widens the
+    // target and truncates the product back down.
     auto targetTy = cast<RankedTensorType>(target.getType());
     auto targetElemTy = cast<FloatType>(targetTy.getElementType());
-    if (scaleElemTy.getIntOrFloatBitWidth() <
-        targetElemTy.getIntOrFloatBitWidth())
-      return rewriter.notifyMatchFailure(
-          mulOp, "scale element type is narrower than target");
+    FloatType computeElemTy = scaleElemTy.getIntOrFloatBitWidth() >=
+                                      targetElemTy.getIntOrFloatBitWidth()
+                                  ? scaleElemTy
+                                  : targetElemTy;
 
     // REWRITE
     LDBG("Applying reassociation on " << *mulOp);
@@ -153,16 +157,21 @@ public:
           rewriter, loc, FloatAttr::get(scaleElemTy, constantSplatValue));
     }
 
+    // Widen the scale scalar up to the compute type if it is narrower
+    // (lossless). Extending before the splat keeps the conversion on a scalar.
+    if (scaleElemTy != computeElemTy)
+      scalarValue =
+          arith::ExtFOp::create(rewriter, loc, computeElemTy, scalarValue);
+
     // Build splat to target shape in compute type
     RankedTensorType splatTy = RankedTensorType::get(
-        targetTy.getShape(), scaleElemTy, targetTy.getEncoding());
+        targetTy.getShape(), computeElemTy, targetTy.getEncoding());
     Value scaleSplat = tt::SplatOp::create(rewriter, loc, splatTy, scalarValue);
 
     // Widen target if needed
     Value targetExt = target;
-    if (targetElemTy != scaleElemTy) {
+    if (targetElemTy != computeElemTy)
       targetExt = arith::ExtFOp::create(rewriter, loc, splatTy, target);
-    }
 
     // Multiply with reassoc fastmath flag
     auto fmf = arith::FastMathFlagsAttr::get(rewriter.getContext(),
@@ -170,11 +179,10 @@ public:
     Value scaledExt =
         arith::MulFOp::create(rewriter, loc, targetExt, scaleSplat, fmf);
 
-    // Truncate back if widened
+    // Truncate back to the target type if we computed in a wider type
     Value scaled = scaledExt;
-    if (targetElemTy != scaleElemTy) {
+    if (targetElemTy != computeElemTy)
       scaled = arith::TruncFOp::create(rewriter, loc, targetTy, scaledExt);
-    }
 
     // Build new dot in original operand positions
     Value newA = (opIdx == 0) ? scaled : dotOp.getA();

--- a/third_party/intel/lib/Dialect/Triton/Transforms/ReassociateDotScale.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/ReassociateDotScale.cpp
@@ -71,6 +71,13 @@ public:
 
     if (auto splat = scaleVal.getDefiningOp<tt::SplatOp>()) {
       scalarValue = splat.getSrc();
+      // Integer dots are intentionally out of scope. The reassociation is
+      // algebraically valid for integers, but scaling a narrow integer DPAS
+      // operand (i8/u8/i4) by an arbitrary scale overflows, and widening the
+      // operand to avoid that defeats the integer DPAS lowering this rewrite
+      // exists to preserve. (Integer scales also reach the dot via muli/sitofp,
+      // not this mulf pattern.) The guard is also load-bearing: it protects the
+      // cast below from a non-float splat source.
       if (!isa<FloatType>(scalarValue.getType()))
         return rewriter.notifyMatchFailure(
             mulOp, "splat source is not a float scalar");

--- a/third_party/intel/lib/Dialect/Triton/Transforms/ReassociateDotScale.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/ReassociateDotScale.cpp
@@ -1,0 +1,213 @@
+#include "intel/include/Dialect/Triton/Transforms/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "triton-intel-reassociate-dot-scale"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace tt = mlir::triton;
+
+namespace mlir::triton::intel {
+#define GEN_PASS_DEF_TRITONINTELREASSOCIATEDOTSCALE
+#include "intel/include/Dialect/Triton/Transforms/Passes.h.inc"
+} // namespace mlir::triton::intel
+
+namespace {
+
+struct ReassociateDotScalePattern : public OpRewritePattern<arith::MulFOp> {
+public:
+  ReassociateDotScalePattern(MLIRContext *context, int benefit = 1)
+      : OpRewritePattern<arith::MulFOp>(context, benefit) {}
+
+  LogicalResult matchAndRewrite(arith::MulFOp mulOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = mulOp.getLoc();
+
+    // Step 1: Identify dot operand vs scale operand
+    Value dotOperand, scaleVal;
+    tt::DotOp dotOp;
+    for (unsigned i = 0; i < 2; ++i) {
+      Value operand = mulOp.getOperand(i);
+      if (auto defDotOp = operand.getDefiningOp<tt::DotOp>()) {
+        dotOp = defDotOp;
+        dotOperand = operand;
+        scaleVal = mulOp.getOperand(1 - i);
+        break;
+      }
+    }
+
+    if (!dotOp)
+      return rewriter.notifyMatchFailure(mulOp,
+                                         "neither operand is a DotOp result");
+
+    // Short-circuit: if both operands are dots (unlikely but possible), fail
+    if (mulOp.getOperand(0).getDefiningOp<tt::DotOp>() &&
+        mulOp.getOperand(1).getDefiningOp<tt::DotOp>())
+      return rewriter.notifyMatchFailure(mulOp,
+                                         "both operands are DotOp results");
+
+    // Step 2: Dot result must have exactly one use
+    if (!dotOp->hasOneUse())
+      return rewriter.notifyMatchFailure(dotOp, "dot result has multiple uses");
+
+    // Step 3: Accumulator must be zero
+    if (!matchPattern(dotOp.getC(), m_AnyZeroFloat()))
+      return rewriter.notifyMatchFailure(dotOp, "accumulator is not zero");
+
+    // Step 4: Scale must be a uniform scalar broadcast
+    Value scalarValue;
+    FloatType scaleElemTy;
+    bool isConstantSplat = false;
+    APFloat constantSplatValue(0.0);
+
+    if (auto splat = scaleVal.getDefiningOp<tt::SplatOp>()) {
+      scalarValue = splat.getSrc();
+      if (!isa<FloatType>(scalarValue.getType()))
+        return rewriter.notifyMatchFailure(
+            mulOp, "splat source is not a float scalar");
+      scaleElemTy = cast<FloatType>(scalarValue.getType());
+    } else if (auto constOp = scaleVal.getDefiningOp<arith::ConstantOp>()) {
+      if (auto denseAttr = dyn_cast<DenseElementsAttr>(constOp.getValue())) {
+        if (!denseAttr.isSplat())
+          return rewriter.notifyMatchFailure(mulOp, "constant is not a splat");
+        auto splatAttr = denseAttr.getSplatValue<Attribute>();
+        if (auto floatAttr = dyn_cast<FloatAttr>(splatAttr)) {
+          constantSplatValue = floatAttr.getValue();
+          scaleElemTy = cast<FloatType>(floatAttr.getType());
+          isConstantSplat = true;
+        } else {
+          return rewriter.notifyMatchFailure(
+              mulOp, "splat constant is not float-typed");
+        }
+      } else {
+        return rewriter.notifyMatchFailure(mulOp, "constant is not dense");
+      }
+    } else {
+      return rewriter.notifyMatchFailure(
+          mulOp, "scale is not a splat or constant splat");
+    }
+
+    // Step 5: Heuristic (LICM-opportunity test)
+    auto loop = dotOp->getParentOfType<LoopLikeOpInterface>();
+    if (!loop)
+      return rewriter.notifyMatchFailure(dotOp, "dot is not inside a loop");
+
+    bool aInv = loop.isDefinedOutsideOfLoop(dotOp.getA());
+    bool bInv = loop.isDefinedOutsideOfLoop(dotOp.getB());
+    // For the scale, check the underlying scalar if splat, otherwise the splat
+    // constant is invariant
+    bool scaleInv = isConstantSplat || loop.isDefinedOutsideOfLoop(scalarValue);
+
+    if (!scaleInv)
+      return rewriter.notifyMatchFailure(mulOp, "scale is not loop-invariant");
+
+    if (aInv && bInv)
+      return rewriter.notifyMatchFailure(
+          dotOp, "both operands invariant (dot already hoistable)");
+
+    Value target;
+    unsigned opIdx;
+    if (aInv && !bInv) {
+      target = dotOp.getA();
+      opIdx = 0;
+      LDBG("Targeting operand A for scaling");
+    } else if (bInv && !aInv) {
+      target = dotOp.getB();
+      opIdx = 1;
+      LDBG("Targeting operand B for scaling");
+    } else {
+      return rewriter.notifyMatchFailure(
+          dotOp, "both operands variant (no hoisting opportunity)");
+    }
+
+    // Step 6: Compute-type safety
+    auto targetTy = cast<RankedTensorType>(target.getType());
+    auto targetElemTy = cast<FloatType>(targetTy.getElementType());
+    if (scaleElemTy.getIntOrFloatBitWidth() <
+        targetElemTy.getIntOrFloatBitWidth())
+      return rewriter.notifyMatchFailure(
+          mulOp, "scale element type is narrower than target");
+
+    // REWRITE
+    LDBG("Applying reassociation on " << *mulOp);
+
+    // Materialize scalar if needed
+    if (isConstantSplat) {
+      scalarValue = arith::ConstantOp::create(
+          rewriter, loc, FloatAttr::get(scaleElemTy, constantSplatValue));
+    }
+
+    // Build splat to target shape in compute type
+    RankedTensorType splatTy = RankedTensorType::get(
+        targetTy.getShape(), scaleElemTy, targetTy.getEncoding());
+    Value scaleSplat = tt::SplatOp::create(rewriter, loc, splatTy, scalarValue);
+
+    // Widen target if needed
+    Value targetExt = target;
+    if (targetElemTy != scaleElemTy) {
+      targetExt = arith::ExtFOp::create(rewriter, loc, splatTy, target);
+    }
+
+    // Multiply with reassoc fastmath flag
+    auto fmf = arith::FastMathFlagsAttr::get(rewriter.getContext(),
+                                             arith::FastMathFlags::reassoc);
+    Value scaledExt =
+        arith::MulFOp::create(rewriter, loc, targetExt, scaleSplat, fmf);
+
+    // Truncate back if widened
+    Value scaled = scaledExt;
+    if (targetElemTy != scaleElemTy) {
+      scaled = arith::TruncFOp::create(rewriter, loc, targetTy, scaledExt);
+    }
+
+    // Build new dot in original operand positions
+    Value newA = (opIdx == 0) ? scaled : dotOp.getA();
+    Value newB = (opIdx == 1) ? scaled : dotOp.getB();
+    RankedTensorType resultTy =
+        cast<RankedTensorType>(dotOp.getResult().getType());
+
+    auto newDot = tt::DotOp::create(rewriter, loc, resultTy, newA, newB,
+                                    dotOp.getC(), dotOp.getInputPrecision(),
+                                    dotOp.getMaxNumImpreciseAcc());
+
+    LDBG("Created new dot: " << *newDot);
+
+    // Replace mulOp with new dot and erase the now-dead old dot
+    rewriter.replaceOp(mulOp, newDot.getResult());
+    rewriter.eraseOp(dotOp);
+
+    return success();
+  }
+};
+
+struct ReassociateDotScale
+    : public mlir::triton::intel::impl::TritonIntelReassociateDotScaleBase<
+          ReassociateDotScale> {
+public:
+  using Base::Base;
+
+  void runOnOperation() override {
+    if (!fastMath) {
+      markAllAnalysesPreserved();
+      return;
+    }
+
+    ModuleOp mod = getOperation();
+    RewritePatternSet patterns(&getContext());
+    patterns.add<ReassociateDotScalePattern>(&getContext());
+
+    if (failed(applyPatternsGreedily(mod, std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+} // namespace

--- a/third_party/intel/lib/Dialect/Triton/Transforms/ReassociateDotScale.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/ReassociateDotScale.cpp
@@ -23,6 +23,14 @@ namespace mlir::triton::intel {
 
 namespace {
 
+// Carries the unpacked scalar scale and its element type.
+struct ScaleInfo {
+  Value scalarValue;
+  FloatType elemTy;
+  bool isConstantSplat = false;
+  APFloat constantValue{0.0};
+};
+
 struct ReassociateDotScalePattern : public OpRewritePattern<arith::MulFOp> {
 public:
   ReassociateDotScalePattern(MLIRContext *context, int benefit = 1)
@@ -30,176 +38,194 @@ public:
 
   LogicalResult matchAndRewrite(arith::MulFOp mulOp,
                                 PatternRewriter &rewriter) const override {
-    Location loc = mulOp.getLoc();
-
-    // Step 1: Identify dot operand vs scale operand
-    Value dotOperand, scaleVal;
     tt::DotOp dotOp;
+    Value scaleVal;
+    if (failed(findDotAndScale(mulOp, rewriter, dotOp, scaleVal)))
+      return failure();
+
+    if (failed(validateDot(dotOp, rewriter)))
+      return failure();
+
+    ScaleInfo scale;
+    if (failed(extractScaleScalar(mulOp, scaleVal, rewriter, scale)))
+      return failure();
+
+    Value target;
+    unsigned opIdx;
+    if (failed(selectTargetOperand(dotOp, scale, rewriter, target, opIdx)))
+      return failure();
+
+    return rewriteWithScaledOperand(mulOp, dotOp, target, opIdx, scale,
+                                    rewriter);
+  }
+
+private:
+  // Step 1: Identify which mulOp operand is the dot result and which is the
+  // scale. Fails if neither operand is a DotOp result, or if both are.
+  LogicalResult findDotAndScale(arith::MulFOp mulOp, PatternRewriter &rewriter,
+                                tt::DotOp &dotOp, Value &scaleVal) const {
     for (unsigned i = 0; i < 2; ++i) {
-      Value operand = mulOp.getOperand(i);
-      if (auto defDotOp = operand.getDefiningOp<tt::DotOp>()) {
+      if (auto defDotOp = mulOp.getOperand(i).getDefiningOp<tt::DotOp>()) {
+        if (mulOp.getOperand(1 - i).getDefiningOp<tt::DotOp>())
+          return rewriter.notifyMatchFailure(mulOp,
+                                             "both operands are DotOp results");
         dotOp = defDotOp;
-        dotOperand = operand;
         scaleVal = mulOp.getOperand(1 - i);
-        break;
+        return success();
       }
     }
+    return rewriter.notifyMatchFailure(mulOp,
+                                       "neither operand is a DotOp result");
+  }
 
-    if (!dotOp)
-      return rewriter.notifyMatchFailure(mulOp,
-                                         "neither operand is a DotOp result");
-
-    // Short-circuit: if both operands are dots (unlikely but possible), fail
-    if (mulOp.getOperand(0).getDefiningOp<tt::DotOp>() &&
-        mulOp.getOperand(1).getDefiningOp<tt::DotOp>())
-      return rewriter.notifyMatchFailure(mulOp,
-                                         "both operands are DotOp results");
-
-    // Step 2: Dot result must have exactly one use
+  // Step 2: Validate the dot: single use and zero accumulator.
+  LogicalResult validateDot(tt::DotOp dotOp, PatternRewriter &rewriter) const {
     if (!dotOp->hasOneUse())
       return rewriter.notifyMatchFailure(dotOp, "dot result has multiple uses");
-
-    // Step 3: Accumulator must be zero
     if (!matchPattern(dotOp.getC(), m_AnyZeroFloat()))
       return rewriter.notifyMatchFailure(dotOp, "accumulator is not zero");
+    return success();
+  }
 
-    // Step 4: Scale must be a uniform scalar broadcast
-    Value scalarValue;
-    FloatType scaleElemTy;
-    bool isConstantSplat = false;
-    APFloat constantSplatValue(0.0);
-
+  // Step 3: Verify the scale is a uniform float scalar broadcast and unpack it.
+  // Accepts tt.splat of a float scalar, or arith.constant dense float splat.
+  // Integer dots are intentionally out of scope: the reassociation is
+  // algebraically valid for integers, but scaling a narrow DPAS operand
+  // (i8/u8/i4) overflows, and widening it defeats the integer DPAS lowering
+  // this rewrite exists to preserve. Integer scales also reach the dot via
+  // muli/sitofp, not the mulf pattern this rewrite matches.
+  LogicalResult extractScaleScalar(arith::MulFOp mulOp, Value scaleVal,
+                                   PatternRewriter &rewriter,
+                                   ScaleInfo &info) const {
     if (auto splat = scaleVal.getDefiningOp<tt::SplatOp>()) {
-      scalarValue = splat.getSrc();
-      // Integer dots are intentionally out of scope. The reassociation is
-      // algebraically valid for integers, but scaling a narrow integer DPAS
-      // operand (i8/u8/i4) by an arbitrary scale overflows, and widening the
-      // operand to avoid that defeats the integer DPAS lowering this rewrite
-      // exists to preserve. (Integer scales also reach the dot via muli/sitofp,
-      // not this mulf pattern.) The guard is also load-bearing: it protects the
-      // cast below from a non-float splat source.
-      if (!isa<FloatType>(scalarValue.getType()))
+      info.scalarValue = splat.getSrc();
+      // The float guard also protects the cast<FloatType> below.
+      if (!isa<FloatType>(info.scalarValue.getType()))
         return rewriter.notifyMatchFailure(
             mulOp, "splat source is not a float scalar");
-      scaleElemTy = cast<FloatType>(scalarValue.getType());
-    } else if (auto constOp = scaleVal.getDefiningOp<arith::ConstantOp>()) {
-      if (auto denseAttr = dyn_cast<DenseElementsAttr>(constOp.getValue())) {
-        if (!denseAttr.isSplat())
-          return rewriter.notifyMatchFailure(mulOp, "constant is not a splat");
-        auto splatAttr = denseAttr.getSplatValue<Attribute>();
-        if (auto floatAttr = dyn_cast<FloatAttr>(splatAttr)) {
-          constantSplatValue = floatAttr.getValue();
-          scaleElemTy = cast<FloatType>(floatAttr.getType());
-          isConstantSplat = true;
-        } else {
-          return rewriter.notifyMatchFailure(
-              mulOp, "splat constant is not float-typed");
-        }
-      } else {
-        return rewriter.notifyMatchFailure(mulOp, "constant is not dense");
-      }
-    } else {
-      return rewriter.notifyMatchFailure(
-          mulOp, "scale is not a splat or constant splat");
+      info.elemTy = cast<FloatType>(info.scalarValue.getType());
+      return success();
     }
 
-    // Step 5: Heuristic (LICM-opportunity test)
+    if (auto constOp = scaleVal.getDefiningOp<arith::ConstantOp>()) {
+      auto denseAttr = dyn_cast<DenseElementsAttr>(constOp.getValue());
+      if (!denseAttr)
+        return rewriter.notifyMatchFailure(mulOp, "constant is not dense");
+      if (!denseAttr.isSplat())
+        return rewriter.notifyMatchFailure(mulOp, "constant is not a splat");
+      auto floatAttr =
+          dyn_cast<FloatAttr>(denseAttr.getSplatValue<Attribute>());
+      if (!floatAttr)
+        return rewriter.notifyMatchFailure(mulOp,
+                                           "splat constant is not float-typed");
+      info.elemTy = cast<FloatType>(floatAttr.getType());
+      info.constantValue = floatAttr.getValue();
+      info.isConstantSplat = true;
+      return success();
+    }
+
+    return rewriter.notifyMatchFailure(
+        mulOp, "scale is not a splat or constant splat");
+  }
+
+  // Step 4: Pick the loop-invariant operand to absorb the scale.  The scale
+  // itself must also be loop-invariant, and the other operand loop-variant
+  // (otherwise the whole dot is already hoistable and the rewrite adds no
+  // value).
+  LogicalResult selectTargetOperand(tt::DotOp dotOp, const ScaleInfo &scale,
+                                    PatternRewriter &rewriter, Value &target,
+                                    unsigned &opIdx) const {
     auto loop = dotOp->getParentOfType<LoopLikeOpInterface>();
     if (!loop)
       return rewriter.notifyMatchFailure(dotOp, "dot is not inside a loop");
 
+    // Constant splats are always loop-invariant.
+    bool scaleInv =
+        scale.isConstantSplat || loop.isDefinedOutsideOfLoop(scale.scalarValue);
+    if (!scaleInv)
+      return rewriter.notifyMatchFailure(dotOp, "scale is not loop-invariant");
+
     bool aInv = loop.isDefinedOutsideOfLoop(dotOp.getA());
     bool bInv = loop.isDefinedOutsideOfLoop(dotOp.getB());
-    // For the scale, check the underlying scalar if splat, otherwise the splat
-    // constant is invariant
-    bool scaleInv = isConstantSplat || loop.isDefinedOutsideOfLoop(scalarValue);
-
-    if (!scaleInv)
-      return rewriter.notifyMatchFailure(mulOp, "scale is not loop-invariant");
 
     if (aInv && bInv)
       return rewriter.notifyMatchFailure(
           dotOp, "both operands invariant (dot already hoistable)");
 
-    Value target;
-    unsigned opIdx;
     if (aInv && !bInv) {
       target = dotOp.getA();
       opIdx = 0;
       LDBG("Targeting operand A for scaling");
-    } else if (bInv && !aInv) {
+      return success();
+    }
+    if (bInv && !aInv) {
       target = dotOp.getB();
       opIdx = 1;
       LDBG("Targeting operand B for scaling");
-    } else {
-      return rewriter.notifyMatchFailure(
-          dotOp, "both operands variant (no hoisting opportunity)");
+      return success();
     }
+    return rewriter.notifyMatchFailure(
+        dotOp, "both operands variant (no hoisting opportunity)");
+  }
 
-    // Step 6: Select the compute type. The scale multiply is performed in the
-    // wider of the scale and target element types so it is always lossless,
-    // then the result is converted back to the target type. A narrower scale is
-    // extended up to the target type (exact); a wider scale instead widens the
-    // target and truncates the product back down.
+  // Step 5: Perform the rewrite. The scale multiply is performed in the wider
+  // of the scale and target element types so it is always lossless, then the
+  // result is converted back to the target type.
+  LogicalResult rewriteWithScaledOperand(arith::MulFOp mulOp, tt::DotOp dotOp,
+                                         Value target, unsigned opIdx,
+                                         const ScaleInfo &scale,
+                                         PatternRewriter &rewriter) const {
+    LDBG("Applying reassociation on " << *mulOp);
+    Location loc = mulOp.getLoc();
+
     auto targetTy = cast<RankedTensorType>(target.getType());
     auto targetElemTy = cast<FloatType>(targetTy.getElementType());
-    FloatType computeElemTy = scaleElemTy.getIntOrFloatBitWidth() >=
+    FloatType computeElemTy = scale.elemTy.getIntOrFloatBitWidth() >=
                                       targetElemTy.getIntOrFloatBitWidth()
-                                  ? scaleElemTy
+                                  ? scale.elemTy
                                   : targetElemTy;
 
-    // REWRITE
-    LDBG("Applying reassociation on " << *mulOp);
-
-    // Materialize scalar if needed
-    if (isConstantSplat) {
+    // Materialize the scalar for constant splats.
+    Value scalarValue = scale.scalarValue;
+    if (scale.isConstantSplat)
       scalarValue = arith::ConstantOp::create(
-          rewriter, loc, FloatAttr::get(scaleElemTy, constantSplatValue));
-    }
+          rewriter, loc, FloatAttr::get(scale.elemTy, scale.constantValue));
 
-    // Widen the scale scalar up to the compute type if it is narrower
-    // (lossless). Extending before the splat keeps the conversion on a scalar.
-    if (scaleElemTy != computeElemTy)
+    // Extend the scale scalar to the compute type if it is narrower (lossless).
+    // Extending before the splat keeps the conversion on a scalar.
+    if (scale.elemTy != computeElemTy)
       scalarValue =
           arith::ExtFOp::create(rewriter, loc, computeElemTy, scalarValue);
 
-    // Build splat to target shape in compute type
     RankedTensorType splatTy = RankedTensorType::get(
         targetTy.getShape(), computeElemTy, targetTy.getEncoding());
     Value scaleSplat = tt::SplatOp::create(rewriter, loc, splatTy, scalarValue);
 
-    // Widen target if needed
+    // Widen the target operand if the compute type is wider.
     Value targetExt = target;
     if (targetElemTy != computeElemTy)
       targetExt = arith::ExtFOp::create(rewriter, loc, splatTy, target);
 
-    // Multiply with reassoc fastmath flag
     auto fmf = arith::FastMathFlagsAttr::get(rewriter.getContext(),
                                              arith::FastMathFlags::reassoc);
     Value scaledExt =
         arith::MulFOp::create(rewriter, loc, targetExt, scaleSplat, fmf);
 
-    // Truncate back to the target type if we computed in a wider type
+    // Truncate the product back to the target type if we widened.
     Value scaled = scaledExt;
     if (targetElemTy != computeElemTy)
       scaled = arith::TruncFOp::create(rewriter, loc, targetTy, scaledExt);
 
-    // Build new dot in original operand positions
     Value newA = (opIdx == 0) ? scaled : dotOp.getA();
     Value newB = (opIdx == 1) ? scaled : dotOp.getB();
-    RankedTensorType resultTy =
-        cast<RankedTensorType>(dotOp.getResult().getType());
-
+    auto resultTy = cast<RankedTensorType>(dotOp.getResult().getType());
     auto newDot = tt::DotOp::create(rewriter, loc, resultTy, newA, newB,
                                     dotOp.getC(), dotOp.getInputPrecision(),
                                     dotOp.getMaxNumImpreciseAcc());
-
     LDBG("Created new dot: " << *newDot);
 
-    // Replace mulOp with new dot and erase the now-dead old dot
     rewriter.replaceOp(mulOp, newDot.getResult());
     rewriter.eraseOp(dotOp);
-
     return success();
   }
 };

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -71,6 +71,8 @@ void init_triton_intel_passes_ttir(py::module &&m) {
                      intel::createTritonIntelGPUFoldTrueCmpI);
   ADD_FUNC_PASS_WRAPPER_0("add_prepare_if_combining",
                           intel::createTritonIntelGPUPrepareIfCombining);
+  ADD_PASS_OPTION_WRAPPER_1("add_reassociate_dot_scale",
+                            intel::createTritonIntelReassociateDotScale, bool);
 }
 
 void init_triton_intel_passes_ttgpuir(py::module &&m) {


### PR DESCRIPTION
 Adds a TTIR pass `triton-intel-reassociate-dot-scale` that rewrites `scale * tt.dot(a, b, 0)` into `tt.dot(scale * a, b, 0)` (or scaling b) when `scale` is a uniform scalar broadcast. The scaled operand becomes loop invariant, so the following `triton-licm` hoists it out of the loop, automating the manual transform in PR #7193 on the vLLM
unified attention kernel.

Since this changes floating-point rounding, it only fires when fast-math is enabled and when the rewrite exposes a hoist: the heuristic mirrors LICM's `isDefinedOutsideOfLoop` test, requiring a loop-variant dot, a loop-invariant scalar, and exactly one loop-invariant dot operand (which the scale is folded into). Guards also require a zero accumulator, a
single-use dot, and a widen-or-equal compute type. The pass runs in `make_ttir` right before `triton-licm`.

Adds lit tests for the positive cases, one negative per guard, and a combined run with `triton-licm` proving the hoist.
Closes #7195.
