### PR TITLE
[vLLM] Enable tensor-descriptor Q load for non-power-of-2 GQA (Qwen2-7B)

### DIFF
--- a/benchmarks/triton_kernels_benchmark/vllm/unified_attention/unified_attention.patch
+++ b/benchmarks/triton_kernels_benchmark/vllm/unified_attention/unified_attention.patch
@@ -1,18 +1,113 @@
 diff --git a/vllm/v1/attention/ops/triton_unified_attention.py b/vllm/v1/attention/ops/triton_unified_attention.py
-index 86ead168e..b288ea7fa 100644
+index f39e44286..27d7f9e61 100644
 --- a/vllm/v1/attention/ops/triton_unified_attention.py
 +++ b/vllm/v1/attention/ops/triton_unified_attention.py
-@@ -282,6 +282,9 @@ def kernel_unified_attention(
+@@ -98,11 +98,18 @@ def _load_q_td(
+         + (cur_batch_in_all_start_index + q_block_local_idx * BLOCK_Q) * query_stride_0
+         + (kv_head_idx * num_queries_per_kv) * query_stride_1
+     )
++    # ``BLOCK_M == BLOCK_Q * NQ_PADDED`` where ``NQ_PADDED`` is
++    # ``next_power_of_2(num_queries_per_kv)``.  The TD validator requires the
++    # flattened inner extent to be a power of 2, so we read ``NQ_PADDED`` heads
++    # worth of columns; the descriptor zero-pads the read past the real
++    # ``num_queries_per_kv * HEAD_SIZE`` extent (same as HEAD_SIZE_PADDED), and
++    # the padded head rows are masked out downstream via ``query_mask_1``.
++    NQ_PADDED: tl.constexpr = BLOCK_M // BLOCK_Q
+     q_desc = tl.make_tensor_descriptor(
+         base=q_base,
+         shape=(q_block_local_len, num_queries_per_kv * HEAD_SIZE),
+         strides=(query_stride_0, 1),
+-        block_shape=(BLOCK_Q, num_queries_per_kv * HEAD_SIZE_PADDED),
++        block_shape=(BLOCK_Q, NQ_PADDED * HEAD_SIZE_PADDED),
+     )
+     return q_desc.load([0, 0]).reshape(BLOCK_M, HEAD_SIZE_PADDED)
+ 
+@@ -251,12 +258,19 @@ def kernel_unified_attention(
+     # Per-(token, head) scale caches: used iff KV_QUANT_MODE in {2, 3}.
+     k_scale_cache_ptr=None,
+     v_scale_cache_ptr=None,
+-    stride_ks_blk: tl.int64 = None,
+-    stride_ks_slot: tl.int64 = None,
+-    stride_ks_head: tl.int64 = None,
+-    stride_vs_blk: tl.int64 = None,
+-    stride_vs_slot: tl.int64 = None,
+-    stride_vs_head: tl.int64 = None,
++    # ``tl.int64`` cannot be combined with a ``None`` default — Triton's JIT
++    # rejects ``Optional[tl.int64]`` / ``tl.int64 | None`` at trace time, and
++    # plain ``tl.int64 = None`` raises ``TypeError: 'NoneType' object cannot
++    # be interpreted as an integer`` when callers omit these arguments.
++    # ``int | None`` is the only annotation that lets the wrapper pass
++    # ``None`` here so Triton can skip materialising the strides when the
++    # ``USE_PER_TOKEN_HEAD_SCALES`` branch is dead.
++    stride_ks_blk: int | None = None,
++    stride_ks_slot: int | None = None,
++    stride_ks_head: int | None = None,
++    stride_vs_blk: int | None = None,
++    stride_vs_slot: int | None = None,
++    stride_vs_head: int | None = None,
+     # KV cache quantization mode handled inside this kernel via constexpr
+     # branches: NONE (0), FP8_PER_TENSOR (1), INT8_PER_TOKEN_HEAD (2),
+     # FP8_PER_TOKEN_HEAD (3).
+@@ -275,9 +289,22 @@ def kernel_unified_attention(
      USE_TD_QO: tl.constexpr = False,
      Q_IS_FP8: tl.constexpr = False,
  ):
+-    USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = KV_QUANT_MODE >= 2
 +    tl.static_assert(BLOCK_SIZE % TILE_SIZE == 0, "BLOCK_SIZE must be multiple of TILE_SIZE")
 +    tl.static_assert(BLOCK_SIZE >= TILE_SIZE, "BLOCK_SIZE must be >= TILE_SIZE")
 +
-     # Per-(token, head) scale caches: used iff KV_QUANT_MODE in {2, 3}.
-     USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = (KV_QUANT_MODE >= 2) and (
-         KV_QUANT_MODE <= 3
-@@ -522,12 +525,12 @@ def kernel_unified_attention(
++    # Per-(token, head) scale caches: used iff KV_QUANT_MODE in {2, 3}.
++    USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = (KV_QUANT_MODE >= 2) and (
++        KV_QUANT_MODE <= 3
++    )
+     USE_FP8_Q_DESCALE: tl.constexpr = KV_QUANT_MODE == 1 and Q_IS_FP8
+ 
++    # The TD *store* writes the real ``num_queries_per_kv`` heads and cannot pad
++    # (padded heads would corrupt the adjacent KV group's output). It is only
++    # valid when NQ_PADDED == num_queries_per_kv, i.e. pow2 GQA. The TD *load*
++    # can pad (zero-padded read), so non-pow2 GQA still benefits from a TD Q
++    # load while falling back to the masked pointer store.
++    USE_TD_STORE: tl.constexpr = USE_TD_QO and (BLOCK_M // BLOCK_Q == num_queries_per_kv)
++
+     if USE_TD:
+         tl.static_assert(
+             BLOCK_SIZE % TILE_SIZE == 0,
+@@ -317,10 +344,17 @@ def kernel_unified_attention(
+     offs_m = tl.arange(0, BLOCK_M)
+     offs_d = tl.arange(0, HEAD_SIZE_PADDED)
+     offs_t = tl.arange(0, TILE_SIZE)
+-    query_pos = q_block_local_idx * BLOCK_Q + offs_m // num_queries_per_kv
++    # Rows are packed as BLOCK_Q query positions x NQ_PADDED head slots, where
++    # NQ_PADDED = next_power_of_2(num_queries_per_kv) = BLOCK_M // BLOCK_Q.
++    # For pow2 GQA NQ_PADDED == num_queries_per_kv and this is unchanged; for
++    # non-pow2 GQA (e.g. Qwen2-7B nq=7) there are NQ_PADDED - nq padding slots
++    # per group that must be masked off so they don't alias the next KV group.
++    NQ_PADDED: tl.constexpr = BLOCK_M // BLOCK_Q
++    head_in_group = offs_m % NQ_PADDED
++    query_pos = q_block_local_idx * BLOCK_Q + offs_m // NQ_PADDED
+ 
+     query_offset_0 = cur_batch_in_all_start_index + query_pos
+-    query_offset_1 = kv_head_idx * num_queries_per_kv + offs_m % num_queries_per_kv
++    query_offset_1 = kv_head_idx * num_queries_per_kv + head_in_group
+     query_offset = (
+         query_offset_0[:, None] * query_stride_0
+         + query_offset_1[:, None] * query_stride_1
+@@ -329,7 +363,13 @@ def kernel_unified_attention(
+ 
+     dim_mask = tl.where(offs_d < HEAD_SIZE, 1, 0).to(tl.int1)
+     query_mask_0 = tl.where(query_pos < cur_batch_query_len, 1, 0).to(tl.int1)
+-    query_mask_1 = tl.where(query_offset_1 < num_query_heads, 1, 0).to(tl.int1)
++    # Mask both out-of-range query heads AND padding head slots
++    # (head_in_group >= num_queries_per_kv) introduced by NQ_PADDED packing.
++    query_mask_1 = tl.where(
++        (query_offset_1 < num_query_heads) & (head_in_group < num_queries_per_kv),
++        1,
++        0,
++    ).to(tl.int1)
+ 
+     # Q : (BLOCK_M, HEAD_SIZE_PADDED)
+     if USE_TD_QO:
+@@ -512,12 +552,12 @@ def kernel_unified_attention(
  
          # S : (BLOCK_M, TILE_SIZE)
          S = tl.zeros(shape=(BLOCK_M, TILE_SIZE), dtype=tl.float32)
@@ -29,7 +124,7 @@ index 86ead168e..b288ea7fa 100644
  
          if USE_SOFTCAP:
              S = apply_softcap(S, softcap)
-@@ -549,27 +552,14 @@ def kernel_unified_attention(
+@@ -539,34 +579,21 @@ def kernel_unified_attention(
          M, L, P, alpha = softmax_step(S, M, L)
          acc = acc * alpha[:, None]
  
@@ -61,16 +156,43 @@ index 86ead168e..b288ea7fa 100644
  
      # ---- Epilogue ---------------------------------------------------------
      if IS_3D:
-@@ -868,7 +858,7 @@ def unified_attention(
+         if USE_FP8_Q_DESCALE:
+             acc *= value_scale
+         # Store per-segment partials; finalized by ``reduce_segments``.
+-        if USE_TD_QO:
++        if USE_TD_STORE:
+             # 3D target: segm_output[token, head, segm_idx, :].  Advance
+             # the base to the correct (token-start, head-start, segm)
+             # slice; strides step between tokens / heads of the flattened
+@@ -625,7 +652,7 @@ def kernel_unified_attention(
+         if USE_FP8:
+             acc = acc * tl.load(out_scale)
+             acc = tl.clamp(acc, FP8_MIN, FP8_MAX)
+-        if USE_TD_QO:
++        if USE_TD_STORE:
+             # 2D target: flat output[token, head, :].  Strides come
+             # straight from the caller (``output_stride_0`` per token,
+             # ``output_stride_1`` per head).
+@@ -858,9 +885,16 @@ def unified_attention(
      head_size = q.shape[2]
  
      BLOCK_M = (
 -        16 if num_queries_per_kv <= 16 else triton.next_power_of_2(num_queries_per_kv)
 +        32 if num_queries_per_kv <= 32 else triton.next_power_of_2(num_queries_per_kv)
      )
-     BLOCK_Q = BLOCK_M // num_queries_per_kv
+-    BLOCK_Q = BLOCK_M // num_queries_per_kv
++    # Pack BLOCK_M rows as BLOCK_Q query positions x NQ_PADDED head slots, where
++    # NQ_PADDED = next_power_of_2(num_queries_per_kv). For pow2 GQA this is the
++    # original BLOCK_M // num_queries_per_kv; for non-pow2 GQA the padded head
++    # slots are masked in the kernel. Recompute BLOCK_M so it is an exact
++    # multiple of (BLOCK_Q * NQ_PADDED) — required for the TD Q load.
++    nq_padded = triton.next_power_of_2(num_queries_per_kv)
++    BLOCK_Q = max(BLOCK_M // nq_padded, 1)
++    BLOCK_M = BLOCK_Q * nq_padded
  
-@@ -913,12 +903,16 @@ def unified_attention(
+     # Tuned launch parameters; ``None`` lets Triton pick its defaults.
+     launch_num_warps: int | None = None
+@@ -903,12 +937,16 @@ def unified_attention(
      elif sliding_window_val <= 0:
          chunk_lookback = -1
  
@@ -93,7 +215,22 @@ index 86ead168e..b288ea7fa 100644
  
      # Wider KV tile for the tuned large-head path (see above). Only the 2D
      # path (used when max_seqlen_q > 1) reads TILE_SIZE_PREFILL.
-@@ -974,18 +968,11 @@ def unified_attention(
+@@ -938,9 +976,12 @@ def unified_attention(
+     # for Q/O in that case — KV tile loads are unaffected because their
+     # ``shape`` already matches ``block_shape`` on the inner axis.
+     head_size_padded = triton.next_power_of_2(head_size)
+-    _is_pow2_nq = (num_queries_per_kv & (num_queries_per_kv - 1)) == 0
+     _is_pow2_hs = head_size == head_size_padded
+-    use_td_qo = use_td and _is_pow2_nq and _is_pow2_hs
++    # Non-pow2 num_queries_per_kv is now supported by the TD Q load (it pads the
++    # head dimension to next_power_of_2 and the kernel masks the padding). The
++    # TD store still requires pow2 nq and is gated separately in-kernel
++    # (USE_TD_STORE); non-pow2 nq uses the masked pointer store.
++    use_td_qo = use_td and _is_pow2_hs
+ 
+     # ``_load_q_td`` / ``_store_output_td`` flatten ``(num_queries_per_kv,
+     # HEAD_SIZE)`` into a single contiguous inner axis.  That's only
+@@ -964,24 +1005,17 @@ def unified_attention(
      # Launch the 2D kernel if
      # 1. No intermediate tiled softmax buffers for the 3D kernel have been allocated, or
      # 2. The batch includes at least one prefill request, or
@@ -117,10 +254,35 @@ index 86ead168e..b288ea7fa 100644
  
      # The kernel signature is the same for 2D and 3D — only the launch
      # grid + a handful of constexpr toggles differ.  Per-token-head scale
-@@ -1006,6 +993,30 @@ def unified_attention(
-         v_scale_ptr = None
-     # 3D needs real segm tensors; 2D never touches them.  Pass ``None`` in
-     # 2D mode so Triton can skip materialising these pointer arguments.
+-    # caches and their strides are required arguments; non-per-token-head
+-    # modes pass dummy zeros (the code path is dead-code eliminated by
+-    # the ``USE_PER_TOKEN_HEAD_SCALES`` constexpr branch in the kernel).
++    # caches and their strides are passed as ``None`` when the
++    # ``USE_PER_TOKEN_HEAD_SCALES`` branch is dead so Triton can skip
++    # materialising those arguments and the associated registers.
+     if use_per_token_head_scales:
+         ks_strides = k_scale_cache.stride()
+         vs_strides = v_scale_cache.stride()
+@@ -990,16 +1024,39 @@ def unified_attention(
+         k_scale_ptr = k_scale_cache
+         v_scale_ptr = v_scale_cache
+     else:
+-        ks_blk = ks_slot = ks_head = 0
+-        vs_blk = vs_slot = vs_head = 0
+-        # Pass the K cache as a stand-in pointer; never dereferenced.
+-        k_scale_ptr = k
+-        v_scale_ptr = v
+-    # 3D needs real segm tensors; 2D never touches them but Triton wants
+-    # a non-null pointer.  Reuse ``out`` as the placeholder.
+-    segm_output_ptr = softmax_segm_output if use_3d else out
+-    segm_max_ptr = softmax_segm_max if use_3d else out
+-    segm_expsum_ptr = softmax_segm_expsum if use_3d else out
++        ks_blk = ks_slot = ks_head = None
++        vs_blk = vs_slot = vs_head = None
++        k_scale_ptr = None
++        v_scale_ptr = None
++    # 3D needs real segm tensors; 2D never touches them.  Pass ``None`` in
++    # 2D mode so Triton can skip materialising these pointer arguments.
 +    if use_3d:
 +        num_par_softmax_segments = 16
 +        softmax_segm_output = torch.empty(
@@ -145,6 +307,9 @@ index 86ead168e..b288ea7fa 100644
 +            dtype=torch.float32,
 +            device=q.device,
 +        )
-     segm_output_ptr = softmax_segm_output if use_3d else None
-     segm_max_ptr = softmax_segm_max if use_3d else None
-     segm_expsum_ptr = softmax_segm_expsum if use_3d else None
++    segm_output_ptr = softmax_segm_output if use_3d else None
++    segm_max_ptr = softmax_segm_max if use_3d else None
++    segm_expsum_ptr = softmax_segm_expsum if use_3d else None
+     num_segments = num_par_softmax_segments if use_3d else 1
+ 
+     grid: tuple[Any, ...]


### PR DESCRIPTION
Applies the non-power-of-2 GQA tensor-descriptor Q-load fix (see #7309) to the unified-attention benchmark via `unified_attention.patch`, so the micro-benchmark that surfaced the Qwen2-7B regression reflects the fix.

The benchmark patches the pinned `vllm-project/vllm` checkout. The fix also lives in the Intel vLLM fork (intel-innersource/applications.ai.gpu.vllm-xpu#207), but that is a different repo than this benchmark pins, so it will not flow in automatically — this patch is the mechanism by which the Triton benchmark carries the change. It can be dropped only if/when the fix lands in upstream `vllm-project/vllm` and the pin here is advanced.

Change: pack `BLOCK_M = BLOCK_Q * next_pow2(nq)`, pad the Q descriptor head dim to `NQ_PADDED`, mask the padding head slots in-kernel; TD store stays pow2-only (`USE_TD_STORE`), non-pow2 uses the masked pointer store. No-op for pow2 GQA. Verified on B60 vs a torch reference (2D/3D, decode, prefill, sliding-window, scattered block tables); ~2x faster Qwen2-7B prefill.

Full analysis: https://github.com/intel/intel-xpu-backend-for-triton/issues/7309