### PR TITLE
[vLLM][unified_attention] Add TILE_SIZE autotuning

### DIFF
--- a/benchmarks/triton_kernels_benchmark/vllm/unified_attention/unified_attention.patch
+++ b/benchmarks/triton_kernels_benchmark/vllm/unified_attention/unified_attention.patch
@@ -87,7 +87,7 @@ index b2667935c..678d938b6 100644
      right = num_seqs
      while left < right:
 diff --git a/vllm/v1/attention/ops/triton_unified_attention.py b/vllm/v1/attention/ops/triton_unified_attention.py
-index ce4a85cfe..b87b4860e 100644
+index ce4a85cfe..995b293ef 100644
 --- a/vllm/v1/attention/ops/triton_unified_attention.py
 +++ b/vllm/v1/attention/ops/triton_unified_attention.py
 @@ -7,8 +7,6 @@
@@ -107,7 +107,7 @@ index ce4a85cfe..b87b4860e 100644
      init_softmax_M,
      load_qq_bias_tile,
      resolve_seq_and_query_len,
-@@ -175,6 +172,118 @@ def _store_output_td(
+@@ -175,6 +172,115 @@ def _store_output_td(
      )
  
  
@@ -121,17 +121,17 @@ index ce4a85cfe..b87b4860e 100644
 +]
 +
 +
-+def q_len_bucket(max_seqlen_q: int) -> int:
++def q_len_bucket(max_seqlen_q):
 +    if max_seqlen_q <= 1:
-+        return 0
++        return 0  # decode
 +    if max_seqlen_q <= 16:
-+        return 1
++        return 1  # chunk tail / tiny prefill
 +    if max_seqlen_q <= 512:
-+        return 2
-+    return 3
++        return 2  # medium prefill
++    return 3  # large prefill
 +
 +
-+def kv_len_bucket(max_seqlen_k: int) -> int:
++def kv_len_bucket(max_seqlen_k):
 +    if max_seqlen_k <= 256:
 +        return 0
 +    if max_seqlen_k <= 1024:
@@ -146,12 +146,9 @@ index ce4a85cfe..b87b4860e 100644
 +ATTENTION_AUTOTUNE_KEY = [
 +    "BLOCK_SIZE",
 +    "HEAD_SIZE",
-+    "IS_FP8_INPUT",
 +    "IS_3D",
 +    "num_queries_per_kv",
-+    "USE_LARGE_HEAD_TILE",
 +    "USE_TD",
-+    "USE_TD_QO",
 +    "Q_LEN_BUCKET",
 +    "KV_LEN_BUCKET",
 +]
@@ -226,7 +223,7 @@ index ce4a85cfe..b87b4860e 100644
  @triton.jit
  def kernel_unified_attention(
      # Output destination for the 2D path.  In 3D mode per-segment partials
-@@ -285,6 +394,11 @@ def kernel_unified_attention(
+@@ -285,6 +391,11 @@ def kernel_unified_attention(
      USE_TD: tl.constexpr = False,
      USE_TD_QO: tl.constexpr = False,
      Q_IS_FP8: tl.constexpr = False,
@@ -238,7 +235,7 @@ index ce4a85cfe..b87b4860e 100644
      # Gemma4: clamp mm_prefix bidirectional ranges by the sliding window
      # instead of letting them override it. Default False preserves the
      # original (causal AND SW) OR mm_prefix behavior for all other models.
-@@ -319,9 +433,30 @@ def kernel_unified_attention(
+@@ -319,9 +430,30 @@ def kernel_unified_attention(
      if q_block_local_idx * BLOCK_Q >= cur_batch_query_len:
          return
  
@@ -269,7 +266,7 @@ index ce4a85cfe..b87b4860e 100644
              return
      else:
          tiles_per_segment = 0
-@@ -332,13 +467,8 @@ def kernel_unified_attention(
+@@ -332,13 +464,8 @@ def kernel_unified_attention(
          BLOCK_Q, cur_batch_query_len - q_block_local_idx * BLOCK_Q
      )
  
@@ -283,7 +280,7 @@ index ce4a85cfe..b87b4860e 100644
      query_offset = (
          query_offset_0[:, None] * query_stride_0
          + query_offset_1[:, None] * query_stride_1
-@@ -346,8 +476,6 @@ def kernel_unified_attention(
+@@ -346,8 +473,6 @@ def kernel_unified_attention(
      )
  
      dim_mask = tl.where(offs_d < HEAD_SIZE, 1, 0).to(tl.int1)
@@ -292,7 +289,7 @@ index ce4a85cfe..b87b4860e 100644
  
      # Q : (BLOCK_M, HEAD_SIZE_PADDED)
      if USE_TD_QO:
-@@ -534,12 +662,12 @@ def kernel_unified_attention(
+@@ -534,12 +659,12 @@ def kernel_unified_attention(
  
          # S : (BLOCK_M, TILE_SIZE)
          S = tl.zeros(shape=(BLOCK_M, TILE_SIZE), dtype=tl.float32)
@@ -309,7 +306,7 @@ index ce4a85cfe..b87b4860e 100644
  
          if USE_SOFTCAP:
              S = apply_softcap(S, softcap)
-@@ -561,27 +689,14 @@ def kernel_unified_attention(
+@@ -561,27 +686,14 @@ def kernel_unified_attention(
          M, L, P, alpha = softmax_step(S, M, L)
          acc = acc * alpha[:, None]
  
@@ -341,7 +338,7 @@ index ce4a85cfe..b87b4860e 100644
  
      # ---- Epilogue ---------------------------------------------------------
      if IS_3D:
-@@ -695,11 +810,9 @@ def reduce_segments(
+@@ -695,11 +807,9 @@ def reduce_segments(
      output_stride_0: tl.int64,  # int
      output_stride_1: tl.int64,  # int, should be equal to head_size
      block_table_stride: tl.int64,  # int
@@ -353,7 +350,7 @@ index ce4a85cfe..b87b4860e 100644
      NUM_SEGMENTS_PER_SEQ: tl.constexpr,  # int
      USE_FP8: tl.constexpr,  # bool
      FP8_MIN: tl.constexpr = float8_info.min,
-@@ -708,31 +821,16 @@ def reduce_segments(
+@@ -708,32 +818,19 @@ def reduce_segments(
      query_token_idx = tl.program_id(0)
      query_head_idx = tl.program_id(1)
  
@@ -386,9 +383,12 @@ index ce4a85cfe..b87b4860e 100644
 +    segm_max = tl.load(segm_max_ptr + segm_offset)
 +    segm_mask = segm_max != float("-inf")
      overall_max = tl.max(segm_max)
++    # Avoid -inf - -inf when every segment is inactive.
++    overall_max = tl.where(overall_max == float("-inf"), 0.0, overall_max)
  
      # load and rescale segment exp sums
-@@ -771,33 +869,6 @@ def reduce_segments(
+     segm_expsum = tl.load(segm_expsum_ptr + segm_offset, mask=segm_mask, other=0.0)
+@@ -771,33 +868,6 @@ def reduce_segments(
      tl.store(output_ptr + output_offset, acc, mask=dim_mask)
  
  
@@ -422,7 +422,7 @@ index ce4a85cfe..b87b4860e 100644
  
  def unified_attention(
      q,
-@@ -929,15 +1000,6 @@ def unified_attention(
+@@ -929,15 +999,6 @@ def unified_attention(
      num_queries_per_kv = num_query_heads // num_kv_heads
      head_size = q.shape[2]
  
@@ -438,7 +438,7 @@ index ce4a85cfe..b87b4860e 100644
      # head_size 256 with many query rows per sequence (e.g. diffusion-gemma
      # bidirectional canvas passes) is prefill-shaped, but the decode-oriented
      # defaults (BLOCK_Q=8, TILE=32, 4 warps) under-tile it. A wider KV tile +
-@@ -948,22 +1010,6 @@ def unified_attention(
+@@ -948,22 +1009,6 @@ def unified_attention(
          and num_queries_per_kv <= 16
          and current_platform.is_device_capability_family(100)
      )
@@ -461,7 +461,7 @@ index ce4a85cfe..b87b4860e 100644
  
      sliding_window_val = 1 + window_size[0] if window_size[0] >= 0 else 0
  
-@@ -975,25 +1021,9 @@ def unified_attention(
+@@ -975,25 +1020,14 @@ def unified_attention(
      elif sliding_window_val <= 0:
          chunk_lookback = -1
  
@@ -485,12 +485,17 @@ index ce4a85cfe..b87b4860e 100644
 -        TILE_SIZE_PREFILL = min(TILE_SIZE_PREFILL, block_size)
 -        TILE_SIZE_DECODE = min(TILE_SIZE_DECODE, block_size)
 +    is_fp8_input = q.element_size() == 1
++    if use_td and is_fp8_input and block_size % 32 != 0:
++        raise ValueError(
++            "FP8 queries with use_td=True require block_size to be a multiple of 32 "
++            f"(got {block_size})."
++        )
 +    q_len_bucket_val = q_len_bucket(max_seqlen_q)
 +    kv_len_bucket_val = kv_len_bucket(max_seqlen_k)
  
      # Tensor descriptors for Q load / output store require every element
      # of ``block_shape`` to be a power of 2.  ``num_queries_per_kv`` is
-@@ -1036,18 +1066,11 @@ def unified_attention(
+@@ -1036,18 +1070,11 @@ def unified_attention(
      # Launch the 2D kernel if
      # 1. No intermediate tiled softmax buffers for the 3D kernel have been allocated, or
      # 2. The batch includes at least one prefill request, or
@@ -514,7 +519,7 @@ index ce4a85cfe..b87b4860e 100644
  
      # The kernel signature is the same for 2D and 3D — only the launch
      # grid + a handful of constexpr toggles differ.  Per-token-head scale
-@@ -1068,24 +1091,56 @@ def unified_attention(
+@@ -1068,24 +1095,56 @@ def unified_attention(
          v_scale_ptr = None
      # 3D needs real segm tensors; 2D never touches them.  Pass ``None`` in
      # 2D mode so Triton can skip materialising these pointer arguments.
@@ -582,7 +587,7 @@ index ce4a85cfe..b87b4860e 100644
  
      kernel_unified_attention[grid](
          output_ptr=out,
-@@ -1117,7 +1172,6 @@ def unified_attention(
+@@ -1117,7 +1176,6 @@ def unified_attention(
          output_stride_1=out.stride(1),
          qq_bias_stride_0=qq_bias.stride(0) if use_qq_bias else 0,
          BLOCK_SIZE=block_size,
@@ -590,7 +595,7 @@ index ce4a85cfe..b87b4860e 100644
          HEAD_SIZE=head_size,
          HEAD_SIZE_PADDED=head_size_padded,
          USE_ALIBI_SLOPES=use_alibi_slopes,
-@@ -1150,11 +1204,13 @@ def unified_attention(
+@@ -1150,12 +1208,14 @@ def unified_attention(
          stride_vs_slot=vs_slot,
          stride_vs_head=vs_head,
          query_start_len_ptr=cu_seqlens_q,
@@ -601,12 +606,13 @@ index ce4a85cfe..b87b4860e 100644
          USE_FP8=output_scale is not None,
 +        IS_FP8_INPUT=is_fp8_input,
 +        USE_LARGE_HEAD_TILE=tuned_large_head,
+         IS_3D=use_3d,
 +        Q_LEN_BUCKET=q_len_bucket_val,
 +        KV_LEN_BUCKET=kv_len_bucket_val,
-         IS_3D=use_3d,
          KV_QUANT_MODE=kv_quant_mode,
          Q_IS_FP8=(q.dtype == current_platform.fp8_dtype()),
-@@ -1163,7 +1219,6 @@ def unified_attention(
+         CHUNK_LOOKBACK=chunk_lookback,
+@@ -1163,7 +1223,6 @@ def unified_attention(
          USE_TD=use_td,
          USE_TD_QO=use_td_qo,
          MM_PREFIX_CLAMP_SW=mm_prefix_clamp_sliding_window,
@@ -614,7 +620,7 @@ index ce4a85cfe..b87b4860e 100644
      )
  
      if use_3d:
-@@ -1179,11 +1234,9 @@ def unified_attention(
+@@ -1179,11 +1238,9 @@ def unified_attention(
              output_stride_0=out.stride(0),
              output_stride_1=out.stride(1),
              block_table_stride=block_table.stride(0),

--- a/benchmarks/triton_kernels_benchmark/vllm/unified_attention/unified_attention.patch
+++ b/benchmarks/triton_kernels_benchmark/vllm/unified_attention/unified_attention.patch
@@ -1,8 +1,8 @@
 diff --git a/tests/kernels/attention/test_triton_unified_attention.py b/tests/kernels/attention/test_triton_unified_attention.py
-index d3435ea66..359fd108a 100644
+index 1c1d4f803..96306794e 100644
 --- a/tests/kernels/attention/test_triton_unified_attention.py
 +++ b/tests/kernels/attention/test_triton_unified_attention.py
-@@ -203,6 +203,7 @@ def test_triton_unified_attn(
+@@ -205,6 +205,7 @@ def test_triton_unified_attn(
          softmax_segm_max=softmax_segm_max,
          softmax_segm_expsum=softmax_segm_expsum,
          kv_quant_mode=kv_quant_mode,
@@ -10,7 +10,7 @@ index d3435ea66..359fd108a 100644
      )
  
      ref_output = ref_paged_attn(
-@@ -323,6 +324,7 @@ def test_triton_unified_attn_bf16_query_fp8_kv(
+@@ -325,6 +326,7 @@ def test_triton_unified_attn_bf16_query_fp8_kv(
          softmax_segm_max=softmax_segm_max,
          softmax_segm_expsum=softmax_segm_expsum,
          kv_quant_mode=KVQuantMode.FP8_PER_TENSOR,
@@ -18,7 +18,7 @@ index d3435ea66..359fd108a 100644
      )
  
      ref_output = ref_paged_attn(
-@@ -442,6 +444,7 @@ def test_triton_unified_attn_fp16_input_fp8_output(
+@@ -444,6 +446,7 @@ def test_triton_unified_attn_fp16_input_fp8_output(
          softmax_segm_output=softmax_segm_output,
          softmax_segm_max=softmax_segm_max,
          softmax_segm_expsum=softmax_segm_expsum,
@@ -26,6 +26,32 @@ index d3435ea66..359fd108a 100644
      )
  
      ref_output = ref_paged_attn(
+@@ -619,23 +622,13 @@ def test_triton_unified_attn_use_td(
+     )
+ 
+ 
+-# Prefill-heavy shape: long query drives the prefill kernel path where
+-# ``_get_tile_size`` returns 32, which exceeds block_size=16 and must be
+-# clamped by the fix in 'clamp TILE_SIZE to block_size when USE_TD'.
+-# Only the prefill launch exercises the clamp, so parameterize only over
+-# the (num_heads, seq_threshold_3D=0) combinations needed to cover it.
++# With block_size=16, both Q/O paths must prune TILE_SIZE=32.
+ @pytest.mark.parametrize("num_heads", [(4, 4), (5, 1)])
+ @torch.inference_mode()
+ def test_triton_unified_attn_use_td_tile_clamp(
+     num_heads: tuple[int, int],
+ ) -> None:
+-    """Regression guard: ``USE_TD`` needs ``BLOCK_SIZE % TILE_SIZE == 0``.
+-
+-    With ``block_size=16`` and ``head_size=128`` (non-Gemma3),
+-    ``_get_tile_size`` returns 32 for prefill, which violates the
+-    ``USE_TD`` constraint unless clamped to ``block_size``.  Without
+-    the clamp the triton kernel ``static_assert`` fires at compile time.
+-    """
++    """Ensure TD candidates satisfy BLOCK_SIZE % TILE_SIZE == 0."""
+     _run_use_td_case(
+         seq_lens=[(256, 256), (128, 128)],
+         num_heads=num_heads,
 diff --git a/vllm/v1/attention/ops/triton_attention_helpers.py b/vllm/v1/attention/ops/triton_attention_helpers.py
 index b2667935c..678d938b6 100644
 --- a/vllm/v1/attention/ops/triton_attention_helpers.py
@@ -61,7 +87,7 @@ index b2667935c..678d938b6 100644
      right = num_seqs
      while left < right:
 diff --git a/vllm/v1/attention/ops/triton_unified_attention.py b/vllm/v1/attention/ops/triton_unified_attention.py
-index 93622957b..b3e348f71 100644
+index ce4a85cfe..b87b4860e 100644
 --- a/vllm/v1/attention/ops/triton_unified_attention.py
 +++ b/vllm/v1/attention/ops/triton_unified_attention.py
 @@ -7,8 +7,6 @@
@@ -73,27 +99,39 @@ index 93622957b..b3e348f71 100644
  import torch
  
  import vllm.envs as envs
-@@ -175,6 +173,87 @@ def _store_output_td(
+@@ -21,7 +19,6 @@ from vllm.v1.attention.ops.triton_attention_helpers import (
+     cdiv_fn,
+     compute_kv_seq_mask,
+     compute_tile_loop_bounds,
+-    find_seq_idx,
+     init_softmax_M,
+     load_qq_bias_tile,
+     resolve_seq_and_query_len,
+@@ -175,6 +172,118 @@ def _store_output_td(
      )
  
  
 +ATTENTION_AUTOTUNE_CONFIGS = [
-+    triton.Config({"BLOCK_M": block_m}, num_stages=2)
++    triton.Config({"BLOCK_M": block_m, "TILE_SIZE": tile_size}, num_stages=2)
 +    for block_m in (16, 32, 64)
++    for tile_size in (16, 32)
++] + [
++    # Use a wider KV tile for large-head prefill.
++    triton.Config({"BLOCK_M": 32, "TILE_SIZE": 128}, num_stages=2, num_warps=8),
 +]
 +
 +
-+def q_len_bucket(max_seqlen_q):
++def q_len_bucket(max_seqlen_q: int) -> int:
 +    if max_seqlen_q <= 1:
-+        return 0  # decode
++        return 0
 +    if max_seqlen_q <= 16:
-+        return 1  # chunk tail / tiny prefill
++        return 1
 +    if max_seqlen_q <= 512:
-+        return 2  # medium prefill
-+    return 3  # large prefill
++        return 2
++    return 3
 +
 +
-+def kv_len_bucket(max_seqlen_k):
++def kv_len_bucket(max_seqlen_k: int) -> int:
 +    if max_seqlen_k <= 256:
 +        return 0
 +    if max_seqlen_k <= 1024:
@@ -108,8 +146,10 @@ index 93622957b..b3e348f71 100644
 +ATTENTION_AUTOTUNE_KEY = [
 +    "BLOCK_SIZE",
 +    "HEAD_SIZE",
++    "IS_FP8_INPUT",
 +    "IS_3D",
 +    "num_queries_per_kv",
++    "USE_LARGE_HEAD_TILE",
 +    "USE_TD",
 +    "USE_TD_QO",
 +    "Q_LEN_BUCKET",
@@ -127,15 +167,40 @@ index 93622957b..b3e348f71 100644
 +
 +def prune_attention_configs(configs, named_args, **kwargs):
 +    all_args = {**named_args, **kwargs}
++    block_size = all_args["BLOCK_SIZE"]
++    is_fp8_input = all_args["IS_FP8_INPUT"]
++    is_3d = all_args["IS_3D"]
 +    num_queries_per_kv = all_args["num_queries_per_kv"]
++    use_large_head_tile = all_args["USE_LARGE_HEAD_TILE"]
++    use_td = all_args["USE_TD"]
 +    use_td_qo = all_args.get("USE_TD_QO", False)
 +
 +    valid_configs = []
 +    for config in configs:
-+        block_q = derive_block_q(
-+            config.kwargs["BLOCK_M"], num_queries_per_kv
-+        )
++        block_m = config.kwargs["BLOCK_M"]
++        tile_size = config.kwargs["TILE_SIZE"]
 +
++        large_head_2d = use_large_head_tile and not is_3d
++        large_head_128_is_legal = large_head_2d and (
++            not use_td or (block_size >= 128 and block_size % 128 == 0)
++        )
++        if large_head_128_is_legal:
++            if tile_size != 128:
++                continue
++        elif tile_size == 128:
++            continue
++
++        # TD loads require TILE_SIZE to divide BLOCK_SIZE.
++        if use_td and tile_size > block_size:
++            continue
++        if use_td and block_size % tile_size != 0:
++            continue
++
++        # FP8 inputs do not support TILE_SIZE=16.
++        if is_fp8_input and tile_size not in (32, 128):
++            continue
++
++        block_q = derive_block_q(block_m, num_queries_per_kv)
 +        if block_q <= 0:
 +            continue
 +        if use_td_qo and not _is_power_of_2(block_q):
@@ -161,24 +226,73 @@ index 93622957b..b3e348f71 100644
  @triton.jit
  def kernel_unified_attention(
      # Output destination for the 2D path.  In 3D mode per-segment partials
-@@ -285,11 +364,16 @@ def kernel_unified_attention(
+@@ -285,6 +394,11 @@ def kernel_unified_attention(
      USE_TD: tl.constexpr = False,
      USE_TD_QO: tl.constexpr = False,
      Q_IS_FP8: tl.constexpr = False,
++    # Key and pruning inputs.
++    IS_FP8_INPUT: tl.constexpr = False,
++    USE_LARGE_HEAD_TILE: tl.constexpr = False,
 +    Q_LEN_BUCKET: tl.constexpr = 0,
 +    KV_LEN_BUCKET: tl.constexpr = 0,
      # Gemma4: clamp mm_prefix bidirectional ranges by the sliding window
      # instead of letting them override it. Default False preserves the
      # original (causal AND SW) OR mm_prefix behavior for all other models.
-     MM_PREFIX_CLAMP_SW: tl.constexpr = False,
- ):
-+    tl.static_assert(BLOCK_SIZE % TILE_SIZE == 0, "BLOCK_SIZE must be multiple of TILE_SIZE")
-+    tl.static_assert(BLOCK_SIZE >= TILE_SIZE, "BLOCK_SIZE must be >= TILE_SIZE")
+@@ -319,9 +433,30 @@ def kernel_unified_attention(
+     if q_block_local_idx * BLOCK_Q >= cur_batch_query_len:
+         return
+ 
++    offs_m = tl.arange(0, BLOCK_M)
++    query_pos = q_block_local_idx * BLOCK_Q + offs_m // num_queries_per_kv
++    query_offset_0 = cur_batch_in_all_start_index + query_pos
++    query_offset_1 = kv_head_idx * num_queries_per_kv + offs_m % num_queries_per_kv
++    query_mask_0 = tl.where(query_pos < cur_batch_query_len, 1, 0).to(tl.int1)
++    query_mask_1 = tl.where(query_offset_1 < num_query_heads, 1, 0).to(tl.int1)
 +
-     # Per-(token, head) scale caches: used iff KV_QUANT_MODE in {2, 3}.
-     USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = (KV_QUANT_MODE >= 2) and (
-         KV_QUANT_MODE <= 3
-@@ -534,12 +618,12 @@ def kernel_unified_attention(
+     if IS_3D:
+         tiles_per_segment = cdiv_fn(seq_len, NUM_SEGMENTS_PER_SEQ * TILE_SIZE)
+         if segm_idx * tiles_per_segment * TILE_SIZE >= seq_len:
++            # Mark empty segments inactive for reduction.
++            store_segm_reduce_scalars(
++                segm_max_ptr,
++                segm_expsum_ptr,
++                query_offset_0,
++                query_offset_1,
++                segm_idx,
++                tl.full([BLOCK_M], float("-inf"), dtype=tl.float32),
++                tl.zeros([BLOCK_M], dtype=tl.float32),
++                query_mask_0,
++                query_mask_1,
++                num_query_heads,
++                NUM_SEGMENTS_PER_SEQ,
++            )
+             return
+     else:
+         tiles_per_segment = 0
+@@ -332,13 +467,8 @@ def kernel_unified_attention(
+         BLOCK_Q, cur_batch_query_len - q_block_local_idx * BLOCK_Q
+     )
+ 
+-    offs_m = tl.arange(0, BLOCK_M)
+     offs_d = tl.arange(0, HEAD_SIZE_PADDED)
+     offs_t = tl.arange(0, TILE_SIZE)
+-    query_pos = q_block_local_idx * BLOCK_Q + offs_m // num_queries_per_kv
+-
+-    query_offset_0 = cur_batch_in_all_start_index + query_pos
+-    query_offset_1 = kv_head_idx * num_queries_per_kv + offs_m % num_queries_per_kv
+     query_offset = (
+         query_offset_0[:, None] * query_stride_0
+         + query_offset_1[:, None] * query_stride_1
+@@ -346,8 +476,6 @@ def kernel_unified_attention(
+     )
+ 
+     dim_mask = tl.where(offs_d < HEAD_SIZE, 1, 0).to(tl.int1)
+-    query_mask_0 = tl.where(query_pos < cur_batch_query_len, 1, 0).to(tl.int1)
+-    query_mask_1 = tl.where(query_offset_1 < num_query_heads, 1, 0).to(tl.int1)
+ 
+     # Q : (BLOCK_M, HEAD_SIZE_PADDED)
+     if USE_TD_QO:
+@@ -534,12 +662,12 @@ def kernel_unified_attention(
  
          # S : (BLOCK_M, TILE_SIZE)
          S = tl.zeros(shape=(BLOCK_M, TILE_SIZE), dtype=tl.float32)
@@ -195,7 +309,7 @@ index 93622957b..b3e348f71 100644
  
          if USE_SOFTCAP:
              S = apply_softcap(S, softcap)
-@@ -561,27 +645,14 @@ def kernel_unified_attention(
+@@ -561,27 +689,14 @@ def kernel_unified_attention(
          M, L, P, alpha = softmax_step(S, M, L)
          acc = acc * alpha[:, None]
  
@@ -227,7 +341,11 @@ index 93622957b..b3e348f71 100644
  
      # ---- Epilogue ---------------------------------------------------------
      if IS_3D:
-@@ -699,7 +770,6 @@ def reduce_segments(
+@@ -695,11 +810,9 @@ def reduce_segments(
+     output_stride_0: tl.int64,  # int
+     output_stride_1: tl.int64,  # int, should be equal to head_size
+     block_table_stride: tl.int64,  # int
+-    TILE_SIZE: tl.constexpr,  # int
      HEAD_SIZE: tl.constexpr,  # int, must be power of 2
      HEAD_SIZE_PADDED: tl.constexpr,  # int, must be power of 2
      query_start_len_ptr,  # [num_seqs+1]
@@ -235,16 +353,76 @@ index 93622957b..b3e348f71 100644
      NUM_SEGMENTS_PER_SEQ: tl.constexpr,  # int
      USE_FP8: tl.constexpr,  # bool
      FP8_MIN: tl.constexpr = float8_info.min,
-@@ -709,7 +779,7 @@ def reduce_segments(
+@@ -708,31 +821,16 @@ def reduce_segments(
+     query_token_idx = tl.program_id(0)
      query_head_idx = tl.program_id(1)
  
-     seq_idx = find_seq_idx(
+-    seq_idx = find_seq_idx(
 -        query_start_len_ptr, query_token_idx, num_seqs, BLOCK_Q, False
-+        query_start_len_ptr, query_token_idx, num_seqs, use_q_block_mode=False
-     )
+-    )
+-
+-    # sequence len for this particular sequence
+-    seq_len = tl.load(seq_lens_ptr + seq_idx)
+-
+-    # number of segments for this particular sequence
+-    num_segments = NUM_SEGMENTS_PER_SEQ
+-    tiles_per_segment = cdiv_fn(seq_len, num_segments * TILE_SIZE)
+-
+-    # create masks for subsequent loads
+-    act_num_segments = cdiv_fn(seq_len, tiles_per_segment * TILE_SIZE)
+-    segm_mask = tl.arange(0, NUM_SEGMENTS_PER_SEQ) < tl.full(
+-        [NUM_SEGMENTS_PER_SEQ], act_num_segments, dtype=tl.int32
+-    )
+     dim_mask = tl.where(tl.arange(0, HEAD_SIZE_PADDED) < HEAD_SIZE, 1, 0).to(tl.int1)
  
-     # sequence len for this particular sequence
-@@ -929,11 +999,6 @@ def unified_attention(
+-    # load segment maxima
++    # A maximum of -inf marks an inactive segment.
+     segm_offset = (
+         query_token_idx.to(tl.int64) * (num_query_heads * NUM_SEGMENTS_PER_SEQ)
+         + query_head_idx * NUM_SEGMENTS_PER_SEQ
+         + tl.arange(0, NUM_SEGMENTS_PER_SEQ)
+     )
+-    segm_max = tl.load(segm_max_ptr + segm_offset, mask=segm_mask, other=float("-inf"))
++    segm_max = tl.load(segm_max_ptr + segm_offset)
++    segm_mask = segm_max != float("-inf")
+     overall_max = tl.max(segm_max)
+ 
+     # load and rescale segment exp sums
+@@ -771,33 +869,6 @@ def reduce_segments(
+     tl.store(output_ptr + output_offset, acc, mask=dim_mask)
+ 
+ 
+-def _is_gemma3_attention(head_size: int, sliding_window: int) -> bool:
+-    """Detect Gemma3 models via unique (head_size, sliding_window) signature.
+-
+-    Gemma3 models are the only ones using sliding_window=1024 with
+-    head_size 128 (27B) or 256 (1B, 4B, 12B). Other SWA models use
+-    different window sizes (Mistral=4096, Phi-3=2047).
+-    """
+-    return sliding_window == 1024 and head_size in (128, 256)
+-
+-
+-def _get_tile_size(
+-    head_size: int,
+-    sliding_window: int,
+-    element_size: int,
+-    is_prefill: bool,
+-) -> int:
+-    """Select tile size with Gemma3-specific optimization."""
+-    if _is_gemma3_attention(head_size, sliding_window):
+-        # Gemma3: use 32 for decode (default is 16)
+-        return 32
+-
+-    # Default behavior
+-    if is_prefill:
+-        return 32
+-    # Note: tile size must be at least 32 for fp8 (element_size == 1).
+-    return 16 if element_size >= 2 else 32
+-
+ 
+ def unified_attention(
+     q,
+@@ -929,15 +1000,6 @@ def unified_attention(
      num_queries_per_kv = num_query_heads // num_kv_heads
      head_size = q.shape[2]
  
@@ -253,18 +431,23 @@ index 93622957b..b3e348f71 100644
 -    )
 -    BLOCK_Q = BLOCK_M // num_queries_per_kv
 -
-     # Tuned launch parameters; ``None`` lets Triton pick its defaults.
-     launch_num_warps: int | None = None
-     launch_num_stages: int | None = None
-@@ -949,22 +1014,9 @@ def unified_attention(
+-    # Tuned launch parameters; ``None`` lets Triton pick its defaults.
+-    launch_num_warps: int | None = None
+-    launch_num_stages: int | None = None
+-
+     # head_size 256 with many query rows per sequence (e.g. diffusion-gemma
+     # bidirectional canvas passes) is prefill-shaped, but the decode-oriented
+     # defaults (BLOCK_Q=8, TILE=32, 4 warps) under-tile it. A wider KV tile +
+@@ -948,22 +1010,6 @@ def unified_attention(
+         and num_queries_per_kv <= 16
          and current_platform.is_device_capability_family(100)
      )
-     if tuned_large_head:
+-    if tuned_large_head:
 -        BLOCK_M = 32
 -        BLOCK_Q = BLOCK_M // num_queries_per_kv
-         launch_num_warps = 8
-         launch_num_stages = 2
- 
+-        launch_num_warps = 8
+-        launch_num_stages = 2
+-
 -    # Ideally we would launch with kernel with:
 -    # \sum_i[ceil(query_len[i] / BLOCK_Q)] blocks.
 -    # However, it is slow to realize the query_lens on cpu.
@@ -275,11 +458,10 @@ index 93622957b..b3e348f71 100644
 -    #   <= floor(\sum_i(query_len[i]) / BLOCK_Q) + num_seqs
 -    #    = floor(q.shape[0] / BLOCK_Q) + num_seqs
 -    total_num_q_blocks = q.shape[0] // BLOCK_Q + num_seqs
--
+ 
      sliding_window_val = 1 + window_size[0] if window_size[0] >= 0 else 0
  
-     # Compute chunked block size from sliding window if needed.
-@@ -975,12 +1027,16 @@ def unified_attention(
+@@ -975,25 +1021,9 @@ def unified_attention(
      elif sliding_window_val <= 0:
          chunk_lookback = -1
  
@@ -289,30 +471,26 @@ index 93622957b..b3e348f71 100644
 -    TILE_SIZE_DECODE = _get_tile_size(
 -        head_size, sliding_window_val, q.element_size(), is_prefill=False
 -    )
-+    if q.element_size() == 1:
-+        # Currently triton fails with TILE_SIZE=16 for fp8 inputs
-+        TILE_SIZE_PREFILL = TILE_SIZE_DECODE = 32
-+    else:
-+        # Good config for simplicity
-+        TILE_SIZE_PREFILL = TILE_SIZE_DECODE = 16
-+    assert TILE_SIZE_PREFILL <= block_size, "TILE_SIZE_PREFILL must be <= block_size"
-+    assert TILE_SIZE_DECODE <= block_size, "TILE_SIZE_DECODE must be <= block_size"
-+    assert block_size % TILE_SIZE_PREFILL == 0, "block_size must be multiple of TILE_SIZE_PREFILL"
-+    assert block_size % TILE_SIZE_DECODE == 0, "block_size must be multiple of TILE_SIZE_DECODE"
- 
-     # Wider KV tile for the tuned large-head path (see above). Only the 2D
-     # path (used when max_seqlen_q > 1) reads TILE_SIZE_PREFILL.
-@@ -994,7 +1050,8 @@ def unified_attention(
-     if use_td:
-         TILE_SIZE_PREFILL = min(TILE_SIZE_PREFILL, block_size)
-         TILE_SIZE_DECODE = min(TILE_SIZE_DECODE, block_size)
 -
+-    # Wider KV tile for the tuned large-head path (see above). Only the 2D
+-    # path (used when max_seqlen_q > 1) reads TILE_SIZE_PREFILL.
+-    if tuned_large_head:
+-        TILE_SIZE_PREFILL = 128
+-
+-    # USE_TD requires BLOCK_SIZE % TILE_SIZE == 0 (enforced by a
+-    # ``tl.static_assert`` in the kernel).  The default prefill tile
+-    # size (32) is larger than a common ``block_size=16``, so clamp it
+-    # down when TD is enabled.  Zero overhead when disabled.
+-    if use_td:
+-        TILE_SIZE_PREFILL = min(TILE_SIZE_PREFILL, block_size)
+-        TILE_SIZE_DECODE = min(TILE_SIZE_DECODE, block_size)
++    is_fp8_input = q.element_size() == 1
 +    q_len_bucket_val = q_len_bucket(max_seqlen_q)
 +    kv_len_bucket_val = kv_len_bucket(max_seqlen_k)
+ 
      # Tensor descriptors for Q load / output store require every element
      # of ``block_shape`` to be a power of 2.  ``num_queries_per_kv`` is
-     # not always pow2 (e.g. Qwen2-7B: 28 / 4 = 7), so gate the Q/O paths
-@@ -1036,18 +1093,11 @@ def unified_attention(
+@@ -1036,18 +1066,11 @@ def unified_attention(
      # Launch the 2D kernel if
      # 1. No intermediate tiled softmax buffers for the 3D kernel have been allocated, or
      # 2. The batch includes at least one prefill request, or
@@ -336,7 +514,7 @@ index 93622957b..b3e348f71 100644
  
      # The kernel signature is the same for 2D and 3D — only the launch
      # grid + a handful of constexpr toggles differ.  Per-token-head scale
-@@ -1068,17 +1118,57 @@ def unified_attention(
+@@ -1068,24 +1091,56 @@ def unified_attention(
          v_scale_ptr = None
      # 3D needs real segm tensors; 2D never touches them.  Pass ``None`` in
      # 2D mode so Triton can skip materialising these pointer arguments.
@@ -382,22 +560,37 @@ index 93622957b..b3e348f71 100644
 +    # BLOCK_Q is autotuned, so compute the grid from meta.
      if not use_3d:
 -        grid = (total_num_q_blocks, num_kv_heads)
+-        tile_size = TILE_SIZE_PREFILL
 +        grid = lambda meta: (
 +            q.shape[0] // meta["BLOCK_Q"] + num_seqs,
 +            num_kv_heads,
 +        )
-         tile_size = TILE_SIZE_PREFILL
      else:
 -        grid = (total_num_q_blocks, num_kv_heads, num_par_softmax_segments)
+-        tile_size = TILE_SIZE_DECODE
+-
+-    launch_kwargs: dict[str, int] = {}
+-    if launch_num_warps is not None:
+-        launch_kwargs["num_warps"] = launch_num_warps
+-    if launch_num_stages is not None:
+-        launch_kwargs["num_stages"] = launch_num_stages
 +        grid = lambda meta: (
 +            q.shape[0] // meta["BLOCK_Q"] + num_seqs,
 +            num_kv_heads,
 +            num_par_softmax_segments,
 +        )
-         tile_size = TILE_SIZE_DECODE
  
-     launch_kwargs: dict[str, int] = {}
-@@ -1150,12 +1240,12 @@ def unified_attention(
+     kernel_unified_attention[grid](
+         output_ptr=out,
+@@ -1117,7 +1172,6 @@ def unified_attention(
+         output_stride_1=out.stride(1),
+         qq_bias_stride_0=qq_bias.stride(0) if use_qq_bias else 0,
+         BLOCK_SIZE=block_size,
+-        TILE_SIZE=tile_size,
+         HEAD_SIZE=head_size,
+         HEAD_SIZE_PADDED=head_size_padded,
+         USE_ALIBI_SLOPES=use_alibi_slopes,
+@@ -1150,11 +1204,13 @@ def unified_attention(
          stride_vs_slot=vs_slot,
          stride_vs_head=vs_head,
          query_start_len_ptr=cu_seqlens_q,
@@ -406,13 +599,26 @@ index 93622957b..b3e348f71 100644
 -        BLOCK_M=BLOCK_M,
          NUM_SEGMENTS_PER_SEQ=num_segments,
          USE_FP8=output_scale is not None,
-         IS_3D=use_3d,
++        IS_FP8_INPUT=is_fp8_input,
++        USE_LARGE_HEAD_TILE=tuned_large_head,
 +        Q_LEN_BUCKET=q_len_bucket_val,
 +        KV_LEN_BUCKET=kv_len_bucket_val,
+         IS_3D=use_3d,
          KV_QUANT_MODE=kv_quant_mode,
          Q_IS_FP8=(q.dtype == current_platform.fp8_dtype()),
-         CHUNK_LOOKBACK=chunk_lookback,
-@@ -1183,7 +1273,6 @@ def unified_attention(
+@@ -1163,7 +1219,6 @@ def unified_attention(
+         USE_TD=use_td,
+         USE_TD_QO=use_td_qo,
+         MM_PREFIX_CLAMP_SW=mm_prefix_clamp_sliding_window,
+-        **launch_kwargs,
+     )
+ 
+     if use_3d:
+@@ -1179,11 +1234,9 @@ def unified_attention(
+             output_stride_0=out.stride(0),
+             output_stride_1=out.stride(1),
+             block_table_stride=block_table.stride(0),
+-            TILE_SIZE=TILE_SIZE_DECODE,
              HEAD_SIZE=head_size,
              HEAD_SIZE_PADDED=head_size_padded,
              query_start_len_ptr=cu_seqlens_q,


### PR DESCRIPTION
### Summary
Adds joint BLOCK_M and TILE_SIZE autotuning to unified attention.

Available tuning configs in this branch:
- BLOCK_M={16,32,64} (already merged),  TILE_SIZE={16,32} (new), specific BLOCK_M=32, TILE_SIZE=128, 8 warp configuration (adapted for the large head 2D path).

New pruning rules:
- Pruner requires TILE_SIZE to fit within and divide the KV block size for tensor descriptor paths, excludes TILE_SIZE=16 for FP8 inputs, restrict the specific 128-wide tile is restricted to large head workloads.

Attention-reduction decoupling
- Attention kernel explicitly marks inactive 3D segments by writing a maximum of -inf and an exponential sum of zero before returning. Now the reduction kernels can use these attention-written sentinels to determine active segment boundaries, replacing the original derivation of these boundaries from `TILE_SIZE`, that removes its TILE_SIZE dependency and sequence lookup.

Misc. support
- Q/KV-bucketed autotune key is extended with FP8-input and large-head-path keys.
- Removes fixed prefill/decode tile selection, tile-clamping logic, and separate attention launch overrides.

Results
CI inputs benchmarked locally and with CI BMG B580, showing speedups. This branch was benchmarked against
ua-blockm-autotune-q-kv-len-bucketing branch, which directly precedes it in the PR stack.

**BMG local testing:** 
3.63% BF16 performance improvement (geomean)
~0% FP8 performance improvement (geomean)
Total time spent autotuning increases from 48.41 to 74.74 seconds per complete run through all 87 BF16

**BMG CI:**
https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/34154501633/job/101863759669?pr=7405

Closes [#6951](https://github.com/intel/intel-xpu-backend-for-triton/issues/6951)