### PR TITLE
Use the correct signature for signbit fp64 function

### DIFF
--- a/third_party/intel/language/intel/libdevice.py
+++ b/third_party/intel/language/intel/libdevice.py
@@ -993,7 +993,7 @@ def signbit(arg0, _semantic=None):
             arg0,
         ], {
             (core.dtype("fp32"), ): ("__imf_signbitf", core.dtype("int32")),
-            (core.dtype("fp64"), ): ("__imf_signbitd", core.dtype("int32")),
+            (core.dtype("fp64"), ): ("__imf_signbit", core.dtype("int32")),
         }, is_pure=True, _semantic=_semantic)
 
 


### PR DESCRIPTION
For double: it's: `define weak dso_local spir_func i32 @__imf_signbit(double noundef %0)`

Note: this change needs to be added to release/3.8.0 branch.

Verified using: `PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=0 python test/inductor/test_op_dtype_prop.py TestCaseXPU.test_op_dtype_propagation_signbit_xpu_float64`