### PR TITLE
Fix tutorials on windows; more robust approach for preserving `os.environ` between tests

### DIFF
--- a/python/test/tutorials/test_tutorials.py
+++ b/python/test/tutorials/test_tutorials.py
@@ -54,7 +54,8 @@ def tutorial_environment(monkeypatch) -> pathlib.Path | None:
     """Prevent tutorials from leaking global state between test runs."""
     monkeypatch.setattr(sys, "argv", sys.argv[:])
 
-    monkeypatch.setattr(os, "environ", os.environ.copy())
+    # Preserve the process-backed environment mapping (important on Windows).
+    saved_environ = os.environ.copy()
     # Save and restore the triton allocator so tutorials that call
     # triton.set_allocator() (06, 08, 09) don't leak into subsequent tests.
     from triton.runtime import _allocation
@@ -66,6 +67,8 @@ def tutorial_environment(monkeypatch) -> pathlib.Path | None:
 
     yield pathlib.Path(reports_dir) if reports_dir else None
 
+    os.environ.clear()
+    os.environ.update(saved_environ)
     _allocation._allocator.reset(saved_token)
 
 


### PR DESCRIPTION
`os.environ` for windows has extra logic so we shouldn't replace it with pure dict:

"On Windows, the keys are converted to uppercase. This also applies when getting, setting, or deleting an item. For example, environ['monty'] = 'python' maps the key 'MONTY' to the value 'python'." from https://docs.python.org/3.10/library/os.html#os.environ

https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29237054927 (started to work)