### PR TITLE
[LoopDistribute] Add loop distribution pass for multi-dot loops (2 dots operations only)

### DIFF
--- a/benchmarks/triton_kernels_benchmark/fused_gemm_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/fused_gemm_benchmark.py
@@ -33,6 +33,7 @@ def get_fused_gemm_autotune_configs() -> list[triton.Config]:
                 'BLOCK_SIZE_K': BK,
                 'GROUP_SIZE_M': G,
                 'grf_mode': '256',
+                'loop_distribute': LD,
             },
             num_stages=s,
             num_warps=w,
@@ -43,6 +44,7 @@ def get_fused_gemm_autotune_configs() -> list[triton.Config]:
         for G in [4, 8, 16]
         for s in [2, 3, 4]
         for w in [8, 16, 32]
+        for LD in [False, True]
     ]
 
 

--- a/benchmarks/triton_kernels_benchmark/fused_gemm_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/fused_gemm_benchmark.py
@@ -33,7 +33,7 @@ def get_fused_gemm_autotune_configs() -> list[triton.Config]:
                 'BLOCK_SIZE_K': BK,
                 'GROUP_SIZE_M': G,
                 'grf_mode': '256',
-                'loop_distribute': LD,
+                'loop_distribute': True,
             },
             num_stages=s,
             num_warps=w,
@@ -44,7 +44,6 @@ def get_fused_gemm_autotune_configs() -> list[triton.Config]:
         for G in [4, 8, 16]
         for s in [2, 3, 4]
         for w in [8, 16, 32]
-        for LD in [False, True]
     ]
 
 

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -595,6 +595,7 @@ class intel_knobs(base_knobs):
     disable_annotate_cache_control: env_bool = env_bool("TRITON_INTEL_DISABLE_ANNOTATE_CACHE_CONTROL", False)
     enable_code_sinking: env_bool = env_bool("TRITON_INTEL_ENABLE_CODE_SINKING", False)
     disable_canonicalize_pointers: env_bool = env_bool("TRITON_INTEL_DISABLE_CANONICALIZE_POINTERS", False)
+    enable_loop_distribution: env_bool = env_bool("TRITON_INTEL_ENABLE_LOOP_DISTRIBUTION", False)
     fast_math: _env_fast_math = _env_fast_math()
 
     enable_dump_spirv_kernel_args: env_bool = env_bool("TRITON_XPU_ENABLE_DUMP_SPIRV_KERNEL_ARGS", False)

--- a/test/TritonIntelGPU/LoopDistribute/basic.mlir
+++ b/test/TritonIntelGPU/LoopDistribute/basic.mlir
@@ -1,0 +1,36 @@
+// RUN: triton-opt %s -split-input-file -tritonintelgpu-loop-distribute | FileCheck %s
+
+// Test: loop with two dots sharing operand A is distributed into two loops.
+// Each loop loads the shared A from %arg0 and only its own B operand.
+// CHECK-LABEL: @dual_dot_distribute
+// CHECK: scf.for
+// CHECK:   %[[X1:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[WG:.*]] = tt.descriptor_load %arg1
+// CHECK-NOT: tt.descriptor_load %arg2
+// CHECK:   tt.dot %[[X1]], %[[WG]]
+// CHECK-NOT: tt.dot
+// CHECK:   scf.yield
+// CHECK: scf.for
+// CHECK:   %[[X2:.*]] = tt.descriptor_load %arg0
+// CHECK-NOT: tt.descriptor_load %arg1
+// CHECK:   %[[WFC:.*]] = tt.descriptor_load %arg2
+// CHECK:   tt.dot %[[X2]], %[[WFC]]
+// CHECK-NOT: tt.dot
+// CHECK:   scf.yield
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @dual_dot_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:2 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}

--- a/test/TritonIntelGPU/LoopDistribute/invalid.mlir
+++ b/test/TritonIntelGPU/LoopDistribute/invalid.mlir
@@ -1,0 +1,173 @@
+// RUN: triton-opt %s -split-input-file -tritonintelgpu-loop-distribute | FileCheck %s
+
+// Test: loop with a single dot is NOT distributed (not exactly 2 dots).
+// CHECK-LABEL: @single_dot_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @single_dot_no_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>) -> tensor<128x128xf32> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc = %cst) -> (tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %w = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d = tt.dot %x, %w, %acc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      scf.yield %d : tensor<128x128xf32>
+    }
+    tt.return %0 : tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: loop with three dots is NOT distributed (not exactly 2 dots).
+// CHECK-LABEL: @three_dots_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK:   tt.dot
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @three_dots_no_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>, %arg3: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:3 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%a0 = %cst, %a1 = %cst, %a2 = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %w0 = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %w1 = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %w2 = tt.descriptor_load %arg3[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %w0, %a0, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %w1, %a1, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d2 = tt.dot %x, %w2, %a2, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      scf.yield %d0, %d1, %d2 : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1, %0#2 : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: dot accumulator not a direct iter_arg is NOT distributed.
+// CHECK-LABEL: @non_direct_acc_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @non_direct_acc_no_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %cst1 = arith.constant dense<1.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:2 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      // acc_g is modified before being used as accumulator
+      %modified_acc = arith.addf %acc_g, %cst1 : tensor<128x128xf32>
+      %d0 = tt.dot %x, %wg, %modified_acc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: dot result not directly yielded is NOT distributed.
+// CHECK-LABEL: @dot_result_not_yielded_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @dot_result_not_yielded_no_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %cst1 = arith.constant dense<1.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:2 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      // yield a modified version of d0 instead of d0 directly
+      %modified = arith.addf %d0, %cst1 : tensor<128x128xf32>
+      scf.yield %modified, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: loop with unclassified side-effecting op is NOT distributed.
+// CHECK-LABEL: @side_effecting_op_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @side_effecting_op_no_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>, %arg3: !tt.tensordesc<128x128xf32>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:2 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      // Side-effecting store not in either dot's slice
+      tt.descriptor_store %arg3[%c0_i32, %c0_i32], %d0 : !tt.tensordesc<128x128xf32>, tensor<128x128xf32>
+      scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: dots with inter-dependencies are NOT distributed.
+// dot1's A operand is derived from dot0's result, creating a dependency.
+// CHECK-LABEL: @inter_dependent_dots_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @inter_dependent_dots_no_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<128x64xbf16>) -> (tensor<128x128xf32>, tensor<128x64xf32>) {
+    %cst0 = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %cst1 = arith.constant dense<0.000000e+00> : tensor<128x64xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:2 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc0 = %cst0, %acc1 = %cst1) -> (tensor<128x128xf32>, tensor<128x64xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %w = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %w, %acc0, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      // d1's A operand is derived from d0's result
+      %trunc = arith.truncf %d0 : tensor<128x128xf32> to tensor<128x128xbf16>
+      %x2 = tt.descriptor_load %arg2[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %d1 = tt.dot %trunc, %x2, %acc1, inputPrecision = tf32 : tensor<128x128xbf16> * tensor<128x64xbf16> -> tensor<128x64xf32>
+      scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x64xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x64xf32>
+  }
+}

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -46,6 +46,7 @@ class XPUOptions:
     allow_fp8e4nv: bool = False
     allow_fp8e4b15: bool = True
     grf_mode: str = 'default'
+    loop_distribute: bool = False
     use_barrier: bool = False
     max_num_imprecise_acc_default: int = 0  # `max_num_imprecise_acc` only applies to fp8 -> fp32 dot on sm_90 for cuda
     extern_libs: dict = None
@@ -317,6 +318,8 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         passes.ttir.add_reorder_broadcast(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
+        if opt.loop_distribute or os.environ.get("TRITON_INTEL_LOOP_DISTRIBUTE", "0") == "1":
+            intel.passes.ttgpuir.add_loop_distribute(pm)
         passes.ttir.add_loop_unroll(pm)
         pm.run(mod, 'make_ttir')
 

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -318,8 +318,6 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         passes.ttir.add_reorder_broadcast(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
-        if opt.loop_distribute or os.environ.get("TRITON_INTEL_LOOP_DISTRIBUTE", "0") == "1":
-            intel.passes.ttgpuir.add_loop_distribute(pm)
         passes.ttir.add_loop_unroll(pm)
         pm.run(mod, 'make_ttir')
 
@@ -350,6 +348,8 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         passes.ttir.add_convert_to_ttgpuir(pm, "xpu", opt.num_warps, opt.warp_size, opt.num_ctas)
+        if opt.loop_distribute or knobs.intel.enable_loop_distribution:
+            intel.passes.ttgpuir.add_loop_distribute(pm)
         # optimize TTGIR
         passes.ttgpuir.add_coalesce(pm)
         if properties["has_256b_load_store"]:

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -449,4 +449,23 @@ def TritonIntelGPUCanonicalizePointers
   ];
 }
 
+def TritonIntelGPULoopDistribute
+    : Pass<"tritonintelgpu-loop-distribute", "mlir::ModuleOp"> {
+  let summary = "Distribute dot operations in loops into separate loops";
+
+  let description = [{
+    Split an `scf.for` loop containing multiple `tt.dot` operations into
+    separate loops, each containing a single `tt.dot`. This reduces register
+    pressure (fewer live accumulators) and descriptor pressure (fewer active
+    2D block I/O descriptors per loop), at the cost of re-loading shared
+    operands.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::TritonDialect",
+    "mlir::scf::SCFDialect",
+    "mlir::triton::gpu::TritonGPUDialect"
+  ];
+}
+
 #endif // TRITON_INTEL_GPU_PASSES

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -463,8 +463,7 @@ def TritonIntelGPULoopDistribute
 
   let dependentDialects = [
     "mlir::triton::TritonDialect",
-    "mlir::scf::SCFDialect",
-    "mlir::triton::gpu::TritonGPUDialect"
+    "mlir::scf::SCFDialect"
   ];
 }
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_triton_library(TritonIntelGPUTransforms
   CanonicalizePointers.cpp
   CodeSinking.cpp
   DecomposeScaledBlocked.cpp
+  LoopDistribute.cpp
   FoldFpToFp.cpp
   HoistLayoutConversions.cpp
   LowerTo2DBlockLoad.cpp

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LoopDistribute.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LoopDistribute.cpp
@@ -1,0 +1,233 @@
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
+#include "llvm/Support/Debug.h"
+
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+namespace mlir::triton::gpu::intel {
+#define GEN_PASS_DEF_TRITONINTELGPULOOPDISTRIBUTE
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
+} // namespace mlir::triton::gpu::intel
+
+using namespace mlir;
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+
+#define DEBUG_TYPE "tritonintelgpu-loop-distribute"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace {
+
+/// Walk backwards from a dot's operands to find all ops in the loop body
+/// that feed into it (excluding the induction variable and iter_args).
+void collectBackwardSlice(tt::DotOp dot, Block *loopBody,
+                          DenseSet<Operation *> &slice) {
+  SmallVector<Value> worklist;
+  // Add A and B operands (not C — that's the accumulator/iter_arg).
+  worklist.push_back(dot.getA());
+  worklist.push_back(dot.getB());
+
+  while (!worklist.empty()) {
+    Value val = worklist.pop_back_val();
+    Operation *defOp = val.getDefiningOp();
+    if (!defOp || defOp->getBlock() != loopBody)
+      continue;
+    if (!slice.insert(defOp).second)
+      continue;
+    for (Value operand : defOp->getOperands())
+      worklist.push_back(operand);
+  }
+}
+
+/// Try to distribute a for loop with exactly two dot operations into two
+/// separate loops. Returns true if the transformation was applied.
+bool tryDistributeLoop(scf::ForOp forOp) {
+  Block *body = forOp.getBody();
+
+  // Collect all dot operations in the loop body (top-level only).
+  SmallVector<tt::DotOp> dots;
+  for (Operation &op : *body) {
+    if (auto dot = dyn_cast<tt::DotOp>(op))
+      dots.push_back(dot);
+  }
+
+  // Only handle exactly 2 dots.
+  if (dots.size() != 2) {
+    LDBG("Skipping loop: does not have exactly 2 dots (has " << dots.size()
+                                                             << ")");
+    return false;
+  }
+
+  tt::DotOp dot0 = dots[0];
+  tt::DotOp dot1 = dots[1];
+
+  // Each dot must consume an iter_arg as its accumulator (operand C) and
+  // yield back to the same iter_arg position.
+  auto yieldOp = cast<scf::YieldOp>(body->getTerminator());
+
+  // Find which iter_arg index each dot accumulates into.
+  // The accumulator (C operand) of each dot should be a block argument
+  // (iter_arg), and the dot result should be yielded back.
+  auto getAccIterArgIndex = [&](tt::DotOp dot) -> std::optional<unsigned> {
+    Value accum = dot.getC();
+    // The accumulator should be either an iter_arg directly or produced by
+    // an op chain from an iter_arg. For simplicity, require it to be a
+    // direct block argument.
+    auto blockArg = dyn_cast<BlockArgument>(accum);
+    if (!blockArg || blockArg.getOwner() != body)
+      return std::nullopt;
+    // iter_args start at index 1 (index 0 is the induction variable).
+    unsigned iterArgIdx = blockArg.getArgNumber() - 1;
+
+    // Verify the dot result is yielded back to this position.
+    Value dotResult = dot.getResult();
+    // The yield operand at this index should be the dot result (possibly
+    // through the same value).
+    if (yieldOp.getOperand(iterArgIdx) != dotResult)
+      return std::nullopt;
+
+    return iterArgIdx;
+  };
+
+  auto idx0 = getAccIterArgIndex(dot0);
+  auto idx1 = getAccIterArgIndex(dot1);
+  if (!idx0 || !idx1) {
+    LDBG("Skipping loop: dot accumulators are not direct iter_args");
+    return false;
+  }
+
+  LDBG("Found distributable loop with dots at iter_arg indices "
+       << *idx0 << " and " << *idx1);
+
+  // Compute the backward slice for each dot (ops that feed A/B operands).
+  DenseSet<Operation *> slice0, slice1;
+  collectBackwardSlice(dot0, body, slice0);
+  collectBackwardSlice(dot1, body, slice1);
+
+  // Check that the two slices don't have conflicting dependencies
+  // (i.e., one dot's result feeds into the other dot's inputs).
+  // The slices may share ops (e.g., a shared load for operand A).
+  if (slice0.contains(dot1.getOperation()) ||
+      slice1.contains(dot0.getOperation())) {
+    LDBG("Skipping loop: dots have inter-dependencies");
+    return false;
+  }
+
+  // Verify there are no other ops with side effects that we can't classify.
+  for (Operation &op : *body) {
+    if (&op == body->getTerminator())
+      continue;
+    if (isa<tt::DotOp>(op))
+      continue;
+    if (slice0.contains(&op) || slice1.contains(&op))
+      continue;
+    if (!isPure(&op)) {
+      LDBG("Skipping loop: contains unclassified side-effecting op: " << op);
+      return false;
+    }
+  }
+
+  OpBuilder builder(forOp);
+
+  // Each distributed loop keeps all original iter_args but only computes
+  // its target dot, yielding the iter_arg unchanged for the other position.
+
+  auto buildDistributedLoop = [&](tt::DotOp targetDot, unsigned targetIdx,
+                                  unsigned otherIdx,
+                                  DenseSet<Operation *> &targetSlice,
+                                  ValueRange initArgs) {
+    // Use the ForOp builder callback to construct the body inline.
+    // This avoids issues with empty blocks and missing terminators.
+    scf::ForOp newForOp;
+    IRMapping mapping;
+
+    newForOp = scf::ForOp::create(
+        builder, forOp.getLoc(), forOp.getLowerBound(), forOp.getUpperBound(),
+        forOp.getStep(), initArgs,
+        [&](OpBuilder &b, Location loc, Value iv, ValueRange iterArgs) {
+          // Map old block args to new block args.
+          mapping.map(forOp.getInductionVar(), iv);
+          for (auto [oldArg, newArg] :
+               llvm::zip(forOp.getRegionIterArgs(), iterArgs)) {
+            mapping.map(oldArg, newArg);
+          }
+
+          // Clone ops in original order, but only those in the target slice
+          // or the target dot.
+          for (Operation &op : *body) {
+            if (&op == body->getTerminator())
+              continue;
+            if (targetSlice.contains(&op) || &op == targetDot.getOperation()) {
+              b.clone(op, mapping);
+            }
+          }
+
+          // Build yield: for the target iter_arg, yield the dot result;
+          // for all others, yield the iter_arg itself (pass-through).
+          SmallVector<Value> yieldOperands;
+          for (unsigned i = 0; i < forOp.getNumRegionIterArgs(); ++i) {
+            if (i == targetIdx) {
+              yieldOperands.push_back(mapping.lookup(targetDot.getResult()));
+            } else {
+              yieldOperands.push_back(iterArgs[i]);
+            }
+          }
+          scf::YieldOp::create(b, loc, yieldOperands);
+        });
+
+    builder.setInsertionPointAfter(newForOp);
+    return newForOp;
+  };
+
+  // Build loop 1 (for dot0).
+  scf::ForOp loop1 =
+      buildDistributedLoop(dot0, *idx0, *idx1, slice0, forOp.getInitArgs());
+
+  // Build loop 2 (for dot1).
+  scf::ForOp loop2 =
+      buildDistributedLoop(dot1, *idx1, *idx0, slice1, forOp.getInitArgs());
+
+  // Replace the original loop's results: idx0 from loop1, idx1 from loop2,
+  // others from either (they're pass-through in both).
+  for (unsigned i = 0; i < forOp.getNumResults(); ++i) {
+    Value replacement;
+    if (i == *idx0)
+      replacement = loop1.getResult(i);
+    else if (i == *idx1)
+      replacement = loop2.getResult(i);
+    else
+      replacement = loop1.getResult(i); // pass-through, same in both
+    forOp.getResult(i).replaceAllUsesWith(replacement);
+  }
+
+  // Erase the original loop.
+  forOp.erase();
+
+  LDBG("Successfully distributed loop into two loops");
+  return true;
+}
+
+class LoopDistributePass
+    : public triton::gpu::intel::impl::TritonIntelGPULoopDistributeBase<
+          LoopDistributePass> {
+public:
+  using triton::gpu::intel::impl::TritonIntelGPULoopDistributeBase<
+      LoopDistributePass>::TritonIntelGPULoopDistributeBase;
+
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+
+    // Collect loops first to avoid modifying while walking.
+    SmallVector<scf::ForOp> loops;
+    mod.walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
+
+    for (scf::ForOp forOp : loops) {
+      tryDistributeLoop(forOp);
+    }
+  }
+};
+
+} // namespace

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LoopDistribute.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LoopDistribute.cpp
@@ -4,7 +4,6 @@
 
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
-#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 namespace mlir::triton::gpu::intel {
 #define GEN_PASS_DEF_TRITONINTELGPULOOPDISTRIBUTE
@@ -13,7 +12,6 @@ namespace mlir::triton::gpu::intel {
 
 using namespace mlir;
 namespace tt = mlir::triton;
-namespace ttg = mlir::triton::gpu;
 
 #define DEBUG_TYPE "tritonintelgpu-loop-distribute"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -161,6 +161,8 @@ void init_triton_intel_passes_ttgpuir(py::module_ &&m) {
                      gpu::intel::createTritonIntelGPULowerTo2DBlockLoad);
   ADD_PASS_WRAPPER_0("add_reduce_variable_liveness",
                      gpu::intel::createTritonIntelGPUReduceVariableLiveness);
+  ADD_PASS_WRAPPER_0("add_loop_distribute",
+                     gpu::intel::createTritonIntelGPULoopDistribute);
   ADD_PASS_WRAPPER_0("add_code_sinking",
                      gpu::intel::createTritonIntelGPUCodeSinking);
   ADD_PASS_WRAPPER_0("add_annotate_cache_control",


### PR DESCRIPTION
Add a new `tritonintelgpu-loop-distribute` pass that splits an `scf.for` loop containing two `tt.dot` operations into two sequential loops, each with a single dot. This reduces register pressure and descriptor pressure at the cost of re-loading shared operands.

The pass is controlled via the `loop_distribute` compiler option, which can be set through autotune configurations, allowing the autotuner to select the optimal strategy.

## Benchmark results (fused GEMM SwiGLU)

| Shape | Max1550 | B580 |
|-------|---------|------|
| [220000, 8192, 512] | +6.4% | +3.3% |
| [1024, 8192, 7168] | +13.6% | +23.9% |
| [1024, 5504, 4096] | +1.7% | +10.8% |
| [2048, 5504, 4096] | +6.8% | +9.3% |
| [4096, 5504, 4096] | +0.3% | +10.2% |
| [8192, 5504, 4096] | +2.3% | +11.8% |
| [1024, 14336, 4096] | +14.8% | +11.3% |
| [2048, 14336, 4096] | +26.8% | +12.6% |
| [4096, 14336, 4096] | +12.7% | +12.7% |
| [8192, 14336, 4096] | +12.8% | +12.3% |
| **GeoMean** | **+9.6%** | **+11.7%** |