### PR TITLE
Fix pitch < base_width for broadcast 2D block I/O after alignment compensation (#7463)

### DIFF
--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/pointer-load.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/pointer-load.mlir
@@ -13,7 +13,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x32x!tt.ptr<f16>, #dot0>
     %3 = tt.addptr %2, %1 : tensor<1x32x!tt.ptr<f16>, #dot0>, tensor<1x32xi32, #dot0>
     %4 = tt.broadcast %3 : tensor<1x32x!tt.ptr<f16>, #dot0> -> tensor<64x32x!tt.ptr<f16>, #dot0>
-    // CHECK: %[[P:.*]] = arith.constant 64 : i32
+    // CHECK: %[[P:.*]] = arith.constant 128 : i32
     // CHECK: ttig.2d_block_load_from_ptr %4, %[[P]] {row_major} {base_height = 1 : i32, base_width = 32 : i32}
     %5 = tt.load %4 {ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f16>, #dot0>
     tt.return %5 : tensor<64x32xf16, #dot0>
@@ -34,7 +34,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x64x!tt.ptr<f16>, #dot1>
     %3 = tt.addptr %2, %1 : tensor<1x64x!tt.ptr<f16>, #dot1>, tensor<1x64xi32, #dot1>
     %4 = tt.broadcast %3 : tensor<1x64x!tt.ptr<f16>, #dot1> -> tensor<32x64x!tt.ptr<f16>, #dot1>
-    // CHECK: %[[P:.*]] = arith.constant 64 : i32
+    // CHECK: %[[P:.*]] = arith.constant 128 : i32
     // CHECK: ttig.2d_block_load_from_ptr %4, %[[P]] {column_major} {base_height = 1 : i32, base_width = 32 : i32}
     %5 = tt.load %4 {ttig.block_io = "column_major"} : tensor<32x64x!tt.ptr<f16>, #dot1>
     tt.return %5 : tensor<32x64xf16, #dot1>

--- a/test/TritonIntelGPU/tensor-pointer-store-block-2d.mlir
+++ b/test/TritonIntelGPU/tensor-pointer-store-block-2d.mlir
@@ -218,9 +218,10 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
   // CHECK-LABEL: @broadcast_row_major_pointer_store
   // CHECK-NOT: triton_gen.2Dblockstore
   // ALL-LAYOUT-LABEL: @broadcast_row_major_pointer_store
-  // COM: surface width = 64 elements and f16 elements are 2 bytes, so the
-  // COM: synthesized full-row pitch is 64 * 2 = 128 bytes.
-  // ALL-LAYOUT: %[[PITCH:.*]] = llvm.mlir.constant(128 : i32) : i32
+  // COM: surface width = 64 elements * 2 bytes = 128 bytes. The pitch must
+  // COM: account for up to 63 bytes of alignment compensation: alignTo(128 +
+  // COM: 63, 16) = 192.
+  // ALL-LAYOUT: %[[PITCH:.*]] = llvm.mlir.constant(192 : i32) : i32
   // ALL-LAYOUT: triton_gen.2Dblockstore {{.*}}, %[[PITCH]], {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 1, v_blocks = 1, cache_control = Default}
   tt.func public @broadcast_row_major_pointer_store(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
     // COM: start=20 gives a non-zero column offset so alignment compensation

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -9,6 +9,7 @@
 #include "triton/Tools/LayoutUtils.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/MathExtras.h"
 
 #include "PatternTritonGPUOpToLLVM.h"
 #include "TargetInfo.h"
@@ -3033,15 +3034,20 @@ struct StoreOpToBlockIOConversion
         // It must be a store height=1 tile. We can set the pitch to an
         // arbitrary value since the row offset is always 0, as long as we can
         // satisfy the HW address payload restriction for the given tile width
-        // and element size. To keep it simple, we can just set the pitch to
-        // surface width * element size to avoid issue pitch < base_width caused
-        // by the compensation of the base address alignment.
+        // and element size. Account for the downstream 64-byte alignment
+        // compensation (up to 63 bytes added to base_width) and the umax(64)
+        // floor so that pitch >= adjusted base_width is always satisfied.
         if (tileHeight != 1)
           return failure();
         constexpr int64_t MIN_PITCH = 64;
-        int64_t surfaceWidth = tensorType.getDimSize(colDim);
-        pitch =
-            b.i32_val(std::max(MIN_PITCH, surfaceWidth * elemSizeInBits / 8));
+        constexpr int64_t MAX_ALIGN_OVERHEAD = 63;
+        int64_t surfaceWidthBytes =
+            tensorType.getDimSize(colDim) * elemSizeInBits / 8;
+        int64_t maxAdjustedWidth =
+            std::max(MIN_PITCH, surfaceWidthBytes) + MAX_ALIGN_OVERHEAD;
+        // Pitch must be a multiple of 16 bytes.
+        pitch = b.i32_val(
+            llvm::alignTo(std::max(MIN_PITCH, maxAdjustedWidth), int64_t(16)));
       } else {
         pitch = getPitch(rewriter, ptr, elemSizeInBits, rowDim);
       }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -13,6 +13,7 @@
 #include "triton/Tools/LinearLayout.h"
 #include "triton/Tools/Sys/GetEnv.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/MathExtras.h"
 #include <limits>
 #include <optional>
 
@@ -429,12 +430,18 @@ private:
 
     if (!has1DReshapeStride) {
       if (isBroadcast) {
-        // Use the full surface row width (in bytes) as the baseline pitch.
-        // Lowering may widen base_width (e.g. due to alignment), so ensure the
-        // dummy pitch doesn't end up smaller than base_width.
+        // For broadcast (height=1) loads, pitch is a dummy value (no row
+        // advancement), but the HW still enforces pitch >= base_width.
+        // Downstream lowering widens base_width by up to 63 bytes for 64-byte
+        // pointer alignment compensation. Account for that here so the
+        // constraint is never violated at runtime.
         int64_t fullRowBytes =
             tensorTy.getDimSize(surfaceWidthDim) * elemSizeInBits / 8;
-        pitch = std::max(MIN_PITCH, fullRowBytes);
+        constexpr int64_t MAX_ALIGN_OVERHEAD = 63;
+        int64_t maxAdjustedWidth = fullRowBytes + MAX_ALIGN_OVERHEAD;
+        // Pitch must be a multiple of 16 bytes.
+        pitch =
+            llvm::alignTo(std::max(MIN_PITCH, maxAdjustedWidth), int64_t(16));
       } else {
         int64_t pitchStride = getStride(strideAnalysis, op.getPtr(), pitchDim);
         if (pitchStride < 0) {


### PR DESCRIPTION
The previous fix (e284b486c) set the dummy pitch for broadcast (stride=0) loads/stores to the full surface row width. However, the downstream LLVM lowering applies 64-byte pointer alignment compensation that widens base_width by up to 63 bytes (ptr & 0x3f). When the surface row width equals the pitch (contiguous memory), this pushes base_width above pitch, violating the HW constraint pitch >= base_width.


(cherry picked from commit f9c5d293eb5fbd8537dea6f352a8946b5d55aea5)