### PR TITLE
Revert "Fix overflow in `CanonicalizePointers` pass (#7447)"

### DIFF
--- a/test/TritonIntelGPU/canonicalize-pointers.mlir
+++ b/test/TritonIntelGPU/canonicalize-pointers.mlir
@@ -33,7 +33,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
         -> (tensor<1024x!tt.ptr<f32>>, tensor<1024x!tt.ptr<f32>>) : i32 {
       // COM: Inside loop: materialize via splat(scalar_base) + lane_range.
       // CHECK: tt.splat %[[ITER_A]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-      // CHECK: tt.addptr {{.*}} : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+      // CHECK: tt.addptr {{.*}} : tensor<1024x!tt.ptr<f32>>, tensor<1024x{{i.*}}>
       %ld_a = tt.load %arg_a : tensor<1024x!tt.ptr<f32>>
       %ld_b = tt.load %arg_b : tensor<1024x!tt.ptr<f32>>
       %sum = arith.addf %ld_a, %ld_b : tensor<1024xf32>
@@ -108,104 +108,6 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK-NOT: tt.descriptor_load
     // CHECK: tt.return
     %val = tt.descriptor_load %desc[%c0_i32] : !tt.tensordesc<1024xf32> -> tensor<1024xf32>
-    tt.return
-  }
-}
-
-// -----
-
-// COM: Test 4 - Regression test for #7435: an i64-typed offset intermediate
-// COM: (e.g. as emitted by PyTorch Inductor to avoid i32 overflow, hence
-// COM: "int64_index_intermediate") must not be narrowed to i32 by the pass.
-
-module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  // CHECK-LABEL: tt.func public @int64_index_intermediate(
-  tt.func public @int64_index_intermediate(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %big_stride: i64) {
-    %pid = tt.get_program_id x : i32
-    %pid_i64 = arith.extsi %pid : i32 to i64
-    // COM: Intermediate computed at i64 specifically to avoid i32 overflow.
-    %offset_i64 = arith.muli %pid_i64, %big_stride : i64
-    %lane_range = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
-    %lane_range_i64 = arith.extsi %lane_range : tensor<1024xi32> to tensor<1024xi64>
-    %offset_splat = tt.splat %offset_i64 : i64 -> tensor<1024xi64>
-    %total_offset = arith.addi %offset_splat, %lane_range_i64 : tensor<1024xi64>
-    %base = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %ptr = tt.addptr %base, %total_offset : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-    // COM: The offset tensor feeding the load/store must stay i64: narrowing
-    // COM: it to i32 here would silently truncate the overflow-avoiding
-    // COM: intermediate and produce a wrong address.
-    // CHECK: tt.addptr {{.*}} : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-    %val = tt.load %ptr : tensor<1024x!tt.ptr<f32>>
-    %out_base = tt.splat %arg1 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %out_ptr = tt.addptr %out_base, %total_offset : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-    // CHECK: tt.addptr {{.*}} : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-    tt.store %out_ptr, %val : tensor<1024x!tt.ptr<f32>>
-    tt.return
-  }
-}
-
-// -----
-
-// COM: Test 5 - Regression test for #7435 (part 2): decomposing a `(x + C) *
-// COM: K` multiply into uniform/non-uniform parts must not distribute into a
-// COM: bare `x * K` cross term computed at the ORIGINAL i32 width. Here `x`
-// COM: (a runtime tensor argument, standing in for a divui/remui-derived
-// COM: index as PyTorch Inductor emits for its cat/split fusions) ranges up
-// COM: to 63, and `x * 67108864` alone overflows i32 (63 * 67108864 >
-// COM: INT32_MAX) even though the original `(x + (-8)) * 67108864` does not
-// COM: for the intended (masked) range of `x`. The cross terms must be
-// COM: computed at i64 to avoid reintroducing this overflow.
-
-module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  // CHECK-LABEL: tt.func public @mul_distribute_no_overflow(
-  tt.func public @mul_distribute_no_overflow(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %x: tensor<64xi32>) {
-    %c-8_i32 = arith.constant dense<-8> : tensor<64xi32>
-    %c67108864_i32 = arith.constant dense<67108864> : tensor<64xi32>
-    %shifted = arith.addi %x, %c-8_i32 : tensor<64xi32>
-    %offset = arith.muli %shifted, %c67108864_i32 : tensor<64xi32>
-    %base = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>>
-    %ptr = tt.addptr %base, %offset : tensor<64x!tt.ptr<f32>>, tensor<64xi32>
-    // COM: The non-uniform cross term (x * 67108864) must be computed at
-    // COM: i64, not the original i32 -- otherwise it silently overflows for
-    // COM: x >= 32 and produces a wrong address.
-    // CHECK: arith.muli {{.*}} : tensor<64xi64>
-    // CHECK: tt.addptr {{.*}} : tensor<64x!tt.ptr<f32>>, tensor<64xi64>
-    %val = tt.load %ptr : tensor<64x!tt.ptr<f32>>
-    %out_base = tt.splat %arg1 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>>
-    tt.store %out_base, %val : tensor<64x!tt.ptr<f32>>
-    tt.return
-  }
-}
-
-// -----
-
-// COM: Test 6 - Regression test for #7435 (part 3): when the non-uniform
-// COM: part of a `tt.broadcast`'s source has been widened to i64 (e.g. by
-// COM: the Test 5 fix inside createDecomposeOffsetFromMul), the rebuilt
-// COM: tt.broadcast must widen its own result type to match -- reusing the
-// COM: original (narrower) broadcast type verbatim would produce a
-// COM: `tt.broadcast` whose operand and result element types disagree,
-// COM: which the verifier rejects (`'tt.broadcast' op requires the same
-// COM: element type for all operands and results`).
-
-module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  // CHECK-LABEL: tt.func public @broadcast_after_mul_widen(
-  tt.func public @broadcast_after_mul_widen(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %x: tensor<8x1xi32>) {
-    %c-8_i32 = arith.constant dense<-8> : tensor<8x1xi32>
-    %c67108864_i32 = arith.constant dense<67108864> : tensor<8x1xi32>
-    %shifted = arith.addi %x, %c-8_i32 : tensor<8x1xi32>
-    // COM: The multiply's non-uniform cross term is widened to i64 (Test 5),
-    // COM: so the tt.broadcast consuming it must also widen to i64 -- not
-    // COM: stay at the original i32 broadcast type.
-    %mul = arith.muli %shifted, %c67108864_i32 : tensor<8x1xi32>
-    %offset = tt.broadcast %mul : tensor<8x1xi32> -> tensor<8x64xi32>
-    %base = tt.splat %arg0 : !tt.ptr<f32> -> tensor<8x64x!tt.ptr<f32>>
-    %ptr = tt.addptr %base, %offset : tensor<8x64x!tt.ptr<f32>>, tensor<8x64xi32>
-    // CHECK: tt.broadcast {{.*}} : tensor<8x1xi64> -> tensor<8x64xi64>
-    // CHECK: tt.addptr {{.*}} : tensor<8x64x!tt.ptr<f32>>, tensor<8x64xi64>
-    %val = tt.load %ptr : tensor<8x64x!tt.ptr<f32>>
-    %out_base = tt.splat %arg1 : !tt.ptr<f32> -> tensor<8x64x!tt.ptr<f32>>
-    tt.store %out_base, %val : tensor<8x64x!tt.ptr<f32>>
     tt.return
   }
 }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/CanonicalizePointers.cpp
@@ -354,21 +354,6 @@ createDecomposeOffsetFromMul(RewriterBase &rewriter, Location loc, Value expr,
       rewriter, loc, mulOp.getLhs(), bitness, scalarToSplatMap);
   auto [uniformOffsetR, nonUniformOffsetR] = createDecomposeOffsetFromExpr(
       rewriter, loc, mulOp.getRhs(), bitness, scalarToSplatMap);
-
-  // Distributing (U(A)+NU(A))*(U(B)+NU(B)) introduces cross terms (e.g.
-  // NU(A)*U(B)) whose magnitude can exceed anything the original,
-  // un-expanded multiplication produced for valid lanes: e.g. Inductor
-  // emits `(x1 + C) * K` where the shift C keeps the effective multiplicand
-  // small, but distributing yields a bare `x1 * K` term that overflows the
-  // original bitness even though `(x1 + C) * K` never did. Compute the
-  // cross terms at i64 so this redistribution cannot reintroduce overflow
-  // the original expression's shape had already avoided.
-  Type i64Ty = rewriter.getI64Type();
-  uniformOffsetL = createCastOffset(rewriter, loc, uniformOffsetL, i64Ty);
-  uniformOffsetR = createCastOffset(rewriter, loc, uniformOffsetR, i64Ty);
-  nonUniformOffsetL = createCastOffset(rewriter, loc, nonUniformOffsetL, i64Ty);
-  nonUniformOffsetR = createCastOffset(rewriter, loc, nonUniformOffsetR, i64Ty);
-
   Value uniformMul =
       arith::MulIOp::create(rewriter, loc, uniformOffsetL, uniformOffsetR);
 
@@ -417,16 +402,8 @@ createDecomposeOffsetFromExpr(RewriterBase &rewriter, Location loc, Value expr,
           .Case<tt::BroadcastOp>([&](auto broadcastOp) {
             auto [uniform, nonUniform] = createDecomposeOffsetFromExpr(
                 rewriter, loc, broadcastOp.getSrc(), bitness, scalarToSplatMap);
-            // nonUniform's element type may have been widened (e.g. by
-            // createDecomposeOffsetFromMul) beyond broadcastOp's original
-            // element type, so re-derive the result type instead of reusing
-            // broadcastOp.getType() verbatim.
-            auto origType = cast<RankedTensorType>(broadcastOp.getType());
-            auto newType = RankedTensorType::get(
-                origType.getShape(), getElementTypeOrSelf(nonUniform),
-                origType.getEncoding());
-            auto broadcastNonUniform =
-                tt::BroadcastOp::create(rewriter, loc, newType, nonUniform);
+            auto broadcastNonUniform = tt::BroadcastOp::create(
+                rewriter, loc, broadcastOp.getType(), nonUniform);
             return std::make_pair(uniform, broadcastNonUniform);
           })
           .Case<tt::ExpandDimsOp>([&](auto expandOp) {


### PR DESCRIPTION
This reverts commit bb3e6e8e09a20c74802321ebc755eec334fe60c4.