### PR TITLE
[BLOCKIO] Fix cooperative prefetch descriptor for broadcast row

### DIFF
--- a/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
+++ b/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
@@ -238,8 +238,10 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32,
     %ptr = tt.addptr %3, %2 : tensor<16x32x!tt.ptr<f32>, #blocked>, tensor<16x32xi32, #blocked>
 
     // COM: base_height comes from the constant 1 (broadcast row); base_width
-    // COM: from the contiguous-dim pitch. Tie both captures into the op
-    // COM: operands so the check fails if either descriptor value regresses.
+    // COM: from the contiguous-dim surface extent (pitch is inflated separately
+    // COM: to satisfy the HW pitch >= base_width constraint after alignment
+    // COM: compensation). Tie both captures into the op operands so the check
+    // COM: fails if either descriptor value regresses.
     // CHECK: %[[BASE_H_I64:.*]] = llvm.mlir.constant(1 : i64) : i64
     // CHECK: %[[BASE_W:.*]] = llvm.trunc %{{.*}} : i64 to i32
     // CHECK: %[[BASE_H:.*]] = llvm.trunc %[[BASE_H_I64]] : i64 to i32

--- a/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
+++ b/test/TritonIntelGPU/prefetch-elementwise-to-llvm.mlir
@@ -220,3 +220,32 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32,
     tt.return
   }
 }
+
+// -----
+
+// COM: Broadcast row (M == 1, row stride 0): the descriptor must use
+// COM: base_height = 1 and a non-zero base_width/pitch (see #7267).
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_broadcast_row_f32
+  tt.func public @prefetch_broadcast_row_f32(%arg0: !tt.ptr<f32>) {
+    // COM: 16x32 tensor-of-pointers with a broadcast row (stride 0).
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked>
+    %2 = tt.broadcast %1 : tensor<1x32xi32, #blocked> -> tensor<16x32xi32, #blocked>
+    %3 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x32x!tt.ptr<f32>, #blocked>
+    %ptr = tt.addptr %3, %2 : tensor<16x32x!tt.ptr<f32>, #blocked>, tensor<16x32xi32, #blocked>
+
+    // COM: base_height comes from the constant 1 (broadcast row); base_width
+    // COM: from the contiguous-dim pitch. Tie both captures into the op
+    // COM: operands so the check fails if either descriptor value regresses.
+    // CHECK: %[[BASE_H_I64:.*]] = llvm.mlir.constant(1 : i64) : i64
+    // CHECK: %[[BASE_W:.*]] = llvm.trunc %{{.*}} : i64 to i32
+    // CHECK: %[[BASE_H:.*]] = llvm.trunc %[[BASE_H_I64]] : i64 to i32
+    // CHECK: triton_gen.2Dblockprefetch %{{.*}}, %[[BASE_W]], %[[BASE_H]], %{{.*}} {elem_size_in_bits = 32, tile_width = 16, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
+    ttig.prefetch %ptr {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 0, 0>, ttig.block_io = "row_major"} : tensor<16x32x!tt.ptr<f32>, #blocked>
+
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1774,23 +1774,30 @@ struct PrefetchOpConversion
     Value rowStride = b.i64_val(stride);
 
     // Surface dimensions for the 2D block prefetch hardware.
-    // baseWidth must equal the row stride (surface width) because the HW
-    // computes addresses as base + y * pitch + x. Using the tile width would
-    // be wrong when pitch > tile width.
-    // baseHeight is the full logical tensor height (surface height), not the
-    // tile height, so the hardware's bounds checking spans the whole tensor.
-    Value baseWidth = b.i64_val(stride);
-    Value baseHeight = b.i64_val(tensorShape[rank - 2]);
+    Value baseWidth;
+    Value baseHeight;
     if (stride == 0) {
-      // Broadcast row (e.g. M == 1): use a single row and a valid pitch from
-      // the contiguous dimension instead of stride 0 (see #7267).
+      // Broadcast row (M == 1): single row, real surface width, inflated pitch
+      // (see #7267). baseWidth stays the true extent so HW x-bounds checking is
+      // preserved; pitch gets headroom so it stays >= baseWidth after alignment
+      // widens baseWidth by up to 63 bytes. With baseHeight == 1, pitch never
+      // affects the address, so inflating it is free.
       constexpr int64_t MIN_PITCH = 64;
+      constexpr int64_t ALIGNMENT_HEADROOM = 64;
+      int64_t surfaceWidthElems = tensorShape[rank - 1];
       int64_t surfaceWidthBytes =
-          tensorShape[rank - 1] * static_cast<int64_t>(elemSizeInBytes);
-      rowStride = b.i64_val(std::max<int64_t>(MIN_PITCH, surfaceWidthBytes) /
-                            elemSizeInBytes);
-      baseWidth = rowStride;
+          surfaceWidthElems * static_cast<int64_t>(elemSizeInBytes);
+      baseWidth = b.i64_val(surfaceWidthElems);
+      int64_t pitchBytes =
+          std::max<int64_t>(MIN_PITCH, surfaceWidthBytes + ALIGNMENT_HEADROOM);
+      pitchBytes = (pitchBytes + 15) & ~15;
+      rowStride = b.i64_val(pitchBytes / elemSizeInBytes);
       baseHeight = b.i64_val(1);
+    } else {
+      // baseWidth is the row stride (surface width); baseHeight is the full
+      // tensor height so HW bounds checking spans the whole surface.
+      baseWidth = b.i64_val(stride);
+      baseHeight = b.i64_val(tensorShape[rank - 2]);
     }
 
     // Offsets start at 0; per-warp offsets computed by emit2DBlockPrefetchOps.

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1781,6 +1781,17 @@ struct PrefetchOpConversion
     // tile height, so the hardware's bounds checking spans the whole tensor.
     Value baseWidth = b.i64_val(stride);
     Value baseHeight = b.i64_val(tensorShape[rank - 2]);
+    if (stride == 0) {
+      // Broadcast row (e.g. M == 1): use a single row and a valid pitch from
+      // the contiguous dimension instead of stride 0 (see #7267).
+      constexpr int64_t MIN_PITCH = 64;
+      int64_t surfaceWidthBytes =
+          tensorShape[rank - 1] * static_cast<int64_t>(elemSizeInBytes);
+      rowStride = b.i64_val(std::max<int64_t>(MIN_PITCH, surfaceWidthBytes) /
+                            elemSizeInBytes);
+      baseWidth = rowStride;
+      baseHeight = b.i64_val(1);
+    }
 
     // Offsets start at 0; per-warp offsets computed by emit2DBlockPrefetchOps.
     Value offsetBaseX = b.i32_val(0);


### PR DESCRIPTION
A 2D block prefetch needs a valid pitch (pitch >= base_width, not zero). When the row stride is 0 (a broadcast row, e.g. M == 1), the prefetch used that 0 as the pitch and width, which is invalid and reads out of bounds -> segfault.

Fix: when the row stride is 0, use base_height = 1 and take the width/pitch from the row size. Same as the store path in #7267.

Fixes the segfault in test_max_autotune.py TestPrologueFusion (test_broadcast_x_K_64, test_mismatched_prologue_group). Adds a lit test.

Found here: https://github.com/intel/intel-xpu-backend-for-triton/pull/7279.
During the update to the new pin, issues were found in the new Inductor tests: test_max_autotune.py (TestPrologueFusion: test_broadcast_x_K_64 and test_mismatched_prologue_group).. 

Closes #7339 #7340 