### PR TITLE
[Windows] Skip test_compile_only_* missing NVIDIA/AMD toolchain on a770/xe2

### DIFF
--- a/scripts/skiplist/a770/language.txt
+++ b/scripts/skiplist/a770/language.txt
@@ -112,3 +112,11 @@ python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-acquire]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]
+# https://github.com/intel/intel-xpu-backend-for-triton/issues/7504
+# Windows: no NVIDIA/AMD toolchain (ptxas-blackwell, hipcc) on Intel-only CI.
+python/test/unit/language/test_compile_only.py::test_compile_only_sm100
+python/test/unit/language/test_compile_only.py::test_compile_only_expect_zero
+python/test/unit/language/test_compile_only.py::test_compile_only_dot
+python/test/unit/language/test_compile_only.py::test_compile_only_k_loop
+python/test/unit/language/test_compile_only.py::test_compile_only_dot_mxfp
+python/test/unit/language/test_compile_only.py::test_fp8_compiles_for_multiple_architectures_hip

--- a/scripts/skiplist/xe2/language.txt
+++ b/scripts/skiplist/xe2/language.txt
@@ -8,3 +8,11 @@ python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-acquire]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]
+# https://github.com/intel/intel-xpu-backend-for-triton/issues/7504
+# Windows: no NVIDIA/AMD toolchain (ptxas-blackwell, hipcc) on Intel-only CI.
+python/test/unit/language/test_compile_only.py::test_compile_only_sm100
+python/test/unit/language/test_compile_only.py::test_compile_only_expect_zero
+python/test/unit/language/test_compile_only.py::test_compile_only_dot
+python/test/unit/language/test_compile_only.py::test_compile_only_k_loop
+python/test/unit/language/test_compile_only.py::test_compile_only_dot_mxfp
+python/test/unit/language/test_compile_only.py::test_fp8_compiles_for_multiple_architectures_hip


### PR DESCRIPTION
## Summary
- `test_compile_only_sm100`, `test_compile_only_expect_zero`, `test_compile_only_dot`, `test_compile_only_k_loop`, `test_compile_only_dot_mxfp` (all in `python/test/unit/language/test_compile_only.py`, inherited unmodified from upstream Triton) cross-compile for `GPUTarget("cuda", 100/90, 32)` and assert `k.asm["cubin"] != b""`, which requires actually invoking `ptxas`/`ptxas-blackwell`:
  ```
  FAILED language\test_compile_only.py::test_compile_only_sm100 - RuntimeError: Cannot find ptxas-blackwell.exe
  ```
- `test_fp8_compiles_for_multiple_architectures_hip` compiles for `GPUTarget("hip", "gfx950", 64)` via the AMD backend, hitting a `PermissionError` inside AMD's own `make_hsaco()` temp-file handling (a similar Windows temp-file issue as #7505, but in vendored upstream code we don't own here).
- None of these are gated by any backend-availability check, so they fail unconditionally on Intel-only CI runners that don't have the NVIDIA/AMD toolchains installed. Filed #7504 to track a possible upstream/environment fix; skiplisted in the meantime on `a770` and `xe2`.

Found while investigating B580/xe2 Windows CI: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29469121809/job/87528579670 (also reproduces on A770).

## Test plan
- [x] Verified against the exact test IDs and error messages from the CI logs.
- [ ] Re-run A770/B580 Windows CI to confirm these no longer fail "Run core tests": https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29544035568