### PR TITLE
[XPU] Support more SYCL capable compilers building kernel launchers (#7311)

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -609,6 +609,8 @@ class intel_knobs(base_knobs):
     # the actual device extensions.
     device_extensions: env_opt_str = env_opt_str("TRITON_INTEL_DEVICE_EXTENSIONS")
     device_arch: env_opt_str = env_opt_str("TRITON_INTEL_DEVICE_ARCH")
+    # SYCL compiler Triton needs to be compatible with when generating kernel launchers
+    sycl_compiler: env_opt_str = env_opt_str("TRITON_INTEL_SYCL_COMPILER")
 
 
 class amd_knobs(base_knobs):

--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -110,18 +110,22 @@ def _build(name: str, src: str, srcdir: str, library_dirs: list[str], include_di
     include_dirs = include_dirs + [srcdir, py_include_dir, *custom_backend_dirs]
 
     if is_xpu():
-        icpx = shutil.which("icpx")
+        csycl = shutil.which(knobs.intel.sycl_compiler) if knobs.intel.sycl_compiler else None
+        if csycl is None:
+            icpx = shutil.which("icpx")
+            dpclang = shutil.which("dpclang++")
+            csycl = icpx or dpclang
         cxx = shutil.which(os.environ.get("CXX", "shutil-dummy-value"))
         if cxx is None:
             clangpp = shutil.which("clang++")
             gxx = shutil.which("g++")
             cl = shutil.which("cl")
-            cxx = icpx or cl if os.name == "nt" else icpx or clangpp or gxx
+            cxx = csycl or cl if os.name == "nt" else csycl or clangpp or gxx
             if cxx is None:
                 raise RuntimeError("Failed to find C++ compiler. Please specify via CXX environment variable.")
         cc = cxx
 
-        if cxx is icpx:
+        if cxx is csycl:
             ccflags += ["-fsycl", "-fno-sycl-id-queries-fit-in-int"]
         else:
             if os.name != "nt":

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -5,6 +5,7 @@ import sys
 import hashlib
 import shutil
 import ctypes
+import subprocess
 import sysconfig
 import tempfile
 from pathlib import Path
@@ -30,23 +31,8 @@ ARG_KERNEL = None
 ARG_TUPLE = None
 
 
-def find_sycl(include_dir: list[str]) -> tuple[list[str], list[str]]:
-    """
-    Looks for the sycl library in known places.
-
-    Arguments:
-      include_dir: list of include directories to pass to compiler.
-
-    Returns:
-      enriched include_dir and libsycl.so location.
-
-    Raises:
-      AssertionError: if library was not found.
-    """
+def find_sycl_icpx(include_dir: list[str]) -> tuple[list[str], list[str]]:
     include_dir = include_dir.copy()
-    assertion_message = ("sycl headers not found, please install `icpx` compiler, "
-                         "or provide `ONEAPI_ROOT` environment "
-                         "or install `intel-sycl-rt>=2025.0.0` wheel")
     icpx_path = shutil.which("icpx")
     if icpx_path:
         # only `icpx` compiler knows where sycl runtime binaries and header files are
@@ -67,10 +53,10 @@ def find_sycl(include_dir: list[str]) -> tuple[list[str], list[str]]:
     try:
         sycl_rt = importlib.metadata.metadata("intel-sycl-rt")
     except importlib.metadata.PackageNotFoundError:
-        raise AssertionError(assertion_message)
+        return include_dir, []
 
     if sycl_rt.get("version", "0.0.0").startswith("2024"):
-        raise AssertionError(assertion_message)
+        return include_dir, []
 
     sycl_dirs = []
     for f in importlib.metadata.files("intel-sycl-rt"):
@@ -87,7 +73,84 @@ def find_sycl(include_dir: list[str]) -> tuple[list[str], list[str]]:
                 _ = os.add_dll_directory(str(dll_path))
             sycl_dirs.append(str(sycl_dir))
 
-    assert len(sycl_dirs) != 0
+    return include_dir, sycl_dirs
+
+
+def find_sycl_dpclang(include_dir: list[str]) -> tuple[list[str], list[str]]:
+    include_dir = include_dir.copy()
+
+    if not shutil.which("pkg-config"):
+        return include_dir, []
+
+    dpclang = shutil.which(knobs.intel.sycl_compiler if knobs.intel.sycl_compiler else "dpclang++")
+    cmd = [dpclang, "-E", "-dM", "-"]
+
+    major = None
+    try:
+        result = subprocess.run(cmd, input="", capture_output=True, text=True, check=True)
+        for line in result.stdout.splitlines():
+            if "__dpcpp_major__" in line:
+                # The line looks like: "#define __dpcpp_major__ 7"
+                parts = line.split()
+                if len(parts) >= 3:
+                    major = int(parts[-1])
+                    break
+    except (subprocess.CalledProcessError, FileNotFoundError, ValueError):
+        return include_dir, []
+
+    if major is None:
+        return include_dir, []
+
+    package_name = f"sycl-dpcpp-{major}"
+    sycl_dirs = []
+    try:
+        cflags_I_res = subprocess.run(
+            ["pkg-config", "--cflags-only-I", package_name],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip().split()
+        include_dir += [flag[2:] for flag in cflags_I_res if flag.startswith("-I") and len(flag) > 2]
+
+        libs_L_res = subprocess.run(
+            ["pkg-config", "--libs-only-L", package_name],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip().split()
+        sycl_dirs = [flag[2:] for flag in libs_L_res if flag.startswith("-L") and len(flag) > 2]
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    return include_dir, sycl_dirs
+
+
+def find_sycl(include_dir: list[str]) -> tuple[list[str], list[str]]:
+    """
+    Looks for the sycl library in known places.
+
+    Arguments:
+      include_dir: list of include directories to pass to compiler.
+
+    Returns:
+      enriched include_dir and libsycl.so location.
+
+    Raises:
+      AssertionError: if library was not found.
+    """
+
+    sycl_dirs = []
+    csycl = knobs.intel.sycl_compiler
+    if not csycl or csycl == "icpx":
+        include_dir, sycl_dirs = find_sycl_icpx(include_dir)
+    if len(sycl_dirs) == 0 and (not csycl or csycl.startswith("dpclang")):
+        include_dir, sycl_dirs = find_sycl_dpclang(include_dir)
+    if len(sycl_dirs) == 0:
+        raise AssertionError("sycl headers not found, please install `icpx` compiler, "
+                             "or provide `ONEAPI_ROOT` environment "
+                             "or install `intel-sycl-rt>=2025.0.0` wheel"
+                             "or instal `dpclang` compiler (experimental)")
+
     return include_dir, sycl_dirs
 
 


### PR DESCRIPTION
This commits adds support for more SYCL capable compilers. At the moment we have 3 relevant to Intel GPUs:

* Intel closed source DPC++ compiler (icpx) - included into oneAPI
* Intel open source DPC++ compiler (dpclang) - https://github.com/intel/llvm
* Clang itself (experimental SYCL support is in active progress)

Pytorch has recently added support for `dpclang` and will soon start working on supporting SYCL capable `clang`. We need this change in Triton to support broader enabling of `dpclang` (and later SYCL capable `clang`). Pytorch has already implemented CI coverage for `dpclang` and looks to address identified issues major of which is missing Triton support affecting multple inductor tests.

This commits makes few changes worth noting:

* Added short path when building kernel launchers with SYCL capable compiler. This compilers can be automatically configured for the SYCL support by passing `-fsycl`. There is no need to manually search for and configure SYCL library.
* Added `TRITON_INTEL_SYCL_COMPILER=icpx|dpclang++|clang|...` knob to notify Triton with which SYCL compiler (i.e. SYCL runtime) kernel launcher must be compatible with. For Pytorch this corresponds to the SYCL compiler which was used to build Pytorch.

See:
https://github.com/pytorch/pytorch/commit/00884edba13647c92d37ec5dbb9a6c2eace576d9 CC: @vlad-penkin, @anmyachev


(cherry picked from commit 16f835c6cafa14e4117c1a80e0b5b8f0981dda2c)