### PR TITLE
[PTL] Skip test_atomic_poll worker-crash failures in language suite

### DIFF
--- a/scripts/skiplist/ptl/language.txt
+++ b/scripts/skiplist/ptl/language.txt
@@ -1,0 +1,7 @@
+# https://github.com/intel/intel-xpu-backend-for-triton/issues/7390
+python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-relaxed]
+python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-acquire]
+python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-relaxed]
+python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-acquire]
+python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-relaxed]
+python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-acquire]

--- a/scripts/skiplist/ptl/language.txt
+++ b/scripts/skiplist/ptl/language.txt
@@ -5,3 +5,6 @@ python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-relaxed]
 python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-acquire]
 python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-relaxed]
 python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-acquire]
+# https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
+python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
+python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]


### PR DESCRIPTION
## Summary
- `scripts/skiplist/ptl/` doesn't exist on `main` yet.
- A recent PTL CI run showed `test_atomic_poll[dtype0-16-{cta,gpu,sys}-{relaxed,acquire}]` failing with pytest-xdist worker crashes — the same known issue already tracked by #7390 and skiplisted on `a770`, `xe2`, `arl-h`, and `arl-s`.
- After skipping those, a follow-up PTL run showed `test_atomic_poll_timeout[1-True]` and `[0-False]` failing with `RuntimeError: PassManager::run failed` — the same known issue tracked by #7391, also already skiplisted on `a770`, `xe2`, `arl-h`, and `arl-s`.
- Adds `scripts/skiplist/ptl/language.txt` with both sets of entries, matching the existing pattern for the other architectures.

## Test plan
- [x] Confirmed the same test IDs are already skiplisted (with the same issue links) on 4 other architectures.
- [x] Verified on a PTL Windows CI run: all 6 `test_atomic_poll[dtype0-...]` variants show `SKIPPED`, no failures; other dtype/`test_frontend.py::test_atomic_poll` variants pass normally (skiplist entries are correctly scoped, not over-skipping).
- [x] Re-ran after adding the timeout entries; confirmed no `FAILED test_atomic_poll*` in the log.