### PR TITLE
Support to load transpose B matrix of sub-group-size=32.

### DIFF
--- a/python/test/unit/intel/test_block_load.py
+++ b/python/test/unit/intel/test_block_load.py
@@ -340,11 +340,11 @@ def test_block_tdesc_column_major_load(device, tmp_path: pathlib.Path):
          and triton.runtime.driver.active.get_current_target().arch['has_subgroup_matrix_multiply_accumulate']),
     reason="Block loads and/or DPAS not supported on this architecture", run=False)
 def test_block_tdesc_column_major_load_subgroup32(device, tmp_path: pathlib.Path):
-    """Verify column_major descriptor load with threadsPerWarp=32, f16/opsPerChan=2.
+    """Verify column_major descriptor load with ``threadsPerWarp = 32``, f16/opsPerChan=2.
 
     This exercises the fix in ``computeTransposeShuffleMapping`` that unblocks
-    B-matrix column-major 2D block loads when ``threadsPerWarp=32``.  Before the
-    fix, the old width-comparison guard rejected this configuration because
+    B-matrix column-major 2D block loads when ``threadsPerWarp = 32``.  Before
+    the fix, the old width-comparison guard rejected this configuration because
     ``dpasInstShapeB()[1] = 16 != threadsPerWarp = 32``, causing a silent
     fallback to gather instead of a hardware transpose load.
 

--- a/python/test/unit/intel/test_block_load.py
+++ b/python/test/unit/intel/test_block_load.py
@@ -329,3 +329,92 @@ def test_block_tdesc_column_major_load(device, tmp_path: pathlib.Path):
     # C should equal A x B_stored.T  (since B was loaded via column_major).
     expected = torch.mm(A.to(torch.float32), B_stored.to(torch.float32).T)
     torch.testing.assert_close(C, expected, atol=1e-1, rtol=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# Column-major descriptor load — threadsPerWarp=32
+# ---------------------------------------------------------------------------
+@pytest.mark.skipif(not is_xpu(), reason="Block descriptor tests are specific to the XPU backend")
+@pytest.mark.xfail(
+    not (triton.runtime.driver.active.get_current_target().arch['has_subgroup_2d_block_io']
+         and triton.runtime.driver.active.get_current_target().arch['has_subgroup_matrix_multiply_accumulate']),
+    reason="Block loads and/or DPAS not supported on this architecture", run=False)
+def test_block_tdesc_column_major_load_subgroup32(device, tmp_path: pathlib.Path):
+    """Verify column_major descriptor load with threadsPerWarp=32, f16/opsPerChan=2.
+
+    This exercises the fix in ``computeTransposeShuffleMapping`` that unblocks
+    B-matrix column-major 2D block loads when ``threadsPerWarp=32``.  Before the
+    fix, the old width-comparison guard rejected this configuration because
+    ``dpasInstShapeB()[1] = 16 != threadsPerWarp = 32``, causing a silent
+    fallback to gather instead of a hardware transpose load.
+
+    The kernel is identical in structure to ``test_block_tdesc_column_major_load``
+    (same M/K/N tile sizes) but uses ``threadsPerWarp = 32`` with a matching
+    DPAS config (``warpsPerCTA = [4, 2]``).  The DPAS per-warp tile shapes
+    remain ``A = [8, 16], B = [16, 16], C = [8, 16]`` and the full tile fits
+    in two repetitions along each dimension (numRep_M = numRep_K = numRep_N = 2).
+    """
+    M, K, N = 64, 32, 64
+
+    ir = f"""
+    #dpas = #ttig.dpas<{{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 32, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}}>
+    #dot0 = #ttg.dot_op<{{opIdx = 0, parent = #dpas, kWidth=1}}>
+    #dot1 = #ttg.dot_op<{{opIdx = 1, parent = #dpas, kWidth=2}}>
+    module attributes {{ttig.min_sg_size = 16 : i32, ttig.support_bfloat16_conversion, ttig.support_subgroup_matrix_multiply_accumulate, ttig.support_2d_block_io, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 32 : i32}} {{
+        tt.func public @column_major_load_subgroup32(%a_ptr: !tt.ptr<f16> {{tt.divisibility = 16 : i32}},
+                                                      %b_ptr: !tt.ptr<f16> {{tt.divisibility = 16 : i32}},
+                                                      %c_ptr: !tt.ptr<f32> {{tt.divisibility = 16 : i32}}) attributes {{noinline = false}} {{
+            %c0_i32 = arith.constant 0 : i32
+            %c1_i64 = arith.constant 1 : i64
+            %cM_i32 = arith.constant {M} : i32
+            %cK_i32 = arith.constant {K} : i32
+            %cN_i32 = arith.constant {N} : i32
+            %cK_i64 = arith.constant {K} : i64
+            %cN_i64 = arith.constant {N} : i64
+
+            // A: [{M}, {K}] row-major.
+            %desc_a = tt.make_tensor_descriptor %a_ptr, [%cM_i32, %cK_i32], [%cK_i64, %c1_i64]
+                      : !tt.ptr<f16>, !tt.tensordesc<{M}x{K}xf16>
+            %a = tt.descriptor_load %desc_a [%c0_i32, %c0_i32] {{ttig.block_io = "row_major"}}
+                 : !tt.tensordesc<{M}x{K}xf16> -> tensor<{M}x{K}xf16, #dot0>
+
+            // B stored as [{N}, {K}] row-major in memory (N rows, K contiguous cols).
+            // column_major load: the permuteDescDim logic swaps the last two descriptor
+            // dimensions before extracting surface parameters, so the result is
+            // tensor<{K}x{N}xf16, #dot1> (the transposed view of the [{N},{K}] storage).
+            %desc_b = tt.make_tensor_descriptor %b_ptr, [%cN_i32, %cK_i32], [%cK_i64, %c1_i64]
+                      : !tt.ptr<f16>, !tt.tensordesc<{N}x{K}xf16>
+            %b = tt.descriptor_load %desc_b [%c0_i32, %c0_i32] {{ttig.block_io = "column_major"}}
+                 : !tt.tensordesc<{N}x{K}xf16> -> tensor<{K}x{N}xf16, #dot1>
+
+            // C = A x B  (dimensions: [{M},{K}] x [{K},{N}] -> [{M},{N}])
+            %C_init = arith.constant dense<0.000000e+00> : tensor<{M}x{N}xf32, #dpas>
+            %C = tt.dot %a, %b, %C_init, inputPrecision = tf32
+                 : tensor<{M}x{K}xf16, #dot0> * tensor<{K}x{N}xf16, #dot1> -> tensor<{M}x{N}xf32, #dpas>
+
+            // Store C: the dpas encoding supports 2D block stores via a descriptor.
+            %desc_c = tt.make_tensor_descriptor %c_ptr, [%cM_i32, %cN_i32], [%cN_i64, %c1_i64]
+                      : !tt.ptr<f32>, !tt.tensordesc<{M}x{N}xf32, #dpas>
+            tt.descriptor_store %desc_c [%c0_i32, %c0_i32], %C {{ttig.block_io = "row_major"}}
+                                : !tt.tensordesc<{M}x{N}xf32, #dpas>, tensor<{M}x{N}xf32, #dpas>
+
+            tt.return
+        }}
+    }}
+    """
+
+    torch.manual_seed(42)
+    A = torch.randn((M, K), dtype=torch.float16, device=device)
+    # B is stored as [N, K] in memory (the transposed representation of a [K, N] B matrix).
+    B_stored = torch.randn((N, K), dtype=torch.float16, device=device)
+    C = torch.empty((M, N), dtype=torch.float32, device=device)
+
+    temp_file = tmp_path / "test_block_tdesc_column_major_load_subgroup32.ttgir"
+    temp_file.write_text(ir)
+    kernel = triton.compile(str(temp_file))
+
+    kernel[(1, 1, 1)](A, B_stored, C)
+
+    # C should equal A x B_stored.T  (since B was loaded via column_major).
+    expected = torch.mm(A.to(torch.float32), B_stored.to(torch.float32).T)
+    torch.testing.assert_close(C, expected, atol=1e-1, rtol=1e-2)

--- a/python/test/unit/intel/test_block_load.py
+++ b/python/test/unit/intel/test_block_load.py
@@ -252,7 +252,8 @@ def test_block_tdesc_dot_product(BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, GROUP
     not (triton.runtime.driver.active.get_current_target().arch['has_subgroup_2d_block_io']
          and triton.runtime.driver.active.get_current_target().arch['has_subgroup_matrix_multiply_accumulate']),
     reason="Block loads and/or DPAS not supported on this architecture", run=False)
-def test_block_tdesc_column_major_load(device, tmp_path: pathlib.Path):
+@pytest.mark.parametrize("threads_per_warp", [16, 32])
+def test_block_tdesc_column_major_load(threads_per_warp, device, tmp_path: pathlib.Path):
     """Verify that a column_major descriptor load correctly loads a transposed matrix.
 
     B is stored in physical memory as [N, K] row-major (N rows, K contiguous
@@ -268,13 +269,13 @@ def test_block_tdesc_column_major_load(device, tmp_path: pathlib.Path):
     M, K, N = 64, 32, 64
 
     ir = f"""
-    #dpas = #ttig.dpas<{{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}}>
+    #dpas = #ttig.dpas<{{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = {threads_per_warp}, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}}>
     #dot0 = #ttg.dot_op<{{opIdx = 0, parent = #dpas, kWidth=1}}>
     #dot1 = #ttg.dot_op<{{opIdx = 1, parent = #dpas, kWidth=2}}>
-    module attributes {{ttig.min_sg_size = 16 : i32, ttig.support_bfloat16_conversion, ttig.support_subgroup_matrix_multiply_accumulate, ttig.support_2d_block_io, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32}} {{
-        tt.func public @column_major_load(%a_ptr: !tt.ptr<f16> {{tt.divisibility = 16 : i32}},
-                                          %b_ptr: !tt.ptr<f16> {{tt.divisibility = 16 : i32}},
-                                          %c_ptr: !tt.ptr<f32> {{tt.divisibility = 16 : i32}}) attributes {{noinline = false}} {{
+    module attributes {{ttig.min_sg_size = 16 : i32, ttig.support_bfloat16_conversion, ttig.support_subgroup_matrix_multiply_accumulate, ttig.support_2d_block_io, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = {threads_per_warp} : i32}} {{
+        tt.func public @column_major_load_tpw{threads_per_warp}(%a_ptr: !tt.ptr<f16> {{tt.divisibility = 16 : i32}},
+                                                                %b_ptr: !tt.ptr<f16> {{tt.divisibility = 16 : i32}},
+                                                                %c_ptr: !tt.ptr<f32> {{tt.divisibility = 16 : i32}}) attributes {{noinline = false}} {{
             %c0_i32 = arith.constant 0 : i32
             %c1_i64 = arith.constant 1 : i64
             %cM_i32 = arith.constant {M} : i32
@@ -320,101 +321,16 @@ def test_block_tdesc_column_major_load(device, tmp_path: pathlib.Path):
     B_stored = torch.randn((N, K), dtype=torch.float16, device=device)
     C = torch.empty((M, N), dtype=torch.float32, device=device)
 
-    temp_file = tmp_path / "test_block_tdesc_column_major_load.ttgir"
+    temp_file = tmp_path / f"test_block_tdesc_column_major_load_tpw{threads_per_warp}.ttgir"
     temp_file.write_text(ir)
     kernel = triton.compile(str(temp_file))
+    llir = kernel.asm["llir"]
 
     kernel[(1, 1, 1)](A, B_stored, C)
 
     # C should equal A x B_stored.T  (since B was loaded via column_major).
     expected = torch.mm(A.to(torch.float32), B_stored.to(torch.float32).T)
     torch.testing.assert_close(C, expected, atol=1e-1, rtol=1e-2)
-
-
-# ---------------------------------------------------------------------------
-# Column-major descriptor load — threadsPerWarp=32
-# ---------------------------------------------------------------------------
-@pytest.mark.skipif(not is_xpu(), reason="Block descriptor tests are specific to the XPU backend")
-@pytest.mark.xfail(
-    not (triton.runtime.driver.active.get_current_target().arch['has_subgroup_2d_block_io']
-         and triton.runtime.driver.active.get_current_target().arch['has_subgroup_matrix_multiply_accumulate']),
-    reason="Block loads and/or DPAS not supported on this architecture", run=False)
-def test_block_tdesc_column_major_load_subgroup32(device, tmp_path: pathlib.Path):
-    """Verify column_major descriptor load with ``threadsPerWarp = 32``, f16/opsPerChan=2.
-
-    This exercises the fix in ``computeTransposeShuffleMapping`` that unblocks
-    B-matrix column-major 2D block loads when ``threadsPerWarp = 32``.  Before
-    the fix, the old width-comparison guard rejected this configuration because
-    ``dpasInstShapeB()[1] = 16 != threadsPerWarp = 32``, causing a silent
-    fallback to gather instead of a hardware transpose load.
-
-    The kernel is identical in structure to ``test_block_tdesc_column_major_load``
-    (same M/K/N tile sizes) but uses ``threadsPerWarp = 32`` with a matching
-    DPAS config (``warpsPerCTA = [4, 2]``).  The DPAS per-warp tile shapes
-    remain ``A = [8, 16], B = [16, 16], C = [8, 16]`` and the full tile fits
-    in two repetitions along each dimension (numRep_M = numRep_K = numRep_N = 2).
-    """
-    M, K, N = 64, 32, 64
-
-    ir = f"""
-    #dpas = #ttig.dpas<{{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 32, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}}>
-    #dot0 = #ttg.dot_op<{{opIdx = 0, parent = #dpas, kWidth=1}}>
-    #dot1 = #ttg.dot_op<{{opIdx = 1, parent = #dpas, kWidth=2}}>
-    module attributes {{ttig.min_sg_size = 16 : i32, ttig.support_bfloat16_conversion, ttig.support_subgroup_matrix_multiply_accumulate, ttig.support_2d_block_io, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 32 : i32}} {{
-        tt.func public @column_major_load_subgroup32(%a_ptr: !tt.ptr<f16> {{tt.divisibility = 16 : i32}},
-                                                      %b_ptr: !tt.ptr<f16> {{tt.divisibility = 16 : i32}},
-                                                      %c_ptr: !tt.ptr<f32> {{tt.divisibility = 16 : i32}}) attributes {{noinline = false}} {{
-            %c0_i32 = arith.constant 0 : i32
-            %c1_i64 = arith.constant 1 : i64
-            %cM_i32 = arith.constant {M} : i32
-            %cK_i32 = arith.constant {K} : i32
-            %cN_i32 = arith.constant {N} : i32
-            %cK_i64 = arith.constant {K} : i64
-            %cN_i64 = arith.constant {N} : i64
-
-            // A: [{M}, {K}] row-major.
-            %desc_a = tt.make_tensor_descriptor %a_ptr, [%cM_i32, %cK_i32], [%cK_i64, %c1_i64]
-                      : !tt.ptr<f16>, !tt.tensordesc<{M}x{K}xf16>
-            %a = tt.descriptor_load %desc_a [%c0_i32, %c0_i32] {{ttig.block_io = "row_major"}}
-                 : !tt.tensordesc<{M}x{K}xf16> -> tensor<{M}x{K}xf16, #dot0>
-
-            // B stored as [{N}, {K}] row-major in memory (N rows, K contiguous cols).
-            // column_major load: the permuteDescDim logic swaps the last two descriptor
-            // dimensions before extracting surface parameters, so the result is
-            // tensor<{K}x{N}xf16, #dot1> (the transposed view of the [{N},{K}] storage).
-            %desc_b = tt.make_tensor_descriptor %b_ptr, [%cN_i32, %cK_i32], [%cK_i64, %c1_i64]
-                      : !tt.ptr<f16>, !tt.tensordesc<{N}x{K}xf16>
-            %b = tt.descriptor_load %desc_b [%c0_i32, %c0_i32] {{ttig.block_io = "column_major"}}
-                 : !tt.tensordesc<{N}x{K}xf16> -> tensor<{K}x{N}xf16, #dot1>
-
-            // C = A x B  (dimensions: [{M},{K}] x [{K},{N}] -> [{M},{N}])
-            %C_init = arith.constant dense<0.000000e+00> : tensor<{M}x{N}xf32, #dpas>
-            %C = tt.dot %a, %b, %C_init, inputPrecision = tf32
-                 : tensor<{M}x{K}xf16, #dot0> * tensor<{K}x{N}xf16, #dot1> -> tensor<{M}x{N}xf32, #dpas>
-
-            // Store C: the dpas encoding supports 2D block stores via a descriptor.
-            %desc_c = tt.make_tensor_descriptor %c_ptr, [%cM_i32, %cN_i32], [%cN_i64, %c1_i64]
-                      : !tt.ptr<f32>, !tt.tensordesc<{M}x{N}xf32, #dpas>
-            tt.descriptor_store %desc_c [%c0_i32, %c0_i32], %C {{ttig.block_io = "row_major"}}
-                                : !tt.tensordesc<{M}x{N}xf32, #dpas>, tensor<{M}x{N}xf32, #dpas>
-
-            tt.return
-        }}
-    }}
-    """
-
-    torch.manual_seed(42)
-    A = torch.randn((M, K), dtype=torch.float16, device=device)
-    # B is stored as [N, K] in memory (the transposed representation of a [K, N] B matrix).
-    B_stored = torch.randn((N, K), dtype=torch.float16, device=device)
-    C = torch.empty((M, N), dtype=torch.float32, device=device)
-
-    temp_file = tmp_path / "test_block_tdesc_column_major_load_subgroup32.ttgir"
-    temp_file.write_text(ir)
-    kernel = triton.compile(str(temp_file))
-
-    kernel[(1, 1, 1)](A, B_stored, C)
-
-    # C should equal A x B_stored.T  (since B was loaded via column_major).
-    expected = torch.mm(A.to(torch.float32), B_stored.to(torch.float32).T)
-    torch.testing.assert_close(C, expected, atol=1e-1, rtol=1e-2)
+    assert 'spirv_Subgroup2DBlockStoreINTEL' in llir or 'GenISA.LSC2DBlockWrite' in llir
+    load_count = llir.count('spirv_Subgroup2DBlockLoad') + llir.count('GenISA.LSC2DBlockRead')
+    assert load_count >= 2

--- a/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
+++ b/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
@@ -195,3 +195,20 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32,
     tt.return
   }
 }
+
+// -----
+
+// COM: Test subgroup-size=32 DotOp-B column-major (transposed) block load with
+// COM: f16/opsPerChan=2. The old width-comparison check rejected this because
+// COM: dpasInstShapeB()[1]=16 != threadsPerWarp=32. The new linear-layout check
+// COM: correctly accepts it.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 32, warpsPerCTA = [2, 2], repCluster = [1, 1], A = [16, 16], B = [16, 16], C = [16, 16]}>
+#dot = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: @block_load_dot_b_subgroup32_transpose
+  tt.func public @block_load_dot_b_subgroup32_transpose(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
+    // CHECK: triton_gen.2Dblockload {{.*}} transpose = true
+    %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] {column_major} : !tt.ptr<f16> -> tensor<32x32xf16, #dot>
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/invalid.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/invalid.mlir
@@ -143,6 +143,27 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 
 // -----
 
+// COM: Column-major B pointer load with fp8 + opsPerChan=2 + threadsPerWarp=32.
+// COM: This combination is intentionally rejected by validate2DBlockLoadTile for
+// COM: transpose handling; it must remain a plain tt.load.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 32, warpsPerCTA = [2, 2], repCluster = [1, 1], A = [16, 16], B = [16, 16], C = [16, 16]}>
+#dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @column_major_b_tpw32_fp8_rejected
+  tt.func @column_major_b_tpw32_fp8_rejected(%arg0: !tt.ptr<f8E4M3FN> {tt.divisibility = 16 : i32}) -> tensor<32x64xf8E4M3FN, #dot1> {
+    %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #dot1}>>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #dot1}>> -> tensor<1x64xi32, #dot1>
+    %2 = tt.splat %arg0 : !tt.ptr<f8E4M3FN> -> tensor<1x64x!tt.ptr<f8E4M3FN>, #dot1>
+    %3 = tt.addptr %2, %1 : tensor<1x64x!tt.ptr<f8E4M3FN>, #dot1>, tensor<1x64xi32, #dot1>
+    %4 = tt.broadcast %3 : tensor<1x64x!tt.ptr<f8E4M3FN>, #dot1> -> tensor<32x64x!tt.ptr<f8E4M3FN>, #dot1>
+    // CHECK: tt.load
+    %5 = tt.load %4 {ttig.block_io = "column_major"} : tensor<32x64x!tt.ptr<f8E4M3FN>, #dot1>
+    tt.return %5 : tensor<32x64xf8E4M3FN, #dot1>
+  }
+}
+
+// -----
+
 // COM: Regression test for issue #7022 (T5 training warmup failure).
 // COM: Inductor's hf_T5 / hf_T5_base softmax-backward kernel produces a
 // COM: column-major tensor-of-pointers load whose column stride is

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
@@ -90,7 +90,7 @@ DpasEncodingAttr getDpasLayout(RankedTensorType tensorTy);
 /// and the LLVM lowering (to produce the actual mapping).
 FailureOr<LinearLayout> computeTransposeShuffleMapping(
     RankedTensorType tensorType, const LinearLayout &regMapping,
-    int64_t numElemsPerLoad, unsigned numPackedVals, unsigned tileHeight,
+    int64_t numElemsPerLoad, const BlockIOTileSizeInfo &sizeInfo,
     unsigned threadsPerWarp, bool hasDPASOperandType, MLIRContext *ctx);
 
 /// Check whether the packed element size and tile width satisfy the

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -142,6 +142,11 @@ static bool isSPVBuiltinAvailableImpl(TritonGEN::Matrix2DBlockLoadOp op) {
       op.getTileWidth() == 4 && op.getVBlocks() == 1)
     return false;
 
+  // intel_sub_group_2d_block_read_32b_4r4x1c
+  if (op.getElemSizeInBits() == 32 && op.getTileHeight() == 4 &&
+      op.getTileWidth() == 4 && op.getVBlocks() == 1)
+    return false;
+
   // FIXME: The SPV block load only support subgroup size 16.
   int subGroupSize = triton::gpu::TritonGPUDialect::getThreadsPerWarp(
       op->getParentOfType<mlir::ModuleOp>());

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -942,11 +942,11 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
 
   static FailureOr<LinearLayout> computeTransposeShuffleMapping(
       RankedTensorType tensorType, const LinearLayout &regMapping,
-      int64_t numElemsPerLoad, unsigned numPackedVals, unsigned tileHeight,
+      int64_t numElemsPerLoad, const BlockIOTileSizeInfo &sizeInfo,
       unsigned threadsPerWarp, bool hasDPASOperandType, MLIRContext *ctx) {
     return triton::gpu::intel::computeTransposeShuffleMapping(
-        tensorType, regMapping, numElemsPerLoad, numPackedVals, tileHeight,
-        threadsPerWarp, hasDPASOperandType, ctx);
+        tensorType, regMapping, numElemsPerLoad, sizeInfo, threadsPerWarp,
+        hasDPASOperandType, ctx);
   }
 
   /// Build a Block2DLoadConfig from a validated BlockIOTileSizeInfo.
@@ -1021,8 +1021,8 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
         LinearLayout::identity1D(cfg.numElemsPerLoad, kRegister, kRegister);
     if (cfg.isTransposeRequired) {
       auto maybeShuffleMapping = computeTransposeShuffleMapping(
-          tensorType, cfg.regMapping, cfg.numElemsPerLoad, cfg.numPackedVals,
-          cfg.tileHeight, threadsPerWarp, !!cfg.packedDPASOperandType, ctx);
+          tensorType, cfg.regMapping, cfg.numElemsPerLoad, sizeInfo,
+          threadsPerWarp, !!cfg.packedDPASOperandType, ctx);
       assert(succeeded(maybeShuffleMapping) &&
              "validate2DBlockLoadTile should have rejected this configuration");
       cfg.shuffleMapping = *maybeShuffleMapping;

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -496,43 +496,14 @@ DpasEncodingAttr getDpasLayout(RankedTensorType tensorTy) {
 
 FailureOr<LinearLayout> computeTransposeShuffleMapping(
     RankedTensorType tensorType, const LinearLayout &regMapping,
-    int64_t numElemsPerLoad, unsigned numPackedVals, unsigned tileHeight,
+    int64_t numElemsPerLoad, const BlockIOTileSizeInfo &sizeInfo,
     unsigned threadsPerWarp, bool hasDPASOperandType, MLIRContext *ctx) {
   StringAttr kRegister = StringAttr::get(ctx, "register");
+  StringAttr kLane = StringAttr::get(ctx, "lane");
   LinearLayout shuffleMapping =
       LinearLayout::identity1D(numElemsPerLoad, kRegister, kRegister);
 
-  // Improve this. The current 2D block load only transposes the matrix at
-  // i32 granularity. We still need to perform an additional in-register
-  // transpose from i32 -> (N × ElemSizeInBits) tiles, using the tile width.
-  // At the moment, we can only achieve this using a bitcast operation,
-  // which implicitly uses the sub-group size as the transpose width. To
-  // optimize further, we should implement this with inline VISA
-  // instructions.
-
-  // tileHeight becomes width after transposing.
-  unsigned widthToTranspose = tileHeight;
   if (hasDPASOperandType) {
-    // For the DPAS related layout, we will do the shuffle at first in the
-    // unpacking of the elements at the DPAS operands granularity.
-    // And then we will do the transposing. So the transposing width is DPAS
-    // op shapes.
-    DpasEncodingAttr::OpIdx opIdx = getOpIdx(tensorType);
-    DpasEncodingAttr dpasLayout = getDpasLayout(tensorType);
-    switch (opIdx) {
-    case DpasEncodingAttr::OpIdx::OperandA: {
-      widthToTranspose = dpasLayout.getDPASInstShapeA()[1];
-      break;
-    }
-    case DpasEncodingAttr::OpIdx::OperandB: {
-      widthToTranspose = dpasLayout.getDPASInstShapeB()[1];
-      break;
-    }
-    case DpasEncodingAttr::OpIdx::OperandC: {
-      widthToTranspose = dpasLayout.getDPASInstShapeC()[1];
-      break;
-    }
-    }
     // For shuffle the transposed Dot operands matrix, we can shuffle the
     // loaded matrix in an reverse order.
     auto invertMapping = regMapping.invert();
@@ -555,8 +526,65 @@ FailureOr<LinearLayout> computeTransposeShuffleMapping(
       return failure();
   }
 
-  if (numPackedVals > 1 && (widthToTranspose) != threadsPerWarp)
-    return failure();
+  Attribute encoding = tensorType.getEncoding();
+  std::optional<LinearLayout> llEncoding =
+      cast<DistributedEncodingTrait>(encoding).toLinearLayout(
+          tensorType.getShape());
+  assert(llEncoding.has_value() && "expected valid linear layout");
+  if (sizeInfo.transpose) {
+    auto dims = llvm::to_vector(llEncoding->getOutDimNames());
+    SmallVector<StringAttr> loadDimName = {dims[sizeInfo.rowDim],
+                                           dims[sizeInfo.colDim]};
+    LinearLayout blockLoadLayoutWithInSubgroup =
+        llEncoding->sublayout({kRegister, kLane}, loadDimName);
+    LinearLayout expectedLoadUnpackLayout =
+        blockLoadLayoutWithInSubgroup
+            .resizeOutDim(dims[sizeInfo.rowDim],
+                          sizeInfo.tileWidth * sizeInfo.numElemPerPackedVal)
+            .resizeOutDim(dims[sizeInfo.colDim], sizeInfo.tileHeight)
+            .resizeInDim(kRegister, numElemsPerLoad);
+    // Compose the load return value layout of the transposed packed type.
+    std::vector<std::vector<int32_t>> regBases;
+    int32_t colBase = 1, rowBase = 1;
+    for (int32_t i = 1; i < sizeInfo.numElemPerPackedVal; i *= 2) {
+      regBases.push_back({rowBase, 0});
+      rowBase <<= 1;
+    }
+    std::vector<std::vector<int32_t>> laneBases;
+    for (int32_t i = 1; i < threadsPerWarp; i *= 2) {
+      if (i < sizeInfo.tileHeight) {
+        laneBases.push_back({0, colBase});
+        colBase <<= 1;
+      } else {
+        laneBases.push_back({rowBase, 0});
+        rowBase <<= 1;
+      }
+    }
+    for (int32_t i = 1; i < numElemsPerLoad / sizeInfo.numElemPerPackedVal;
+         i *= 2) {
+      if (i < mlir::ceil(sizeInfo.tileHeight, (int32_t)threadsPerWarp)) {
+        regBases.push_back({0, colBase});
+        colBase <<= 1;
+      } else {
+        regBases.push_back({rowBase, 0});
+        rowBase <<= 1;
+      }
+    }
+    LinearLayout transPackedLayout = LinearLayout(
+        {{kRegister, regBases}, {kLane, laneBases}}, ArrayRef(loadDimName));
+    if (transPackedLayout != expectedLoadUnpackLayout) {
+      // Improve this. The current 2D block load only transposes the matrix at
+      // i32 granularity. We still need to perform an additional in-register
+      // transpose from i32 -> (N × ElemSizeInBits) tiles, using the tile width.
+      // At the moment, we can only achieve this using a bitcast operation,
+      // which implicitly uses the sub-group size as the transpose width. To
+      // optimize further, we should implement this with inline VISA
+      // instructions.
+      // E.G: A case that to load fp8 B matrix with DPAS opsChan=2 layout under
+      // sub-group-size=32.
+      return failure();
+    }
+  }
 
   return shuffleMapping;
 }
@@ -618,8 +646,7 @@ bool validate2DBlockLoadTile(const LinearLayout &ll, unsigned memContiguousDim,
     }
 
     if (failed(computeTransposeShuffleMapping(
-            tensorType, regMapping, numElemsPerLoad,
-            sizeInfo.numElemPerPackedVal, sizeInfo.tileHeight, threadsPerWarp,
+            tensorType, regMapping, numElemsPerLoad, sizeInfo, threadsPerWarp,
             hasDPASOperandType, ctx)))
       return false;
   }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -532,6 +532,40 @@ FailureOr<LinearLayout> computeTransposeShuffleMapping(
           tensorType.getShape());
   assert(llEncoding.has_value() && "expected valid linear layout");
   if (sizeInfo.transpose) {
+    // As for the transpose case, the value from the 2D block IO load is in the
+    // packed i32 transposed order. We need to do extra transpose within
+    // register if the matrix is not fully transposed by DataPort when load
+    // back. (Extra shuffle and transpose happened in unpackBlockLoadResult.)
+    // Let's take the example for extra transpose of DPAS layout OpsChan=2 of
+    // fp8 type. (which is from case to do fp8 DPAS on BMG) The 2D block IO tile
+    // size is of height = 16, width = 4, numElemPerPackedVal = 4, transpose =
+    // True. The value in register will be filled by DataPort as the layout
+    // clang-format off
+    // which is only transposed at i32 granularity:
+    //              i32
+    // r0 (0),  (1),  (2),  (3)   | .....     x16
+    // r1 (64), (65), (66), (67)  | .....     x16
+    // r2 (128),(129),(130),(131) | .....     x16
+    // r3 (192),(193),(194),(195) | .....     x16
+    // The extra transpose to i16 granularity is required to make the value
+    // layout as:
+    //       i16           i16
+    // r0 (0),  (1),  | (4),  (5), | .....   x8  (2),  (3),  | (6),  (7), | .....   x8
+    // r1 (64), (65), | (68), (69),| .....   x8  (66), (67), | (70), (71),| .....   x8
+    // r2 (128),(129),|(132),(133),| .....   x8  (130),(131),|(134),(135),| .....   x8
+    // r3 (192),(193),|(196),(197),| .....   x8  (194),(195),|(198),(199),| .....   x8
+    // A transpose is required on each GRF like:
+    // r0: (0), (1), (2), (3), (4), (5), (6), (7), ... (32), (33), (34), (35), (36), (37), (38), (39), (40), ...
+    // r0: (0), (1), (4), (5), (8), (9), (12), (13), ... (2), (3), (6), (7), (10), (11), (14), (15), ...
+    // clang-format on
+    // It could be expressed by the ops `bitcast i32 -> 2xi16` when
+    // sub-group-size=16. But the semantic is not same when sub-group-size=32.
+    // We need an extra interface to express within register
+    // transposing/transforming to do this.
+
+    // Right now we only support naive case which the returned value layout is
+    // same to the expected layout. More information of PoC of inline VISA:
+    // https://github.com/intel/intel-xpu-backend-for-triton/issues/3572#issuecomment-3550809750
     auto dims = llvm::to_vector(llEncoding->getOutDimNames());
     SmallVector<StringAttr> loadDimName = {dims[sizeInfo.rowDim],
                                            dims[sizeInfo.colDim]};

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -572,6 +572,11 @@ FailureOr<LinearLayout> computeTransposeShuffleMapping(
     }
     LinearLayout transPackedLayout = LinearLayout(
         {{kRegister, regBases}, {kLane, laneBases}}, ArrayRef(loadDimName));
+    if (sizeInfo.rowDim > sizeInfo.colDim) {
+      // to align the output dims order to the input linear layout.
+      std::swap(loadDimName[0], loadDimName[1]);
+      transPackedLayout = transPackedLayout.transposeOuts(loadDimName);
+    }
     if (transPackedLayout != expectedLoadUnpackLayout) {
       // Improve this. The current 2D block load only transposes the matrix at
       // i32 granularity. We still need to perform an additional in-register

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -577,7 +577,15 @@ FailureOr<LinearLayout> computeTransposeShuffleMapping(
                           sizeInfo.tileWidth * sizeInfo.numElemPerPackedVal)
             .resizeOutDim(dims[sizeInfo.colDim], sizeInfo.tileHeight)
             .resizeInDim(kRegister, numElemsPerLoad);
-    // Compose the load return value layout of the transposed packed type.
+
+    // Construct the layout of a transposed 2D block load result:
+    // - Register bases (first group): pack sub-elements within a lane along row
+    // dim because it is transposed.
+    // - Lane bases: lanes < tileHeight map to the col dimension (original rows
+    // become
+    //   columns after transpose); remaining lanes map to the row dimension
+    // - Register bases (second group): cover rows/cols when numElemsPerLoad >
+    // numElemPerPackedVal
     std::vector<std::vector<int32_t>> regBases;
     int32_t colBase = 1, rowBase = 1;
     for (int32_t i = 1; i < sizeInfo.numElemPerPackedVal; i *= 2) {

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -602,6 +602,8 @@ FailureOr<LinearLayout> computeTransposeShuffleMapping(
         rowBase <<= 1;
       }
     }
+    assert(numElemsPerLoad % sizeInfo.numElemPerPackedVal == 0 &&
+           "numElemsPerLoad must be a multiple of numElemPerPackedVal");
     for (int32_t i = 1; i < numElemsPerLoad / sizeInfo.numElemPerPackedVal;
          i *= 2) {
       if (i < mlir::ceil(sizeInfo.tileHeight, (int32_t)threadsPerWarp)) {

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -580,7 +580,7 @@ FailureOr<LinearLayout> computeTransposeShuffleMapping(
       // which implicitly uses the sub-group size as the transpose width. To
       // optimize further, we should implement this with inline VISA
       // instructions.
-      // E.G: A case that to load fp8 B matrix with DPAS opsChan=2 layout under
+      // E.g. a case that loads fp8 B matrix with DPAS opsChan=2 layout under
       // sub-group-size=32.
       return failure();
     }

--- a/third_party/intel/unittest/Dialect/TritonIntelGPU/BlockIOUtilsTest.cpp
+++ b/third_party/intel/unittest/Dialect/TritonIntelGPU/BlockIOUtilsTest.cpp
@@ -1,10 +1,10 @@
-/// Tests for validate2DBlockLoadTile in BlockIOUtils.
-///
-/// PR #7487 changed computeTransposeShuffleMapping from a simple width
-/// comparison to a linear-layout comparison, enabling column-major B matrix
-/// loads with sub-group-size=32.  These tests verify:
-///   1. tpw=32, f16/opsPerChan=2, column-major B is now accepted.
-///   2. tpw=16, f16/opsPerChan=2, column-major B is still accepted (regression).
+// Tests for validate2DBlockLoadTile in BlockIOUtils.
+//
+// PR #7487 changed computeTransposeShuffleMapping from a simple width
+// comparison to a linear-layout comparison, enabling column-major B matrix
+// loads with sub-group-size=32.  These tests verify:
+//   1. tpw=32, f16/opsPerChan=2, column-major B is now accepted.
+//   2. tpw=16, f16/opsPerChan=2, column-major B is still accepted (regression).
 
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h"
 #include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"

--- a/third_party/intel/unittest/Dialect/TritonIntelGPU/BlockIOUtilsTest.cpp
+++ b/third_party/intel/unittest/Dialect/TritonIntelGPU/BlockIOUtilsTest.cpp
@@ -1,0 +1,76 @@
+/// Tests for validate2DBlockLoadTile in BlockIOUtils.
+///
+/// PR #7487 changed computeTransposeShuffleMapping from a simple width
+/// comparison to a linear-layout comparison, enabling column-major B matrix
+/// loads with sub-group-size=32.  These tests verify:
+///   1. tpw=32, f16/opsPerChan=2, column-major B is now accepted.
+///   2. tpw=16, f16/opsPerChan=2, column-major B is still accepted (regression).
+
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h"
+#include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/Support/Signals.h"
+#include <gtest/gtest.h>
+
+using namespace mlir;
+using namespace mlir::triton::gpu;
+using namespace mlir::triton::gpu::intel;
+
+namespace {
+
+class BlockIOUtilsTest : public ::testing::Test {
+public:
+  void SetUp() override {
+    ctx.getOrLoadDialect<TritonGPUDialect>();
+    ctx.getOrLoadDialect<TritonIntelGPUDialect>();
+  }
+
+  DpasEncodingAttr makeDpas(ArrayRef<unsigned> warpsPerCTA,
+                             unsigned threadsPerWarp, unsigned opsPerChan) {
+    return DpasEncodingAttr::get(&ctx, /*repeatCount=*/8, /*systolicDepth=*/8,
+                                 /*executionSize=*/16, opsPerChan, warpsPerCTA,
+                                 /*repCluster=*/{1, 1}, threadsPerWarp,
+                                 std::nullopt);
+  }
+
+protected:
+  MLIRContext ctx;
+};
+
+// Test that validate2DBlockLoadTile accepts a column-major B matrix load with
+// sub-group-size=32 and f16/opsPerChan=2.
+//
+// Old code: computeTransposeShuffleMapping failed because
+//   numPackedVals(=2) > 1 && dpasInstShapeB()[1](=16) != threadsPerWarp(=32)
+// New code: linear-layout comparison succeeds for this configuration.
+TEST_F(BlockIOUtilsTest, ColumnMajorB_Tpw32_F16_Accepted) {
+  auto dpas = makeDpas(/*warpsPerCTA=*/{2, 2}, /*threadsPerWarp=*/32,
+                       /*opsPerChan=*/2);
+  auto dot = DotOperandEncodingAttr::get(&ctx, /*opIdx=*/1, dpas, /*kWidth=*/2);
+  auto f16 = Float16Type::get(&ctx);
+  SmallVector<int64_t> shape = {32, 64}; // K=32, N=64
+  auto tensorType = RankedTensorType::get(shape, f16, dot);
+  LinearLayout ll = cast<DistributedEncodingTrait>(dot).toLinearLayout(shape);
+  // column_major: memContiguousDim = rank-2 = 0 (K direction)
+  EXPECT_TRUE(validate2DBlockLoadTile(ll, /*memContiguousDim=*/0,
+                                      /*elemSizeInBits=*/16, tensorType));
+}
+
+// Regression test: validate2DBlockLoadTile must still accept a column-major B
+// matrix load with sub-group-size=16 and f16/opsPerChan=2 after PR #7487.
+TEST_F(BlockIOUtilsTest, ColumnMajorB_Tpw16_F16_Accepted) {
+  auto dpas = makeDpas(/*warpsPerCTA=*/{4, 2}, /*threadsPerWarp=*/16,
+                       /*opsPerChan=*/2);
+  auto dot = DotOperandEncodingAttr::get(&ctx, /*opIdx=*/1, dpas, /*kWidth=*/2);
+  auto f16 = Float16Type::get(&ctx);
+  SmallVector<int64_t> shape = {32, 64}; // K=32, N=64
+  auto tensorType = RankedTensorType::get(shape, f16, dot);
+  LinearLayout ll = cast<DistributedEncodingTrait>(dot).toLinearLayout(shape);
+  // column_major: memContiguousDim = rank-2 = 0 (K direction)
+  EXPECT_TRUE(validate2DBlockLoadTile(ll, /*memContiguousDim=*/0,
+                                      /*elemSizeInBits=*/16, tensorType));
+}
+
+} // namespace

--- a/third_party/intel/unittest/Dialect/TritonIntelGPU/BlockIOUtilsTest.cpp
+++ b/third_party/intel/unittest/Dialect/TritonIntelGPU/BlockIOUtilsTest.cpp
@@ -28,7 +28,7 @@ public:
   }
 
   DpasEncodingAttr makeDpas(ArrayRef<unsigned> warpsPerCTA,
-                             unsigned threadsPerWarp, unsigned opsPerChan) {
+                            unsigned threadsPerWarp, unsigned opsPerChan) {
     return DpasEncodingAttr::get(&ctx, /*repeatCount=*/8, /*systolicDepth=*/8,
                                  /*executionSize=*/16, opsPerChan, warpsPerCTA,
                                  /*repCluster=*/{1, 1}, threadsPerWarp,
@@ -52,7 +52,7 @@ TEST_F(BlockIOUtilsTest, ColumnMajorB_Tpw32_F16_Accepted) {
   auto f16 = Float16Type::get(&ctx);
   SmallVector<int64_t> shape = {32, 64}; // K=32, N=64
   auto tensorType = RankedTensorType::get(shape, f16, dot);
-  LinearLayout ll = cast<DistributedEncodingTrait>(dot).toLinearLayout(shape);
+  auto ll = cast<DistributedEncodingTrait>(dot).toLinearLayout(shape);
   // column_major: memContiguousDim = rank-2 = 0 (K direction)
   EXPECT_TRUE(validate2DBlockLoadTile(ll, /*memContiguousDim=*/0,
                                       /*elemSizeInBits=*/16, tensorType));
@@ -67,7 +67,7 @@ TEST_F(BlockIOUtilsTest, ColumnMajorB_Tpw16_F16_Accepted) {
   auto f16 = Float16Type::get(&ctx);
   SmallVector<int64_t> shape = {32, 64}; // K=32, N=64
   auto tensorType = RankedTensorType::get(shape, f16, dot);
-  LinearLayout ll = cast<DistributedEncodingTrait>(dot).toLinearLayout(shape);
+  auto ll = cast<DistributedEncodingTrait>(dot).toLinearLayout(shape);
   // column_major: memContiguousDim = rank-2 = 0 (K direction)
   EXPECT_TRUE(validate2DBlockLoadTile(ll, /*memContiguousDim=*/0,
                                       /*elemSizeInBits=*/16, tensorType));

--- a/third_party/intel/unittest/Dialect/TritonIntelGPU/CMakeLists.txt
+++ b/third_party/intel/unittest/Dialect/TritonIntelGPU/CMakeLists.txt
@@ -18,3 +18,14 @@ add_triton_ut(
 		TritonIntelGPUTransforms
 		TritonNvidiaGPUTransforms
 )
+add_triton_ut(
+  NAME BlockIOUtils
+  SRCS BlockIOUtilsTest.cpp
+  LIBS
+    TritonIntelGPUIR
+    TritonGPUIR
+    TritonGPUTransforms
+    TritonIntelAnalysis
+    TritonIntelGPUTransforms
+    TritonNvidiaGPUTransforms
+)


### PR DESCRIPTION
This PR updates the Intel XPU 2D block-load transpose handling to better support transpose loads (notably for sub-group-size=32) by refining how the transpose shuffle mapping is validated/computed and by threading the full BlockIOTileSizeInfo into the shuffle-mapping API.