### PR TITLE
Add missing has_fp64 xfail guard to test_libdevice_rint

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -7379,6 +7379,9 @@ def test_dot_multidim(rank, trans_a, trans_b, device):
 
 @pytest.mark.parametrize("dtype_str", ["float32", "float64"])
 def test_libdevice_rint(dtype_str, device):
+    if device in ['xpu']:
+        if dtype_str in ["float64"] and not xpu_has_fp64():
+            pytest.xfail("float64 not supported on current xpu hardware")
     iinfo32 = np.iinfo(np.int32)
     iinfo64 = np.iinfo(np.int64)
     size = 1000


### PR DESCRIPTION
## Summary
A770 (Arc, Xe-HPG) lacks fp64 hardware support — a known, permanent limitation (see #1840, #3015). `test_libdevice_rint` was missing the `has_fp64` xfail guard present on sibling tests (e.g. `test_bessel` in `test_libdevice.py`, which already guards this).

Split out of #7523, which bundled this with an unrelated fix (the `float32` parametrization's numpy-dtype-leak bug, now in #7526).

Found while investigating residual "Run core tests" failures on the A770 Windows CI run https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29677396365/job/88167249143.

## Test plan
- [x] Verified on A770 Windows CI (run https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29698245555, which carries both this guard and the #7526 dtype fix): `test_libdevice_rint[float64]` now cleanly `XFAIL`s instead of erroring with `ZE_RESULT_ERROR_MODULE_BUILD_FAILURE`.