### PR TITLE
Make sure `self.n_regs` is 128 by default

### DIFF
--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -382,10 +382,7 @@ struct BuildFlags {
     if (build_flags_str.find(SMALL_GRF_FLAG) != std::string::npos) {
       return 128;
     }
-    // TODO: arguably we could return 128 if we find no flag instead of 0. For
-    // now, stick with the conservative choice and alert the user only if a
-    // specific GRF mode is specified.
-    return 0;
+    return 128; // default GRF size if no flag is specified
   }
 
   const bool hasGRFSizeFlag() const {


### PR DESCRIPTION
"default: Provide no specification to IGC on the register file mode to select. Currently, IGC always chooses small register file mode with no specification.". For details: https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2025-2/small-register-mode-vs-large-register-mode.html