### PR TITLE
[AxisInfo][StrideInfo] Disable signed division/remainder optimizations

### DIFF
--- a/benchmarks/triton_kernels_benchmark/gemm_tensor_of_ptr_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/gemm_tensor_of_ptr_benchmark.py
@@ -40,7 +40,7 @@ def matmul_kernel(
     num_pid_in_group = GROUP_SIZE_M * num_pid_n
     group_id = pid // num_pid_in_group
     first_pid_m = group_id * GROUP_SIZE_M
-    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    group_size_m = max(min(num_pid_m - first_pid_m, GROUP_SIZE_M), 1)
     pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
     pid_n = (pid % num_pid_in_group) // group_size_m
 
@@ -94,7 +94,7 @@ def matmul_kernel_batched(
     num_pid_in_group = GROUP_SIZE_M * num_pid_n
     group_id = pid // num_pid_in_group
     first_pid_m = group_id * GROUP_SIZE_M
-    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    group_size_m = max(min(num_pid_m - first_pid_m, GROUP_SIZE_M), 1)
     pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
     pid_n = (pid % num_pid_in_group) // group_size_m
 

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -444,11 +444,18 @@ private:
     // the minimal constancy is gcd(d_lhs, d_rhs).
     // Since gcd(d_lhs, d_rhs) maybe > len(lhs),
     // we need to use another gcd to get the actual constancy.
-    if (AxisInfoVisitor::isContiguousDim(lhs, shape, dim) &&
-        AxisInfoVisitor::isConstantDim(rhs, shape, dim)) {
-      constancy = std::max(constancy,
-                           gcd(lhs.getContiguity(dim), lhs.getDivisibility(dim),
-                               rhs.getDivisibility(dim)));
+    //
+    // NOTE: This optimization is only valid for unsigned division (DivUIOp).
+    // For signed division (DivSIOp), truncation toward zero breaks the
+    // constancy pattern for negative inputs. Without range analysis we
+    // cannot prove inputs are non-negative, so we conservatively skip.
+    if constexpr (!std::is_same_v<OpTy, arith::DivSIOp>) {
+      if (AxisInfoVisitor::isContiguousDim(lhs, shape, dim) &&
+          AxisInfoVisitor::isConstantDim(rhs, shape, dim)) {
+        constancy = std::max(constancy, gcd(lhs.getContiguity(dim),
+                                            lhs.getDivisibility(dim),
+                                            rhs.getDivisibility(dim)));
+      }
     }
     return constancy;
   }
@@ -506,16 +513,32 @@ private:
     // The minimal contiguity is gcd(d_lhs, d_rhs).
     // Since gcd(d_lhs, d_rhs) maybe > len(lhs),
     // we need to use another gcd to get the actual contiguity.
-    if (AxisInfoVisitor::isContiguousDim(lhs, shape, dim) &&
-        AxisInfoVisitor::isConstantDim(rhs, shape, dim)) {
-      contiguity = gcd(lhs.getContiguity(dim), lhs.getDivisibility(dim),
-                       rhs.getDivisibility(dim));
+    //
+    // NOTE: This optimization is only valid for unsigned remainder (RemUIOp).
+    // For signed remainder (RemSIOp), the contiguity pattern breaks for
+    // negative inputs because srem produces negative results for negative
+    // dividends. Without range analysis we cannot prove inputs are
+    // non-negative, so we conservatively skip.
+    if constexpr (!std::is_same_v<OpTy, arith::RemSIOp>) {
+      if (AxisInfoVisitor::isContiguousDim(lhs, shape, dim) &&
+          AxisInfoVisitor::isConstantDim(rhs, shape, dim)) {
+        contiguity = gcd(lhs.getContiguity(dim), lhs.getDivisibility(dim),
+                         rhs.getDivisibility(dim));
+      }
     }
     return contiguity;
   }
 
   int64_t getDivisibility(OpTy op, const AxisInfo &lhs, const AxisInfo &rhs,
                           int dim) override {
+    // NOTE: The divisibility claim gcd(d_lhs, d_rhs) only holds for the
+    // first element of each contiguity group. For RemSIOp we disable the
+    // contiguity optimization (see getContiguity), so contiguity is 1 and
+    // divisibility must hold for ALL elements — which it doesn't in
+    // general. Conservatively return 1 for RemSIOp.
+    if constexpr (std::is_same_v<OpTy, arith::RemSIOp>) {
+      return 1;
+    }
     if (rhs.getConstancy(dim) > 1) {
       // lhs: d_lhs * k = gcd(d_lhs, d_rhs) * k' * k = gcd(d_lhs, d_rhs) * k''
       // rhs: d_rhs * p = gcd(d_lhs, d_rhs) * p' * p = gcd(d_lhs, d_rhs) * p''

--- a/scripts/patch-pytorch.sh
+++ b/scripts/patch-pytorch.sh
@@ -36,3 +36,4 @@ echo "Applying PyTorch patches in $REPO_ROOT"
 
 # put your patch applies here
 apply_patch patch/skip-test-topk-xpu.patch
+apply_patch patch/175168-floordiv-xpu.patch

--- a/scripts/patch/175168-floordiv-xpu.patch
+++ b/scripts/patch/175168-floordiv-xpu.patch
@@ -1,0 +1,19 @@
+diff --git a/torch/_inductor/codegen/triton.py b/torch/_inductor/codegen/triton.py
+index fe7b1c7d865..e09bbe79af1 100644
+--- a/torch/_inductor/codegen/triton.py
++++ b/torch/_inductor/codegen/triton.py
+@@ -2319,6 +2319,14 @@ class TritonOverrides(OpOverrides):
+         # See the comment in lowering.div_mode. a and b are integer type.
+         # Notice that // in triton behaves as truncdiv instead of floordiv.
+         #
++        # The XPU backend fixes the Triton AxisInfo bug for signed division
++        # and converts provably non-negative divsi to divui early, so use
++        # the simple floordiv lowering without the bitwise workaround.
++        if V.graph.get_current_device_or_throw().type == "xpu":
++            quot = f"{a} // {b}"
++            rem = f"{a} % {b}"
++            return f"tl.where(({a} < 0) != ({b} < 0), tl.where({rem} != 0, {quot} - 1, {quot}), {quot})"
++        #
+         # We avoid feeding negative values into Triton's // operator because
+         # Triton's AxisInfo analysis incorrectly deduplicates signed division
+         # results for contiguous inputs (triton-lang/triton#XXXX). Instead we

--- a/test/Analysis/intel/test-axis-info.mlir
+++ b/test/Analysis/intel/test-axis-info.mlir
@@ -146,7 +146,7 @@ tt.func @div() {
   %3 = arith.divui %1, %0 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [64], constancy = [128], constant_value = 64
   %4 = arith.constant dense<64> : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [64], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %5 = arith.divsi %0, %4 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %6 = arith.divsi %4, %0 : tensor<128xi32>
@@ -158,8 +158,12 @@ tt.func @div() {
   %9 = arith.divui %0, %8 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [128], divisibility = [8192], constancy = [1], constant_value = <none>
   %10 = tt.make_range {end = 8320 : i32, start = 8192 : i32} : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [64], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %11 = arith.divsi %10, %4 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [128], divisibility = [32], constancy = [1], constant_value = <none>
+  %12 = tt.make_range {end = 160 : i32, start = 32 : i32} : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %13 = arith.divsi %12, %4 : tensor<128xi32>
   tt.return
 }
 
@@ -177,7 +181,7 @@ tt.func @rem() {
   %3 = arith.remui %1, %0 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [64], constancy = [128], constant_value = 64
   %4 = arith.constant dense<64> : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [64], divisibility = [64], constancy = [1], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %5 = arith.remsi %0, %4 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %6 = arith.remsi %4, %0 : tensor<128xi32>
@@ -274,17 +278,17 @@ tt.func @cmp_partial_contiguous() {
   %1 = arith.constant dense<8> : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [32], constancy = [128], constant_value = 32
   %3 = arith.constant dense<32> : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [32], divisibility = [32], constancy = [1], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %4 = arith.remsi %0, %3 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %5 = arith.cmpi eq, %4, %1 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %6 = arith.cmpi ne, %4, %1 : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %7 = arith.cmpi slt, %4, %1 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %8 = arith.cmpi sle, %4, %1 : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %9 = arith.cmpi sge, %4, %1 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %10 = arith.cmpi sgt, %4, %1 : tensor<128xi32>
@@ -294,25 +298,25 @@ tt.func @cmp_partial_contiguous() {
   %12 = arith.cmpi ne, %1, %4 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %13 = arith.cmpi slt, %1, %4 : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %14 = arith.cmpi sle, %1, %4 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %15 = arith.cmpi sge, %1, %4 : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %16 = arith.cmpi sgt, %1, %4 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [16], constancy = [128], constant_value = 48
   %17 = arith.constant dense<48> : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [16], divisibility = [16], constancy = [1], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %18 = arith.remsi %0, %17 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %19 = arith.cmpi eq, %18, %3 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %20 = arith.cmpi ne, %18, %3 : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [16], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %21 = arith.cmpi slt, %18, %3 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %22 = arith.cmpi sle, %18, %3 : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [16], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %23 = arith.cmpi sge, %18, %3 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %24 = arith.cmpi sgt, %18, %3 : tensor<128xi32>
@@ -322,11 +326,11 @@ tt.func @cmp_partial_contiguous() {
   %26 = arith.cmpi ne, %3, %18 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %27 = arith.cmpi slt, %3, %18 : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [16], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %28 = arith.cmpi sle, %3, %18 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %29 = arith.cmpi sge, %3, %18 : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [16], constant_value = <none
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %30 = arith.cmpi sgt, %3, %18 : tensor<128xi32>
   tt.return
 }
@@ -339,11 +343,11 @@ tt.func @logic() {
   %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [64], constancy = [128], constant_value = 64
   %1 = arith.constant dense<64> : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [64], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %2 = arith.divsi %0, %1 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [8], constancy = [128], constant_value = 8
   %3 = arith.constant dense<8> : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %4 = arith.divsi %0, %3 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %5 = arith.andi %0, %1 : tensor<128xi32>
@@ -351,11 +355,11 @@ tt.func @logic() {
   %6 = arith.ori %0, %1 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %7 = arith.xori %0, %1 : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %8 = arith.andi %2, %4 : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %9 = arith.ori %2, %4 : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %10 = arith.xori %2, %4 : tensor<128xi32>
   tt.return
 }
@@ -635,21 +639,21 @@ tt.func @load_constancy(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1:
   %eight = arith.constant dense<8> : tensor<1024xi32>
   // CHECK-NEXT: contiguity = [1024], divisibility = [1073741824], constancy = [1]
   %1 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
-  // CHECK-NEXT: constancy = [16]
+  // CHECK-NEXT: constancy = [1]
   %2 = arith.divsi %1, %sixteen : tensor<1024xi32>
   // CHECK-NEXT: constancy = [1024]
   %3 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
   // CHECK-NEXT: constancy = [1024]
   %4 = tt.splat %arg1 : i32 -> tensor<1024xi32>
-  // CHECK-NEXT: constancy = [8]
+  // CHECK-NEXT: constancy = [1]
   %5 = arith.divsi %1, %eight : tensor<1024xi32>
-  // CHECK-NEXT: constancy = [8]
+  // CHECK-NEXT: constancy = [1]
   %6 = arith.cmpi slt, %5, %4 : tensor<1024xi32>
-  // CHECK-NEXT: constancy = [16]
+  // CHECK-NEXT: constancy = [1]
   %7 = tt.addptr %3, %2 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
-  // CHECK-NEXT: constancy = [16]
+  // CHECK-NEXT: constancy = [1]
   %8 = tt.load %7 : tensor<1024x!tt.ptr<f32>>
-  // CHECK-NEXT: constancy = [8]
+  // CHECK-NEXT: constancy = [1]
   %9 = tt.load %7, %6 : tensor<1024x!tt.ptr<f32>>
   tt.return
 }
@@ -988,9 +992,9 @@ tt.func public @ptr_offset(%arg0: i32, %arg1: tensor<128x1xi32>) {
   %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
   // CHECK: contiguity = [128], divisibility = [128], constancy = [1], constant_value = <none>
   %3 = arith.addi %1, %2 : tensor<128xi32>
-  // CHECK: contiguity = [128], divisibility = [128], constancy = [1], constant_value = <none>
+  // CHECK: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %4 = arith.remsi %3, %cst_1 : tensor<128xi32>
-  // CHECK: contiguity = [128, 1], divisibility = [128, 1], constancy = [1, 1], constant_value = <none>
+  // CHECK: contiguity = [1, 1], divisibility = [1, 1], constancy = [1, 1], constant_value = <none>
   %5 = tt.expand_dims %4 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
   // CHECK: contiguity = [1, 1], divisibility = [512, 512], constancy = [1, 1], constant_value = <none>
   %6 = arith.muli %5, %cst_0 : tensor<128x1xi32>

--- a/test/Analysis/intel/test-stride-info.mlir
+++ b/test/Analysis/intel/test-stride-info.mlir
@@ -119,8 +119,8 @@ tt.func @div() {
   // stride(range) * 4 = 4, then 4 / 4 = 1
   // CHECK: arith.muli {{.*}} => stride = [4]
   %1 = arith.muli %0, %cst4 : tensor<128xi32>
-  // stride(4) / const(4) = 1
-  // CHECK: arith.divsi {{.*}} => stride = [1]
+  // stride(4) / const(4) — cannot prove non-negative for DivSIOp
+  // CHECK: arith.divsi {{.*}} => stride = [-1]
   %2 = arith.divsi %1, %cst4 : tensor<128xi32>
   // CHECK: arith.divui {{.*}} => stride = [1]
   %3 = arith.divui %1, %cst4 : tensor<128xi32>
@@ -159,8 +159,8 @@ tt.func @rem() {
   %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
   // CHECK: arith.constant {{.*}} => stride = [0]
   %cst_mod = arith.constant dense<512> : tensor<128xi32>
-  // Range span (127) < modulus (512): no wrap-around, stride preserved.
-  // CHECK: arith.remsi {{.*}} => stride = [1]
+  // Cannot prove non-negative for RemSIOp — conservatively unknown.
+  // CHECK: arith.remsi {{.*}} => stride = [-1]
   %1 = arith.remsi %0, %cst_mod : tensor<128xi32>
   // CHECK: arith.remui {{.*}} => stride = [1]
   %2 = arith.remui %0, %cst_mod : tensor<128xi32>
@@ -189,8 +189,8 @@ tt.func @rem_stride_wrap(%arg0: i32) {
   // CHECK: arith.remsi {{.*}} => stride = [-1]
   %rem_wrap = arith.remsi %range, %c8 : tensor<32xi32>
 
-  // Range span (31) < modulus (64): no wrap-around, stride preserved.
-  // CHECK: arith.remsi {{.*}} => stride = [1]
+  // Cannot prove non-negative for RemSIOp — conservatively unknown.
+  // CHECK: arith.remsi {{.*}} => stride = [-1]
   %rem_nowrap = arith.remsi %range, %c64 : tensor<32xi32>
 
   // Non-constant rhs (unknown stride): cannot reason about modulus.
@@ -382,17 +382,17 @@ tt.func @ptr_offset_pattern(%arg0: i32, %arg1: tensor<128x1xi32>) {
   // [0] + [1] = [1]
   // CHECK: arith.addi {{.*}} => stride = [1]
   %3 = arith.addi %1, %2 : tensor<128xi32>
-  // rem with constant modulus preserves stride
-  // CHECK: arith.remsi {{.*}} => stride = [1]
+  // Cannot prove non-negative for RemSIOp — conservatively unknown.
+  // CHECK: arith.remsi {{.*}} => stride = [-1]
   %4 = arith.remsi %3, %cst_1 : tensor<128xi32>
-  // expand_dims at axis=1: [1] -> [1, 0]
-  // CHECK: tt.expand_dims {{.*}} => stride = [1, 0]
+  // expand_dims at axis=1: [-1] -> [-1, 0]
+  // CHECK: tt.expand_dims {{.*}} => stride = [-1, 0]
   %5 = tt.expand_dims %4 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
-  // [1, 0] * splat(512) => stride = [512, 0]
-  // CHECK: arith.muli {{.*}} => stride = [512, 0]
+  // [-1, 0] * splat(512) => stride = [-1, 0]
+  // CHECK: arith.muli {{.*}} => stride = [-1, 0]
   %6 = arith.muli %5, %cst_0 : tensor<128x1xi32>
-  // broadcast preserves stride: [512, 0]
-  // CHECK: tt.broadcast {{.*}} => stride = [512, 0]
+  // broadcast preserves stride: [-1, 0]
+  // CHECK: tt.broadcast {{.*}} => stride = [-1, 0]
   %7 = tt.broadcast %6 : tensor<128x1xi32> -> tensor<128x64xi32>
   // muli with unknown stride input => [-1, -1]
   // CHECK: arith.muli {{.*}} => stride = [-1, -1]
@@ -545,8 +545,8 @@ tt.func @rem_stride_divisibility() {
   // CHECK: tt.make_range {{.*}} => stride = [1]
   %range_16_20 = tt.make_range {end = 20 : i32, start = 16 : i32} : tensor<4xi32>
 
-  // gcd(16, 4) = 4, maxVal=3 < 4 => no wrap
-  // CHECK: arith.remsi {{.*}} => stride = [1]
+  // Cannot prove non-negative for RemSIOp — conservatively unknown.
+  // CHECK: arith.remsi {{.*}} => stride = [-1]
   %rem3 = arith.remsi %range_16_20, %c4 : tensor<4xi32>
 
   // divisibility(start=0) = 2^62

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -198,7 +198,7 @@ tt.func @div(%arg0: i32 {tt.divisibility = 16 : i32}) {
   %3 = arith.divui %1, %0 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [128], constant_value = 64}}
   %4 = arith.constant dense<64> : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [64], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %5 = arith.divsi %0, %4 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %6 = arith.divsi %4, %0 : tensor<128xi32>
@@ -210,7 +210,7 @@ tt.func @div(%arg0: i32 {tt.divisibility = 16 : i32}) {
   %9 = arith.divui %0, %8 : tensor<128xi32>
   // expected-remark @below {{contiguity = [128], divisibility = [8192], constancy = [1], constant_value = <none>}}
   %10 = tt.make_range {end = 8320 : i32, start = 8192 : i32} : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [64], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %11 = arith.divsi %10, %4 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [2], constancy = [1], constant_value = 2}}
   %12 = arith.constant 2 : i32
@@ -227,7 +227,7 @@ tt.func @div(%arg0: i32 {tt.divisibility = 16 : i32}) {
   %17 = arith.divsi %arg0, %16 : i32
   // expected-remark @below {{contiguity = [1], divisibility = [2], constancy = [128], constant_value = 2}}
   %18 = arith.constant dense<2> : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [2], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %19 = arith.divsi %0, %18 : tensor<128xi32>
   tt.return
 }
@@ -246,7 +246,7 @@ tt.func @rem() {
   %3 = arith.remui %1, %0 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [128], constant_value = 64}}
   %4 = arith.constant dense<64> : tensor<128xi32>
-  // expected-remark @below {{contiguity = [64], divisibility = [64], constancy = [1], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %5 = arith.remsi %0, %4 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %6 = arith.remsi %4, %0 : tensor<128xi32>
@@ -256,7 +256,7 @@ tt.func @rem() {
   %8 = arith.remui %0, %7 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [128], constant_value = 192}}
   %9 = arith.constant dense<192> : tensor<128xi32>
-  // expected-remark @below {{contiguity = [64], divisibility = [64], constancy = [1], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %10 = arith.remsi %0, %9 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %11 = arith.remsi %9, %0 : tensor<128xi32>
@@ -266,7 +266,7 @@ tt.func @rem() {
   %13 = arith.remsi %0, %12 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %14 = arith.remsi %12, %0 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [32], divisibility = [32], constancy = [1], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %15 = arith.remsi %12, %4 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %16 = arith.remsi %4, %12 : tensor<128xi32>
@@ -457,17 +457,17 @@ tt.func @cmp_partial_contiguous() {
   %1 = arith.constant dense<8> : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [32], constancy = [128], constant_value = 32}}
   %3 = arith.constant dense<32> : tensor<128xi32>
-  // expected-remark @below {{contiguity = [32], divisibility = [32], constancy = [1], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %4 = arith.remsi %0, %3 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %5 = arith.cmpi eq, %4, %1 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %6 = arith.cmpi ne, %4, %1 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %7 = arith.cmpi slt, %4, %1 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %8 = arith.cmpi sle, %4, %1 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %9 = arith.cmpi sge, %4, %1 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %10 = arith.cmpi sgt, %4, %1 : tensor<128xi32>
@@ -477,25 +477,25 @@ tt.func @cmp_partial_contiguous() {
   %12 = arith.cmpi ne, %1, %4 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %13 = arith.cmpi slt, %1, %4 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %14 = arith.cmpi sle, %1, %4 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %15 = arith.cmpi sge, %1, %4 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %16 = arith.cmpi sgt, %1, %4 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [16], constancy = [128], constant_value = 48}}
   %17 = arith.constant dense<48> : tensor<128xi32>
-  // expected-remark @below {{contiguity = [16], divisibility = [16], constancy = [1], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %18 = arith.remsi %0, %17 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %19 = arith.cmpi eq, %18, %3 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %20 = arith.cmpi ne, %18, %3 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [16], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %21 = arith.cmpi slt, %18, %3 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %22 = arith.cmpi sle, %18, %3 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [16], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %23 = arith.cmpi sge, %18, %3 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %24 = arith.cmpi sgt, %18, %3 : tensor<128xi32>
@@ -505,11 +505,11 @@ tt.func @cmp_partial_contiguous() {
   %26 = arith.cmpi ne, %3, %18 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %27 = arith.cmpi slt, %3, %18 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [16], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %28 = arith.cmpi sle, %3, %18 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %29 = arith.cmpi sge, %3, %18 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [16], constant_value = <none}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %30 = arith.cmpi sgt, %3, %18 : tensor<128xi32>
   tt.return
 }
@@ -521,11 +521,11 @@ tt.func @logic() {
   %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [128], constant_value = 64}}
   %1 = arith.constant dense<64> : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [64], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %2 = arith.divsi %0, %1 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [8], constancy = [128], constant_value = 8}}
   %3 = arith.constant dense<8> : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %4 = arith.divsi %0, %3 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %5 = arith.andi %0, %1 : tensor<128xi32>
@@ -533,11 +533,11 @@ tt.func @logic() {
   %6 = arith.ori %0, %1 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %7 = arith.xori %0, %1 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %8 = arith.andi %2, %4 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %9 = arith.ori %2, %4 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %10 = arith.xori %2, %4 : tensor<128xi32>
   tt.return
 }
@@ -827,21 +827,21 @@ tt.func @load_constancy(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1:
   %eight = arith.constant dense<8> : tensor<1024xi32>
   // expected-remark @below {{contiguity = [1024], divisibility = [1073741824], constancy = [1]}}
   %1 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
-  // expected-remark @below {{constancy = [16]}}
+  // expected-remark @below {{constancy = [1]}}
   %2 = arith.divsi %1, %sixteen : tensor<1024xi32>
   // expected-remark @below {{constancy = [1024]}}
   %3 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
   // expected-remark @below {{constancy = [1024]}}
   %4 = tt.splat %arg1 : i32 -> tensor<1024xi32>
-  // expected-remark @below {{constancy = [8]}}
+  // expected-remark @below {{constancy = [1]}}
   %5 = arith.divsi %1, %eight : tensor<1024xi32>
-  // expected-remark @below {{constancy = [8]}}
+  // expected-remark @below {{constancy = [1]}}
   %6 = arith.cmpi slt, %5, %4 : tensor<1024xi32>
-  // expected-remark @below {{constancy = [16]}}
+  // expected-remark @below {{constancy = [1]}}
   %7 = tt.addptr %3, %2 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
-  // expected-remark @below {{constancy = [16]}}
+  // expected-remark @below {{constancy = [1]}}
   %8 = tt.load %7 : tensor<1024x!tt.ptr<f32>>
-  // expected-remark @below {{constancy = [8]}}
+  // expected-remark @below {{constancy = [1]}}
   %9 = tt.load %7, %6 : tensor<1024x!tt.ptr<f32>>
   tt.return
 }

--- a/test/Conversion/dedup-by-constancy.mlir
+++ b/test/Conversion/dedup-by-constancy.mlir
@@ -5,8 +5,8 @@
 // CHECK-NOT: llvm.add
 // CHECK: llvm.icmp "slt"
 // CHECK-NOT: llvm.icmp "slt"
-// CHECK: llvm.sdiv
-// CHECK-NOT: llvm.sdiv
+// CHECK: llvm.udiv
+// CHECK-NOT: llvm.udiv
 // CHECK: llvm.getelementptr %arg0[[[REGISTER:%[0-9]+]]]
 // CHECK-COUNT-7: llvm.getelementptr %arg0[[[REGISTER]]]
 // CHECK-NOT: llvm.getelementptr %arg0[[[REGISTER]]]
@@ -22,7 +22,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
     %4 = arith.addi %3, %2 : tensor<1024xi32, #blocked>
     %5 = tt.splat %arg2 : i32 -> tensor<1024xi32, #blocked>
     %6 = arith.cmpi slt, %4, %5 : tensor<1024xi32, #blocked>
-    %7 = arith.divsi %4, %cst : tensor<1024xi32, #blocked>
+    %7 = arith.divui %4, %cst : tensor<1024xi32, #blocked>
     %8 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked>
     %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<f16>, #blocked>, tensor<1024xi32, #blocked>
     %10 = tt.load %9, %6 : tensor<1024x!tt.ptr<f16>, #blocked>
@@ -40,8 +40,8 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // CHECK-NOT: llvm.add
 // CHECK: llvm.icmp "slt"
 // CHECK-NOT: llvm.icmp "slt"
-// CHECK-COUNT-2: llvm.sdiv
-// CHECK-NOT: llvm.sdiv
+// CHECK-COUNT-2: llvm.udiv
+// CHECK-NOT: llvm.udiv
 // CHECK: llvm.getelementptr %arg0[[[REGISTER1:%[0-9]+]]]
 // CHECK-COUNT-3: llvm.getelementptr %arg0[[[REGISTER1]]]
 // CHECK-NOT: llvm.getelementptr %arg0[[[REGISTER1]]]
@@ -60,7 +60,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
     %4 = arith.addi %3, %2 : tensor<1024xi32, #blocked>
     %5 = tt.splat %arg2 : i32 -> tensor<1024xi32, #blocked>
     %6 = arith.cmpi slt, %4, %5 : tensor<1024xi32, #blocked>
-    %7 = arith.divsi %4, %cst : tensor<1024xi32, #blocked>
+    %7 = arith.divui %4, %cst : tensor<1024xi32, #blocked>
     %8 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked>
     %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<f16>, #blocked>, tensor<1024xi32, #blocked>
     %10 = tt.load %9, %6 : tensor<1024x!tt.ptr<f16>, #blocked>

--- a/test/TritonGPU/loop-pipeline-hip.mlir
+++ b/test/TritonGPU/loop-pipeline-hip.mlir
@@ -490,7 +490,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %2 = tt.splat %1 : i32 -> tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
     %3 = arith.addi %2, %0 : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
     %4 = tt.splat %arg6 : i32 -> tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
-    %5 = arith.remsi %3, %4 : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
+    %5 = arith.remui %3, %4 : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
     %6 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
     %7 = tt.expand_dims %6 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked>
     %8 = tt.broadcast %7 : tensor<1x32xi32, #blocked> -> tensor<64x32xi32, #blocked>

--- a/third_party/intel/lib/Analysis/StrideInfo.cpp
+++ b/third_party/intel/lib/Analysis/StrideInfo.cpp
@@ -613,9 +613,17 @@ protected:
     stride.reserve(lhs.size());
     for (unsigned d = 0, rank = lhs.size(); d < rank; ++d) {
       if (lhs[d] > 0 && rhsConst.has_value() && rhsConst.value() > 0 &&
-          lhs[d] % rhsConst.value() == 0)
-        stride.push_back(lhs[d] / rhsConst.value());
-      else if (lhs[d] == 0 && rhsConst.has_value() && rhsConst.value() != 0)
+          lhs[d] % rhsConst.value() == 0) {
+        // For signed division (DivSIOp), truncation toward zero means
+        // the stride pattern breaks when the input window crosses zero:
+        //   divsi([-2,-1,0,1], 2) = [-1,0,0,0] (not evenly strided)
+        // Without range analysis we cannot prove inputs are non-negative
+        // for DivSIOp, so conservatively report unknown stride.
+        if constexpr (std::is_same_v<OpTy, arith::DivSIOp>)
+          stride.push_back(-1);
+        else
+          stride.push_back(lhs[d] / rhsConst.value());
+      } else if (lhs[d] == 0 && rhsConst.has_value() && rhsConst.value() != 0)
         stride.push_back(0);
       else
         stride.push_back(-1);
@@ -644,22 +652,33 @@ protected:
         // Stride preserved when range span doesn't cross a modulus boundary.
         // Effective period is gcd(divisibility, modulus) when AxisInfo is
         // available; falls back to modulus otherwise.
-        auto resTy = dyn_cast<RankedTensorType>(op.getType());
-        if (resTy) {
-          int64_t dimSize = resTy.getDimSize(d);
-          int64_t maxVal = lhs[d] * (dimSize - 1);
-          int64_t modulus = rhsConst.value();
-          int64_t g = modulus; // fallback when no AxisInfo
-          if (auto *ai = this->axisInfoLookup(op.getLhs())) {
-            int64_t divisibility = ai->getDivisibility(d);
-            g = std::gcd(divisibility, modulus);
-          }
-          if (maxVal < g)
-            stride.push_back(lhs[d]);
-          else
-            stride.push_back(-1);
-        } else {
+        //
+        // NOTE: For signed remainder (RemSIOp), this only holds when the
+        // input window starts at a non-negative value. For negative starts
+        // at multiples of M, truncation-toward-zero creates a discontinuity
+        // between x=kM and x=kM+1 (k<0), breaking stride. Without range
+        // analysis we cannot prove inputs are non-negative for RemSIOp, so
+        // conservatively report unknown stride.
+        if constexpr (std::is_same_v<OpTy, arith::RemSIOp>) {
           stride.push_back(-1);
+        } else {
+          auto resTy = dyn_cast<RankedTensorType>(op.getType());
+          if (resTy) {
+            int64_t dimSize = resTy.getDimSize(d);
+            int64_t maxVal = lhs[d] * (dimSize - 1);
+            int64_t modulus = rhsConst.value();
+            int64_t g = modulus; // fallback when no AxisInfo
+            if (auto *ai = this->axisInfoLookup(op.getLhs())) {
+              int64_t divisibility = ai->getDivisibility(d);
+              g = std::gcd(divisibility, modulus);
+            }
+            if (maxVal < g)
+              stride.push_back(lhs[d]);
+            else
+              stride.push_back(-1);
+          } else {
+            stride.push_back(-1);
+          }
         }
       } else {
         stride.push_back(-1);


### PR DESCRIPTION
Without range analysis, we cannot prove inputs to signed division/remainder are non-negative. Truncation toward zero breaks contiguity/stride/constancy for negative inputs:
- `srem([-64, -63, ..., -57], 32) = [0, -31, -30, ..., -25]` (not contiguous, not stride-1)
- `sdiv([-4, -3, -2, -1, 0, 1, 2, 3], 2) = [-2, -1, -1, 0, 0, 0, 1, 1]` (not constant-2)

This PR:

1. **[AxisInfo]** Disable constancy/contiguity/divisibility for DivSIOp and RemSIOp, conservatively returning 1 for all properties.

2. **[StrideInfo]** Disable stride preservation for DivSIOp and RemSIOp (same soundness issue).

3. **[PyTorch]** Patch floordiv to bypass the XOR-based workaround for XPU, using the simple `tl.where`-based floordiv instead.

4. **[Benchmark]** Clamp `group_size_m` with `max(..., 1)` in `gemm_tensor_of_ptr_benchmark.py` to make it provably positive, enabling `SimplifySignedArithmetic` to prove `pid_n >= 0` and convert the offset `remsi` to `remui`.

Fixes #6376