### PR TITLE
test_line_info: Fix Windows path-separator mismatch in check_file_lines

### DIFF
--- a/python/test/unit/language/test_line_info.py
+++ b/python/test/unit/language/test_line_info.py
@@ -1,4 +1,5 @@
 import inspect
+import re
 import subprocess
 import tempfile
 
@@ -157,7 +158,13 @@ def check_file_lines(file_lines, file_name, lineno, should_contain=True):
         lineno: line number, -1 means do not check line number
         should_contain: whether the file name and line number should be in the file_lines
     """
+    # On Windows, disassemblers print path separators as backslashes, and
+    # escape each backslash again in the string literal (e.g. "/path\\test.py"
+    # for source path "/path/test.py"), so normalize both sides before
+    # comparing.
+    file_name = re.sub(r"\\+", "/", file_name)
     for file, line in file_lines:
+        file = re.sub(r"\\+", "/", file)
         if lineno == -1 and file_name in file:
             return True
         if file_name in file and str(lineno) in line:


### PR DESCRIPTION
## Summary
- `check_file_lines()` in `test_line_info.py` did a plain substring match between a hardcoded forward-slash path and disassembler debug-line metadata, which on Windows is backslash-escaped (e.g. `"/path\\test.py"`). The match never succeeded even though the correct line number was present, causing `test_line_info_ir_source[]` to fail on the A770 Windows runner.
- Normalize backslash runs to forward slashes on both sides of the comparison before matching.

Fixes #7484

## Test plan
- [x] Verified the fix against the exact failure repro from the issue and additional edge cases (should_contain=True/False, lineno=-1 path-only checks, Linux forward-slash paths) using standalone Python (no triton import needed, since the bug is pure string-matching logic).
- [x] A770 Windows CI run: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29460764886 (test_line_info have to pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)