### PR TITLE
Fix test_libdevice_rint float32 case silently testing float64 precision

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -7385,7 +7385,7 @@ def test_libdevice_rint(dtype_str, device):
     x0_np = np.random.uniform(iinfo32.min, iinfo32.max + 1, size)
     x1_np = np.random.uniform(iinfo64.min, iinfo64.max + 1, size)
     x2_np = np.array([-2.5, -1.5, -0.5, -0., 0., 0.5, 1.5, 2.5, float("inf"), -float("inf"), float("nan")])
-    x_np = np.concatenate((x0_np, x1_np, x2_np))
+    x_np = np.concatenate((x0_np, x1_np, x2_np)).astype(dtype_str)
     x_tri = to_triton(x_np, device=device, dst_type=dtype_str)
 
     @triton.jit


### PR DESCRIPTION
## Summary
`to_triton(x_np, dst_type=dtype_str)` doesn't actually cast `x_np`'s underlying numpy dtype for plain float types, so the `float32` parametrization of `test_libdevice_rint` was silently sending a real fp64 tensor to the device (`x_np` is built via `np.random.uniform`, which always returns `float64`). Fixed by casting `x_np` to `dtype_str` before use — this makes the `float32` parametrization actually test float32 precision instead of float64 precision end-to-end.

On A770 (which lacks fp64 hardware support), this caused `test_libdevice_rint[float32]` to fail with the same `ZE_RESULT_ERROR_MODULE_BUILD_FAILURE` / "Double type is not supported on this platform" error as the `float64` case, even though `float32` is otherwise fully supported.

Split out of #7523, which bundled this with an unrelated fix (the missing `has_fp64` guard, now in #7525).

Found while investigating residual "Run core tests" failures on the A770 Windows CI run https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29677396365/job/88167249143.

## Test plan
- [x] Verified on A770 Windows CI (run https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29698245555, which carries both this dtype fix and the #7525 guard): `test_libdevice_rint[float32]` now `PASSED` (previously errored with `ZE_RESULT_ERROR_MODULE_BUILD_FAILURE`).