### PR TITLE
[VLLM][unified attention] Add in-place softmax, drop WA

### DIFF
--- a/benchmarks/triton_kernels_benchmark/vllm/run_benchmark.sh
+++ b/benchmarks/triton_kernels_benchmark/vllm/run_benchmark.sh
@@ -13,12 +13,6 @@
 #   DEBUG_BENCH=1 - run only one configuration (faster for sanity checking)
 set -e
 
-# Workaround for #6759: BMG OOM after Agama 1222 -> 1249 driver bump.
-# expandable_segments alone causes UR_RESULT_ERROR_DEVICE_LOST in CI; pairs with
-# torch.xpu.set_per_process_memory_fraction(1.0) called early in the benchmark
-# to materialize the virtual segment via the working init path.
-export PYTORCH_ALLOC_CONF="${PYTORCH_ALLOC_CONF:-expandable_segments:True}"
-
 BENCHMARK_FOLDER="$1"
 shift
 

--- a/benchmarks/triton_kernels_benchmark/vllm/unified_attention/unified_attention_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/vllm/unified_attention/unified_attention_benchmark.py
@@ -80,7 +80,7 @@ def ref_paged_attn(
         if soft_cap is not None and soft_cap > 0:
             attn = soft_cap * torch.tanh(attn / soft_cap)
         attn.masked_fill_(mask, float("-inf"))
-        attn = torch.softmax(attn, dim=-1)  # expected peak memory usage is here
+        torch.softmax(attn, dim=-1, out=attn)
         attn = attn.to(v.dtype)  # cast in a second step to reduce peak memory usage
         out = torch.einsum("hqk,khd->qhd", attn, v)
 
@@ -295,11 +295,6 @@ def get_unified_attention_benchmark(
         quantiles = [0.5, 0.0, 1.0]
 
         torch.set_default_device("xpu")
-        # Workaround for #6759 (BMG OOM after Agama 1222 -> 1249). Pairs with
-        # PYTORCH_ALLOC_CONF=expandable_segments:True from run_benchmark.sh: the
-        # explicit fraction call materializes the virtual segment via the init
-        # path that does not trigger UR_RESULT_ERROR_DEVICE_LOST.
-        torch.xpu.set_per_process_memory_fraction(1.0)
 
         num_seqs = len(seq_lens)
         query_lens = [x[0] for x in seq_lens]


### PR DESCRIPTION
Agama update to 1249 corrected total memory size value returned from the api, and that resulted in +.6 higher value for B580. In turn, that enabled additional configs to run and OOM error.

This PR introduces in-place softmax, reducing ref-peak from 8.45 to 6.52 GiB by not creating additional copy of a tensor, allowing us to keep all of the newly admitted configs without workarounds.

[BMG_SUCCESFUL_CI_RUN](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/27940356407)
[failing_run_without_wa_nor_softmax_change](https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/28019992562)