### PR TITLE
Fix test_libdevice_rint fp64-gating gap on A770

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -7379,13 +7379,16 @@ def test_dot_multidim(rank, trans_a, trans_b, device):
 
 @pytest.mark.parametrize("dtype_str", ["float32", "float64"])
 def test_libdevice_rint(dtype_str, device):
+    if device in ['xpu']:
+        if dtype_str in ["float64"] and not xpu_has_fp64():
+            pytest.xfail("float64 not supported on current xpu hardware")
     iinfo32 = np.iinfo(np.int32)
     iinfo64 = np.iinfo(np.int64)
     size = 1000
     x0_np = np.random.uniform(iinfo32.min, iinfo32.max + 1, size)
     x1_np = np.random.uniform(iinfo64.min, iinfo64.max + 1, size)
     x2_np = np.array([-2.5, -1.5, -0.5, -0., 0., 0.5, 1.5, 2.5, float("inf"), -float("inf"), float("nan")])
-    x_np = np.concatenate((x0_np, x1_np, x2_np))
+    x_np = np.concatenate((x0_np, x1_np, x2_np)).astype(dtype_str)
     x_tri = to_triton(x_np, device=device, dst_type=dtype_str)
 
     @triton.jit


### PR DESCRIPTION
## Summary
A770 (Arc, Xe-HPG) lacks fp64 hardware support — a known, permanent limitation (see #1840, #3015). `test_libdevice_rint` was missing the `has_fp64` xfail guard present on sibling tests (e.g. `test_bessel` in `test_libdevice.py`, which already guards this).

Separately — and this is why even the `float32` parametrization failed — `to_triton(x_np, dst_type=dtype_str)` doesn't actually cast `x_np`'s underlying numpy dtype for plain float types, so the `float32` case was silently sending a real fp64 tensor to the device too. Fixed by casting `x_np` to `dtype_str` before use — this also makes the `float32` parametrization test float32 precision instead of silently testing float64 precision end-to-end.

Found while investigating residual "Run core tests" failures on the A770 Windows CI run https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29677396365/job/88167249143.

## Test plan
- [ ] Re-run A770 Windows CI to confirm `test_libdevice_rint[float32]` passes and `test_libdevice_rint[float64]` cleanly `xfail`s (rather than erroring): https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29698245555