### PR TITLE
Fix LSC d16 block width constraint violation in prefetch

### DIFF
--- a/test/TritonGEN/tritongen-2Dblockprefetch-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockprefetch-to-llvm.mlir
@@ -441,3 +441,14 @@ llvm.func @triton_gen.2Dblockprefetch(%ptr : !llvm.ptr<1>, %base_width : i32, %b
   llvm.return
 }
 }
+
+// -----
+
+// COM: d16 with tile_width=32, vBlocks=1 has no SPV runtime builtin (16b_?r32x1c
+// COM: is missing). Verify it falls back to GenISA LSC2DBlockPrefetch intrinsic.
+llvm.func @triton_gen.2Dblockprefetch_d16_genisa_fallback(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // CHECK-NOT: @_Z36__spirv_Subgroup2DBlockPrefetchINTEL
+  // CHECK:     llvm.call spir_funccc @llvm.genx.GenISA.LSC2DBlockPrefetch.isVoid({{.*}}) {{.*}} : (i64, i32, i32, i32, i32, i32, i32, i32, i32, i32, i1, i1, i32) -> ()
+  triton_gen.2Dblockprefetch %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=16, tile_width=32, tile_height=8, v_blocks=1, cache_control=Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32)
+  llvm.return
+}

--- a/test/TritonIntelGPU/prefetch-descriptor-to-llvm.mlir
+++ b/test/TritonIntelGPU/prefetch-descriptor-to-llvm.mlir
@@ -53,8 +53,8 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK:     %[[OFFSET_X:.*]] = llvm.add {{.*}}, %{{.*}} : i32
     // CHECK:     %[[OFFSET_Y:.*]] = llvm.add {{.*}}, %{{.*}} : i32
 
-    // COM: 16x32xf16 with 8 warps: tile_height=2, tile_width=32 → vBlocks=2, tile_width=16.
-    // CHECK:     triton_gen.2Dblockprefetch %[[BASE_PTR]], %[[BASE_WIDTH_I32]], %[[BASE_HEIGHT_I32]], %[[PITCH]], %[[OFFSET_X]], %[[OFFSET_Y]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 2, v_blocks = 2, cache_control = L1C_L3C}
+    // COM: 16x32xf16 with 8 warps: tile_height=2, tile_width=32, vBlocks=1.
+    // CHECK:     triton_gen.2Dblockprefetch %[[BASE_PTR]], %[[BASE_WIDTH_I32]], %[[BASE_HEIGHT_I32]], %[[PITCH]], %[[OFFSET_X]], %[[OFFSET_Y]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 2, v_blocks = 1, cache_control = L1C_L3C}
     ttig.descriptor_prefetch %desc[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<16x32xf16>
 
     tt.return
@@ -127,8 +127,8 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     // CHECK:     %[[DESC:.*]] = llvm.insertvalue %{{.*}}, %{{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
     // CHECK:     %[[BASE_PTR:.*]] = llvm.extractvalue %[[DESC]][4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
 
-    // COM: 128 bytes per row falls back to 64 bytes prefetch → tile_width=16, tile_height=4, v_blocks=2.
-    // CHECK:     triton_gen.2Dblockprefetch %[[BASE_PTR]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 4, v_blocks = 2, cache_control = L1C_L3C}
+    // COM: 128 bytes per row falls back to 64 bytes prefetch → tile_width=32, tile_height=4, v_blocks=1.
+    // CHECK:     triton_gen.2Dblockprefetch %[[BASE_PTR]], {{.*}} {elem_size_in_bits = 16, tile_width = 32, tile_height = 4, v_blocks = 1, cache_control = L1C_L3C}
     ttig.descriptor_prefetch %desc[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<16x64xf16>
 
     tt.return
@@ -159,9 +159,9 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
 
     // COM: Verify batch dimension folded via GEP and 2D prefetch ops emitted.
     // CHECK:     llvm.getelementptr
-    // CHECK:     triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 4, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK:     triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 32, tile_height = 4, v_blocks = 1, cache_control = L1C_L3C}
     // CHECK:     llvm.getelementptr
-    // CHECK:     triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 4, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK:     triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 32, tile_height = 4, v_blocks = 1, cache_control = L1C_L3C}
     ttig.descriptor_prefetch %desc[%c0_i32, %c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<2x16x32xf16>
 
     tt.return

--- a/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
+++ b/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
@@ -6,7 +6,7 @@
 
 // COM: Test case: f16 blocked prefetch, 128x64 tensor, 4 warps.
 // COM: With 128x64xf16 and 4 warps (256B prefetch support enabled):
-// COM:   tileHeight=32, tileWidth=32 -> vBlocks=2, tile_width=16
+// COM:   tileHeight=32, tileWidth=32 -> vBlocks=1, tile_width=32
 // COM:   warpsM=2, warpsN=2
 // COM:   numTilesPerWarp = (128*64) / (32*32*4) = 2
 // COM: Expect 2 triton_gen.2Dblockprefetch ops per prefetch invocation.
@@ -28,7 +28,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32,
     %9 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
     %ptr = tt.addptr %9, %8 : tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<128x64xi32, #blocked>
 
-    // CHECK-COUNT-2: triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK-COUNT-2: triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 32, tile_height = 32, v_blocks = 1, cache_control = L1C_L3C}
     ttig.prefetch %ptr {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 0, 0>, ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f16>, #blocked>
 
     tt.return
@@ -101,9 +101,9 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32,
     // COM: prefetch when the predicate is false. Check that the prefetch is
     // COM: still emitted (twice) and that its offsetY comes from an llvm.select.
     // CHECK: %[[SEL0:.*]] = llvm.select %{{.*}}, %{{.*}}, %{{.*}} : i1, i32
-    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL0]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL0]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 32, v_blocks = 1, cache_control = L1C_L3C}
     // CHECK: %[[SEL1:.*]] = llvm.select %{{.*}}, %{{.*}}, %{{.*}} : i1, i32
-    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL1]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL1]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 32, v_blocks = 1, cache_control = L1C_L3C}
     ttig.prefetch %ptr, %mask {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 1, 0>, ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f16>, #blocked>
 
     tt.return
@@ -146,9 +146,9 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32,
     // COM: The uniform `%pred` is folded into offsetY via llvm.select; the
     // COM: per-element `%boundsMask` is dropped (safe for a prefetch hint).
     // CHECK: %[[SEL0:.*]] = llvm.select %{{.*}}, %{{.*}}, %{{.*}} : i1, i32
-    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL0]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL0]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 32, v_blocks = 1, cache_control = L1C_L3C}
     // CHECK: %[[SEL1:.*]] = llvm.select %{{.*}}, %{{.*}}, %{{.*}} : i1, i32
-    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL1]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL1]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 32, v_blocks = 1, cache_control = L1C_L3C}
     ttig.prefetch %ptr, %mask {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 1, 0>, ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f16>, #blocked>
 
     tt.return
@@ -214,7 +214,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32,
     %9 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
     %ptr = tt.addptr %9, %8 : tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<128x64xi32, #blocked>
 
-    // CHECK-COUNT-2: triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1UC_L3C}
+    // CHECK-COUNT-2: triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 32, tile_height = 32, v_blocks = 1, cache_control = L1UC_L3C}
     ttig.prefetch %ptr {boundaryCheck = array<i32>, cache = 3 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 0, 0>, ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f16>, #blocked>
 
     tt.return

--- a/test/TritonIntelGPU/prefetch-to-llvm.mlir
+++ b/test/TritonIntelGPU/prefetch-to-llvm.mlir
@@ -37,7 +37,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK: %[[VAL_13:.*]] = llvm.ptrtoint %[[ADDR_0]] : !llvm.ptr<1> to i64
     // CHECK: %[[UNIFIED_BASE:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[VAL_13]], %[[CST_0]]) {convergent, no_unwind, will_return} : (i64, i32) -> i64
     // CHECK: %[[VAL_26:.*]] = llvm.inttoptr %[[UNIFIED_BASE]] : i64 to !llvm.ptr<1>
-    // CHECK: triton_gen.2Dblockprefetch %[[VAL_26]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[OFFSET_Y]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK: triton_gen.2Dblockprefetch %[[VAL_26]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[OFFSET_Y]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
 
     // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK: %[[VAL_29:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflecj(%{{.*}}, %[[CST_0]]) {convergent, no_unwind, will_return} : (i8, i32) -> i8
@@ -48,7 +48,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK: %[[VAL_32:.*]] = llvm.ptrtoint %[[ADDR_16]] : !llvm.ptr<1> to i64
     // CHECK: %[[VAL_33:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[VAL_32]], %[[CST_0]]) {convergent, no_unwind, will_return} : (i64, i32) -> i64
     // CHECK: %[[VAL_34:.*]] = llvm.inttoptr %[[VAL_33]] : i64 to !llvm.ptr<1>
-    // CHECK: triton_gen.2Dblockprefetch %[[VAL_34]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[VAL_31]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK: triton_gen.2Dblockprefetch %[[VAL_34]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[VAL_31]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
 
     // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK: %[[VAL_36:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflecj(%{{.*}}, %[[CST_0]]) {convergent, no_unwind, will_return} : (i8, i32) -> i8
@@ -59,7 +59,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK: %[[VAL_39:.*]] = llvm.ptrtoint %[[ADDR_32]] : !llvm.ptr<1> to i64
     // CHECK: %[[VAL_40:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[VAL_39]], %[[CST_0]]) {convergent, no_unwind, will_return} : (i64, i32) -> i64
     // CHECK: %[[VAL_41:.*]] = llvm.inttoptr %[[VAL_40]] : i64 to !llvm.ptr<1>
-    // CHECK: triton_gen.2Dblockprefetch %[[VAL_41]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[VAL_38]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK: triton_gen.2Dblockprefetch %[[VAL_41]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[VAL_38]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
 
     // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK: %[[VAL_43:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflecj(%{{.*}}, %[[CST_0]]) {convergent, no_unwind, will_return} : (i8, i32) -> i8
@@ -70,12 +70,12 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK: %[[VAL_46:.*]] = llvm.ptrtoint %[[ADDR_48]] : !llvm.ptr<1> to i64
     // CHECK: %[[VAL_47:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[VAL_46]], %[[CST_0]]) {convergent, no_unwind, will_return} : (i64, i32) -> i64
     // CHECK: %[[VAL_48:.*]] = llvm.inttoptr %[[VAL_47]] : i64 to !llvm.ptr<1>
-    // CHECK: triton_gen.2Dblockprefetch %[[VAL_48]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[VAL_45]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK: triton_gen.2Dblockprefetch %[[VAL_48]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[VAL_45]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
 
     %mask_tensor = arith.constant dense<1> : tensor<64x32xi1, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
     ttig.prefetch %tensor_of_ptr, %mask_tensor {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 1, 1>, ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
 
-    // CHECK-COUNT-4: triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK-COUNT-4: triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
 
     ttig.prefetch %tensor_of_ptr {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 1, 1>, ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
 

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -190,6 +190,13 @@ static bool isSPVBuiltinAvailableImpl(TritonGEN::Matrix2DBlockStoreOp op) {
 }
 
 static bool isSPVBuiltinAvailableImpl(TritonGEN::Matrix2DBlockPrefetchOp op) {
+  // The SPV runtime library only has builtins for d16 with tile_width=16
+  // (i.e. 16b_?r16x2c). The 16b_?r32x1c configuration is not available,
+  // so fall back to GenISA which supports any hardware-valid configuration.
+  if (op.getElemSizeInBits() == 16 && op.getTileWidth() == 32 &&
+      op.getVBlocks() == 1)
+    return false;
+
   return true;
 }
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1270,14 +1270,6 @@ static LogicalResult emit2DBlockPrefetchOps(
       tileWidthInElem = 32;
     }
     break;
-  case 16:
-    if (tileWidthInElem == 32) {
-      // OCL interface supports 16b_?r16x2c for 64 bytes per row of 16 bits
-      // element.
-      vBlocks = 2;
-      tileWidthInElem = 16;
-    }
-    break;
   }
 
   StringAttr kOffset = S("offset");
@@ -1479,14 +1471,6 @@ struct PrefetchOpConversion
         // element.
         vBlocks = 2;
         tileWidthInElem = 32;
-      }
-      break;
-    case 16:
-      if (tileWidthInElem == 32) {
-        // OCL interface supports 16b_?r16x2c for 64 bytes per row of 16 bits
-        // element.
-        vBlocks = 2;
-        tileWidthInElem = 16;
       }
       break;
     }


### PR DESCRIPTION
## Summary

Fixes a fatal TBX emulator crash on BMG (gen12.9) caused by an invalid LSC 2D block prefetch instruction for d16 (16-bit) elements.

**Root cause:** The prefetch emit paths in `LoadStoreOpToLLVM.cpp` split a 32-element d16 tile (64 bytes) into 2 x 16-element blocks (`vBlocks=2`), producing `block_width=32` with `array_length=2`. The hardware requires `block_width_bytes * array_length == 128` when `array_length > 1`, but `32 * 2 = 64 != 128` -> CB_FATAL.

**Fix:** Remove the `case 16` split entirely. Keep d16 tiles as single-block prefetches (`vBlocks=1`, `tile_width=32`), which are always valid and more efficient (IGC converts splits back to single-block anyway). Add a GenISA fallback for this config since the SPV runtime library lacks the `16b_?r32x1c` builtin.

## Files Changed

- `third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp` — remove both `case 16` d16 split blocks
- `third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp` — add GenISA fallback for d16 tile_width=32 vBlocks=1
- `test/TritonGEN/tritongen-2Dblockprefetch-to-llvm.mlir` — add GenISA fallback test
- `test/TritonIntelGPU/prefetch-descriptor-to-llvm.mlir` — update expected output
- `test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir` — update expected output
- `test/TritonIntelGPU/prefetch-to-llvm.mlir` — update expected output

## Test Plan

- [ ] Existing prefetch MLIR lit tests pass with updated expectations
- [ ] CRI daily job no longer crashes on d16 prefetch

## References

- Internal CRI PR: intel-tools/intel-xpu-backend-for-triton#1832
- Jira: [PYTORCHDGQ-9207](https://jira.devtools.intel.com/browse/PYTORCHDGQ-9207)
- Bspec: https://gfxspecs.intel.com/Predator/Home/Index/57329