### PR TITLE
Fix test_fast_sin_cos reference to avoid device-side fp64 aspect check

### DIFF
--- a/python/test/unit/intel/test_fast_sin_cos.py
+++ b/python/test/unit/intel/test_fast_sin_cos.py
@@ -40,8 +40,10 @@ def test_fast_sin(N, device):
     grid = lambda meta: ((N + meta["BLOCK_SIZE"] - 1) // meta["BLOCK_SIZE"], )
     fast_sin_kernel[grid](x, out, N, BLOCK_SIZE)
 
-    # Reference (via float64 for better precision)
-    ref = torch.sin(x.to(torch.float64)).to(torch.float32)
+    # Reference (via float64 for better precision). Cast on CPU: XPU devices without
+    # fp64 hardware support (e.g. A770) would otherwise raise "Required aspect fp64
+    # is not supported on the device".
+    ref = torch.sin(x.cpu().to(torch.float64)).to(torch.float32).to(device)
 
     # Graphics-grade tolerance: max abs error <= 1e-3
     max_err = torch.max(torch.abs(out - ref)).item()
@@ -61,8 +63,10 @@ def test_fast_cos(N, device):
     grid = lambda meta: ((N + meta["BLOCK_SIZE"] - 1) // meta["BLOCK_SIZE"], )
     fast_cos_kernel[grid](x, out, N, BLOCK_SIZE)
 
-    # Reference (via float64 for better precision)
-    ref = torch.cos(x.to(torch.float64)).to(torch.float32)
+    # Reference (via float64 for better precision). Cast on CPU: XPU devices without
+    # fp64 hardware support (e.g. A770) would otherwise raise "Required aspect fp64
+    # is not supported on the device".
+    ref = torch.cos(x.cpu().to(torch.float64)).to(torch.float32).to(device)
 
     # Graphics-grade tolerance: max abs error <= 1e-3
     max_err = torch.max(torch.abs(out - ref)).item()


### PR DESCRIPTION
## Summary
A770 (Arc, Xe-HPG) lacks fp64 hardware support — a known, permanent limitation (see #1840, #3015). `test_fast_sin_cos.py::test_fast_sin`/`test_fast_cos` computed their reference with `x.to(torch.float64)` where `x` is a device tensor, triggering the SYCL fp64-aspect check on-device:

```
RuntimeError: Required aspect fp64 is not supported on the device
```

Fixed by casting on CPU instead, matching the pattern already used elsewhere (e.g. `test_precise_math`).

Found while investigating residual "Run core tests" failures on the A770 Windows CI run https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29677396365/job/88167249143.

## Test plan
- [ ] Re-run A770 Windows CI to confirm `test_fast_sin[256]`, `test_fast_sin[1024]`, `test_fast_cos[256]`, `test_fast_cos[1024]` now pass: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29698227168