### PR TITLE
[CI] Move vLLM benchmarks PVC schedule into the PVC wrapper

### DIFF
--- a/.github/workflows/vllm-benchmarks-pvc.yml
+++ b/.github/workflows/vllm-benchmarks-pvc.yml
@@ -7,9 +7,12 @@ on:
     branches:
       - main
     types: [opened, synchronize, reopened, labeled]
+  schedule:
+    - cron: "0 8 * * *"
 
 jobs:
   check-paths:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       benchmarks: ${{ steps.check.outputs.changed }}
@@ -25,7 +28,12 @@ jobs:
 
   build-wheel:
     needs: check-paths
-    if: needs.check-paths.outputs.benchmarks == 'true' || github.event.label.name == 'run-benchmarks'
+    # Always build on schedule; on PRs only when benchmark paths changed or the label is applied.
+    if: >-
+      always() && !cancelled() &&
+      (github.event_name == 'schedule' ||
+       needs.check-paths.outputs.benchmarks == 'true' ||
+       github.event.label.name == 'run-benchmarks')
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
@@ -34,7 +42,9 @@ jobs:
     needs: [check-paths, build-wheel]
     if: >-
       always() && !cancelled() &&
-      (needs.check-paths.outputs.benchmarks == 'true' || github.event.label.name == 'run-benchmarks')
+      (github.event_name == 'schedule' ||
+       needs.check-paths.outputs.benchmarks == 'true' ||
+       github.event.label.name == 'run-benchmarks')
     uses: ./.github/workflows/vllm-benchmarks.yml
     with:
       runner_label: max1550

--- a/.github/workflows/vllm-benchmarks.yml
+++ b/.github/workflows/vllm-benchmarks.yml
@@ -23,9 +23,9 @@ on:
         description: Use prebuilt vLLM XPU kernels wheel from the current branch (must have a successful nightly build)
         type: boolean
         default: false
-  # PR runs come through the vllm-benchmarks-pvc.yml wrapper (which builds the
-  # branch benchmarks wheel first), mirroring triton-benchmarks.yml; the bmg
-  # wrapper drives the BMG schedule. This workflow keeps its own PVC schedule.
+  # PR runs and the PVC schedule come through the vllm-benchmarks-pvc.yml wrapper
+  # (which builds the branch benchmarks wheel first), mirroring triton-benchmarks.yml;
+  # the bmg wrapper drives the BMG schedule.
   workflow_call:
     inputs:
       runner_label:
@@ -49,9 +49,6 @@ on:
         description: Use prebuilt vLLM XPU kernels wheel from the current branch (must have a successful nightly build)
         type: boolean
         default: false
-
-  schedule:
-    - cron: "0 8 * * *"
 
 permissions: read-all
 


### PR DESCRIPTION
## Summary

Relocate the PVC benchmarks cron schedule out of the reusable `vllm-benchmarks.yml` and into `vllm-benchmarks-pvc.yml`, mirroring the `triton-benchmarks` / `*-bmg` layout.

- **`vllm-benchmarks.yml`** — drop the embedded PVC schedule; now a pure `workflow_dispatch` + `workflow_call` reusable.
- **`vllm-benchmarks-pvc.yml`** — gains the PVC schedule with schedule-aware gating (`check-paths` runs only on `pull_request`; `build-wheel`/`benchmarks` gate on the `schedule` event explicitly).

## Behavior

The scheduled PVC benchmarks run now builds the **branch** benchmarks wheel via the wrapper's `build-wheel` job (same path as PR runs) instead of falling back to the `main` wheel — matching the BMG scheduled run. `TAG` resolution is unchanged (`workflow_call` inherits the caller's `schedule` event → `ci` tag).

No new triggers or labels. Split out of the vLLM tests workflow cleanup so each PR has a single thesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)