### PR TITLE
Fix pitch < base_width issue when store stride=0 matrix on CRI.

### DIFF
--- a/test/TritonIntelGPU/tensor-pointer-store-block-2d.mlir
+++ b/test/TritonIntelGPU/tensor-pointer-store-block-2d.mlir
@@ -205,3 +205,29 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     tt.return
   }
 }
+
+// -----
+
+// COM: Regression test for stride=0 row-major pointer stores. Broadcasting a
+// COM: single row across the row dimension makes the row stride zero, while the
+// COM: non-zero column start forces base-width alignment compensation to widen
+// COM: the emitted block store's base_width. The lowering must still use 2D
+// COM: block store by synthesizing a pitch from the full surface width.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 4], order = [1, 0]}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: @broadcast_row_major_pointer_store
+  // CHECK-NOT: triton_gen.2Dblockstore
+  // ALL-LAYOUT-LABEL: @broadcast_row_major_pointer_store
+  // ALL-LAYOUT: %[[PITCH:.*]] = llvm.mlir.constant(128 : i32) : i32
+  // ALL-LAYOUT: triton_gen.2Dblockstore {{.*}}, %[[PITCH]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 1, v_blocks = 1, cache_control = Default}
+  tt.func public @broadcast_row_major_pointer_store(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    %0 = tt.make_range {end = 84 : i32, start = 20 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x64x!tt.ptr<f16>, #blocked>
+    %3 = tt.addptr %2, %1 : tensor<1x64x!tt.ptr<f16>, #blocked>, tensor<1x64xi32, #blocked>
+    %addr = tt.broadcast %3 : tensor<1x64x!tt.ptr<f16>, #blocked> -> tensor<64x64x!tt.ptr<f16>, #blocked>
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf16, #blocked>
+    tt.store %addr, %cst {ttig.block_io = "row_major"} : tensor<64x64x!tt.ptr<f16>, #blocked>
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/tensor-pointer-store-block-2d.mlir
+++ b/test/TritonIntelGPU/tensor-pointer-store-block-2d.mlir
@@ -223,6 +223,8 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
   // ALL-LAYOUT: %[[PITCH:.*]] = llvm.mlir.constant(128 : i32) : i32
   // ALL-LAYOUT: triton_gen.2Dblockstore {{.*}}, %[[PITCH]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 1, v_blocks = 1, cache_control = Default}
   tt.func public @broadcast_row_major_pointer_store(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    // COM: start=20 gives a non-zero column offset so alignment compensation
+    // COM: widens base_width, while end=84 keeps the broadcasted row width at 64.
     %0 = tt.make_range {end = 84 : i32, start = 20 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
     %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
     %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x64x!tt.ptr<f16>, #blocked>

--- a/test/TritonIntelGPU/tensor-pointer-store-block-2d.mlir
+++ b/test/TritonIntelGPU/tensor-pointer-store-block-2d.mlir
@@ -218,6 +218,8 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
   // CHECK-LABEL: @broadcast_row_major_pointer_store
   // CHECK-NOT: triton_gen.2Dblockstore
   // ALL-LAYOUT-LABEL: @broadcast_row_major_pointer_store
+  // COM: surface width = 64 elements and f16 elements are 2 bytes, so the
+  // COM: synthesized full-row pitch is 64 * 2 = 128 bytes.
   // ALL-LAYOUT: %[[PITCH:.*]] = llvm.mlir.constant(128 : i32) : i32
   // ALL-LAYOUT: triton_gen.2Dblockstore {{.*}}, %[[PITCH]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 1, v_blocks = 1, cache_control = Default}
   tt.func public @broadcast_row_major_pointer_store(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -704,7 +704,6 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
     int stride = getStride(ptr, dim);
     // If the stride is 0, we assume a minimum pitch of 64 bytes.
     constexpr int MIN_PITCH = 64;
-
     if (stride == 0)
       return b.i32_val(MIN_PITCH);
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -704,6 +704,7 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
     int stride = getStride(ptr, dim);
     // If the stride is 0, we assume a minimum pitch of 64 bytes.
     constexpr int MIN_PITCH = 64;
+
     if (stride == 0)
       return b.i32_val(MIN_PITCH);
 
@@ -2877,7 +2878,24 @@ struct StoreOpToBlockIOConversion
     } else {
       // Always get the stride of the row dim since block store only supports
       // row major matrix.
-      pitch = getPitch(rewriter, ptr, elemSizeInBits, rowDim);
+      int64_t rowStride = getStride(ptr, rowDim);
+      if (rowStride == 0) {
+        // stride=0 along rowDim means each row is mapped to the same location.
+        // It must be a store height=1 tile. We can set the pitch to an
+        // arbitrary value since the row offset is always 0, as long as we can
+        // satisfy the HW address payload restriction for the given tile width
+        // and element size. To keep it simple, we can just set the pitch to
+        // surface width * element size to avoid issue pitch < base_width caused
+        // by the compensation of the base address alignment.
+        if (tileHeight != 1)
+          return failure();
+        constexpr int64_t MIN_PITCH = 64;
+        int64_t surfaceWidth = tensorType.getDimSize(colDim);
+        pitch =
+            b.i32_val(std::max(MIN_PITCH, surfaceWidth * elemSizeInBits / 8));
+      } else {
+        pitch = getPitch(rewriter, ptr, elemSizeInBits, rowDim);
+      }
     }
     if (!pitch)
       return failure();


### PR DESCRIPTION
Fixes an Intel 2D block store lowering corner case where stride=0 along the row dimension could lead to pitch < base_width after base-address alignment compensation (notably on CRI).