### PR TITLE
[vLLM] Disable `fused_moe` fp8 benchmark

### DIFF
--- a/.github/workflows/vllm-benchmarks.yml
+++ b/.github/workflows/vllm-benchmarks.yml
@@ -260,29 +260,30 @@ jobs:
             --benchmark fused-moe-benchmark \
             --param_cols="num_tokens,output_hidden_size,hidden_size,num_experts,topk"
 
-      - name: Run vllm fused moe fp8
-        if: ${{ steps.install-vllm.outcome == 'success' && !cancelled() }}
-        run: |
-          source ./scripts/capture-hw-details.sh
-
-          cd benchmarks/triton_kernels_benchmark/vllm
-          FP8="1" bash run_benchmark.sh fused_moe --reports $REPORTS
-          # Transform baseline results
-          python ../../transform_results.py \
-            $REPORTS/fused-moe-gemm-performance.csv \
-            $REPORTS/fused-moe-gemm-fp8-report.csv \
-            --tag $TAG \
-            --bgroup vllm \
-            --benchmark fused-moe-fp8-benchmark \
-            --param_cols="num_tokens,output_hidden_size,hidden_size,num_experts,topk"
-          # Transform tensor descriptor patched results
-          python ../../transform_results.py \
-            $REPORTS/fused-moe-gemm-performance-td.csv \
-            $REPORTS/fused-moe-gemm-fp8-td-report.csv \
-            --tag $TAG \
-            --bgroup vllm \
-            --benchmark fused-moe-fp8-benchmark \
-            --param_cols="num_tokens,output_hidden_size,hidden_size,num_experts,topk"
+      # FIXME: https://github.com/intel/intel-xpu-backend-for-triton/issues/7233
+      # - name: Run vllm fused moe fp8
+      #   if: ${{ steps.install-vllm.outcome == 'success' && !cancelled() }}
+      #   run: |
+      #     source ./scripts/capture-hw-details.sh
+      #
+      #     cd benchmarks/triton_kernels_benchmark/vllm
+      #     FP8="1" bash run_benchmark.sh fused_moe --reports $REPORTS
+      #     # Transform baseline results
+      #     python ../../transform_results.py \
+      #       $REPORTS/fused-moe-gemm-performance.csv \
+      #       $REPORTS/fused-moe-gemm-fp8-report.csv \
+      #       --tag $TAG \
+      #       --bgroup vllm \
+      #       --benchmark fused-moe-fp8-benchmark \
+      #       --param_cols="num_tokens,output_hidden_size,hidden_size,num_experts,topk"
+      #     # Transform tensor descriptor patched results
+      #     python ../../transform_results.py \
+      #       $REPORTS/fused-moe-gemm-performance-td.csv \
+      #       $REPORTS/fused-moe-gemm-fp8-td-report.csv \
+      #       --tag $TAG \
+      #       --bgroup vllm \
+      #       --benchmark fused-moe-fp8-benchmark \
+      #       --param_cols="num_tokens,output_hidden_size,hidden_size,num_experts,topk"
 
       - name: Upload benchmark reports
         if: ${{ steps.install.outcome == 'success' && !cancelled() }}

--- a/.github/workflows/vllm-benchmarks.yml
+++ b/.github/workflows/vllm-benchmarks.yml
@@ -260,31 +260,6 @@ jobs:
             --benchmark fused-moe-benchmark \
             --param_cols="num_tokens,output_hidden_size,hidden_size,num_experts,topk"
 
-      # FIXME: https://github.com/intel/intel-xpu-backend-for-triton/issues/7233
-      # - name: Run vllm fused moe fp8
-      #   if: ${{ steps.install-vllm.outcome == 'success' && !cancelled() }}
-      #   run: |
-      #     source ./scripts/capture-hw-details.sh
-      #
-      #     cd benchmarks/triton_kernels_benchmark/vllm
-      #     FP8="1" bash run_benchmark.sh fused_moe --reports $REPORTS
-      #     # Transform baseline results
-      #     python ../../transform_results.py \
-      #       $REPORTS/fused-moe-gemm-performance.csv \
-      #       $REPORTS/fused-moe-gemm-fp8-report.csv \
-      #       --tag $TAG \
-      #       --bgroup vllm \
-      #       --benchmark fused-moe-fp8-benchmark \
-      #       --param_cols="num_tokens,output_hidden_size,hidden_size,num_experts,topk"
-      #     # Transform tensor descriptor patched results
-      #     python ../../transform_results.py \
-      #       $REPORTS/fused-moe-gemm-performance-td.csv \
-      #       $REPORTS/fused-moe-gemm-fp8-td-report.csv \
-      #       --tag $TAG \
-      #       --bgroup vllm \
-      #       --benchmark fused-moe-fp8-benchmark \
-      #       --param_cols="num_tokens,output_hidden_size,hidden_size,num_experts,topk"
-
       - name: Upload benchmark reports
         if: ${{ steps.install.outcome == 'success' && !cancelled() }}
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Disable `fused_moe` fp8 for now.

Tracked by https://github.com/intel/intel-xpu-backend-for-triton/issues/7233.

