### PR TITLE
[CI] Add ignore_errors input to build-test-windows.yml

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -12,6 +12,10 @@ on:
         description: Skip list
         type: string
         default: a770
+      ignore_errors:
+        description: Ignore test errors
+        type: boolean
+        default: false
       run_name:
         description: Custom run name
         type: string
@@ -24,7 +28,7 @@ env:
   PYTHON_VERSION: "3.10"
   NEW_WORKSPACE: C:\gh${{ github.run_id }}
   SKIPLIST: --skip-list scripts/skiplist/${{ inputs.skip_list }}
-  TRITON_TEST_CMD: bash -x scripts/test-triton.sh --skip-pytorch-install --skip-pip-install --skip-list scripts/skiplist/${{ inputs.skip_list }} --reports-dir reports --run-all
+  TRITON_TEST_CMD: bash -x scripts/test-triton.sh --skip-pytorch-install --skip-pip-install --skip-list scripts/skiplist/${{ inputs.skip_list }} --reports-dir reports --run-all ${{ inputs.ignore_errors && '--ignore-errors' || '' }}
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Add an `ignore_errors` boolean workflow input to `build-test-windows.yml`, mirroring the existing input in `build-test-reusable.yml`.
- When set, appends `--ignore-errors` to the `test-triton.sh` invocation, causing `handle_test_error` in `pytest-utils.sh` to swallow test failures instead of failing the run.

## Test plan
- [x] Trigger and check whether a run on a B580 Windows runner with `ignore_errors=true` will success: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/29873006147