### PR TITLE
Improve codegen retry for CRI.

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -494,9 +494,12 @@ class CompiledKernel:
         # `build_flags`/`generate_native_code` are Intel/XPU-specific metadata fields.
         # Backends that don't define them (e.g. NVIDIA/CUDA) use the plain load_binary signature.
         if hasattr(self.metadata, "build_flags"):
+            device_arch = "unknown"
+            if isinstance(self.metadata.target.arch, dict):
+                device_arch = self.metadata.target.arch.get("arch", "unknown")
             self.module, self.function, self.n_regs, self.n_spills, self.n_max_threads = driver.active.utils.load_binary(
                 self.name, self.kernel, self.metadata.shared, self.metadata.build_flags,
-                not self.metadata.generate_native_code, device)
+                not self.metadata.generate_native_code, device, device_arch)
             # PyTorch could use the updated build flags in load binary.
             if hasattr(driver.active.utils, "get_last_selected_build_flags"):
                 new_build_flags = driver.active.utils.get_last_selected_build_flags()

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -620,61 +620,56 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
                 '-options', metadata['build_flags'] + shader_dump_opt
             ]
 
-            try:
-                subprocess.check_output(ocloc_cmd, stderr=subprocess.STDOUT, text=True)
-                if options.grf_mode == 'default':
-                    spill_size = extract_spill_size_from_zebin(fbin)
-                    # The threshold for spill_size is chosen based on empirical observations
-                    # and aligned with triton/backends/intel/driver.c
-                    if spill_size > MAX_REG_SPILL:
-                        metadata["build_flags"] += " -cl-intel-256-GRF-per-thread"
-                        # re-run with double GRF mode
-                        ocloc_cmd[-1] = metadata["build_flags"] + shader_dump_opt
-                        subprocess.check_output(ocloc_cmd, stderr=subprocess.STDOUT, text=True)
-            except (subprocess.CalledProcessError, IntelGPUError) as e:
-                # If GRF mode was not explicitly set, retry with large GRF mode
-                # before giving up. This handles cases where the default GRF mode
-                # doesn't provide enough registers (e.g., scratch space exceeds
-                # HW PTSS limit). Also covers degenerate zebin (no .text/.symtab)
-                # detected by extract_spill_size_from_zebin (LTS2 IGC silent
-                # PTSS overflow).
-                retry_succeeded = False
-                if options.grf_mode == 'default' and \
-                        "-cl-intel-256-GRF-per-thread" not in metadata.get("build_flags", ""):
-                    metadata["build_flags"] += " -cl-intel-256-GRF-per-thread"
-                    ocloc_cmd[-1] = metadata["build_flags"] + shader_dump_opt
-                    try:
-                        subprocess.check_output(ocloc_cmd, stderr=subprocess.STDOUT, text=True)
-                        retry_succeeded = True
-                    except subprocess.CalledProcessError:
-                        # Retry also failed — fall through to the original error
-                        # handling below, which will classify based on `e.output`
-                        # (the original failure's stderr) and raise either
-                        # OutOfResources or re-raise the original error.
-                        pass
+            if options.grf_mode == 'default':
+                # Try rebuilding with larger GRF modes (default first, then larger).
+                retry_grf_mode_list = [""]  # default GRF mode by omitting the flag
+                if metadata["target"].arch.get("arch") == 'cri':
+                    retry_grf_mode_list.append("-cl-intel-512-GRF-per-thread")
+                else:
+                    retry_grf_mode_list.append("-cl-intel-256-GRF-per-thread")
+            else:
+                # Non-default GRF mode is already encoded in metadata["build_flags"] (including "auto").
+                retry_grf_mode_list = [""]
 
-                if not retry_succeeded:
-                    # Only reclassify as OutOfResources when ocloc's stderr explicitly
-                    # reports a PTSS overflow. Other IntelGPUErrors (e.g. degenerate
-                    # zebin from extract_spill_size_from_zebin, ocloc SIGSEGV) keep
-                    # their original error class so the user sees the real cause.
-                    output = getattr(e, 'output', '') or ''
-                    if ptss_match := PTSS_OVERFLOW_RE.search(output):
-                        required = int(ptss_match.group(1)) if ptss_match.group(1) else 0
-                        limit = int(ptss_match.group(2)) if ptss_match.group(2) else 0
-                        raise OutOfResources(required, limit, "per-thread scratch space (PTSS)") from e
-                    if isinstance(e, IntelGPUError):
-                        raise
-                    if e.returncode == 255:
-                        error = 'Internal Triton ZEBIN codegen error'
-                    elif e.returncode == 128 + signal.SIGSEGV:
-                        error = '`ocloc` raised SIGSEGV'
-                    else:
-                        error = f'`ocloc` failed with error code {e.returncode}'
+            base_build_flags = metadata["build_flags"]
+            for grf_flag in retry_grf_mode_list:
+                metadata["build_flags"] = f"{base_build_flags} {grf_flag}".strip()
+                ocloc_cmd[-1] = metadata["build_flags"] + shader_dump_opt
+                try:
+                    subprocess.check_output(ocloc_cmd, stderr=subprocess.STDOUT, text=True)
+                    if options.grf_mode == "default":
+                        spill_size = extract_spill_size_from_zebin(fbin)
+                        if spill_size <= MAX_REG_SPILL:
+                            break
+                except (subprocess.CalledProcessError, IntelGPUError) as e:
+                    # If GRF mode was not last yet, retry with different GRF mode
+                    # before giving up. This handles cases where the default GRF mode
+                    # doesn't provide enough registers (e.g., scratch space exceeds
+                    # HW PTSS limit). Also covers degenerate zebin (no .text/.symtab)
+                    # detected by extract_spill_size_from_zebin (LTS2 IGC silent
+                    # PTSS overflow).
+                    if grf_flag == retry_grf_mode_list[-1]:
+                        # Only reclassify as OutOfResources when ocloc's stderr explicitly
+                        # reports a PTSS overflow. Other IntelGPUErrors (e.g. degenerate
+                        # zebin from extract_spill_size_from_zebin, ocloc SIGSEGV) keep
+                        # their original error class so the user sees the real cause.
+                        output = getattr(e, 'output', '') or ''
+                        if ptss_match := PTSS_OVERFLOW_RE.search(output):
+                            required = int(ptss_match.group(1)) if ptss_match.group(1) else 0
+                            limit = int(ptss_match.group(2)) if ptss_match.group(2) else 0
+                            raise OutOfResources(required, limit, "per-thread scratch space (PTSS)") from e
+                        if isinstance(e, IntelGPUError):
+                            raise
+                        if e.returncode == 255:
+                            error = 'Internal Triton ZEBIN codegen error'
+                        elif e.returncode == 128 + signal.SIGSEGV:
+                            error = '`ocloc` raised SIGSEGV'
+                        else:
+                            error = f'`ocloc` failed with error code {e.returncode}'
 
-                    raise IntelGPUError(f'{error}\n'
-                                        f'`ocloc` stderr:\n{e.output}\n'
-                                        f'Repro command: {ocloc_cmd}\n') from e
+                        raise IntelGPUError(f'{error}\n'
+                                            f'`ocloc` stderr:\n{e.output}\n'
+                                            f'Repro command: {ocloc_cmd}\n') from e
 
             with open(fbin, 'rb') as f:
                 zebin = f.read()

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -384,6 +384,7 @@ struct BuildFlags {
   std::string build_flags_str;
 
   const char *LARGE_GRF_FLAG{"-cl-intel-256-GRF-per-thread"};
+  const char *XLARGE_GRF_FLAG{"-cl-intel-512-GRF-per-thread"};
   const char *SMALL_GRF_FLAG{"-cl-intel-128-GRF-per-thread"};
   const char *AUTO_GRF_FLAG{"-cl-intel-enable-auto-large-GRF-mode"};
 
@@ -392,6 +393,9 @@ struct BuildFlags {
   const std::string &operator()() const { return build_flags_str; }
 
   int32_t n_regs() const {
+    if (build_flags_str.find(XLARGE_GRF_FLAG) != std::string::npos) {
+      return 512;
+    }
     if (build_flags_str.find(LARGE_GRF_FLAG) != std::string::npos) {
       return 256;
     }
@@ -403,6 +407,7 @@ struct BuildFlags {
 
   const bool hasGRFSizeFlag() const {
     if (build_flags_str.find(LARGE_GRF_FLAG) != std::string::npos ||
+        build_flags_str.find(XLARGE_GRF_FLAG) != std::string::npos ||
         build_flags_str.find(SMALL_GRF_FLAG) != std::string::npos ||
         build_flags_str.find(AUTO_GRF_FLAG) != std::string::npos) {
       return true;
@@ -413,6 +418,10 @@ struct BuildFlags {
 
   void addLargeGRFSizeFlag() {
     build_flags_str = build_flags_str.append(" ").append(LARGE_GRF_FLAG);
+  }
+
+  void addXLargeGRFSizeFlag() {
+    build_flags_str = build_flags_str.append(" ").append(XLARGE_GRF_FLAG);
   }
 };
 
@@ -451,17 +460,20 @@ extern "C" EXPORT_FUNC PyObject *get_last_selected_build_flags() {
 }
 
 extern "C" EXPORT_FUNC PyObject *load_binary(PyObject *args) {
-  const char *name, *build_flags_ptr;
+  const char *name, *build_flags_ptr, *deviceArch = nullptr;
   int shared;
   PyObject *py_bytes;
   int is_spv;
   int devId;
 
-  if (!PyArg_ParseTuple(args, "sSispi", &name, &py_bytes, &shared,
-                        &build_flags_ptr, &is_spv, &devId)) {
+  if (!PyArg_ParseTuple(args, "sSispi|z", &name, &py_bytes, &shared,
+                        &build_flags_ptr, &is_spv, &devId, &deviceArch)) {
     // PyArg_ParseTuple will set a PyErr
     return NULL;
   }
+
+  const char *resolvedDeviceArch =
+      (deviceArch != nullptr && deviceArch[0] != '\0') ? deviceArch : "unknown";
 
   TRITON_ZE_FAIL_IF(devId >= g_sycl_l0_device_list.size(),
                     "Device is not found");
@@ -513,7 +525,11 @@ extern "C" EXPORT_FUNC PyObject *load_binary(PyObject *args) {
                 << kernel_name << "\", retrying with large GRF mode"
                 << std::endl;
 
-    build_flags.addLargeGRFSizeFlag();
+    if (std::strcmp(resolvedDeviceArch, "cri") == 0) {
+      build_flags.addXLargeGRFSizeFlag();
+    } else {
+      build_flags.addLargeGRFSizeFlag();
+    }
 
     try {
       auto [l0_module_retry, l0_kernel_retry, n_spills_retry] =

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -289,8 +289,12 @@ class SpirvUtils:
     def load_binary(self, *args):
         # if we don't use parameter passing in this way,
         # we will need to rewrite the line in the general part of the code:
-        # driver.active.utils.load_binary(self.name, self.kernel, self.metadata.shared, self.metadata.build_flags, device) ->
-        # driver.active.utils.load_binary((self.name, self.kernel, self.metadata.shared, self.metadata.build_flags, device))
+        # driver.active.utils.load_binary(
+        #     self.name, self.kernel, self.metadata.shared,
+        #     self.metadata.build_flags, is_spv, device, deviceArch) ->
+        # driver.active.utils.load_binary(
+        #     (self.name, self.kernel, self.metadata.shared,
+        #      self.metadata.build_flags, is_spv, device, deviceArch))
         # PTSS-overflow detection happens at the C level (driver.c
         # tryRaisePTSSOutOfResources): when zeModuleCreate fails and the
         # IGC build log carries a PTSS marker, OutOfResources is raised


### PR DESCRIPTION
This PR updates the Intel XPU native-codegen retry behavior to support larger GRF modes (including 512-GRF for CRI) and refactors the retry logic in both the Level Zero driver path and the ocloc-based ZEBIN generation path.