### PR TITLE
[RewriteBlockPtr] Skip tensor descriptor when last dim < 16 bytes

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1910,6 +1910,10 @@ class _block_ptr:
             return False
         if not self._inner_stride_one.value:
             return False
+        # Descriptor needs >= 16 bytes in the last dim.
+        elem_size = self.base.type.element_ty.primitive_bitwidth // 8
+        if self._tile_shape()[-1] * elem_size < 16:
+            return False
         rank = len(self._tile_shape())
         checked_dims = _canonicalize_block_ptr_boundary_check(boundary_check, rank)
         return checked_dims == set(builtins.range(rank))


### PR DESCRIPTION
A block pointer with less than 16 bytes in the last dimension was marked eligible for tensor-descriptor lowering, then _make_tensor_desc raised and the kernel failed to compile. Skip such block pointers in _is_tdesc_eligible so they use the pointer path.

Failing test: inductor/test_torchinductor.py::GPUTests::test_tmp_not_defined_issue1_use_block_ptr_True_xpu
https://github.com/pytorch/pytorch/blob/1c23e463efdf735913fabb00c48f0d0e5f6e2282/test/inductor/test_torchinductor.py#L13064

The CI run/job where test_tmp_not_defined_issue1_use_block_ptr_True_xpu failed: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/28034568644/job/82984301830