### PR TITLE
Add triton intel gpu gather op lowering.

### DIFF
--- a/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
+++ b/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
@@ -1,0 +1,94 @@
+// RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s
+// RUN: env TRITON_INTEL_ENABLE_BLOCK_IO_ALL_LAYOUTS=1 triton-opt %s -split-input-file --tritonintelgpu-lower-to-2d-block-load --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s --check-prefix=FAST
+
+// Test that ttig.descriptor_gather is lowered to LLVM correctly.
+// Two lowering paths are covered:
+//   1. Default fallback path: generates per-element predicated loads using
+//      pointer arithmetic computed from the descriptor's base/shape/stride.
+//   2. Fast path: generates triton_gen.sub_group_gather_load for DPAS dot_op A
+//      layouts that satisfy block-IO tile constraints.
+
+// ---------------------------------------------------------------------------
+// Test 1: Default fallback path
+//
+// A blocked encoding that does not satisfy block-IO tile constraints falls
+// through to the default path which emits one predicated llvm.load per result
+// element.
+// ---------------------------------------------------------------------------
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked_x = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [16], warpsPerCTA = [8], order = [0]}>
+
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @descriptor_gather_default_path
+  tt.func public @descriptor_gather_default_path(
+      %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %arg1: tensor<8xi32, #blocked_x>,
+      %arg2: i32) -> tensor<8x16xf16, #blocked> {
+    %c1_i64 = arith.constant 1 : i64
+    %c256_i32 = arith.constant 256 : i32
+    %c16_i64 = arith.constant 16 : i64
+    // Descriptor over a 2D matrix; block shape is 1×16 (one row, 16 cols).
+    %desc = tt.make_tensor_descriptor %arg0, [%c256_i32, %c256_i32], [%c16_i64, %c1_i64] : <f16>, <1x16xf16>
+
+    // Verify descriptor struct is built:
+    // CHECK: llvm.insertvalue {{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+
+    // Verify descriptor fields are extracted:
+    // CHECK-DAG: %[[SHAPE0:.*]] = llvm.extractvalue {{.*}}[0] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[SHAPE1:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[BASE:.*]] = llvm.extractvalue {{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+
+    // Fast path must NOT be used for this blocked layout (checked before the
+    // first predicated-load pattern so the scope is anchored correctly):
+    // CHECK-NOT: triton_gen.sub_group_gather_load
+
+    // Verify that bounds checks are generated for both dimensions:
+    // CHECK: llvm.icmp "ult" {{.*}} : i64
+    // CHECK: llvm.icmp "ult" {{.*}} : i64
+
+    // Verify predicated load block structure:
+    // CHECK: llvm.cond_br {{.*}}
+    // CHECK: llvm.load {{.*}} : !llvm.ptr<1> -> f16
+
+    %result = ttig.descriptor_gather %desc[%arg1, %arg2]
+        : (!tt.tensordesc<1x16xf16>, tensor<8xi32, #blocked_x>, i32) -> tensor<8x16xf16, #blocked>
+    tt.return %result : tensor<8x16xf16, #blocked>
+  }
+}
+
+// -----
+
+// ---------------------------------------------------------------------------
+// Test 2: Fast path (SubGroupGatherLoad)
+//
+// When the result tensor uses a dot_op A DPAS encoding the fast-path emits
+// triton_gen.sub_group_gather_load instead of scalar predicated loads.
+// ---------------------------------------------------------------------------
+
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+// x_offsets live in a slice layout that removes the column (dim1) dimension so
+// that the same row index is broadcast to every column-thread in the warp.
+#slice_x = #ttg.slice<{dim = 1, parent = #dpas}>
+
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // FAST-LABEL: llvm.func spir_kernelcc @descriptor_gather_fast_path
+  tt.func public @descriptor_gather_fast_path(
+      %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %arg1: tensor<64xi32, #slice_x>,
+      %arg2: i32) -> tensor<64x32xf16, #dot0> {
+    %c1_i64 = arith.constant 1 : i64
+    %c256_i32 = arith.constant 256 : i32
+    %c32_i64 = arith.constant 32 : i64
+    // Descriptor block shape is 1×32 (one row, 32 cols).
+    %desc = tt.make_tensor_descriptor %arg0, [%c256_i32, %c256_i32], [%c32_i64, %c1_i64] : <f16>, <1x32xf16>
+
+    // Fast path emits SubGroupGatherLoadOp.
+    // FAST: triton_gen.sub_group_gather_load
+
+    %result = ttig.descriptor_gather %desc[%arg1, %arg2]
+        : (!tt.tensordesc<1x32xf16>, tensor<64xi32, #slice_x>, i32) -> tensor<64x32xf16, #dot0>
+    tt.return %result : tensor<64x32xf16, #dot0>
+  }
+}

--- a/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
+++ b/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
@@ -1,13 +1,14 @@
 // RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s
 
 // Test that ttig.descriptor_gather is lowered to LLVM correctly.
-// Two lowering paths are covered:
-//   1. Default fallback path: generates per-element predicated loads using
-//      pointer arithmetic computed from the descriptor's base/shape/stride.
-//   2. Fast path: generates triton_gen.sub_group_gather_load for DPAS dot_op A
-//      layouts that satisfy block-IO tile constraints.
+// The split-file tests below cover three cases:
+//   1. Fallback path when the gather cannot use the fast path. (no coalescing)
+//   2. Fast path when numPtrsPerLoad == threadsPerWarp, which lowers to
+//      per-lane predicated llvm.load operations on lane-mapped addresses. (Could be coalesced)
+//   3. Fast path when numPtrsPerLoad != threadsPerWarp, which lowers to
+//      triton_gen.sub_group_gather_load.
 
-// Test 1: Default fallback path
+// Test 1: Fallback path
 //
 // A blocked encoding that does not satisfy block-IO tile constraints falls
 // through to the default path which emits one predicated llvm.load per result
@@ -17,14 +18,79 @@
 //   → and with predY → cond_br → predicated llvm.load
 //   mul by stride0 → add with y linear offset → gep into base ptr
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
-#blocked_x = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [16], warpsPerCTA = [8], order = [0]}>
+#blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [1, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
+#slice_x = #ttg.slice<{dim = 1, parent = #blocked}>
 
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
   // CHECK-LABEL: llvm.func spir_kernelcc @descriptor_gather_default_path
   tt.func public @descriptor_gather_default_path(
       %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
-      %arg1: tensor<8xi32, #blocked_x>,
+      %arg1: tensor<8xi32, #slice_x>,
+      %arg2: i32) -> tensor<8x16xf16, #blocked> {
+    %c1_i64 = arith.constant 1 : i64
+    %c256_i32 = arith.constant 256 : i32
+    %c16_i64 = arith.constant 16 : i64
+    // Descriptor over a 2D matrix; block shape is 1×16 (one row, 16 cols).
+    %desc = tt.make_tensor_descriptor %arg0, [%c256_i32, %c256_i32], [%c16_i64, %c1_i64] : <f16>, <1x16xf16>
+
+    // Verify descriptor struct is built:
+    // CHECK:     llvm.insertvalue {{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+
+    // x_offsets tensor argument is unpacked to a scalar i32 per thread
+    // (comes before descriptor field extraction in the lowered output):
+    // CHECK:     %[[OFFX_I32:.*]] = llvm.extractvalue {{.*}} : !llvm.struct<(i32, i32)>
+
+    // Descriptor fields are extracted after the x_offsets unpack:
+    // CHECK-DAG: %[[SHAPE0:.*]] = llvm.extractvalue {{.*}}[0] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[STRIDE0:.*]] = llvm.extractvalue {{.*}}[2] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[BASE:.*]] = llvm.extractvalue {{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+
+    // Offset X data flow inside the per-element loop:
+    //   1. Widen offsetX from i32 to i64 for pointer arithmetic.
+    // CHECK:     %[[OFFX64:.*]] = llvm.zext %[[OFFX_I32]] : i32 to i64
+    //   2. Bounds check: offsetX < shape0 (predX).
+    // CHECK:     %[[PRED_X:.*]] = llvm.icmp "ult" %[[OFFX64]], %[[SHAPE0]] : i64
+    //   3. Combine predX with predY (offsetY < shape1) to form the load predicate.
+    // CHECK:     llvm.and %[[PRED_X]], {{.*}} : i1
+    //   4. Row linear offset: offsetX * stride0.
+    // CHECK:     %[[X_LIN_OFF:.*]] = llvm.mul %[[OFFX64]], %[[STRIDE0]] : i64
+    //   5. Combined linear offset (x + y) fed into the final GEP.
+    // CHECK:     %[[LIN_OFF:.*]] = llvm.add %[[X_LIN_OFF]], {{.*}} : i64
+    // CHECK:     llvm.getelementptr %[[BASE]][%[[LIN_OFF]]] {{.*}} -> !llvm.ptr<1>, f16
+    //   6. Predicated load: branch on the combined predicate.
+    // CHECK:     llvm.cond_br {{.*}}
+    // CHECK:     llvm.load {{.*}} : !llvm.ptr<1> -> vector<1xf16>
+    // Verify the fast path is NOT taken for the blocked encoding.
+    // CHECK-NOT: triton_gen.sub_group_gather_load
+
+    %result = ttig.descriptor_gather %desc[%arg1, %arg2]
+        : (!tt.tensordesc<1x16xf16>, tensor<8xi32, #slice_x>, i32) -> tensor<8x16xf16, #blocked>
+    tt.return %result : tensor<8x16xf16, #blocked>
+  }
+}
+
+// -----
+
+// Test 2: Fast path with numPtrsPerLoad == threadsPerWarp
+//
+// This shape satisfies the gather fast-path tile checks, but each pointer can
+// be mapped directly to one SIMD lane because numPtrsPerLoad matches
+// threadsPerWarp. The lowering therefore uses predicated llvm.load operations
+// on non-uniform per-lane addresses instead of triton_gen.sub_group_gather_load.
+// The test tracks the offset X data flow end-to-end:
+//   %arg1 (x_offsets tensor) → unpack → offsetX i32
+//   → zext i64 → bounds-check icmp against shape0
+//   → and with predY → cond_br → predicated llvm.load
+//   mul by stride0 → add with y linear offset → gep into base ptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
+#slice_x = #ttg.slice<{dim = 1, parent = #blocked}>
+
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @descriptor_gather_default_path
+  tt.func public @descriptor_gather_default_path(
+      %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %arg1: tensor<8xi32, #slice_x>,
       %arg2: i32) -> tensor<8x16xf16, #blocked> {
     %c1_i64 = arith.constant 1 : i64
     %c256_i32 = arith.constant 256 : i32
@@ -58,23 +124,26 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK:     llvm.getelementptr %[[BASE]][%[[LIN_OFF]]] {{.*}} -> !llvm.ptr<1>, f16
     //   6. Predicated load: branch on the combined predicate.
     // CHECK:     llvm.cond_br {{.*}}
-    // CHECK:     llvm.load {{.*}} : !llvm.ptr<1> -> f16
-    // Verify the fast path is NOT taken for the blocked encoding.
+    // CHECK:     llvm.load {{.*}} : !llvm.ptr<1> -> vector<1xf16>
+    // Verify the subgroup gather intrinsic is not used in the per-lane fast path.
     // CHECK-NOT: triton_gen.sub_group_gather_load
 
     %result = ttig.descriptor_gather %desc[%arg1, %arg2]
-        : (!tt.tensordesc<1x16xf16>, tensor<8xi32, #blocked_x>, i32) -> tensor<8x16xf16, #blocked>
+        : (!tt.tensordesc<1x16xf16>, tensor<8xi32, #slice_x>, i32) -> tensor<8x16xf16, #blocked>
     tt.return %result : tensor<8x16xf16, #blocked>
   }
 }
 
+
 // -----
 
-// Test 2: Fast path (SubGroupGatherLoad)
+// Test 3: Fast path with numPtrsPerLoad != threadsPerWarp
 //
-// When the result tensor uses a dot_op A DPAS encoding the fast-path emits
-// triton_gen.sub_group_gather_load instead of scalar predicated loads.
-// The test tracks the offset X data flow end-to-end:
+// This DPAS dot-op A layout satisfies the gather fast-path tile checks, and it
+// requires fewer pointer-producing lanes than threadsPerWarp. The lowering packs
+// the computed addresses and predicates into vectors and emits
+// triton_gen.sub_group_gather_load. The test tracks the offset X data flow
+// through the pointer-vector construction.
 //   %arg1 (x_offsets tensor) → unpack → shuffleIdx(lane 0 broadcast)
 //   → zext i64 → bounds-check icmp against shape0
 //   → mul against stride0 → second gep to build row-offset address
@@ -117,27 +186,149 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK:     %[[OFFX_15_I32F:.*]] = llvm.extractvalue %arg1[15] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
 
     // Descriptor fields are extracted after the x_offsets unpack:
-    // CHECK-DAG: %[[SHAPE0F:.*]] = llvm.extractvalue {{.*}}[0] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
-    // CHECK-DAG: %[[STRIDE0F:.*]] = llvm.extractvalue {{.*}}[2] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
-    // CHECK-DAG: %[[BASEF:.*]] = llvm.extractvalue {{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK:     %[[SHAPE_X:.*]] = llvm.extractvalue {{.*}}[0] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK:     %[[SHAPE_Y:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK:     %[[STRIDE_X:.*]] = llvm.extractvalue {{.*}}[2] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK:     %[[STRIDE_Y:.*]] = llvm.extractvalue {{.*}}[3] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK:     %[[BASEF:.*]] = llvm.extractvalue {{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+
+    // CHECK:     %[[BASE_OFFSET_Y:.*]] = llvm.add %arg2, {{.*}} : i32
 
     // Offset X data flow (fast path) inside the per-load inner loop:
-    //   1. Broadcast lane 0's row index to all threads in the sub-group.
     // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_0_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
-    //   2. Widen to i64 for 64-bit pointer arithmetic.
-    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
-    //   3. Bounds check: offsetX < shape0 (predX).
-    // CHECK:     %[[PRED_XF:.*]] = llvm.icmp "ult" %[[OFFX64F]], %[[SHAPE0F]] : i64
-    //   4. Row offset: offsetX * stride0.
-    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
-    //   5. Combine predX with predY (offsetY < shape1) to form the load predicate.
-    // CHECK:     llvm.and %[[PRED_XF]], {{.*}} : i1
-    //   6. First GEP advances by the constant y sub-offset; second GEP folds in
-    //      the row offset (X_OFF64F) derived from offsetX.
-    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr {{.*}}[{{.*}}] {{.*}} -> !llvm.ptr<1>, f16
-    // CHECK:     llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
-    //   7. Gather all 32 pointers and predicates into vectors for the gather load.
-    // CHECK:     triton_gen.sub_group_gather_load {{.*}} :  (vector<32xi64>, vector<32xi1>) -> vector<8xf16>
+    // Offset Y 0 for first row of the 8*4 load (sub-offset Y = 0, 4, 8, 12):
+    // CHECK:     %[[SUB_OFF_Y_0:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:     %[[OFF_Y:.*]] = llvm.add %[[BASE_OFFSET_Y]], %[[SUB_OFF_Y_0]] : i32
+    // CHECK:     %[[OFF_X_64:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[PRED_X:.*]] = llvm.icmp "ult" %[[OFF_X_64]], %[[SHAPE_X]] : i64
+    // CHECK:     %[[OFF_Y_64:.*]] = llvm.zext %[[OFF_Y]] : i32 to i64
+    // CHECK:     %[[PRED_Y:.*]] = llvm.icmp "ult" %[[OFF_Y_64]], %[[SHAPE_Y]] : i64
+    // CHECK:     %[[PRED:.*]] = llvm.and %[[PRED_X]], %[[PRED_Y]] : i1
+    // CHECK:     %[[LINEAR_OFF_X:.*]] = llvm.mul %[[OFF_X_64]], %[[STRIDE_X]] : i64
+    // CHECK:     %[[LINEAR_OFF_Y:.*]] = llvm.mul %[[OFF_Y_64]], %[[STRIDE_Y]] : i64
+    // CHECK:     %[[LINEAR_OFF:.*]] = llvm.add %[[LINEAR_OFF_X]], %[[LINEAR_OFF_Y]] : i64
+    // CHECK:     %[[PTR_0:.*]] = llvm.getelementptr %[[BASEF]]{{\[}}%[[LINEAR_OFF]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_0_I64:.*]] = llvm.ptrtoint %[[PTR_0]] : !llvm.ptr<1> to i64
+
+    // Offset Y 4 for first row of the 8*4 load (sub-offset Y = 0, 4, 8, 12):
+    // CHECK:     %[[SUB_OFF_Y_4:.*]] = llvm.mlir.constant(4 : i32) : i32
+    // CHECK:     %[[OFF_Y:.*]] = llvm.add %[[BASE_OFFSET_Y]], %[[SUB_OFF_Y_4]] : i32
+    // CHECK:     %[[OFF_X_64:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[PRED_X:.*]] = llvm.icmp "ult" %[[OFF_X_64]], %[[SHAPE_X]] : i64
+    // CHECK:     %[[OFF_Y_64:.*]] = llvm.zext %[[OFF_Y]] : i32 to i64
+    // CHECK:     %[[PRED_Y:.*]] = llvm.icmp "ult" %[[OFF_Y_64]], %[[SHAPE_Y]] : i64
+    // CHECK:     %[[PRED:.*]] = llvm.and %[[PRED_X]], %[[PRED_Y]] : i1
+    // CHECK:     %[[LINEAR_OFF_X:.*]] = llvm.mul %[[OFF_X_64]], %[[STRIDE_X]] : i64
+    // CHECK:     %[[LINEAR_OFF_Y:.*]] = llvm.mul %[[OFF_Y_64]], %[[STRIDE_Y]] : i64
+    // CHECK:     %[[LINEAR_OFF:.*]] = llvm.add %[[LINEAR_OFF_X]], %[[LINEAR_OFF_Y]] : i64
+    // CHECK:     %[[PTR_1:.*]] = llvm.getelementptr %[[BASEF]]{{\[}}%[[LINEAR_OFF]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_1_I64:.*]] = llvm.ptrtoint %[[PTR_1]] : !llvm.ptr<1> to i64
+
+    // Offset Y 8 for first row of the 8*4 load (sub-offset Y = 0, 4, 8, 12):
+    // CHECK:     %[[SUB_OFF_Y_8:.*]] = llvm.mlir.constant(8 : i32) : i32
+    // CHECK:     %[[OFF_Y:.*]] = llvm.add %[[BASE_OFFSET_Y]], %[[SUB_OFF_Y_8]] : i32
+    // CHECK:     %[[OFF_X_64:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[PRED_X:.*]] = llvm.icmp "ult" %[[OFF_X_64]], %[[SHAPE_X]] : i64
+    // CHECK:     %[[OFF_Y_64:.*]] = llvm.zext %[[OFF_Y]] : i32 to i64
+    // CHECK:     %[[PRED_Y:.*]] = llvm.icmp "ult" %[[OFF_Y_64]], %[[SHAPE_Y]] : i64
+    // CHECK:     %[[PRED:.*]] = llvm.and %[[PRED_X]], %[[PRED_Y]] : i1
+    // CHECK:     %[[LINEAR_OFF_X:.*]] = llvm.mul %[[OFF_X_64]], %[[STRIDE_X]] : i64
+    // CHECK:     %[[LINEAR_OFF_Y:.*]] = llvm.mul %[[OFF_Y_64]], %[[STRIDE_Y]] : i64
+    // CHECK:     %[[LINEAR_OFF:.*]] = llvm.add %[[LINEAR_OFF_X]], %[[LINEAR_OFF_Y]] : i64
+    // CHECK:     %[[PTR_2:.*]] = llvm.getelementptr %[[BASEF]]{{\[}}%[[LINEAR_OFF]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_2_I64:.*]] = llvm.ptrtoint %[[PTR_2]] : !llvm.ptr<1> to i64
+
+    // Offset Y 12 for first row of the 8*4 load (sub-offset Y = 0, 4, 8, 12):
+    // CHECK:     %[[SUB_OFF_Y_12:.*]] = llvm.mlir.constant(12 : i32) : i32
+    // CHECK:     %[[OFF_Y:.*]] = llvm.add %[[BASE_OFFSET_Y]], %[[SUB_OFF_Y_12]] : i32
+    // CHECK:     %[[OFF_X_64:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[PRED_X:.*]] = llvm.icmp "ult" %[[OFF_X_64]], %[[SHAPE_X]] : i64
+    // CHECK:     %[[OFF_Y_64:.*]] = llvm.zext %[[OFF_Y]] : i32 to i64
+    // CHECK:     %[[PRED_Y:.*]] = llvm.icmp "ult" %[[OFF_Y_64]], %[[SHAPE_Y]] : i64
+    // CHECK:     %[[PRED:.*]] = llvm.and %[[PRED_X]], %[[PRED_Y]] : i1
+    // CHECK:     %[[LINEAR_OFF_X:.*]] = llvm.mul %[[OFF_X_64]], %[[STRIDE_X]] : i64
+    // CHECK:     %[[LINEAR_OFF_Y:.*]] = llvm.mul %[[OFF_Y_64]], %[[STRIDE_Y]] : i64
+    // CHECK:     %[[LINEAR_OFF:.*]] = llvm.add %[[LINEAR_OFF_X]], %[[LINEAR_OFF_Y]] : i64
+    // CHECK:     %[[PTR_3:.*]] = llvm.getelementptr %[[BASEF]]{{\[}}%[[LINEAR_OFF]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_3_I64:.*]] = llvm.ptrtoint %[[PTR_3]] : !llvm.ptr<1> to i64
+
+    // COM: The offset X data flow is repeated for the next 7 rows of the 8*4 load:
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_1_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_2_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_3_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_4_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_5_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_6_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_7_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+
+    // COMM:  Gather all 32 pointers and predicates into vectors for the gather load.
+    // CHECK:     triton_gen.sub_group_gather_load {{.*}}, {{.*}} :  (vector<32xi64>, vector<32xi1>) -> vector<8xf16>
+
+    // COM: load for sub-offset Y from 16 to 28.
+    // CHECK:     triton_gen.sub_group_gather_load {{.*}}, {{.*}} :  (vector<32xi64>, vector<32xi1>) -> vector<8xf16>
+
+    // COM: load for offset X index from 8 to 15, sub-offset Y from 0 to 12.
+    // CHECK:     triton_gen.sub_group_gather_load {{.*}}, {{.*}} :  (vector<32xi64>, vector<32xi1>) -> vector<8xf16>
+
+    // COM: load for offset X index from 8 to 15, sub-offset Y from 16 to 28.
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_8_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // Offset Y 16 for first row of the 8*4 load (sub-offset Y = 16, 20, 24, 28):
+    // CHECK:     %[[SUB_OFF_Y_0:.*]] = llvm.mlir.constant(16 : i32) : i32
+    // CHECK:     %[[OFF_Y:.*]] = llvm.add %[[BASE_OFFSET_Y]], %[[SUB_OFF_Y_0]] : i32
+    // CHECK:     %[[OFF_X_64:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[PRED_X:.*]] = llvm.icmp "ult" %[[OFF_X_64]], %[[SHAPE_X]] : i64
+    // CHECK:     %[[OFF_Y_64:.*]] = llvm.zext %[[OFF_Y]] : i32 to i64
+    // CHECK:     %[[PRED_Y:.*]] = llvm.icmp "ult" %[[OFF_Y_64]], %[[SHAPE_Y]] : i64
+    // CHECK:     %[[PRED:.*]] = llvm.and %[[PRED_X]], %[[PRED_Y]] : i1
+    // CHECK:     %[[LINEAR_OFF_X:.*]] = llvm.mul %[[OFF_X_64]], %[[STRIDE_X]] : i64
+    // CHECK:     %[[LINEAR_OFF_Y:.*]] = llvm.mul %[[OFF_Y_64]], %[[STRIDE_Y]] : i64
+    // CHECK:     %[[LINEAR_OFF:.*]] = llvm.add %[[LINEAR_OFF_X]], %[[LINEAR_OFF_Y]] : i64
+    // CHECK:     %[[PTR_0:.*]] = llvm.getelementptr %[[BASEF]]{{\[}}%[[LINEAR_OFF]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_0_I64:.*]] = llvm.ptrtoint %[[PTR_0]] : !llvm.ptr<1> to i64
+
+    // Offset Y 20 for first row of the 8*4 load (sub-offset Y = 16, 20, 24, 28):
+    // CHECK:     %[[SUB_OFF_Y_4:.*]] = llvm.mlir.constant(20 : i32) : i32
+    // CHECK:     %[[OFF_Y:.*]] = llvm.add %[[BASE_OFFSET_Y]], %[[SUB_OFF_Y_4]] : i32
+    // CHECK:     %[[OFF_X_64:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[PRED_X:.*]] = llvm.icmp "ult" %[[OFF_X_64]], %[[SHAPE_X]] : i64
+    // CHECK:     %[[OFF_Y_64:.*]] = llvm.zext %[[OFF_Y]] : i32 to i64
+    // CHECK:     %[[PRED_Y:.*]] = llvm.icmp "ult" %[[OFF_Y_64]], %[[SHAPE_Y]] : i64
+    // CHECK:     %[[PRED:.*]] = llvm.and %[[PRED_X]], %[[PRED_Y]] : i1
+    // CHECK:     %[[LINEAR_OFF_X:.*]] = llvm.mul %[[OFF_X_64]], %[[STRIDE_X]] : i64
+    // CHECK:     %[[LINEAR_OFF_Y:.*]] = llvm.mul %[[OFF_Y_64]], %[[STRIDE_Y]] : i64
+    // CHECK:     %[[LINEAR_OFF:.*]] = llvm.add %[[LINEAR_OFF_X]], %[[LINEAR_OFF_Y]] : i64
+    // CHECK:     %[[PTR_1:.*]] = llvm.getelementptr %[[BASEF]]{{\[}}%[[LINEAR_OFF]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_1_I64:.*]] = llvm.ptrtoint %[[PTR_1]] : !llvm.ptr<1> to i64
+
+    // Offset Y 24 for first row of the 8*4 load (sub-offset Y = 16, 20, 24, 28):
+    // CHECK:     %[[SUB_OFF_Y_8:.*]] = llvm.mlir.constant(24 : i32) : i32
+    // CHECK:     %[[OFF_Y:.*]] = llvm.add %[[BASE_OFFSET_Y]], %[[SUB_OFF_Y_8]] : i32
+    // CHECK:     %[[OFF_X_64:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[PRED_X:.*]] = llvm.icmp "ult" %[[OFF_X_64]], %[[SHAPE_X]] : i64
+    // CHECK:     %[[OFF_Y_64:.*]] = llvm.zext %[[OFF_Y]] : i32 to i64
+    // CHECK:     %[[PRED_Y:.*]] = llvm.icmp "ult" %[[OFF_Y_64]], %[[SHAPE_Y]] : i64
+    // CHECK:     %[[PRED:.*]] = llvm.and %[[PRED_X]], %[[PRED_Y]] : i1
+    // CHECK:     %[[LINEAR_OFF_X:.*]] = llvm.mul %[[OFF_X_64]], %[[STRIDE_X]] : i64
+    // CHECK:     %[[LINEAR_OFF_Y:.*]] = llvm.mul %[[OFF_Y_64]], %[[STRIDE_Y]] : i64
+    // CHECK:     %[[LINEAR_OFF:.*]] = llvm.add %[[LINEAR_OFF_X]], %[[LINEAR_OFF_Y]] : i64
+    // CHECK:     %[[PTR_2:.*]] = llvm.getelementptr %[[BASEF]]{{\[}}%[[LINEAR_OFF]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_2_I64:.*]] = llvm.ptrtoint %[[PTR_2]] : !llvm.ptr<1> to i64
+
+    // Offset Y 28 for first row of the 8*4 load (sub-offset Y = 16, 20, 24, 28):
+    // CHECK:     %[[SUB_OFF_Y_12:.*]] = llvm.mlir.constant(28 : i32) : i32
+    // CHECK:     %[[OFF_Y:.*]] = llvm.add %[[BASE_OFFSET_Y]], %[[SUB_OFF_Y_12]] : i32
+    // CHECK:     %[[OFF_X_64:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[PRED_X:.*]] = llvm.icmp "ult" %[[OFF_X_64]], %[[SHAPE_X]] : i64
+    // CHECK:     %[[OFF_Y_64:.*]] = llvm.zext %[[OFF_Y]] : i32 to i64
+    // CHECK:     %[[PRED_Y:.*]] = llvm.icmp "ult" %[[OFF_Y_64]], %[[SHAPE_Y]] : i64
+    // CHECK:     %[[PRED:.*]] = llvm.and %[[PRED_X]], %[[PRED_Y]] : i1
+    // CHECK:     %[[LINEAR_OFF_X:.*]] = llvm.mul %[[OFF_X_64]], %[[STRIDE_X]] : i64
+    // CHECK:     %[[LINEAR_OFF_Y:.*]] = llvm.mul %[[OFF_Y_64]], %[[STRIDE_Y]] : i64
+    // CHECK:     %[[LINEAR_OFF:.*]] = llvm.add %[[LINEAR_OFF_X]], %[[LINEAR_OFF_Y]] : i64
+    // CHECK:     %[[PTR_3:.*]] = llvm.getelementptr %[[BASEF]]{{\[}}%[[LINEAR_OFF]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_3_I64:.*]] = llvm.ptrtoint %[[PTR_3]] : !llvm.ptr<1> to i64
+
+    // CHECK:     triton_gen.sub_group_gather_load {{.*}}, {{.*}} :  (vector<32xi64>, vector<32xi1>) -> vector<8xf16>
 
     %result = ttig.descriptor_gather %desc[%arg1, %arg2]
         : (!tt.tensordesc<1x32xf16>, tensor<64xi32, #slice_x>, i32) -> tensor<64x32xf16, #dot0>

--- a/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
+++ b/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
@@ -99,7 +99,22 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     %desc = tt.make_tensor_descriptor %arg0, [%c256_i32, %c256_i32], [%c32_i64, %c1_i64] : <f16>, <1x32xf16>
 
     // x_offsets tensor argument is unpacked first (before descriptor fields):
-    // CHECK:     %[[OFFX_I32F:.*]] = llvm.extractvalue {{.*}} : !llvm.struct<(i32)>
+    // CHECK:     %[[OFFX_0_I32F:.*]] = llvm.extractvalue %arg1[0] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+    // CHECK:     %[[OFFX_1_I32F:.*]] = llvm.extractvalue %arg1[1] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+    // CHECK:     %[[OFFX_2_I32F:.*]] = llvm.extractvalue %arg1[2] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+    // CHECK:     %[[OFFX_3_I32F:.*]] = llvm.extractvalue %arg1[3] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+    // CHECK:     %[[OFFX_4_I32F:.*]] = llvm.extractvalue %arg1[4] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+    // CHECK:     %[[OFFX_5_I32F:.*]] = llvm.extractvalue %arg1[5] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+    // CHECK:     %[[OFFX_6_I32F:.*]] = llvm.extractvalue %arg1[6] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+    // CHECK:     %[[OFFX_7_I32F:.*]] = llvm.extractvalue %arg1[7] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+    // CHECK:     %[[OFFX_8_I32F:.*]] = llvm.extractvalue %arg1[8] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+    // CHECK:     %[[OFFX_9_I32F:.*]] = llvm.extractvalue %arg1[9] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+    // CHECK:     %[[OFFX_10_I32F:.*]] = llvm.extractvalue %arg1[10] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+    // CHECK:     %[[OFFX_11_I32F:.*]] = llvm.extractvalue %arg1[11] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+    // CHECK:     %[[OFFX_12_I32F:.*]] = llvm.extractvalue %arg1[12] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+    // CHECK:     %[[OFFX_13_I32F:.*]] = llvm.extractvalue %arg1[13] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+    // CHECK:     %[[OFFX_14_I32F:.*]] = llvm.extractvalue %arg1[14] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+    // CHECK:     %[[OFFX_15_I32F:.*]] = llvm.extractvalue %arg1[15] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
 
     // Descriptor fields are extracted after the x_offsets unpack:
     // CHECK-DAG: %[[SHAPE0F:.*]] = llvm.extractvalue {{.*}}[0] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
@@ -108,7 +123,7 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
 
     // Offset X data flow (fast path) inside the per-load inner loop:
     //   1. Broadcast lane 0's row index to all threads in the sub-group.
-    // CHECK:     %[[OFFX_UNIF:.*]] = triton_gen.sub_group_shuffle {{.*}} %[[OFFX_I32F]], {{.*}} : i32
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_0_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
     //   2. Widen to i64 for 64-bit pointer arithmetic.
     // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
     //   3. Bounds check: offsetX < shape0 (predX).
@@ -122,7 +137,7 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr {{.*}}[{{.*}}] {{.*}} -> !llvm.ptr<1>, f16
     // CHECK:     llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
     //   7. Gather all 32 pointers and predicates into vectors for the gather load.
-    // CHECK:     triton_gen.sub_group_gather_load {{.*}} : vector<{{.*}}>
+    // CHECK:     triton_gen.sub_group_gather_load {{.*}} :  (vector<32xi64>, vector<32xi1>) -> vector<8xf16>
 
     %result = ttig.descriptor_gather %desc[%arg1, %arg2]
         : (!tt.tensordesc<1x32xf16>, tensor<64xi32, #slice_x>, i32) -> tensor<64x32xf16, #dot0>

--- a/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
+++ b/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
@@ -129,4 +129,3 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     tt.return %result : tensor<64x32xf16, #dot0>
   }
 }
-

--- a/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
+++ b/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
@@ -1,5 +1,4 @@
 // RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s
-// RUN: env TRITON_INTEL_ENABLE_BLOCK_IO_ALL_LAYOUTS=1 triton-opt %s -split-input-file --tritonintelgpu-lower-to-2d-block-load --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s --check-prefix=FAST
 
 // Test that ttig.descriptor_gather is lowered to LLVM correctly.
 // Two lowering paths are covered:
@@ -8,13 +7,11 @@
 //   2. Fast path: generates triton_gen.sub_group_gather_load for DPAS dot_op A
 //      layouts that satisfy block-IO tile constraints.
 
-// ---------------------------------------------------------------------------
 // Test 1: Default fallback path
 //
 // A blocked encoding that does not satisfy block-IO tile constraints falls
 // through to the default path which emits one predicated llvm.load per result
 // element.
-// ---------------------------------------------------------------------------
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked_x = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [16], warpsPerCTA = [8], order = [0]}>
@@ -59,12 +56,10 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
 
 // -----
 
-// ---------------------------------------------------------------------------
 // Test 2: Fast path (SubGroupGatherLoad)
 //
 // When the result tensor uses a dot_op A DPAS encoding the fast-path emits
 // triton_gen.sub_group_gather_load instead of scalar predicated loads.
-// ---------------------------------------------------------------------------
 
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
@@ -85,7 +80,7 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     %desc = tt.make_tensor_descriptor %arg0, [%c256_i32, %c256_i32], [%c32_i64, %c1_i64] : <f16>, <1x32xf16>
 
     // Fast path emits SubGroupGatherLoadOp.
-    // FAST: triton_gen.sub_group_gather_load
+    // CHECK: triton_gen.sub_group_gather_load
 
     %result = ttig.descriptor_gather %desc[%arg1, %arg2]
         : (!tt.tensordesc<1x32xf16>, tensor<64xi32, #slice_x>, i32) -> tensor<64x32xf16, #dot0>

--- a/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
+++ b/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
@@ -117,9 +117,11 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK:     %[[OFFX_15_I32F:.*]] = llvm.extractvalue %arg1[15] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
 
     // Descriptor fields are extracted after the x_offsets unpack:
-    // CHECK-DAG: %[[SHAPE0F:.*]] = llvm.extractvalue {{.*}}[0] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
-    // CHECK-DAG: %[[STRIDE0F:.*]] = llvm.extractvalue {{.*}}[2] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
-    // CHECK-DAG: %[[BASEF:.*]] = llvm.extractvalue {{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK:     %[[SHAPE0F:.*]] = llvm.extractvalue {{.*}}[0] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK:     %[[STRIDE0F:.*]] = llvm.extractvalue {{.*}}[2] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK:     %[[BASEF:.*]] = llvm.extractvalue {{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK:     %[[BASE_WITH_OFF_Y:.*]] = llvm.getelementptr %[[BASEF]]{{\[}}%arg2{{\]}} : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, f16
+
 
     // Offset X data flow (fast path) inside the per-load inner loop:
     //   1. Broadcast lane 0's row index to all threads in the sub-group.
@@ -134,10 +136,210 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK:     llvm.and %[[PRED_XF]], {{.*}} : i1
     //   6. First GEP advances by the constant y sub-offset; second GEP folds in
     //      the row offset (X_OFF64F) derived from offsetX.
-    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr {{.*}}[{{.*}}] {{.*}} -> !llvm.ptr<1>, f16
-    // CHECK:     llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[SUB_OFF_Y_0:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_0]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_0:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_0_I64:.*]] = llvm.ptrtoint %[[PTR_0]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_1_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_4:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_4_I64:.*]] = llvm.ptrtoint %[[PTR_4]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_2_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_8:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_8_I64:.*]] = llvm.ptrtoint %[[PTR_8]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_3_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_12:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_12_I64:.*]] = llvm.ptrtoint %[[PTR_12]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_4_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_16:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_16_I64:.*]] = llvm.ptrtoint %[[PTR_16]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_5_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_20:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_20_I64:.*]] = llvm.ptrtoint %[[PTR_20]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_6_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_24:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_24_I64:.*]] = llvm.ptrtoint %[[PTR_24]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_7_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_28:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_28_I64:.*]] = llvm.ptrtoint %[[PTR_28]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_7_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(4 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_29:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_29_I64:.*]] = llvm.ptrtoint %[[PTR_29]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_7_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(8 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_30:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_30_I64:.*]] = llvm.ptrtoint %[[PTR_30]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_7_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(12 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_31:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_31_I64:.*]] = llvm.ptrtoint %[[PTR_31]] : !llvm.ptr<1> to i64
+
+    // CHECK:      llvm.insertelement %[[PTR_0_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      llvm.insertelement %[[PTR_4_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      llvm.insertelement %[[PTR_8_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      llvm.insertelement %[[PTR_16_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      llvm.insertelement %[[PTR_20_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      llvm.insertelement %[[PTR_24_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      llvm.insertelement %[[PTR_28_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      llvm.insertelement %[[PTR_29_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      llvm.insertelement %[[PTR_30_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      %[[VECTOR_OF_PTR:.*]] = llvm.insertelement %[[PTR_31_I64]], {{.*}} : vector<32xi64>
     //   7. Gather all 32 pointers and predicates into vectors for the gather load.
-    // CHECK:     triton_gen.sub_group_gather_load {{.*}} :  (vector<32xi64>, vector<32xi1>) -> vector<8xf16>
+    // CHECK:     triton_gen.sub_group_gather_load %[[VECTOR_OF_PTR]], {{.*}} :  (vector<32xi64>, vector<32xi1>) -> vector<8xf16>
+
+    // COM: load for sub-offset Y from 16 to 28.
+    // CHECK:     triton_gen.sub_group_gather_load {{.*}}, {{.*}} :  (vector<32xi64>, vector<32xi1>) -> vector<8xf16>
+
+    // COM: load for offset X index from 8 to 15, sub-offset Y from 0 to 12.
+    // CHECK:     triton_gen.sub_group_gather_load {{.*}}, {{.*}} :  (vector<32xi64>, vector<32xi1>) -> vector<8xf16>
+
+    // COM: load for offset X index from 8 to 15, sub-offset Y from 16 to 28.
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_8_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(16 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_0:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_0_I64:.*]] = llvm.ptrtoint %[[PTR_0]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_9_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(16 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_4:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_4_I64:.*]] = llvm.ptrtoint %[[PTR_4]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_10_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(16 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_8:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_8_I64:.*]] = llvm.ptrtoint %[[PTR_8]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_11_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(16 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_12:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_12_I64:.*]] = llvm.ptrtoint %[[PTR_12]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_12_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(16 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_16:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_16_I64:.*]] = llvm.ptrtoint %[[PTR_16]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_13_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(16 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_20:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_20_I64:.*]] = llvm.ptrtoint %[[PTR_20]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_14_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(16 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_24:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_24_I64:.*]] = llvm.ptrtoint %[[PTR_24]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_15_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(16 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_28:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_28_I64:.*]] = llvm.ptrtoint %[[PTR_28]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_15_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(20 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_29:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_29_I64:.*]] = llvm.ptrtoint %[[PTR_29]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_15_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(24 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_30:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_30_I64:.*]] = llvm.ptrtoint %[[PTR_30]] : !llvm.ptr<1> to i64
+
+    // CHECK:     %[[OFFX_UNIF:.*]] = llvm.call spir_funccc @_Z17sub_group_shuffleij(%[[OFFX_15_I32F]], {{.*}}) {convergent, no_unwind, will_return} : (i32, i32) -> i32
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    // CHECK:     %[[SUB_OFF_Y_1:.*]] = llvm.mlir.constant(28 : i32) : i32
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr %[[BASE_WITH_OFF_Y]]{{\[}}%[[SUB_OFF_Y_1]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_31:.*]] = llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     %[[PTR_31_I64:.*]] = llvm.ptrtoint %[[PTR_31]] : !llvm.ptr<1> to i64
+
+    // CHECK:      llvm.insertelement %[[PTR_0_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      llvm.insertelement %[[PTR_4_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      llvm.insertelement %[[PTR_8_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      llvm.insertelement %[[PTR_16_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      llvm.insertelement %[[PTR_20_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      llvm.insertelement %[[PTR_24_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      llvm.insertelement %[[PTR_28_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      llvm.insertelement %[[PTR_29_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      llvm.insertelement %[[PTR_30_I64]], {{.*}} : vector<32xi64>
+    // CHECK:      %[[VECTOR_OF_PTR:.*]] = llvm.insertelement %[[PTR_31_I64]], {{.*}} : vector<32xi64>
+    // CHECK:     triton_gen.sub_group_gather_load %[[VECTOR_OF_PTR]], {{.*}} :  (vector<32xi64>, vector<32xi1>) -> vector<8xf16>
 
     %result = ttig.descriptor_gather %desc[%arg1, %arg2]
         : (!tt.tensordesc<1x32xf16>, tensor<64xi32, #slice_x>, i32) -> tensor<64x32xf16, #dot0>

--- a/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
+++ b/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
@@ -59,6 +59,8 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     //   6. Predicated load: branch on the combined predicate.
     // CHECK:     llvm.cond_br {{.*}}
     // CHECK:     llvm.load {{.*}} : !llvm.ptr<1> -> f16
+    // Verify the fast path is NOT taken for the blocked encoding.
+    // CHECK-NOT: triton_gen.sub_group_gather_load
 
     %result = ttig.descriptor_gather %desc[%arg1, %arg2]
         : (!tt.tensordesc<1x16xf16>, tensor<8xi32, #blocked_x>, i32) -> tensor<8x16xf16, #blocked>

--- a/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
+++ b/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
@@ -11,7 +11,11 @@
 //
 // A blocked encoding that does not satisfy block-IO tile constraints falls
 // through to the default path which emits one predicated llvm.load per result
-// element.
+// element.  The test tracks the offset X data flow end-to-end:
+//   %arg1 (x_offsets tensor) → unpack → offsetX i32
+//   → zext i64 → bounds-check icmp against shape0
+//   → and with predY → cond_br → predicated llvm.load
+//   mul by stride0 → add with y linear offset → gep into base ptr
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked_x = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [16], warpsPerCTA = [8], order = [0]}>
@@ -29,24 +33,32 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     %desc = tt.make_tensor_descriptor %arg0, [%c256_i32, %c256_i32], [%c16_i64, %c1_i64] : <f16>, <1x16xf16>
 
     // Verify descriptor struct is built:
-    // CHECK: llvm.insertvalue {{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK:     llvm.insertvalue {{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
 
-    // Verify descriptor fields are extracted:
+    // x_offsets tensor argument is unpacked to a scalar i32 per thread
+    // (comes before descriptor field extraction in the lowered output):
+    // CHECK:     %[[OFFX_I32:.*]] = llvm.extractvalue {{.*}} : !llvm.struct<(i32)>
+
+    // Descriptor fields are extracted after the x_offsets unpack:
     // CHECK-DAG: %[[SHAPE0:.*]] = llvm.extractvalue {{.*}}[0] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
-    // CHECK-DAG: %[[SHAPE1:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[STRIDE0:.*]] = llvm.extractvalue {{.*}}[2] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
     // CHECK-DAG: %[[BASE:.*]] = llvm.extractvalue {{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
 
-    // Fast path must NOT be used for this blocked layout (checked before the
-    // first predicated-load pattern so the scope is anchored correctly):
-    // CHECK-NOT: triton_gen.sub_group_gather_load
-
-    // Verify that bounds checks are generated for both dimensions:
-    // CHECK: llvm.icmp "ult" {{.*}} : i64
-    // CHECK: llvm.icmp "ult" {{.*}} : i64
-
-    // Verify predicated load block structure:
-    // CHECK: llvm.cond_br {{.*}}
-    // CHECK: llvm.load {{.*}} : !llvm.ptr<1> -> f16
+    // Offset X data flow inside the per-element loop:
+    //   1. Widen offsetX from i32 to i64 for pointer arithmetic.
+    // CHECK:     %[[OFFX64:.*]] = llvm.zext %[[OFFX_I32]] : i32 to i64
+    //   2. Bounds check: offsetX < shape0 (predX).
+    // CHECK:     %[[PRED_X:.*]] = llvm.icmp "ult" %[[OFFX64]], %[[SHAPE0]] : i64
+    //   3. Combine predX with predY (offsetY < shape1) to form the load predicate.
+    // CHECK:     llvm.and %[[PRED_X]], {{.*}} : i1
+    //   4. Row linear offset: offsetX * stride0.
+    // CHECK:     %[[X_LIN_OFF:.*]] = llvm.mul %[[OFFX64]], %[[STRIDE0]] : i64
+    //   5. Combined linear offset (x + y) fed into the final GEP.
+    // CHECK:     %[[LIN_OFF:.*]] = llvm.add %[[X_LIN_OFF]], {{.*}} : i64
+    // CHECK:     llvm.getelementptr %[[BASE]][%[[LIN_OFF]]] {{.*}} -> !llvm.ptr<1>, f16
+    //   6. Predicated load: branch on the combined predicate.
+    // CHECK:     llvm.cond_br {{.*}}
+    // CHECK:     llvm.load {{.*}} : !llvm.ptr<1> -> f16
 
     %result = ttig.descriptor_gather %desc[%arg1, %arg2]
         : (!tt.tensordesc<1x16xf16>, tensor<8xi32, #blocked_x>, i32) -> tensor<8x16xf16, #blocked>
@@ -60,6 +72,11 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
 //
 // When the result tensor uses a dot_op A DPAS encoding the fast-path emits
 // triton_gen.sub_group_gather_load instead of scalar predicated loads.
+// The test tracks the offset X data flow end-to-end:
+//   %arg1 (x_offsets tensor) → unpack → shuffleIdx(lane 0 broadcast)
+//   → zext i64 → bounds-check icmp against shape0
+//   → mul against stride0 → second gep to build row-offset address
+//   → address inserted into a vector → sub_group_gather_load
 
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
@@ -68,7 +85,7 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
 #slice_x = #ttg.slice<{dim = 1, parent = #dpas}>
 
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  // FAST-LABEL: llvm.func spir_kernelcc @descriptor_gather_fast_path
+  // CHECK-LABEL: llvm.func spir_kernelcc @descriptor_gather_fast_path
   tt.func public @descriptor_gather_fast_path(
       %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
       %arg1: tensor<64xi32, #slice_x>,
@@ -79,11 +96,35 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
     // Descriptor block shape is 1×32 (one row, 32 cols).
     %desc = tt.make_tensor_descriptor %arg0, [%c256_i32, %c256_i32], [%c32_i64, %c1_i64] : <f16>, <1x32xf16>
 
-    // Fast path emits SubGroupGatherLoadOp.
-    // CHECK: triton_gen.sub_group_gather_load
+    // x_offsets tensor argument is unpacked first (before descriptor fields):
+    // CHECK:     %[[OFFX_I32F:.*]] = llvm.extractvalue {{.*}} : !llvm.struct<(i32)>
+
+    // Descriptor fields are extracted after the x_offsets unpack:
+    // CHECK-DAG: %[[SHAPE0F:.*]] = llvm.extractvalue {{.*}}[0] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[STRIDE0F:.*]] = llvm.extractvalue {{.*}}[2] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+    // CHECK-DAG: %[[BASEF:.*]] = llvm.extractvalue {{.*}}[4] : !llvm.struct<(i64, i64, i64, i64, ptr<1>)>
+
+    // Offset X data flow (fast path) inside the per-load inner loop:
+    //   1. Broadcast lane 0's row index to all threads in the sub-group.
+    // CHECK:     %[[OFFX_UNIF:.*]] = triton_gen.sub_group_shuffle {{.*}} %[[OFFX_I32F]], {{.*}} : i32
+    //   2. Widen to i64 for 64-bit pointer arithmetic.
+    // CHECK:     %[[OFFX64F:.*]] = llvm.zext %[[OFFX_UNIF]] : i32 to i64
+    //   3. Bounds check: offsetX < shape0 (predX).
+    // CHECK:     %[[PRED_XF:.*]] = llvm.icmp "ult" %[[OFFX64F]], %[[SHAPE0F]] : i64
+    //   4. Row offset: offsetX * stride0.
+    // CHECK:     %[[X_OFF64F:.*]] = llvm.mul %[[OFFX64F]], %[[STRIDE0F]] : i64
+    //   5. Combine predX with predY (offsetY < shape1) to form the load predicate.
+    // CHECK:     llvm.and %[[PRED_XF]], {{.*}} : i1
+    //   6. First GEP advances by the constant y sub-offset; second GEP folds in
+    //      the row offset (X_OFF64F) derived from offsetX.
+    // CHECK:     %[[INNER_PTR:.*]] = llvm.getelementptr {{.*}}[{{.*}}] {{.*}} -> !llvm.ptr<1>, f16
+    // CHECK:     llvm.getelementptr %[[INNER_PTR]][%[[X_OFF64F]]] {{.*}} -> !llvm.ptr<1>, f16
+    //   7. Gather all 32 pointers and predicates into vectors for the gather load.
+    // CHECK:     triton_gen.sub_group_gather_load {{.*}} : vector<{{.*}}>
 
     %result = ttig.descriptor_gather %desc[%arg1, %arg2]
         : (!tt.tensordesc<1x32xf16>, tensor<64xi32, #slice_x>, i32) -> tensor<64x32xf16, #dot0>
     tt.return %result : tensor<64x32xf16, #dot0>
   }
 }
+

--- a/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
+++ b/test/TritonIntelGPU/descriptor-gather-to-llvm.mlir
@@ -87,8 +87,8 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
 #slice_x = #ttg.slice<{dim = 1, parent = #blocked}>
 
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  // CHECK-LABEL: llvm.func spir_kernelcc @descriptor_gather_default_path
-  tt.func public @descriptor_gather_default_path(
+  // CHECK-LABEL: llvm.func spir_kernelcc @descriptor_gather_fast_path_nonuniform_ptrs
+  tt.func public @descriptor_gather_fast_path_nonuniform_ptrs(
       %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
       %arg1: tensor<8xi32, #slice_x>,
       %arg2: i32) -> tensor<8x16xf16, #blocked> {
@@ -140,8 +140,8 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
 // Test 3: Fast path with numPtrsPerLoad != threadsPerWarp
 //
 // This DPAS dot-op A layout satisfies the gather fast-path tile checks, and it
-// requires fewer pointer-producing lanes than threadsPerWarp. The lowering packs
-// the computed addresses and predicates into vectors and emits
+// requires more number of pointers per load than threadsPerWarp. The lowering packs
+// the computed uniform addresses and predicates into vectors and emits
 // triton_gen.sub_group_gather_load. The test tracks the offset X data flow
 // through the pointer-vector construction.
 //   %arg1 (x_offsets tensor) → unpack → shuffleIdx(lane 0 broadcast)
@@ -156,8 +156,8 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32}
 #slice_x = #ttg.slice<{dim = 1, parent = #dpas}>
 
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  // CHECK-LABEL: llvm.func spir_kernelcc @descriptor_gather_fast_path
-  tt.func public @descriptor_gather_fast_path(
+  // CHECK-LABEL: llvm.func spir_kernelcc @descriptor_gather_fast_path_uniform_ptrs
+  tt.func public @descriptor_gather_fast_path_uniform_ptrs(
       %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
       %arg1: tensor<64xi32, #slice_x>,
       %arg2: i32) -> tensor<64x32xf16, #dot0> {

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2319,12 +2319,9 @@ private:
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     auto typeConverter = getTypeConverter();
     MLIRContext *ctx = rewriter.getContext();
-    // Get the descriptor and indices
+    // Get the descriptor and indices (no IR generated yet).
     Value llDesc = adaptor.getDesc();
-    SmallVector<Value> offsetsX =
-        unpackLLElements(loc, adaptor.getXOffsets(), rewriter);
     RankedTensorType offXTy = op.getXOffsets().getType();
-
     Value offsetY = adaptor.getYOffset();
     // Get result type information
     auto resultType = cast<RankedTensorType>(op.getType());
@@ -2387,6 +2384,9 @@ private:
     if (failed(offMapping))
       return failure();
 
+    // All validity checks passed; now generate IR.
+    SmallVector<Value> offsetsX =
+        unpackLLElements(loc, adaptor.getXOffsets(), rewriter);
     DescriptorFields desc = unpackDescriptor(llDesc, descRank, loc, rewriter);
     assert(regPackedBases.has_value() &&
            "invalid register bases for packing elems.");

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2252,6 +2252,8 @@ struct DescriptorGatherConversionBase : public BlockIOConversionBase {
     constexpr unsigned totalBytesPerGatherLoadNonTrans = 256;
     unsigned bytesPerRow =
         sizeInfo.numElemPerPackedVal * sizeInfo.tileWidth * elemSizeInBits / 8;
+    if (bytesPerRow == 0 || bytesPerRow > totalBytesPerGatherLoadNonTrans)
+      return failure();
     sizeInfo.tileHeight = std::min(
         sizeInfo.tileHeight,
         static_cast<int>(totalBytesPerGatherLoadNonTrans / bytesPerRow));

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2367,9 +2367,8 @@ struct DescriptorGatherOpConversion
     if (succeeded(lowerSubGroupGatherFastPath(op, adaptor, rewriter)))
       return success();
 
-    llvm_unreachable(
-        "DescriptorGatherOpConversion: failed to lower DescriptorGatherOp");
-    return failure();
+    return rewriter.notifyMatchFailure(op,
+                                      "failed to lower ttig.descriptor_gather");
   }
 
 private:

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2423,8 +2423,9 @@ private:
     std::optional<LinearLayout> llEncoding =
         cast<DistributedEncodingTrait>(resultType.getEncoding())
             .toLinearLayout(resultType.getShape());
-    assert(llEncoding.has_value() &&
-           "unexpected failure when getting linear layout");
+    if (!llEncoding)
+      return rewriter.notifyMatchFailure(
+          op, "result encoding not convertible to LinearLayout");
 
     StringAttr kRegister = S("register");
     StringAttr kLane = S("lane");

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2366,11 +2366,11 @@ struct DescriptorGatherOpConversion
   matchAndRewrite(mlir::triton::gpu::intel::DescriptorGatherOp op,
                   OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (succeeded(lowerSubGroupGatherFastPath(op, adaptor, rewriter)))
+    if (succeeded(lowerDescriptorGather(op, adaptor, rewriter)))
       return success();
 
-    return rewriter.notifyMatchFailure(op,
-                                      "failed to lower ttig.descriptor_gather");
+    return rewriter.notifyMatchFailure(
+        op, "failed to lower ttig.descriptor_gather");
   }
 
 private:
@@ -2407,9 +2407,9 @@ private:
   }
 
   LogicalResult
-  lowerSubGroupGatherFastPath(mlir::triton::gpu::intel::DescriptorGatherOp op,
-                              OpAdaptor adaptor,
-                              ConversionPatternRewriter &rewriter) const {
+  lowerDescriptorGather(mlir::triton::gpu::intel::DescriptorGatherOp op,
+                        OpAdaptor adaptor,
+                        ConversionPatternRewriter &rewriter) const {
     Location loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     auto typeConverter = getTypeConverter();

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2288,12 +2288,9 @@ private:
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     auto typeConverter = getTypeConverter();
     MLIRContext *ctx = rewriter.getContext();
-    // Get the descriptor and indices
+    // Get the descriptor and indices (no IR generated yet).
     Value llDesc = adaptor.getDesc();
-    SmallVector<Value> offsetsX =
-        unpackLLElements(loc, adaptor.getXOffsets(), rewriter);
     RankedTensorType offXTy = op.getXOffsets().getType();
-
     Value offsetY = adaptor.getYOffset();
     // Get result type information
     auto resultType = cast<RankedTensorType>(op.getType());
@@ -2356,6 +2353,9 @@ private:
     if (failed(offMapping))
       return failure();
 
+    // All validity checks passed; now generate IR.
+    SmallVector<Value> offsetsX =
+        unpackLLElements(loc, adaptor.getXOffsets(), rewriter);
     DescriptorFields desc = unpackDescriptor(llDesc, descRank, loc, rewriter);
     assert(regPackedBases.has_value() &&
            "invalid register bases for packing elems.");

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2262,10 +2262,12 @@ struct DescriptorGatherConversionBase : public BlockIOConversionBase {
     unsigned numElemsPerTile = numPackedValsPerTile * cfg.numPackedVals;
     unsigned totalBytesPerTile = numElemsPerTile * (elemSizeInBits / 8);
     cfg.bytesPerPtr = mlir::ceil(totalBytesPerTile, cfg.numPtrsPerLoad);
-    cfg.ptrsPerRow = ceil(bytesPerRow, cfg.bytesPerPtr);
+    cfg.ptrsPerRow = mlir::ceil(bytesPerRow, cfg.bytesPerPtr);
     cfg.numElemsPerLoad =
         (sizeInfo.tileHeight * sizeInfo.tileWidth * cfg.numPackedVals) /
         threadsPerWarp;
+    if (cfg.numElemsPerLoad == 0)
+      return failure();
 
     FailureOr<LinearLayout> offsetMapping = buildDescriptorGatherOffsetMapping(
         resultType, offsetsXType, cfg.numPtrsPerLoad, cfg.ptrsPerRow,
@@ -2493,6 +2495,9 @@ private:
       std::optional<LinearLayout> offsetsXLLEncoding =
           cast<DistributedEncodingTrait>(offsetsXType.getEncoding())
               .toLinearLayout(offsetsXType.getShape());
+      if (!offsetsXLLEncoding)
+        return rewriter.notifyMatchFailure(
+            op, "offsetsX encoding not convertible to LinearLayout");
       LinearLayout valueToOffsetMap =
           subLayout.invertAndCompose(*offsetsXLLEncoding);
       valueToOffsetMap = valueToOffsetMap.sublayout({kRegister}, {kRegister});

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -22,7 +22,10 @@
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/Utility.h"
 #include "intel/include/Utils/Utility.h"
 #include "triton/Tools/LinearLayout.h"
+#include <TritonIntelGPUToLLVM/XeAsmFormat.h>
 #include <limits>
+#include <llvm/IR/InlineAsm.h>
+#include <llvm/Support/FormatVariadic.h>
 #include <optional>
 #include <triton/Tools/Sys/GetEnv.h>
 
@@ -2145,6 +2148,382 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
 
     Value resultStruct = packTensorElements(loc, typeConverter, loadedVals,
                                             rewriter, op.getType());
+    rewriter.replaceOp(op, {resultStruct});
+    return success();
+  }
+};
+
+struct DescriptorGatherConversionBase : public BlockIOConversionBase {
+  DescriptorGatherConversionBase(
+      const triton::intel::TargetInfo &targetInfo,
+      const triton::intel::ModuleAxisInfoAnalysis &axisAnalysisPass,
+      triton::intel::ModuleStrideAnalysis &strideAnalysis)
+      : BlockIOConversionBase(targetInfo, axisAnalysisPass, strideAnalysis) {}
+
+  static LinearLayout buildRegisterMapping(const SetVector<unsigned> &regBases,
+                                           const LinearLayout &llEncoding,
+                                           MLIRContext *ctx) {
+    StringAttr kRegister = StringAttr::get(ctx, "register");
+    std::vector<std::vector<int>> bases(regBases.size());
+    llvm::transform(regBases, bases.begin(),
+                    [](int base) { return std::vector<int>{base}; });
+    return LinearLayout({{kRegister, bases}},
+                        {{kRegister, llEncoding.getInDimSize(kRegister)}},
+                        /*requireSurjective=*/true);
+  }
+
+  static const std::vector<std::vector<int>> &
+  getInputDimBasesOrCrash(const LinearLayout &ll, StringRef inDim) {
+    const LinearLayout::BasesT &bases = ll.getBases();
+    auto it = llvm::find_if(bases, [&](const auto &base) {
+      return base.first.getValue() == inDim;
+    });
+    if (it != bases.end())
+      return it->second;
+    std::string msg = (Twine("Could not find input dim '") + inDim +
+                       "' in layout: " + ll.toString())
+                          .str();
+    llvm_unreachable(msg.c_str());
+  }
+
+  static FailureOr<LinearLayout> buildDescriptorGatherOffsetMapping(
+      RankedTensorType resultType, RankedTensorType offsetsXType,
+      unsigned numPtrsPerLoad, unsigned ptrsPerRow, unsigned bytesPerPtr,
+      unsigned elemSizeInBits) {
+    std::optional<LinearLayout> llEncoding =
+        cast<DistributedEncodingTrait>(resultType.getEncoding())
+            .toLinearLayout(resultType.getShape());
+    std::optional<LinearLayout> offsetsXLLEncoding =
+        cast<DistributedEncodingTrait>(offsetsXType.getEncoding())
+            .toLinearLayout(offsetsXType.getShape());
+    if (!llEncoding || !offsetsXLLEncoding)
+      return failure();
+
+    MLIRContext *ctx = resultType.getContext();
+    StringAttr kRegister = StringAttr::get(ctx, "register");
+    StringAttr kLane = StringAttr::get(ctx, "lane");
+    StringAttr kWarp = StringAttr::get(ctx, "warp");
+    StringAttr kBlock = StringAttr::get(ctx, "block");
+    StringAttr dim0Attr = StringAttr::get(ctx, "dim0");
+    StringAttr dim1Attr = StringAttr::get(ctx, "dim1");
+    StringAttr offxIdxAttr = StringAttr::get(ctx, "offx_idx");
+
+    auto subLayout = llEncoding->sublayout(
+        llvm::to_vector(llEncoding->getInDimNames()), {dim0Attr});
+    auto regMLayout = subLayout.invertAndCompose(*offsetsXLLEncoding);
+
+    std::optional<LinearLayout> conversion = regMLayout.quotient(kBlock);
+    if (!conversion)
+      return failure();
+    conversion = conversion->quotient(kWarp);
+    if (!conversion)
+      return failure();
+    conversion = conversion->quotient(kLane);
+    if (!conversion)
+      return failure();
+
+    auto offsetYLayout = llEncoding->sublayout(kRegister, {dim1Attr});
+    if (!llvm::isPowerOf2_32(numPtrsPerLoad) ||
+        !llvm::isPowerOf2_32(ptrsPerRow))
+      return failure();
+
+    std::vector<std::vector<int>> ptrBases;
+    for (unsigned i = 0; i < llvm::Log2_32(numPtrsPerLoad); ++i) {
+      if (i < llvm::Log2_32(ptrsPerRow)) {
+        ptrBases.push_back({0, (int)(bytesPerPtr / (elemSizeInBits / 8)) << i});
+      } else {
+        ptrBases.push_back({1 << (i - llvm::Log2_32(ptrsPerRow)), 0});
+      }
+    }
+
+    auto offsetXIndexBases = getInputDimBasesOrCrash(*conversion, "register");
+    auto offsetYBases = getInputDimBasesOrCrash(offsetYLayout, "register");
+    std::vector<std::vector<int>> offsetMapBases;
+    for (auto const &[offsetXBase, offsetYBase] :
+         llvm::zip(offsetXIndexBases, offsetYBases)) {
+      offsetMapBases.push_back({offsetXBase[0], offsetYBase[0]});
+    }
+
+    auto inDimSize = offsetsXLLEncoding->getInDimSize(kRegister);
+    return LinearLayout(
+        {{kRegister, offsetMapBases}, {StringAttr::get(ctx, "ptrs"), ptrBases}},
+        {{offxIdxAttr, inDimSize},
+         {dim1Attr, llEncoding->getOutDimSize(dim1Attr)}},
+        /*requireSurjective=*/false);
+  }
+};
+
+struct DescriptorGatherOpConversion
+    : public ConvertOpToLLVMPattern<
+          mlir::triton::gpu::intel::DescriptorGatherOp>,
+      public DescriptorGatherConversionBase {
+  using ConvertOpToLLVMPattern<
+      mlir::triton::gpu::intel::DescriptorGatherOp>::ConvertOpToLLVMPattern;
+
+  DescriptorGatherOpConversion(
+      LLVMTypeConverter &converter, const triton::intel::TargetInfo &targetInfo,
+      const triton::intel::ModuleAxisInfoAnalysis &axisAnalysisPass,
+      triton::intel::ModuleStrideAnalysis &strideAnalysis,
+      PatternBenefit benefit)
+      : ConvertOpToLLVMPattern<mlir::triton::gpu::intel::DescriptorGatherOp>(
+            converter, benefit),
+        DescriptorGatherConversionBase(targetInfo, axisAnalysisPass,
+                                       strideAnalysis) {}
+
+  LogicalResult
+  matchAndRewrite(mlir::triton::gpu::intel::DescriptorGatherOp op,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (succeeded(lowerSubGroupGatherFastPath(op, adaptor, rewriter)))
+      return success();
+    return lowerDefaultGatherFallback(op, adaptor, rewriter);
+  }
+
+private:
+  LogicalResult
+  lowerSubGroupGatherFastPath(mlir::triton::gpu::intel::DescriptorGatherOp op,
+                              OpAdaptor adaptor,
+                              ConversionPatternRewriter &rewriter) const {
+    Location loc = op->getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto typeConverter = getTypeConverter();
+    MLIRContext *ctx = rewriter.getContext();
+    // Get the descriptor and indices
+    Value llDesc = adaptor.getDesc();
+    SmallVector<Value> offsetsX =
+        unpackLLElements(loc, adaptor.getXOffsets(), rewriter);
+    RankedTensorType offXTy = op.getXOffsets().getType();
+
+    Value offsetY = adaptor.getYOffset();
+    // Get result type information
+    auto resultType = cast<RankedTensorType>(op.getType());
+    std::optional<LinearLayout> llEncoding =
+        cast<DistributedEncodingTrait>(resultType.getEncoding())
+            .toLinearLayout(resultType.getShape());
+    assert(llEncoding.has_value() &&
+           "unexpected failure when getting linear layout");
+
+    StringAttr kRegister = S("register");
+    StringAttr kLane = S("lane");
+
+    size_t resultRank = resultType.getRank();
+    Type valueElemTy = typeConverter->convertType(resultType.getElementType());
+    unsigned numElems = getTotalElemsPerThread(resultType);
+
+    auto descType = cast<triton::TensorDescType>(op.getDesc().getType());
+    RankedTensorType descTensorType = descType.getBlockType();
+    size_t descRank = descTensorType.getRank();
+
+    unsigned elemSizeInBits = std::max(8u, valueElemTy.getIntOrFloatBitWidth());
+    BlockIOTileSizeInfo sizeInfo = getBlockIOLoadTileSize(
+        llEncoding.value(), resultRank - 1, elemSizeInBits, nullptr, false);
+
+    if (!sizeInfo.isValid())
+      return failure();
+    int tileHeight = sizeInfo.tileHeight;
+    int tileWidth = sizeInfo.tileWidth;
+    int numPackedVals = sizeInfo.numElemPerPackedVal;
+    int vBlocks = sizeInfo.vBlocks;
+    int rowDim = sizeInfo.rowDim;
+    int colDim = sizeInfo.colDim;
+    bool isTransposeRequired = sizeInfo.transpose;
+    bool useVNNIFormat = sizeInfo.vnni;
+    if (isTransposeRequired)
+      return failure();
+    assert(rowDim == 0 && "only support rowDim=0 for 1D block I/O");
+    assert(colDim == 1 && "only support colDim=1 for 1D block I/O");
+    std::optional<SetVector<unsigned>> regPackedBases =
+        std::move(sizeInfo.regPackedBases);
+
+    constexpr unsigned totalBytesPerGatherLoadNonTrans = 256;
+    constexpr unsigned totalBytesPerGatherLoadTrans = 512;
+    unsigned bytesPerRow = numPackedVals * tileWidth * elemSizeInBits / 8;
+    tileHeight = std::min(tileHeight,
+                          (int)(totalBytesPerGatherLoadNonTrans / bytesPerRow));
+    unsigned numElemsPerTile = tileHeight * tileWidth * numPackedVals;
+    unsigned totalBytesPerTile = numElemsPerTile * (elemSizeInBits / 8);
+    constexpr unsigned numPtrsPerLoad = 32u;
+    unsigned bytesPerPtr = mlir::ceil(totalBytesPerTile, numPtrsPerLoad);
+    unsigned ptrsPerRow = ceil(bytesPerRow, bytesPerPtr);
+    unsigned threadsPerWarp =
+        TritonGPUDialect::getThreadsPerWarp(op->getParentOfType<ModuleOp>());
+    unsigned numElemsPerLoad =
+        (tileHeight * tileWidth * numPackedVals) / threadsPerWarp;
+
+    FailureOr<LinearLayout> offMapping = buildDescriptorGatherOffsetMapping(
+        resultType, offXTy, numPtrsPerLoad, ptrsPerRow, bytesPerPtr,
+        elemSizeInBits);
+    if (failed(offMapping))
+      return failure();
+
+    DescriptorFields desc = unpackDescriptor(llDesc, descRank, loc, rewriter);
+    assert(regPackedBases.has_value() &&
+           "invalid register bases for packing elems.");
+    LinearLayout regMapping =
+        buildRegisterMapping(*regPackedBases, *llEncoding, ctx);
+    LinearLayout shuffleMapping =
+        LinearLayout::identity1D(numElemsPerLoad, kRegister, kRegister);
+
+    Type unpackedType = LLVM::getVectorType(valueElemTy, numElemsPerLoad);
+
+    SmallVector<Value> loadedVals(numElems);
+
+    for (size_t elemIdx = 0; elemIdx < numElems; elemIdx += numElemsPerLoad) {
+      unsigned registerIdx = regMapping.apply({{kRegister, elemIdx}})[0].second;
+
+      // update offset Y.
+      Value addrElem = b.gep(ptr_ty(ctx, 1), valueElemTy, desc.base, offsetY);
+
+      SmallVector<Value> addrs, predicts;
+      for (size_t i = 0; i < numPtrsPerLoad; ++i) {
+        auto offsetsForLoad = offMapping->apply(
+            {{kRegister, registerIdx}, {str_attr("ptrs"), i}});
+        auto linearOffsetY = offsetsForLoad[1];
+        assert(linearOffsetY.first == str_attr("dim1"));
+        Value subOffsetY = b.i32_val(linearOffsetY.second);
+
+        auto offsetXIdx = offsetsForLoad[0];
+        assert(offsetXIdx.first == str_attr("offx_idx"));
+        // Note: here assume the offsetX is uniform value which is deduced from
+        // slice layout of the result layout.
+        // TODO: need to improve this.
+        Value offsetXUniform = targetInfo.shuffleIdx(
+            rewriter, loc, offsetsX[offsetXIdx.second], 0);
+        Value offsetX = b.zext(int_ty(64), offsetXUniform);
+        Value pred = b.icmp_ult(offsetX, desc.shapes[0]);
+        Value offset64 = b.mul(offsetX, desc.strides[rowDim]);
+
+        predicts.push_back(b.and_(
+            pred, b.icmp_ult(b.zext(int_ty(64), b.add(subOffsetY, offsetY)),
+                             desc.shapes[1])));
+
+        Value addr = b.gep(ptr_ty(ctx, 1), valueElemTy, addrElem,
+                           b.i32_val(linearOffsetY.second));
+        addr = b.gep(ptr_ty(ctx, 1), valueElemTy, addr, offset64);
+
+        addrs.push_back(b.ptrtoint(i64_ty, addr));
+      }
+      Value ptrVec = b.undef(vec_ty(i64_ty, addrs.size()));
+      Value predVec = b.undef(vec_ty(i1_ty, addrs.size()));
+      for (size_t i = 0; i < addrs.size(); ++i) {
+        Value sVal = createIndexAttrConstant(rewriter, loc,
+                                             typeConverter->getIndexType(), i);
+        ptrVec = b.insert_element(ptrVec, addrs[i], sVal);
+        predVec = b.insert_element(predVec, predicts[i], sVal);
+      }
+
+      Value ret = TritonGEN::SubGroupGatherLoadOp::create(
+          rewriter, loc, unpackedType, ptrVec, predVec);
+
+      unpackBlockLoadResult(ret, loadedVals, elemIdx, regMapping,
+                            shuffleMapping, {}, unpackedType, numElemsPerLoad,
+                            numPackedVals, {}, {},
+                            /*nanMaskElems=*/{}, loc, rewriter, ctx);
+    }
+    Type llvmResultStructTy = typeConverter->convertType(op.getType());
+    Value resultStruct = packLLElements(loc, typeConverter, loadedVals,
+                                        rewriter, llvmResultStructTy);
+    rewriter.replaceOp(op, {resultStruct});
+    return success();
+  }
+
+  LogicalResult
+  lowerDefaultGatherFallback(mlir::triton::gpu::intel::DescriptorGatherOp op,
+                             OpAdaptor adaptor,
+                             ConversionPatternRewriter &rewriter) const {
+    Location loc = op->getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto typeConverter = getTypeConverter();
+    MLIRContext *ctx = rewriter.getContext();
+
+    Value llDesc = adaptor.getDesc();
+    SmallVector<Value> offsetsX =
+        unpackLLElements(loc, adaptor.getXOffsets(), rewriter);
+    Value offsetY = adaptor.getYOffset();
+
+    auto resultType = cast<RankedTensorType>(op.getType());
+    std::optional<LinearLayout> llEncoding =
+        cast<DistributedEncodingTrait>(resultType.getEncoding())
+            .toLinearLayout(resultType.getShape());
+    assert(llEncoding.has_value() &&
+           "unexpected failure when getting linear layout");
+
+    Type valueElemTy = typeConverter->convertType(resultType.getElementType());
+    unsigned numElems = getTotalElemsPerThread(resultType);
+
+    auto descType = cast<triton::TensorDescType>(op.getDesc().getType());
+    RankedTensorType descTensorType = descType.getBlockType();
+    size_t descRank = descTensorType.getRank();
+    DescriptorFields desc = unpackDescriptor(llDesc, descRank, loc, rewriter);
+
+    StringAttr kBlock = S("block");
+    StringAttr kWarp = S("warp");
+    StringAttr kLane = S("lane");
+    StringAttr kRegister = S("register");
+    StringAttr kDim0 = S("dim0");
+    StringAttr kDim1 = S("dim1");
+
+    Value fallbackDefault = b.undef(valueElemTy);
+    SmallVector<Value> loadedVals;
+    loadedVals.reserve(numElems);
+    auto subLayout = llEncoding->sublayout(
+        llvm::to_vector(llEncoding->getInDimNames()), {kDim0});
+    auto offsetsXType = cast<RankedTensorType>(op.getXOffsets().getType());
+    std::optional<LinearLayout> offsetsXLLEncoding =
+        cast<DistributedEncodingTrait>(offsetsXType.getEncoding())
+            .toLinearLayout(offsetsXType.getShape());
+    auto regMLayout = subLayout.invertAndCompose(*offsetsXLLEncoding);
+
+    auto registerMap = regMLayout.sublayout({kRegister}, {kRegister});
+
+    auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
+    for (unsigned elemIdx = 0; elemIdx < numElems; ++elemIdx) {
+      auto offsetIdx = registerMap.apply({{kRegister, elemIdx}})[0].second;
+
+      // Get the offset X index from register index first.
+      auto offsets = applyLinearLayout(loc, rewriter, *llEncoding,
+                                       {{kRegister, b.i32_val(elemIdx)},
+                                        {kLane, laneId},
+                                        {kWarp, warpId},
+                                        {kBlock, b.i32_val(0)}});
+      // Get the offset Y from the warp id, lane id and register id.
+      Value ySubOffset;
+      for (auto [name, value] : offsets) {
+        if (name == kDim1) {
+          ySubOffset = value;
+          break;
+        }
+      }
+
+      Value offsetX = offsetsX[offsetIdx];
+      Value offsetX64 = b.zext(i64_ty, offsetX);
+      Value predX = b.icmp_ult(offsetX64, desc.shapes[0]);
+
+      Value yOffset = b.add(offsetY, ySubOffset);
+      Value yOffset64 = b.zext(i64_ty, yOffset);
+      Value predY = b.icmp_ult(yOffset64, desc.shapes[1]);
+      Value pred = b.and_(predX, predY);
+
+      Value xLinearOffset = b.mul(offsetX64, desc.strides[0]);
+      Value yLinearOffset = b.mul(yOffset64, desc.strides[1]);
+      Value linearOffset = b.add(xLinearOffset, yLinearOffset);
+      Value addr = b.gep(ptr_ty(ctx, 1), valueElemTy, desc.base, linearOffset);
+
+      auto createLoad = [&]() {
+        return SmallVector<Value>{b.load(valueElemTy, addr, /*align=*/1,
+                                         /*isVolatile=*/false,
+                                         /*isNonTemporal=*/false)};
+      };
+      Block &endBlock = LLVM::intel::createPredicatedBlock(
+          rewriter, loc, pred, SmallVector<Value, 1>{fallbackDefault},
+          createLoad);
+      Value loaded = *endBlock.args_begin();
+      loadedVals.push_back(loaded);
+    }
+
+    Type llvmResultStructTy = typeConverter->convertType(op.getType());
+    Value resultStruct = packLLElements(loc, typeConverter, loadedVals,
+                                        rewriter, llvmResultStructTy);
     rewriter.replaceOp(op, {resultStruct});
     return success();
   }
@@ -4512,10 +4891,10 @@ void mlir::triton::intel::populateLoadStoreOpToLLVMPatterns(
   patterns.add<LocalAtomicScatterRMWOpConversion>(typeConverter, targetInfo,
                                                   benefit);
   // Block IO store patterns (loads are handled via ttig.2d_block_load path).
-  patterns
-      .add<StoreOpToBlockIOConversion, DescriptorStoreOpToBlockIOConversion>(
-          typeConverter, targetInfo, axisInfoAnalysis, strideAnalysis,
-          benefit.getBenefit() + 2);
+  patterns.add<StoreOpToBlockIOConversion, DescriptorStoreOpToBlockIOConversion,
+               DescriptorGatherOpConversion>(typeConverter, targetInfo,
+                                             axisInfoAnalysis, strideAnalysis,
+                                             benefit.getBenefit() + 2);
   // TTIG ops from LowerTo2DBlockLoad TTGIR pass.
   patterns.add<ExtractDescOpConversion>(typeConverter, benefit);
   patterns.add<Subgroup2DBlockLoadOpConversion,

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -22,10 +22,7 @@
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/Utility.h"
 #include "intel/include/Utils/Utility.h"
 #include "triton/Tools/LinearLayout.h"
-#include <TritonIntelGPUToLLVM/XeAsmFormat.h>
 #include <limits>
-#include <llvm/IR/InlineAsm.h>
-#include <llvm/Support/FormatVariadic.h>
 #include <optional>
 #include <triton/Tools/Sys/GetEnv.h>
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -22,7 +22,10 @@
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/Utility.h"
 #include "intel/include/Utils/Utility.h"
 #include "triton/Tools/LinearLayout.h"
+#include <TritonIntelGPUToLLVM/XeAsmFormat.h>
 #include <limits>
+#include <llvm/IR/InlineAsm.h>
+#include <llvm/Support/FormatVariadic.h>
 #include <optional>
 #include <triton/Tools/Sys/GetEnv.h>
 
@@ -2176,6 +2179,382 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
 
     Value resultStruct = packTensorElements(loc, typeConverter, loadedVals,
                                             rewriter, op.getType());
+    rewriter.replaceOp(op, {resultStruct});
+    return success();
+  }
+};
+
+struct DescriptorGatherConversionBase : public BlockIOConversionBase {
+  DescriptorGatherConversionBase(
+      const triton::intel::TargetInfo &targetInfo,
+      const triton::intel::ModuleAxisInfoAnalysis &axisAnalysisPass,
+      triton::intel::ModuleStrideAnalysis &strideAnalysis)
+      : BlockIOConversionBase(targetInfo, axisAnalysisPass, strideAnalysis) {}
+
+  static LinearLayout buildRegisterMapping(const SetVector<unsigned> &regBases,
+                                           const LinearLayout &llEncoding,
+                                           MLIRContext *ctx) {
+    StringAttr kRegister = StringAttr::get(ctx, "register");
+    std::vector<std::vector<int>> bases(regBases.size());
+    llvm::transform(regBases, bases.begin(),
+                    [](int base) { return std::vector<int>{base}; });
+    return LinearLayout({{kRegister, bases}},
+                        {{kRegister, llEncoding.getInDimSize(kRegister)}},
+                        /*requireSurjective=*/true);
+  }
+
+  static const std::vector<std::vector<int>> &
+  getInputDimBasesOrCrash(const LinearLayout &ll, StringRef inDim) {
+    const LinearLayout::BasesT &bases = ll.getBases();
+    auto it = llvm::find_if(bases, [&](const auto &base) {
+      return base.first.getValue() == inDim;
+    });
+    if (it != bases.end())
+      return it->second;
+    std::string msg = (Twine("Could not find input dim '") + inDim +
+                       "' in layout: " + ll.toString())
+                          .str();
+    llvm_unreachable(msg.c_str());
+  }
+
+  static FailureOr<LinearLayout> buildDescriptorGatherOffsetMapping(
+      RankedTensorType resultType, RankedTensorType offsetsXType,
+      unsigned numPtrsPerLoad, unsigned ptrsPerRow, unsigned bytesPerPtr,
+      unsigned elemSizeInBits) {
+    std::optional<LinearLayout> llEncoding =
+        cast<DistributedEncodingTrait>(resultType.getEncoding())
+            .toLinearLayout(resultType.getShape());
+    std::optional<LinearLayout> offsetsXLLEncoding =
+        cast<DistributedEncodingTrait>(offsetsXType.getEncoding())
+            .toLinearLayout(offsetsXType.getShape());
+    if (!llEncoding || !offsetsXLLEncoding)
+      return failure();
+
+    MLIRContext *ctx = resultType.getContext();
+    StringAttr kRegister = StringAttr::get(ctx, "register");
+    StringAttr kLane = StringAttr::get(ctx, "lane");
+    StringAttr kWarp = StringAttr::get(ctx, "warp");
+    StringAttr kBlock = StringAttr::get(ctx, "block");
+    StringAttr dim0Attr = StringAttr::get(ctx, "dim0");
+    StringAttr dim1Attr = StringAttr::get(ctx, "dim1");
+    StringAttr offxIdxAttr = StringAttr::get(ctx, "offx_idx");
+
+    auto subLayout = llEncoding->sublayout(
+        llvm::to_vector(llEncoding->getInDimNames()), {dim0Attr});
+    auto regMLayout = subLayout.invertAndCompose(*offsetsXLLEncoding);
+
+    std::optional<LinearLayout> conversion = regMLayout.quotient(kBlock);
+    if (!conversion)
+      return failure();
+    conversion = conversion->quotient(kWarp);
+    if (!conversion)
+      return failure();
+    conversion = conversion->quotient(kLane);
+    if (!conversion)
+      return failure();
+
+    auto offsetYLayout = llEncoding->sublayout(kRegister, {dim1Attr});
+    if (!llvm::isPowerOf2_32(numPtrsPerLoad) ||
+        !llvm::isPowerOf2_32(ptrsPerRow))
+      return failure();
+
+    std::vector<std::vector<int>> ptrBases;
+    for (unsigned i = 0; i < llvm::Log2_32(numPtrsPerLoad); ++i) {
+      if (i < llvm::Log2_32(ptrsPerRow)) {
+        ptrBases.push_back({0, (int)(bytesPerPtr / (elemSizeInBits / 8)) << i});
+      } else {
+        ptrBases.push_back({1 << (i - llvm::Log2_32(ptrsPerRow)), 0});
+      }
+    }
+
+    auto offsetXIndexBases = getInputDimBasesOrCrash(*conversion, "register");
+    auto offsetYBases = getInputDimBasesOrCrash(offsetYLayout, "register");
+    std::vector<std::vector<int>> offsetMapBases;
+    for (auto const &[offsetXBase, offsetYBase] :
+         llvm::zip(offsetXIndexBases, offsetYBases)) {
+      offsetMapBases.push_back({offsetXBase[0], offsetYBase[0]});
+    }
+
+    auto inDimSize = offsetsXLLEncoding->getInDimSize(kRegister);
+    return LinearLayout(
+        {{kRegister, offsetMapBases}, {StringAttr::get(ctx, "ptrs"), ptrBases}},
+        {{offxIdxAttr, inDimSize},
+         {dim1Attr, llEncoding->getOutDimSize(dim1Attr)}},
+        /*requireSurjective=*/false);
+  }
+};
+
+struct DescriptorGatherOpConversion
+    : public ConvertOpToLLVMPattern<
+          mlir::triton::gpu::intel::DescriptorGatherOp>,
+      public DescriptorGatherConversionBase {
+  using ConvertOpToLLVMPattern<
+      mlir::triton::gpu::intel::DescriptorGatherOp>::ConvertOpToLLVMPattern;
+
+  DescriptorGatherOpConversion(
+      LLVMTypeConverter &converter, const triton::intel::TargetInfo &targetInfo,
+      const triton::intel::ModuleAxisInfoAnalysis &axisAnalysisPass,
+      triton::intel::ModuleStrideAnalysis &strideAnalysis,
+      PatternBenefit benefit)
+      : ConvertOpToLLVMPattern<mlir::triton::gpu::intel::DescriptorGatherOp>(
+            converter, benefit),
+        DescriptorGatherConversionBase(targetInfo, axisAnalysisPass,
+                                       strideAnalysis) {}
+
+  LogicalResult
+  matchAndRewrite(mlir::triton::gpu::intel::DescriptorGatherOp op,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (succeeded(lowerSubGroupGatherFastPath(op, adaptor, rewriter)))
+      return success();
+    return lowerDefaultGatherFallback(op, adaptor, rewriter);
+  }
+
+private:
+  LogicalResult
+  lowerSubGroupGatherFastPath(mlir::triton::gpu::intel::DescriptorGatherOp op,
+                              OpAdaptor adaptor,
+                              ConversionPatternRewriter &rewriter) const {
+    Location loc = op->getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto typeConverter = getTypeConverter();
+    MLIRContext *ctx = rewriter.getContext();
+    // Get the descriptor and indices
+    Value llDesc = adaptor.getDesc();
+    SmallVector<Value> offsetsX =
+        unpackLLElements(loc, adaptor.getXOffsets(), rewriter);
+    RankedTensorType offXTy = op.getXOffsets().getType();
+
+    Value offsetY = adaptor.getYOffset();
+    // Get result type information
+    auto resultType = cast<RankedTensorType>(op.getType());
+    std::optional<LinearLayout> llEncoding =
+        cast<DistributedEncodingTrait>(resultType.getEncoding())
+            .toLinearLayout(resultType.getShape());
+    assert(llEncoding.has_value() &&
+           "unexpected failure when getting linear layout");
+
+    StringAttr kRegister = S("register");
+    StringAttr kLane = S("lane");
+
+    size_t resultRank = resultType.getRank();
+    Type valueElemTy = typeConverter->convertType(resultType.getElementType());
+    unsigned numElems = getTotalElemsPerThread(resultType);
+
+    auto descType = cast<triton::TensorDescType>(op.getDesc().getType());
+    RankedTensorType descTensorType = descType.getBlockType();
+    size_t descRank = descTensorType.getRank();
+
+    unsigned elemSizeInBits = std::max(8u, valueElemTy.getIntOrFloatBitWidth());
+    BlockIOTileSizeInfo sizeInfo = getBlockIOLoadTileSize(
+        llEncoding.value(), resultRank - 1, elemSizeInBits, nullptr, false);
+
+    if (!sizeInfo.isValid())
+      return failure();
+    int tileHeight = sizeInfo.tileHeight;
+    int tileWidth = sizeInfo.tileWidth;
+    int numPackedVals = sizeInfo.numElemPerPackedVal;
+    int vBlocks = sizeInfo.vBlocks;
+    int rowDim = sizeInfo.rowDim;
+    int colDim = sizeInfo.colDim;
+    bool isTransposeRequired = sizeInfo.transpose;
+    bool useVNNIFormat = sizeInfo.vnni;
+    if (isTransposeRequired)
+      return failure();
+    assert(rowDim == 0 && "only support rowDim=0 for 1D block I/O");
+    assert(colDim == 1 && "only support colDim=1 for 1D block I/O");
+    std::optional<SetVector<unsigned>> regPackedBases =
+        std::move(sizeInfo.regPackedBases);
+
+    constexpr unsigned totalBytesPerGatherLoadNonTrans = 256;
+    constexpr unsigned totalBytesPerGatherLoadTrans = 512;
+    unsigned bytesPerRow = numPackedVals * tileWidth * elemSizeInBits / 8;
+    tileHeight = std::min(tileHeight,
+                          (int)(totalBytesPerGatherLoadNonTrans / bytesPerRow));
+    unsigned numElemsPerTile = tileHeight * tileWidth * numPackedVals;
+    unsigned totalBytesPerTile = numElemsPerTile * (elemSizeInBits / 8);
+    constexpr unsigned numPtrsPerLoad = 32u;
+    unsigned bytesPerPtr = mlir::ceil(totalBytesPerTile, numPtrsPerLoad);
+    unsigned ptrsPerRow = ceil(bytesPerRow, bytesPerPtr);
+    unsigned threadsPerWarp =
+        TritonGPUDialect::getThreadsPerWarp(op->getParentOfType<ModuleOp>());
+    unsigned numElemsPerLoad =
+        (tileHeight * tileWidth * numPackedVals) / threadsPerWarp;
+
+    FailureOr<LinearLayout> offMapping = buildDescriptorGatherOffsetMapping(
+        resultType, offXTy, numPtrsPerLoad, ptrsPerRow, bytesPerPtr,
+        elemSizeInBits);
+    if (failed(offMapping))
+      return failure();
+
+    DescriptorFields desc = unpackDescriptor(llDesc, descRank, loc, rewriter);
+    assert(regPackedBases.has_value() &&
+           "invalid register bases for packing elems.");
+    LinearLayout regMapping =
+        buildRegisterMapping(*regPackedBases, *llEncoding, ctx);
+    LinearLayout shuffleMapping =
+        LinearLayout::identity1D(numElemsPerLoad, kRegister, kRegister);
+
+    Type unpackedType = LLVM::getVectorType(valueElemTy, numElemsPerLoad);
+
+    SmallVector<Value> loadedVals(numElems);
+
+    for (size_t elemIdx = 0; elemIdx < numElems; elemIdx += numElemsPerLoad) {
+      unsigned registerIdx = regMapping.apply({{kRegister, elemIdx}})[0].second;
+
+      // update offset Y.
+      Value addrElem = b.gep(ptr_ty(ctx, 1), valueElemTy, desc.base, offsetY);
+
+      SmallVector<Value> addrs, predicts;
+      for (size_t i = 0; i < numPtrsPerLoad; ++i) {
+        auto offsetsForLoad = offMapping->apply(
+            {{kRegister, registerIdx}, {str_attr("ptrs"), i}});
+        auto linearOffsetY = offsetsForLoad[1];
+        assert(linearOffsetY.first == str_attr("dim1"));
+        Value subOffsetY = b.i32_val(linearOffsetY.second);
+
+        auto offsetXIdx = offsetsForLoad[0];
+        assert(offsetXIdx.first == str_attr("offx_idx"));
+        // Note: here assume the offsetX is uniform value which is deduced from
+        // slice layout of the result layout.
+        // TODO: need to improve this.
+        Value offsetXUniform = targetInfo.shuffleIdx(
+            rewriter, loc, offsetsX[offsetXIdx.second], 0);
+        Value offsetX = b.zext(int_ty(64), offsetXUniform);
+        Value pred = b.icmp_ult(offsetX, desc.shapes[0]);
+        Value offset64 = b.mul(offsetX, desc.strides[rowDim]);
+
+        predicts.push_back(b.and_(
+            pred, b.icmp_ult(b.zext(int_ty(64), b.add(subOffsetY, offsetY)),
+                             desc.shapes[1])));
+
+        Value addr = b.gep(ptr_ty(ctx, 1), valueElemTy, addrElem,
+                           b.i32_val(linearOffsetY.second));
+        addr = b.gep(ptr_ty(ctx, 1), valueElemTy, addr, offset64);
+
+        addrs.push_back(b.ptrtoint(i64_ty, addr));
+      }
+      Value ptrVec = b.undef(vec_ty(i64_ty, addrs.size()));
+      Value predVec = b.undef(vec_ty(i1_ty, addrs.size()));
+      for (size_t i = 0; i < addrs.size(); ++i) {
+        Value sVal = createIndexAttrConstant(rewriter, loc,
+                                             typeConverter->getIndexType(), i);
+        ptrVec = b.insert_element(ptrVec, addrs[i], sVal);
+        predVec = b.insert_element(predVec, predicts[i], sVal);
+      }
+
+      Value ret = TritonGEN::SubGroupGatherLoadOp::create(
+          rewriter, loc, unpackedType, ptrVec, predVec);
+
+      unpackBlockLoadResult(ret, loadedVals, elemIdx, regMapping,
+                            shuffleMapping, {}, unpackedType, numElemsPerLoad,
+                            numPackedVals, {}, {},
+                            /*nanMaskElems=*/{}, loc, rewriter, ctx);
+    }
+    Type llvmResultStructTy = typeConverter->convertType(op.getType());
+    Value resultStruct = packLLElements(loc, typeConverter, loadedVals,
+                                        rewriter, llvmResultStructTy);
+    rewriter.replaceOp(op, {resultStruct});
+    return success();
+  }
+
+  LogicalResult
+  lowerDefaultGatherFallback(mlir::triton::gpu::intel::DescriptorGatherOp op,
+                             OpAdaptor adaptor,
+                             ConversionPatternRewriter &rewriter) const {
+    Location loc = op->getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto typeConverter = getTypeConverter();
+    MLIRContext *ctx = rewriter.getContext();
+
+    Value llDesc = adaptor.getDesc();
+    SmallVector<Value> offsetsX =
+        unpackLLElements(loc, adaptor.getXOffsets(), rewriter);
+    Value offsetY = adaptor.getYOffset();
+
+    auto resultType = cast<RankedTensorType>(op.getType());
+    std::optional<LinearLayout> llEncoding =
+        cast<DistributedEncodingTrait>(resultType.getEncoding())
+            .toLinearLayout(resultType.getShape());
+    assert(llEncoding.has_value() &&
+           "unexpected failure when getting linear layout");
+
+    Type valueElemTy = typeConverter->convertType(resultType.getElementType());
+    unsigned numElems = getTotalElemsPerThread(resultType);
+
+    auto descType = cast<triton::TensorDescType>(op.getDesc().getType());
+    RankedTensorType descTensorType = descType.getBlockType();
+    size_t descRank = descTensorType.getRank();
+    DescriptorFields desc = unpackDescriptor(llDesc, descRank, loc, rewriter);
+
+    StringAttr kBlock = S("block");
+    StringAttr kWarp = S("warp");
+    StringAttr kLane = S("lane");
+    StringAttr kRegister = S("register");
+    StringAttr kDim0 = S("dim0");
+    StringAttr kDim1 = S("dim1");
+
+    Value fallbackDefault = b.undef(valueElemTy);
+    SmallVector<Value> loadedVals;
+    loadedVals.reserve(numElems);
+    auto subLayout = llEncoding->sublayout(
+        llvm::to_vector(llEncoding->getInDimNames()), {kDim0});
+    auto offsetsXType = cast<RankedTensorType>(op.getXOffsets().getType());
+    std::optional<LinearLayout> offsetsXLLEncoding =
+        cast<DistributedEncodingTrait>(offsetsXType.getEncoding())
+            .toLinearLayout(offsetsXType.getShape());
+    auto regMLayout = subLayout.invertAndCompose(*offsetsXLLEncoding);
+
+    auto registerMap = regMLayout.sublayout({kRegister}, {kRegister});
+
+    auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
+    for (unsigned elemIdx = 0; elemIdx < numElems; ++elemIdx) {
+      auto offsetIdx = registerMap.apply({{kRegister, elemIdx}})[0].second;
+
+      // Get the offset X index from register index first.
+      auto offsets = applyLinearLayout(loc, rewriter, *llEncoding,
+                                       {{kRegister, b.i32_val(elemIdx)},
+                                        {kLane, laneId},
+                                        {kWarp, warpId},
+                                        {kBlock, b.i32_val(0)}});
+      // Get the offset Y from the warp id, lane id and register id.
+      Value ySubOffset;
+      for (auto [name, value] : offsets) {
+        if (name == kDim1) {
+          ySubOffset = value;
+          break;
+        }
+      }
+
+      Value offsetX = offsetsX[offsetIdx];
+      Value offsetX64 = b.zext(i64_ty, offsetX);
+      Value predX = b.icmp_ult(offsetX64, desc.shapes[0]);
+
+      Value yOffset = b.add(offsetY, ySubOffset);
+      Value yOffset64 = b.zext(i64_ty, yOffset);
+      Value predY = b.icmp_ult(yOffset64, desc.shapes[1]);
+      Value pred = b.and_(predX, predY);
+
+      Value xLinearOffset = b.mul(offsetX64, desc.strides[0]);
+      Value yLinearOffset = b.mul(yOffset64, desc.strides[1]);
+      Value linearOffset = b.add(xLinearOffset, yLinearOffset);
+      Value addr = b.gep(ptr_ty(ctx, 1), valueElemTy, desc.base, linearOffset);
+
+      auto createLoad = [&]() {
+        return SmallVector<Value>{b.load(valueElemTy, addr, /*align=*/1,
+                                         /*isVolatile=*/false,
+                                         /*isNonTemporal=*/false)};
+      };
+      Block &endBlock = LLVM::intel::createPredicatedBlock(
+          rewriter, loc, pred, SmallVector<Value, 1>{fallbackDefault},
+          createLoad);
+      Value loaded = *endBlock.args_begin();
+      loadedVals.push_back(loaded);
+    }
+
+    Type llvmResultStructTy = typeConverter->convertType(op.getType());
+    Value resultStruct = packLLElements(loc, typeConverter, loadedVals,
+                                        rewriter, llvmResultStructTy);
     rewriter.replaceOp(op, {resultStruct});
     return success();
   }
@@ -4482,10 +4861,10 @@ void mlir::triton::intel::populateLoadStoreOpToLLVMPatterns(
   patterns.add<LocalAtomicScatterRMWOpConversion>(typeConverter, targetInfo,
                                                   benefit);
   // Block IO store patterns (loads are handled via ttig.2d_block_load path).
-  patterns
-      .add<StoreOpToBlockIOConversion, DescriptorStoreOpToBlockIOConversion>(
-          typeConverter, targetInfo, axisInfoAnalysis, strideAnalysis,
-          benefit.getBenefit() + 2);
+  patterns.add<StoreOpToBlockIOConversion, DescriptorStoreOpToBlockIOConversion,
+               DescriptorGatherOpConversion>(typeConverter, targetInfo,
+                                             axisInfoAnalysis, strideAnalysis,
+                                             benefit.getBenefit() + 2);
   // TTIG ops from LowerTo2DBlockLoad TTGIR pass.
   patterns.add<ExtractDescOpConversion>(typeConverter, benefit);
   patterns.add<Subgroup2DBlockLoadOpConversion,

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2368,11 +2368,11 @@ private:
 
     SmallVector<Value> loadedVals(numElems);
 
+    // update offset Y.
+    Value addrElem = b.gep(ptr_ty(ctx, 1), valueElemTy, desc.base, offsetY);
+
     for (size_t elemIdx = 0; elemIdx < numElems; elemIdx += numElemsPerLoad) {
       unsigned registerIdx = regMapping.apply({{kRegister, elemIdx}})[0].second;
-
-      // update offset Y.
-      Value addrElem = b.gep(ptr_ty(ctx, 1), valueElemTy, desc.base, offsetY);
 
       SmallVector<Value> addrs, predicts;
       for (size_t i = 0; i < numPtrsPerLoad; ++i) {

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2217,6 +2217,66 @@ struct DescriptorGatherConversionBase : public BlockIOConversionBase {
     llvm_unreachable(msg.c_str());
   }
 
+  /// Configuration for DescriptorGather fast-path load decomposition.
+  struct DescriptorGatherLoadConfig {
+    int numPackedVals;
+    std::optional<SetVector<unsigned>> regPackedBases;
+    unsigned numPtrsPerLoad;
+    unsigned ptrsPerRow;
+    unsigned bytesPerPtr;
+    unsigned numElemsPerLoad;
+    LinearLayout offsetMapping;
+  };
+
+  static FailureOr<DescriptorGatherLoadConfig> buildDescriptorGatherLoadConfig(
+      const LinearLayout &llEncoding, RankedTensorType resultType,
+      RankedTensorType offsetsXType, size_t resultRank, Type valueElemTy,
+      ModuleOp moduleOp) {
+    unsigned elemSizeInBits = std::max(8u, valueElemTy.getIntOrFloatBitWidth());
+    BlockIOTileSizeInfo sizeInfo = getBlockIOLoadTileSize(
+        llEncoding, resultRank - 1, elemSizeInBits, nullptr, false);
+    if (!sizeInfo.isValid() || sizeInfo.transpose)
+      return failure();
+
+    DescriptorGatherLoadConfig cfg{
+        sizeInfo.numElemPerPackedVal,
+        std::move(sizeInfo.regPackedBases),
+        0,
+        0,
+        0,
+        0,
+        LinearLayout::empty(),
+    };
+
+    unsigned threadsPerWarp = TritonGPUDialect::getThreadsPerWarp(moduleOp);
+    constexpr unsigned totalBytesPerGatherLoadNonTrans = 256;
+    unsigned bytesPerRow =
+        sizeInfo.numElemPerPackedVal * sizeInfo.tileWidth * elemSizeInBits / 8;
+    sizeInfo.tileHeight = std::min(
+        sizeInfo.tileHeight,
+        static_cast<int>(totalBytesPerGatherLoadNonTrans / bytesPerRow));
+
+    unsigned numPackedValsPerTile = sizeInfo.tileHeight * sizeInfo.tileWidth;
+    constexpr unsigned maxNumPtrsPerLoad = 32;
+    cfg.numPtrsPerLoad = std::min(numPackedValsPerTile, maxNumPtrsPerLoad);
+
+    unsigned numElemsPerTile = numPackedValsPerTile * cfg.numPackedVals;
+    unsigned totalBytesPerTile = numElemsPerTile * (elemSizeInBits / 8);
+    cfg.bytesPerPtr = mlir::ceil(totalBytesPerTile, cfg.numPtrsPerLoad);
+    cfg.ptrsPerRow = ceil(bytesPerRow, cfg.bytesPerPtr);
+    cfg.numElemsPerLoad =
+        (sizeInfo.tileHeight * sizeInfo.tileWidth * cfg.numPackedVals) /
+        threadsPerWarp;
+
+    FailureOr<LinearLayout> offsetMapping = buildDescriptorGatherOffsetMapping(
+        resultType, offsetsXType, cfg.numPtrsPerLoad, cfg.ptrsPerRow,
+        cfg.bytesPerPtr, elemSizeInBits);
+    if (failed(offsetMapping))
+      return failure();
+    cfg.offsetMapping = *offsetMapping;
+    return std::move(cfg);
+  }
+
   static FailureOr<LinearLayout> buildDescriptorGatherOffsetMapping(
       RankedTensorType resultType, RankedTensorType offsetsXType,
       unsigned numPtrsPerLoad, unsigned ptrsPerRow, unsigned bytesPerPtr,
@@ -2242,7 +2302,6 @@ struct DescriptorGatherConversionBase : public BlockIOConversionBase {
     auto subLayout = llEncoding->sublayout(
         llvm::to_vector(llEncoding->getInDimNames()), {dim0Attr});
     auto regMLayout = subLayout.invertAndCompose(*offsetsXLLEncoding);
-
     std::optional<LinearLayout> conversion = regMLayout.quotient(kBlock);
     if (!conversion)
       return failure();
@@ -2307,10 +2366,45 @@ struct DescriptorGatherOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     if (succeeded(lowerSubGroupGatherFastPath(op, adaptor, rewriter)))
       return success();
-    return lowerDefaultGatherFallback(op, adaptor, rewriter);
+
+    llvm_unreachable(
+        "DescriptorGatherOpConversion: failed to lower DescriptorGatherOp");
+    return failure();
   }
 
 private:
+  struct GatherAddressAndPred {
+    Value pred;
+    Value addr;
+  };
+
+  static Value
+  getNamedOffset(const SmallVector<std::pair<StringAttr, Value>> &offsets,
+                 StringAttr dimName) {
+    auto it = llvm::find_if(
+        offsets, [&](const auto &offset) { return offset.first == dimName; });
+    assert(it != offsets.end() && "expected offset for requested dimension");
+    return it->second;
+  }
+
+  GatherAddressAndPred
+  buildGatherAddressAndPred(TritonLLVMOpBuilder &b, MLIRContext *ctx,
+                            Type valueElemTy, const DescriptorFields &desc,
+                            Value offsetX, Value offsetY) const {
+    Value offsetX64 = b.zext(IntegerType::get(ctx, 64), offsetX);
+    Value predX = b.icmp_ult(offsetX64, desc.shapes[0]);
+
+    Value yOffset64 = b.zext(IntegerType::get(ctx, 64), offsetY);
+    Value predY = b.icmp_ult(yOffset64, desc.shapes[1]);
+
+    Value pred = b.and_(predX, predY);
+    Value xLinearOffset = b.mul(offsetX64, desc.strides[0]);
+    Value yLinearOffset = b.mul(yOffset64, desc.strides[1]);
+    Value linearOffset = b.add(xLinearOffset, yLinearOffset);
+    Value addr = b.gep(ptr_ty(ctx, 1), valueElemTy, desc.base, linearOffset);
+    return {pred, addr};
+  }
+
   LogicalResult
   lowerSubGroupGatherFastPath(mlir::triton::gpu::intel::DescriptorGatherOp op,
                               OpAdaptor adaptor,
@@ -2333,6 +2427,12 @@ private:
 
     StringAttr kRegister = S("register");
     StringAttr kLane = S("lane");
+    StringAttr kBlock = S("block");
+    StringAttr kWarp = S("warp");
+    StringAttr kDim0 = S("dim0");
+    StringAttr kDim1 = S("dim1");
+    StringAttr kPtrs = S("ptrs");
+    StringAttr kOffIdx = S("offx_idx");
 
     size_t resultRank = resultType.getRank();
     Type valueElemTy = typeConverter->convertType(resultType.getElementType());
@@ -2342,216 +2442,178 @@ private:
     RankedTensorType descTensorType = descType.getBlockType();
     size_t descRank = descTensorType.getRank();
 
-    unsigned elemSizeInBits = std::max(8u, valueElemTy.getIntOrFloatBitWidth());
-    BlockIOTileSizeInfo sizeInfo = getBlockIOLoadTileSize(
-        llEncoding.value(), resultRank - 1, elemSizeInBits, nullptr, false);
-
-    if (!sizeInfo.isValid())
-      return failure();
-    int tileHeight = sizeInfo.tileHeight;
-    int tileWidth = sizeInfo.tileWidth;
-    int numPackedVals = sizeInfo.numElemPerPackedVal;
-    int vBlocks = sizeInfo.vBlocks;
-    int rowDim = sizeInfo.rowDim;
-    int colDim = sizeInfo.colDim;
-    bool isTransposeRequired = sizeInfo.transpose;
-    bool useVNNIFormat = sizeInfo.vnni;
-    if (isTransposeRequired)
-      return failure();
-    assert(rowDim == 0 && "only support rowDim=0 for 1D block I/O");
-    assert(colDim == 1 && "only support colDim=1 for 1D block I/O");
-    std::optional<SetVector<unsigned>> regPackedBases =
-        std::move(sizeInfo.regPackedBases);
-
-    constexpr unsigned totalBytesPerGatherLoadNonTrans = 256;
-    constexpr unsigned totalBytesPerGatherLoadTrans = 512;
-    unsigned bytesPerRow = numPackedVals * tileWidth * elemSizeInBits / 8;
-    tileHeight = std::min(tileHeight,
-                          (int)(totalBytesPerGatherLoadNonTrans / bytesPerRow));
-    unsigned numElemsPerTile = tileHeight * tileWidth * numPackedVals;
-    unsigned totalBytesPerTile = numElemsPerTile * (elemSizeInBits / 8);
-    constexpr unsigned numPtrsPerLoad = 32u;
-    unsigned bytesPerPtr = mlir::ceil(totalBytesPerTile, numPtrsPerLoad);
-    unsigned ptrsPerRow = ceil(bytesPerRow, bytesPerPtr);
+    unsigned numElemsPerLoad = 1;
+    unsigned numPackedVals = 1;
+    LinearLayout regMapping;
+    LinearLayout offMapping;
     unsigned threadsPerWarp =
         TritonGPUDialect::getThreadsPerWarp(op->getParentOfType<ModuleOp>());
-    unsigned numElemsPerLoad =
-        (tileHeight * tileWidth * numPackedVals) / threadsPerWarp;
+    unsigned numPtrsPerLoad = threadsPerWarp;
+    unsigned numPtrToOffY, numPtrToOffX;
+    FailureOr<DescriptorGatherLoadConfig> gatherLoadCfgOr =
+        buildDescriptorGatherLoadConfig(llEncoding.value(), resultType, offXTy,
+                                        resultRank, valueElemTy,
+                                        op->getParentOfType<ModuleOp>());
+    if (succeeded(gatherLoadCfgOr)) {
+      DescriptorGatherLoadConfig &gatherLoadCfg = *gatherLoadCfgOr;
+      numPackedVals = gatherLoadCfg.numPackedVals;
+      std::optional<SetVector<unsigned>> regPackedBases =
+          std::move(gatherLoadCfg.regPackedBases);
+      numPtrsPerLoad = gatherLoadCfg.numPtrsPerLoad;
+      numElemsPerLoad = gatherLoadCfg.numElemsPerLoad;
+      offMapping = gatherLoadCfg.offsetMapping;
 
-    FailureOr<LinearLayout> offMapping = buildDescriptorGatherOffsetMapping(
-        resultType, offXTy, numPtrsPerLoad, ptrsPerRow, bytesPerPtr,
-        elemSizeInBits);
-    if (failed(offMapping))
-      return failure();
+      auto ptrToOffX = offMapping.sublayout({kPtrs}, {kOffIdx});
+      auto ptrToOffY = offMapping.sublayout({kPtrs}, {kDim1});
+      if (numPtrsPerLoad == threadsPerWarp) {
+        // If the number pointers for gather load is same to the threadsPerWarp,
+        // we can map the pointers to each SIMD lane. By doing so, we can use
+        // normal llvm.load or predicated load operation with the non-uniform
+        // pointer input.
+        auto newMapping =
+            LinearLayout::identity1D(offMapping.getInDimSize(kRegister),
+                                     {kRegister}, {kRegister}) *
+            LinearLayout::identity1D(numPtrsPerLoad, {kLane}, {kPtrs});
+        offMapping = newMapping.compose(offMapping);
+      }
+      numPtrToOffY =
+          ptrToOffY.removeZeroBasesAlongDim(kPtrs).getInDimSize(kPtrs);
+      numPtrToOffX =
+          ptrToOffX.removeZeroBasesAlongDim(kPtrs).getInDimSize(kPtrs);
+      assert(numPtrToOffX * numPtrToOffY == numPtrsPerLoad &&
+             "invalid ptrToOffMapping");
+      assert(regPackedBases.has_value() &&
+             "invalid register bases for packing elems.");
+      regMapping = buildRegisterMapping(*regPackedBases, *llEncoding, ctx);
+    } else {
+      regMapping = LinearLayout::identity1D(numElems, {kRegister}, {kRegister});
+
+      auto subLayout = llEncoding->sublayout(
+          llvm::to_vector(llEncoding->getInDimNames()), {kDim0});
+      auto offsetsXType = cast<RankedTensorType>(op.getXOffsets().getType());
+      std::optional<LinearLayout> offsetsXLLEncoding =
+          cast<DistributedEncodingTrait>(offsetsXType.getEncoding())
+              .toLinearLayout(offsetsXType.getShape());
+      LinearLayout valueToOffsetMap =
+          subLayout.invertAndCompose(*offsetsXLLEncoding);
+      valueToOffsetMap = valueToOffsetMap.sublayout({kRegister}, {kRegister});
+      valueToOffsetMap =
+          renameLinearLayoutDims(valueToOffsetMap, /*inDimRenames=*/{},
+                                 /*outDimRenames=*/{{kRegister, kOffIdx}});
+      valueToOffsetMap = valueToOffsetMap.concatOuts(
+          llEncoding->sublayout({kRegister}, {kDim1}));
+      LinearLayout laneMapping = llEncoding->sublayout({kLane}, {kDim1});
+      laneMapping =
+          LinearLayout::zeros1D(threadsPerWarp, {kLane}, {kOffIdx},
+                                valueToOffsetMap.getOutDimSize(kOffIdx))
+              .concatOuts(laneMapping);
+      offMapping = valueToOffsetMap.concatIns(laneMapping);
+    }
 
     // All validity checks passed; now generate IR.
     SmallVector<Value> offsetsX =
         unpackLLElements(loc, adaptor.getXOffsets(), rewriter);
     DescriptorFields desc = unpackDescriptor(llDesc, descRank, loc, rewriter);
-    assert(regPackedBases.has_value() &&
-           "invalid register bases for packing elems.");
-    LinearLayout regMapping =
-        buildRegisterMapping(*regPackedBases, *llEncoding, ctx);
+
     LinearLayout shuffleMapping =
         LinearLayout::identity1D(numElemsPerLoad, kRegister, kRegister);
-
     Type unpackedType = LLVM::getVectorType(valueElemTy, numElemsPerLoad);
 
     SmallVector<Value> loadedVals(numElems);
 
+    auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
+    // Get the sub offset Y from the warp ID.
+    auto offsets = applyLinearLayout(loc, rewriter, *llEncoding,
+                                     {{kRegister, b.i32_val(0)},
+                                      {kLane, b.i32_val(0)},
+                                      {kWarp, warpId},
+                                      {kBlock, b.i32_val(0)}});
+    // Add sub-offset Y from warp Id.
+    Value basicOffsetY = b.add(offsetY, getNamedOffset(offsets, kDim1));
+
     for (size_t elemIdx = 0; elemIdx < numElems; elemIdx += numElemsPerLoad) {
       unsigned registerIdx = regMapping.apply({{kRegister, elemIdx}})[0].second;
 
-      // update offset Y.
-      Value addrElem = b.gep(ptr_ty(ctx, 1), valueElemTy, desc.base, offsetY);
+      Value ret;
+      if (numPtrsPerLoad == threadsPerWarp) {
+        // Get the offset X index from offMapping.
+        auto offsetsForX =
+            offMapping.apply({{kRegister, registerIdx}, {kLane, 0}});
+        auto offsetXIdx = offsetsForX[0];
+        assert(offsetXIdx.first == kOffIdx);
+        // Get the offset Y index from offMapping.
+        auto offsetsForY = applyLinearLayout(
+            loc, rewriter, offMapping,
+            {{kRegister, b.i32_val(registerIdx)}, {kLane, laneId}});
 
-      SmallVector<Value> addrs, predicts;
-      for (size_t i = 0; i < numPtrsPerLoad; ++i) {
-        auto offsetsForLoad = offMapping->apply(
-            {{kRegister, registerIdx}, {str_attr("ptrs"), i}});
-        auto linearOffsetY = offsetsForLoad[1];
-        assert(linearOffsetY.first == str_attr("dim1"));
-        Value subOffsetY = b.i32_val(linearOffsetY.second);
+        Value offsetX = offsetsX[offsetXIdx.second];
+        // Add sub-offset Y from register, lane id.
+        Value laneOffsetY =
+            b.add(basicOffsetY, getNamedOffset(offsetsForY, kDim1));
+        // The address and pred are non-uniform value.
+        GatherAddressAndPred gatherAddr = buildGatherAddressAndPred(
+            b, ctx, valueElemTy, desc, offsetX, laneOffsetY);
 
-        auto offsetXIdx = offsetsForLoad[0];
-        assert(offsetXIdx.first == str_attr("offx_idx"));
-        // Note: here assume the offsetX is uniform value which is deduced from
-        // slice layout of the result layout.
-        // TODO: need to improve this.
-        Value offsetXUniform = targetInfo.shuffleIdx(
-            rewriter, loc, offsetsX[offsetXIdx.second], 0);
-        Value offsetX = b.zext(int_ty(64), offsetXUniform);
-        Value pred = b.icmp_ult(offsetX, desc.shapes[0]);
-        Value offset64 = b.mul(offsetX, desc.strides[rowDim]);
+        auto createLoad = [&]() {
+          return SmallVector<Value>{b.load(unpackedType, gatherAddr.addr,
+                                           /*align=*/1,
+                                           /*isVolatile=*/false,
+                                           /*isNonTemporal=*/false)};
+        };
+        Block &endBlock = LLVM::intel::createPredicatedBlock(
+            rewriter, loc, gatherAddr.pred,
+            SmallVector<Value, 1>{b.undef(unpackedType)}, createLoad);
+        ret = *endBlock.args_begin();
+      } else {
+        SmallVector<Value> addrs, predicts;
+        // Compute the addresses one by one.
+        for (size_t i = 0; i < numPtrToOffX; ++i) {
+          unsigned ptrIdx = i * numPtrToOffY;
+          auto offsetsForX =
+              offMapping.apply({{kRegister, registerIdx}, {kPtrs, ptrIdx}});
+          auto offsetXIdx = offsetsForX[0];
+          assert(offsetXIdx.first == kOffIdx);
 
-        predicts.push_back(b.and_(
-            pred, b.icmp_ult(b.zext(int_ty(64), b.add(subOffsetY, offsetY)),
-                             desc.shapes[1])));
+          // Note: here assume the offsetX is uniform value which is deduced
+          // from slice layout of the result layout.
+          // TODO: need to improve this.
+          Value offsetX = targetInfo.shuffleIdx(rewriter, loc,
+                                                offsetsX[offsetXIdx.second], 0);
 
-        Value addr = b.gep(ptr_ty(ctx, 1), valueElemTy, addrElem,
-                           b.i32_val(linearOffsetY.second));
-        addr = b.gep(ptr_ty(ctx, 1), valueElemTy, addr, offset64);
+          for (size_t j = 0; j < numPtrToOffY; ++j) {
+            ptrIdx = i * numPtrToOffY + j;
+            auto offsetsForY =
+                offMapping.apply({{kRegister, registerIdx}, {kPtrs, ptrIdx}});
+            auto linearOffsetY = offsetsForY[1];
+            assert(linearOffsetY.first == kDim1);
+            Value ptrOffsetY =
+                b.add(basicOffsetY, b.i32_val(linearOffsetY.second));
+            // The address and pred are uniform value.
+            GatherAddressAndPred gatherAddr = buildGatherAddressAndPred(
+                b, ctx, valueElemTy, desc, offsetX, ptrOffsetY);
 
-        addrs.push_back(b.ptrtoint(i64_ty, addr));
+            predicts.push_back(gatherAddr.pred);
+            addrs.push_back(b.ptrtoint(i64_ty, gatherAddr.addr));
+          }
+        }
+        Value ptrVec = b.undef(vec_ty(i64_ty, addrs.size()));
+        Value predVec = b.undef(vec_ty(i1_ty, addrs.size()));
+        for (size_t i = 0; i < addrs.size(); ++i) {
+          Value sVal = createIndexAttrConstant(
+              rewriter, loc, typeConverter->getIndexType(), i);
+          ptrVec = b.insert_element(ptrVec, addrs[i], sVal);
+          predVec = b.insert_element(predVec, predicts[i], sVal);
+        }
+
+        ret = TritonGEN::SubGroupGatherLoadOp::create(
+            rewriter, loc, unpackedType, ptrVec, predVec);
       }
-      Value ptrVec = b.undef(vec_ty(i64_ty, addrs.size()));
-      Value predVec = b.undef(vec_ty(i1_ty, addrs.size()));
-      for (size_t i = 0; i < addrs.size(); ++i) {
-        Value sVal = createIndexAttrConstant(rewriter, loc,
-                                             typeConverter->getIndexType(), i);
-        ptrVec = b.insert_element(ptrVec, addrs[i], sVal);
-        predVec = b.insert_element(predVec, predicts[i], sVal);
-      }
-
-      Value ret = TritonGEN::SubGroupGatherLoadOp::create(
-          rewriter, loc, unpackedType, ptrVec, predVec);
 
       unpackBlockLoadResult(ret, loadedVals, elemIdx, regMapping,
                             shuffleMapping, {}, unpackedType, numElemsPerLoad,
                             numPackedVals, {}, {},
                             /*nanMaskElems=*/{}, loc, rewriter, ctx);
     }
-    Type llvmResultStructTy = typeConverter->convertType(op.getType());
-    Value resultStruct = packLLElements(loc, typeConverter, loadedVals,
-                                        rewriter, llvmResultStructTy);
-    rewriter.replaceOp(op, {resultStruct});
-    return success();
-  }
-
-  LogicalResult
-  lowerDefaultGatherFallback(mlir::triton::gpu::intel::DescriptorGatherOp op,
-                             OpAdaptor adaptor,
-                             ConversionPatternRewriter &rewriter) const {
-    Location loc = op->getLoc();
-    auto b = TritonLLVMOpBuilder(loc, rewriter);
-    auto typeConverter = getTypeConverter();
-    MLIRContext *ctx = rewriter.getContext();
-
-    Value llDesc = adaptor.getDesc();
-    SmallVector<Value> offsetsX =
-        unpackLLElements(loc, adaptor.getXOffsets(), rewriter);
-    Value offsetY = adaptor.getYOffset();
-
-    auto resultType = cast<RankedTensorType>(op.getType());
-    std::optional<LinearLayout> llEncoding =
-        cast<DistributedEncodingTrait>(resultType.getEncoding())
-            .toLinearLayout(resultType.getShape());
-    assert(llEncoding.has_value() &&
-           "unexpected failure when getting linear layout");
-
-    Type valueElemTy = typeConverter->convertType(resultType.getElementType());
-    unsigned numElems = getTotalElemsPerThread(resultType);
-
-    auto descType = cast<triton::TensorDescType>(op.getDesc().getType());
-    RankedTensorType descTensorType = descType.getBlockType();
-    size_t descRank = descTensorType.getRank();
-    DescriptorFields desc = unpackDescriptor(llDesc, descRank, loc, rewriter);
-
-    StringAttr kBlock = S("block");
-    StringAttr kWarp = S("warp");
-    StringAttr kLane = S("lane");
-    StringAttr kRegister = S("register");
-    StringAttr kDim0 = S("dim0");
-    StringAttr kDim1 = S("dim1");
-
-    Value fallbackDefault = b.undef(valueElemTy);
-    SmallVector<Value> loadedVals;
-    loadedVals.reserve(numElems);
-    auto subLayout = llEncoding->sublayout(
-        llvm::to_vector(llEncoding->getInDimNames()), {kDim0});
-    auto offsetsXType = cast<RankedTensorType>(op.getXOffsets().getType());
-    std::optional<LinearLayout> offsetsXLLEncoding =
-        cast<DistributedEncodingTrait>(offsetsXType.getEncoding())
-            .toLinearLayout(offsetsXType.getShape());
-    auto regMLayout = subLayout.invertAndCompose(*offsetsXLLEncoding);
-
-    auto registerMap = regMLayout.sublayout({kRegister}, {kRegister});
-
-    auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
-    for (unsigned elemIdx = 0; elemIdx < numElems; ++elemIdx) {
-      auto offsetIdx = registerMap.apply({{kRegister, elemIdx}})[0].second;
-
-      // Get the offset X index from register index first.
-      auto offsets = applyLinearLayout(loc, rewriter, *llEncoding,
-                                       {{kRegister, b.i32_val(elemIdx)},
-                                        {kLane, laneId},
-                                        {kWarp, warpId},
-                                        {kBlock, b.i32_val(0)}});
-      // Get the offset Y from the warp id, lane id and register id.
-      Value ySubOffset;
-      for (auto [name, value] : offsets) {
-        if (name == kDim1) {
-          ySubOffset = value;
-          break;
-        }
-      }
-
-      Value offsetX = offsetsX[offsetIdx];
-      Value offsetX64 = b.zext(i64_ty, offsetX);
-      Value predX = b.icmp_ult(offsetX64, desc.shapes[0]);
-
-      Value yOffset = b.add(offsetY, ySubOffset);
-      Value yOffset64 = b.zext(i64_ty, yOffset);
-      Value predY = b.icmp_ult(yOffset64, desc.shapes[1]);
-      Value pred = b.and_(predX, predY);
-
-      Value xLinearOffset = b.mul(offsetX64, desc.strides[0]);
-      Value yLinearOffset = b.mul(yOffset64, desc.strides[1]);
-      Value linearOffset = b.add(xLinearOffset, yLinearOffset);
-      Value addr = b.gep(ptr_ty(ctx, 1), valueElemTy, desc.base, linearOffset);
-
-      auto createLoad = [&]() {
-        return SmallVector<Value>{b.load(valueElemTy, addr, /*align=*/1,
-                                         /*isVolatile=*/false,
-                                         /*isNonTemporal=*/false)};
-      };
-      Block &endBlock = LLVM::intel::createPredicatedBlock(
-          rewriter, loc, pred, SmallVector<Value, 1>{fallbackDefault},
-          createLoad);
-      Value loaded = *endBlock.args_begin();
-      loadedVals.push_back(loaded);
-    }
-
     Type llvmResultStructTy = typeConverter->convertType(op.getType());
     Value resultStruct = packLLElements(loc, typeConverter, loadedVals,
                                         rewriter, llvmResultStructTy);


### PR DESCRIPTION
Adds LLVM lowering support for ttig.descriptor_gather on the Intel GPU backend, enabling conversion of descriptor-based gathers into either predicated LLVM loads (fallback) or a subgroup gather-load fast path when the layout/tile constraints allow it. This fits into the TritonIntelGPUToLLVM lowering pipeline by extending LoadStoreOpToLLVM.cpp pattern coverage and providing a dedicated regression test.