### PR TITLE
[Windows][WIP] SYCL-TLA workaround patches (draft, pending upstream)

### DIFF
--- a/benchmarks/sycl_tla_kernel/patches/0002-mma-xe-legacy-spirv-bare-ushort.patch
+++ b/benchmarks/sycl_tla_kernel/patches/0002-mma-xe-legacy-spirv-bare-ushort.patch
@@ -1,0 +1,13 @@
+diff --git a/include/cute/arch/mma_xe_legacy_spirv.hpp b/include/cute/arch/mma_xe_legacy_spirv.hpp
+index 2d512bb6..307bebd6 100644
+--- a/include/cute/arch/mma_xe_legacy_spirv.hpp
++++ b/include/cute/arch/mma_xe_legacy_spirv.hpp
+@@ -44,7 +44,7 @@ SYCL_EXTERNAL               short __spirv_SubgroupMatrixMultiplyAccumulateINTEL(
+ SYCL_EXTERNAL cute::intel::int8 __spirv_SubgroupMatrixMultiplyAccumulateINTEL(int32_t, cute::intel::ushort8, cute::intel::uint8, cute::intel::int8, int32_t);
+ SYCL_EXTERNAL cute::intel::int4 __spirv_SubgroupMatrixMultiplyAccumulateINTEL(int32_t, cute::intel::ushort4, cute::intel::uint8, cute::intel::int4, int32_t);
+ SYCL_EXTERNAL cute::intel::int2 __spirv_SubgroupMatrixMultiplyAccumulateINTEL(int32_t, cute::intel::ushort2, cute::intel::uint8, cute::intel::int2, int32_t);
+-SYCL_EXTERNAL               int __spirv_SubgroupMatrixMultiplyAccumulateINTEL(int32_t,               ushort, cute::intel::uint8,               int, int32_t);
++SYCL_EXTERNAL               int __spirv_SubgroupMatrixMultiplyAccumulateINTEL(int32_t,        unsigned short, cute::intel::uint8,               int, int32_t);
+
+ SYCL_EXTERNAL cute::intel::float8 __spirv_SubgroupMatrixMultiplyAccumulateINTEL(int32_t, cute::intel::float4, cute::intel::float8, cute::intel::float8, int32_t);
+ SYCL_EXTERNAL cute::intel::float4 __spirv_SubgroupMatrixMultiplyAccumulateINTEL(int32_t, cute::intel::float2, cute::intel::float8, cute::intel::float4, int32_t);

--- a/benchmarks/sycl_tla_kernel/patches/0003-xe-mma-mixed-input-bare-ushort.patch
+++ b/benchmarks/sycl_tla_kernel/patches/0003-xe-mma-mixed-input-bare-ushort.patch
@@ -1,0 +1,13 @@
+diff --git a/include/cutlass/gemm/collective/xe_mma_mixed_input.hpp b/include/cutlass/gemm/collective/xe_mma_mixed_input.hpp
+index a99d8b97..f6bed7f1 100644
+--- a/include/cutlass/gemm/collective/xe_mma_mixed_input.hpp
++++ b/include/cutlass/gemm/collective/xe_mma_mixed_input.hpp
+@@ -432,7 +432,7 @@ public:
+     static constexpr auto N = decltype(size<1>(in))::value;
+     static constexpr auto K = decltype(size<2>(in))::value;
+ 
+-    using format_type = ushort;
++    using format_type = unsigned short;
+     static constexpr auto src_bits = sizeof_bits_v<SrcType>;
+     static constexpr auto scalar = sizeof_bits_v<format_type> / src_bits;
+     static constexpr auto loop_cnt = decltype(size(out))::value / N;

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -1,4 +1,13 @@
 """isort:skip_file"""
+import os
+import sys
+if sys.platform == 'win32':
+    _p = r'C:\Program Files (x86)\Intel\oneAPI\compiler\latest\bin'
+    if os.path.isdir(_p):
+        try:
+            os.add_dll_directory(_p)
+        except (OSError, AttributeError):
+            pass
 __version__ = '3.8.0'
 
 # ---------------------------------------

--- a/third_party/intel/backend/proton_utils.cpp
+++ b/third_party/intel/backend/proton_utils.cpp
@@ -6,19 +6,27 @@
 #include <string>
 #include <sycl/sycl.hpp>
 
-extern "C" void waitOnSyclQueue(void *syclQueue) {
+#ifdef _WIN32
+#define PROTON_UTILS_EXPORT __declspec(dllexport)
+#else
+#define PROTON_UTILS_EXPORT
+#endif
+
+extern "C" PROTON_UTILS_EXPORT void waitOnSyclQueue(void *syclQueue) {
   sycl::queue *queue = static_cast<sycl::queue *>(syclQueue);
   queue->wait();
 }
 
-extern "C" void copyDeviceToHostAsync(void *syclQueue, void *dst,
-                                      const void *src, size_t size) {
+extern "C" PROTON_UTILS_EXPORT void copyDeviceToHostAsync(void *syclQueue,
+                                                          void *dst,
+                                                          const void *src,
+                                                          size_t size) {
   sycl::queue *queue = static_cast<sycl::queue *>(syclQueue);
   queue->memcpy(dst, src, size);
 }
 
-extern "C" void allocateHostBuffer(void *syclQueue, uint8_t **buffer,
-                                   size_t size) {
+extern "C" PROTON_UTILS_EXPORT void
+allocateHostBuffer(void *syclQueue, uint8_t **buffer, size_t size) {
   sycl::queue *queue = static_cast<sycl::queue *>(syclQueue);
   *buffer = static_cast<uint8_t *>(sycl::malloc_host(size, *queue));
   if (*buffer == nullptr) {
@@ -27,13 +35,14 @@ extern "C" void allocateHostBuffer(void *syclQueue, uint8_t **buffer,
   }
 }
 
-extern "C" void freeHostBuffer(void *syclQueue, uint8_t *buffer) {
+extern "C" PROTON_UTILS_EXPORT void freeHostBuffer(void *syclQueue,
+                                                   uint8_t *buffer) {
   sycl::queue *queue = static_cast<sycl::queue *>(syclQueue);
   sycl::free(buffer, *queue);
 }
 
-extern "C" void allocateDeviceBuffer(void *syclQueue, uint8_t **buffer,
-                                     size_t size) {
+extern "C" PROTON_UTILS_EXPORT void
+allocateDeviceBuffer(void *syclQueue, uint8_t **buffer, size_t size) {
   sycl::queue *queue = static_cast<sycl::queue *>(syclQueue);
   *buffer = static_cast<uint8_t *>(sycl::malloc_device(size, *queue));
   if (*buffer == nullptr) {
@@ -42,25 +51,26 @@ extern "C" void allocateDeviceBuffer(void *syclQueue, uint8_t **buffer,
   }
 }
 
-extern "C" void freeDeviceBuffer(void *syclQueue, uint8_t *buffer) {
+extern "C" PROTON_UTILS_EXPORT void freeDeviceBuffer(void *syclQueue,
+                                                     uint8_t *buffer) {
   sycl::queue *queue = static_cast<sycl::queue *>(syclQueue);
   sycl::free(buffer, *queue);
 }
 
-extern "C" void memsetAsync(void *syclQueue, void *devicePtr, int32_t value,
-                            size_t size) {
+extern "C" PROTON_UTILS_EXPORT void
+memsetAsync(void *syclQueue, void *devicePtr, int32_t value, size_t size) {
   sycl::queue *queue = static_cast<sycl::queue *>(syclQueue);
   queue->memset(devicePtr, static_cast<unsigned char>(value), size);
 }
 
-extern "C" void synchronizeDevice(void *syclQueue) {
+extern "C" PROTON_UTILS_EXPORT void synchronizeDevice(void *syclQueue) {
   sycl::queue *queue = static_cast<sycl::queue *>(syclQueue);
   queue->wait_and_throw();
 }
 
 // Returns the Level-Zero native device handle as a stable map key for
 // MetricBuffer's per-device buffer cache.
-extern "C" void *getDeviceKey(void *syclQueue) {
+extern "C" PROTON_UTILS_EXPORT void *getDeviceKey(void *syclQueue) {
   sycl::queue *queue = static_cast<sycl::queue *>(syclQueue);
   auto native = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
       queue->get_device());
@@ -69,7 +79,7 @@ extern "C" void *getDeviceKey(void *syclQueue) {
 
 // FIXME: Should it be in DeviceInfo class?
 // Inspired by Kineto: `XpuptiActivityProfiler.cpp`
-extern "C" void enumDeviceUUIDs(void *deviceUUIDsPtr) {
+extern "C" PROTON_UTILS_EXPORT void enumDeviceUUIDs(void *deviceUUIDsPtr) {
   auto *deviceUUIDs_ =
       reinterpret_cast<std::vector<std::array<uint8_t, 16>> *>(deviceUUIDsPtr);
   if (!deviceUUIDs_->empty()) {
@@ -117,10 +127,10 @@ void check(ze_result_t ret, const char *functionName) {
 // FIXME: rewrite with
 // sycl::device.get_info<sycl::ext::intel::info::device::architecture>; cache
 // the result
-extern "C" void getDeviceProperties(uint64_t index, uint32_t *clockRate,
-                                    uint32_t *memoryClockRate,
-                                    uint32_t *busWidth, uint32_t *numSms,
-                                    char arch[256]) {
+extern "C" PROTON_UTILS_EXPORT void
+getDeviceProperties(uint64_t index, uint32_t *clockRate,
+                    uint32_t *memoryClockRate, uint32_t *busWidth,
+                    uint32_t *numSms, char arch[256]) {
   // ref: getDeviceProperties
 
   // FIXME: double check that initialization is needed

--- a/third_party/proton/csrc/Proton.cpp
+++ b/third_party/proton/csrc/Proton.cpp
@@ -86,7 +86,7 @@ static void initProton(nanobind::module_ &m) {
       "start",
       [](const std::string &path, const std::string &contextSourceName,
          const std::string &dataName, const std::string &profilerName,
-         const std::string &mode, long sycl_queue,
+         const std::string &mode, int64_t sycl_queue,
          const std::string &utils_cache_path) {
         void *queue = reinterpret_cast<void *>(sycl_queue);
         auto sessionId = SessionManager::instance().addSession(

--- a/third_party/proton/csrc/lib/Driver/GPU/XpuptiApi.cpp
+++ b/third_party/proton/csrc/lib/Driver/GPU/XpuptiApi.cpp
@@ -8,7 +8,11 @@ namespace xpupti {
 
 struct ExternLibXpupti : public ExternLibBase {
   using RetType = pti_result;
+#if defined(_WIN32)
+  static constexpr const char *name = "pti_view-0.dll";
+#else
   static constexpr const char *name = "libpti_view.so";
+#endif
   static constexpr const char *defaultDir = "";
   static constexpr const char *pathEnv = "TRITON_XPUPTI_LIB_PATH";
   static constexpr RetType success = PTI_SUCCESS;


### PR DESCRIPTION
## Summary

**Draft PR.** Adds the SYCL-TLA fixes needed to build `sycl_tla_kernel.pyd` (GEMM / attention benchmarks) on Windows, as a workaround while the proper fix is prepared upstream in `intel/sycl-tla`.

## Depends on

- #7374 — mainline Windows fixes (this PR builds on top of it)

## Blocked on

- Upstream `intel/sycl-tla` PR (to be filed). If accepted and this repo bumps the SYCL-TLA pin past the fix, **this PR should be closed without merging** and the two `.patch` files dropped.

Refs: #7362

## Changes

Two `.patch` files under `benchmarks/sycl_tla_kernel/patches/` that `FindSyclTlaLibrary.cmake` applies at FetchContent time (matching the existing `0001-*.patch` convention). They replace bare OpenCL C `ushort` with `unsigned short` in:

- `include/cute/arch/mma_xe_legacy_spirv.hpp` (line 47)
- `include/cutlass/gemm/collective/xe_mma_mixed_input.hpp` (line 435)

## Why

Bare `ushort` is an OpenCL C builtin, defined only during SYCL **device** compilation. Both sites use it in host-context template instantiation, where the identifier is undefined. In `cute::intel` the type is `typedef unsigned short`, so this substitution is a **no-op on Linux** — the two spellings are equivalent for host compilation. On Windows / icx host compilation, only the explicit form works.

## Symptom without this fix

```
error: unknown type name 'ushort'
   47 | SYCL_EXTERNAL int __spirv_SubgroupMatrixMultiplyAccumulateINTEL(
      |                                                                 ^
```

## Verification

- `sycl_tla_kernel.pyd` builds successfully (~5 min)
- `import triton_kernels_benchmark.sycl_tla_kernel` exposes real functions (`gemm`, `gemm_splitk`, `attention`)
- flex-attention-causal benchmark reaches the compute path
