### PR TITLE
[vLLM] Add kda tests

### DIFF
--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -268,7 +268,7 @@ jobs:
         run: |
           ${{ env.TRITON_TEST_CMD }} --vllm-quant
 
-      # vllm-rest groups short suites: gdn-attn, linear-attn, deepgemm
+      # vllm-rest groups short suites: gdn-attn, linear-attn, deepgemm, kda
       - name: Run gdn-attn tests
         if: ${{ matrix.suite == 'vllm-rest' && steps.install-vllm.outcome == 'success' && !cancelled() }}
         run: |
@@ -283,6 +283,11 @@ jobs:
         if: ${{ matrix.suite == 'vllm-rest' && steps.install-vllm.outcome == 'success' && !cancelled() }}
         run: |
           ${{ env.TRITON_TEST_CMD }} --vllm-deepgemm
+
+      - name: Run kda tests
+        if: ${{ matrix.suite == 'vllm-rest' && steps.install-vllm.outcome == 'success' && !cancelled() }}
+        run: |
+          ${{ env.TRITON_TEST_CMD }} --vllm-kda
 
       - name: Save pip cache
         if: ${{ steps.pip-cache.outputs.status == 'miss' }}

--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -142,6 +142,7 @@ jobs:
           - vllm-triton-attn
           - vllm-mamba
           - vllm-quant
+          - vllm-kda
           - vllm-rest
     runs-on:
       - linux
@@ -268,7 +269,12 @@ jobs:
         run: |
           ${{ env.TRITON_TEST_CMD }} --vllm-quant
 
-      # vllm-rest groups short suites: gdn-attn, linear-attn, deepgemm, kda
+      - name: Run kda tests
+        if: ${{ matrix.suite == 'vllm-kda' && steps.install-vllm.outcome == 'success' && !cancelled() }}
+        run: |
+          ${{ env.TRITON_TEST_CMD }} --vllm-kda
+
+      # vllm-rest groups short suites: gdn-attn, linear-attn, deepgemm
       - name: Run gdn-attn tests
         if: ${{ matrix.suite == 'vllm-rest' && steps.install-vllm.outcome == 'success' && !cancelled() }}
         run: |
@@ -283,11 +289,6 @@ jobs:
         if: ${{ matrix.suite == 'vllm-rest' && steps.install-vllm.outcome == 'success' && !cancelled() }}
         run: |
           ${{ env.TRITON_TEST_CMD }} --vllm-deepgemm
-
-      - name: Run kda tests
-        if: ${{ matrix.suite == 'vllm-rest' && steps.install-vllm.outcome == 'success' && !cancelled() }}
-        run: |
-          ${{ env.TRITON_TEST_CMD }} --vllm-kda
 
       - name: Save pip cache
         if: ${{ steps.pip-cache.outputs.status == 'miss' }}

--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -136,14 +136,14 @@ jobs:
       fail-fast: false
       matrix:
         suite:
-          - vllm-spec-decode
-          - vllm-mrv2
-          - vllm-moe
-          - vllm-triton-attn
-          - vllm-mamba
-          - vllm-quant
+          #- vllm-spec-decode
+          #- vllm-mrv2
+          #- vllm-moe
+          #- vllm-triton-attn
+          #- vllm-mamba
+          #- vllm-quant
           - vllm-kda
-          - vllm-rest
+          #- vllm-rest
     runs-on:
       - linux
       - ${{ inputs.runner_label || 'max1550' }}

--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -136,14 +136,14 @@ jobs:
       fail-fast: false
       matrix:
         suite:
-          #- vllm-spec-decode
-          #- vllm-mrv2
-          #- vllm-moe
-          #- vllm-triton-attn
-          #- vllm-mamba
-          #- vllm-quant
+          - vllm-spec-decode
+          - vllm-mrv2
+          - vllm-moe
+          - vllm-triton-attn
+          - vllm-mamba
+          - vllm-quant
           - vllm-kda
-          #- vllm-rest
+          - vllm-rest
     runs-on:
       - linux
       - ${{ inputs.runner_label || 'max1550' }}

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -1101,9 +1101,11 @@ run_vllm_kda_tests() {
   echo "******  Running vLLM KDA tests                   *******"
   echo "********************************************************"
 
-  # No dedicated kernel tests exist yet — KDA is model-level integration only.
-  # This is a placeholder for when kernel-level tests are added.
-  echo "WARNING: No dedicated KDA kernel tests available. Skipping."
+  enter_vllm_test_env
+  TRITON_TEST_SUITE=vllm_kda \
+    run_pytest_command -vvv \
+      tests/kernels/test_kda.py \
+      tests/kernels/core/test_fused_rms_norm_gated.py
 }
 
 

--- a/scripts/vllm/vllm_xpu_patch.py
+++ b/scripts/vllm/vllm_xpu_patch.py
@@ -56,7 +56,7 @@ def _find_cuda_patterns(source: str) -> list[dict]:
                     "col": node.value.col_offset,
                 })
 
-        # torch.device("cuda") and torch.device(f"cuda:{index}") calls
+        # torch.device("cuda"), torch.device("cuda:0"), and torch.device(f"cuda:{index}") calls
         if isinstance(node, ast.Call):
             func = node.func
             is_torch_device = (isinstance(func, ast.Attribute) and func.attr == "device"
@@ -65,6 +65,13 @@ def _find_cuda_patterns(source: str) -> list[dict]:
                                                             ast.Constant) and node.args[0].value == "cuda":
                 patterns.append({
                     "type": "torch_device",
+                    "line": node.args[0].lineno,
+                    "col": node.args[0].col_offset,
+                })
+            if (is_torch_device and node.args and isinstance(node.args[0], ast.Constant)
+                    and isinstance(node.args[0].value, str) and node.args[0].value.startswith("cuda:")):
+                patterns.append({
+                    "type": "torch_device_indexed",
                     "line": node.args[0].lineno,
                     "col": node.args[0].col_offset,
                 })
@@ -183,6 +190,10 @@ def _apply_patches(source: str, patterns: list[dict]) -> str:
             # Replace "cuda" with "xpu" in device arguments
             lines[line_idx] = line.replace('"cuda"', '"xpu"', 1)
 
+        elif ptype == "torch_device_indexed":
+            # Replace "cuda:N" with "xpu:N" in torch.device call
+            lines[line_idx] = line.replace('"cuda:', '"xpu:', 1).replace("'cuda:", "'xpu:", 1)
+
         elif ptype == "torch_device_fstring":
             # Replace f"cuda:" with f"xpu:" in torch.device call
             lines[line_idx] = line.replace('f"cuda:', 'f"xpu:', 1).replace("f'cuda:", "f'xpu:", 1)
@@ -261,10 +272,7 @@ def main() -> None:
     # Patch test files and source files that need CUDA->XPU transformation
     patch_dirs = [
         # Test directories
-        vllm_root / "tests" / "kernels" / "attention",
-        vllm_root / "tests" / "kernels" / "mamba",
-        vllm_root / "tests" / "kernels" / "moe",
-        vllm_root / "tests" / "kernels" / "quantization",
+        vllm_root / "tests" / "kernels",
         vllm_root / "tests" / "v1" / "sample",
         vllm_root / "tests" / "v1" / "spec_decode",
         vllm_root / "tests" / "v1" / "worker",


### PR DESCRIPTION
This patch implements a vLLM sub-suite for kda kernels our repo.

Closes https://github.com/intel/intel-xpu-backend-for-triton/issues/6596.

Part of https://github.com/intel/intel-xpu-backend-for-triton/issues/7213.

---

vLLM tests: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/28606732989
vLLM tests BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/28606744874