### PR TITLE
[TritonIntel] Add Intel descriptor gather/scatter op.

### DIFF
--- a/test/TritonIntelGPU/tritonintelgpu-invalid.mlir
+++ b/test/TritonIntelGPU/tritonintelgpu-invalid.mlir
@@ -142,3 +142,59 @@ tt.func @ttig.descriptor_prefetch.indices_mismatch(%desc: !tt.tensordesc<256x32x
   ttig.descriptor_prefetch %desc[%x] : !tt.tensordesc<256x32xf16>
   tt.return
 }
+
+// -----
+
+tt.func @invalid_desc_gather(%arg0: !tt.tensordesc<128xbf16>, %arg1: tensor<32xi32>, %arg2: i32) {
+  // expected-error @below {{block must be a 2D tensor}}
+  %0 = ttig.descriptor_gather %arg0[%arg1, %arg2] : (!tt.tensordesc<128xbf16>, tensor<32xi32>, i32) -> tensor<32xbf16>
+  tt.return
+}
+
+// -----
+
+tt.func @invalid_desc_gather(%arg0: !tt.tensordesc<2x128xbf16>, %arg1: tensor<32xi32>, %arg2: i32) {
+  // expected-error @below {{block must have exactly 1 row}}
+  %0 = ttig.descriptor_gather %arg0[%arg1, %arg2] : (!tt.tensordesc<2x128xbf16>, tensor<32xi32>, i32) -> tensor<32x128xbf16>
+  tt.return
+}
+
+// -----
+
+tt.func @invalid_desc_gather(%arg0: !tt.tensordesc<1x128xbf16>, %arg1: tensor<1x32xi32>, %arg2: i32) {
+  // expected-error @below {{x offsets must be a 1D tensor}}
+  %0 = ttig.descriptor_gather %arg0[%arg1, %arg2] : (!tt.tensordesc<1x128xbf16>, tensor<1x32xi32>, i32) -> tensor<32x128xbf16>
+  tt.return
+}
+
+// -----
+
+tt.func @invalid_desc_gather(%arg0: !tt.tensordesc<1x128xbf16>, %arg1: tensor<32xi32>, %arg2: i32) {
+  // expected-error @below {{result must be a 2D tensor}}
+  %0 = ttig.descriptor_gather %arg0[%arg1, %arg2] : (!tt.tensordesc<1x128xbf16>, tensor<32xi32>, i32) -> tensor<128xbf16>
+  tt.return
+}
+
+// -----
+
+tt.func @invalid_desc_gather(%arg0: !tt.tensordesc<1x128xbf16>, %arg1: tensor<32xi32>, %arg2: i32) {
+  // expected-error @below {{result tensor number of columns must match block (128)}}
+  %0 = ttig.descriptor_gather %arg0[%arg1, %arg2] : (!tt.tensordesc<1x128xbf16>, tensor<32xi32>, i32) -> tensor<32x64xbf16>
+  tt.return
+}
+
+// -----
+
+tt.func @invalid_desc_gather(%arg0: !tt.tensordesc<1x128xbf16>, %arg1: tensor<32xi32>, %arg2: i32) {
+  // expected-error @below {{result tensor must have as many rows as indices (32)}}
+  %0 = ttig.descriptor_gather %arg0[%arg1, %arg2] : (!tt.tensordesc<1x128xbf16>, tensor<32xi32>, i32) -> tensor<64x128xbf16>
+  tt.return
+}
+
+// -----
+
+tt.func @invalid_desc_gather(%arg0: !tt.tensordesc<1x128xbf16>, %arg1: tensor<32xi32>, %arg2: i32) {
+  // expected-error @below {{result tensor element type must match block ('bf16')}}
+  %0 = ttig.descriptor_gather %arg0[%arg1, %arg2] : (!tt.tensordesc<1x128xbf16>, tensor<32xi32>, i32) -> tensor<32x128xf32>
+  tt.return
+}

--- a/test/TritonIntelGPU/tritonintelgpu-invalid.mlir
+++ b/test/TritonIntelGPU/tritonintelgpu-invalid.mlir
@@ -198,3 +198,19 @@ tt.func @invalid_desc_gather(%arg0: !tt.tensordesc<1x128xbf16>, %arg1: tensor<32
   %0 = ttig.descriptor_gather %arg0[%arg1, %arg2] : (!tt.tensordesc<1x128xbf16>, tensor<32xi32>, i32) -> tensor<32x128xf32>
   tt.return
 }
+
+// -----
+
+tt.func @invalid_desc_gather_i64_too_few_cols(%arg0: !tt.tensordesc<1x2xi64>, %arg1: tensor<32xi32>, %arg2: i32) {
+  // expected-error @below {{must have at least 4 columns}}
+  %0 = ttig.descriptor_gather %arg0[%arg1, %arg2] : (!tt.tensordesc<1x2xi64>, tensor<32xi32>, i32) -> tensor<32x2xi64>
+  tt.return
+}
+
+// -----
+
+tt.func @invalid_desc_scatter_src_rank(%arg0: !tt.tensordesc<1x128xbf16>, %arg1: tensor<32xi32>, %arg2: i32, %arg3: tensor<128xbf16>) {
+  // expected-error @below {{result must be a 2D tensor}}
+  ttig.descriptor_scatter %arg0[%arg1, %arg2], %arg3 : !tt.tensordesc<1x128xbf16>, tensor<32xi32>, i32, tensor<128xbf16>
+  tt.return
+}

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -329,8 +329,8 @@ def TTIG_DescriptorGatherOp : TTIG_Op<"descriptor_gather", [TT_DescriptorLoadLik
 def TTIG_DescriptorScatterOp : TTIG_Op<"descriptor_scatter", [TT_DescriptorStoreLikeOpInterface]> {
   let summary = "scatter multiple rows to a descriptor from a single tensor";
   let description = [{
-    The `ttig.descriptor_scatter` op has same semantic to the `ttg.descriptor_scatter`.
-    It's verifier and infer is Intel specific.
+    The `ttig.descriptor_scatter` op has the same semantics as `tt.descriptor_scatter`.
+    Its verifier and layout inference are Intel-specific.
   }];
 
   let arguments = (ins

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -304,4 +304,48 @@ def TTIG_Subgroup2DBlockLoadFromPtrOp : TTIG_Op<"2d_block_load_from_ptr", [
   let hasVerifier = 1;
 }
 
+def TTIG_DescriptorGatherOp : TTIG_Op<"descriptor_gather", [TT_DescriptorLoadLikeOpInterface]> {
+  let summary = "gather multiple rows from a descriptor into a single tensor";
+  let description = [{
+    The `ttig.descriptor_gather` op has same semantic to the `ttg.descriptor_gather`.
+    It's verifier and infer is Intel specific.
+  }];
+
+  let arguments = (ins
+    Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>]>:$desc,
+    RankedTensorOf<[I16, I32]>:$x_offsets,
+    I32:$y_offset
+  );
+  let results = (outs TT_Tensor:$result);
+
+  let assemblyFormat = [{
+    $desc `[` $x_offsets `,` $y_offset `]`
+    attr-dict `:` functional-type(operands, results)
+  }];
+
+  let hasVerifier = 1;
+}
+
+def TTIG_DescriptorScatterOp : TTIG_Op<"descriptor_scatter", [TT_DescriptorStoreLikeOpInterface]> {
+  let summary = "scatter multiple rows to a descriptor from a single tensor";
+  let description = [{
+    The `ttig.descriptor_scatter` op has same semantic to the `ttg.descriptor_scatter`.
+    It's verifier and infer is Intel specific.
+  }];
+
+  let arguments = (ins
+    Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$desc,
+    RankedTensorOf<[I16, I32]>:$x_offsets,
+    I32:$y_offset,
+    TT_Tensor:$src
+  );
+
+  let assemblyFormat = [{
+    $desc `[` $x_offsets `,` $y_offset `]` `,` $src
+    attr-dict `:` type(operands)
+  }];
+
+  let hasVerifier = 1;
+}
+
 #endif

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -307,8 +307,8 @@ def TTIG_Subgroup2DBlockLoadFromPtrOp : TTIG_Op<"2d_block_load_from_ptr", [
 def TTIG_DescriptorGatherOp : TTIG_Op<"descriptor_gather", [TT_DescriptorLoadLikeOpInterface]> {
   let summary = "gather multiple rows from a descriptor into a single tensor";
   let description = [{
-    The `ttig.descriptor_gather` op has same semantic to the `ttg.descriptor_gather`.
-    It's verifier and infer is Intel specific.
+    The `ttig.descriptor_gather` op has the same semantics as `tt.descriptor_gather`.
+    Its verifier and layout inference are Intel-specific.
   }];
 
   let arguments = (ins

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
@@ -149,9 +149,9 @@ LogicalResult Subgroup2DBlockLoadFromPtrOp::verify() {
 }
 
 // -- DescriptorGatherOp
-LogicalResult verifyGatherScatterResultType(Operation *op,
-                                            ShapedType resultType,
-                                            ShapedType indicesType) {
+static LogicalResult verifyGatherScatterResultType(Operation *op,
+                                                   ShapedType resultType,
+                                                   ShapedType indicesType) {
   if (indicesType.getRank() != 1)
     return op->emitOpError("x offsets must be a 1D tensor, but got ")
            << indicesType;
@@ -178,9 +178,9 @@ LogicalResult verifyGatherScatterResultType(Operation *op,
   return success();
 }
 
-LogicalResult verifyGatherScatterOp(Operation *op, ShapedType blockType,
-                                    ShapedType resultType,
-                                    ShapedType indicesType) {
+static LogicalResult verifyGatherScatterOp(Operation *op, ShapedType blockType,
+                                           ShapedType resultType,
+                                           ShapedType indicesType) {
   // Gather from `!tt.tensordesc<1xMxdtype>`.
   if (blockType.getRank() != 2) {
     return op->emitOpError("descriptor block must be a 2D tensor, but got ")

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
@@ -148,4 +148,75 @@ LogicalResult Subgroup2DBlockLoadFromPtrOp::verify() {
   return success();
 }
 
+// -- DescriptorGatherOp
+LogicalResult verifyGatherScatterResultType(Operation *op,
+                                            ShapedType resultType,
+                                            ShapedType indicesType) {
+  if (indicesType.getRank() != 1)
+    return op->emitOpError("x offsets must be a 1D tensor, but got ")
+           << indicesType;
+  if (resultType.getRank() != 2)
+    return op->emitOpError("result must be a 2D tensor, but got ")
+           << resultType;
+
+  Type dtype = resultType.getElementType();
+  if (dtype.getIntOrFloatBitWidth() > 64)
+    return op->emitOpError("dtype cannot be greater than 32 bits");
+
+  unsigned minCols = 32 / dtype.getIntOrFloatBitWidth() * 8;
+  if (unsigned cols = resultType.getShape()[1]; cols < minCols) {
+    return op->emitOpError("must have at least ")
+           << minCols << " columns for " << dtype << ", but got " << cols;
+  }
+
+  if (resultType.getShape()[0] != indicesType.getShape()[0]) {
+    return op->emitOpError("result tensor must have as many rows as indices (")
+           << indicesType.getShape()[0] << "), but got " << resultType;
+  }
+
+  return success();
+}
+
+LogicalResult verifyGatherScatterOp(Operation *op, ShapedType blockType,
+                                    ShapedType resultType,
+                                    ShapedType indicesType) {
+  // Gather from `!tt.tensordesc<1xMxdtype>`.
+  if (blockType.getRank() != 2) {
+    return op->emitOpError("descriptor block must be a 2D tensor, but got ")
+           << blockType;
+  }
+  if (blockType.getShape()[0] != 1) {
+    return op->emitOpError("descriptor block must have exactly 1 row, but got ")
+           << blockType;
+  }
+
+  // With x offsets `tensor<Nxinttype>` into `tensor<NxMxdtype>`.
+  if (failed(verifyGatherScatterResultType(op, resultType, indicesType)))
+    return failure();
+
+  if (resultType.getShape()[1] != blockType.getShape()[1]) {
+    return op->emitOpError("result tensor number of columns must match block (")
+           << blockType.getShape()[1] << "), but got " << resultType;
+  }
+  if (resultType.getElementType() != blockType.getElementType()) {
+    return op->emitOpError("result tensor element type must match block (")
+           << blockType.getElementType() << "), but got " << resultType;
+  }
+
+  return success();
+}
+
+LogicalResult DescriptorGatherOp::verify() {
+  return intel::verifyGatherScatterOp(
+      *this, getDesc().getType().getSignlessBlockType(), getResult().getType(),
+      getXOffsets().getType());
+}
+
+// -- DescriptorScatterOp --
+LogicalResult DescriptorScatterOp::verify() {
+  return intel::verifyGatherScatterOp(
+      *this, getDesc().getType().getSignlessBlockType(), getSrc().getType(),
+      getXOffsets().getType());
+}
+
 } // namespace mlir::triton::gpu::intel

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
@@ -208,7 +208,7 @@ LogicalResult verifyGatherScatterOp(Operation *op, ShapedType blockType,
 }
 
 LogicalResult DescriptorGatherOp::verify() {
-  return intel::verifyGatherScatterOp(
+  return verifyGatherScatterOp(
       *this, getDesc().getType().getSignlessBlockType(), getResult().getType(),
       getXOffsets().getType());
 }

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
@@ -208,7 +208,7 @@ LogicalResult verifyGatherScatterOp(Operation *op, ShapedType blockType,
 }
 
 LogicalResult DescriptorGatherOp::verify() {
-  return verifyGatherScatterOp(
+  return intel::verifyGatherScatterOp(
       *this, getDesc().getType().getSignlessBlockType(), getResult().getType(),
       getXOffsets().getType());
 }

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
@@ -215,7 +215,7 @@ LogicalResult DescriptorGatherOp::verify() {
 
 // -- DescriptorScatterOp --
 LogicalResult DescriptorScatterOp::verify() {
-  return intel::verifyGatherScatterOp(
+  return verifyGatherScatterOp(
       *this, getDesc().getType().getSignlessBlockType(), getSrc().getType(),
       getXOffsets().getType());
 }

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
@@ -160,10 +160,11 @@ LogicalResult verifyGatherScatterResultType(Operation *op,
            << resultType;
 
   Type dtype = resultType.getElementType();
-  if (dtype.getIntOrFloatBitWidth() > 64)
-    return op->emitOpError("dtype cannot be greater than 32 bits");
+  unsigned bitWidth = dtype.getIntOrFloatBitWidth();
+  if (bitWidth > 64)
+    return op->emitOpError("dtype cannot be greater than 64 bits");
 
-  unsigned minCols = 32 / dtype.getIntOrFloatBitWidth() * 8;
+  unsigned minCols = 256 / bitWidth;
   if (unsigned cols = resultType.getShape()[1]; cols < minCols) {
     return op->emitOpError("must have at least ")
            << minCols << " columns for " << dtype << ", but got " << cols;

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
@@ -215,7 +215,7 @@ LogicalResult DescriptorGatherOp::verify() {
 
 // -- DescriptorScatterOp --
 LogicalResult DescriptorScatterOp::verify() {
-  return verifyGatherScatterOp(
+  return intel::verifyGatherScatterOp(
       *this, getDesc().getType().getSignlessBlockType(), getSrc().getType(),
       getXOffsets().getType());
 }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
@@ -109,6 +109,14 @@ bool isDivisible(Value value, unsigned divisor) {
   return false;
 }
 
+static Attribute inferSrcEncoding(ttgi::DescriptorGatherOp op,
+                                  Attribute dstEnc) {
+  // only the offsets require the slice encoding, the base pointer is a scalar
+  // and does not require any encoding.
+  return SliceEncodingAttr::get(op->getContext(), 1,
+                                cast<DistributedEncodingTrait>(dstEnc));
+}
+
 Attribute inferSrcEncoding(Operation *op, Attribute encoding) {
   if (auto dotEnc = dyn_cast<DotOperandEncodingAttr>(encoding)) {
     if (auto parentEnc = dyn_cast<DpasEncodingAttr>(dotEnc.getParent())) {
@@ -127,6 +135,9 @@ Attribute inferSrcEncoding(Operation *op, Attribute encoding) {
       }
     }
   }
+
+  if (auto gatherOp = dyn_cast<ttgi::DescriptorGatherOp>(op))
+    return inferSrcEncoding(gatherOp, encoding);
 
   return mlir::inferSrcEncoding(op, encoding);
 }

--- a/third_party/intel/unittest/Analysis/SpatialReuseAnalysisTest.cpp
+++ b/third_party/intel/unittest/Analysis/SpatialReuseAnalysisTest.cpp
@@ -428,8 +428,8 @@ TEST_F(SpatialReuseAnalysisTest, DescriptorGatherOpOverload) {
   BlockArgument xOffsets = block->getArgument(1);
   BlockArgument yOffset = block->getArgument(2);
 
-  auto gatherOp = DescriptorGatherOp::create(*builder, builder->getUnknownLoc(),
-                                             resultTy, desc, xOffsets, yOffset);
+  auto gatherOp = mlir::triton::DescriptorGatherOp::create(
+      *builder, builder->getUnknownLoc(), resultTy, desc, xOffsets, yOffset);
 
   SpatialReuseAnalysis analysis(module);
   SmallVector<unsigned> opAxes = analysis.getWarpInvariantOutDims(gatherOp);


### PR DESCRIPTION
This PR introduces Intel-specific ttig.descriptor_gather / ttig.descriptor_scatter ops in the TritonIntelGPU dialect to provide descriptor-based gather/scatter semantics without NVIDIA TMA-specific limitations, and wires them into Intel’s layout/analysis utilities and negative tests.