### PR TITLE
Fix test_isinf fp64-gating gap on A770

### DIFF
--- a/python/test/unit/language/test_libdevice.py
+++ b/python/test/unit/language/test_libdevice.py
@@ -93,6 +93,9 @@ def test_popc(device):
 
 @pytest.mark.parametrize("dtype_str", ["float32", "float64"])
 def test_isinf(device, dtype_str):
+    if device in ['xpu']:
+        if dtype_str in ["float64"] and not triton.runtime.driver.active.get_current_target().arch['has_fp64']:
+            pytest.xfail("float64 not supported on current xpu hardware")
 
     @triton.jit
     def triton_isinf(in_ptr, out_ptr, numel, BLOCK_SIZE: tl.constexpr):


### PR DESCRIPTION
## Summary
A770 (Arc, Xe-HPG) lacks fp64 hardware support — a known, permanent limitation (see #1840, #3015). `test_isinf` was missing the `has_fp64` xfail guard already present on its sibling `test_bessel`.

Found while investigating residual "Run core tests" failures on the A770 Windows CI run https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29677396365/job/88167249143.

## Test plan
- [x] Re-ran A770 Windows CI: confirmed `test_isinf[float64]` cleanly `xfail`s (no more `ZE_RESULT_ERROR_MODULE_BUILD_FAILURE`) and `test_isinf[float32]` still `PASSED`: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29698184116