### PR TITLE
[XPU] Add barrier for global buffer read back with a different layout

### DIFF
--- a/test/TritonIntelGPU/insert-global-barrier.mlir
+++ b/test/TritonIntelGPU/insert-global-barrier.mlir
@@ -1,0 +1,107 @@
+// RUN: triton-opt %s -split-input-file -tritonintelgpu-insert-global-barrier | FileCheck %s
+
+// A global store followed by a load from the same kernel argument at a
+// different layout is a cross-thread read-after-write: a barrier must be
+// inserted before the load.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 2], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @global_exchange
+  tt.func public @global_exchange(%arg0: !tt.ptr<f16>) {
+    %cst = arith.constant dense<0.0> : tensor<2x256xf16, #blocked1>
+    %mask = arith.constant dense<true> : tensor<2x256xi1, #blocked1>
+    %maskld = arith.constant dense<true> : tensor<2x256xi1, #blocked>
+    %other = arith.constant dense<0.0> : tensor<2x256xf16, #blocked>
+    %off = arith.constant dense<0> : tensor<2x256xi32, #blocked1>
+    %off2 = arith.constant dense<0> : tensor<2x256xi32, #blocked>
+    %sp = tt.splat %arg0 : !tt.ptr<f16> -> tensor<2x256x!tt.ptr<f16>, #blocked1>
+    %pst = tt.addptr %sp, %off : tensor<2x256x!tt.ptr<f16>, #blocked1>, tensor<2x256xi32, #blocked1>
+    // CHECK: tt.store
+    tt.store %pst, %cst, %mask : tensor<2x256x!tt.ptr<f16>, #blocked1>
+    %sp2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<2x256x!tt.ptr<f16>, #blocked>
+    %pld = tt.addptr %sp2, %off2 : tensor<2x256x!tt.ptr<f16>, #blocked>, tensor<2x256xi32, #blocked>
+    // CHECK: ttg.barrier all
+    // CHECK-NEXT: tt.load
+    %v = tt.load %pld, %maskld, %other : tensor<2x256x!tt.ptr<f16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Same layout on both sides: each thread reads back what it wrote, no
+// cross-thread exchange, so no barrier is inserted.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @same_layout_roundtrip
+  // CHECK-NOT: ttg.barrier
+  tt.func public @same_layout_roundtrip(%arg0: !tt.ptr<f16>) {
+    %cst = arith.constant dense<0.0> : tensor<2x256xf16, #blocked>
+    %mask = arith.constant dense<true> : tensor<2x256xi1, #blocked>
+    %other = arith.constant dense<0.0> : tensor<2x256xf16, #blocked>
+    %off = arith.constant dense<0> : tensor<2x256xi32, #blocked>
+    %sp = tt.splat %arg0 : !tt.ptr<f16> -> tensor<2x256x!tt.ptr<f16>, #blocked>
+    %p = tt.addptr %sp, %off : tensor<2x256x!tt.ptr<f16>, #blocked>, tensor<2x256xi32, #blocked>
+    tt.store %p, %cst, %mask : tensor<2x256x!tt.ptr<f16>, #blocked>
+    %v = tt.load %p, %mask, %other : tensor<2x256x!tt.ptr<f16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// A load with no prior store to the same argument (reading an input) must not
+// be fenced.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 2], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @load_before_store
+  // CHECK-NOT: ttg.barrier
+  tt.func public @load_before_store(%arg0: !tt.ptr<f16>) {
+    %cst = arith.constant dense<0.0> : tensor<2x256xf16, #blocked1>
+    %mask = arith.constant dense<true> : tensor<2x256xi1, #blocked1>
+    %maskld = arith.constant dense<true> : tensor<2x256xi1, #blocked>
+    %other = arith.constant dense<0.0> : tensor<2x256xf16, #blocked>
+    %off = arith.constant dense<0> : tensor<2x256xi32, #blocked1>
+    %off2 = arith.constant dense<0> : tensor<2x256xi32, #blocked>
+    %sp2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<2x256x!tt.ptr<f16>, #blocked>
+    %pld = tt.addptr %sp2, %off2 : tensor<2x256x!tt.ptr<f16>, #blocked>, tensor<2x256xi32, #blocked>
+    %v = tt.load %pld, %maskld, %other : tensor<2x256x!tt.ptr<f16>, #blocked>
+    %sp = tt.splat %arg0 : !tt.ptr<f16> -> tensor<2x256x!tt.ptr<f16>, #blocked1>
+    %pst = tt.addptr %sp, %off : tensor<2x256x!tt.ptr<f16>, #blocked1>, tensor<2x256xi32, #blocked1>
+    tt.store %pst, %cst, %mask : tensor<2x256x!tt.ptr<f16>, #blocked1>
+    tt.return
+  }
+}
+
+// -----
+
+// A store/load pair nested in an scf.if region must NOT be fenced: a
+// work-group barrier under divergent control flow is undefined behavior.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 2], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @exchange_in_divergent_region
+  // CHECK-NOT: ttg.barrier
+  tt.func public @exchange_in_divergent_region(%arg0: !tt.ptr<f16>, %cond: i1) {
+    %cst = arith.constant dense<0.0> : tensor<2x256xf16, #blocked1>
+    %mask = arith.constant dense<true> : tensor<2x256xi1, #blocked1>
+    %maskld = arith.constant dense<true> : tensor<2x256xi1, #blocked>
+    %other = arith.constant dense<0.0> : tensor<2x256xf16, #blocked>
+    %off = arith.constant dense<0> : tensor<2x256xi32, #blocked1>
+    %off2 = arith.constant dense<0> : tensor<2x256xi32, #blocked>
+    scf.if %cond {
+      %sp = tt.splat %arg0 : !tt.ptr<f16> -> tensor<2x256x!tt.ptr<f16>, #blocked1>
+      %pst = tt.addptr %sp, %off : tensor<2x256x!tt.ptr<f16>, #blocked1>, tensor<2x256xi32, #blocked1>
+      tt.store %pst, %cst, %mask : tensor<2x256x!tt.ptr<f16>, #blocked1>
+      %sp2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<2x256x!tt.ptr<f16>, #blocked>
+      %pld = tt.addptr %sp2, %off2 : tensor<2x256x!tt.ptr<f16>, #blocked>, tensor<2x256xi32, #blocked>
+      %v = tt.load %pld, %maskld, %other : tensor<2x256x!tt.ptr<f16>, #blocked>
+    }
+    tt.return
+  }
+}

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -409,6 +409,9 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         passes.common.add_symbol_dce(pm)
         passes.common.add_sccp(pm)
         passes.common.add_canonicalizer(pm)
+        # Add a barrier when a global store is read back with a different
+        # layout. Runs after reordering so the op order is final by now.
+        intel.passes.ttgpuir.add_insert_global_barrier(pm)
         if knobs.intel.opt_reduction_locality:
             intel.passes.ttgpuir.add_optimize_reduction_locality(pm)
         intel.passes.arith.add_arith_emulate_unsupported_floats(pm, ["bf16"], "f32")

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -467,4 +467,23 @@ def TritonIntelGPULoopDistribute
   ];
 }
 
+def TritonIntelGPUInsertGlobalBarrier
+    : Pass<"tritonintelgpu-insert-global-barrier", "mlir::ModuleOp"> {
+  let summary = "Insert a barrier around cross-thread global memory exchanges";
+
+  let description = [{
+    Sometimes a kernel writes a global buffer and then reads it back with a
+    different layout, so one thread reads what another thread wrote. Membar
+    only checks shared memory and misses this. When a load reads a kernel
+    argument that an earlier store in the same block wrote with a different
+    layout, put a `ttg.barrier` before the load. Loads with the same layout,
+    or with no earlier store, are left alone.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::TritonDialect",
+    "mlir::triton::gpu::TritonGPUDialect"
+  ];
+}
+
 #endif // TRITON_INTEL_GPU_PASSES

--- a/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_triton_library(TritonIntelGPUTransforms
   LoopDistribute.cpp
   FoldFpToFp.cpp
   HoistLayoutConversions.cpp
+  InsertGlobalBarrier.cpp
   LowerTo2DBlockLoad.cpp
   MaterializeBlockPointer.cpp
   OptimizeDotOperands.cpp

--- a/third_party/intel/lib/TritonIntelGPUTransforms/InsertGlobalBarrier.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/InsertGlobalBarrier.cpp
@@ -1,0 +1,80 @@
+//===- InsertGlobalBarrier.cpp - Barrier cross-thread global exchange -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Sometimes a kernel writes a global buffer and then reads it back with a
+// different layout. When that happens one thread can read a value another
+// thread wrote. Membar only checks shared memory, so it does not catch this.
+// This pass puts a barrier before that read.
+//
+//===----------------------------------------------------------------------===//
+
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+using namespace mlir;
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+
+namespace mlir::triton::gpu::intel {
+#define GEN_PASS_DEF_TRITONINTELGPUINSERTGLOBALBARRIER
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
+} // namespace mlir::triton::gpu::intel
+
+namespace {
+
+// Follow a load/store pointer back through splat and addptr to find which
+// kernel argument it points into. Returns null if it is not one.
+BlockArgument getKernelArgBase(Value ptr) {
+  while (Operation *def = ptr.getDefiningOp()) {
+    if (auto addPtr = dyn_cast<tt::AddPtrOp>(def))
+      ptr = addPtr.getPtr();
+    else if (auto splat = dyn_cast<tt::SplatOp>(def))
+      ptr = splat.getSrc();
+    else
+      return nullptr;
+  }
+  return dyn_cast<BlockArgument>(ptr);
+}
+
+struct TritonIntelGPUInsertGlobalBarrierPass
+    : public triton::gpu::intel::impl::TritonIntelGPUInsertGlobalBarrierBase<
+          TritonIntelGPUInsertGlobalBarrierPass> {
+  void runOnOperation() override {
+    // Only look at the function's top block. If we put a barrier inside an
+    // scf.if or scf.for, some threads may skip it and the kernel hangs. As we
+    // go, keep the layout of the last store to each kernel argument.
+    getOperation().walk([](Block *block) {
+      if (!isa<tt::FuncOp>(block->getParentOp()))
+        return;
+      llvm::DenseMap<Value, Attribute> storedEnc;
+      for (Operation &op : *block) {
+        if (auto store = dyn_cast<tt::StoreOp>(&op)) {
+          auto ty = dyn_cast<RankedTensorType>(store.getValue().getType());
+          if (BlockArgument base =
+                  ty ? getKernelArgBase(store.getPtr()) : nullptr)
+            storedEnc[base] = ty.getEncoding();
+        } else if (auto load = dyn_cast<tt::LoadOp>(&op)) {
+          auto ty = dyn_cast<RankedTensorType>(load.getType());
+          BlockArgument base = ty ? getKernelArgBase(load.getPtr()) : nullptr;
+          auto it = base ? storedEnc.find(base) : storedEnc.end();
+          // Same layout: each thread reads back its own data, so it is safe.
+          // Different layout: a thread reads another thread's data, so we
+          // need a barrier first.
+          if (it != storedEnc.end() && it->second != ty.getEncoding()) {
+            OpBuilder builder(&op);
+            ttg::BarrierOp::create(builder, op.getLoc(), ttg::AddrSpace::All);
+            storedEnc.erase(it);
+          }
+        }
+      }
+    });
+  }
+};
+
+} // namespace

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -152,6 +152,8 @@ void init_triton_intel_passes_ttgpuir(py::module_ &&m) {
 
   ADD_PASS_WRAPPER_0("add_reduce_data_duplication",
                      gpu::intel::createTritonIntelGPUReduceDataDuplication);
+  ADD_PASS_WRAPPER_0("add_insert_global_barrier",
+                     gpu::intel::createTritonIntelGPUInsertGlobalBarrier);
   ADD_PASS_OPTION_WRAPPER_1(
       "add_canonicalize_pointers",
       gpu::intel::createTritonIntelGPUCanonicalizePointers, bool);


### PR DESCRIPTION
Some kernels write a global buffer and then read it back with a different layout. When that happens, one thread can read a value another thread wrote. There is no barrier between the write and the read, so the read can run before the write finishes and the result is wrong. IGC provided an example of the corrected generated kernel.

Close #7043 