### PR TITLE
[BLOCKIO] Support VNNI transform 2D block IO when sub-group-size=32.

### DIFF
--- a/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
+++ b/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
@@ -167,3 +167,31 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
     tt.return
   }
 }
+
+// -----
+
+// COM: Test subgroup-size=32 DotOp-B block load lowers with VNNI transform.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 32, warpsPerCTA = [2, 2], repCluster = [1, 1], A = [16, 16], B = [16, 16], C = [16, 16]}>
+#dot = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: @block_load_dot_a_subgroup32_vnni
+  tt.func public @block_load_dot_a_subgroup32_vnni(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
+    // CHECK: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 1, transpose = false, vnni_transform = true, cache_control = Default}
+    %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] {row_major} : !tt.ptr<f16> -> tensor<128x32xf16, #dot>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Test subgroup-size=32 DotOp-B bf8 block load lowers with VNNI transform.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 4, threadsPerWarp = 32, warpsPerCTA = [2, 2], repCluster = [1, 1], A = [16, 32], B = [32, 16], C = [16, 16]}>
+#dot = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 4}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: @block_load_dot_a_subgroup32_vnni_bf8
+  tt.func public @block_load_dot_a_subgroup32_vnni_bf8(%arg0: !tt.ptr<f8E5M2>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
+    // CHECK: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 8, tile_width = 16, tile_height = 32, v_blocks = 1, transpose = false, vnni_transform = true, cache_control = Default}
+    %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] {row_major} : !tt.ptr<f8E5M2> -> tensor<128x32xf8E5M2, #dot>
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
+++ b/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
@@ -174,8 +174,8 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 32, warpsPerCTA = [2, 2], repCluster = [1, 1], A = [16, 16], B = [16, 16], C = [16, 16]}>
 #dot = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, "ttig.support_2d_block_io"} {
-  // CHECK-LABEL: @block_load_dot_a_subgroup32_vnni
-  tt.func public @block_load_dot_a_subgroup32_vnni(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
+  // CHECK-LABEL: @block_load_dot_b_subgroup32_vnni
+  tt.func public @block_load_dot_b_subgroup32_vnni(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
     // CHECK: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 32, v_blocks = 1, transpose = false, vnni_transform = true, cache_control = Default}
     %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] {row_major} : !tt.ptr<f16> -> tensor<128x32xf16, #dot>
     tt.return
@@ -188,8 +188,8 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32,
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 4, threadsPerWarp = 32, warpsPerCTA = [2, 2], repCluster = [1, 1], A = [16, 32], B = [32, 16], C = [16, 16]}>
 #dot = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 4}>
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, "ttig.support_2d_block_io"} {
-  // CHECK-LABEL: @block_load_dot_a_subgroup32_vnni_bf8
-  tt.func public @block_load_dot_a_subgroup32_vnni_bf8(%arg0: !tt.ptr<f8E5M2>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
+  // CHECK-LABEL: @block_load_dot_b_subgroup32_vnni_bf8
+  tt.func public @block_load_dot_b_subgroup32_vnni_bf8(%arg0: !tt.ptr<f8E5M2>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
     // CHECK: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 8, tile_width = 16, tile_height = 32, v_blocks = 1, transpose = false, vnni_transform = true, cache_control = Default}
     %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] {row_major} : !tt.ptr<f8E5M2> -> tensor<128x32xf8E5M2, #dot>
     tt.return

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
@@ -23,13 +23,14 @@ struct BlockIOTileSizeInfo {
   BlockIOTileSizeInfo() = delete;
   BlockIOTileSizeInfo(int tileHeight, int tileWidth, int numElemPerPackedVal,
                       int vBlocks, int rowDim, int colDim, bool transpose,
+                      bool vnni,
                       std::optional<SetVector<unsigned>> regPackedBases)
       : tileHeight(tileHeight), tileWidth(tileWidth),
         numElemPerPackedVal(numElemPerPackedVal), vBlocks(vBlocks),
-        rowDim(rowDim), colDim(colDim), transpose(transpose),
+        rowDim(rowDim), colDim(colDim), transpose(transpose), vnni(vnni),
         regPackedBases(regPackedBases) {}
   static BlockIOTileSizeInfo unknown() {
-    return {-1, -1, -1, -1, -1, -1, false, std::nullopt};
+    return {-1, -1, -1, -1, -1, -1, false, false, std::nullopt};
   }
 
   int tileHeight;
@@ -39,6 +40,7 @@ struct BlockIOTileSizeInfo {
   int rowDim;
   int colDim;
   bool transpose;
+  bool vnni;
   std::optional<SetVector<unsigned>> regPackedBases;
 
   bool isValid() const {

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1008,7 +1008,7 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
     // type. Note: the cfg.numPackedVals is still 1 for VNNI format which it is
     // not same as non-vnni packing.
     cfg.numValuesPerLoad =
-        mlir::ceil((unsigned)cfg.numElemsPerLoad,
+        mlir::ceil(static_cast<unsigned>(cfg.numElemsPerLoad),
                    sizeInfo.vnni ? (32 / elemSizeInBits) : cfg.numPackedVals);
     cfg.packedType =
         IntegerType::get(ctx, sizeInfo.vnni ? 32 : cfg.packedElemSizeInBits);
@@ -2655,6 +2655,7 @@ struct DescriptorStoreOpToBlockIOConversion
     auto [tileHeight, tileWidth, numPackedVals, vBlocks, rowDim, colDim,
           isTransposeRequired, useVNNIFormat, regPackedBases] =
         std::move(sizeInfo);
+    assert(!useVNNIFormat && "2D block store does not support VNNI");
     unsigned packedElemSizeInBits = elemSizeInBits * numPackedVals;
 
     Location loc = op.getLoc();
@@ -2918,6 +2919,7 @@ struct StoreOpToBlockIOConversion
     auto [tileHeight, tileWidth, numPackedVals, vBlocks, rowDim, colDim,
           isTransposeRequired, useVNNIFormat, regPackedBases] =
         std::move(sizeInfo);
+    assert(!useVNNIFormat && "2D block store does not support VNNI");
     unsigned packedElemSizeInBits = elemSizeInBits * numPackedVals;
 
     Location loc = op.getLoc();
@@ -4111,8 +4113,8 @@ struct Subgroup2DBlockLoadFromPtrOpConversion
       sizeInfo =
           BlockIOTileSizeInfo(height, width, /*numElemPerPackedVal=*/1,
                               /*vBlocks=*/1, /*rowDim=*/0,
-                              /*colDim=*/rank - 1, false, /*transpose=*/false,
-                              std::move(regPackBases));
+                              /*colDim=*/rank - 1, /*vnni=*/false,
+                              /*transpose=*/false, std::move(regPackBases));
     } else {
       sizeInfo =
           getBlockIOTileSize<true>(*llEncoding, contiguousDim, elemSizeInBits,

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -4110,11 +4110,10 @@ struct Subgroup2DBlockLoadFromPtrOpConversion
       SetVector<unsigned> regPackBases;
       for (unsigned i = 1; i < regDimSize; i <<= 1)
         regPackBases.insert(i);
-      sizeInfo =
-          BlockIOTileSizeInfo(height, width, /*numElemPerPackedVal=*/1,
-                              /*vBlocks=*/1, /*rowDim=*/0,
-                              /*colDim=*/rank - 1, /*vnni=*/false,
-                              /*transpose=*/false, std::move(regPackBases));
+      sizeInfo = BlockIOTileSizeInfo(height, width, /*numElemPerPackedVal=*/1,
+                                     /*vBlocks=*/1, /*rowDim=*/0,
+                                     /*colDim=*/rank - 1, /*transpose=*/false,
+                                     /*vnni=*/false, std::move(regPackBases));
     } else {
       sizeInfo =
           getBlockIOTileSize<true>(*llEncoding, contiguousDim, elemSizeInBits,

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1026,7 +1026,7 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
     cfg.unpackedType = dpasCfg.unpackedType;
     cfg.load2DGenXType = dpasCfg.load2DGenXType;
     cfg.packedType = dpasCfg.packedType;
-    cfg.useVNNIFormat = sizeInfo.vnni | dpasCfg.useVNNIFormat;
+    cfg.useVNNIFormat = sizeInfo.vnni || dpasCfg.useVNNIFormat;
     cfg.tileHeight = dpasCfg.tileHeight;
     cfg.tileWidth = dpasCfg.tileWidth;
     cfg.vBlocks = dpasCfg.vBlocks;

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1004,9 +1004,14 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
         mlir::ceil(sizeInfo.tileHeight * sizeInfo.tileWidth *
                        static_cast<int>(cfg.numPackedVals) * sizeInfo.vBlocks,
                    static_cast<int>(threadsPerWarp));
-    cfg.numValuesPerLoad = mlir::ceil(static_cast<int>(cfg.numElemsPerLoad),
-                                      static_cast<int>(cfg.numPackedVals));
-    cfg.packedType = IntegerType::get(ctx, cfg.packedElemSizeInBits);
+    // For the VNNI hardware format, use the packed i32 type as the load result
+    // type. Note: the cfg.numPackedVals is still 1 for VNNI format which it is
+    // not same as non-vnni packing.
+    cfg.numValuesPerLoad =
+        mlir::ceil((unsigned)cfg.numElemsPerLoad,
+                   sizeInfo.vnni ? (32 / elemSizeInBits) : cfg.numPackedVals);
+    cfg.packedType =
+        IntegerType::get(ctx, sizeInfo.vnni ? 32 : cfg.packedElemSizeInBits);
     cfg.load2DGenXType =
         LLVM::getVectorType(cfg.packedType, cfg.numValuesPerLoad);
     cfg.unpackedType = LLVM::getVectorType(eltTy, cfg.numElemsPerLoad);
@@ -1021,7 +1026,7 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
     cfg.unpackedType = dpasCfg.unpackedType;
     cfg.load2DGenXType = dpasCfg.load2DGenXType;
     cfg.packedType = dpasCfg.packedType;
-    cfg.useVNNIFormat = dpasCfg.useVNNIFormat;
+    cfg.useVNNIFormat = sizeInfo.vnni | dpasCfg.useVNNIFormat;
     cfg.tileHeight = dpasCfg.tileHeight;
     cfg.tileWidth = dpasCfg.tileWidth;
     cfg.vBlocks = dpasCfg.vBlocks;
@@ -2648,7 +2653,8 @@ struct DescriptorStoreOpToBlockIOConversion
       return failure();
 
     auto [tileHeight, tileWidth, numPackedVals, vBlocks, rowDim, colDim,
-          isTransposeRequired, regPackedBases] = std::move(sizeInfo);
+          isTransposeRequired, useVNNIFormat, regPackedBases] =
+        std::move(sizeInfo);
     unsigned packedElemSizeInBits = elemSizeInBits * numPackedVals;
 
     Location loc = op.getLoc();
@@ -2889,7 +2895,7 @@ struct StoreOpToBlockIOConversion
       sizeInfo = BlockIOTileSizeInfo(height, width, /*numElemPerPackedVal=*/1,
                                      /*vBlocks=*/1, /*rowDim=*/0,
                                      /*colDim=*/rank - 1, /*transpose=*/false,
-                                     std::move(regPackBases));
+                                     /*vnni=*/false, std::move(regPackBases));
       // The reshape path bypasses getBlockIOTileSize (and thus
       // validate2DBlockStoreTile), so apply the HW address payload restriction
       // here; vBlocks and transpose are already fixed (1 / false) above.
@@ -2910,7 +2916,8 @@ struct StoreOpToBlockIOConversion
     }
 
     auto [tileHeight, tileWidth, numPackedVals, vBlocks, rowDim, colDim,
-          isTransposeRequired, regPackedBases] = std::move(sizeInfo);
+          isTransposeRequired, useVNNIFormat, regPackedBases] =
+        std::move(sizeInfo);
     unsigned packedElemSizeInBits = elemSizeInBits * numPackedVals;
 
     Location loc = op.getLoc();
@@ -4101,10 +4108,11 @@ struct Subgroup2DBlockLoadFromPtrOpConversion
       SetVector<unsigned> regPackBases;
       for (unsigned i = 1; i < regDimSize; i <<= 1)
         regPackBases.insert(i);
-      sizeInfo = BlockIOTileSizeInfo(height, width, /*numElemPerPackedVal=*/1,
-                                     /*vBlocks=*/1, /*rowDim=*/0,
-                                     /*colDim=*/rank - 1, /*transpose=*/false,
-                                     std::move(regPackBases));
+      sizeInfo =
+          BlockIOTileSizeInfo(height, width, /*numElemPerPackedVal=*/1,
+                              /*vBlocks=*/1, /*rowDim=*/0,
+                              /*colDim=*/rank - 1, false, /*transpose=*/false,
+                              std::move(regPackBases));
     } else {
       sizeInfo =
           getBlockIOTileSize<true>(*llEncoding, contiguousDim, elemSizeInBits,

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -129,6 +129,7 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
   // transpose, we'd prefer smaller d32 type cause hardware could
   // transpose more to reduce the number of mov operation in register.
   constexpr unsigned MAX_BITS_TRANSPOSE = 32;
+  constexpr unsigned MAX_BITS_VNNI = 32;
   constexpr unsigned MAX_BITS_WIDTH_NORMAL = 64 * 8;       // 64 bytes.
   constexpr unsigned MAX_BITS_WIDTH_TRANSPOSE = 8 * 4 * 8; // 8xd32. (and 4xd64)
   constexpr unsigned TRANSPOSE_LOAD_D64_HEIGHT = 8;
@@ -145,42 +146,61 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
   unsigned MAX_BITS_WIDTH =
       transpose ? MAX_BITS_WIDTH_TRANSPOSE : MAX_BITS_WIDTH_NORMAL;
 
-  unsigned maxElemPackedVal = mlir::ceil<unsigned>(
-      transpose ? MAX_BITS_TRANSPOSE : MAX_BITS_NORMAL, elemSizeInBits);
   SetVector<unsigned> regPackBases;
-  for (unsigned regBaseIter = 0; regBaseIter < basesOfRegister.size();
-       ++regBaseIter) {
-    if (numElemPerPackedVal >= maxElemPackedVal) {
-      // Reached the maximum number of elements per packed value.
-      break;
+  auto packRegister = [&](unsigned dim, unsigned maxPackNum) {
+    for (unsigned regBaseIter = 0; regBaseIter < basesOfRegister.size();
+         ++regBaseIter) {
+      if (numElemPerPackedVal >= maxPackNum) {
+        // Reached the maximum number of elements per packed value.
+        break;
+      }
+      const std::vector<int> &base = basesOfRegister[regBaseIter];
+      if (!validateBase(base))
+        continue; // Skip as the register can not be trivial packed.
+      int baseDim = getFirstNonZeroDim(base);
+      if (dim == baseDim) {
+        if (tileShape[dim] != base[dim])
+          continue; // Skip the register not in dense tile.
+        // The value can be loaded as packed value.
+        tileShape[dim] <<= 1;
+        numElemPerPackedVal <<= 1;
+        regPackBases.insert(1 << regBaseIter);
+      }
     }
-    const std::vector<int> &base = basesOfRegister[regBaseIter];
-    if (!validateBase(base))
-      continue; // Skip as the register can not be trivial packed.
-    int dim = getFirstNonZeroDim(base);
-    if (memContiguousDim == dim) {
-      if (tileShape[dim] != base[dim])
-        continue; // Skip the register not in dense tile.
-      // The value can be loaded as packed value.
-      tileShape[dim] <<= 1;
-      numElemPerPackedVal <<= 1;
-      regPackBases.insert(1 << regBaseIter);
-    }
-  }
+  };
+
+  packRegister(
+      memContiguousDim,
+      mlir::ceil<unsigned>(transpose ? MAX_BITS_TRANSPOSE : MAX_BITS_NORMAL,
+                           elemSizeInBits));
 
   // For the transpose case, we have to pack the elements to d32.
-  if (transpose && numElemPerPackedVal != maxElemPackedVal)
+  if (transpose && (numElemPerPackedVal * elemSizeInBits) != MAX_BITS_TRANSPOSE)
     return BlockIOTileSizeInfo::unknown();
 
   // We already get the basic tile shape in packing values.
   // To increase the tile shape along each lane dimension.
+  bool vnni = false;
   for (const std::vector<int> &base : basesOfLane) {
     if (!validateBase(base))
       break; // break if the lane bases are not trivial.
     int dim = getFirstNonZeroDim(base);
     if (tileShape[dim] != base[dim]) {
-      // TODO: Check whether we can add an VNNI pack to make a larger tile.
-      break;
+      if (numElemPerPackedVal == 1) {
+        // There are no register packing. Try to pack here.
+        if (dim != fastChangeDim) {
+          // VNNI pack:
+          packRegister(dim,
+                       mlir::ceil<unsigned>(MAX_BITS_VNNI, elemSizeInBits));
+          if ((numElemPerPackedVal * elemSizeInBits) == MAX_BITS_VNNI)
+            vnni = true;
+        }
+      }
+      if (tileShape[dim] != base[dim]) {
+        // break if we can not increase the tile shape along this dim after
+        // packing.
+        break;
+      }
     }
     tileShape[dim] <<= 1;
   }
@@ -379,9 +399,14 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
     // insert the remaining register base.
     regPackBases.insert(1 << regBaseIter);
   }
+
+  // VNNI packing is not like non-vnni packing elements to a packed value which
+  // is transparent to HW.
+  unsigned packedValueNumber = vnni ? 1 : numElemPerPackedVal;
+
   int tileHeight = tileShape[transpose ? fastChangeDim : rowDim];
   int tileWidth =
-      tileShape[transpose ? rowDim : fastChangeDim] / numElemPerPackedVal;
+      tileShape[transpose ? rowDim : fastChangeDim] / packedValueNumber;
 
   // Cap vBlocks for loads based on HW constraints.
   if constexpr (isLoad) {
@@ -399,8 +424,8 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
       vBlocks = 1;
   }
 
-  return BlockIOTileSizeInfo(tileHeight, tileWidth, numElemPerPackedVal,
-                             vBlocks, rowDim, fastChangeDim, transpose,
+  return BlockIOTileSizeInfo(tileHeight, tileWidth, packedValueNumber, vBlocks,
+                             rowDim, fastChangeDim, transpose, vnni,
                              std::move(regPackBases));
 }
 
@@ -612,6 +637,10 @@ bool validate2DBlockStoreTile(const LinearLayout &ll, unsigned memContiguousDim,
 
   // 2D block store does not support transpose.
   if (sizeInfo.transpose)
+    return false;
+
+  // 2D block store does not support vnni packing.
+  if (sizeInfo.vnni)
     return false;
 
   // The store always issues a single v-block per message.

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -174,8 +174,9 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
       mlir::ceil<unsigned>(transpose ? MAX_BITS_TRANSPOSE : MAX_BITS_NORMAL,
                            elemSizeInBits));
 
-  // For the transpose case, we have to pack the elements to d32.
-  if (transpose && (numElemPerPackedVal * elemSizeInBits) != MAX_BITS_TRANSPOSE)
+  // For the transpose case, elements up to d32 must be packed to d32.
+  if (transpose && elemSizeInBits <= MAX_BITS_TRANSPOSE &&
+      (numElemPerPackedVal * elemSizeInBits) != MAX_BITS_TRANSPOSE)
     return BlockIOTileSizeInfo::unknown();
 
   // We already get the basic tile shape in packing values.

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -401,7 +401,7 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
     regPackBases.insert(1 << regBaseIter);
   }
 
-  // VNNI packing is not like non-vnni packing elements to a packed value which
+  // VNNI packing doesn't impacts the tileWidth and tileHeight which
   // is transparent to HW.
   unsigned packedValueNumber = vnni ? 1 : numElemPerPackedVal;
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -188,18 +188,29 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
     int dim = getFirstNonZeroDim(base);
     if (tileShape[dim] != base[dim]) {
       if (numElemPerPackedVal == 1) {
-        // There are no register packing. Try to pack here.
+        // There is no register packing yet.
         if (dim != fastChangeDim) {
-          // VNNI pack:
+          // Try to pack along the non-fast change dim with VNNI capability.
           packRegister(dim,
                        mlir::ceil<unsigned>(MAX_BITS_VNNI, elemSizeInBits));
-          if ((numElemPerPackedVal * elemSizeInBits) == MAX_BITS_VNNI)
-            vnni = true;
+          if (numElemPerPackedVal != 1) {
+            // Check if packRegister partially packed the register along the
+            // non-fast change dim.
+            if ((numElemPerPackedVal * elemSizeInBits) == MAX_BITS_VNNI) {
+              vnni = true;
+            } else {
+              // break if the numElemPerPackedVal not matched to the VNNI
+              // packing bits number.
+              return BlockIOTileSizeInfo::unknown();
+            }
+          }
         }
       }
+      // Temply changed tileShape by packRegister is safe because the
+      // lane-density check below will reject it.
       if (tileShape[dim] != base[dim]) {
         // break if we can not increase the tile shape along this dim after
-        // packing.
+        // VNNI packing.
         break;
       }
     }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -206,7 +206,7 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
           }
         }
       }
-      // Temply changed tileShape by packRegister is safe because the
+      // Temporarily changed tileShape by packRegister is safe because the
       // lane-density check below will reject it.
       if (tileShape[dim] != base[dim]) {
         // break if we can not increase the tile shape along this dim after

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -401,7 +401,7 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
     regPackBases.insert(1 << regBaseIter);
   }
 
-  // VNNI packing doesn't impacts the tileWidth and tileHeight which
+  // VNNI packing doesn't impact the tileWidth and tileHeight which
   // is transparent to HW.
   unsigned packedValueNumber = vnni ? 1 : numElemPerPackedVal;
 


### PR DESCRIPTION
This PR extends the Intel XPU Triton 2D Block I/O support to handle VNNI-format packing for sub-group-size=32 by carrying an explicit vnni flag through tile-size computation (getBlockIOTileSize) into the LLVM lowering, and adjusting load type/legalization accordingly.