### PR TITLE
[LoadStore] Fix i32 overflow in 2D block IO stride/pitch lowering (#7334)

### DIFF
--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load-bigstride.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load-bigstride.mlir
@@ -1,0 +1,52 @@
+// RUN: triton-opt %s -split-input-file --tritonintelgpu-lower-to-2d-block-load | FileCheck %s
+
+// Regression tests for large-stride bugs in the descriptor→2Dblockload
+// lowering (companion to test/TritonIntelGPU/prefetch-bigstride.mlir; see
+// intel/intel-xpu-backend-for-triton#7334).
+//
+// The 2Dblockload HW pitch/base_width operands are i32; the transform
+// used to unconditionally truncate `stride * elemBytes` to i32, so a
+// compile-time-foldable pitch stride exceeding INT32_MAX would silently
+// produce a garbage surface descriptor. With the INT32_MAX guard, the
+// transform now leaves the tt.descriptor_load unlowered (the HW verifier
+// catches invalid pitches produced by runtime strides).
+
+// Case 1: descriptor pitch stride = 2^30 f16 elements → byte pitch = 2^31,
+// > INT32_MAX. The `arith.constant %stride` is a compile-time value the
+// transform's `getFoldedConstantValue` can inspect. Expected: no
+// ttig.2d_block_load emitted, and the tt.descriptor_load survives.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @descriptor_load_pitch_overflow_f16
+  tt.func @descriptor_load_pitch_overflow_f16(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32) -> tensor<64x32xf16, #dot0> {
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    // Pitch stride: 2^30 f16 elements. Byte pitch = 2^30 * 2 = 2^31 (> INT32_MAX).
+    %big_stride = arith.constant 1073741824 : i64
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%big_stride, %c1_i64] : <f16>, <64x32xf16>
+    // CHECK-NOT: ttig.2d_block_load
+    // CHECK: tt.descriptor_load
+    %0 = tt.descriptor_load %desc[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #dot0>
+    tt.return %0 : tensor<64x32xf16, #dot0>
+  }
+}
+
+// -----
+
+// Case 2 (control): pitch stride = 64 f16 elements → byte pitch = 128,
+// well within i32. Confirms the guard does not fire for legitimate strides.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @descriptor_load_control_f16
+  tt.func @descriptor_load_control_f16(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32) -> tensor<64x32xf16, #dot0> {
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %stride = arith.constant 64 : i64
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%stride, %c1_i64] : <f16>, <64x32xf16>
+    // CHECK: ttig.2d_block_load
+    %0 = tt.descriptor_load %desc[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #dot0>
+    tt.return %0 : tensor<64x32xf16, #dot0>
+  }
+}

--- a/test/TritonIntelGPU/descriptor-store-bigstride.mlir
+++ b/test/TritonIntelGPU/descriptor-store-bigstride.mlir
@@ -6,13 +6,15 @@
 //
 // The descriptor-store lowering path computes baseWidth and pitch as
 // `mul(i64_stride, i64_val(elemBytes)) : i64` followed by `trunc i64 to i32`.
-// Without the truncStrideProductToI32() guard, a compile-time-foldable
-// pitch/shape whose byte value exceeds INT32_MAX silently produces a garbage
-// surface descriptor. With the guard, the pattern returns failure() and the
-// tt.descriptor_store is left in place (or lowered via another pattern).
+// Without the narrowSurfaceBytesOrNull() guard, a compile-time-foldable
+// pitch/shape whose byte value exceeds the HW's 24-bit field silently
+// produces a garbage surface descriptor. With the guard, the pattern
+// returns failure() and the tt.descriptor_store is left in place (or
+// lowered via another pattern).
 
-// Case 1: pitch stride = 2^30 f16 elements → byte pitch = 2^31, > INT32_MAX.
-// Expected: no triton_gen.2Dblockstore emitted (pattern bails cleanly).
+// Case 1: pitch stride = 2^30 f16 elements → byte pitch = 2^31, well over
+// the HW's 24-bit limit. Expected: no triton_gen.2Dblockstore emitted
+// (pattern bails cleanly).
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
   // CHECK-LABEL: llvm.func spir_kernelcc @store_pitch_overflow_f16

--- a/test/TritonIntelGPU/descriptor-store-bigstride.mlir
+++ b/test/TritonIntelGPU/descriptor-store-bigstride.mlir
@@ -1,0 +1,50 @@
+// RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s
+
+// Regression tests for large-stride bugs in the descriptor→2Dblockstore
+// lowering (companion to test/TritonIntelGPU/prefetch-bigstride.mlir; see
+// intel/intel-xpu-backend-for-triton#7334).
+//
+// The descriptor-store lowering path computes baseWidth and pitch as
+// `mul(i64_stride, i64_val(elemBytes)) : i64` followed by `trunc i64 to i32`.
+// Without the truncStrideProductToI32() guard, a compile-time-foldable
+// pitch/shape whose byte value exceeds INT32_MAX silently produces a garbage
+// surface descriptor. With the guard, the pattern returns failure() and the
+// tt.descriptor_store is left in place (or lowered via another pattern).
+
+// Case 1: pitch stride = 2^30 f16 elements → byte pitch = 2^31, > INT32_MAX.
+// Expected: no triton_gen.2Dblockstore emitted (pattern bails cleanly).
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @store_pitch_overflow_f16
+  tt.func public @store_pitch_overflow_f16(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf16, #dpas>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    // pitch stride = 2^30 f16 → 2^31 bytes (overflows i32).
+    %big_stride = arith.constant 1073741824 : i64
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%big_stride, %c1_i64] : <f16>, <64x64xf16, #dpas>
+    // CHECK-NOT: triton_gen.2Dblockstore
+    tt.descriptor_store %desc[%c0_i32, %c0_i32], %cst {ttig.block_io = "row_major"} : !tt.tensordesc<64x64xf16, #dpas>, tensor<64x64xf16, #dpas>
+    tt.return
+  }
+}
+
+// -----
+
+// Case 2 (control): pitch stride = 64 f16 elements → byte pitch = 128,
+// well within i32. Confirms the guard does not fire for legitimate strides
+// and the ordinary store lowering emits triton_gen.2Dblockstore ops.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @store_control_f16
+  tt.func public @store_control_f16(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf16, #dpas>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %stride = arith.constant 64 : i64
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%stride, %c1_i64] : <f16>, <64x64xf16, #dpas>
+    // CHECK: triton_gen.2Dblockstore
+    tt.descriptor_store %desc[%c0_i32, %c0_i32], %cst {ttig.block_io = "row_major"} : !tt.tensordesc<64x64xf16, #dpas>, tensor<64x64xf16, #dpas>
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/prefetch-bigstride.mlir
+++ b/test/TritonIntelGPU/prefetch-bigstride.mlir
@@ -4,22 +4,30 @@
 // lowering (see intel/intel-xpu-backend-for-triton#7334):
 //   1. getStride() truncated StrideInfo's int64 to int32, so a row stride of
 //      2^31 became negative and the cooperative prefetch bailed out via
-//      `if (stride < 0) return failure()`, emitting 0 prefetch ops.
+//      `if (stride < 0) return failure()`, emitting 0 prefetch ops. Widened
+//      to int64.
 //   2. In the rank>2 batch-stride loop, `dimStride * elemSizeInBytes` was an
 //      int32-times-unsigned product, so a batch stride whose byte value
 //      exceeded INT32_MAX truncated to 0 and every batch prefetched the
-//      same surface.
+//      same surface. Widened to int64.
 //   3. getPitch() computed `(unsigned)stride * elemSizeInBits / 8` in 32-bit
 //      unsigned arithmetic, so a stride whose byte pitch wrapped mod 2^32
 //      to a value >= MIN_PITCH silently returned an i32 constant with the
-//      truncated pitch. The new INT32_MAX guard returns null instead, so
-//      the DPAS regular-pointer path bails out and the cooperative fallback
-//      (which computes pitch via i64 mul + trunc) takes over.
+//      truncated pitch. Now returns null on INT32_MAX overflow.
+//   4. emit2DBlockPrefetchOps() computed pitch/baseWidth via i64 mul then
+//      unconditional `trunc i64 to i32`, so the cooperative-fallback and
+//      descriptor-prefetch paths silently emitted a garbage descriptor for
+//      any byte pitch > INT32_MAX. Now bails via truncStrideProductToI32().
 //
 // Cases 4 and 5 are in-range controls that exercise the ordinary path to
-// prove the widened arithmetic and INT32_MAX guard don't break it.
+// prove the widened arithmetic and INT32_MAX guards don't break it.
 
-// Case 1: row stride 2^31 (f16) — truncation bug on the cooperative path.
+// Case 1: row stride 2^31 (f16). Byte pitch = 2^32, so both the getStride()
+// int64 fix AND the emit2DBlockPrefetchOps() INT32_MAX guard are exercised.
+// Before either fix: `stride < 0` bailout in the cooperative path silently
+// emitted 0 prefetches. With just the getStride fix: 2 prefetches with a
+// bogus base_pitch = trunc(2^32) = 0. With both fixes: 0 prefetches, and
+// the pattern warns instead of lowering.
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_prefetch_256b"} {
   // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_bigstride_f16
@@ -37,7 +45,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32,
     %8 = arith.addi %6, %7 : tensor<128x64xi64, #blocked>
     %9 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
     %ptr = tt.addptr %9, %8 : tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<128x64xi64, #blocked>
-    // CHECK-COUNT-2: triton_gen.2Dblockprefetch
+    // CHECK-NOT: triton_gen.2Dblockprefetch
     ttig.prefetch %ptr {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 0, 0>, ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f16>, #blocked>
     tt.return
   }
@@ -98,13 +106,11 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32,
 // Case 3: DPAS regular-pointer prefetch with row stride 2^30 + 16 f32
 // elements (byte pitch = 4 * (2^30 + 16) = 2^32 + 64). Chosen so the
 // buggy 32-bit unsigned multiply in getPitch() wraps to exactly 64
-// (>= MIN_PITCH), which passes the "unsupported pitch" check and used
-// to return `i32_val(64)`. The DPAS path would then emit prefetches
-// with a bogus 64-byte pitch. With the INT32_MAX guard, getPitch()
-// returns null, the DPAS path fails, and the cooperative fallback
-// materializes pitch via i64 mul + trunc — so the pitch fed to the
-// prefetch op is an `llvm.trunc ... : i64 to i32` rather than a bare
-// i32 constant.
+// (>= MIN_PITCH), passes the "unsupported pitch" check, and used to return
+// `i32_val(64)` — the DPAS path then emitted 8 prefetches with a bogus
+// 64-byte pitch. With both the getPitch() and emit2DBlockPrefetchOps()
+// INT32_MAX guards, the DPAS path bails and the cooperative fallback also
+// bails, so nothing is lowered.
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 1, threadsPerWarp = 16, warpsPerCTA = [2, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
   // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_getpitch_overflow_f32
@@ -123,11 +129,12 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
     %8 = arith.addi %6, %7 : tensor<64x32xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
     %9 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
     %ptr = tt.addptr %9, %8 : tensor<64x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>, tensor<64x32xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
-    // Fixed getPitch bails on INT32_MAX overflow, so the DPAS regular-pointer
-    // pattern fails and the cooperative fallback emits exactly one prefetch
-    // for this warp's tile. The buggy code emitted 8 prefetches (one per
-    // DPAS repetition) with a bogus base_pitch of 64 bytes.
-    // CHECK-COUNT-1: triton_gen.2Dblockprefetch
+    // Both getPitch() and emit2DBlockPrefetchOps() now bail on i32 pitch
+    // overflow, so no prefetch is emitted at all — the pattern warns and
+    // erases the op rather than lowering it with a garbage base_pitch. The
+    // buggy code emitted 8 DPAS-path prefetches with base_pitch = 64 bytes;
+    // an intermediate fix that only guarded getPitch() still emitted 1
+    // cooperative-fallback prefetch with base_pitch = trunc(mul) mod 2^32.
     // CHECK-NOT: triton_gen.2Dblockprefetch
     ttig.prefetch %ptr {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 0, 0>, ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
     tt.return

--- a/test/TritonIntelGPU/prefetch-bigstride.mlir
+++ b/test/TritonIntelGPU/prefetch-bigstride.mlir
@@ -1,0 +1,191 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm | FileCheck %s
+
+// Regression tests for large-stride bugs in the 2D-block-IO prefetch
+// lowering (see intel/intel-xpu-backend-for-triton#7334):
+//   1. getStride() truncated StrideInfo's int64 to int32, so a row stride of
+//      2^31 became negative and the cooperative prefetch bailed out via
+//      `if (stride < 0) return failure()`, emitting 0 prefetch ops.
+//   2. In the rank>2 batch-stride loop, `dimStride * elemSizeInBytes` was an
+//      int32-times-unsigned product, so a batch stride whose byte value
+//      exceeded INT32_MAX truncated to 0 and every batch prefetched the
+//      same surface.
+//   3. getPitch() computed `(unsigned)stride * elemSizeInBits / 8` in 32-bit
+//      unsigned arithmetic, so a stride whose byte pitch wrapped mod 2^32
+//      to a value >= MIN_PITCH silently returned an i32 constant with the
+//      truncated pitch. The new INT32_MAX guard returns null instead, so
+//      the DPAS regular-pointer path bails out and the cooperative fallback
+//      (which computes pitch via i64 mul + trunc) takes over.
+//
+// Cases 4 and 5 are in-range controls that exercise the ordinary path to
+// prove the widened arithmetic and INT32_MAX guard don't break it.
+
+// Case 1: row stride 2^31 (f16) — truncation bug on the cooperative path.
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_prefetch_256b"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_bigstride_f16
+  tt.func public @prefetch_bigstride_f16(%arg0: !tt.ptr<f16>) {
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xi32, #blocked>
+    %e1 = arith.extsi %1 : tensor<128x1xi32, #blocked> to tensor<128x1xi64, #blocked>
+    %2 = arith.constant dense<2147483648> : tensor<128x1xi64, #blocked>
+    %3 = arith.muli %e1, %2 : tensor<128x1xi64, #blocked>
+    %4 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %e5 = arith.extsi %5 : tensor<1x64xi32, #blocked> to tensor<1x64xi64, #blocked>
+    %6 = tt.broadcast %3 : tensor<128x1xi64, #blocked> -> tensor<128x64xi64, #blocked>
+    %7 = tt.broadcast %e5 : tensor<1x64xi64, #blocked> -> tensor<128x64xi64, #blocked>
+    %8 = arith.addi %6, %7 : tensor<128x64xi64, #blocked>
+    %9 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    %ptr = tt.addptr %9, %8 : tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<128x64xi64, #blocked>
+    // CHECK-COUNT-2: triton_gen.2Dblockprefetch
+    ttig.prefetch %ptr {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 0, 0>, ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Case 2: rank-3, batch stride 2^32 (f16) — exercises the extra-dim stride
+// loop at LoadStoreOpToLLVM.cpp:1784-1788, where `dimStride *
+// elemSizeInBytes` is now widened to int64 via `static_cast<int64_t>`.
+// Without the cast, an int32 * unsigned product would lose the high bits and
+// synthesize aliasing per-batch offsets, silently prefetching the wrong
+// surfaces. The inner (H, W) tile keeps small strides so only the batch
+// dim carries the >INT32_MAX value.
+#blocked3d = #ttg.blocked<{sizePerThread = [1, 1, 4], threadsPerWarp = [1, 1, 16], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_prefetch_256b"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_bigstride_rank3_f16
+  tt.func public @prefetch_bigstride_rank3_f16(%arg0: !tt.ptr<f16>) {
+    // Batch axis (dim 0): range [0..1] scaled by 2^32 -> batch stride = 2^32.
+    %b0 = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32, #ttg.slice<{dim = 1, parent = #ttg.slice<{dim = 2, parent = #blocked3d}>}>>
+    %b1 = tt.expand_dims %b0 {axis = 1 : i32} : tensor<2xi32, #ttg.slice<{dim = 1, parent = #ttg.slice<{dim = 2, parent = #blocked3d}>}>> -> tensor<2x1xi32, #ttg.slice<{dim = 2, parent = #blocked3d}>>
+    %b2 = tt.expand_dims %b1 {axis = 2 : i32} : tensor<2x1xi32, #ttg.slice<{dim = 2, parent = #blocked3d}>> -> tensor<2x1x1xi32, #blocked3d>
+    %be = arith.extsi %b2 : tensor<2x1x1xi32, #blocked3d> to tensor<2x1x1xi64, #blocked3d>
+    %bs = arith.constant dense<4294967296> : tensor<2x1x1xi64, #blocked3d>
+    %bmul = arith.muli %be, %bs : tensor<2x1x1xi64, #blocked3d>
+    // Row axis (dim 1): stride = 64 elements.
+    %r0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 2, parent = #blocked3d}>}>>
+    %r1 = tt.expand_dims %r0 {axis = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 2, parent = #blocked3d}>}>> -> tensor<1x128xi32, #ttg.slice<{dim = 2, parent = #blocked3d}>>
+    %r2 = tt.expand_dims %r1 {axis = 2 : i32} : tensor<1x128xi32, #ttg.slice<{dim = 2, parent = #blocked3d}>> -> tensor<1x128x1xi32, #blocked3d>
+    %re = arith.extsi %r2 : tensor<1x128x1xi32, #blocked3d> to tensor<1x128x1xi64, #blocked3d>
+    %rs = arith.constant dense<64> : tensor<1x128x1xi64, #blocked3d>
+    %rmul = arith.muli %re, %rs : tensor<1x128x1xi64, #blocked3d>
+    // Col axis (dim 2): stride = 1.
+    %c0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 1, parent = #blocked3d}>}>>
+    %c1 = tt.expand_dims %c0 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 1, parent = #blocked3d}>}>> -> tensor<1x64xi32, #ttg.slice<{dim = 1, parent = #blocked3d}>>
+    %c2 = tt.expand_dims %c1 {axis = 1 : i32} : tensor<1x64xi32, #ttg.slice<{dim = 1, parent = #blocked3d}>> -> tensor<1x1x64xi32, #blocked3d>
+    %ce = arith.extsi %c2 : tensor<1x1x64xi32, #blocked3d> to tensor<1x1x64xi64, #blocked3d>
+    // Broadcast to the full 3D shape and combine.
+    %bB = tt.broadcast %bmul : tensor<2x1x1xi64, #blocked3d> -> tensor<2x128x64xi64, #blocked3d>
+    %rB = tt.broadcast %rmul : tensor<1x128x1xi64, #blocked3d> -> tensor<2x128x64xi64, #blocked3d>
+    %cB = tt.broadcast %ce : tensor<1x1x64xi64, #blocked3d> -> tensor<2x128x64xi64, #blocked3d>
+    %sum1 = arith.addi %bB, %rB : tensor<2x128x64xi64, #blocked3d>
+    %sum2 = arith.addi %sum1, %cB : tensor<2x128x64xi64, #blocked3d>
+    %splat = tt.splat %arg0 : !tt.ptr<f16> -> tensor<2x128x64x!tt.ptr<f16>, #blocked3d>
+    %ptr = tt.addptr %splat, %sum2 : tensor<2x128x64x!tt.ptr<f16>, #blocked3d>, tensor<2x128x64xi64, #blocked3d>
+    // The extra-dim (batch) stride in bytes must be `2^32 * sizeof(f16)` =
+    // 8589934592. Without the int64 widening at LoadStoreOpToLLVM.cpp:1788,
+    // this value would truncate to 0 and every batch would prefetch surface 0.
+    // CHECK: llvm.mlir.constant(8589934592 : i64) : i64
+    // CHECK-COUNT-4: triton_gen.2Dblockprefetch
+    ttig.prefetch %ptr {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 0, 0>, ttig.block_io = "row_major"} : tensor<2x128x64x!tt.ptr<f16>, #blocked3d>
+    tt.return
+  }
+}
+
+// -----
+
+// Case 3: DPAS regular-pointer prefetch with row stride 2^30 + 16 f32
+// elements (byte pitch = 4 * (2^30 + 16) = 2^32 + 64). Chosen so the
+// buggy 32-bit unsigned multiply in getPitch() wraps to exactly 64
+// (>= MIN_PITCH), which passes the "unsupported pitch" check and used
+// to return `i32_val(64)`. The DPAS path would then emit prefetches
+// with a bogus 64-byte pitch. With the INT32_MAX guard, getPitch()
+// returns null, the DPAS path fails, and the cooperative fallback
+// materializes pitch via i64 mul + trunc — so the pitch fed to the
+// prefetch op is an `llvm.trunc ... : i64 to i32` rather than a bare
+// i32 constant.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 1, threadsPerWarp = 16, warpsPerCTA = [2, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_getpitch_overflow_f32
+  tt.func public @prefetch_getpitch_overflow_f32(%arg0: !tt.ptr<f32>) {
+    %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>}>> -> tensor<64x1xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %e1 = arith.extsi %1 : tensor<64x1xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>> to tensor<64x1xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    // row stride = 2^30 + 16 elements; buggy `(unsigned)stride * 32 / 8` wraps to 64.
+    %2 = arith.constant dense<1073741840> : tensor<64x1xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %3 = arith.muli %e1, %2 : tensor<64x1xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %4 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>}>> -> tensor<1x32xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %e5 = arith.extsi %5 : tensor<1x32xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>> to tensor<1x32xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %6 = tt.broadcast %3 : tensor<64x1xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>> -> tensor<64x32xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %7 = tt.broadcast %e5 : tensor<1x32xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>> -> tensor<64x32xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %8 = arith.addi %6, %7 : tensor<64x32xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %9 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %ptr = tt.addptr %9, %8 : tensor<64x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>, tensor<64x32xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    // Fixed getPitch bails on INT32_MAX overflow, so the DPAS regular-pointer
+    // pattern fails and the cooperative fallback emits exactly one prefetch
+    // for this warp's tile. The buggy code emitted 8 prefetches (one per
+    // DPAS repetition) with a bogus base_pitch of 64 bytes.
+    // CHECK-COUNT-1: triton_gen.2Dblockprefetch
+    // CHECK-NOT: triton_gen.2Dblockprefetch
+    ttig.prefetch %ptr {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 0, 0>, ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    tt.return
+  }
+}
+
+// -----
+
+// Case 4 (control): identical to case 1 but with a small (in-range) stride.
+// Verifies that the widened-int64 code path does not break ordinary strides —
+// a legitimately small stride/pitch still lowers to prefetch ops.
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_prefetch_256b"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_control_f16
+  tt.func public @prefetch_control_f16(%arg0: !tt.ptr<f16>) {
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xi32, #blocked>
+    %e1 = arith.extsi %1 : tensor<128x1xi32, #blocked> to tensor<128x1xi64, #blocked>
+    %2 = arith.constant dense<64> : tensor<128x1xi64, #blocked>
+    %3 = arith.muli %e1, %2 : tensor<128x1xi64, #blocked>
+    %4 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %e5 = arith.extsi %5 : tensor<1x64xi32, #blocked> to tensor<1x64xi64, #blocked>
+    %6 = tt.broadcast %3 : tensor<128x1xi64, #blocked> -> tensor<128x64xi64, #blocked>
+    %7 = tt.broadcast %e5 : tensor<1x64xi64, #blocked> -> tensor<128x64xi64, #blocked>
+    %8 = arith.addi %6, %7 : tensor<128x64xi64, #blocked>
+    %9 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    %ptr = tt.addptr %9, %8 : tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<128x64xi64, #blocked>
+    // CHECK-COUNT-2: triton_gen.2Dblockprefetch
+    ttig.prefetch %ptr {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 0, 0>, ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Case 5 (control): DPAS regular-pointer prefetch with a small pitch
+// (row stride = 32 f32 elements → pitch = 128 bytes). Confirms the
+// getPitch() path still emits the pitch as an i32 constant when in range,
+// exercising the INT32_MAX guard's non-overflow branch.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 1, threadsPerWarp = 16, warpsPerCTA = [2, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_pitch_ok_f32
+  tt.func public @prefetch_pitch_ok_f32(%arg0: !tt.ptr<f32>) {
+    %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>}>> -> tensor<64x1xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %2 = arith.constant dense<32> : tensor<64x1xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %3 = arith.muli %1, %2 : tensor<64x1xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %4 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>}>> -> tensor<1x32xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %6 = tt.broadcast %3 : tensor<64x1xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>> -> tensor<64x32xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %7 = tt.broadcast %5 : tensor<1x32xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>> -> tensor<64x32xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %8 = arith.addi %6, %7 : tensor<64x32xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %9 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %ptr = tt.addptr %9, %8 : tensor<64x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>, tensor<64x32xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    // CHECK: llvm.mlir.constant(128 : i32) : i32
+    // CHECK: triton_gen.2Dblockprefetch
+    ttig.prefetch %ptr {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 0, 0>, ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/prefetch-bigstride.mlir
+++ b/test/TritonIntelGPU/prefetch-bigstride.mlir
@@ -13,14 +13,20 @@
 //   3. getPitch() computed `(unsigned)stride * elemSizeInBits / 8` in 32-bit
 //      unsigned arithmetic, so a stride whose byte pitch wrapped mod 2^32
 //      to a value >= MIN_PITCH silently returned an i32 constant with the
-//      truncated pitch. Now returns null on INT32_MAX overflow.
+//      truncated pitch. Now returns null on 24-bit overflow.
 //   4. emit2DBlockPrefetchOps() computed pitch/baseWidth via i64 mul then
 //      unconditional `trunc i64 to i32`, so the cooperative-fallback and
 //      descriptor-prefetch paths silently emitted a garbage descriptor for
-//      any byte pitch > INT32_MAX. Now bails via truncStrideProductToI32().
+//      any byte pitch that didn't fit in the HW field. Now bails via
+//      narrowSurfaceBytesOrNull().
+//
+// The HW pitch/base_width/base_height fields are 24 bits (value-1 encoded),
+// so all guards reject byte values > 2^24. Case 6 exercises this tighter
+// bound with a stride that would have slipped through an INT32_MAX check
+// but is still too large for the HW.
 //
 // Cases 4 and 5 are in-range controls that exercise the ordinary path to
-// prove the widened arithmetic and INT32_MAX guards don't break it.
+// prove the widened arithmetic and 24-bit guards don't break it.
 
 // Case 1: row stride 2^31 (f16). Byte pitch = 2^32, so both the getStride()
 // int64 fix AND the emit2DBlockPrefetchOps() INT32_MAX guard are exercised.
@@ -192,6 +198,39 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
     %ptr = tt.addptr %9, %8 : tensor<64x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>, tensor<64x32xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
     // CHECK: llvm.mlir.constant(128 : i32) : i32
     // CHECK: triton_gen.2Dblockprefetch
+    ttig.prefetch %ptr {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 0, 0>, ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    tt.return
+  }
+}
+
+// -----
+
+// Case 6: DPAS regular-pointer prefetch with row stride 2^22 + 1 f32
+// elements (byte pitch = 4 * (2^22 + 1) = 2^24 + 4). Exercises the HW's
+// tighter 24-bit pitch limit — a stride that fits in the i32 operand but
+// exceeds the 24-bit HW field would silently drop the top bits and produce
+// a garbage descriptor. Both getPitch() and the cooperative fallback now
+// bail on byte pitch > 2^24, so nothing is lowered.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 1, threadsPerWarp = 16, warpsPerCTA = [2, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_pitch_24bit_overflow_f32
+  tt.func public @prefetch_pitch_24bit_overflow_f32(%arg0: !tt.ptr<f32>) {
+    %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>}>> -> tensor<64x1xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %e1 = arith.extsi %1 : tensor<64x1xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>> to tensor<64x1xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    // row stride = 2^22 + 1 elements; byte pitch = 4 * (2^22 + 1) = 2^24 + 4.
+    // Fits in i32 (well under INT32_MAX) but exceeds the HW 24-bit field.
+    %2 = arith.constant dense<4194305> : tensor<64x1xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %3 = arith.muli %e1, %2 : tensor<64x1xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %4 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>}>> -> tensor<1x32xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %e5 = arith.extsi %5 : tensor<1x32xi32, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>> to tensor<1x32xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %6 = tt.broadcast %3 : tensor<64x1xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>> -> tensor<64x32xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %7 = tt.broadcast %e5 : tensor<1x32xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>> -> tensor<64x32xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %8 = arith.addi %6, %7 : tensor<64x32xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %9 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    %ptr = tt.addptr %9, %8 : tensor<64x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>, tensor<64x32xi64, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    // CHECK-NOT: triton_gen.2Dblockprefetch
     ttig.prefetch %ptr {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 0, 0>, ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f32>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
     tt.return
   }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -581,6 +581,14 @@ protected:
   const triton::intel::TargetInfo &targetInfo;
 };
 
+/// The 2D-block-IO HW encodes base_width / base_height / base_pitch in
+/// **24 bits** on the wire (the TritonGEN→LLVM lowering subtracts 1 before
+/// passing the field, so the user-facing max is 2^24; anything larger
+/// wraps mod 2^24 and produces a garbage surface). See
+/// verify2DBlockAddressPayloadRestriction() in TritonGEN which enforces
+/// the same 24-bit bound on already-emitted ops.
+static constexpr int64_t kMax2DBlockField = int64_t(1) << 24;
+
 struct BlockIOConversionBase : public LoadStoreConversionBase {
   explicit BlockIOConversionBase(
       const triton::intel::TargetInfo &targetInfo,
@@ -629,8 +637,7 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
   /// Return the pitch (in bytes) for an op annotated by the 1D→2D reshape.
   /// The stride attribute is in elements; this converts to bytes.
   /// Returns std::nullopt if the attribute is absent, non-positive, or if
-  /// the resulting byte pitch does not fit in a signed 32-bit integer (the
-  /// HW pitch operand is i32).
+  /// the resulting byte pitch exceeds the HW 24-bit pitch field.
   template <typename OpTy>
   static std::optional<int64_t>
   getAnnotated1DReshapePitch(OpTy op, unsigned elemSizeInBits) {
@@ -642,7 +649,7 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
     if (strideElems <= 0)
       return std::nullopt;
     int64_t pitchBytes = strideElems * elemSizeInBits / 8;
-    if (pitchBytes > std::numeric_limits<int32_t>::max())
+    if (pitchBytes > kMax2DBlockField)
       return std::nullopt;
     return pitchBytes;
   }
@@ -725,8 +732,9 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
       int64_t pitch = stride * elemSizeInBits / 8;
       if (pitch < MIN_PITCH)
         return nullptr; // unsupported pitch
-      // The HW pitch operand is i32; bail out rather than silently truncating.
-      if (pitch > std::numeric_limits<int32_t>::max())
+      // The HW pitch field is 24 bits (value encoded as value-1); bail
+      // rather than silently truncating.
+      if (pitch > kMax2DBlockField)
         return nullptr;
       return b.i32_val(static_cast<int32_t>(pitch));
     }
@@ -1250,40 +1258,44 @@ static TritonGEN::LoadCacheControl prefetchCacheControl(CacheModifier cm) {
   }
 }
 
-/// Truncate `v` to i32 for a 2D-block-IO baseHeight operand. Returns
-/// `Value()` when `v` can be compile-time folded and exceeds INT32_MAX, so
-/// the caller can bail rather than silently emit garbage. Non-foldable
-/// (runtime) values pass through unchecked — the HW verifier catches
-/// invalid sizes.
-static Value truncI64ToI32OrNull(ConversionPatternRewriter &rewriter,
-                                 Location loc, Value v) {
+/// Narrow `v` to the i32 slot of a 2D-block-IO surface field measured in
+/// rows (base_height). Returns `Value()` when `v` folds to a value
+/// exceeding the HW's 24-bit field (see kMax2DBlockField). Callers should
+/// bail with `failure()` on null. Non-foldable (runtime) values pass
+/// through unchecked — the HW verifier catches invalid sizes for
+/// already-constant ops, but a runtime overflow is the caller's
+/// responsibility. Lower-bound (positivity / MIN_*) policy is left to
+/// callers. For byte-valued fields (pitch, base_width) use
+/// narrowSurfaceBytesOrNull instead.
+static Value narrowSurfaceRowsOrNull(ConversionPatternRewriter &rewriter,
+                                     Location loc, Value v) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   if (auto folded = triton::intel::getFoldedConstantValue(v)) {
-    if (*folded > std::numeric_limits<int32_t>::max() ||
-        *folded < std::numeric_limits<int32_t>::min())
+    if (*folded > kMax2DBlockField)
       return Value();
   }
   return b.trunc(i32_ty, v);
 }
 
-/// Materialize `stride * elemBytes` as an i32 for a 2D-block-IO
-/// pitch/base_width operand. Returns `Value()` when the stride can be
-/// compile-time folded and `stride * elemBytes` exceeds INT32_MAX, so the
-/// caller can bail rather than silently emit garbage. Callers should check
-/// the result and return `failure()` on null. A non-foldable (runtime)
-/// stride is passed through unchecked — the HW pitch operand is i32, so
-/// the caller is trusting the stride to fit at runtime; that matches
-/// getRuntimePitch()'s policy.
-static Value truncStrideProductToI32(ConversionPatternRewriter &rewriter,
-                                     Location loc, Value stride,
-                                     int64_t elemBytes) {
+/// Materialize `stride * elemBytes` as the i32 slot of a 2D-block-IO
+/// surface field measured in bytes (pitch or base_width). Returns
+/// `Value()` when the byte product folds to a value exceeding the HW's
+/// 24-bit field (see kMax2DBlockField). Callers should bail with
+/// `failure()` on null. Non-foldable (runtime) strides pass through
+/// unchecked — the HW pitch operand is i32 but only 24 bits are honored,
+/// so the caller is trusting the stride to fit at runtime; that matches
+/// getRuntimePitch()'s policy. Lower-bound (positivity / MIN_PITCH) policy
+/// is left to callers. For row-valued fields (base_height) use
+/// narrowSurfaceRowsOrNull instead.
+static Value narrowSurfaceBytesOrNull(ConversionPatternRewriter &rewriter,
+                                      Location loc, Value stride,
+                                      int64_t elemBytes) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   if (auto folded = triton::intel::getFoldedConstantValue(stride)) {
     // elemBytes fits in a handful of bits (element sizes are ≤ 8 bytes),
     // so the int64 product is safe from overflow.
     int64_t product = *folded * elemBytes;
-    if (product > std::numeric_limits<int32_t>::max() ||
-        product < std::numeric_limits<int32_t>::min())
+    if (product > kMax2DBlockField)
       return Value();
   }
   Value i64Stride = stride;
@@ -1316,21 +1328,21 @@ static LogicalResult emit2DBlockPrefetchOps(
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   MLIRContext *ctx = rewriter.getContext();
 
-  // Convert baseWidth and rowStride to bytes and truncate to i32, bailing out
-  // if a compile-time-foldable byte pitch/base_width would overflow the HW's
-  // i32 operand. baseHeight is a raw row count with no multiply, but the HW
-  // operand is also i32, so guard it too.
+  // Convert baseWidth and rowStride to bytes and narrow to the HW's 24-bit
+  // surface field (see kMax2DBlockField), bailing out if a compile-time
+  // foldable byte pitch/base_width would exceed it. baseHeight is a raw row
+  // count with no multiply, but goes through the same 24-bit guard.
   int64_t elemBytes = eltTy.getIntOrFloatBitWidth() / 8;
-  Value baseWidthI32 = truncStrideProductToI32(rewriter, loc, baseWidth,
-                                               /*elemBytes=*/elemBytes);
-  Value baseHeightI32 = truncI64ToI32OrNull(rewriter, loc, baseHeight);
+  Value baseWidthI32 = narrowSurfaceBytesOrNull(rewriter, loc, baseWidth,
+                                                /*elemBytes=*/elemBytes);
+  Value baseHeightI32 = narrowSurfaceRowsOrNull(rewriter, loc, baseHeight);
   if (!baseWidthI32 || !baseHeightI32)
     return failure();
   baseWidth = baseWidthI32;
   baseHeight = baseHeightI32;
 
-  Value rowStrideInBytes = truncStrideProductToI32(rewriter, loc, rowStride,
-                                                   /*elemBytes=*/elemBytes);
+  Value rowStrideInBytes = narrowSurfaceBytesOrNull(rewriter, loc, rowStride,
+                                                    /*elemBytes=*/elemBytes);
   if (!rowStrideInBytes)
     return failure();
 
@@ -2749,23 +2761,24 @@ struct DescriptorStoreOpToBlockIOConversion
 
     // --- Shapes (base width / height for 2D block IO payload) ---
     // TensorDesc carries shape as i64 values. The 2D block IO payload
-    // expects baseWidth in bytes and baseHeight in elements. All three
-    // are truncated to i32, so a compile-time-foldable value exceeding
-    // INT32_MAX bails the pattern out rather than silently corrupting
-    // the surface descriptor.
+    // expects baseWidth in bytes and baseHeight in elements. Both are
+    // narrowed to the HW's 24-bit surface field (see kMax2DBlockField),
+    // so a compile-time-foldable value exceeding that limit bails the
+    // pattern out rather than silently corrupting the surface descriptor.
     Value shapeRow = desc.shapes[descRowDim]; // i64
     Value shapeCol = desc.shapes[descColDim]; // i64
-    Value baseWidth = truncStrideProductToI32(rewriter, loc, shapeCol,
-                                              /*elemBytes=*/elemSizeInBits / 8);
-    Value baseHeight = truncI64ToI32OrNull(rewriter, loc, shapeRow);
+    Value baseWidth =
+        narrowSurfaceBytesOrNull(rewriter, loc, shapeCol,
+                                 /*elemBytes=*/elemSizeInBits / 8);
+    Value baseHeight = narrowSurfaceRowsOrNull(rewriter, loc, shapeRow);
 
     // --- Pitch (row stride in bytes) ---
     // TODO: DescriptorStoreOp does not expose a "memory order" attribute, so
     // we always use the row-major stride dimension. Once a memory order
     // attribute is added, this should be adjusted.
     Value strideForPitch = desc.strides[descRowDim]; // i64
-    Value pitch = truncStrideProductToI32(rewriter, loc, strideForPitch,
-                                          /*elemBytes=*/elemSizeInBits / 8);
+    Value pitch = narrowSurfaceBytesOrNull(rewriter, loc, strideForPitch,
+                                           /*elemBytes=*/elemSizeInBits / 8);
     if (!baseWidth || !baseHeight || !pitch)
       return failure();
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -140,7 +140,7 @@ struct LoadStoreConversionBase {
       : targetInfo(targetInfo), axisAnalysisPass(axisAnalysisPass),
         strideAnalysis(strideAnalysis) {}
 
-  int getStride(Value ptr, unsigned dim) const {
+  int64_t getStride(Value ptr, unsigned dim) const {
     triton::intel::StrideInfo *strideInfo = strideAnalysis.getStrideInfo(ptr);
     if (strideInfo) {
       const auto &stride = strideInfo->getStride();
@@ -715,17 +715,20 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
     Location loc = ptr.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-    int stride = getStride(ptr, dim);
+    int64_t stride = getStride(ptr, dim);
     // If the stride is 0, we assume a minimum pitch of 64 bytes.
-    constexpr int MIN_PITCH = 64;
+    constexpr int64_t MIN_PITCH = 64;
     if (stride == 0)
       return b.i32_val(MIN_PITCH);
 
     if (stride > 0) {
-      unsigned pitch = (unsigned)stride * elemSizeInBits / 8;
+      int64_t pitch = stride * elemSizeInBits / 8;
       if (pitch < MIN_PITCH)
         return nullptr; // unsupported pitch
-      return b.i32_val(pitch);
+      // The HW pitch operand is i32; bail out rather than silently truncating.
+      if (pitch > std::numeric_limits<int32_t>::max())
+        return nullptr;
+      return b.i32_val(static_cast<int32_t>(pitch));
     }
     assert(stride == -1 && "invalid stride < 0");
     return nullptr;
@@ -1533,7 +1536,7 @@ struct PrefetchOpConversion
       return failure();
 
     // If the stride is 0, we want to load only the first row.
-    int stride = getStride(op.getPtr(), rank - 2);
+    int64_t stride = getStride(op.getPtr(), rank - 2);
     Value baseHeight = b.i32_val(stride == 0 ? 1 : tileHeightInElem);
     Value baseWidth = b.i32_val(
         std::max(64u, vBlocks * tileWidthInElem * (elemSizeInBits / 8)));
@@ -1773,7 +1776,7 @@ struct PrefetchOpConversion
       return failure();
 
     // Row stride in elements (i64) -- emit2DBlockPrefetchOps converts to bytes.
-    int stride = getStride(op.getPtr(), rank - 2);
+    int64_t stride = getStride(op.getPtr(), rank - 2);
     if (stride < 0)
       return failure();
     Value rowStride = b.i64_val(stride);
@@ -1815,10 +1818,11 @@ struct PrefetchOpConversion
     // slices would prefetch the same (x,y) surface), so bail out instead.
     SmallVector<Value> extraDimStrides, extraDimBaseOffsets;
     for (unsigned d = 0; d < rank - 2; ++d) {
-      int dimStride = getStride(op.getPtr(), d);
+      int64_t dimStride = getStride(op.getPtr(), d);
       if (dimStride <= 0)
         return failure();
-      extraDimStrides.push_back(b.i64_val(dimStride * elemSizeInBytes));
+      extraDimStrides.push_back(
+          b.i64_val(dimStride * static_cast<int64_t>(elemSizeInBytes)));
       extraDimBaseOffsets.push_back(b.i32_val(0));
     }
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1250,6 +1250,51 @@ static TritonGEN::LoadCacheControl prefetchCacheControl(CacheModifier cm) {
   }
 }
 
+/// Truncate `v` to i32 for a 2D-block-IO baseHeight operand. Returns
+/// `Value()` when `v` can be compile-time folded and exceeds INT32_MAX, so
+/// the caller can bail rather than silently emit garbage. Non-foldable
+/// (runtime) values pass through unchecked — the HW verifier catches
+/// invalid sizes.
+static Value truncI64ToI32OrNull(ConversionPatternRewriter &rewriter,
+                                 Location loc, Value v) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  if (auto folded = triton::intel::getFoldedConstantValue(v)) {
+    if (*folded > std::numeric_limits<int32_t>::max() ||
+        *folded < std::numeric_limits<int32_t>::min())
+      return Value();
+  }
+  return b.trunc(i32_ty, v);
+}
+
+/// Materialize `stride * elemBytes` as an i32 for a 2D-block-IO
+/// pitch/base_width operand. Returns `Value()` when the stride can be
+/// compile-time folded and `stride * elemBytes` exceeds INT32_MAX, so the
+/// caller can bail rather than silently emit garbage. Callers should check
+/// the result and return `failure()` on null. A non-foldable (runtime)
+/// stride is passed through unchecked — the HW pitch operand is i32, so
+/// the caller is trusting the stride to fit at runtime; that matches
+/// getRuntimePitch()'s policy.
+static Value truncStrideProductToI32(ConversionPatternRewriter &rewriter,
+                                     Location loc, Value stride,
+                                     int64_t elemBytes) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  if (auto folded = triton::intel::getFoldedConstantValue(stride)) {
+    // elemBytes fits in a handful of bits (element sizes are ≤ 8 bytes),
+    // so the int64 product is safe from overflow.
+    int64_t product = *folded * elemBytes;
+    if (product > std::numeric_limits<int32_t>::max() ||
+        product < std::numeric_limits<int32_t>::min())
+      return Value();
+  }
+  Value i64Stride = stride;
+  if (auto intTy = dyn_cast<IntegerType>(stride.getType())) {
+    if (intTy.getWidth() < 64)
+      i64Stride = b.sext(i64_ty, stride);
+  }
+  Value product = b.mul(i64Stride, b.i64_val(elemBytes));
+  return b.trunc(i32_ty, product);
+}
+
 /// Emit 2D block prefetch operations for a tiled prefetch.
 ///
 /// Converts base dimensions to bytes, determines vBlocks from element size,
@@ -1271,15 +1316,23 @@ static LogicalResult emit2DBlockPrefetchOps(
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   MLIRContext *ctx = rewriter.getContext();
 
-  // Convert baseWidth and rowStride to bytes and truncate to i32.
-  baseWidth = b.mul(baseWidth, b.i64_val(eltTy.getIntOrFloatBitWidth() / 8));
-  baseWidth = b.trunc(i32_ty, baseWidth);
+  // Convert baseWidth and rowStride to bytes and truncate to i32, bailing out
+  // if a compile-time-foldable byte pitch/base_width would overflow the HW's
+  // i32 operand. baseHeight is a raw row count with no multiply, but the HW
+  // operand is also i32, so guard it too.
+  int64_t elemBytes = eltTy.getIntOrFloatBitWidth() / 8;
+  Value baseWidthI32 = truncStrideProductToI32(rewriter, loc, baseWidth,
+                                               /*elemBytes=*/elemBytes);
+  Value baseHeightI32 = truncI64ToI32OrNull(rewriter, loc, baseHeight);
+  if (!baseWidthI32 || !baseHeightI32)
+    return failure();
+  baseWidth = baseWidthI32;
+  baseHeight = baseHeightI32;
 
-  baseHeight = b.trunc(i32_ty, baseHeight);
-
-  Value rowStrideInBytes =
-      b.mul(rowStride, b.i64_val(eltTy.getIntOrFloatBitWidth() / 8));
-  rowStrideInBytes = b.trunc(i32_ty, rowStrideInBytes);
+  Value rowStrideInBytes = truncStrideProductToI32(rewriter, loc, rowStride,
+                                                   /*elemBytes=*/elemBytes);
+  if (!rowStrideInBytes)
+    return failure();
 
   unsigned elemSizeInBits = eltTy.getIntOrFloatBitWidth();
   unsigned vBlocks = 1;
@@ -2696,20 +2749,25 @@ struct DescriptorStoreOpToBlockIOConversion
 
     // --- Shapes (base width / height for 2D block IO payload) ---
     // TensorDesc carries shape as i64 values. The 2D block IO payload
-    // expects baseWidth in bytes and baseHeight in elements.
+    // expects baseWidth in bytes and baseHeight in elements. All three
+    // are truncated to i32, so a compile-time-foldable value exceeding
+    // INT32_MAX bails the pattern out rather than silently corrupting
+    // the surface descriptor.
     Value shapeRow = desc.shapes[descRowDim]; // i64
     Value shapeCol = desc.shapes[descColDim]; // i64
-    Value baseWidth =
-        b.trunc(i32_ty, b.mul(shapeCol, b.i64_val(elemSizeInBits / 8)));
-    Value baseHeight = b.trunc(i32_ty, shapeRow);
+    Value baseWidth = truncStrideProductToI32(rewriter, loc, shapeCol,
+                                              /*elemBytes=*/elemSizeInBits / 8);
+    Value baseHeight = truncI64ToI32OrNull(rewriter, loc, shapeRow);
 
     // --- Pitch (row stride in bytes) ---
     // TODO: DescriptorStoreOp does not expose a "memory order" attribute, so
     // we always use the row-major stride dimension. Once a memory order
     // attribute is added, this should be adjusted.
     Value strideForPitch = desc.strides[descRowDim]; // i64
-    Value pitch =
-        b.trunc(i32_ty, b.mul(strideForPitch, b.i64_val(elemSizeInBits / 8)));
+    Value pitch = truncStrideProductToI32(rewriter, loc, strideForPitch,
+                                          /*elemBytes=*/elemSizeInBits / 8);
+    if (!baseWidth || !baseHeight || !pitch)
+      return failure();
 
     // --- Offsets ---
     // Unlike block pointers which store offsets in the struct, tensor

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -258,28 +258,31 @@ private:
       }
     }
 
-    // The 2Dblockload HW pitch/base_width operands are i32. Bail out if any
-    // compile-time-foldable byte value overflows the i32 range so we don't
-    // silently emit a garbage surface descriptor. Non-foldable (runtime)
-    // shapes/strides are trusted to fit — the HW verifier will complain if
-    // they don't.
+    // The 2Dblockload HW encodes base_width / base_pitch in 24 bits (the
+    // TritonGEN→LLVM lowering subtracts 1 on emission, so the user-facing
+    // max is 2^24). Bail out if any compile-time-foldable byte value
+    // exceeds that range — otherwise the top bits would be silently
+    // dropped, producing a garbage surface descriptor. Non-foldable
+    // (runtime) shapes/strides are trusted to fit — the HW verifier will
+    // complain if they don't.
     //
     // We chase the descriptor's defining MakeTensorDescOp(s) to reach the
     // original SSA — `strides`/`shapes` above are ttig.extract_desc results
     // whose defining ops the folder can't see through.
-    constexpr int64_t kInt32Max = std::numeric_limits<int32_t>::max();
+    constexpr int64_t kMax2DBlockField = int64_t(1) << 24;
     int64_t elemBytesConst = elemSizeInBits / 8;
     auto wouldOverflow = [&](unsigned operandIdx) {
       return llvm::any_of(allDescs, [&](tt::MakeTensorDescOp d) {
         auto folded =
             tt::intel::getFoldedConstantValue(d->getOperand(operandIdx));
-        return folded && *folded * elemBytesConst > kInt32Max;
+        return folded && *folded * elemBytesConst > kMax2DBlockField;
       });
     };
     // MakeTensorDescOp operands: base, shape[rank], strides[rank].
     if (wouldOverflow(/*inner shape*/ 1 + (descRank - 1)) ||
         wouldOverflow(/*pitch stride*/ 1 + descRank + (descRank - 2))) {
-      LDBG("Pitch/base_width would overflow i32 for descriptor load: " << *op);
+      LDBG("Pitch/base_width exceeds HW 24-bit range for descriptor load: "
+           << *op);
       return;
     }
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -13,6 +13,7 @@
 #include "triton/Tools/LinearLayout.h"
 #include "triton/Tools/Sys/GetEnv.h"
 #include "llvm/Support/Debug.h"
+#include <limits>
 #include <optional>
 
 #define DEBUG_TYPE "tritonintelgpu-lower-to-2d-block-load"
@@ -255,6 +256,31 @@ private:
           return;
         }
       }
+    }
+
+    // The 2Dblockload HW pitch/base_width operands are i32. Bail out if any
+    // compile-time-foldable byte value overflows the i32 range so we don't
+    // silently emit a garbage surface descriptor. Non-foldable (runtime)
+    // shapes/strides are trusted to fit — the HW verifier will complain if
+    // they don't.
+    //
+    // We chase the descriptor's defining MakeTensorDescOp(s) to reach the
+    // original SSA — `strides`/`shapes` above are ttig.extract_desc results
+    // whose defining ops the folder can't see through.
+    constexpr int64_t kInt32Max = std::numeric_limits<int32_t>::max();
+    int64_t elemBytesConst = elemSizeInBits / 8;
+    auto wouldOverflow = [&](unsigned operandIdx) {
+      return llvm::any_of(allDescs, [&](tt::MakeTensorDescOp d) {
+        auto folded =
+            tt::intel::getFoldedConstantValue(d->getOperand(operandIdx));
+        return folded && *folded * elemBytesConst > kInt32Max;
+      });
+    };
+    // MakeTensorDescOp operands: base, shape[rank], strides[rank].
+    if (wouldOverflow(/*inner shape*/ 1 + (descRank - 1)) ||
+        wouldOverflow(/*pitch stride*/ 1 + descRank + (descRank - 2))) {
+      LDBG("Pitch/base_width would overflow i32 for descriptor load: " << *op);
+      return;
     }
 
     // Surface width = inner dimension size * element bytes.


### PR DESCRIPTION
This PR addresses incorrect 2D block IO surface descriptor formation on Intel GPU paths when large (but compile-time foldable) strides/shapes cause i32 truncation/overflow during pitch/base_width lowering. It broadens stride arithmetic to i64 and adds guards so the compiler bails out instead of silently producing invalid hardware operands, with new MLIR regression tests covering the large-stride scenarios.

Fixes #7334