### PR TITLE
[HostTensorDescriptor] Include shape values in specialization for `constexpr` optimization (#7519)

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -228,40 +228,42 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
     @staticmethod
     def parse_attr(desc):
         ret = BaseBackend.parse_attr(desc)
-        if "L" in desc:
-            ret += [["tt.last_dim_divisibility", 8]]
         if "N" in desc:
             ret += [["tt.padding", 1]]
-        # "S<val>,<val>,..." encodes non-last stride values for rank-3+
-        # descriptors (enables constexpr stride optimization for FuseReshape).
+        # "S" section: encodes shape and stride values as constexpr.
+        # Format: "S<shape0>,<shape1>,...;<stride0>,<stride1>,..."
+        # Enables isDivisible checks to pass trivially on constants.
         if "S" in desc:
             idx = desc.index("S") + 1
-            stride_str = desc[idx:]
+            s_str = desc[idx:]
             try:
-                strides = [int(x) for x in stride_str.split(",") if x]
-                for i, s in enumerate(strides):
-                    ret += [[f"tt.stride.{i}", s]]
-            except ValueError:
+                parts = s_str.split(";")
+                shapes = [int(x) for x in parts[0].split(",") if x]
+                for i, s in enumerate(shapes):
+                    ret += [[f"tt.shape.{i}", s]]
+                if len(parts) > 1:
+                    strides = [int(x) for x in parts[1].split(",") if x]
+                    for i, s in enumerate(strides):
+                        ret += [[f"tt.stride.{i}", s]]
+            except (ValueError, IndexError):
                 pass
         return ret
 
     @staticmethod
     def get_tensordesc_specialization(arg, **kwargs):
-        # "L" = last-dim shape satisfies 2D block IO surface width alignment
-        #   (needed for satisfies2DBlockReadAlignment in MaterializeBlockPointer).
-        #   HW requires 4-byte (DW) alignment; combined with minimum 2 elements
-        #   for the stride-one dim this means shape[-1] * elem_bytes % 8 == 0.
         # "N" = NaN padding (enables tt.padding attribute).
-        # "S<val>,..." = non-last stride values for rank-3+ (enables constexpr
-        #   stride optimization for FuseReshape).
+        # "S<shapes>;<strides>" = shape and stride values as constexpr.
+        #   Shapes: enables satisfies2DBlockReadAlignment and FuseReshape checks.
+        #   Strides (rank-3+ only): enables FuseReshape stride divisibility.
         key = ""
-        elem_bytes = arg.base.dtype.itemsize
-        if (arg.shape[-1] * elem_bytes) % 8 == 0:
-            key += "L"
         if getattr(arg, "padding", None) == "nan":
             key += "N"
-        if len(arg.strides) >= 3:
-            key += "S" + ",".join(str(s) for s in arg.strides[:-1])
+        # Encode all shapes and non-last strides (rank-3+ only) as constants.
+        shapes_str = ",".join(str(s) for s in arg.shape)
+        strides_str = ",".join(str(s) for s in arg.strides[:-1]) if len(arg.strides) >= 3 else ""
+        key += "S" + shapes_str
+        if strides_str:
+            key += ";" + strides_str
         return key
 
     def pack_metadata(self, metadata):

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
@@ -1193,9 +1193,22 @@ static void synthesizeDescriptorsFromFuncArgs(Operation *moduleOp) {
                                            builder.getI64IntegerAttr(1));
       strideArgs.back() = c1;
 
+      // Replace shapes with constants from tt.shape.N attributes (set by
+      // specialization). This enables satisfies2DBlockReadAlignment and
+      // FuseReshape's shape divisibility checks to pass.
+      for (unsigned d = 0; d < rank; ++d) {
+        std::string attrName = "tt.shape." + std::to_string(d);
+        if (auto attr = funcOp.getArgAttrOfType<IntegerAttr>(
+                idx, StringRef(attrName))) {
+          shapeArgs[d] = arith::ConstantOp::create(
+              builder, loc, builder.getI32Type(),
+              builder.getI32IntegerAttr(
+                  static_cast<int32_t>(attr.getValue().getSExtValue())));
+        }
+      }
+
       // For rank-3+, replace non-last strides with constants from tt.stride.N
-      // attributes. This enables FuseReshape to prove stride divisibility for
-      // rank-reducing loads.
+      // attributes. This enables FuseReshape to prove stride divisibility.
       if (rank >= 3) {
         for (unsigned d = 0; d < rank - 1; ++d) {
           std::string attrName = "tt.stride." + std::to_string(d);
@@ -1236,22 +1249,10 @@ static void synthesizeDescriptorsFromFuncArgs(Operation *moduleOp) {
       unsigned strideDivisibility = 16 / std::max(1u, elemBytes);
 
       pendingAttrs.push_back({basePtr, 16});
-      // Frontend stride args used by MakeTensorDescOp (guaranteed by
-      // TensorDescriptor: stride * elem_bytes % 16 == 0).
-      // Only need to add to BlockArgument strides (not constants).
+      // Frontend stride args: only add BlockArgument strides (not constants).
       for (unsigned d = 0; d < rank - 1; ++d)
         if (isa<BlockArgument>(strideArgs[d]))
           pendingAttrs.push_back({strideArgs[d], strideDivisibility});
-
-      // Last-dim shape divisibility (set by "L" specialization key when
-      // shape[-1] * elem_bytes % 8 == 0). Required by
-      // satisfies2DBlockReadAlignment.
-      if (auto lastDimAttr = funcOp.getArgAttrOfType<IntegerAttr>(
-              idx, "tt.last_dim_divisibility")) {
-        unsigned lastDimDiv =
-            lastDimAttr.getValue().getZExtValue() / std::max(1u, elemBytes);
-        pendingAttrs.push_back({shapeArgs.back(), lastDimDiv});
-      }
 
       // Refresh for next iteration.
       funcType = funcOp.getFunctionType();


### PR DESCRIPTION
Replace the "L" (last-dim divisibility) approach with encoding all shape values in the "S" specialization key alongside strides. The pre-pass emits shapes as constants, which:

1. Fixes the regression from PR#7471 (FuseReshape's new check isDivisible(shapes[1], blockExtent) now passes trivially on constants)
2. Enables satisfies2DBlockReadAlignment without needing a separate divisibility attribute
3. Gives LLVM full constant information for better optimization

Format: "S<shape0>,<shape1>,...;<stride0>,<stride1>,..." Shapes are included for all ranks; strides only for rank-3+.


(cherry picked from commit 03a091f07aa2d9b3b277b34414d1d2d42674ed48)