### PR TITLE
Use the correct signature for signbit fp64 function (#7373)

### DIFF
--- a/third_party/intel/language/intel/libdevice.py
+++ b/third_party/intel/language/intel/libdevice.py
@@ -993,7 +993,7 @@ def signbit(arg0, _semantic=None):
             arg0,
         ], {
             (core.dtype("fp32"), ): ("__imf_signbitf", core.dtype("int32")),
-            (core.dtype("fp64"), ): ("__imf_signbitd", core.dtype("int32")),
+            (core.dtype("fp64"), ): ("__imf_signbit", core.dtype("int32")),
         }, is_pure=True, _semantic=_semantic)
 
 


### PR DESCRIPTION
For double: it's: `define weak dso_local spir_func i32 @__imf_signbit(double noundef %0)`


(cherry picked from commit c4ffbb9b41be7cfb593c3100c2fd2f9541dc95a6)