### PR TITLE
Added TritonTableGen because they are required to build TritonAnnotateModule

### DIFF
--- a/third_party/intel/lib/TritonAnnotateModule/CMakeLists.txt
+++ b/third_party/intel/lib/TritonAnnotateModule/CMakeLists.txt
@@ -3,6 +3,7 @@ add_triton_library(TritonAnnotateModule
 
     DEPENDS
     TritonAnnotateModulePassIncGen
+    TritonTableGen
 
     LINK_LIBS PUBLIC
     MLIRIR


### PR DESCRIPTION
Add missing build dependency.