### PR TITLE
[CI] Build on Windows: use GitHub-hosted windows-2022 CPU runner (#7443)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -20,8 +20,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on:
-      - windows
+    runs-on: windows-2022
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -30,6 +29,11 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.10'
+
+      - name: Set up MSVC
+        uses: ilammy/msvc-dev-cmd@v1.13.0
+        with:
+          arch: amd64
 
       - name: Clean up old workspaces
         shell: bash
@@ -45,13 +49,9 @@ jobs:
         run:
           python -m venv .venv
 
-      # We need ninja >= 1.12.0 to support long names on Windows. At the moment there is no required
-      # version in pypi, so instead of installing ninja with pip we use a preinstalled 1.12.1 on the
-      # runner.
       - name: Setup Triton
         run: |
           .venv\Scripts\activate.ps1
-          Invoke-BatchFile "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
           cd ${{ env.NEW_WORKSPACE }}
           pip install -U pybind11 cmake
           pip install -v '.[build]'


### PR DESCRIPTION
Closes https://github.com/intel/intel-xpu-backend-for-triton/issues/7443