### PR TITLE
[Windows] Skip test_chain_reduce PTSS scratch-space overflow on a770/xe2

### DIFF
--- a/scripts/skiplist/a770/intel.txt
+++ b/scripts/skiplist/a770/intel.txt
@@ -1,2 +1,7 @@
 # test_gather_warp_shuffle
 python/test/unit/intel/test_core.py::test_gather_warp_shuffle[src_shape1-indices_shape1-0-linear<{register = [[0, 2], [32, 0], [2, 0], [0, 16], [0, 32], [64, 0]], lane = [[0, 8], [8, 0], [1, 0], [4, 0], [16, 0]], warp = [[0, 1], [0, 4]], block = []}>-linear<{register = [[0, 2], [32, 0], [0, 32], [2, 0], [0, 16], [64, 0], [128, 0]], lane = [[0, 8], [8, 0], [1, 0], [4, 0], [16, 0]], warp = [[0, 1], [0, 4]], block = []}>]
+# https://github.com/intel/intel-xpu-backend-for-triton/issues/7503
+# Windows: kernel exceeds HW PTSS (per-thread scratch space) limit for this
+# layout/shape even after the 256-GRF retry path.
+python/test/unit/intel/test_core.py::test_chain_reduce[1-max-src_layout2-256-128]
+python/test/unit/intel/test_core.py::test_chain_reduce[1-max-src_layout2-256-256]

--- a/scripts/skiplist/xe2/intel.txt
+++ b/scripts/skiplist/xe2/intel.txt
@@ -1,0 +1,5 @@
+# https://github.com/intel/intel-xpu-backend-for-triton/issues/7503
+# Windows: kernel exceeds HW PTSS (per-thread scratch space) limit for this
+# layout/shape even after the 256-GRF retry path.
+python/test/unit/intel/test_core.py::test_chain_reduce[1-max-src_layout2-256-128]
+python/test/unit/intel/test_core.py::test_chain_reduce[1-max-src_layout2-256-256]


### PR DESCRIPTION
## Summary
- `test_chain_reduce[1-max-src_layout2-256-128]` and `[...-256-256]` fail on A770 and B580 (xe2) Windows CI with:
  ```
  triton.runtime.errors.OutOfResources: out of resource: per-thread scratch space (PTSS). IGC build log:
  error: in kernel 'sum_kernel_0d1d': total scratch space exceeds HW supported limit: 428288 bytes (max permitted PTSS 262144 bytes)
  ```
- This is a genuine HW resource-limit failure for this specific `BlockedLayout` (`src_layout2`) at `M=256`, `op=max`, `first_axis=1` — the kernel needs ~428-435KB of scratch space, well over the 256KB limit, even after the existing 256-GRF retry path in `third_party/intel/backend/compiler.py` kicks in.
- Filed #7503 to track investigating whether the kernel construction can be made cheaper for this case; skiplisted in the meantime on both `a770` (`intel.txt`) and `xe2` (new `intel.txt`, xe2 didn't have one yet).

Found while investigating B580/xe2 Windows CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29469121809/job/87528579670 (also reproduces on A770).

## Test plan
- [x] Verified against the exact test IDs and error messages from the CI logs.
- [x] Re-run A770/B580 Windows CI to confirm these no longer fail in "Run core tests": https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29544175173