### PR TITLE
[FUSED GEMM] Support check the offset divisibility which is deduced from the loop var.

### DIFF
--- a/benchmarks/triton_kernels_benchmark/fused_gemm_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/fused_gemm_benchmark.py
@@ -110,14 +110,12 @@ def fused_gemm_swiglu_kernel(
 
     acc_g = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     acc_fc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-    off_k = 0
-    for _ in range(0, K, BLOCK_SIZE_K):
-        x = desc_x.load([off_m, off_k])
-        w_g = desc_wg.load([off_k, off_n])
-        w_fc = desc_wfc.load([off_k, off_n])
+    for k in range(0, K, BLOCK_SIZE_K):
+        x = desc_x.load([off_m, k])
+        w_g = desc_wg.load([k, off_n])
+        w_fc = desc_wfc.load([k, off_n])
         acc_g = tl.dot(x, w_g, acc_g)
         acc_fc = tl.dot(x, w_fc, acc_fc)
-        off_k += BLOCK_SIZE_K
 
     acc_g += b_g[None, :]
     acc_fc += b_fc[None, :]

--- a/test/TritonIntelGPU/materialize-block-pointer.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer.mlir
@@ -256,3 +256,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+// COM: A nested-loop induction variable must not enable block IO lowering.
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func public @offset_nested_loop_var
+  tt.func public @offset_nested_loop_var(%x_ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %M: i32 {tt.divisibility = 16 : i32}, %K: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i32 = arith.constant 64 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %desc_x = arith.extsi %K : i32 to i64
+    %desc = tt.make_tensor_descriptor %x_ptr, [%M, %K], [%desc_x, %c1_i64] : <bf16>, <128x64xbf16>
+    scf.for %i = %c0_i32 to %M step %c64_i32 : i32 {
+      scf.for %k = %c0_i32 to %K step %c64_i32 : i32 {
+        // CHECK-NOT: ttig.block_io
+        %x = tt.descriptor_load %desc[%c128_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16, #blocked>
+      }
+    }
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/materialize-block-pointer.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer.mlir
@@ -214,3 +214,25 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32,
     tt.return
   }
 }
+
+
+// -----
+
+// COM: Ensure offsets derived from a loop induction variable preserve divisibility for block IO lowering.
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func public @offset_loop_var
+  tt.func public @offset_loop_var(%x_ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %w_g_ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %w_fc_ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %b_g_ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %b_fc_ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %y_ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %M: i32 {tt.divisibility = 16 : i32}, %N: i32 {tt.divisibility = 16 : i32}, %K: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i32 = arith.constant 64 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %desc_x = arith.extsi %K : i32 to i64
+    %desc = tt.make_tensor_descriptor %x_ptr, [%M, %K], [%desc_x, %c1_i64] : <bf16>, <128x64xbf16>
+    scf.for %k = %c0_i32 to %K step %c64_i32 : i32 {
+      // CHECK: tt.descriptor_load {{.*}} {ttig.block_io = "row_major", ttig.desc_padding = 1 : i32}
+      %x = tt.descriptor_load %desc[%c128_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16, #blocked>
+    }
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/materialize-block-pointer.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer.mlir
@@ -236,3 +236,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+// COM: A non-divisible loop step must not enable block IO lowering.
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func public @offset_loop_var_indivisible
+  tt.func public @offset_loop_var_indivisible(%x_ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %M: i32 {tt.divisibility = 16 : i32}, %K: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c3_i32 = arith.constant 3 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %desc_x = arith.extsi %K : i32 to i64
+    %desc = tt.make_tensor_descriptor %x_ptr, [%M, %K], [%desc_x, %c1_i64] : <bf16>, <128x64xbf16>
+    scf.for %k = %c0_i32 to %K step %c3_i32 : i32 {
+      // CHECK-NOT: ttig.block_io
+      %x = tt.descriptor_load %desc[%c128_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16, #blocked>
+    }
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
@@ -72,6 +72,18 @@ bool isDivisible(Value value, unsigned divisor) {
       return divisibilityAttr &&
              divisibilityAttr.getValue().getZExtValue() % divisor == 0;
     }
+    if (scf::ForOp forOp = dyn_cast<scf::ForOp>(parentOp)) {
+      // Nested loops aren't currently handled.
+      if (forOp->template getParentOfType<scf::ForOp>())
+        return false;
+      if (!forOp.getSingleInductionVar())
+        return false;
+      // Check only if the block arg is the loop-var.
+      if (blockArg != forOp.getInductionVar())
+        return false;
+      return isDivisible(forOp.getLowerBound(), divisor) &&
+             isDivisible(forOp.getStep(), divisor);
+    }
   }
 
   // Case 3: Value is defined by a muli operation.


### PR DESCRIPTION
Adds loop-induction-variable based divisibility reasoning to the Intel GPU transform utilities so block pointer/block IO materialization can recognize offsets whose divisibility is implied by scf.for loop structure (lower bound + step), and validates the behavior with MLIR test coverage.

The tests now cover:
- a positive path where divisible lower bound/step enables `ttig.block_io`,
- a negative path where a non-divisible step does not enable `ttig.block_io`,
- a negative path where nested-loop IV usage does not enable `ttig.block_io`.

It also helps issue #7092