### PR TITLE
[B580/xe2] Skip test_debug.py failures in "Run core tests"

### DIFF
--- a/scripts/skiplist/xe2/debug.txt
+++ b/scripts/skiplist/xe2/debug.txt
@@ -1,0 +1,42 @@
+# https://github.com/intel/intel-xpu-backend-for-triton/issues/7480
+# Windows: TRITON_DEBUG multiprocessing worker crashes before returning a
+# result, so run_in_process() sees an empty queue instead of the child's exc.
+# Same root cause as the identical A770 skip in scripts/skiplist/a770/debug.txt.
+python/test/unit/test_debug.py::test_expect_zero_device_assert
+
+# https://github.com/intel/intel-xpu-backend-for-triton/issues/7481
+# Windows: device-side assert aborts the child process with Windows
+# exit code 3221226505 (0xc0000409, STATUS_STACK_BUFFER_OVERRUN) instead of
+# the expected SIGABRT (-6) used to detect the assert on Linux/XPU.
+python/test/unit/test_debug.py::test_device_assert[False-False-True-None-False]
+python/test/unit/test_debug.py::test_device_assert[False-False-True-True-False]
+python/test/unit/test_debug.py::test_device_assert[False-True-False-None-False]
+python/test/unit/test_debug.py::test_device_assert[False-True-False-True-False]
+python/test/unit/test_debug.py::test_device_assert[False-True-None-None-False]
+python/test/unit/test_debug.py::test_device_assert[False-True-None-True-False]
+python/test/unit/test_debug.py::test_device_assert[False-True-True-None-False]
+python/test/unit/test_debug.py::test_device_assert[False-True-True-True-False]
+python/test/unit/test_debug.py::test_device_assert[True-False-None-None-False]
+python/test/unit/test_debug.py::test_device_assert[True-False-None-True-False]
+python/test/unit/test_debug.py::test_device_assert[True-False-True-None-False]
+python/test/unit/test_debug.py::test_device_assert[True-False-True-True-False]
+python/test/unit/test_debug.py::test_device_assert[True-True-False-None-False]
+python/test/unit/test_debug.py::test_device_assert[True-True-False-True-False]
+python/test/unit/test_debug.py::test_device_assert[True-True-None-None-False]
+python/test/unit/test_debug.py::test_device_assert[True-True-None-True-False]
+python/test/unit/test_debug.py::test_device_assert[True-True-True-None-False]
+python/test/unit/test_debug.py::test_device_assert[True-True-True-True-False]
+
+# https://github.com/intel/intel-xpu-backend-for-triton/issues/7481
+# Windows: same SIGABRT-vs-exit-code mismatch as test_device_assert above,
+# hit via the debug=True/should_overflow=True subprocess path.
+python/test/unit/test_debug.py::test_sanitize_int_add_overflow[-2147483648--1-int32-int32-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_add_overflow[2147483647-1-int32-int32-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_add_overflow[2147483647-100-int32-int32-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_add_overflow[-32768--1-int16-int16-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_add_overflow[32767-1-int16-int16-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_mul_overflow[1073741824-4-int32-int32-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_mul_overflow[1073741824-2-int32-int32-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_mul_overflow[-1073741824--4-int32-int32-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_sub_overflow[-2147483648-1-int32-int32-True-True]
+python/test/unit/test_debug.py::test_sanitize_int_sub_overflow[2147483647--1-int32-int32-True-True]


### PR DESCRIPTION
## Summary
Checked run https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29677396936/job/88167250715 ("Build and test B580, Windows") for a possible common cause across failures — turned out every single failure in "Run core tests" (29 total) is the exact same `test_debug.py` issue already tracked and skiplisted for A770 in #7482 (see #7480, #7481 — still open/unresolved):

- Windows reports device-side-assert crashes via exit code `3221226505` (`0xc0000409`, `STATUS_STACK_BUFFER_OVERRUN`) instead of POSIX `SIGABRT` (`-6`)
- `run_in_process()`'s multiprocessing worker crashes before returning a result

All 29 failing test IDs are byte-for-byte identical to the ones already skiplisted in `scripts/skiplist/a770/debug.txt` — confirming this is a Windows-wide test-harness issue, not A770-specific. `scripts/skiplist/xe2` had no `debug.txt` at all before this. This PR only extends the existing skip to B580/xe2; it does not fix the underlying issue.

## Test plan
- [x] Diffed the 29 failing test IDs from the original run against `scripts/skiplist/a770/debug.txt`'s existing entries — identical set.
- [x] Re-ran "Build and test B580, Windows" on this branch (https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29699350485): "Run core tests" now passes. `test_debug.py` reports 29 SKIPPED (exactly the new skiplist entries, no more/less) + 67 PASSED.