### PR TITLE
[LLVMIR] Fix IGC segfault on sub-byte int bitcast  (#7352)

### DIFF
--- a/bin/triton-llvm-opt.cpp
+++ b/bin/triton-llvm-opt.cpp
@@ -68,6 +68,12 @@ static cl::opt<bool> ExpandSubByteBitwiseAnd(
     "expand-subbyte-bitwise-and",
     llvm::cl::desc("widen sub-byte `and iN` through i32"), cl::init(false));
 
+static cl::opt<bool> ExpandSubByteVectorBitcast(
+    "expand-subbyte-vector-bitcast",
+    llvm::cl::desc("rewrite `bitcast <K x i1> to <M x iN>` fed to "
+                   "extractelement + icmp onto the source i1 lanes"),
+    cl::init(false));
+
 namespace {
 static std::function<Error(Module *)> makeOptimizingPipeline() {
   return [](Module *m) -> Error {
@@ -91,6 +97,8 @@ static std::function<Error(Module *)> makeOptimizingPipeline() {
       mpm.addPass(ExpandSubByteBitReversePass());
     if (ExpandSubByteBitwiseAnd)
       mpm.addPass(ExpandSubByteBitwiseAndPass());
+    if (ExpandSubByteVectorBitcast)
+      mpm.addPass(ExpandSubByteVectorBitcastPass());
     llvm::FunctionPassManager fpm;
     if (BreakStructPhiNodes)
       fpm.addPass(BreakStructPhiNodesPass());

--- a/test/LLVMIR/expand-subbyte-vector-bitcast.ll
+++ b/test/LLVMIR/expand-subbyte-vector-bitcast.ll
@@ -1,0 +1,52 @@
+; RUN: triton-llvm-opt -expand-subbyte-vector-bitcast %s | FileCheck %s
+
+; A `bitcast <K x i1> to <M x iN>` (N<8) read back via extractelement and tested
+; with icmp eq/ne <const> is rewritten onto the source i1 lanes, so no sub-byte
+; integer type (scalar iN or <M x iN> vector) reaches the SPIR-V translator
+; (arbitrary-precision OpTypeInt crashes IGC on LTS2).
+
+; "any of the first two lanes set": icmp ne <lane0>, 0 lowers to
+; not((not bit0) and (not bit1)), i.e. bit0 or bit1, over the source i1 lanes.
+; CHECK-LABEL: @any_of_first_two
+define i1 @any_of_first_two(<4 x float> %v) {
+; CHECK-NOT:   bitcast <4 x i1> {{.*}} to <2 x i2>
+; CHECK-NOT:   extractelement <2 x i2>
+; CHECK-NOT:    i2
+; CHECK:       [[CMP:%.*]] = fcmp ule <4 x float> %v,
+; CHECK:       [[B0:%.*]] = extractelement <4 x i1> [[CMP]], i64 0
+; CHECK:       [[N0:%.*]] = xor i1 [[B0]], true
+; CHECK:       [[B1:%.*]] = extractelement <4 x i1> [[CMP]], i64 1
+; CHECK:       [[N1:%.*]] = xor i1 [[B1]], true
+; CHECK:       [[AND:%.*]] = and i1 [[N0]], [[N1]]
+; CHECK:       [[NE:%.*]] = xor i1 [[AND]], true
+; CHECK:       ret i1 [[NE]]
+  %cmp = fcmp ule <4 x float> %v, <float 1.0, float 1.0, float poison, float poison>
+  %bc = bitcast <4 x i1> %cmp to <2 x i2>
+  %e = extractelement <2 x i2> %bc, i64 0
+  %ne = icmp ne i2 %e, 0
+  ret i1 %ne
+}
+
+; icmp eq <lane1>, 3 (both bits set): (bit2 and bit3).
+; CHECK-LABEL: @lane_one_eq_three
+define i1 @lane_one_eq_three(<4 x i1> %bits) {
+; CHECK-NOT:    i2
+; CHECK:       [[B2:%.*]] = extractelement <4 x i1> %bits, i64 2
+; CHECK:       [[B3:%.*]] = extractelement <4 x i1> %bits, i64 3
+; CHECK:       [[AND:%.*]] = and i1 [[B2]], [[B3]]
+; CHECK:       ret i1 [[AND]]
+  %bc = bitcast <4 x i1> %bits to <2 x i2>
+  %e = extractelement <2 x i2> %bc, i64 1
+  %eq = icmp eq i2 %e, 3
+  ret i1 %eq
+}
+
+; A wider (>=8-bit) integer vector bitcast is left untouched.
+; CHECK-LABEL: @vec_i8_untouched
+define i8 @vec_i8_untouched(<4 x i16> %v) {
+; CHECK:       [[BC:%.*]] = bitcast <4 x i16> %v to <8 x i8>
+; CHECK:       extractelement <8 x i8> [[BC]]
+  %bc = bitcast <4 x i16> %v to <8 x i8>
+  %e = extractelement <8 x i8> %bc, i64 0
+  ret i8 %e
+}

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -501,7 +501,8 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
             llvm.link_extern_libs(llvm_mod, paths)
 
         cls.optimize_llvm_mod(llvm_mod, options)
-        intel.post_process_llir(llvm_mod)
+        is_lts = cls.is_lts(metadata["target"].arch.get("driver_version"))
+        intel.post_process_llir(llvm_mod, is_lts)
 
         # Get some metadata
         total_num_warps = src.get_int_attr("ttg.total-num-warps")

--- a/third_party/intel/include/Target/LLVMIR/PostProcess.h
+++ b/third_party/intel/include/Target/LLVMIR/PostProcess.h
@@ -6,7 +6,7 @@ class Module;
 } // namespace llvm
 
 namespace mlir::triton::intel {
-void postProcessLLVMIR(llvm::Module &module);
+void postProcessLLVMIR(llvm::Module &module, bool isLTS);
 } // namespace mlir::triton::intel
 
 #endif // TRITON_TARGET_LLVMIR_POSTPROCESS_H

--- a/third_party/intel/lib/Target/LLVMIR/LLVMPasses.h
+++ b/third_party/intel/lib/Target/LLVMIR/LLVMPasses.h
@@ -30,4 +30,10 @@ struct ExpandSubByteBitwiseAndPass
   static StringRef name() { return "ExpandSubByteBitwiseAndPass"; }
 };
 
+struct ExpandSubByteVectorBitcastPass
+    : PassInfoMixin<ExpandSubByteVectorBitcastPass> {
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  static StringRef name() { return "ExpandSubByteVectorBitcastPass"; }
+};
+
 } // namespace llvm

--- a/third_party/intel/lib/Target/LLVMIR/PostProcess.cpp
+++ b/third_party/intel/lib/Target/LLVMIR/PostProcess.cpp
@@ -3,6 +3,7 @@
 
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/Module.h"
 
@@ -148,7 +149,101 @@ void expandSubByteBitwiseAnd(Module &module) {
   }
 }
 
-void postProcessLLVMIR(llvm::Module &mod) {
+// W/A for IGC crash on LTS2 driver (IGC < 2.19.0).
+//
+// A sub-byte integer type (iN, N<8) lowers to an arbitrary-precision OpTypeInt
+// (SPV_INTEL_arbitrary_precision_integers); IGC segfaults compiling it, whether
+// scalar or as an OpTypeVector element. Such types appear when the LLVM
+// optimizer packs several i1 lanes (e.g. the results of a vector fcmp) into a
+// narrow integer via `bitcast <K x i1> to <M x iN>`, reads a lane back with
+// extractelement, and tests it against a constant with icmp -- the shape of an
+// "any/all over a comparison" reduction.
+//
+// Rewrite the whole `bitcast -> extractelement -> icmp eq/ne <const>` chain
+// onto the source i1 lanes so no sub-byte integer type is ever created. Lane j
+// of the <M x iN> value aliases source i1 lanes [j*N, j*N + N); on
+// little-endian (SPIR-V targets) bit i of the lane is source lane j*N + i.
+// `lane == C` is thus the AND over those bits of (bit == the corresponding bit
+// of C), built from i1 and/not; `ne` negates the result. Chains not matching
+// this shape are left untouched (correctness preserved; other shapes are not
+// observed in practice).
+void expandSubByteVectorBitcast(Module &module) {
+  SmallVector<BitCastInst *> bitcasts;
+
+  for (auto &func : module)
+    for (auto &block : func)
+      for (auto &inst : block)
+        if (auto *bc = dyn_cast<BitCastInst>(&inst))
+          if (auto *vecTy = dyn_cast<FixedVectorType>(bc->getType()))
+            if (auto *elemTy = dyn_cast<IntegerType>(vecTy->getElementType()))
+              if (elemTy->getBitWidth() < 8)
+                if (auto *srcTy =
+                        dyn_cast<FixedVectorType>(bc->getOperand(0)->getType()))
+                  if (srcTy->getElementType()->isIntegerTy(1))
+                    bitcasts.push_back(bc);
+
+  for (BitCastInst *bc : bitcasts) {
+    unsigned narrowBits =
+        cast<IntegerType>(
+            cast<FixedVectorType>(bc->getType())->getElementType())
+            ->getBitWidth();
+    Value *bits = bc->getOperand(0);
+
+    // Every user must be `extractelement <const>` feeding `icmp eq/ne <const>`.
+    struct Rewrite {
+      ICmpInst *cmp;
+      ExtractElementInst *extract;
+      uint64_t lane;
+    };
+    SmallVector<Rewrite> rewrites;
+    bool rewritable = true;
+    for (User *user : bc->users()) {
+      auto *extract = dyn_cast<ExtractElementInst>(user);
+      auto *idx =
+          extract ? dyn_cast<ConstantInt>(extract->getIndexOperand()) : nullptr;
+      if (!idx || !extract->hasOneUse()) {
+        rewritable = false;
+        break;
+      }
+      auto *cmp = dyn_cast<ICmpInst>(*extract->user_begin());
+      if (!cmp || !cmp->isEquality() || !isa<ConstantInt>(cmp->getOperand(1))) {
+        rewritable = false;
+        break;
+      }
+      rewrites.push_back({cmp, extract, idx->getZExtValue()});
+    }
+    if (!rewritable || rewrites.empty())
+      continue;
+
+    for (const Rewrite &r : rewrites) {
+      uint64_t cst = cast<ConstantInt>(r.cmp->getOperand(1))->getZExtValue();
+      IRBuilder<> b(r.cmp);
+      // AND over bits of the lane: bit set in C must be 1, bit clear must be 0.
+      Value *acc = nullptr;
+      for (unsigned i = 0; i < narrowBits; ++i) {
+        Value *bit = b.CreateExtractElement(bits, r.lane * narrowBits + i);
+        if (!((cst >> i) & 1))
+          bit = b.CreateNot(bit);
+        acc = acc ? b.CreateAnd(acc, bit) : bit;
+      }
+      // acc is true iff lane == C; adjust for eq vs ne.
+      if (r.cmp->getPredicate() == ICmpInst::ICMP_NE)
+        acc = b.CreateNot(acc);
+      r.cmp->replaceAllUsesWith(acc);
+    }
+
+    // Erase the replaced chain in dependency order: compare, then its
+    // single-use extractelement, then the bitcast once its last user is gone.
+    for (const Rewrite &r : rewrites) {
+      r.cmp->eraseFromParent();
+      r.extract->eraseFromParent();
+    }
+    if (bc->use_empty())
+      bc->eraseFromParent();
+  }
+}
+
+void postProcessLLVMIR(llvm::Module &mod, bool isLTS) {
   // __devicelib_assert_fail must be a declaration so that
   // IGC can replace it with a runtime assert function.
   // If a 'fallback' implementation is defined in SYCL libarary, the
@@ -167,6 +262,11 @@ void postProcessLLVMIR(llvm::Module &mod) {
   // Widen sub-byte bit ops forbidden by SPV_INTEL_int4.
   expandSubByteBitReverse(mod);
   expandSubByteBitwiseAnd(mod);
+
+  // Remove sub-byte integer vector bitcasts that crash IGC on LTS2. Gated on
+  // the LTS driver so it can be dropped once the driver ships the IGC fix.
+  if (isLTS)
+    expandSubByteVectorBitcast(mod);
 }
 
 } // namespace mlir::triton::intel
@@ -186,5 +286,11 @@ PreservedAnalyses ExpandSubByteBitReversePass::run(Module &M,
 PreservedAnalyses ExpandSubByteBitwiseAndPass::run(Module &M,
                                                    ModuleAnalysisManager &) {
   mlir::triton::intel::expandSubByteBitwiseAnd(M);
+  return PreservedAnalyses::none();
+}
+
+PreservedAnalyses ExpandSubByteVectorBitcastPass::run(Module &M,
+                                                      ModuleAnalysisManager &) {
+  mlir::triton::intel::expandSubByteVectorBitcast(M);
   return PreservedAnalyses::none();
 }

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -396,8 +396,9 @@ void init_triton_intel(py::module &&m) {
     mod->setDataLayout(layout);
   });
 
-  m.def("post_process_llir",
-        [](llvm::Module *mod) { intel::postProcessLLVMIR(*mod); });
+  m.def("post_process_llir", [](llvm::Module *mod, bool isLTS) {
+    intel::postProcessLLVMIR(*mod, isLTS);
+  });
 
   m.def(
       "translate_to_spirv",


### PR DESCRIPTION
Sub-byte integer types (`iN`, N<8) lower to
`SPV_INTEL_arbitrary_precision_integers`, which segfaults IGC on the LTS2 driver line. The LLVM optimizer emits them via `bitcast <K x i1> to <M x iN>` fed to extractelement + icmp (an "any/all over a comparison" reduction, e.g. `torch.all(x > 1)`).

New `expandSubByteVectorBitcast` post-process pass rewrites that chain onto the source `i1` lanes, so no sub-byte int type reaches the SPIR-V translator. Sits alongside the existing LTS2 IGC workarounds.

Fixes #7343.

(cherry picked from commit 0aef0b997c2e18ad52ac052a4accff9d7387c817)