### PR TITLE
[CRI] Re-enable INT8 types in `03a-matrix-multiplication-tensor-descriptor` tutorial

### DIFF
--- a/python/tutorials/03a-matrix-multiplication-tensor-descriptor.py
+++ b/python/tutorials/03a-matrix-multiplication-tensor-descriptor.py
@@ -336,8 +336,7 @@ FP8_TYPES = [(torch.float8_e4m3fn, torch.float32, torch.float16)]
 
 torch.manual_seed(0)
 matmul_size = 128 if is_xpu_cri() else 512
-# FIXME: Fix INT8 hangs on CRI
-test_types = FP16_TYPES + FP32_TYPES + ([] if is_xpu_cri() else INT8_TYPES) + FP8_TYPES
+test_types = FP16_TYPES + FP32_TYPES + INT8_TYPES + FP8_TYPES
 for dtype, accum_dtype, res_dtype in test_types:
     for shape in [(matmul_size, matmul_size), (4, matmul_size, matmul_size)]:
         assert shape[-1] == shape[-2], "Only square matrices are supported"


### PR DESCRIPTION
Test passes now