### PR TITLE
capture-hw-details.sh: Return "Unknown" for new agama versioning scheme

### DIFF
--- a/scripts/capture-hw-details.sh
+++ b/scripts/capture-hw-details.sh
@@ -61,12 +61,24 @@ function agama_version {
         powershell -Command '(Get-WmiObject Win32_VideoController | where {$_.VideoProcessor -like "*Intel*" }).DriverVersion'
         return
     fi
+    local pkg version upstream_version
     if dpkg-query --show libigc2 &> /dev/null; then
-        dpkg-query --show --showformat='${version}\n' libigc2 | sed 's/.*-\(.*\)~.*/\1/'
+        pkg=libigc2
     elif dpkg-query --show libigc1 &> /dev/null; then
-        dpkg-query --show --showformat='${version}\n' libigc1 | sed 's/.*-\(.*\)~.*/\1/'
+        pkg=libigc1
     else
         echo "Not Installed"
+        return
+    fi
+    version="$(dpkg-query --show --showformat='${version}\n' "$pkg")"
+    # Starting with libigc2 2.36, the Debian revision no longer carries the
+    # old-style agama build number (it's a plain package revision now), so
+    # there is nothing meaningful left to extract.
+    upstream_version="${version%%-*}"
+    if dpkg --compare-versions "$upstream_version" ge "2.36"; then
+        echo "Unknown"
+    else
+        echo "$version" | sed 's/.*-\(.*\)~.*/\1/'
     fi
 }
 


### PR DESCRIPTION
The fix in `capture-hw-details.sh` compares the upstream `libigc2/libigc1` version against `2.36` via `dpkg --compare-versions` and returns `Unknown` when it's `>=`, since Kobuk dropped the embedded agama build number from the package revision number starting at that version.

Both cases work as expected:

Case 1 (`libigc2 2.30.3-1249~24.04`) → `AGAMA_VERSION=1249` — unchanged, old-style extraction still works below the 2.36 cutoff.
Case 2 `(libigc2 2.36.3-2~24.04)` → `AGAMA_VERSION=Unknown` — no longer misreports the Debian package revision (2) as an agama build number

```
=== Image 1 (agama1249, libigc 2.30.3-1249) ===
LIBIGC1_VERSION=2.30.3-1249
AGAMA_VERSION=1249

=== Image 2 (agama2 tag, libigc 2.36.3-2) ===
LIBIGC1_VERSION=2.36.3-2
AGAMA_VERSION=Unknown
```