### PR TITLE
[CodeSinking] Expose code_sinking as autotune-controllable compiler option

### DIFF
--- a/benchmarks/triton_kernels_benchmark/fused_gemm_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/fused_gemm_benchmark.py
@@ -34,7 +34,6 @@ def get_fused_gemm_autotune_configs() -> list[triton.Config]:
                 'GROUP_SIZE_M': G,
                 'grf_mode': '256',
                 'loop_distribute': True,
-                'code_sinking': CS,
             },
             num_stages=s,
             num_warps=w,
@@ -45,7 +44,6 @@ def get_fused_gemm_autotune_configs() -> list[triton.Config]:
         for G in [4, 8, 16]
         for s in [2, 3, 4]
         for w in [8, 16, 32]
-        for CS in [False, True]
     ]
 
 

--- a/benchmarks/triton_kernels_benchmark/fused_gemm_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/fused_gemm_benchmark.py
@@ -34,6 +34,7 @@ def get_fused_gemm_autotune_configs() -> list[triton.Config]:
                 'GROUP_SIZE_M': G,
                 'grf_mode': '256',
                 'loop_distribute': True,
+                'code_sinking': CS,
             },
             num_stages=s,
             num_warps=w,
@@ -44,6 +45,7 @@ def get_fused_gemm_autotune_configs() -> list[triton.Config]:
         for G in [4, 8, 16]
         for s in [2, 3, 4]
         for w in [8, 16, 32]
+        for CS in [False, True]
     ]
 
 

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -47,6 +47,7 @@ class XPUOptions:
     allow_fp8e4b15: bool = True
     grf_mode: str = 'default'
     loop_distribute: bool = False
+    code_sinking: bool = False
     use_barrier: bool = False
     max_num_imprecise_acc_default: int = 0  # `max_num_imprecise_acc` only applies to fp8 -> fp32 dot on sm_90 for cuda
     extern_libs: dict = None
@@ -381,7 +382,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         # Off by default: code sinking is perf-neutral on measured kernels (it
         # reliably reduces register spills, but the relieved traffic is not on
         # the critical path on current HW). Opt in via the env var for A/B work.
-        if knobs.intel.enable_code_sinking:
+        if opt.code_sinking or knobs.intel.enable_code_sinking:
             intel.passes.ttgpuir.add_code_sinking(pm)
 
         passes.ttir.add_loop_aware_cse(pm)

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -319,6 +319,8 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         passes.ttir.add_reorder_broadcast(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
+        if opt.loop_distribute or knobs.intel.enable_loop_distribution:
+            intel.passes.ttgpuir.add_loop_distribute(pm)
         passes.ttir.add_loop_unroll(pm)
         pm.run(mod, 'make_ttir')
 
@@ -349,8 +351,6 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         passes.ttir.add_convert_to_ttgpuir(pm, "xpu", opt.num_warps, opt.warp_size, opt.num_ctas)
-        if opt.loop_distribute or knobs.intel.enable_loop_distribution:
-            intel.passes.ttgpuir.add_loop_distribute(pm)
         # optimize TTGIR
         passes.ttgpuir.add_coalesce(pm)
         if properties["has_256b_load_store"]:


### PR DESCRIPTION
Add `code_sinking` as an XPUOptions field (default False) so it can be toggled per autotune config, same as `loop_distribute`. The existing env var `TRITON_INTEL_ENABLE_CODE_SINKING` still works as an override.