### PR TITLE
Clean up stale skiplist entries in a770, arl-h, arl-s

### DIFF
--- a/scripts/skiplist/a770/language.txt
+++ b/scripts/skiplist/a770/language.txt
@@ -72,7 +72,6 @@ python/test/unit/language/test_core.py::test_dot[1-32-128-64-4-False-False-none-
 python/test/unit/language/test_core.py::test_dot[1-32-128-64-4-False-False-none-tf32-int8-int8-1-None1]
 # test_dot_max_num_imprecise_acc
 python/test/unit/language/test_core.py::test_dot_max_num_imprecise_acc[r".*-128-128-256-256"]@regexp
-python/test/unit/language/test_core.py::test_math_extern[float64]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/2005
 python/test/unit/language/test_core.py::test_abs_fp8[r"in_dtype[0-2]"]@regexp
 python/test/unit/language/test_core.py::test_precise_math[1-tl.math.sqrt_rn(x)-tl.math.sqrt(x.to(tl.float64)).to(tl.float32)]
@@ -84,7 +83,8 @@ python/test/unit/language/test_pipeliner.py::test_pipeline_matmul[True]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/3388
 # test_indirect_matmul
 python/test/unit/language/test_pipeliner.py::test_indirect_matmul
-python/test/unit/language/test_core.py::test_atomic_cas[1-acquire]
+python/test/unit/language/test_core.py::test_atomic_cas[int32-1-acquire]
+python/test/unit/language/test_core.py::test_atomic_cas[int64-1-acquire]
 python/test/unit/language/test_core.py::test_indirect_load[float64]
 python/test/unit/language/test_core.py::test_indirect_store[float64]
 python/test/unit/language/test_core.py::test_strided_load[float64]

--- a/scripts/skiplist/a770/matmul.txt
+++ b/scripts/skiplist/a770/matmul.txt
@@ -1,4 +1,3 @@
-python/test/unit/intel/test_mxfp_matmul.py::test_mxfp_matmul
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/3388
 python/test/unit/language/test_matmul.py::test_simple_matmul[r".*-1-32-32-32-4-float16-float16"]@regexp
 python/test/unit/language/test_matmul.py::test_simple_matmul[r".*-1-64-16-64-4-float16-float16"]@regexp
@@ -15,18 +14,18 @@ python/test/unit/language/test_matmul.py::test_simple_matmul[r".*-4-1-256-128-32
 python/test/unit/language/test_matmul.py::test_simple_matmul[r".*-4-1-256-128-32-4-float32-float16"]@regexp
 python/test/unit/language/test_matmul.py::test_simple_matmul[r".*-4-1-256-128-32-4-float32-float8e5"]@regexp
 python/test/unit/language/test_matmul.py::test_simple_matmul[r".*-4-1-256-128-32-4-float32-tensorfloat32"]@regexp
-python/test/unit/language/test_matmul.py::test_simple_matmul[True-True-4-1-512-64-32-2-float32-float32]
-python/test/unit/language/test_matmul.py::test_simple_matmul[False-True-4-1-512-64-32-2-float32-float32]
-python/test/unit/language/test_matmul.py::test_simple_matmul[True-True-8-1-64-512-32-2-float32-tensorfloat32]
-python/test/unit/language/test_matmul.py::test_simple_matmul[False-True-8-1-64-512-32-2-float32-tensorfloat32]
-python/test/unit/language/test_matmul.py::test_simple_matmul[False-True-8-1-32-32-32-4-float64-float64]
-python/test/unit/language/test_matmul.py::test_simple_matmul[False-True-8-1-64-16-64-4-float64-float64]
-python/test/unit/language/test_matmul.py::test_simple_matmul[False-False-4-1-32-32-32-4-float64-float64]
-python/test/unit/language/test_matmul.py::test_simple_matmul[False-False-4-1-64-16-64-4-float64-float64]
-python/test/unit/language/test_matmul.py::test_simple_matmul[False-False-8-1-32-32-32-4-float64-float64]
-python/test/unit/language/test_matmul.py::test_simple_matmul[False-False-8-1-64-16-64-4-float64-float64]
-python/test/unit/language/test_matmul.py::test_simple_matmul[False-True-4-1-32-32-32-4-float64-float64]
-python/test/unit/language/test_matmul.py::test_simple_matmul[False-True-4-1-64-16-64-4-float64-float64]
+python/test/unit/language/test_matmul.py::test_simple_matmul[True-4-1-512-64-32-2-float32-float32]
+python/test/unit/language/test_matmul.py::test_simple_matmul[False-4-1-512-64-32-2-float32-float32]
+python/test/unit/language/test_matmul.py::test_simple_matmul[True-8-1-64-512-32-2-float32-tensorfloat32]
+python/test/unit/language/test_matmul.py::test_simple_matmul[False-8-1-64-512-32-2-float32-tensorfloat32]
+python/test/unit/language/test_matmul.py::test_simple_matmul[True-8-1-32-32-32-4-float64-float64]
+python/test/unit/language/test_matmul.py::test_simple_matmul[True-8-1-64-16-64-4-float64-float64]
+python/test/unit/language/test_matmul.py::test_simple_matmul[False-4-1-32-32-32-4-float64-float64]
+python/test/unit/language/test_matmul.py::test_simple_matmul[False-4-1-64-16-64-4-float64-float64]
+python/test/unit/language/test_matmul.py::test_simple_matmul[False-8-1-32-32-32-4-float64-float64]
+python/test/unit/language/test_matmul.py::test_simple_matmul[False-8-1-64-16-64-4-float64-float64]
+python/test/unit/language/test_matmul.py::test_simple_matmul[True-4-1-32-32-32-4-float64-float64]
+python/test/unit/language/test_matmul.py::test_simple_matmul[True-4-1-64-16-64-4-float64-float64]
 python/test/unit/language/test_matmul.py::test_blocked_scale_mxfp[r"[^-]*-[^-]*-[^-]*-128-[^-]*-[^-]*-[^-]*-512"]@regexp
 python/test/unit/language/test_matmul.py::test_blocked_scale_mxfp[r"[^-]*-[^-]*-[^-]*-[^-]*-128-[^-]*-[^-]*-512"]@regexp
 python/test/unit/language/test_matmul.py::test_lhs_in_tmem_mxfp

--- a/scripts/skiplist/arl-h/language.txt
+++ b/scripts/skiplist/arl-h/language.txt
@@ -66,7 +66,6 @@ python/test/unit/language/test_core.py::test_dot[1-32-128-64-4-False-False-none-
 # test_dot_max_num_imprecise_acc
 python/test/unit/language/test_core.py::test_dot_max_num_imprecise_acc[r".*-128-128-256-256"]@regexp
 
-python/test/unit/language/test_core.py::test_math_extern[float64]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/2005
 python/test/unit/language/test_core.py::test_abs_fp8[r"in_dtype[0-2]"]@regexp
 
@@ -80,7 +79,8 @@ python/test/unit/language/test_pipeliner.py::test_pipeline_matmul[True]
 # test_indirect_matmul
 python/test/unit/language/test_pipeliner.py::test_indirect_matmul
 
-python/test/unit/language/test_core.py::test_atomic_cas[1-acquire]
+python/test/unit/language/test_core.py::test_atomic_cas[int32-1-acquire]
+python/test/unit/language/test_core.py::test_atomic_cas[int64-1-acquire]
 python/test/unit/language/test_core.py::test_indirect_load[float64]
 python/test/unit/language/test_core.py::test_indirect_store[float64]
 python/test/unit/language/test_core.py::test_strided_load[float64]

--- a/scripts/skiplist/arl-h/matmul.txt
+++ b/scripts/skiplist/arl-h/matmul.txt
@@ -1,4 +1,3 @@
-python/test/unit/intel/test_mxfp_matmul.py::test_mxfp_matmul
 python/test/unit/language/test_matmul.py::test_blocked_scale_mxfp[r"[^-]*-[^-]*-[^-]*-128-[^-]*-[^-]*-[^-]*-512"]@regexp
 python/test/unit/language/test_matmul.py::test_blocked_scale_mxfp[r"[^-]*-[^-]*-[^-]*-[^-]*-128-[^-]*-[^-]*-512"]@regexp
 python/test/unit/language/test_matmul.py::test_lhs_in_tmem_mxfp

--- a/scripts/skiplist/arl-s/language.txt
+++ b/scripts/skiplist/arl-s/language.txt
@@ -64,7 +64,6 @@ python/test/unit/language/test_core.py::test_dot[1-32-128-64-4-False-False-none-
 python/test/unit/language/test_core.py::test_dot[1-32-128-64-4-False-False-none-tf32-int8-int8-1-None1]
 # test_dot_max_num_imprecise_acc
 python/test/unit/language/test_core.py::test_dot_max_num_imprecise_acc[r".*-128-128-256-256"]@regexp
-python/test/unit/language/test_core.py::test_math_extern[float64]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/2005
 python/test/unit/language/test_core.py::test_abs_fp8[r"in_dtype[0-2]"]@regexp
 python/test/unit/language/test_core.py::test_precise_math[1-tl.math.sqrt_rn(x)-tl.math.sqrt(x.to(tl.float64)).to(tl.float32)]
@@ -75,7 +74,8 @@ python/test/unit/language/test_core.py::test_cast[1-uint32-uint64-False-1024]
 python/test/unit/language/test_pipeliner.py::test_pipeline_matmul[True]
 # test_indirect_matmul
 python/test/unit/language/test_pipeliner.py::test_indirect_matmul
-python/test/unit/language/test_core.py::test_atomic_cas[1-acquire]
+python/test/unit/language/test_core.py::test_atomic_cas[int32-1-acquire]
+python/test/unit/language/test_core.py::test_atomic_cas[int64-1-acquire]
 python/test/unit/language/test_core.py::test_indirect_load[float64]
 python/test/unit/language/test_core.py::test_indirect_store[float64]
 python/test/unit/language/test_core.py::test_strided_load[float64]

--- a/scripts/skiplist/arl-s/matmul.txt
+++ b/scripts/skiplist/arl-s/matmul.txt
@@ -1,4 +1,3 @@
-python/test/unit/intel/test_mxfp_matmul.py::test_mxfp_matmul
 python/test/unit/language/test_matmul.py::test_blocked_scale_mxfp[r"[^-]*-[^-]*-[^-]*-128-[^-]*-[^-]*-[^-]*-512"]@regexp
 python/test/unit/language/test_matmul.py::test_blocked_scale_mxfp[r"[^-]*-[^-]*-[^-]*-[^-]*-128-[^-]*-[^-]*-512"]@regexp
 python/test/unit/language/test_matmul.py::test_lhs_in_tmem_mxfp


### PR DESCRIPTION
## Summary
`pytest-skip`'s `--select-fail-on-missing` aborts the entire test suite when a skiplist entry doesn't match any collected test ID. This was silently failing the "Run core tests" step on A770 Windows CI (and presumably arl-h/arl-s, which share the same stale entries) for several test IDs that drifted out of date:

- `test_math_extern[float64]` — the whole function was removed upstream (ee42f1670, "fix libdevice", #8400). No replacement to skip.
- `test_atomic_cas[1-acquire]` — gained a `dtype_str` parametrize axis (a90ac8662, "[BACKEND] Fix 64 bit `atomic_cas`", #8105), so the 2-field ID no longer exists. Split into `test_atomic_cas[int32-1-acquire]` and `test_atomic_cas[int64-1-acquire]`.
- `test_mxfp_matmul.py::test_mxfp_matmul` — the whole file was removed upstream (f826ed98b, "[TEST] Remove `test_mxfp_matmul.py`", #5863); coverage folded into `test_mxfp8_mxfp4_matmul`, which is already tracked separately.
- a770's `matmul.txt`: 12 `test_simple_matmul[...]` entries had a duplicated boolean field (e.g. `[True-True-4-1-...]` instead of `[True-4-1-...]`) — a copy-paste artifact from commit c7eb9eabd (Apr 2025) that never matched any real parametrize ID once `EPILOGUE_SUBTILE` was added as an axis. Corrected to the real IDs, verified via local `pytest --collect-only` against the current decorator signature (`EPILOGUE_SUBTILE-NUM_WARPS-NUM_CTAS-BLOCK_M-BLOCK_N-BLOCK_K-NUM_STAGES-dtype_src-dtype_dst`).

Found while investigating unrelated `test_debug.py`/`test_line_info.py` A770 Windows failures fixed in #7482 and #7485 — after those merged, this was the next thing blocking a clean "Run core tests" run on A770.

## Test plan
- [x] Verified all 12 corrected `test_simple_matmul` IDs and the 2 corrected `test_atomic_cas` IDs each match exactly one collected test via a standalone `pytest --collect-only` repro against the current `test_matmul.py`/`test_core.py` decorator signatures.
- [x] Confirmed via `git log -S` that each removed/renamed test's history matches the described upstream commit.
- [x] Re-run "Build and test A770, Windows" workflow to confirm "Run core tests" no longer aborts on `pytest-skip: Not all tests to skip exist`: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29530899207/job/87730696340