### PR TITLE
Add E2E regression test for d16 LSC block prefetch crash

### DIFF
--- a/python/test/unit/intel/test_prefetch_d16_regression.py
+++ b/python/test/unit/intel/test_prefetch_d16_regression.py
@@ -1,0 +1,293 @@
+"""Regression tests for LSC d16 block prefetch crash on BMG/CRI (gen12.9).
+
+The Triton compiler's prefetch emit path previously split d16 (16-bit) tile_width=32
+into {tile_width=16, vBlocks=2}, producing block_width=32 bytes with array_length=2.
+This violated the TBX emulator constraint (block_width × array_length == 128 when
+array_length > 1), causing a CB_FATAL.
+
+The fix removes the d16 split entirely, emitting single-block prefetches
+(tile_width=32, vBlocks=1) which are always valid and more efficient.
+
+Two layers of verification:
+1. **IR-level (runs on any platform)**: assert the lowered IR never contains the
+   buggy {tile_width=16, v_blocks=2} pattern for d16. This catches a regression
+   regardless of whether the test machine is CRI/BMG/PVC.
+2. **End-to-end (XPU only)**: run the matmul and check correctness against
+   torch.matmul. On CRI this is what previously crashed.
+
+References:
+    PYTORCHDGQ-9207
+    https://gfxspecs.intel.com/Predator/Home/Index/57329
+"""
+
+import re
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton._internal_testing import is_xpu
+
+
+@triton.jit
+def _matmul_kernel_tdesc(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    stride_a0,
+    stride_b0,
+    stride_cm,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    pid_m = pid % num_pid_m
+    pid_n = pid // num_pid_m
+
+    a_desc = tl.make_tensor_descriptor(a_ptr, shape=[M, K], strides=[stride_a0, 1],
+                                       block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = tl.make_tensor_descriptor(b_ptr, shape=[K, N], strides=[stride_b0, 1],
+                                       block_shape=[BLOCK_SIZE_K, BLOCK_SIZE_N])
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in tl.range(0, K, BLOCK_SIZE_K, num_stages=NUM_STAGES):
+        a = a_desc.load([pid_m * BLOCK_SIZE_M, k])
+        b = b_desc.load([k, pid_n * BLOCK_SIZE_N])
+        accumulator += tl.dot(a, b)
+
+    c_desc = tl.make_tensor_descriptor(c_ptr, shape=[M, N], strides=[stride_cm, 1],
+                                       block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_N])
+    c_desc.store([pid_m * BLOCK_SIZE_M, pid_n * BLOCK_SIZE_N], accumulator.to(c_ptr.dtype.element_ty))
+
+
+@triton.jit
+def _matmul_kernel_ptrs(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    pid_m = pid % num_pid_m
+    pid_n = pid // num_pid_m
+
+    offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K), num_stages=NUM_STAGES):
+        a = tl.load(a_ptrs)
+        b = tl.load(b_ptrs)
+        accumulator += tl.dot(a, b)
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    tl.store(c_ptrs, accumulator.to(c_ptr.dtype.element_ty))
+
+
+# The lowered LLVM IR contains the SPIRV prefetch call with positional integer args:
+#   __spirv_Subgroup2DBlockPrefetchINTEL...(i32 elem_size_bytes, i32 tile_width,
+#                                           i32 tile_height, i32 v_blocks, ...)
+# The original bug emitted (i32 2, i32 16, i32 X, i32 2, ...) — d16 (2 bytes),
+# tile_width=16, any tile_height, v_blocks=2 → block_width × array_length = 32 × 2
+# = 64 ≠ 128 → CB_FATAL on CRI.
+_LLIR_PREFETCH_CALL = re.compile(
+    r"@_Z\d+__spirv_Subgroup2DBlockPrefetchINTEL\w*\("
+    r"\s*i32\s+(\d+)\s*,"  # elem_size_bytes
+    r"\s*i32\s+(\d+)\s*,"  # tile_width
+    r"\s*i32\s+(\d+)\s*,"  # tile_height
+    r"\s*i32\s+(\d+)\s*,",  # v_blocks
+)
+
+
+def _find_buggy_d16_prefetch_calls(llir):
+    """Return a list of (tile_width, tile_height, v_blocks) for every d16 prefetch
+    call in `llir` that matches the buggy crash shape (tile_width=16, v_blocks=2).
+
+    On a fixed compiler this list will be empty.
+    """
+    buggy = []
+    for m in _LLIR_PREFETCH_CALL.finditer(llir):
+        elem_bytes, tile_w, tile_h, v_blocks = (int(g) for g in m.groups())
+        if elem_bytes == 2 and tile_w == 16 and v_blocks == 2:
+            buggy.append((tile_w, tile_h, v_blocks))
+    return buggy
+
+
+def _count_d16_prefetch_calls(llir):
+    """Total number of d16 (elem_size_bytes==2) prefetch calls in `llir`."""
+    return sum(1 for m in _LLIR_PREFETCH_CALL.finditer(llir) if int(m.group(1)) == 2)
+
+
+# ---------------------------------------------------------------------------
+# IR-level regression check (runs on any platform — does not require CRI/BMG).
+# Catches the regression at compile time by inspecting the lowered IR.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K", [[32, 32, 32], [64, 64, 32], [32, 32, 64]])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("num_stages", [2, 3])
+@pytest.mark.skipif(not is_xpu(), reason="XPU compiler target required (compile-only, no kernel launch)")
+def test_d16_prefetch_ir_no_buggy_split(BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, dtype, num_stages, device):
+    """Compile-only check: lowered LLIR must not contain a (2, 16, *, 2, ...) prefetch call.
+
+    The bug emitted `__spirv_Subgroup2DBlockPrefetchINTEL(2, 16, X, 2, ...)` for
+    d16 inputs — block_width(32 bytes) × array_length(2) = 64 ≠ 128, which crashed
+    on CRI. The fix collapses the split, so the corresponding call should be
+    `(2, 32, X, 1, ...)` (single-block).
+
+    This compile-only check runs on any XPU build host (no CRI/BMG required), so
+    a regression of PYTORCHDGQ-9207 is caught in standard CI rather than only on
+    the daily CRI job. Fails if zero d16 prefetch calls are emitted, since that
+    means the kernel is not exercising the path under test.
+    """
+    M, N, K = 128, 128, 128
+    a = torch.empty((M, K), device=device, dtype=dtype)
+    b = torch.empty((K, N), device=device, dtype=dtype)
+    c = torch.empty((M, N), device=device, dtype=dtype)
+
+    compiled = _matmul_kernel_tdesc.warmup(
+        a,
+        b,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        b.stride(0),
+        c.stride(0),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        NUM_STAGES=num_stages,
+        grid=(1, ),
+    )
+
+    llir = compiled.asm.get("llir", "")
+    n_d16 = _count_d16_prefetch_calls(llir)
+    assert n_d16 > 0, ("Test setup is broken: the kernel did not emit any d16 2D block prefetch calls in LLIR — "
+                       "this configuration does not exercise the regression path. "
+                       "Try different BLOCK_SIZE values or check that ttig.support_2d_block_io is set on the target.")
+    buggy = _find_buggy_d16_prefetch_calls(llir)
+    assert not buggy, (f"Found {len(buggy)} buggy d16 prefetch call(s) (tile_width=16, v_blocks=2) in LLIR. "
+                       f"This is the PYTORCHDGQ-9207 crash shape — block_width(32B) × array_length(2) = 64 != 128. "
+                       f"Sample: {buggy[0]}")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end matmul via tensor descriptor (cooperative prefetch path).
+# Runs on actual XPU hardware; previously crashed on CRI.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K", [[32, 32, 32], [64, 64, 32], [32, 32, 64]])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("num_stages", [2, 3])
+@pytest.mark.skipif(not is_xpu(), reason="XPU-specific 2D block prefetch test")
+@pytest.mark.xfail(
+    not (triton.runtime.driver.active.get_current_target().arch['has_subgroup_2d_block_io']
+         and triton.runtime.driver.active.get_current_target().arch['has_subgroup_matrix_multiply_accumulate']),
+    reason="Block loads and/or DPAS not supported on this architecture", run=False)
+def test_d16_prefetch_tensor_desc(BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, dtype, num_stages, device):
+    """End-to-end correctness check via tensor descriptor path.
+
+    Before the fix, this kernel would crash on CRI with CB_FATAL because the
+    compiler emitted an LSC 2D block prefetch with `block_width=32 bytes,
+    array_length=2`, violating the gen12.9 hardware/emulator constraint.
+    """
+    M, N, K = 128, 128, 128
+    torch.manual_seed(0)
+    a = torch.randn((M, K), device=device, dtype=dtype, requires_grad=False)
+    b = torch.randn((K, N), device=device, dtype=dtype, requires_grad=False)
+    c = torch.empty((M, N), device=device, dtype=dtype)
+
+    grid = (triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N), )
+    _matmul_kernel_tdesc[grid](
+        a,
+        b,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        b.stride(0),
+        c.stride(0),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        NUM_STAGES=num_stages,
+    )
+
+    ref = torch.matmul(a.float(), b.float()).to(dtype)
+    torch.testing.assert_close(c, ref, atol=0.05, rtol=0.05)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end matmul via tensor-of-pointers (regular pointer prefetch path).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K", [[32, 32, 32], [64, 64, 32], [32, 32, 64]])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("num_stages", [2, 3])
+@pytest.mark.skipif(not is_xpu(), reason="XPU-specific 2D block prefetch test")
+@pytest.mark.xfail(
+    not (triton.runtime.driver.active.get_current_target().arch['has_subgroup_2d_block_io']
+         and triton.runtime.driver.active.get_current_target().arch['has_subgroup_matrix_multiply_accumulate']),
+    reason="Block loads and/or DPAS not supported on this architecture", run=False)
+def test_d16_prefetch_tensor_of_ptr(BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, dtype, num_stages, device):
+    """End-to-end correctness check via tensor-of-pointers path.
+
+    Exercises rewriteRegularPointerPrefetch via a matmul with explicit
+    pointer arithmetic and num_stages > 1.
+    """
+    M, N, K = 128, 128, 128
+    torch.manual_seed(0)
+    a = torch.randn((M, K), device=device, dtype=dtype, requires_grad=False)
+    b = torch.randn((K, N), device=device, dtype=dtype, requires_grad=False)
+    c = torch.empty((M, N), device=device, dtype=dtype)
+
+    grid = (triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N), )
+    _matmul_kernel_ptrs[grid](
+        a,
+        b,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        NUM_STAGES=num_stages,
+    )
+
+    ref = torch.matmul(a.float(), b.float()).to(dtype)
+    torch.testing.assert_close(c, ref, atol=0.05, rtol=0.05)

--- a/test/TritonGEN/tritongen-2Dblockprefetch-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockprefetch-to-llvm.mlir
@@ -441,3 +441,14 @@ llvm.func @triton_gen.2Dblockprefetch(%ptr : !llvm.ptr<1>, %base_width : i32, %b
   llvm.return
 }
 }
+
+// -----
+
+// COM: d16 with tile_width=32, vBlocks=1 has no SPV runtime builtin (16b_?r32x1c
+// COM: is missing). Verify it falls back to GenISA LSC2DBlockPrefetch intrinsic.
+llvm.func @triton_gen.2Dblockprefetch_d16_genisa_fallback(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // CHECK-NOT: @_Z36__spirv_Subgroup2DBlockPrefetchINTEL
+  // CHECK:     llvm.call spir_funccc @llvm.genx.GenISA.LSC2DBlockPrefetch.isVoid({{.*}}) {{.*}} : (i64, i32, i32, i32, i32, i32, i32, i32, i32, i32, i1, i1, i32) -> ()
+  triton_gen.2Dblockprefetch %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=16, tile_width=32, tile_height=8, v_blocks=1, cache_control=Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32)
+  llvm.return
+}

--- a/test/TritonIntelGPU/prefetch-descriptor-to-llvm.mlir
+++ b/test/TritonIntelGPU/prefetch-descriptor-to-llvm.mlir
@@ -53,8 +53,8 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK:     %[[OFFSET_X:.*]] = llvm.add {{.*}}, %{{.*}} : i32
     // CHECK:     %[[OFFSET_Y:.*]] = llvm.add {{.*}}, %{{.*}} : i32
 
-    // COM: 16x32xf16 with 8 warps: tile_height=2, tile_width=32 → vBlocks=2, tile_width=16.
-    // CHECK:     triton_gen.2Dblockprefetch %[[BASE_PTR]], %[[BASE_WIDTH_I32]], %[[BASE_HEIGHT_I32]], %[[PITCH]], %[[OFFSET_X]], %[[OFFSET_Y]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 2, v_blocks = 2, cache_control = L1C_L3C}
+    // COM: 16x32xf16 with 8 warps: tile_height=2, tile_width=32, vBlocks=1.
+    // CHECK:     triton_gen.2Dblockprefetch %[[BASE_PTR]], %[[BASE_WIDTH_I32]], %[[BASE_HEIGHT_I32]], %[[PITCH]], %[[OFFSET_X]], %[[OFFSET_Y]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 2, v_blocks = 1, cache_control = L1C_L3C}
     ttig.descriptor_prefetch %desc[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<16x32xf16>
 
     tt.return
@@ -127,8 +127,8 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     // CHECK:     %[[DESC:.*]] = llvm.insertvalue %{{.*}}, %{{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
     // CHECK:     %[[BASE_PTR:.*]] = llvm.extractvalue %[[DESC]][4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
 
-    // COM: 128 bytes per row falls back to 64 bytes prefetch → tile_width=16, tile_height=4, v_blocks=2.
-    // CHECK:     triton_gen.2Dblockprefetch %[[BASE_PTR]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 4, v_blocks = 2, cache_control = L1C_L3C}
+    // COM: 128 bytes per row falls back to 64 bytes prefetch → tile_width=32, tile_height=4, v_blocks=1.
+    // CHECK:     triton_gen.2Dblockprefetch %[[BASE_PTR]], {{.*}} {elem_size_in_bits = 16, tile_width = 32, tile_height = 4, v_blocks = 1, cache_control = L1C_L3C}
     ttig.descriptor_prefetch %desc[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<16x64xf16>
 
     tt.return
@@ -159,9 +159,9 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
 
     // COM: Verify batch dimension folded via GEP and 2D prefetch ops emitted.
     // CHECK:     llvm.getelementptr
-    // CHECK:     triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 4, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK:     triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 32, tile_height = 4, v_blocks = 1, cache_control = L1C_L3C}
     // CHECK:     llvm.getelementptr
-    // CHECK:     triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 4, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK:     triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 32, tile_height = 4, v_blocks = 1, cache_control = L1C_L3C}
     ttig.descriptor_prefetch %desc[%c0_i32, %c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<2x16x32xf16>
 
     tt.return

--- a/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
+++ b/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
@@ -6,7 +6,7 @@
 
 // COM: Test case: f16 blocked prefetch, 128x64 tensor, 4 warps.
 // COM: With 128x64xf16 and 4 warps (256B prefetch support enabled):
-// COM:   tileHeight=32, tileWidth=32 -> vBlocks=2, tile_width=16
+// COM:   tileHeight=32, tileWidth=32 -> vBlocks=1, tile_width=32
 // COM:   warpsM=2, warpsN=2
 // COM:   numTilesPerWarp = (128*64) / (32*32*4) = 2
 // COM: Expect 2 triton_gen.2Dblockprefetch ops per prefetch invocation.
@@ -28,7 +28,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32,
     %9 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
     %ptr = tt.addptr %9, %8 : tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<128x64xi32, #blocked>
 
-    // CHECK-COUNT-2: triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK-COUNT-2: triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 32, tile_height = 32, v_blocks = 1, cache_control = L1C_L3C}
     ttig.prefetch %ptr {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 0, 0>, ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f16>, #blocked>
 
     tt.return
@@ -101,9 +101,9 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32,
     // COM: prefetch when the predicate is false. Check that the prefetch is
     // COM: still emitted (twice) and that its offsetY comes from an llvm.select.
     // CHECK: %[[SEL0:.*]] = llvm.select %{{.*}}, %{{.*}}, %{{.*}} : i1, i32
-    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL0]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL0]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 32, v_blocks = 1, cache_control = L1C_L3C}
     // CHECK: %[[SEL1:.*]] = llvm.select %{{.*}}, %{{.*}}, %{{.*}} : i1, i32
-    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL1]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL1]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 32, v_blocks = 1, cache_control = L1C_L3C}
     ttig.prefetch %ptr, %mask {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 1, 0>, ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f16>, #blocked>
 
     tt.return
@@ -146,9 +146,9 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32,
     // COM: The uniform `%pred` is folded into offsetY via llvm.select; the
     // COM: per-element `%boundsMask` is dropped (safe for a prefetch hint).
     // CHECK: %[[SEL0:.*]] = llvm.select %{{.*}}, %{{.*}}, %{{.*}} : i1, i32
-    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL0]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL0]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 32, v_blocks = 1, cache_control = L1C_L3C}
     // CHECK: %[[SEL1:.*]] = llvm.select %{{.*}}, %{{.*}}, %{{.*}} : i1, i32
-    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL1]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK-NEXT: triton_gen.2Dblockprefetch %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[SEL1]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 32, v_blocks = 1, cache_control = L1C_L3C}
     ttig.prefetch %ptr, %mask {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 1, 0>, ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f16>, #blocked>
 
     tt.return
@@ -214,7 +214,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32,
     %9 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
     %ptr = tt.addptr %9, %8 : tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<128x64xi32, #blocked>
 
-    // CHECK-COUNT-2: triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 2, cache_control = L1UC_L3C}
+    // CHECK-COUNT-2: triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 32, tile_height = 32, v_blocks = 1, cache_control = L1UC_L3C}
     ttig.prefetch %ptr {boundaryCheck = array<i32>, cache = 3 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 0, 0>, ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f16>, #blocked>
 
     tt.return

--- a/test/TritonIntelGPU/prefetch-to-llvm.mlir
+++ b/test/TritonIntelGPU/prefetch-to-llvm.mlir
@@ -37,7 +37,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK: %[[VAL_13:.*]] = llvm.ptrtoint %[[ADDR_0]] : !llvm.ptr<1> to i64
     // CHECK: %[[UNIFIED_BASE:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[VAL_13]], %[[CST_0]]) {convergent, no_unwind, will_return} : (i64, i32) -> i64
     // CHECK: %[[VAL_26:.*]] = llvm.inttoptr %[[UNIFIED_BASE]] : i64 to !llvm.ptr<1>
-    // CHECK: triton_gen.2Dblockprefetch %[[VAL_26]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[OFFSET_Y]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK: triton_gen.2Dblockprefetch %[[VAL_26]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[OFFSET_Y]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
 
     // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK: %[[VAL_29:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflecj(%{{.*}}, %[[CST_0]]) {convergent, no_unwind, will_return} : (i8, i32) -> i8
@@ -48,7 +48,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK: %[[VAL_32:.*]] = llvm.ptrtoint %[[ADDR_16]] : !llvm.ptr<1> to i64
     // CHECK: %[[VAL_33:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[VAL_32]], %[[CST_0]]) {convergent, no_unwind, will_return} : (i64, i32) -> i64
     // CHECK: %[[VAL_34:.*]] = llvm.inttoptr %[[VAL_33]] : i64 to !llvm.ptr<1>
-    // CHECK: triton_gen.2Dblockprefetch %[[VAL_34]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[VAL_31]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK: triton_gen.2Dblockprefetch %[[VAL_34]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[VAL_31]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
 
     // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK: %[[VAL_36:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflecj(%{{.*}}, %[[CST_0]]) {convergent, no_unwind, will_return} : (i8, i32) -> i8
@@ -59,7 +59,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK: %[[VAL_39:.*]] = llvm.ptrtoint %[[ADDR_32]] : !llvm.ptr<1> to i64
     // CHECK: %[[VAL_40:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[VAL_39]], %[[CST_0]]) {convergent, no_unwind, will_return} : (i64, i32) -> i64
     // CHECK: %[[VAL_41:.*]] = llvm.inttoptr %[[VAL_40]] : i64 to !llvm.ptr<1>
-    // CHECK: triton_gen.2Dblockprefetch %[[VAL_41]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[VAL_38]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK: triton_gen.2Dblockprefetch %[[VAL_41]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[VAL_38]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
 
     // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK: %[[VAL_43:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflecj(%{{.*}}, %[[CST_0]]) {convergent, no_unwind, will_return} : (i8, i32) -> i8
@@ -70,12 +70,12 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK: %[[VAL_46:.*]] = llvm.ptrtoint %[[ADDR_48]] : !llvm.ptr<1> to i64
     // CHECK: %[[VAL_47:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[VAL_46]], %[[CST_0]]) {convergent, no_unwind, will_return} : (i64, i32) -> i64
     // CHECK: %[[VAL_48:.*]] = llvm.inttoptr %[[VAL_47]] : i64 to !llvm.ptr<1>
-    // CHECK: triton_gen.2Dblockprefetch %[[VAL_48]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[VAL_45]] {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK: triton_gen.2Dblockprefetch %[[VAL_48]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[VAL_45]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
 
     %mask_tensor = arith.constant dense<1> : tensor<64x32xi1, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
     ttig.prefetch %tensor_of_ptr, %mask_tensor {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 1, 1>, ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
 
-    // CHECK-COUNT-4: triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 2, cache_control = L1C_L3C}
+    // CHECK-COUNT-4: triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
 
     ttig.prefetch %tensor_of_ptr {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 1, 1>, ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
 

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -190,6 +190,13 @@ static bool isSPVBuiltinAvailableImpl(TritonGEN::Matrix2DBlockStoreOp op) {
 }
 
 static bool isSPVBuiltinAvailableImpl(TritonGEN::Matrix2DBlockPrefetchOp op) {
+  // The SPV runtime library only has builtins for d16 with tile_width=16
+  // (i.e. 16b_?r16x2c). The 16b_?r32x1c configuration is not available,
+  // so fall back to GenISA which supports any hardware-valid configuration.
+  if (op.getElemSizeInBits() == 16 && op.getTileWidth() == 32 &&
+      op.getVBlocks() == 1)
+    return false;
+
   return true;
 }
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1270,14 +1270,6 @@ static LogicalResult emit2DBlockPrefetchOps(
       tileWidthInElem = 32;
     }
     break;
-  case 16:
-    if (tileWidthInElem == 32) {
-      // OCL interface supports 16b_?r16x2c for 64 bytes per row of 16 bits
-      // element.
-      vBlocks = 2;
-      tileWidthInElem = 16;
-    }
-    break;
   }
 
   StringAttr kOffset = S("offset");
@@ -1479,14 +1471,6 @@ struct PrefetchOpConversion
         // element.
         vBlocks = 2;
         tileWidthInElem = 32;
-      }
-      break;
-    case 16:
-      if (tileWidthInElem == 32) {
-        // OCL interface supports 16b_?r16x2c for 64 bytes per row of 16 bits
-        // element.
-        vBlocks = 2;
-        tileWidthInElem = 16;
       }
       break;
     }


### PR DESCRIPTION
## Summary

Adds Python regression tests for the d16 LSC block prefetch crash fixed in #7269 (PYTORCHDGQ-9207).

## What this PR adds

A new test file `python/test/unit/intel/test_prefetch_d16_regression.py` with three test functions:

### 1. `test_d16_prefetch_ir_no_buggy_split` — compile-only IR check

Runs on any XPU build host (no CRI/BMG required). Compiles the kernel and parses the lowered LLVM IR to detect the exact buggy SPIRV prefetch call shape `(i32 2, i32 16, i32 X, i32 2, ...)` — d16 x tile_width=16 x array_length=2 = 64 != 128.

### 2. `test_d16_prefetch_tensor_desc` — end-to-end via tensor descriptor

Exercises the cooperative prefetch path. Validates correctness against `torch.matmul`.

### 3. `test_d16_prefetch_tensor_of_ptr` — end-to-end via tensor-of-pointers

Exercises `rewriteRegularPointerPrefetch` via explicit pointer arithmetic.

## Test Plan

- [ ] IR check passes on XPU CI (catches regression at compile time)
- [ ] E2E tests pass on XPU hardware (tensor descriptor + tensor-of-pointers paths)

## Dependencies

- Depends on #7269

## References

- Internal CRI PR: intel-tools/intel-xpu-backend-for-triton#1866
- Jira: [PYTORCHDGQ-9207](https://jira.devtools.intel.com/browse/PYTORCHDGQ-9207)