### PR TITLE
[vLLM] Remove unnecessary patch change that excludes skipped moe test configs

### DIFF
--- a/scripts/vllm/vllm-fix.patch
+++ b/scripts/vllm/vllm-fix.patch
@@ -86,28 +86,6 @@ index fb8a4b0a2..7ab490aaf 100644
      if D is not None:
          out += (x * D).to(out.dtype)
      out = (out if z is None else out * F.silu(z)).to(x.dtype)
-diff --git a/tests/kernels/moe/test_batched_moe.py b/tests/kernels/moe/test_batched_moe.py
-index b9fe8ceaf..845a2db64 100644
---- a/tests/kernels/moe/test_batched_moe.py
-+++ b/tests/kernels/moe/test_batched_moe.py
-@@ -104,7 +104,7 @@ class BatchedMMTensors:
- @pytest.mark.parametrize("N", [128, 1024])
- @pytest.mark.parametrize("dtype", DTYPES)
- @pytest.mark.parametrize("block_shape", [None, [128, 128]])
--@pytest.mark.parametrize("per_act_token_quant", [False, True])
-+@pytest.mark.parametrize("per_act_token_quant", [False])
- def test_batched_mm(
-     num_experts: int,
-     max_tokens_per_expert: int,
-@@ -236,7 +236,7 @@ def test_batched_mm(
- @pytest.mark.parametrize("e", NUM_EXPERTS)
- @pytest.mark.parametrize("topk", TOP_KS)
- @pytest.mark.parametrize("dtype", DTYPES)
--@pytest.mark.parametrize("per_act_token_quant", [False, True])
-+@pytest.mark.parametrize("per_act_token_quant", [False])
- @pytest.mark.parametrize("block_shape", [None, [128, 128]])
- @pytest.mark.parametrize("input_scales", [False])
- def test_fused_moe_batched_experts(
 diff --git a/tests/kernels/moe/utils.py b/tests/kernels/moe/utils.py
 index 4899de44a..aee58d32c 100644
 --- a/tests/kernels/moe/utils.py


### PR DESCRIPTION
This PR removes an unnecessary change from the `vllm-fix.patch`.

Removing the change enables some skipped moe tests to the vLLM test runs. There are no new failures.

---

vLLM benchmarks: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27710080250
vLLM benchmarks BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27710094536
vLLM tests: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27710106052
vLLM tests BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27710135570

Note: fused_moe benchmark failures are unrelated and tracked by https://github.com/intel/intel-xpu-backend-for-triton/issues/7229.

vLLM benchmarks performance: no change.