### PR TITLE
[LoadStore] Skip redundant registers in atomic RMW/CAS lowering (#7448)

### DIFF
--- a/test/Conversion/intel/atomic_rmw_redundant_regs.mlir
+++ b/test/Conversion/intel/atomic_rmw_redundant_regs.mlir
@@ -1,0 +1,27 @@
+// RUN: env TRITON_INTEL_PREDICATED_LOAD=0 TRITON_INTEL_PREDICATED_STORE=0 triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm --convert-tritongen-to-llvm | FileCheck %s
+
+// COM: Regression test for a fused reduction + scatter (atomic_rmw) miscompile
+//      (multi_margin_loss backward, issue #7436). When a layout places several
+//      registers of the same value in one thread (register redundancy, e.g. a
+//      broadcasted reduction result), the atomic must be emitted only ONCE per
+//      thread. Emitting it once per redundant register double-counts the
+//      atomic_add and produces a 2x (or Nx) result.
+
+// COM: sizePerThread = [1, 4] over a 16x1 tensor gives 4 registers per thread
+//      that all map to the same tensor element -> 3 of the 4 are redundant.
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [16, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: @atomic_rmw_reg_redundant
+  // CHECK-COUNT-1: llvm.atomicrmw fadd
+  // CHECK-NOT: llvm.atomicrmw fadd
+  tt.func public @atomic_rmw_reg_redundant(%ptr: !tt.ptr<f32>, %val: f32) {
+    %mask = arith.constant dense<true> : tensor<16x1xi1, #blocked>
+    %ptr_splat = tt.splat %ptr : !tt.ptr<f32> -> tensor<16x1x!tt.ptr<f32>, #blocked>
+    %range = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %range_exp = tt.expand_dims %range {axis = 1 : i32} : tensor<16xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<16x1xi32, #blocked>
+    %ptrs = tt.addptr %ptr_splat, %range_exp : tensor<16x1x!tt.ptr<f32>, #blocked>, tensor<16x1xi32, #blocked>
+    %v = tt.splat %val : f32 -> tensor<16x1xf32, #blocked>
+    %0 = tt.atomic_rmw fadd, relaxed, gpu, %ptrs, %v, %mask : (tensor<16x1x!tt.ptr<f32>, #blocked>, tensor<16x1xf32, #blocked>, tensor<16x1xi1, #blocked>) -> tensor<16x1xf32, #blocked>
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -3292,6 +3292,7 @@ struct AtomicCASOpConversion
     auto freeVarMasks = getFreeVariableMasks(valueTy);
     Value mask =
         emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
+    uint32_t regMask = freeVarMasks[str_attr("register")];
     SmallVector<Value> resultVals(elemsPerThread);
 
     MemSemantic memSem = op.getSem();
@@ -3304,6 +3305,12 @@ struct AtomicCASOpConversion
         TritonIntelGPUDialect::getSupport16BitAtomicsAttrName());
 
     for (size_t i = 0; i < elemsPerThread; ++i) {
+      if (auto canonicalStart = getCanonicalIndex(i, regMask);
+          canonicalStart != i) {
+        resultVals[i] = resultVals[canonicalStart];
+        continue;
+      }
+
       Value casPtr = ptrElements[i];
       Value casCmp = cmpElements[i];
       Value casVal = valElements[i];
@@ -3513,6 +3520,7 @@ struct AtomicRMWOpConversion
     auto freeVarMasks = getFreeVariableMasks(valueTy);
     Value threadPred =
         emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
+    uint32_t regMask = freeVarMasks[str_attr("register")];
 
     bool support16BitAtomics = moduleOp->hasAttr(
         TritonIntelGPUDialect::getSupport16BitAtomicsAttrName());
@@ -3526,6 +3534,13 @@ struct AtomicRMWOpConversion
     auto vecTy = vec_ty(valueElemTy, vec);
     SmallVector<Value> resultVals(elemsPerThread);
     for (size_t i = 0; i < elemsPerThread; i += vec) {
+      if (auto canonicalStart = getCanonicalIndex(i, regMask);
+          canonicalStart != i) {
+        for (unsigned ii = 0; ii < vec; ++ii)
+          resultVals[i + ii] = resultVals[canonicalStart + ii];
+        continue;
+      }
+
       Value rmwVal = b.undef(vecTy);
       for (int ii = 0; ii < vec; ++ii) {
         Value iiVal = createIndexAttrConstant(


### PR DESCRIPTION
Adjusted Intel's LoadStore atomic lowering to NVIDIA.

Closes #7436


(cherry picked from commit f42880b0ae4de1d82d7e5e50d29cee058f24faa7)