### PR TITLE
[vLLM] Import vllm tests in benchmarks via `sys.path` instead of copying

### DIFF
--- a/benchmarks/triton_kernels_benchmark/vllm/batched_moe/batched_moe_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/vllm/batched_moe/batched_moe_benchmark.py
@@ -11,12 +11,16 @@ batched MoE implementations using vLLM kernels.
 
 """
 import os
+import sys
 from typing import Optional
 
 import torch
 import triton.language as tl
 
 import triton_kernels_benchmark as benchmark_suite
+
+# Make vLLM's `tests/` package importable from its source checkout at <repo>/vllm/.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "vllm")))
 
 from vllm.model_executor.layers.fused_moe.experts.fused_batched_moe import invoke_moe_batched_triton_kernel
 

--- a/benchmarks/triton_kernels_benchmark/vllm/fused_moe/fused_moe_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/vllm/fused_moe/fused_moe_benchmark.py
@@ -12,6 +12,7 @@ different implementations using vLLM kernels.
 """
 import os
 import random
+import sys
 from math import prod
 from typing import Optional
 
@@ -21,6 +22,10 @@ import triton
 import triton.language as tl
 
 import triton_kernels_benchmark as benchmark_suite
+
+# Make vLLM's `tests/` package importable from its source checkout at <repo>/vllm/.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "vllm")))
+
 from tests.kernels.moe.utils import make_quantized_test_activations, make_test_weight
 from vllm.model_executor.layers.fused_moe.fused_moe import invoke_fused_moe_triton_kernel, get_default_config
 from vllm_xpu_kernels.fused_moe_interface import cutlass_grouped_gemm as sycl_tla_grouped_gemm

--- a/scripts/vllm/install-vllm.sh
+++ b/scripts/vllm/install-vllm.sh
@@ -124,10 +124,6 @@ install_vllm() {
     exit 1
   fi
 
-  local benchmark_tests_dir="$ROOT/benchmarks/triton_kernels_benchmark/vllm/batched_moe/tests"
-  rm -rf "$benchmark_tests_dir"
-  cp -r "$VLLM_PROJ/tests" "$benchmark_tests_dir"
-
   sed -i \
     -e '/^pytest-shard/d' \
     -e '/^torch/d' \


### PR DESCRIPTION
This patch fixes the vLLM benchmark fused_moe bf16 & fp8 failures that are on main.

Both batched_moe and fused_moe benchmarks need helpers from vLLM's `tests/` package. Previously, `install-vllm.sh` copied `vllm/tests/` into the `batched_moe` dir. To fix the `fused_moe` failures in the same way would mean that we add another copy of the tests into the `fused_moe` dir. Instead of further duplicating the vLLM test dir, this patch adds `<repo>/vllm` to `sys.path` inside each benchmark script. The vLLM source checkout already lives there from `install-vllm.sh`.

Closes https://github.com/intel/intel-xpu-backend-for-triton/issues/7229.

Created https://github.com/intel/intel-xpu-backend-for-triton/issues/7233.

---

vLLM benchmarks: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27706308922
vLLM benchmarks BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27706331225

Note: the fused_moe fp8 benchmarks fail with a new error that will be tracked by https://github.com/intel/intel-xpu-backend-for-triton/issues/7233.

vLLM benchmarks performance: no change.

