### PR TITLE
[RemoveMasks] Classify masks using IV-equivalent loop iter_args

### DIFF
--- a/test/Triton/Intel/RemoveMasks/iter-arg-mask.mlir
+++ b/test/Triton/Intel/RemoveMasks/iter-arg-mask.mlir
@@ -1,0 +1,46 @@
+// RUN: triton-opt %s -split-input-file -triton-intel-remove-masks | FileCheck %s
+
+module {
+  // COM: Test that a K-dimension mask using an iter_arg (not the canonical IV)
+  // COM: is correctly classified as always-true via getIVEquivalentRange.
+  // COM: The iter_arg off_k starts at 0 and increments by 32 (same as the loop
+  // COM: IV), so its range is [0, 96]. Max element = 96 + 31 = 127 < 4096.
+  tt.func public @test_iter_arg_k_mask(
+      %ptr: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c0_i64 = arith.constant 0 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %cst = arith.constant dense<0.000000e+00> : tensor<32xf16>
+
+    %k_range = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %k_range_i64 = arith.extsi %k_range : tensor<32xi32> to tensor<32xi64>
+    %base_splat = tt.splat %ptr : !tt.ptr<f16> -> tensor<32x!tt.ptr<f16>>
+
+    // Loop with off_k as iter_arg (same as IV: init=0, step=32).
+    %result = scf.for %iv = %c0_i32 to %c128_i32 step %c32_i32
+        iter_args(%off_k = %c0_i32) -> (i32) : i32 {
+      %off_k_i64 = arith.extsi %off_k : i32 to i64
+      %k_splat = tt.splat %off_k_i64 : i64 -> tensor<32xi64>
+      %k_offset = arith.addi %k_splat, %k_range_i64 : tensor<32xi64>
+
+      // K boundary check: (off_k + range(0,32)) < splat(4096).
+      // Always true since off_k in [0, 96], max element = 127 < 4096.
+      %k_ub = tt.splat %c4096_i64 : i64 -> tensor<32xi64>
+      %k_mask = arith.cmpi slt, %k_offset, %k_ub : tensor<32xi64>
+
+      %loaded = tt.load %base_splat, %k_mask, %cst : tensor<32x!tt.ptr<f16>>
+
+      %next_off_k = arith.addi %off_k, %c32_i32 : i32
+      scf.yield %next_off_k : i32
+    }
+    tt.return
+  }
+
+  // CHECK: tt.func public @test_iter_arg_k_mask
+  // COM: The mask is proven always-true and directly removed.
+  // CHECK: scf.for
+  // CHECK:   tt.load {{%[0-9]+}} : tensor<32x!tt.ptr<f16>>
+  // CHECK: }
+}

--- a/test/Triton/Intel/RemoveMasks/iter-arg-mask.mlir
+++ b/test/Triton/Intel/RemoveMasks/iter-arg-mask.mlir
@@ -38,7 +38,7 @@ module {
     tt.return
   }
 
-  // CHECK: tt.func public @test_iter_arg_k_mask
+  // CHECK-LABEL: @test_iter_arg_k_mask
   // COM: The mask is proven always-true and directly removed.
   // CHECK: scf.for
   // CHECK:   tt.load {{%[0-9]+}} : tensor<32x!tt.ptr<f16>>

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RemoveMasks.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RemoveMasks.cpp
@@ -225,16 +225,6 @@ public:
     return opToMaskValue[op];
   }
 
-private:
-  // Record the final mask value for the given masked operation.
-  // Fixes #6871: each operation must record only its own mask, not the masks of
-  // its other users (which would poison the map for ops consuming two masks,
-  // e.g. an arith.select using one mask as condition and another as
-  // true-value).
-  void registerMaskValue(Operation *op, bool maskVal) const {
-    opToMaskValue.insert({op, maskVal});
-  }
-
   // Dispatch on the mask's defining op: `arith.andi` is combined recursively,
   // otherwise fall through to cmp classification.
   MaskClassification classify(scf::ForOp &forOp, Value mask) const {
@@ -244,6 +234,16 @@ private:
     if (auto andOp = dyn_cast_or_null<arith::AndIOp>(finalVal.getDefiningOp()))
       return classifyAnd(forOp, andOp);
     return classifyCmp(forOp, finalVal);
+  }
+
+private:
+  // Record the final mask value for the given masked operation.
+  // Fixes #6871: each operation must record only its own mask, not the masks of
+  // its other users (which would poison the map for ops consuming two masks,
+  // e.g. an arith.select using one mask as condition and another as
+  // true-value).
+  void registerMaskValue(Operation *op, bool maskVal) const {
+    opToMaskValue.insert({op, maskVal});
   }
 
   // Combine classifications of the two operands of an `arith.andi` mask:
@@ -263,9 +263,84 @@ private:
     return MaskClassification::Unknown;
   }
 
+  // Check whether a value is the loop induction variable or a loop iter_arg
+  // that is equivalent to the IV (same init as lower bound, same step).
+  std::optional<ConstantIntRanges> getIVEquivalentRange(scf::ForOp &forOp,
+                                                        Value val) const {
+    std::optional<ConstantIntRanges> ivRange =
+        tt::intel::collectLoopIVRange(forOp, *solver);
+    if (!ivRange)
+      return std::nullopt;
+
+    if (val == forOp.getSingleInductionVar())
+      return ivRange;
+
+    // Check if val resolved (via getFinalValue) to the loop's lower bound
+    // constant, meaning it was an iter_arg with that init. Verify there
+    // exists an iter_arg with init == lb and yield == self + step.
+    OpFoldResult lbOFR = *forOp.getSingleLowerBound();
+    OpFoldResult stepOFR = *forOp.getSingleStep();
+
+    auto getConstant = [](OpFoldResult ofr) -> std::optional<int64_t> {
+      if (auto attr = dyn_cast<Attribute>(ofr)) {
+        if (auto intAttr = dyn_cast_or_null<IntegerAttr>(attr))
+          return intAttr.getInt();
+        return std::nullopt;
+      }
+      APInt intVal;
+      if (matchPattern(cast<Value>(ofr), m_ConstantInt(&intVal)))
+        return intVal.getSExtValue();
+      return std::nullopt;
+    };
+
+    std::optional<int64_t> lbConst = getConstant(lbOFR);
+    std::optional<int64_t> stepConst = getConstant(stepOFR);
+    if (!lbConst || !stepConst)
+      return std::nullopt;
+
+    auto matchesInt = [](Value v, int64_t expected) -> bool {
+      APInt intVal;
+      if (matchPattern(v, m_ConstantInt(&intVal)))
+        return intVal.getSExtValue() == expected;
+      DenseElementsAttr denseAttr;
+      if (matchPattern(v, m_Constant(&denseAttr)) && denseAttr.isSplat()) {
+        if (auto intAttr =
+                dyn_cast<IntegerAttr>(denseAttr.getSplatValue<Attribute>()))
+          return intAttr.getInt() == expected;
+      }
+      return false;
+    };
+
+    if (!matchesInt(val, *lbConst))
+      return std::nullopt;
+
+    auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+    for (unsigned i = 0, e = forOp.getNumRegionIterArgs(); i < e; ++i) {
+      Value initArg = forOp.getInitArgs()[i];
+      if (!matchesInt(initArg, *lbConst))
+        continue;
+
+      Value yieldVal = yieldOp.getOperand(i);
+      auto yieldAdd = yieldVal.getDefiningOp<arith::AddIOp>();
+      if (!yieldAdd)
+        continue;
+
+      BlockArgument iterArg = forOp.getRegionIterArg(i);
+      bool lhsIsIterArg = (yieldAdd.getLhs() == iterArg);
+      bool rhsIsIterArg = (yieldAdd.getRhs() == iterArg);
+      if (!lhsIsIterArg && !rhsIsIterArg)
+        continue;
+
+      Value stepOperand = lhsIsIterArg ? yieldAdd.getRhs() : yieldAdd.getLhs();
+      if (matchesInt(stepOperand, *stepConst))
+        return ivRange;
+    }
+
+    return std::nullopt;
+  }
+
   // Classify a single `arith.cmpi` mask against the loop IV range.
   MaskClassification classifyCmp(scf::ForOp &forOp, Value finalVal) const {
-    // Ensure the loop range is known.
     std::optional<ConstantIntRanges> optRange =
         tt::intel::collectLoopIVRange(forOp, *solver);
     if (!optRange)
@@ -306,7 +381,10 @@ private:
 
     Value addLhs = tt::intel::getFinalValue(addOp.getLhs());
     Value addRhs = tt::intel::getFinalValue(addOp.getRhs());
-    if (addLhs != forOp.getSingleInductionVar())
+
+    std::optional<ConstantIntRanges> lhsRange =
+        getIVEquivalentRange(forOp, addLhs);
+    if (!lhsRange)
       return MaskClassification::Unknown;
 
     auto makeRangeOp =
@@ -314,7 +392,7 @@ private:
     if (!makeRangeOp)
       return MaskClassification::Unknown;
 
-    return classifyMask(pred, *optRange, makeRangeOp.getStart(),
+    return classifyMask(pred, *lhsRange, makeRangeOp.getStart(),
                         makeRangeOp.getEnd(), *constIntVal);
   }
 

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RemoveMasks.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RemoveMasks.cpp
@@ -341,11 +341,6 @@ private:
 
   // Classify a single `arith.cmpi` mask against the loop IV range.
   MaskClassification classifyCmp(scf::ForOp &forOp, Value finalVal) const {
-    std::optional<ConstantIntRanges> optRange =
-        tt::intel::collectLoopIVRange(forOp, *solver);
-    if (!optRange)
-      return MaskClassification::Unknown;
-
     if (!finalVal.getDefiningOp() ||
         !isa<arith::CmpIOp>(finalVal.getDefiningOp()))
       return MaskClassification::Unknown;


### PR DESCRIPTION
Add getIVEquivalentRange to detect loop iter_args that behave identically to the canonical induction variable (same init value as the loop lower bound, yield = self + loop step). This allows classifyCmp to prove masks always-true when the offset is maintained as a separate iter_arg rather than using the loop IV directly.