### PR TITLE
[vLLM] Remove unnecessary change from `vllm-fix.patch`

### DIFF
--- a/scripts/vllm/vllm-fix.patch
+++ b/scripts/vllm/vllm-fix.patch
@@ -52,22 +52,6 @@ index b674d55a1..545b638dc 100644
  
  if _is_hip():
      ext_modules.append(CMakeExtension(name="vllm._rocm_C"))
-diff --git a/tests/conftest.py b/tests/conftest.py
-index ebf9608b0..16fa7a7f6 100644
---- a/tests/conftest.py
-+++ b/tests/conftest.py
-@@ -293,6 +293,11 @@ def workspace_init():
- 
-     if torch.cuda.is_available():
-         device = torch.device("cuda:0")
-+    elif torch.xpu.is_available():
-+        device = torch.device("xpu:0")
-+    else:
-+        device = None
-+    if device is not None:
-         init_workspace_manager(device)
-     yield
-     reset_workspace_manager()
 diff --git a/tests/kernels/mamba/utils.py b/tests/kernels/mamba/utils.py
 index fb8a4b0a2..7ab490aaf 100644
 --- a/tests/kernels/mamba/utils.py


### PR DESCRIPTION
This patch removes a change from `vllm-fix.patch` that has no impact on the vLLM benchmarks and tests.

Closes https://github.com/intel/intel-xpu-backend-for-triton/issues/6466.

---

vLLM benchmarks: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27848249068
vLLM benchmarks BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27848257093
vLLM tests: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27848268534
vLLM tests BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27848283245

vLLM benchmarks performance: no change.