### PR TITLE
[Compiler] Add DecomposeFMADots pass: K-tile large FMA dots on non-DPAS hardware

### DIFF
--- a/test/TritonIntelGPU/decompose-fma-dots.mlir
+++ b/test/TritonIntelGPU/decompose-fma-dots.mlir
@@ -80,3 +80,46 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32,
     tt.return %result : tensor<64x128xf32, #blocked4>
   }
 }
+
+// -----
+
+// Test 4: f32 dot with inputPrecision = ieee (= 2) on FMA hardware.
+// f32 ieee lowers via FMA the same way f16 does, and the doubled element
+// size means smaller shapes already trip the pressure threshold.
+// Shape 64x64x128, spt=[1,1], tpw=[2,16], wpc=[4,1]:
+//   ctaTileM = 1*2*4 = 8, ctaTileN = 1*16*1 = 16
+//   mReps = 64/8 = 8, nReps = 64/16 = 4
+//   aBytes = 8*1*128*4 = 4096
+//   bBytes = 128*4*1*4 = 2048
+//   cBytes = 8*1*4*1*4 = 128
+//   total = 6272 > 4096  -> decompose
+//   perCTAK = 1*16*1 = 16, selectKTile(128) -> 32
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked7 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 4], order = [0, 1]}>
+#dot0d = #ttg.dot_op<{opIdx = 0, parent = #blocked6}>
+#dot1d = #ttg.dot_op<{opIdx = 1, parent = #blocked6}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @f32_ieee_dot_decomposed
+  // CHECK: scf.for
+  // CHECK:   tt.dot
+  // CHECK-NOT: inputPrecision = tf32
+  // CHECK-NOT: inputPrecision = tf32x3
+  // CHECK:   scf.yield
+  tt.func public @f32_ieee_dot_decomposed(
+      %base_a: !tt.ptr<f32>,
+      %base_b: !tt.ptr<f32>) -> tensor<64x64xf32, #blocked6> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked6>
+    %a_splat = tt.splat %base_a : !tt.ptr<f32> -> tensor<64x128x!tt.ptr<f32>, #blocked6>
+    %c0a = arith.constant dense<0> : tensor<64x128xi32, #blocked6>
+    %a_ptr = tt.addptr %a_splat, %c0a : tensor<64x128x!tt.ptr<f32>, #blocked6>, tensor<64x128xi32, #blocked6>
+    %a = tt.load %a_ptr : tensor<64x128x!tt.ptr<f32>, #blocked6>
+    %a_cvt = ttg.convert_layout %a : tensor<64x128xf32, #blocked6> -> tensor<64x128xf32, #dot0d>
+    %b_splat = tt.splat %base_b : !tt.ptr<f32> -> tensor<128x64x!tt.ptr<f32>, #blocked7>
+    %c0b = arith.constant dense<0> : tensor<128x64xi32, #blocked7>
+    %b_ptr = tt.addptr %b_splat, %c0b : tensor<128x64x!tt.ptr<f32>, #blocked7>, tensor<128x64xi32, #blocked7>
+    %b = tt.load %b_ptr : tensor<128x64x!tt.ptr<f32>, #blocked7>
+    %b_cvt = ttg.convert_layout %b : tensor<128x64xf32, #blocked7> -> tensor<128x64xf32, #dot1d>
+    %result = tt.dot %a_cvt, %b_cvt, %cst {inputPrecision = 2 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<64x128xf32, #dot0d> * tensor<128x64xf32, #dot1d> -> tensor<64x64xf32, #blocked6>
+    tt.return %result : tensor<64x64xf32, #blocked6>
+  }
+}

--- a/test/TritonIntelGPU/decompose-fma-dots.mlir
+++ b/test/TritonIntelGPU/decompose-fma-dots.mlir
@@ -1,47 +1,46 @@
 // RUN: triton-opt %s -split-input-file --tritonintelgpu-decompose-fma-dots | FileCheck %s
 
-// Test: Large K dot on non-DPAS hardware should be decomposed into scf.for.
-// Encoding: sizePerThread=[1,4], K=512, f16 → perThreadBytes = (1*512 + 512*4)*2 = 5120 > 4096
-// perCTAK = 4*4*1 = 16, selectKTile(512, 16) → 32 (512%32==0, 32%16==0)
-#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
+// Test 1: Real crashing config on ARL-S (64x128x128, f16, 4 warps, warp_size=32)
+// This exactly matches the config that caused 587KB PTSS overflow.
+// Encoding: spt=[1,1], tpw=[2,16], wpc=[4,1] for result shape 64x128
+// perThreadBytes: aBytes=8*1*128*2=2048 + bBytes=128*8*1*2=2048 + cBytes=8*8*4=256 = 4352 > 4096
+// perCTAK = 1*16*1 = 16, selectKTile(128, 16) -> 32
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 4], order = [0, 1]}>
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
 #dot1 = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
-module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  // CHECK-LABEL: @large_k_dot_decomposed
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @arl_s_crashing_dot_decomposed
   // CHECK: scf.for
   // CHECK:   tt.dot
   // CHECK:   scf.yield
-  tt.func public @large_k_dot_decomposed(
+  tt.func public @arl_s_crashing_dot_decomposed(
       %base_a: !tt.ptr<f16>,
-      %base_b: !tt.ptr<f16>) -> tensor<64x64xf32, #blocked> {
-    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked>
-    // Pointer for A [64, 512] via splat + offset
-    %a_splat = tt.splat %base_a : !tt.ptr<f16> -> tensor<64x512x!tt.ptr<f16>, #blocked>
-    %c0_i32 = arith.constant dense<0> : tensor<64x512xi32, #blocked>
-    %a_ptr = tt.addptr %a_splat, %c0_i32 : tensor<64x512x!tt.ptr<f16>, #blocked>, tensor<64x512xi32, #blocked>
-    %a = tt.load %a_ptr : tensor<64x512x!tt.ptr<f16>, #blocked>
-    %a_cvt = ttg.convert_layout %a : tensor<64x512xf16, #blocked> -> tensor<64x512xf16, #dot0>
-    // Pointer for B [512, 64] via splat + offset
-    %b_splat = tt.splat %base_b : !tt.ptr<f16> -> tensor<512x64x!tt.ptr<f16>, #blocked1>
-    %c0b_i32 = arith.constant dense<0> : tensor<512x64xi32, #blocked1>
-    %b_ptr = tt.addptr %b_splat, %c0b_i32 : tensor<512x64x!tt.ptr<f16>, #blocked1>, tensor<512x64xi32, #blocked1>
-    %b = tt.load %b_ptr : tensor<512x64x!tt.ptr<f16>, #blocked1>
-    %b_cvt = ttg.convert_layout %b : tensor<512x64xf16, #blocked1> -> tensor<512x64xf16, #dot1>
-    // Dot
-    %result = tt.dot %a_cvt, %b_cvt, %cst {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<64x512xf16, #dot0> * tensor<512x64xf16, #dot1> -> tensor<64x64xf32, #blocked>
-    tt.return %result : tensor<64x64xf32, #blocked>
+      %base_b: !tt.ptr<f16>) -> tensor<64x128xf32, #blocked> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #blocked>
+    %a_splat = tt.splat %base_a : !tt.ptr<f16> -> tensor<64x128x!tt.ptr<f16>, #blocked>
+    %c0a = arith.constant dense<0> : tensor<64x128xi32, #blocked>
+    %a_ptr = tt.addptr %a_splat, %c0a : tensor<64x128x!tt.ptr<f16>, #blocked>, tensor<64x128xi32, #blocked>
+    %a = tt.load %a_ptr : tensor<64x128x!tt.ptr<f16>, #blocked>
+    %a_cvt = ttg.convert_layout %a : tensor<64x128xf16, #blocked> -> tensor<64x128xf16, #dot0>
+    %b_splat = tt.splat %base_b : !tt.ptr<f16> -> tensor<128x128x!tt.ptr<f16>, #blocked1>
+    %c0b = arith.constant dense<0> : tensor<128x128xi32, #blocked1>
+    %b_ptr = tt.addptr %b_splat, %c0b : tensor<128x128x!tt.ptr<f16>, #blocked1>, tensor<128x128xi32, #blocked1>
+    %b = tt.load %b_ptr : tensor<128x128x!tt.ptr<f16>, #blocked1>
+    %b_cvt = ttg.convert_layout %b : tensor<128x128xf16, #blocked1> -> tensor<128x128xf16, #dot1>
+    %result = tt.dot %a_cvt, %b_cvt, %cst {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<64x128xf16, #dot0> * tensor<128x128xf16, #dot1> -> tensor<64x128xf32, #blocked>
+    tt.return %result : tensor<64x128xf32, #blocked>
   }
 }
 
 // -----
 
-// Test: Small K dot should NOT be decomposed (below pressure threshold)
-#blocked2 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
-#blocked3 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
+// Test 2: Small K dot should NOT be decomposed (below pressure threshold)
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 4], order = [0, 1]}>
 #dot0b = #ttg.dot_op<{opIdx = 0, parent = #blocked2}>
 #dot1b = #ttg.dot_op<{opIdx = 1, parent = #blocked2}>
-module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @small_k_dot_unchanged
   // CHECK-NOT: scf.for
   // CHECK: tt.dot
@@ -60,24 +59,24 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
 
 // -----
 
-// Test: Dot on DPAS-capable hardware should NOT be decomposed
-#blocked4 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
-#blocked5 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
+// Test 3: Dot on DPAS-capable hardware should NOT be decomposed
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 4], order = [0, 1]}>
 #dot0c = #ttg.dot_op<{opIdx = 0, parent = #blocked4}>
 #dot1c = #ttg.dot_op<{opIdx = 1, parent = #blocked4}>
-module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_subgroup_matrix_multiply_accumulate"} {
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttig.support_subgroup_matrix_multiply_accumulate"} {
   // CHECK-LABEL: @dpas_hardware_unchanged
   // CHECK-NOT: scf.for
   // CHECK: tt.dot
   tt.func public @dpas_hardware_unchanged(
       %a_ptr: tensor<64x128x!tt.ptr<f16>, #blocked4>,
-      %b_ptr: tensor<128x64x!tt.ptr<f16>, #blocked5>) -> tensor<64x64xf32, #blocked4> {
-    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked4>
+      %b_ptr: tensor<128x128x!tt.ptr<f16>, #blocked5>) -> tensor<64x128xf32, #blocked4> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #blocked4>
     %a = tt.load %a_ptr : tensor<64x128x!tt.ptr<f16>, #blocked4>
     %a_cvt = ttg.convert_layout %a : tensor<64x128xf16, #blocked4> -> tensor<64x128xf16, #dot0c>
-    %b = tt.load %b_ptr : tensor<128x64x!tt.ptr<f16>, #blocked5>
-    %b_cvt = ttg.convert_layout %b : tensor<128x64xf16, #blocked5> -> tensor<128x64xf16, #dot1c>
-    %result = tt.dot %a_cvt, %b_cvt, %cst {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<64x128xf16, #dot0c> * tensor<128x64xf16, #dot1c> -> tensor<64x64xf32, #blocked4>
-    tt.return %result : tensor<64x64xf32, #blocked4>
+    %b = tt.load %b_ptr : tensor<128x128x!tt.ptr<f16>, #blocked5>
+    %b_cvt = ttg.convert_layout %b : tensor<128x128xf16, #blocked5> -> tensor<128x128xf16, #dot1c>
+    %result = tt.dot %a_cvt, %b_cvt, %cst {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<64x128xf16, #dot0c> * tensor<128x128xf16, #dot1c> -> tensor<64x128xf32, #blocked4>
+    tt.return %result : tensor<64x128xf32, #blocked4>
   }
 }

--- a/test/TritonIntelGPU/decompose-fma-dots.mlir
+++ b/test/TritonIntelGPU/decompose-fma-dots.mlir
@@ -1,0 +1,86 @@
+// RUN: triton-opt %s -split-input-file --tritonintelgpu-decompose-fma-dots | FileCheck %s
+
+// Test: Large K dot on non-DPAS hardware should be decomposed into scf.for.
+// The dot operands come from loads with pointer arithmetic that can be tiled.
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: @large_k_dot_decomposed
+  // CHECK: scf.for
+  // CHECK:   tt.dot
+  // CHECK:   scf.yield
+  tt.func public @large_k_dot_decomposed(
+      %base_a: !tt.ptr<f16>,
+      %base_b: !tt.ptr<f16>) -> tensor<64x64xf32, #blocked> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked>
+    // Build pointer for A [64, 128]
+    %a_base = tt.splat %base_a : !tt.ptr<f16> -> tensor<64x128x!tt.ptr<f16>, #blocked>
+    %a_range_m = tt.make_range {start = 0 : i32, end = 64 : i32} : tensor<64xi32>
+    %a_range_k = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+    %c128_i32 = arith.constant dense<128> : tensor<64xi32>
+    %a_m_offset = arith.muli %a_range_m, %c128_i32 : tensor<64xi32>
+    %a_m_exp = tt.expand_dims %a_m_offset {axis = 1 : i32} : tensor<64xi32> -> tensor<64x1xi32>
+    %a_m_bcast = tt.broadcast %a_m_exp : tensor<64x1xi32> -> tensor<64x128xi32>
+    %a_k_exp = tt.expand_dims %a_range_k {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+    %a_k_bcast = tt.broadcast %a_k_exp : tensor<1x128xi32> -> tensor<64x128xi32>
+    %a_offset = arith.addi %a_m_bcast, %a_k_bcast : tensor<64x128xi32>
+    %a_ptr = tt.addptr %a_base, %a_offset : tensor<64x128x!tt.ptr<f16>, #blocked>, tensor<64x128xi32>
+    %a = tt.load %a_ptr : tensor<64x128x!tt.ptr<f16>, #blocked>
+    // Build pointer for B [128, 64]
+    %b_base = tt.splat %base_b : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked1>
+    %b_range_k = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+    %b_range_n = tt.make_range {start = 0 : i32, end = 64 : i32} : tensor<64xi32>
+    %c64_i32 = arith.constant dense<64> : tensor<128xi32>
+    %b_k_offset = arith.muli %b_range_k, %c64_i32 : tensor<128xi32>
+    %b_k_exp = tt.expand_dims %b_k_offset {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
+    %b_k_bcast = tt.broadcast %b_k_exp : tensor<128x1xi32> -> tensor<128x64xi32>
+    %b_n_exp = tt.expand_dims %b_range_n {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
+    %b_n_bcast = tt.broadcast %b_n_exp : tensor<1x64xi32> -> tensor<128x64xi32>
+    %b_offset = arith.addi %b_k_bcast, %b_n_bcast : tensor<128x64xi32>
+    %b_ptr = tt.addptr %b_base, %b_offset : tensor<128x64x!tt.ptr<f16>, #blocked1>, tensor<128x64xi32>
+    %b = tt.load %b_ptr : tensor<128x64x!tt.ptr<f16>, #blocked1>
+    // Dot
+    %result = tt.dot %a, %b, %cst {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<64x128xf16, #blocked> * tensor<128x64xf16, #blocked1> -> tensor<64x64xf32, #blocked>
+    tt.return %result : tensor<64x64xf32, #blocked>
+  }
+}
+
+// -----
+
+// Test: Small K dot should NOT be decomposed (below pressure threshold)
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: @small_k_dot_unchanged
+  // CHECK-NOT: scf.for
+  // CHECK: tt.dot
+  tt.func public @small_k_dot_unchanged(
+      %a_ptr: tensor<16x16x!tt.ptr<f16>, #blocked2>,
+      %b_ptr: tensor<16x16x!tt.ptr<f16>, #blocked3>) -> tensor<16x16xf32, #blocked2> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #blocked2>
+    %a = tt.load %a_ptr : tensor<16x16x!tt.ptr<f16>, #blocked2>
+    %b = tt.load %b_ptr : tensor<16x16x!tt.ptr<f16>, #blocked3>
+    %result = tt.dot %a, %b, %cst {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<16x16xf16, #blocked2> * tensor<16x16xf16, #blocked3> -> tensor<16x16xf32, #blocked2>
+    tt.return %result : tensor<16x16xf32, #blocked2>
+  }
+}
+
+// -----
+
+// Test: Dot on DPAS-capable hardware should NOT be decomposed
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_subgroup_matrix_multiply_accumulate"} {
+  // CHECK-LABEL: @dpas_hardware_unchanged
+  // CHECK-NOT: scf.for
+  // CHECK: tt.dot
+  tt.func public @dpas_hardware_unchanged(
+      %a_ptr: tensor<64x128x!tt.ptr<f16>, #blocked4>,
+      %b_ptr: tensor<128x64x!tt.ptr<f16>, #blocked5>) -> tensor<64x64xf32, #blocked4> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked4>
+    %a = tt.load %a_ptr : tensor<64x128x!tt.ptr<f16>, #blocked4>
+    %b = tt.load %b_ptr : tensor<128x64x!tt.ptr<f16>, #blocked5>
+    %result = tt.dot %a, %b, %cst {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<64x128xf16, #blocked4> * tensor<128x64xf16, #blocked5> -> tensor<64x64xf32, #blocked4>
+    tt.return %result : tensor<64x64xf32, #blocked4>
+  }
+}

--- a/test/TritonIntelGPU/decompose-fma-dots.mlir
+++ b/test/TritonIntelGPU/decompose-fma-dots.mlir
@@ -1,9 +1,12 @@
 // RUN: triton-opt %s -split-input-file --tritonintelgpu-decompose-fma-dots | FileCheck %s
 
 // Test: Large K dot on non-DPAS hardware should be decomposed into scf.for.
-// The dot operands come from loads with pointer arithmetic that can be tiled.
+// Encoding: sizePerThread=[1,4], K=512, f16 → perThreadBytes = (1*512 + 512*4)*2 = 5120 > 4096
+// perCTAK = 4*4*1 = 16, selectKTile(512, 16) → 32 (512%32==0, 32%16==0)
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+#dot1 = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
   // CHECK-LABEL: @large_k_dot_decomposed
   // CHECK: scf.for
@@ -13,34 +16,20 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
       %base_a: !tt.ptr<f16>,
       %base_b: !tt.ptr<f16>) -> tensor<64x64xf32, #blocked> {
     %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked>
-    // Build pointer for A [64, 128]
-    %a_base = tt.splat %base_a : !tt.ptr<f16> -> tensor<64x128x!tt.ptr<f16>, #blocked>
-    %a_range_m = tt.make_range {start = 0 : i32, end = 64 : i32} : tensor<64xi32>
-    %a_range_k = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
-    %c128_i32 = arith.constant dense<128> : tensor<64xi32>
-    %a_m_offset = arith.muli %a_range_m, %c128_i32 : tensor<64xi32>
-    %a_m_exp = tt.expand_dims %a_m_offset {axis = 1 : i32} : tensor<64xi32> -> tensor<64x1xi32>
-    %a_m_bcast = tt.broadcast %a_m_exp : tensor<64x1xi32> -> tensor<64x128xi32>
-    %a_k_exp = tt.expand_dims %a_range_k {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
-    %a_k_bcast = tt.broadcast %a_k_exp : tensor<1x128xi32> -> tensor<64x128xi32>
-    %a_offset = arith.addi %a_m_bcast, %a_k_bcast : tensor<64x128xi32>
-    %a_ptr = tt.addptr %a_base, %a_offset : tensor<64x128x!tt.ptr<f16>, #blocked>, tensor<64x128xi32>
-    %a = tt.load %a_ptr : tensor<64x128x!tt.ptr<f16>, #blocked>
-    // Build pointer for B [128, 64]
-    %b_base = tt.splat %base_b : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked1>
-    %b_range_k = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
-    %b_range_n = tt.make_range {start = 0 : i32, end = 64 : i32} : tensor<64xi32>
-    %c64_i32 = arith.constant dense<64> : tensor<128xi32>
-    %b_k_offset = arith.muli %b_range_k, %c64_i32 : tensor<128xi32>
-    %b_k_exp = tt.expand_dims %b_k_offset {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
-    %b_k_bcast = tt.broadcast %b_k_exp : tensor<128x1xi32> -> tensor<128x64xi32>
-    %b_n_exp = tt.expand_dims %b_range_n {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
-    %b_n_bcast = tt.broadcast %b_n_exp : tensor<1x64xi32> -> tensor<128x64xi32>
-    %b_offset = arith.addi %b_k_bcast, %b_n_bcast : tensor<128x64xi32>
-    %b_ptr = tt.addptr %b_base, %b_offset : tensor<128x64x!tt.ptr<f16>, #blocked1>, tensor<128x64xi32>
-    %b = tt.load %b_ptr : tensor<128x64x!tt.ptr<f16>, #blocked1>
+    // Pointer for A [64, 512] via splat + offset
+    %a_splat = tt.splat %base_a : !tt.ptr<f16> -> tensor<64x512x!tt.ptr<f16>, #blocked>
+    %c0_i32 = arith.constant dense<0> : tensor<64x512xi32, #blocked>
+    %a_ptr = tt.addptr %a_splat, %c0_i32 : tensor<64x512x!tt.ptr<f16>, #blocked>, tensor<64x512xi32, #blocked>
+    %a = tt.load %a_ptr : tensor<64x512x!tt.ptr<f16>, #blocked>
+    %a_cvt = ttg.convert_layout %a : tensor<64x512xf16, #blocked> -> tensor<64x512xf16, #dot0>
+    // Pointer for B [512, 64] via splat + offset
+    %b_splat = tt.splat %base_b : !tt.ptr<f16> -> tensor<512x64x!tt.ptr<f16>, #blocked1>
+    %c0b_i32 = arith.constant dense<0> : tensor<512x64xi32, #blocked1>
+    %b_ptr = tt.addptr %b_splat, %c0b_i32 : tensor<512x64x!tt.ptr<f16>, #blocked1>, tensor<512x64xi32, #blocked1>
+    %b = tt.load %b_ptr : tensor<512x64x!tt.ptr<f16>, #blocked1>
+    %b_cvt = ttg.convert_layout %b : tensor<512x64xf16, #blocked1> -> tensor<512x64xf16, #dot1>
     // Dot
-    %result = tt.dot %a, %b, %cst {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<64x128xf16, #blocked> * tensor<128x64xf16, #blocked1> -> tensor<64x64xf32, #blocked>
+    %result = tt.dot %a_cvt, %b_cvt, %cst {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<64x512xf16, #dot0> * tensor<512x64xf16, #dot1> -> tensor<64x64xf32, #blocked>
     tt.return %result : tensor<64x64xf32, #blocked>
   }
 }
@@ -50,6 +39,8 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
 // Test: Small K dot should NOT be decomposed (below pressure threshold)
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked3 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
+#dot0b = #ttg.dot_op<{opIdx = 0, parent = #blocked2}>
+#dot1b = #ttg.dot_op<{opIdx = 1, parent = #blocked2}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
   // CHECK-LABEL: @small_k_dot_unchanged
   // CHECK-NOT: scf.for
@@ -59,8 +50,10 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
       %b_ptr: tensor<16x16x!tt.ptr<f16>, #blocked3>) -> tensor<16x16xf32, #blocked2> {
     %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #blocked2>
     %a = tt.load %a_ptr : tensor<16x16x!tt.ptr<f16>, #blocked2>
+    %a_cvt = ttg.convert_layout %a : tensor<16x16xf16, #blocked2> -> tensor<16x16xf16, #dot0b>
     %b = tt.load %b_ptr : tensor<16x16x!tt.ptr<f16>, #blocked3>
-    %result = tt.dot %a, %b, %cst {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<16x16xf16, #blocked2> * tensor<16x16xf16, #blocked3> -> tensor<16x16xf32, #blocked2>
+    %b_cvt = ttg.convert_layout %b : tensor<16x16xf16, #blocked3> -> tensor<16x16xf16, #dot1b>
+    %result = tt.dot %a_cvt, %b_cvt, %cst {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<16x16xf16, #dot0b> * tensor<16x16xf16, #dot1b> -> tensor<16x16xf32, #blocked2>
     tt.return %result : tensor<16x16xf32, #blocked2>
   }
 }
@@ -70,6 +63,8 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
 // Test: Dot on DPAS-capable hardware should NOT be decomposed
 #blocked4 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked5 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
+#dot0c = #ttg.dot_op<{opIdx = 0, parent = #blocked4}>
+#dot1c = #ttg.dot_op<{opIdx = 1, parent = #blocked4}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_subgroup_matrix_multiply_accumulate"} {
   // CHECK-LABEL: @dpas_hardware_unchanged
   // CHECK-NOT: scf.for
@@ -79,8 +74,10 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32,
       %b_ptr: tensor<128x64x!tt.ptr<f16>, #blocked5>) -> tensor<64x64xf32, #blocked4> {
     %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked4>
     %a = tt.load %a_ptr : tensor<64x128x!tt.ptr<f16>, #blocked4>
+    %a_cvt = ttg.convert_layout %a : tensor<64x128xf16, #blocked4> -> tensor<64x128xf16, #dot0c>
     %b = tt.load %b_ptr : tensor<128x64x!tt.ptr<f16>, #blocked5>
-    %result = tt.dot %a, %b, %cst {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<64x128xf16, #blocked4> * tensor<128x64xf16, #blocked5> -> tensor<64x64xf32, #blocked4>
+    %b_cvt = ttg.convert_layout %b : tensor<128x64xf16, #blocked5> -> tensor<128x64xf16, #dot1c>
+    %result = tt.dot %a_cvt, %b_cvt, %cst {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<64x128xf16, #dot0c> * tensor<128x64xf16, #dot1c> -> tensor<64x64xf32, #blocked4>
     tt.return %result : tensor<64x64xf32, #blocked4>
   }
 }

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -344,6 +344,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         intel.passes.ttgpuir.add_remove_layout_conversions(pm)
 
         intel.passes.ttgpuir.add_accelerate_matmul(pm)
+        intel.passes.ttgpuir.add_decompose_fma_dots(pm)
         intel.passes.ttgpuir.add_materialize_block_pointer(pm)
         intel.passes.ttgpuir.add_remove_layout_conversions(pm)
         intel.passes.ttgpuir.add_fold_fp_to_fp(pm)

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -54,6 +54,26 @@ def TritonIntelGPUFoldFpToFp
   let dependentDialects = ["mlir::triton::TritonDialect"];
 }
 
+def TritonIntelGPUDecomposeFMADots
+    : Pass<"tritonintelgpu-decompose-fma-dots", "mlir::ModuleOp"> {
+  let summary = "Decompose large blocked-encoding dot ops into K-tiled loops";
+
+  let description = [{
+    On non-DPAS Intel GPUs, large tt.dot operations with BlockedEncoding and
+    large K dimensions cause per-thread scratch space (PTSS) overflow during
+    FMA lowering. This pass decomposes such dots into scf.for loops that
+    accumulate partial products with smaller K tiles, reducing per-iteration
+    register pressure.
+  }];
+
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::scf::SCFDialect",
+    "mlir::triton::TritonDialect",
+    "mlir::triton::gpu::TritonGPUDialect"
+  ];
+}
+
 def TritonIntelGPUOptimizeDotOperands
     : Pass<"tritonintelgpu-optimize-dot-operands", "mlir::ModuleOp"> {
   let summary = "Intel optimize dot operands";

--- a/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_triton_library(TritonIntelGPUTransforms
   AccelerateMatmul.cpp
   AnnotateCacheControl.cpp
   BlockIOUtils.cpp
+  DecomposeFMADots.cpp
   DecomposeScaledBlocked.cpp
   FoldFpToFp.cpp
   HoistLayoutConversions.cpp

--- a/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeFMADots.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeFMADots.cpp
@@ -1,0 +1,430 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
+#include "llvm/Support/Debug.h"
+
+#include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+namespace mlir::triton::gpu::intel {
+#define GEN_PASS_DEF_TRITONINTELGPUDECOMPOSEFMADOTS
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
+} // namespace mlir::triton::gpu::intel
+
+using namespace mlir;
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+namespace ttgi = mlir::triton::gpu::intel;
+
+#define DEBUG_TYPE "tritonintelgpu-decompose-fma-dots"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace {
+
+constexpr unsigned K_PRESSURE_THRESHOLD_BYTES = 4096;
+
+/// Estimate per-thread register pressure from a dot with BlockedEncoding.
+/// Returns the approximate bytes each thread needs live for the K-loop.
+static unsigned estimatePerThreadBytes(tt::DotOp dotOp) {
+  auto aType = cast<RankedTensorType>(dotOp.getA().getType());
+  auto bType = cast<RankedTensorType>(dotOp.getB().getType());
+  auto resultType = dotOp.getType();
+
+  auto enc = dyn_cast<ttg::BlockedEncodingAttr>(resultType.getEncoding());
+  if (!enc)
+    return 0;
+
+  unsigned rank = aType.getRank();
+  unsigned kDimA = rank - 1;
+  unsigned kDimB = rank - 2;
+
+  int64_t K = aType.getShape()[kDimA];
+  unsigned elemBits = aType.getElementTypeBitWidth();
+  unsigned elemBytes = std::max(1u, elemBits / 8);
+
+  auto sizePerThread = enc.getSizePerThread();
+  unsigned mSpt = sizePerThread[rank - 2];
+  unsigned nSpt = sizePerThread[rank - 1];
+
+  return (mSpt * K + K * nSpt) * elemBytes;
+}
+
+/// Select a K tile size that is compatible with the encoding.
+/// Returns 0 if tiling is not possible.
+static unsigned selectKTile(unsigned K, ttg::BlockedEncodingAttr enc,
+                            unsigned kDim) {
+  auto sizePerThread = enc.getSizePerThread();
+  auto threadsPerWarp = enc.getThreadsPerWarp();
+  auto warpsPerCTA = enc.getWarpsPerCTA();
+
+  unsigned perCTAK =
+      sizePerThread[kDim] * threadsPerWarp[kDim] * warpsPerCTA[kDim];
+
+  for (unsigned tile : {32u, 64u, 16u}) {
+    if (tile < K && K % tile == 0 && tile % perCTAK == 0)
+      return tile;
+  }
+  return 0;
+}
+
+/// Trace a dot operand back to its defining tt.load, through optional
+/// intermediate ops (arith.extf, ttg.convert_layout). Returns nullptr if
+/// the operand cannot be traced to a load.
+static tt::LoadOp traceToLoad(Value operand) {
+  Value current = operand;
+  for (unsigned depth = 0; depth < 8; ++depth) {
+    if (!current.getDefiningOp())
+      return nullptr;
+    if (auto loadOp = dyn_cast<tt::LoadOp>(current.getDefiningOp()))
+      return loadOp;
+    if (auto extOp = dyn_cast<arith::ExtFOp>(current.getDefiningOp())) {
+      current = extOp.getIn();
+      continue;
+    }
+    if (auto cvtOp = dyn_cast<ttg::ConvertLayoutOp>(current.getDefiningOp())) {
+      current = cvtOp.getSrc();
+      continue;
+    }
+    if (auto truncOp = dyn_cast<arith::TruncFOp>(current.getDefiningOp())) {
+      current = truncOp.getIn();
+      continue;
+    }
+    return nullptr;
+  }
+  return nullptr;
+}
+
+/// Collect ops between a load and the dot operand (the intermediate chain).
+/// Returns them in order from load output to dot input.
+static SmallVector<Operation *> collectIntermediateOps(Value dotOperand,
+                                                      tt::LoadOp loadOp) {
+  SmallVector<Operation *> chain;
+  Value current = dotOperand;
+  while (current.getDefiningOp() != loadOp.getOperation()) {
+    chain.push_back(current.getDefiningOp());
+    if (auto extOp = dyn_cast<arith::ExtFOp>(current.getDefiningOp()))
+      current = extOp.getIn();
+    else if (auto cvtOp =
+                 dyn_cast<ttg::ConvertLayoutOp>(current.getDefiningOp()))
+      current = cvtOp.getSrc();
+    else if (auto truncOp = dyn_cast<arith::TruncFOp>(current.getDefiningOp()))
+      current = truncOp.getIn();
+    else
+      break;
+  }
+  std::reverse(chain.begin(), chain.end());
+  return chain;
+}
+
+/// Adjust tensor types in a shape by replacing one dimension.
+static RankedTensorType adjustTensorType(RankedTensorType origType,
+                                         unsigned dim, int64_t newSize) {
+  SmallVector<int64_t> newShape(origType.getShape());
+  newShape[dim] = newSize;
+  return RankedTensorType::get(newShape, origType.getElementType(),
+                               origType.getEncoding());
+}
+
+/// Clone the pointer subgraph for a load, adjusting K dimension from full K
+/// to K_TILE. Returns the new pointer value for the tiled load.
+/// Also produces an "advance" value that can be added per iteration.
+static Value clonePtrForTile(OpBuilder &builder, tt::LoadOp loadOp,
+                             unsigned kDim, unsigned kTile,
+                             IRMapping &mapping) {
+  Value origPtr = loadOp.getPtr();
+  auto ptrType = cast<RankedTensorType>(origPtr.getType());
+  RankedTensorType tiledPtrType = adjustTensorType(ptrType, kDim, kTile);
+
+  Operation *ptrDef = origPtr.getDefiningOp();
+  if (!ptrDef) {
+    return nullptr;
+  }
+
+  // Collect the backward slice of ops that define the pointer
+  SmallVector<Operation *> ptrOps;
+  SmallVector<Operation *> worklist = {ptrDef};
+  DenseSet<Operation *> visited;
+  while (!worklist.empty()) {
+    Operation *op = worklist.pop_back_val();
+    if (!op || visited.contains(op))
+      continue;
+    visited.insert(op);
+    ptrOps.push_back(op);
+    for (Value operand : op->getOperands()) {
+      if (Operation *defOp = operand.getDefiningOp()) {
+        if (isa<tt::MakeRangeOp, tt::SplatOp, tt::ExpandDimsOp,
+                tt::BroadcastOp, tt::AddPtrOp, arith::MulIOp, arith::AddIOp,
+                arith::ConstantOp>(defOp)) {
+          worklist.push_back(defOp);
+        }
+      }
+    }
+  }
+
+  // Sort by topological order (reverse of collection order, approximately)
+  std::reverse(ptrOps.begin(), ptrOps.end());
+
+  // Clone each op, adjusting shapes and make_range as needed
+  for (Operation *op : ptrOps) {
+    if (auto makeRange = dyn_cast<tt::MakeRangeOp>(op)) {
+      auto rangeType = makeRange.getType();
+      int64_t end = makeRange.getEnd();
+      // If this make_range produces the K-dimension range, tile it
+      if (end > static_cast<int64_t>(kTile) &&
+          rangeType.getShape()[0] > static_cast<int64_t>(kTile)) {
+        auto newType = RankedTensorType::get({kTile}, rangeType.getElementType(),
+                                             rangeType.getEncoding());
+        auto newRange = tt::MakeRangeOp::create(builder, makeRange.getLoc(),
+                                                newType, 0, kTile);
+        mapping.map(makeRange.getResult(), newRange);
+        continue;
+      }
+    }
+
+    // Clone op with remapped operands and adjust result types
+    Operation *cloned = builder.clone(*op, mapping);
+
+    // Adjust result types for ops that produce pointer/tensor types
+    for (unsigned i = 0; i < cloned->getNumResults(); ++i) {
+      auto origResultType =
+          dyn_cast<RankedTensorType>(op->getResult(i).getType());
+      if (!origResultType)
+        continue;
+      auto shape = origResultType.getShape();
+      if (kDim < shape.size() &&
+          shape[kDim] > static_cast<int64_t>(kTile)) {
+        auto newType = adjustTensorType(origResultType, kDim, kTile);
+        cloned->getResult(i).setType(newType);
+      }
+    }
+    mapping.map(op->getResults(), cloned->getResults());
+  }
+
+  if (mapping.contains(origPtr))
+    return mapping.lookup(origPtr);
+  return nullptr;
+}
+
+/// Decompose a single dot op into a K-tiled scf.for loop.
+static LogicalResult decomposeDot(tt::DotOp dotOp, unsigned kTile) {
+  auto resultType = dotOp.getType();
+  auto aType = cast<RankedTensorType>(dotOp.getA().getType());
+  auto bType = cast<RankedTensorType>(dotOp.getB().getType());
+  unsigned rank = aType.getRank();
+  unsigned kDimA = rank - 1; // K is last dim of A
+  unsigned kDimB = rank - 2; // K is second-to-last dim of B
+  int64_t K = aType.getShape()[kDimA];
+  unsigned numTiles = K / kTile;
+
+  // Trace operands to loads
+  tt::LoadOp aLoad = traceToLoad(dotOp.getA());
+  tt::LoadOp bLoad = traceToLoad(dotOp.getB());
+  if (!aLoad || !bLoad) {
+    LDBG("Cannot trace dot operands to loads, skipping");
+    return failure();
+  }
+
+  // Collect intermediate op chains
+  SmallVector<Operation *> aChain = collectIntermediateOps(dotOp.getA(), aLoad);
+  SmallVector<Operation *> bChain = collectIntermediateOps(dotOp.getB(), bLoad);
+
+  Location loc = dotOp.getLoc();
+  OpBuilder builder(dotOp);
+
+  // Create loop bounds
+  auto indexType = builder.getIndexType();
+  Value zero = arith::ConstantOp::create(builder, loc, builder.getIndexAttr(0));
+  Value numTilesVal = arith::ConstantOp::create(
+      builder, loc, builder.getIndexAttr(numTiles));
+  Value one = arith::ConstantOp::create(builder, loc, builder.getIndexAttr(1));
+
+  // Build tiled pointer for A (initial tile)
+  IRMapping aMappingInit;
+  Value aTiledPtrInit = clonePtrForTile(builder, aLoad, kDimA, kTile, aMappingInit);
+  if (!aTiledPtrInit) {
+    LDBG("Failed to clone A pointer chain");
+    return failure();
+  }
+
+  // Build tiled pointer for B (initial tile)
+  IRMapping bMappingInit;
+  Value bTiledPtrInit = clonePtrForTile(builder, bLoad, kDimB, kTile, bMappingInit);
+  if (!bTiledPtrInit) {
+    LDBG("Failed to clone B pointer chain");
+    return failure();
+  }
+
+  // Compute stride advance tensors for A and B
+  // A advances by kTile elements along kDimA
+  auto aPtrType = cast<RankedTensorType>(aTiledPtrInit.getType());
+  auto i32Type = builder.getI32Type();
+  auto aStrideType = RankedTensorType::get(
+      aPtrType.getShape(), i32Type, aPtrType.getEncoding());
+  Value aKTileConst = arith::ConstantOp::create(
+      builder, loc,
+      DenseElementsAttr::get(aStrideType, builder.getI32IntegerAttr(kTile)));
+
+  auto bPtrType = cast<RankedTensorType>(bTiledPtrInit.getType());
+  auto bStrideType = RankedTensorType::get(
+      bPtrType.getShape(), i32Type, bPtrType.getEncoding());
+  // For B, K is along rows (dim kDimB), stride = kTile * N for row-stepping
+  // But since pointer tensors already have element-level addressing,
+  // each B pointer element at row k points to B[k, n], so advancing K
+  // means adding kTile * N to each pointer element... Actually, for
+  // contiguous pointers generated via make_range, the stride is already
+  // baked into the pointer values. We need to add kTile * b_stride_k to
+  // each pointer element.
+  // Simpler: advance by kTile * number_of_columns for B's pointer tensor
+  int64_t bN = bType.getShape()[rank - 1]; // N dimension of B
+  Value bKTileConst = arith::ConstantOp::create(
+      builder, loc,
+      DenseElementsAttr::get(bStrideType,
+                             builder.getI32IntegerAttr(kTile * bN)));
+
+  // The accumulator is the dot's C operand
+  Value initAcc = dotOp.getC();
+
+  // Create the scf.for loop
+  SmallVector<Value> iterArgs = {initAcc, aTiledPtrInit, bTiledPtrInit};
+  auto forOp =
+      scf::ForOp::create(builder, loc, zero, numTilesVal, one, iterArgs);
+
+  // Build loop body
+  builder.setInsertionPointToStart(forOp.getBody());
+  Value loopAcc = forOp.getRegionIterArg(0);
+  Value loopAPtr = forOp.getRegionIterArg(1);
+  Value loopBPtr = forOp.getRegionIterArg(2);
+
+  // Load A tile
+  auto aTileType = adjustTensorType(aType, kDimA, kTile);
+  Value aTile = tt::LoadOp::create(builder, loc, aTileType, loopAPtr);
+
+  // Load B tile
+  auto bTileType = adjustTensorType(bType, kDimB, kTile);
+  Value bTile = tt::LoadOp::create(builder, loc, bTileType, loopBPtr);
+
+  // Apply intermediate ops on A (extf, convert_layout, etc.)
+  Value aPrepared = aTile;
+  for (Operation *op : aChain) {
+    IRMapping tileMapping;
+    tileMapping.map(op->getOperand(0), aPrepared);
+    Operation *cloned = builder.clone(*op, tileMapping);
+    // Adjust result type for K dimension
+    for (unsigned i = 0; i < cloned->getNumResults(); ++i) {
+      if (auto rtt = dyn_cast<RankedTensorType>(cloned->getResult(i).getType())) {
+        if (kDimA < rtt.getShape().size() &&
+            rtt.getShape()[kDimA] != static_cast<int64_t>(kTile)) {
+          cloned->getResult(i).setType(adjustTensorType(rtt, kDimA, kTile));
+        }
+      }
+    }
+    aPrepared = cloned->getResult(0);
+  }
+
+  // Apply intermediate ops on B
+  Value bPrepared = bTile;
+  for (Operation *op : bChain) {
+    IRMapping tileMapping;
+    tileMapping.map(op->getOperand(0), bPrepared);
+    Operation *cloned = builder.clone(*op, tileMapping);
+    for (unsigned i = 0; i < cloned->getNumResults(); ++i) {
+      if (auto rtt = dyn_cast<RankedTensorType>(cloned->getResult(i).getType())) {
+        if (kDimB < rtt.getShape().size() &&
+            rtt.getShape()[kDimB] != static_cast<int64_t>(kTile)) {
+          cloned->getResult(i).setType(adjustTensorType(rtt, kDimB, kTile));
+        }
+      }
+    }
+    bPrepared = cloned->getResult(0);
+  }
+
+  // Create tiled dot
+  auto tiledDot = tt::DotOp::create(builder, loc, resultType, aPrepared,
+                                    bPrepared, loopAcc,
+                                    dotOp.getInputPrecision(),
+                                    dotOp.getMaxNumImpreciseAcc());
+
+  // Advance pointers
+  Value aNextPtr = tt::AddPtrOp::create(builder, loc, aPtrType, loopAPtr,
+                                        aKTileConst);
+  Value bNextPtr = tt::AddPtrOp::create(builder, loc, bPtrType, loopBPtr,
+                                        bKTileConst);
+
+  // Yield
+  scf::YieldOp::create(builder, loc,
+                        ValueRange{tiledDot.getResult(), aNextPtr, bNextPtr});
+
+  // Replace original dot with loop result
+  dotOp.replaceAllUsesWith(forOp.getResult(0));
+  dotOp.erase();
+
+  // Clean up dead original loads if they have no other users
+  if (aLoad->use_empty())
+    aLoad.erase();
+  if (bLoad->use_empty())
+    bLoad.erase();
+
+  LDBG("Decomposed dot [K=" << K << "] into " << numTiles << " tiles of "
+                             << kTile);
+  return success();
+}
+
+struct DecomposeFMADotsPass
+    : public ttgi::impl::TritonIntelGPUDecomposeFMADotsBase<
+          DecomposeFMADotsPass> {
+  using ttgi::impl::TritonIntelGPUDecomposeFMADotsBase<
+      DecomposeFMADotsPass>::TritonIntelGPUDecomposeFMADotsBase;
+
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+
+    // Only run on non-DPAS hardware
+    if (mod->hasAttr(ttgi::TritonIntelGPUDialect::getSupportDPASAttrName()))
+      return;
+
+    SmallVector<tt::DotOp> dotsToDecompose;
+    mod.walk([&](tt::DotOp dotOp) {
+      auto resultType = dotOp.getType();
+      auto enc = dyn_cast<ttg::BlockedEncodingAttr>(resultType.getEncoding());
+      if (!enc)
+        return;
+
+      unsigned perThreadBytes = estimatePerThreadBytes(dotOp);
+      if (perThreadBytes <= K_PRESSURE_THRESHOLD_BYTES)
+        return;
+
+      auto aType = cast<RankedTensorType>(dotOp.getA().getType());
+      unsigned rank = aType.getRank();
+      unsigned kDimA = rank - 1;
+      int64_t K = aType.getShape()[kDimA];
+
+      unsigned kTile = selectKTile(K, enc, kDimA);
+      if (kTile == 0)
+        return;
+
+      LDBG("Found decomposable dot: K=" << K << " → kTile=" << kTile
+                                         << " perThreadBytes="
+                                         << perThreadBytes);
+      dotsToDecompose.push_back(dotOp);
+    });
+
+    for (tt::DotOp dotOp : dotsToDecompose) {
+      auto aType = cast<RankedTensorType>(dotOp.getA().getType());
+      auto enc =
+          cast<ttg::BlockedEncodingAttr>(dotOp.getType().getEncoding());
+      unsigned rank = aType.getRank();
+      unsigned kDimA = rank - 1;
+      int64_t K = aType.getShape()[kDimA];
+      unsigned kTile = selectKTile(K, enc, kDimA);
+
+      if (failed(decomposeDot(dotOp, kTile))) {
+        LDBG("Failed to decompose dot, skipping");
+      }
+    }
+  }
+};
+
+} // namespace

--- a/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeFMADots.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeFMADots.cpp
@@ -198,6 +198,16 @@ static Value clonePtrForTile(OpBuilder &builder, tt::LoadOp loadOp,
           shape[kDim] > static_cast<int64_t>(kTile)) {
         auto newType = adjustTensorType(origResultType, kDim, kTile);
         cloned->getResult(i).setType(newType);
+        // For arith.constant, also update the value attribute to match
+        if (auto constOp = dyn_cast<arith::ConstantOp>(cloned)) {
+          if (auto denseAttr = dyn_cast<DenseElementsAttr>(constOp.getValue())) {
+            if (denseAttr.isSplat()) {
+              auto newAttr = DenseElementsAttr::get(
+                  newType, denseAttr.getSplatValue<Attribute>());
+              constOp.setValueAttr(newAttr);
+            }
+          }
+        }
       }
     }
     mapping.map(op->getResults(), cloned->getResults());
@@ -298,13 +308,17 @@ static LogicalResult decomposeDot(tt::DotOp dotOp, unsigned kTile) {
   Value loopAPtr = forOp.getRegionIterArg(1);
   Value loopBPtr = forOp.getRegionIterArg(2);
 
-  // Load A tile
-  auto aTileType = adjustTensorType(aType, kDimA, kTile);
-  Value aTile = tt::LoadOp::create(builder, loc, aTileType, loopAPtr);
+  // Load A tile — type inferred from tiled pointer
+  auto aTileLoad = tt::LoadOp::create(
+      builder, loc, loopAPtr, aLoad.getCache(), aLoad.getEvict(),
+      aLoad.getIsVolatile());
+  Value aTile = aTileLoad.getResult();
 
-  // Load B tile
-  auto bTileType = adjustTensorType(bType, kDimB, kTile);
-  Value bTile = tt::LoadOp::create(builder, loc, bTileType, loopBPtr);
+  // Load B tile — type inferred from tiled pointer
+  auto bTileLoad = tt::LoadOp::create(
+      builder, loc, loopBPtr, bLoad.getCache(), bLoad.getEvict(),
+      bLoad.getIsVolatile());
+  Value bTile = bTileLoad.getResult();
 
   // Apply intermediate ops on A (extf, convert_layout, etc.)
   Value aPrepared = aTile;

--- a/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeFMADots.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeFMADots.cpp
@@ -27,7 +27,8 @@ namespace {
 constexpr unsigned K_PRESSURE_THRESHOLD_BYTES = 4096;
 
 /// Estimate per-thread register pressure from a dot with BlockedEncoding.
-/// Returns the approximate bytes each thread needs live for the K-loop.
+/// FMA lowering fully unrolls K, so each thread must hold all A and B values
+/// for its repetitions simultaneously. Returns approximate live bytes.
 static unsigned estimatePerThreadBytes(tt::DotOp dotOp) {
   auto aType = cast<RankedTensorType>(dotOp.getA().getType());
   auto bType = cast<RankedTensorType>(dotOp.getB().getType());
@@ -39,17 +40,37 @@ static unsigned estimatePerThreadBytes(tt::DotOp dotOp) {
 
   unsigned rank = aType.getRank();
   unsigned kDimA = rank - 1;
-  unsigned kDimB = rank - 2;
 
+  int64_t M = resultType.getShape()[rank - 2];
+  int64_t N = resultType.getShape()[rank - 1];
   int64_t K = aType.getShape()[kDimA];
   unsigned elemBits = aType.getElementTypeBitWidth();
   unsigned elemBytes = std::max(1u, elemBits / 8);
+  unsigned accBytes = resultType.getElementTypeBitWidth() / 8;
 
   auto sizePerThread = enc.getSizePerThread();
+  auto threadsPerWarp = enc.getThreadsPerWarp();
+  auto warpsPerCTA = enc.getWarpsPerCTA();
+
   unsigned mSpt = sizePerThread[rank - 2];
   unsigned nSpt = sizePerThread[rank - 1];
+  unsigned mTpw = threadsPerWarp[rank - 2];
+  unsigned nTpw = threadsPerWarp[rank - 1];
+  unsigned mWpc = warpsPerCTA[rank - 2];
+  unsigned nWpc = warpsPerCTA[rank - 1];
 
-  return (mSpt * K + K * nSpt) * elemBytes;
+  unsigned ctaTileM = mSpt * mTpw * mWpc;
+  unsigned ctaTileN = nSpt * nTpw * nWpc;
+  unsigned mReps = (ctaTileM > 0) ? M / ctaTileM : 1;
+  unsigned nReps = (ctaTileN > 0) ? N / ctaTileN : 1;
+
+  // Each thread holds: mReps*mSpt*K operand-A values + K*nReps*nSpt operand-B
+  // values + mReps*mSpt*nReps*nSpt accumulators
+  unsigned aBytes = mReps * mSpt * K * elemBytes;
+  unsigned bBytes = K * nReps * nSpt * elemBytes;
+  unsigned cBytes = mReps * mSpt * nReps * nSpt * accBytes;
+
+  return aBytes + bBytes + cBytes;
 }
 
 /// Select a K tile size that is compatible with the encoding.

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -83,6 +83,8 @@ void init_triton_intel_passes_ttgpuir(py::module &&m) {
                      gpu::intel::createTritonIntelGPUAccelerateMatmul);
   ADD_PASS_WRAPPER_0("add_fold_fp_to_fp",
                      gpu::intel::createTritonIntelGPUFoldFpToFp);
+  ADD_PASS_WRAPPER_0("add_decompose_fma_dots",
+                     gpu::intel::createTritonIntelGPUDecomposeFMADots);
   ADD_PASS_WRAPPER_0("add_rewrite_stack_ptr",
                      gpu::intel::createTritonIntelGPURewriteStackPtr);
   ADD_PASS_OPTION_WRAPPER_2(


### PR DESCRIPTION
## Summary

Adds `tritonintelgpu-decompose-fma-dots`, a TTGIR pass that decomposes large blocked-encoding `tt.dot` ops into a K-tiled `scf.for` loop on non-DPAS Intel hardware. Without this, FMA lowering fully unrolls the K dimension at LLVM level and produces register schedules that exceed the 4KB GRF and spill to PTSS, blowing past the 256KB hardware limit on ARL-S and similar.

> **Note (revised PR):** Per @chengjunlu's review, the unrelated PTSS error-message change has been split out into #7285. This PR is now focused entirely on the DecomposeFMADots pass. The fp32 `inputPrecision=ieee` coverage requested in point 2 of the review is added as the final commit.

## Why

On non-DPAS hardware (ARL-S iGPU, MTL, integrated Xe-LPG), `tt.dot` lowers through `FMADotUtility.cpp` which fully unrolls K at the LLVM level. For non-trivial matmul shapes (the original crash was 64×128×128 f16), each thread holds all its operand values in registers simultaneously across multiple tile repetitions. The register allocator can't fit the live set into the 4KB GRF and spills to scratch space, exceeding the 256KB PTSS hardware limit and failing IGC compilation.

This pass detects the situation at TTGIR (before LLVM unrolls), wraps the K dimension in an `scf.for`, and reduces each thread's live-value window to one chunk at a time.

## Pipeline position

```
add_accelerate_matmul →
add_decompose_fma_dots →   ← new
add_materialize_block_pointer
```

Pass is a no-op on DPAS-capable hardware (PVC, BMG, ARL-H with Xe2) — gated by the absence of `ttig.support_subgroup_matrix_multiply_accumulate` module attribute.

## Pressure formula

```
ctaTileM = sizePerThread_M × threadsPerWarp_M × warpsPerCTA_M
ctaTileN = sizePerThread_N × threadsPerWarp_N × warpsPerCTA_N
mReps = M / ctaTileM
nReps = N / ctaTileN

aBytes = mReps × sizePerThread_M × K × elemBytes
bBytes = K × nReps × sizePerThread_N × elemBytes
cBytes = mReps × sizePerThread_M × nReps × sizePerThread_N × accBytes

perThreadBytes = aBytes + bBytes + cBytes
```

Pass fires when `perThreadBytes > 4096` and a kTile in `{32, 64, 16}` divides K and aligns with the per-CTA K tile.

## What changed since the original PR

- **PTSS error-handling commit removed** — moved to #7285 (Point 1 of review)
- **f32 inputPrecision=ieee coverage** — pass already handled f32 correctly (the trigger uses operand element bitwidth, so f32 trips at smaller K than f16); added a lit test case locking it down (Point 2 of review). Sample: 64×64×128 f32 ieee → aBytes=4096 + bBytes=2048 + cBytes=128 = 6272 > 4096, decomposed into 4 iterations of K=32.

## Files

| File | Purpose |
|---|---|
| `third_party/intel/lib/TritonIntelGPUTransforms/DecomposeFMADots.cpp` | Pass implementation (pressure analysis + scf.for transform) |
| `third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td` | Pass declaration with `dependentDialects` |
| `third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt` | Add source |
| `third_party/intel/triton_xpu.cc` | Python binding |
| `third_party/intel/backend/compiler.py` | Wire into pass pipeline |
| `test/TritonIntelGPU/decompose-fma-dots.mlir` | Lit tests: ARL-S crashing config, small-K negative, DPAS-hardware negative, **f32 ieee positive** (new) |

## Test plan

- [x] Lit test verifies positive case (real ARL-S crashing config: 64×128×128 f16 → scf.for with K=32 chunks)
- [x] Lit test verifies negative cases (small-K stays unrolled; DPAS hardware skipped; f32 tf32x3 not leaked into f32 ieee path)
- [x] Lit test verifies f32 inputPrecision=ieee triggers correctly
- [x] Original ARL-S PTSS overflow on 64×128×128 f16 no longer occurs after the pass fires
- [ ] CI lit suite passes
- [ ] CI Python tests pass on PVC/BMG (no-op there)
- [ ] Pre-commit hooks pass

## Risk

- **No-op on DPAS hardware** (PVC, BMG, ARL-H Xe2) — the module-attribute gate excludes it explicitly.
- **Conservative cost model** on non-DPAS hardware — only fires when the live-value estimate exceeds 4 KB. Threshold is empirical; could be tuned.
- **No new runtime dependencies.**

## Related

- #7285 — split-off PTSS error-message handling (Point 1 of review)
- #7282 — Cooperative FMA Dots pass (downstream of this PR; depends on `add_decompose_fma_dots` being available)

