### PR TITLE
[vLLM] Remove unnecessary `torch.stack` change from `vllm-fix.patch`

### DIFF
--- a/scripts/vllm/vllm-fix.patch
+++ b/scripts/vllm/vllm-fix.patch
@@ -86,25 +86,6 @@ index fb8a4b0a2..7ab490aaf 100644
      if D is not None:
          out += (x * D).to(out.dtype)
      out = (out if z is None else out * F.silu(z)).to(x.dtype)
-diff --git a/tests/kernels/moe/utils.py b/tests/kernels/moe/utils.py
-index 4899de44a..aee58d32c 100644
---- a/tests/kernels/moe/utils.py
-+++ b/tests/kernels/moe/utils.py
-@@ -317,7 +317,13 @@ def moe_quantize_weights(
-             w[idx], None, quant_dtype, per_token_quant, block_shape
-         )
- 
--    w = torch.stack(w_l)
-+    new_shape = torch.Size((len(w_l), ) + w_l[0].shape)
-+    new_w = torch.zeros(new_shape,
-+                        dtype=w_l[0].dtype,
-+                        device=w_l[0].device)
-+    for (i, wt) in enumerate(w_l):
-+        new_w[i] = wt
-+    w = new_w
-     w_s = torch.stack(w_s_l)
-     w_gs = torch.stack(w_gs_l) if e > 0 and w_gs_l[0] is not None else None
- 
 diff --git a/vllm/model_executor/layers/fused_moe/experts/fused_batched_moe.py b/vllm/model_executor/layers/fused_moe/experts/fused_batched_moe.py
 index 1f5724ac3..8bbbab3e5 100644
 --- a/vllm/model_executor/layers/fused_moe/experts/fused_batched_moe.py


### PR DESCRIPTION
This patch removes an unnecessary change from `vllm-fix.patch`. Without this change there are no performance or functional regressions.

---

vLLM benchmarks: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27782556550
vLLM benchmarks BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27782571084
vLLM tests: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27782591005
vLLM tests BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27782606986

vLLM benchmarks performance: no change.