### PR TITLE
[vLLM] Add tests to fill coverage gap

### DIFF
--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -136,13 +136,13 @@ jobs:
       fail-fast: false
       matrix:
         suite:
-          # - vllm-spec-decode
+          - vllm-spec-decode
           - vllm-mrv2
           - vllm-moe
-          # - vllm-triton-attn
+          - vllm-triton-attn
           - vllm-mamba
-          # - vllm-quant
-          # - vllm-rest
+          - vllm-quant
+          - vllm-rest
     runs-on:
       - linux
       - ${{ inputs.runner_label || 'max1550' }}

--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -136,13 +136,13 @@ jobs:
       fail-fast: false
       matrix:
         suite:
-          - vllm-spec-decode
+          # - vllm-spec-decode
           - vllm-mrv2
           - vllm-moe
-          - vllm-triton-attn
+          # - vllm-triton-attn
           - vllm-mamba
-          - vllm-quant
-          - vllm-rest
+          # - vllm-quant
+          # - vllm-rest
     runs-on:
       - linux
       - ${{ inputs.runner_label || 'max1550' }}

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -959,7 +959,8 @@ run_vllm_mrv2_tests() {
       tests/v1/worker/test_gpu_input_batch.py \
       tests/v1/worker/test_gpu_model_runner_v2_eplb.py \
       tests/v1/sample/test_sampler.py \
-      tests/v1/sample/test_logprobs.py
+      tests/v1/sample/test_logprobs.py \
+      tests/v1/worker/test_gpu_gumbel_sample.py
 }
 
 
@@ -1038,7 +1039,8 @@ run_vllm_mamba_tests() {
       tests/kernels/mamba/test_causal_conv1d.py \
       tests/kernels/mamba/test_mamba_ssm.py \
       tests/kernels/mamba/test_mamba_ssm_ssd.py \
-      tests/kernels/mamba/test_mamba_mixer2.py
+      tests/kernels/mamba/test_mamba_mixer2.py \
+      tests/kernels/mamba/test_ssu_dispatch.py
 }
 
 
@@ -1061,7 +1063,8 @@ run_vllm_quant_tests() {
       tests/kernels/quantization/test_block_int8.py \
       tests/kernels/quantization/test_fp8_quant.py \
       tests/kernels/quantization/test_fp8_quant_group.py \
-      tests/kernels/quantization/test_block_fp8.py
+      tests/kernels/quantization/test_block_fp8.py \
+      tests/kernels/moe/test_silu_mul_per_token_group_quant_fp8_colmajor.py
 }
 
 

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -983,7 +983,8 @@ run_vllm_moe_tests() {
       tests/kernels/moe/test_triton_moe_ptpc_fp8.py \
       tests/kernels/moe/test_silu_mul_fp8_quant_deep_gemm.py \
       tests/kernels/moe/test_batched_deepgemm.py \
-      tests/kernels/moe/test_gpt_oss_triton_kernels.py
+      tests/kernels/moe/test_gpt_oss_triton_kernels.py \
+      tests/kernels/moe/test_silu_mul_per_token_group_quant_fp8_colmajor.py
 }
 
 
@@ -1063,8 +1064,7 @@ run_vllm_quant_tests() {
       tests/kernels/quantization/test_block_int8.py \
       tests/kernels/quantization/test_fp8_quant.py \
       tests/kernels/quantization/test_fp8_quant_group.py \
-      tests/kernels/quantization/test_block_fp8.py \
-      tests/kernels/moe/test_silu_mul_per_token_group_quant_fp8_colmajor.py
+      tests/kernels/quantization/test_block_fp8.py
 }
 
 


### PR DESCRIPTION
This patch adds the following tests to our the vllm test-suite:
-  `tests/kernels/moe/test_silu_mul_per_token_group_quant_fp8_colmajor.py` tests `_per_token_group_quant_fp8_colmajor`
- `tests/v1/worker/test_gpu_gumbel_sample.py` tests `_gumbel_sample_kernel`
- `tests/kernels/mamba/test_ssu_dispatch.py` tests `_selective_scan_update_kernel`

Part of https://github.com/intel/intel-xpu-backend-for-triton/issues/7213.

---

vLLM tests: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/28599489041
vLLM tests BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/28599511084