### PR TITLE
Fix crash on null layout inference through tt.scan (#7336)

### DIFF
--- a/test/TritonIntelGPU/RemoveLayoutConversions/remove_layout_conversions_7336.mlir
+++ b/test/TritonIntelGPU/RemoveLayoutConversions/remove_layout_conversions_7336.mlir
@@ -1,0 +1,29 @@
+// RUN: triton-opt %s -split-input-file -tritonintelgpu-remove-layout-conversions 2>&1 | FileCheck %s
+
+// COM: https://github.com/intel/intel-xpu-backend-for-triton/issues/7336
+// COM: A value feeding both a tt.scan and a convert_layout to a non-blocked
+// COM: (slice) encoding used to crash backward rematerialization: the layout
+// COM: was forward-propagated onto the scan, inferDstEncoding returned a null
+// COM: Attribute for the scan, and the null later hit a dyn_cast (isPresent
+// COM: assertion / segfault). The pass must now complete and keep the scan.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [16], warpsPerCTA = [1], order = [0]}>
+#parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [1, 1], order = [1, 0]}>
+#slice = #ttg.slice<{dim = 0, parent = #parent}>
+
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: tt.func @scan_forward_remat_slice
+  tt.func @scan_forward_remat_slice() -> (tensor<16xi32, #blocked>, tensor<16xi32, #slice>) {
+    %a = tt.make_range {start = 0 : i32, end = 16 : i32} : tensor<16xi32, #blocked>
+    %add = arith.addi %a, %a : tensor<16xi32, #blocked>
+    // CHECK: "tt.scan"
+    %scan = "tt.scan"(%add) <{axis = 0 : i32, reverse = false}> ({
+    ^bb0(%lhs: i32, %rhs: i32):
+      %sum = arith.addi %lhs, %rhs : i32
+      tt.scan.return %sum : i32
+    }) : (tensor<16xi32, #blocked>) -> tensor<16xi32, #blocked>
+    %cvt = ttg.convert_layout %add : tensor<16xi32, #blocked> -> tensor<16xi32, #slice>
+    // CHECK: tt.return
+    tt.return %scan, %cvt : tensor<16xi32, #blocked>, tensor<16xi32, #slice>
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -1356,6 +1356,10 @@ void LayoutRematerialization::setEncoding(DenseMap<Value, Attribute> &values,
     } else {
       dstEncoding = inferDstEncoding(op, layout);
     }
+    // Don't propagate a failed (null) layout inference; it later crashes
+    // layout inference for the sort+cumsum tt.scan kernel (#7336).
+    if (!dstEncoding)
+      continue;
     if (!values.contains(value)) {
       values[value] = dstEncoding;
       changed.push_back(value);


### PR DESCRIPTION
A torch.compile kernel fusing torch.sort + torch.cumsum lowers to a tt.scan. During backward rematerialization, a value feeding both the scan and a convert_layout to a non-blocked (slice) encoding had that layout forward-propagated onto the scan. inferDstEncoding() returns a null Attribute for a tt.scan whose target layout is not blocked; LayoutRematerialization:: setEncoding recorded that null and it later reached a dyn_cast on a null Attribute, asserting/crashing the pass.

Skip recording a failed (null) inference so propagation stops for that edge, leaving the existing (legal) IR in place.

Add a minimal lit regression test.

Fixes #7336 