### PR TITLE
[E2E] Remove `CamemBert` and `Speech2Text2ForCausalLM` Huggingface models as old ones

### DIFF
--- a/.github/models/accuracy/huggingface.txt
+++ b/.github/models/accuracy/huggingface.txt
@@ -1,10 +1,8 @@
 BlenderbotSmallForCausalLM
-CamemBert
 DistilBertForMaskedLM
 ElectraForCausalLM
 GPT2ForSequenceClassification
 MobileBertForMaskedLM
 MobileBertForQuestionAnswering
-Speech2Text2ForCausalLM
 T5ForConditionalGeneration
 XLNetLMHeadModel

--- a/.github/models/performance/huggingface.txt
+++ b/.github/models/performance/huggingface.txt
@@ -1,10 +1,8 @@
 BlenderbotSmallForCausalLM
-CamemBert
 DistilBertForMaskedLM
 ElectraForCausalLM
 GPT2ForSequenceClassification
 MobileBertForMaskedLM
 MobileBertForQuestionAnswering
-Speech2Text2ForCausalLM
 T5ForConditionalGeneration
 XLNetLMHeadModel


### PR DESCRIPTION
`transformers-5.10.1` no longer supports these models https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/28726231045/job/85184029588#step:23:247 