### PR TITLE
Fix pitch < base_width issue when load stride=0 matrix on CRI.

### DIFF
--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/pointer-load.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/pointer-load.mlir
@@ -14,7 +14,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %3 = tt.addptr %2, %1 : tensor<1x32x!tt.ptr<f16>, #dot0>, tensor<1x32xi32, #dot0>
     %4 = tt.broadcast %3 : tensor<1x32x!tt.ptr<f16>, #dot0> -> tensor<64x32x!tt.ptr<f16>, #dot0>
     // CHECK: %[[P:.*]] = arith.constant 64 : i32
-    // CHECK: ttig.2d_block_load_from_ptr %4, %[[P]] {row_major} {base_height = 1 : i32, base_width = 64 : i32}
+    // CHECK: ttig.2d_block_load_from_ptr %4, %[[P]] {row_major} {base_height = 1 : i32, base_width = 32 : i32}
     %5 = tt.load %4 {ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f16>, #dot0>
     tt.return %5 : tensor<64x32xf16, #dot0>
   }
@@ -35,7 +35,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %3 = tt.addptr %2, %1 : tensor<1x64x!tt.ptr<f16>, #dot1>, tensor<1x64xi32, #dot1>
     %4 = tt.broadcast %3 : tensor<1x64x!tt.ptr<f16>, #dot1> -> tensor<32x64x!tt.ptr<f16>, #dot1>
     // CHECK: %[[P:.*]] = arith.constant 64 : i32
-    // CHECK: ttig.2d_block_load_from_ptr %4, %[[P]] {column_major} {base_height = 1 : i32, base_width = 64 : i32}
+    // CHECK: ttig.2d_block_load_from_ptr %4, %[[P]] {column_major} {base_height = 1 : i32, base_width = 32 : i32}
     %5 = tt.load %4 {ttig.block_io = "column_major"} : tensor<32x64x!tt.ptr<f16>, #dot1>
     tt.return %5 : tensor<32x64xf16, #dot1>
   }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -392,7 +392,7 @@ private:
     }
 
     int64_t perWarpWidth;
-    if (isBroadcast || has1DReshapeStride)
+    if (has1DReshapeStride)
       perWarpWidth = tensorTy.getDimSize(surfaceWidthDim);
     else
       perWarpWidth = tileWidth * numPackedVals;
@@ -400,7 +400,12 @@ private:
 
     if (!has1DReshapeStride) {
       if (isBroadcast) {
-        pitch = std::max((int64_t)MIN_PITCH, baseWidthBytes);
+        // Use the full surface row width (in bytes) as the baseline pitch.
+        // Lowering may widen base_width (e.g. due to alignment), so ensure the
+        // dummy pitch doesn't end up smaller than base_width.
+        int64_t fullRowBytes =
+            tensorTy.getDimSize(surfaceWidthDim) * elemSizeInBits / 8;
+        pitch = std::max(MIN_PITCH, fullRowBytes);
       } else {
         int64_t pitchStride = getStride(strideAnalysis, op.getPtr(), pitchDim);
         if (pitchStride < 0) {


### PR DESCRIPTION
This PR fixes an Intel 2D block I/O lowering issue where broadcast (stride=0) pointer-based matrix loads can end up with base_pitch < base_width after downstream lowering adjusts base_width (e.g., for address alignment), which can break triton_gen.2Dblockload HW/verifier constraints on CRI.