### PR TITLE
Include `libsycl_dir` in `compile_module_from_src` cache key to prevent cross-environment collision (#7338)

### DIFF
--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -292,9 +292,22 @@ class ExtensionUtils:
                 ctypes.windll.kernel32.FreeLibrary(handle)
 
 
+@lru_cache
+def get_hasher_common():
+    hasher = hashlib.sha256((__CACHE_VERSION + platform_key()).encode("utf-8"))
+    # Include libsycl_dir in the hash to prevent cache collisions across
+    # environments with different oneAPI versions (e.g. 2025.3 vs 2026.0).
+    # The compiled .so has libsycl_dir baked in as RPATH; without this,
+    # two envs with identical extension_utils.c but different oneAPI stacks
+    # share the same cache entry and load an incompatible .so.
+    if COMPILATION_HELPER.libsycl_dir:
+        hasher.update(str(COMPILATION_HELPER.libsycl_dir).encode("utf-8"))
+    return hasher
+
+
 def compile_module_from_src(src: str, name: str):
-    hasher = hashlib.sha256(__CACHE_VERSION.encode("utf-8"))
-    hasher.update((src + platform_key()).encode("utf-8"))
+    hasher = get_hasher_common().copy()
+    hasher.update(src.encode("utf-8"))
     key = hasher.hexdigest()
     cache = get_cache_manager(key)
     suffix = sysconfig.get_config_var("EXT_SUFFIX")


### PR DESCRIPTION
## Summary

Fixes #7337

When two conda environments with different oneAPI versions (e.g. 2025.3 and 2026.0) are used on the same machine, `torch.compile` on XPU fails for whichever environment runs second with:

```
OSError: libsycl.so.8: cannot open shared object file: No such file or directory
```
or
```
OSError: libsycl.so.9: undefined symbol: urDeviceWaitExp, version LIBUR_LOADER_0.12
```

## Root Cause

The actual collision happens in
`torchinductor_<user>/triton/<device>/<hash>/`, **not** in `~/.triton/cache/`.

When `TRITON_CACHE_DIR` is not set, torch inductor stores compiled triton kernels (including `extension_utils_impl.so`) under `$TORCHINDUCTOR_CACHE_DIR/triton/<device>/<hash>/`, which defaults to `/tmp/torchinductor_<user>/triton/<device>/<hash>/`.

In `compile_module_from_src()`, the cache key is computed from `extension_utils.c` content and platform info only — `libsycl_dir` is **not** included in the hash, but it is baked into the compiled `.so` as RPATH via `-Wl,-rpath,<libsycl_dir>` at build time.

Since both PyTorch 2.12 (oneAPI 2025.3, `libsycl.so.8`) and PyTorch 2.13 (oneAPI 2026.0, `libsycl.so.9`) ship identical `extension_utils.c`, they produce the same hash and share the same cache entry. The second environment loads a `.so` compiled with the wrong oneAPI RPATH, causing a missing library or symbol mismatch at runtime.

Both failure directions are reproducible:
- Release first → RC second: RC loads `.so` with `NEEDED: libsycl.so.8` → not found in RC env → crash
- RC first → Release second: Release loads `.so` with `NEEDED: libsycl.so.9` → symbol mismatch → crash

## Fix

Include `libsycl_dir` in the cache hash so each oneAPI version gets its own cache entry:

```python
if COMPILATION_HELPER.libsycl_dir:
    hasher.update(str(COMPILATION_HELPER.libsycl_dir).encode("utf-8"))
```

## Validation

Tested locally with PyTorch 2.12.1+xpu (oneAPI 2025.3) and PyTorch 2.13.0+xpu (oneAPI 2026.0) in separate conda environments (`kokoro_rls` / `kokoro_rc`).

Both Scenario 1 (release first → RC second) and Scenario 2 (RC first → release second) pass after this fix, without clearing any cache between runs.

---------


(cherry picked from commit df2a5b70feb1abc5d3960b75f93cc0a26251df63)