### PR TITLE
[Windows] Fix PermissionError in test_auto_large_grf's zebin temp file

### DIFF
--- a/python/test/unit/intel/test_native_code_generation.py
+++ b/python/test/unit/intel/test_native_code_generation.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 
 import pytest
@@ -32,10 +33,16 @@ def test_auto_large_grf(device):
     x = to_triton(numpy_random(SIZE, dtype_str="float32"), device=device, dst_type="float32")
     # Triton XPU will choose large GRF mode when spill_size > MAX_REG_SPILL.
     k = kernel[(1, )](x, SIZE=SIZE, num_warps=1, generate_native_code=True, grf_mode='default')
-    with tempfile.NamedTemporaryFile(mode='wb', suffix='.zebin') as f:
+    # delete=False + explicit close: on Windows, extract_spill_size_from_zebin's own
+    # open() of the same path would otherwise hit a PermissionError while this
+    # handle is still open (no such restriction on POSIX).
+    f = tempfile.NamedTemporaryFile(mode='wb', suffix='.zebin', delete=False)
+    try:
         f.write(k.kernel)
-        f.flush()
+        f.close()
         spill_size = extract_spill_size_from_zebin(f.name)
+    finally:
+        os.unlink(f.name)
     if spill_size <= MAX_REG_SPILL:
         pytest.skip(f"Kernel did not spill above MAX_REG_SPILL ({spill_size} <= {MAX_REG_SPILL}); "
                     "auto-large-GRF path was not exercised. Consider increasing SIZE.")

--- a/python/test/unit/intel/test_native_code_generation.py
+++ b/python/test/unit/intel/test_native_code_generation.py
@@ -1,6 +1,3 @@
-import os
-import tempfile
-
 import pytest
 import triton
 import triton.language as tl
@@ -21,7 +18,7 @@ def test_empty_kernel(device):
 
 
 @pytest.mark.xfail(is_xpu_cri(), reason="unable to get spill_size")
-def test_auto_large_grf(device):
+def test_auto_large_grf(device, tmp_path):
     SIZE = 2048
 
     @triton.jit
@@ -33,16 +30,9 @@ def test_auto_large_grf(device):
     x = to_triton(numpy_random(SIZE, dtype_str="float32"), device=device, dst_type="float32")
     # Triton XPU will choose large GRF mode when spill_size > MAX_REG_SPILL.
     k = kernel[(1, )](x, SIZE=SIZE, num_warps=1, generate_native_code=True, grf_mode='default')
-    # delete=False + explicit close: on Windows, extract_spill_size_from_zebin's own
-    # open() of the same path would otherwise hit a PermissionError while this
-    # handle is still open (no such restriction on POSIX).
-    f = tempfile.NamedTemporaryFile(mode='wb', suffix='.zebin', delete=False)
-    try:
-        f.write(k.kernel)
-        f.close()
-        spill_size = extract_spill_size_from_zebin(f.name)
-    finally:
-        os.unlink(f.name)
+    zebin = tmp_path / "kernel.zebin"
+    zebin.write_bytes(k.kernel)
+    spill_size = extract_spill_size_from_zebin(str(zebin))
     if spill_size <= MAX_REG_SPILL:
         pytest.skip(f"Kernel did not spill above MAX_REG_SPILL ({spill_size} <= {MAX_REG_SPILL}); "
                     "auto-large-GRF path was not exercised. Consider increasing SIZE.")


### PR DESCRIPTION
## Summary
- `test_auto_large_grf` (`python/test/unit/intel/test_native_code_generation.py`) calls `extract_spill_size_from_zebin(f.name)` while `f` (a `NamedTemporaryFile`) is still open for writing. On Windows this hits the OS's exclusive file lock and fails with `PermissionError: [Errno 13] Permission denied`; it only worked on POSIX because that platform allows concurrent opens of the same file.
- Fixed by using pytest's `tmp_path` fixture: write the zebin bytes to `tmp_path / "kernel.zebin"` (which closes the file handle after the write), then call `extract_spill_size_from_zebin` on that path. Matches the pattern already used in `test_extract_spill_size.py`; pytest cleans up `tmp_path` automatically, no manual unlink needed.

Found while investigating B580/xe2 and A770 Windows CI failures:
- https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29469121809/job/87528579670
- https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29478420821/job/87556434928

## Test plan
- [x] Confirmed the production call site (`third_party/intel/backend/compiler.py` line ~616) is unaffected — it opens a freshly-written path from `ocloc`'s own output, not a still-held file handle, so this is purely a test-code bug.
- [x] Re-run A770 Windows CI to confirm `test_auto_large_grf` passes: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29592223795