### PR TITLE
[NIT] Add the code sinking option in knobs.py to the kernel hash key.

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -46,8 +46,8 @@ class XPUOptions:
     allow_fp8e4nv: bool = False
     allow_fp8e4b15: bool = True
     grf_mode: str = 'default'
-    loop_distribute: bool = False
-    code_sinking: bool = False
+    loop_distribute: bool = knobs.intel.enable_loop_distribution
+    code_sinking: bool = knobs.intel.enable_code_sinking
     sub_32_dpas: bool = knobs.intel.enable_sub_32_dpas
     use_barrier: bool = False
     max_num_imprecise_acc_default: int = 0  # `max_num_imprecise_acc` only applies to fp8 -> fp32 dot on sm_90 for cuda
@@ -321,7 +321,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         passes.ttir.add_reorder_broadcast(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
-        if opt.loop_distribute or knobs.intel.enable_loop_distribution:
+        if opt.loop_distribute:
             intel.passes.ttgpuir.add_loop_distribute(pm)
         passes.ttir.add_loop_unroll(pm)
         pm.run(mod, 'make_ttir')
@@ -384,7 +384,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         # Off by default: code sinking is perf-neutral on measured kernels (it
         # reliably reduces register spills, but the relieved traffic is not on
         # the critical path on current HW). Opt in via the env var for A/B work.
-        if opt.code_sinking or knobs.intel.enable_code_sinking:
+        if opt.code_sinking:
             intel.passes.ttgpuir.add_code_sinking(pm)
 
         passes.ttir.add_loop_aware_cse(pm)


### PR DESCRIPTION
This PR updates the Intel XPU backend’s compilation options so the CODE_SINKING and LOOP_DISRIBUTE knob are reflected in the kernel cache key by default, ensuring cache entries differ when they are toggled via knobs.