### PR TITLE
[vLLM] Remove BMG skips for hanging triton attention configs

### DIFF
--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -136,13 +136,13 @@ jobs:
       fail-fast: false
       matrix:
         suite:
-          - vllm-spec-decode
-          - vllm-mrv2
-          - vllm-moe
+          #- vllm-spec-decode
+          #- vllm-mrv2
+          #- vllm-moe
           - vllm-triton-attn
-          - vllm-mamba
-          - vllm-quant
-          - vllm-rest
+          #- vllm-mamba
+          #- vllm-quant
+          #- vllm-rest
     runs-on:
       - linux
       - ${{ inputs.runner_label || 'max1550' }}

--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -136,14 +136,14 @@ jobs:
       fail-fast: false
       matrix:
         suite:
-          #- vllm-spec-decode
-          #- vllm-mrv2
-          #- vllm-moe
+          - vllm-spec-decode
+          - vllm-mrv2
+          - vllm-moe
           - vllm-triton-attn
-          #- vllm-mamba
-          #- vllm-quant
-          #- vllm-kda
-          #- vllm-rest
+          - vllm-mamba
+          - vllm-quant
+          - vllm-kda
+          - vllm-rest
     runs-on:
       - linux
       - ${{ inputs.runner_label || 'max1550' }}

--- a/scripts/skiplist/xe2/vllm_triton_attn.txt
+++ b/scripts/skiplist/xe2/vllm_triton_attn.txt
@@ -1,11 +1,3 @@
-# Hangs on B580: https://github.com/intel/intel-xpu-backend-for-triton/issues/7121
-tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_attn_fp16_input_fp8_output[r".*-seq_lens2"]@regexp
-tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_attn_fp16_input_fp8_output[r"0-32768-None-(64|128|256)-16-256-num_heads1-seq_lens3"]@regexp
-tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_attn_fp16_input_fp8_output[r"0-32768-50.0-(None|64|128|256)-16-256-num_heads1-seq_lens3"]@regexp
-tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_attn_fp16_input_fp8_output[r"8-32768-None-(None|64|128|256)-16-256-num_heads1-seq_lens3"]@regexp
-tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_attn_fp16_input_fp8_output[r"8-32768-50.0-(None|64|128|256)-16-256-num_heads1-seq_lens3"]@regexp
-tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_attn_fp16_input_fp8_output[r"0-2048-50.0-(64|128|256)-16-256-num_heads2-seq_lens3"]@regexp
-
 # Out of memory on B580: https://github.com/intel/intel-xpu-backend-for-triton/issues/7122
 tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_attn_fp16_input_fp8_output[0-2048-50.0-256-16-256-num_heads1-seq_lens3]
 tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_attn_fp16_input_fp8_output[0-2048-50.0-256-16-256-num_heads2-seq_lens0]


### PR DESCRIPTION
The configs no longer hang on BMG.

Closes https://github.com/intel/intel-xpu-backend-for-triton/issues/7121.

vLLM tests BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/28846258020