### PR TITLE
[BMG][Benchmarks] add profiler warmup

### DIFF
--- a/benchmarks/triton_kernels_benchmark/benchmark_testing.py
+++ b/benchmarks/triton_kernels_benchmark/benchmark_testing.py
@@ -149,8 +149,13 @@ def do_bench_upstream_pytorch_profiler(fn, n_warmup=25, n_repeat=100, grad_to_no
 
     assert return_mode in ["min", "max", "mean", "median"]
 
-    fn()
-    synchronize()
+    # warm up the profiler infrastructure to eliminate cold-start overhead.
+    # Without this, the first profiler context creation has significant overhead
+    # (e.g., 2.5ms vs 1.7ms, causing bimodal benchmark results - issue #5208).
+    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.XPU]) as _warmup_prof:
+        with record_function("__warmup_profiler"):
+            fn()
+            synchronize()
 
     # We maintain a buffer of 256 MB that we clear
     # before each kernel call to make sure that the L2


### PR DESCRIPTION
Adds profiler infrastructure warmup to do_bench_upstream_pytorch_profiler()
to eliminate cold-start overhead causing bimodal benchmark results.

The first profiler context creation had significant overhead (e.g., 2.5ms vs 1.7ms),
making the first measurement consistently slower.

Wrapping the initial warmup with a profiler context
ensures timed measurements don't include one-time setup costs.
