### PR TITLE
[PTL] Make test_auto_large_grf robust across IGC versions

### DIFF
--- a/python/test/unit/intel/test_native_code_generation.py
+++ b/python/test/unit/intel/test_native_code_generation.py
@@ -1,8 +1,11 @@
+import tempfile
+
 import pytest
 import triton
 import triton.language as tl
 
 from triton._internal_testing import numpy_random, to_triton, is_xpu_cri
+from triton.backends.intel.compiler import MAX_REG_SPILL, extract_spill_size_from_zebin
 
 
 def test_empty_kernel(device):
@@ -18,7 +21,7 @@ def test_empty_kernel(device):
 
 @pytest.mark.xfail(is_xpu_cri(), reason="unable to get spill_size")
 def test_auto_large_grf(device):
-    SIZE = 1024
+    SIZE = 2048
 
     @triton.jit
     def kernel(X, SIZE: tl.constexpr):
@@ -27,6 +30,13 @@ def test_auto_large_grf(device):
         tl.store(X + x, y)
 
     x = to_triton(numpy_random(SIZE, dtype_str="float32"), device=device, dst_type="float32")
-    # Triton XPU will auto choose large GRF mode for grf_mode='default'
+    # Triton XPU will choose large GRF mode when spill_size > MAX_REG_SPILL.
     k = kernel[(1, )](x, SIZE=SIZE, num_warps=1, generate_native_code=True, grf_mode='default')
+    with tempfile.NamedTemporaryFile(mode='wb', suffix='.zebin') as f:
+        f.write(k.kernel)
+        f.flush()
+        spill_size = extract_spill_size_from_zebin(f.name)
+    if spill_size <= MAX_REG_SPILL:
+        pytest.skip(f"Kernel did not spill above MAX_REG_SPILL ({spill_size} <= {MAX_REG_SPILL}); "
+                    "auto-large-GRF path was not exercised. Consider increasing SIZE.")
     assert "-cl-intel-256-GRF-per-thread" in k.metadata.build_flags

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -74,6 +74,9 @@ class XPUOptions:
         return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
 
+# Aligned with max_reg_spill in third_party/intel/backend/driver.c
+MAX_REG_SPILL = 1000
+
 SPILL_SIZE_RE = re.compile(r'spill_size\s*[:=]\s*(\d+)')
 
 
@@ -544,9 +547,9 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
                 subprocess.check_output(ocloc_cmd, stderr=subprocess.STDOUT, text=True)
                 if options.grf_mode == 'default':
                     spill_size = extract_spill_size_from_zebin(fbin)
-                    # The threshold of 1000 for spill_size is chosen based on empirical observations
+                    # The threshold for spill_size is chosen based on empirical observations
                     # and aligned with triton/backends/intel/driver.c
-                    if spill_size > 1000:
+                    if spill_size > MAX_REG_SPILL:
                         metadata["build_flags"] += " -cl-intel-256-GRF-per-thread"
                         # re-run with double GRF mode
                         ocloc_cmd[-1] = metadata["build_flags"] + shader_dump_opt


### PR DESCRIPTION
Increase SIZE to 2048 so the kernel spills past the auto-256-GRF threshold on current IGC.
Skip when a future IGC compiles it without spilling.
Extract the threshold to MAX_REG_SPILL in compiler.py, shared between the test and the auto-GRF path;
aligned with driver.c via a comment.

Related: intel-tools/intel-xpu-backend-for-triton#1835

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it's a fix for a pre-existing test`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
