### PR TITLE
[LLVMIR] Run expandSubByteVectorBitcast unconditionally to fix IGC segfault on non-LTS drivers 

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -540,8 +540,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
             llvm.link_extern_libs(llvm_mod, paths)
 
         cls.optimize_llvm_mod(llvm_mod, options)
-        is_lts = cls.is_lts(metadata["target"].arch.get("driver_version"))
-        intel.post_process_llir(llvm_mod, is_lts)
+        intel.post_process_llir(llvm_mod)
 
         # Get some metadata
         total_num_warps = src.get_int_attr("ttg.total-num-warps")

--- a/third_party/intel/include/Target/LLVMIR/PostProcess.h
+++ b/third_party/intel/include/Target/LLVMIR/PostProcess.h
@@ -6,7 +6,7 @@ class Module;
 } // namespace llvm
 
 namespace mlir::triton::intel {
-void postProcessLLVMIR(llvm::Module &module, bool isLTS);
+void postProcessLLVMIR(llvm::Module &module);
 } // namespace mlir::triton::intel
 
 #endif // TRITON_TARGET_LLVMIR_POSTPROCESS_H

--- a/third_party/intel/lib/Target/LLVMIR/PostProcess.cpp
+++ b/third_party/intel/lib/Target/LLVMIR/PostProcess.cpp
@@ -243,7 +243,7 @@ void expandSubByteVectorBitcast(Module &module) {
   }
 }
 
-void postProcessLLVMIR(llvm::Module &mod, bool isLTS) {
+void postProcessLLVMIR(llvm::Module &mod) {
   // __devicelib_assert_fail must be a declaration so that
   // IGC can replace it with a runtime assert function.
   // If a 'fallback' implementation is defined in SYCL libarary, the
@@ -263,10 +263,7 @@ void postProcessLLVMIR(llvm::Module &mod, bool isLTS) {
   expandSubByteBitReverse(mod);
   expandSubByteBitwiseAnd(mod);
 
-  // Remove sub-byte integer vector bitcasts that crash IGC on LTS2. Gated on
-  // the LTS driver so it can be dropped once the driver ships the IGC fix.
-  if (isLTS)
-    expandSubByteVectorBitcast(mod);
+  expandSubByteVectorBitcast(mod);
 }
 
 } // namespace mlir::triton::intel

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -396,9 +396,8 @@ void init_triton_intel(py::module &&m) {
     mod->setDataLayout(layout);
   });
 
-  m.def("post_process_llir", [](llvm::Module *mod, bool isLTS) {
-    intel::postProcessLLVMIR(*mod, isLTS);
-  });
+  m.def("post_process_llir",
+        [](llvm::Module *mod) { intel::postProcessLLVMIR(*mod); });
 
   m.def(
       "translate_to_spirv",


### PR DESCRIPTION
Closes #7512 