### PR TITLE
[Benchmarks] Set `TORCHINDUCTOR_USE_EXPERIMENTAL_BENCHMARKER=0` for CI perf runs

### DIFF
--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -70,6 +70,7 @@ permissions: read-all
 env:
   PYTHON_VERSION: "3.10"
   BENCHMARKING_METHOD: ${{ inputs.benchmarking_method || 'UPSTREAM_PYTORCH_PROFILER' }}
+  TORCHINDUCTOR_USE_EXPERIMENTAL_BENCHMARKER: '0'
   VERIFY: ${{ (github.event_name == 'pull_request' || github.event_name == 'schedule' || inputs.verify) && '1' || '0' }}
   TAG: ${{ inputs.tag || (github.event_name == 'pull_request' && format('pr-{0}', github.event.number)) || (github.event_name == 'schedule' && 'ci') || 'test' }}
   N_RUNS: ${{ inputs.n_runs || '1' }}

--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -70,6 +70,7 @@ permissions: read-all
 env:
   PYTHON_VERSION: "3.10"
   BENCHMARKING_METHOD: ${{ inputs.benchmarking_method || 'UPSTREAM_PYTORCH_PROFILER' }}
+  # FIXME: When https://github.com/pytorch/pytorch/issues/189144 will be addressed
   TORCHINDUCTOR_USE_EXPERIMENTAL_BENCHMARKER: '0'
   VERIFY: ${{ (github.event_name == 'pull_request' || github.event_name == 'schedule' || inputs.verify) && '1' || '0' }}
   TAG: ${{ inputs.tag || (github.event_name == 'pull_request' && format('pr-{0}', github.event.number)) || (github.event_name == 'schedule' && 'ci') || 'test' }}


### PR DESCRIPTION
PyTorch by [default uses it's own benchmarker](https://github.com/pytorch/pytorch/blob/9be99224e399c4767fd5ad7d41ef919803bf3b94/torch/_inductor/config.py#L486-L490) and for example https://github.com/intel/intel-xpu-backend-for-triton/issues/7302 as explained in this issue

`InductorBenchmarker` uses L2 cache size clear between runs [pytorch/torch/_inductor/runtime/benchmarking.py@582](https://github.com/pytorch/pytorch/blob/23b1588b32ea2d46410793347d635017fdc49c75/torch/_inductor/runtime/benchmarking.py#L582)

While triton xpu `do_bench` uses default `256MB` regardless of GPU https://github.com/intel/intel-xpu-backend-for-triton/blob/d9d2389ebc3acb9817f9786d6872103af558e927/third_party/intel/backend/driver.py#L721

That can lead to some discrepancies while our goal is to have more deterministic CI from triton perspective