### PR TITLE
[LoadStore][DPAS] Fix crash on broadcast layouts

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM/DPAS.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM/DPAS.cpp
@@ -96,15 +96,15 @@ public:
     std::tie(dTy, cTy, aTy, bTy) = getDPASOperandsType<DPASEngineType>(
         dpasType, op.getContext(), dpasEncoding);
     ValueTable ha = getValuesFromDotOperandLayoutStruct(
-        loadedA, repBatch, repM, repK,
+        loadedA, ATensorTy, repBatch, repM, repK,
         typeConverter->convertType(ATensorTy.getElementType()),
         DpasEncodingAttr::OpIdx::OperandA);
     ValueTable hb = getValuesFromDotOperandLayoutStruct(
-        loadedB, repBatch, repN, repK,
+        loadedB, BTensorTy, repBatch, repN, repK,
         typeConverter->convertType(BTensorTy.getElementType()),
         DpasEncodingAttr::OpIdx::OperandB);
     ValueTable fc = getValuesFromDotOperandLayoutStruct(
-        loadedC, repBatch, repM, repN,
+        loadedC, CTensorTy, repBatch, repM, repN,
         typeConverter->convertType(CTensorTy.getElementType()),
         DpasEncodingAttr::OpIdx::OperandC);
 
@@ -228,8 +228,8 @@ public:
           innerLoop(b, k, outer, repNumM, repNumN, repInner, reverseLoop);
         }
 
-    Value res = composeValuesToDotOperandLayoutStruct(fc, repBatch, repM, repN,
-                                                      resElemTy);
+    Value res = composeValuesToDotOperandLayoutStruct(fc, DTensorTy, repBatch,
+                                                      repM, repN, resElemTy);
 
     rewriter.replaceOp(op, res);
 
@@ -406,6 +406,7 @@ private:
   }
 
   Value composeValuesToDotOperandLayoutStruct(const ValueTable &vals,
+                                              RankedTensorType tensorTy,
                                               int64_t dimBatch, int64_t dimRow,
                                               int64_t dimCol,
                                               Type elemTy) const {
@@ -435,16 +436,16 @@ private:
     assert(!elems.empty() &&
            "unexpected empty result in composing the DPAS result.");
 
-    Type structTy = LLVM::LLVMStructType::getLiteral(
-        ctx, SmallVector<Type>(elems.size(), elemTy));
-    return packLLElements(loc, typeConverter, elems, rewriter, structTy);
+    SmallVector<Value> resultVals(elems.begin(), elems.end());
+    return packTensorElements(loc, typeConverter, resultVals, rewriter,
+                              tensorTy);
   }
 
-  ValueTable
-  getValuesFromDotOperandLayoutStruct(Value val, int64_t batch, int64_t outer,
-                                      int64_t inner, Type elemTy,
-                                      DpasEncodingAttr::OpIdx opIdx) const {
-    SmallVector<Value> elems = unpackLLElements(loc, val, rewriter);
+  ValueTable getValuesFromDotOperandLayoutStruct(
+      Value val, RankedTensorType tensorTy, int64_t batch, int64_t outer,
+      int64_t inner, Type elemTy, DpasEncodingAttr::OpIdx opIdx) const {
+    SmallVector<Value> elems =
+        unpackTensorElements(loc, val, rewriter, tensorTy);
     ArrayRef<unsigned> repCluster = dpasLayout.getRepCluster();
     size_t rank = repCluster.size();
     unsigned repClusterOuter = 0u;

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2798,7 +2798,7 @@ struct DescriptorStoreOpToBlockIOConversion
 
     // --- Get the LLVM values for store values ---
     SmallVector<Value> valElems =
-        unpackLLElements(loc, adaptor.getSrc(), rewriter);
+        unpackTensorElements(loc, adaptor.getSrc(), rewriter, tensorType);
     assert(valElems.size() == numElems &&
            "the number of store values does not match the number of elements");
 
@@ -3015,7 +3015,8 @@ struct StoreOpToBlockIOConversion
     unsigned numElems = getTotalElemsPerThread(tensorType);
 
     // Get the LLVM values for pointers
-    SmallVector<Value> ptrElems = unpackLLElements(loc, llPtr, rewriter);
+    SmallVector<Value> ptrElems =
+        unpackTensorElements(loc, llPtr, rewriter, op.getPtr().getType());
     assert(ptrElems.size() == numElems &&
            "the number of pointer values is not matched with the number of "
            "elements");
@@ -3024,7 +3025,8 @@ struct StoreOpToBlockIOConversion
     Value llMask = adaptor.getMask();
     // Get the LLVM values for mask
     if (llMask) {
-      maskElems = unpackLLElements(loc, llMask, rewriter);
+      maskElems =
+          unpackTensorElements(loc, llMask, rewriter, op.getMask().getType());
       assert(maskElems.size() == numElems &&
              "the number of mask values is not matched with the number of "
              "elements");
@@ -3072,8 +3074,8 @@ struct StoreOpToBlockIOConversion
     Value offsetBaseY = b.i32_val(0);
 
     // Get the LLVM values for store values
-    SmallVector<Value> valElems =
-        unpackLLElements(loc, adaptor.getValue(), rewriter);
+    SmallVector<Value> valElems = unpackTensorElements(
+        loc, adaptor.getValue(), rewriter, op.getValue().getType());
     assert(valElems.size() == numElems &&
            "the number of store values does not match the number of elements");
 
@@ -4238,14 +4240,15 @@ struct Subgroup2DBlockLoadFromPtrOpConversion
         tensorType, eltTy, sizeInfo, *llEncoding, threadsPerWarp, ctx);
 
     // Unpack pointer elements.
-    SmallVector<Value> ptrElems =
-        unpackLLElements(loc, adaptor.getPtr(), rewriter);
+    SmallVector<Value> ptrElems = unpackTensorElements(
+        loc, adaptor.getPtr(), rewriter, op.getPtr().getType());
 
     // Unpack mask/other elements.
     SmallVector<Value> maskElems;
     Value llMask = adaptor.getMask();
     if (llMask)
-      maskElems = unpackLLElements(loc, llMask, rewriter);
+      maskElems =
+          unpackTensorElements(loc, llMask, rewriter, op.getMask().getType());
 
     SmallVector<Value> otherElems;
     Value llOther = adaptor.getOther();
@@ -4269,7 +4272,8 @@ struct Subgroup2DBlockLoadFromPtrOpConversion
               handleSplatValue(constAttr.getSplatValue<APInt>());
             });
       } else {
-        otherElems = unpackLLElements(loc, llOther, rewriter);
+        otherElems = unpackTensorElements(loc, llOther, rewriter,
+                                          op.getOther().getType());
       }
     }
 


### PR DESCRIPTION
Loads and dot ops with a broadcast layout unpack fewer values than the register indices and DPAS tiles expect, which crashed the compiler. Pad the values back to the full count and drop the extras when repacking.

Closes #7492
