### PR TITLE
[vLLM] Add vLLM BMG benchmarks to source change trigger and move PVC schedule

### DIFF
--- a/.github/workflows/vllm-benchmarks-bmg.yml
+++ b/.github/workflows/vllm-benchmarks-bmg.yml
@@ -3,18 +3,40 @@ name: vLLM benchmarks, BMG
 permissions: read-all
 
 on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, labeled]
   schedule:
     - cron: "0 8 * * *"
 
 jobs:
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      benchmarks: ${{ steps.check.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Check for vLLM benchmark changes
+        id: check
+        uses: ./.github/actions/check-path-changes
+        with:
+          patterns: '^(\.github/workflows/(vllm-benchmarks|build-benchmarks-wheel).*\.yml|\.github/actions/(install-benchmarks|install-vllm)/|benchmarks/|scripts/vllm/|\.github/pins/pytorch\.txt)'
+
   build-wheel:
+    needs: check-paths
+    if: needs.check-paths.outputs.benchmarks == 'true' || github.event.label.name == 'run-benchmarks'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
 
   benchmarks:
-    needs: build-wheel
-    if: always() && !cancelled()
+    needs: [check-paths, build-wheel]
+    if: >-
+      always() && !cancelled() &&
+      (needs.check-paths.outputs.benchmarks == 'true' || github.event.label.name == 'run-benchmarks')
     uses: ./.github/workflows/vllm-benchmarks.yml
     with:
       runner_label: b580

--- a/.github/workflows/vllm-benchmarks-bmg.yml
+++ b/.github/workflows/vllm-benchmarks-bmg.yml
@@ -10,6 +10,11 @@ on:
   schedule:
     - cron: "0 8 * * *"
 
+# Cancel in-progress runs for the same PR or schedule.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}
+  cancel-in-progress: true
+
 jobs:
   check-paths:
     runs-on: ubuntu-latest

--- a/.github/workflows/vllm-benchmarks-bmg.yml
+++ b/.github/workflows/vllm-benchmarks-bmg.yml
@@ -27,7 +27,10 @@ jobs:
 
   build-wheel:
     needs: check-paths
-    if: needs.check-paths.outputs.benchmarks == 'true' || github.event.label.name == 'run-benchmarks'
+    if: >-
+      github.event_name == 'schedule' ||
+      needs.check-paths.outputs.benchmarks == 'true' ||
+      github.event.label.name == 'run-benchmarks'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
@@ -36,7 +39,9 @@ jobs:
     needs: [check-paths, build-wheel]
     if: >-
       always() && !cancelled() &&
-      (needs.check-paths.outputs.benchmarks == 'true' || github.event.label.name == 'run-benchmarks')
+      (github.event_name == 'schedule' ||
+       needs.check-paths.outputs.benchmarks == 'true' ||
+       github.event.label.name == 'run-benchmarks')
     uses: ./.github/workflows/vllm-benchmarks.yml
     with:
       runner_label: b580

--- a/.github/workflows/vllm-benchmarks-bmg.yml
+++ b/.github/workflows/vllm-benchmarks-bmg.yml
@@ -12,7 +12,7 @@ on:
 
 # Cancel in-progress runs for the same PR or schedule.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || "ci" }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/vllm-benchmarks-bmg.yml
+++ b/.github/workflows/vllm-benchmarks-bmg.yml
@@ -12,7 +12,7 @@ on:
 
 # Cancel in-progress runs for the same PR or schedule.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || "ci" }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/vllm-benchmarks-bmg.yml
+++ b/.github/workflows/vllm-benchmarks-bmg.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
   schedule:
     - cron: "0 8 * * *"
 
@@ -28,14 +28,13 @@ jobs:
         id: check
         uses: ./.github/actions/check-path-changes
         with:
-          patterns: '^(\.github/workflows/(vllm-benchmarks|build-benchmarks-wheel).*\.yml|\.github/actions/(install-benchmarks|install-vllm)/|benchmarks/|scripts/vllm/|\.github/pins/pytorch\.txt)'
+          patterns: '^(\.github/workflows/(vllm-benchmarks|build-benchmarks-wheel).*\.yml|\.github/actions/(install-benchmarks|install-vllm)/|benchmarks/triton_kernels_benchmark/vllm/|scripts/vllm/|\.github/pins/pytorch\.txt)'
 
   build-wheel:
     needs: check-paths
     if: >-
       github.event_name == 'schedule' ||
-      needs.check-paths.outputs.benchmarks == 'true' ||
-      github.event.label.name == 'run-benchmarks'
+      needs.check-paths.outputs.benchmarks == 'true'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
@@ -45,8 +44,7 @@ jobs:
     if: >-
       always() && !cancelled() &&
       (github.event_name == 'schedule' ||
-       needs.check-paths.outputs.benchmarks == 'true' ||
-       github.event.label.name == 'run-benchmarks')
+       needs.check-paths.outputs.benchmarks == 'true')
     uses: ./.github/workflows/vllm-benchmarks.yml
     with:
       runner_label: b580

--- a/.github/workflows/vllm-benchmarks-pvc.yml
+++ b/.github/workflows/vllm-benchmarks-pvc.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
     types: [opened, synchronize, reopened, labeled]
+  schedule:
+    - cron: "0 8 * * *"
 
 jobs:
   check-paths:

--- a/.github/workflows/vllm-benchmarks-pvc.yml
+++ b/.github/workflows/vllm-benchmarks-pvc.yml
@@ -10,6 +10,11 @@ on:
   schedule:
     - cron: "0 8 * * *"
 
+# Cancel in-progress runs for the same PR or schedule.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}
+  cancel-in-progress: true
+
 jobs:
   check-paths:
     runs-on: ubuntu-latest

--- a/.github/workflows/vllm-benchmarks-pvc.yml
+++ b/.github/workflows/vllm-benchmarks-pvc.yml
@@ -12,7 +12,7 @@ on:
 
 # Cancel in-progress runs for the same PR or schedule.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || "ci" }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/vllm-benchmarks-pvc.yml
+++ b/.github/workflows/vllm-benchmarks-pvc.yml
@@ -12,7 +12,7 @@ on:
 
 # Cancel in-progress runs for the same PR or schedule.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || "ci" }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/vllm-benchmarks-pvc.yml
+++ b/.github/workflows/vllm-benchmarks-pvc.yml
@@ -27,7 +27,10 @@ jobs:
 
   build-wheel:
     needs: check-paths
-    if: needs.check-paths.outputs.benchmarks == 'true' || github.event.label.name == 'run-benchmarks'
+    if: >-
+      github.event_name == 'schedule' ||
+      needs.check-paths.outputs.benchmarks == 'true' ||
+      github.event.label.name == 'run-benchmarks'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
@@ -36,7 +39,9 @@ jobs:
     needs: [check-paths, build-wheel]
     if: >-
       always() && !cancelled() &&
-      (needs.check-paths.outputs.benchmarks == 'true' || github.event.label.name == 'run-benchmarks')
+      (github.event_name == 'schedule' ||
+       needs.check-paths.outputs.benchmarks == 'true' ||
+       github.event.label.name == 'run-benchmarks')
     uses: ./.github/workflows/vllm-benchmarks.yml
     with:
       runner_label: max1550

--- a/.github/workflows/vllm-benchmarks-pvc.yml
+++ b/.github/workflows/vllm-benchmarks-pvc.yml
@@ -28,7 +28,7 @@ jobs:
         id: check
         uses: ./.github/actions/check-path-changes
         with:
-          patterns: '^(\.github/workflows/(vllm-benchmarks|build-benchmarks-wheel).*\.yml|\.github/actions/(install-benchmarks|install-vllm)/|benchmarks/|scripts/vllm/|\.github/pins/pytorch\.txt)'
+          patterns: '^(\.github/workflows/(vllm-benchmarks|build-benchmarks-wheel).*\.yml|\.github/actions/(install-benchmarks|install-vllm)/|benchmarks/triton_kernels_benchmark/vllm/|scripts/vllm/|\.github/pins/pytorch\.txt)'
 
   build-wheel:
     needs: check-paths

--- a/.github/workflows/vllm-benchmarks.yml
+++ b/.github/workflows/vllm-benchmarks.yml
@@ -23,9 +23,6 @@ on:
         description: Use prebuilt vLLM XPU kernels wheel from the current branch (must have a successful nightly build)
         type: boolean
         default: false
-  # PR runs come through the vllm-benchmarks-pvc.yml wrapper (which builds the
-  # branch benchmarks wheel first), mirroring triton-benchmarks.yml; the bmg
-  # wrapper drives the BMG schedule. This workflow keeps its own PVC schedule.
   workflow_call:
     inputs:
       runner_label:

--- a/.github/workflows/vllm-benchmarks.yml
+++ b/.github/workflows/vllm-benchmarks.yml
@@ -50,9 +50,6 @@ on:
         type: boolean
         default: false
 
-  schedule:
-    - cron: "0 8 * * *"
-
 permissions: read-all
 
 # VLLM installation from upstream uses vllm-xpu-kernels wheel which is built just for python==3.12


### PR DESCRIPTION
Source changes already trigger the vLLM benchmark PVC runs. I think that adding BMG will not increase the duration of benchmark testing and may catch BMG specific regressions quicker.

This patch restricts the existing source change detection for PVC runs from `benchmarks/` -> `benchmarks/triton_kernels_benchmark/vllm/`.

This patch also moves the PVC schedule into the `vllm-benchmarks-pvc.yml` workflow for consistency.