### PR TITLE
[RemoveMasks] Fix unsound IV-equivalent iter_arg classification

### DIFF
--- a/test/Triton/Intel/RemoveMasks/iter-arg-mask.mlir
+++ b/test/Triton/Intel/RemoveMasks/iter-arg-mask.mlir
@@ -44,3 +44,50 @@ module {
   // CHECK:   tt.load {{%[0-9]+}} : tensor<32x!tt.ptr<f16>>
   // CHECK: }
 }
+
+// -----
+
+module {
+  // COM: Regression test: a "decoy" iter_arg that is IV-equivalent (init = lb,
+  // COM: step = loop step) must NOT vouch for an UNRELATED offset iter_arg that
+  // COM: steps differently. Here off_k steps by 2048 (true range [0, 6144]), so
+  // COM: the mask (off_k + range(0,32)) < 4096 is NOT always-true and must be
+  // COM: kept. The decoy off_decoy steps by 32 (== loop step); the pass must
+  // COM: not use it to classify off_k's mask.
+  tt.func public @test_decoy_iter_arg_mask(
+      %ptr: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c2048_i32 = arith.constant 2048 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c4096_i64 = arith.constant 4096 : i64
+    %cst = arith.constant dense<0.000000e+00> : tensor<32xf16>
+
+    %k_range = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %k_range_i64 = arith.extsi %k_range : tensor<32xi32> to tensor<32xi64>
+    %base_splat = tt.splat %ptr : !tt.ptr<f16> -> tensor<32x!tt.ptr<f16>>
+
+    %res:2 = scf.for %iv = %c0_i32 to %c128_i32 step %c32_i32
+        iter_args(%off_k = %c0_i32, %off_decoy = %c0_i32) -> (i32, i32) : i32 {
+      %off_k_i64 = arith.extsi %off_k : i32 to i64
+      %k_splat = tt.splat %off_k_i64 : i64 -> tensor<32xi64>
+      %k_offset = arith.addi %k_splat, %k_range_i64 : tensor<32xi64>
+      %k_ub = tt.splat %c4096_i64 : i64 -> tensor<32xi64>
+      %k_mask = arith.cmpi slt, %k_offset, %k_ub : tensor<32xi64>
+
+      %loaded = tt.load %base_splat, %k_mask, %cst : tensor<32x!tt.ptr<f16>>
+
+      // off_k steps by 2048 (NOT the loop step); off_decoy steps by 32.
+      %next_off_k = arith.addi %off_k, %c2048_i32 : i32
+      %next_decoy = arith.addi %off_decoy, %c32_i32 : i32
+      scf.yield %next_off_k, %next_decoy : i32, i32
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @test_decoy_iter_arg_mask
+  // COM: The mask must be preserved (load keeps its mask + default operands).
+  // CHECK: scf.for
+  // CHECK:   tt.load {{%[0-9]+}}, {{%[0-9]+}}, {{%[a-z0-9_]+}} : tensor<32x!tt.ptr<f16>>
+  // CHECK: }
+}

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RemoveMasks.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RemoveMasks.cpp
@@ -272,12 +272,24 @@ private:
     if (!ivRange)
       return std::nullopt;
 
-    if (val == forOp.getSingleInductionVar())
+    // Peel view/cast ops to find the block argument `val` is derived from. We
+    // stop at the block argument instead of resolving it to its init value, so
+    // the specific iter_arg backing `val` can be checked below.
+    while (Operation *defOp = val.getDefiningOp()) {
+      if (!isa<tt::ExpandDimsOp, tt::BroadcastOp, tt::SplatOp,
+               arith::IndexCastOp, arith::ExtSIOp, arith::ExtUIOp>(defOp))
+        return std::nullopt;
+      val = defOp->getOperand(0);
+    }
+    auto blockArg = dyn_cast<BlockArgument>(val);
+    if (!blockArg || blockArg.getOwner() != forOp.getBody())
+      return std::nullopt;
+
+    if (blockArg == forOp.getInductionVar())
       return ivRange;
 
-    // Check if val resolved (via getFinalValue) to the loop's lower bound
-    // constant, meaning it was an iter_arg with that init. Verify there
-    // exists an iter_arg with init == lb and yield == self + step.
+    // `val` is an iter_arg: prove it is IV-equivalent (init == lb and
+    // yield == self + step).
     OpFoldResult lbOFR = *forOp.getSingleLowerBound();
     OpFoldResult stepOFR = *forOp.getSingleStep();
 
@@ -311,32 +323,25 @@ private:
       return false;
     };
 
-    if (!matchesInt(val, *lbConst))
+    unsigned i = blockArg.getArgNumber() - forOp.getNumInductionVars();
+    if (!matchesInt(forOp.getInitArgs()[i], *lbConst))
       return std::nullopt;
 
     auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
-    for (unsigned i = 0, e = forOp.getNumRegionIterArgs(); i < e; ++i) {
-      Value initArg = forOp.getInitArgs()[i];
-      if (!matchesInt(initArg, *lbConst))
-        continue;
+    auto yieldAdd = yieldOp.getOperand(i).getDefiningOp<arith::AddIOp>();
+    if (!yieldAdd)
+      return std::nullopt;
 
-      Value yieldVal = yieldOp.getOperand(i);
-      auto yieldAdd = yieldVal.getDefiningOp<arith::AddIOp>();
-      if (!yieldAdd)
-        continue;
+    bool lhsIsIterArg = (yieldAdd.getLhs() == blockArg);
+    bool rhsIsIterArg = (yieldAdd.getRhs() == blockArg);
+    if (!lhsIsIterArg && !rhsIsIterArg)
+      return std::nullopt;
 
-      BlockArgument iterArg = forOp.getRegionIterArg(i);
-      bool lhsIsIterArg = (yieldAdd.getLhs() == iterArg);
-      bool rhsIsIterArg = (yieldAdd.getRhs() == iterArg);
-      if (!lhsIsIterArg && !rhsIsIterArg)
-        continue;
+    Value stepOperand = lhsIsIterArg ? yieldAdd.getRhs() : yieldAdd.getLhs();
+    if (!matchesInt(stepOperand, *stepConst))
+      return std::nullopt;
 
-      Value stepOperand = lhsIsIterArg ? yieldAdd.getRhs() : yieldAdd.getLhs();
-      if (matchesInt(stepOperand, *stepConst))
-        return ivRange;
-    }
-
-    return std::nullopt;
+    return ivRange;
   }
 
   // Classify a single `arith.cmpi` mask against the loop IV range.
@@ -374,11 +379,12 @@ private:
     if (!addOp)
       return MaskClassification::Unknown;
 
-    Value addLhs = tt::intel::getFinalValue(addOp.getLhs());
     Value addRhs = tt::intel::getFinalValue(addOp.getRhs());
 
+    // Pass the un-collapsed lhs so getIVEquivalentRange sees the actual
+    // iter_arg rather than its init constant.
     std::optional<ConstantIntRanges> lhsRange =
-        getIVEquivalentRange(forOp, addLhs);
+        getIVEquivalentRange(forOp, addOp.getLhs());
     if (!lhsRange)
       return MaskClassification::Unknown;
 


### PR DESCRIPTION
RemoveMasks could drop a mask that isn't always true, causing out-of-bounds loads and wrong results.

The classifier treated an offset as IV-equivalent if any iter_arg had init == lb and step == loop step, without checking the offset actually came from that iter_arg. So an unrelated iter_arg could vouch for an offset that steps differently.

Fix: trace the offset to its own block argument and check that iter_arg's init and step. Added a regression test with a decoy iter_arg.