### PR TITLE
Fix tt.atomic_poll runtime crash for 16-bit types

### DIFF
--- a/scripts/skiplist/a770/language.txt
+++ b/scripts/skiplist/a770/language.txt
@@ -102,13 +102,6 @@ python/test/unit/language/test_tensor_descriptor.py::test_tensor_descriptor_batc
 python/test/unit/language/test_tensor_descriptor.py::test_tensor_descriptor_batched_gemm_3d_tma
 # test_tensor_atomic_add_access_patterns
 python/test/unit/language/test_core.py::test_tensor_atomic_add_access_patterns[shape128-random_no_duplication-3-1-float32]
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7390
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-acquire]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-acquire]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-acquire]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]

--- a/scripts/skiplist/arl-h/language.txt
+++ b/scripts/skiplist/arl-h/language.txt
@@ -89,13 +89,6 @@ python/test/unit/language/test_core.py::test_strided_store[float64]
 python/test/unit/language/test_tensor_descriptor.py::test_tensor_descriptor_store
 python/test/unit/language/test_tensor_descriptor.py::test_make_tensor_descriptor_matmul
 python/test/unit/language/test_tensor_descriptor.py::test_tensor_descriptor_rank_reducing_matmul
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7390
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-acquire]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-acquire]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-acquire]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]

--- a/scripts/skiplist/arl-s/language.txt
+++ b/scripts/skiplist/arl-s/language.txt
@@ -83,13 +83,6 @@ python/test/unit/language/test_core.py::test_strided_store[float64]
 python/test/unit/language/test_tensor_descriptor.py::test_tensor_descriptor_store
 python/test/unit/language/test_tensor_descriptor.py::test_make_tensor_descriptor_matmul
 python/test/unit/language/test_tensor_descriptor.py::test_tensor_descriptor_rank_reducing_matmul
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7390
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-acquire]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-acquire]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-acquire]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]

--- a/scripts/skiplist/default/language.txt
+++ b/scripts/skiplist/default/language.txt
@@ -55,13 +55,6 @@ python/test/unit/language/test_standard.py::test_sort[int32-False-1-8-64]
 python/test/unit/language/test_standard.py::test_sort[int32-True-1-256-16]
 python/test/unit/language/test_standard.py::test_sort[int32-True-1-512-8]
 python/test/unit/language/test_standard.py::test_sort[int32-True-1-8-64]
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7390
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-acquire]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-acquire]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-acquire]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]

--- a/scripts/skiplist/lts/language.txt
+++ b/scripts/skiplist/lts/language.txt
@@ -8,13 +8,6 @@ python/test/unit/language/test_tensor_descriptor.py::test_tensor_descriptor_redu
 # Below tests require AGAMA 1208 or above
 python/test/unit/language/test_core.py::test_side_effectful_reduction
 python/test/unit/language/test_core.py::test_side_effectful_reduction_2d
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7390
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-acquire]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-acquire]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-acquire]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]

--- a/scripts/skiplist/mtl/language.txt
+++ b/scripts/skiplist/mtl/language.txt
@@ -65,13 +65,6 @@ python/test/unit/language/test_core.py::test_dot[1-64-128-128-4-False-False-none
 python/test/unit/language/test_core.py::test_dot[1-64-128-128-4-False-False-none-tf32-float32-float32-1-None1]
 python/test/unit/language/test_core.py::test_dot[1-128-128-64-4-False-False-chain-dot-ieee-float8e5-float32-1-None]
 python/test/unit/language/test_core.py::test_dot[1-128-128-64-4-False-False-chain-dot-ieee-float8e4nv-float32-1-None]
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7390
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-acquire]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-acquire]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-acquire]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]

--- a/scripts/skiplist/ptl/language.txt
+++ b/scripts/skiplist/ptl/language.txt
@@ -1,10 +1,3 @@
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7390
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-acquire]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-acquire]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-acquire]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]

--- a/scripts/skiplist/xe2/language.txt
+++ b/scripts/skiplist/xe2/language.txt
@@ -1,10 +1,3 @@
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7390
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-cta-acquire]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-gpu-acquire]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-relaxed]
-python/test/unit/language/test_core.py::test_atomic_poll[dtype0-16-sys-acquire]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
 python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]

--- a/test/TritonIntelGPU/atomic_poll.mlir
+++ b/test/TritonIntelGPU/atomic_poll.mlir
@@ -1,0 +1,58 @@
+// RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s
+
+// COM: 16-bit poll must not lower to a raw `load atomic i16` (issue #7390).
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @poll_i16_relaxed
+  tt.func @poll_i16_relaxed(%ptr: !tt.ptr<i16, 1>, %expected: i16) {
+    // CHECK-NOT: llvm.load {{.*}} atomic {{.*}} : !llvm.ptr<1> -> i16
+    // CHECK: %[[WORD:.*]] = llvm.load %{{.*}} atomic syncscope("device") monotonic {alignment = 4 : i64} : !llvm.ptr<1> -> i32
+    // CHECK: %[[VEC:.*]] = llvm.bitcast %[[WORD]] : i32 to vector<2xi16>
+    // CHECK: %[[HALF:.*]] = llvm.extractelement %[[VEC]][%{{.*}} : i32] : vector<2xi16>
+    // CHECK: %{{.*}} = llvm.icmp "eq" %[[HALF]], %arg1 : i16
+    %0 = tt.atomic_poll relaxed, gpu, %ptr, %expected : !tt.ptr<i16, 1>, i16 -> i1
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @poll_i16_acquire
+  tt.func @poll_i16_acquire(%ptr: !tt.ptr<i16, 1>, %expected: i16) {
+    // CHECK-NOT: llvm.load {{.*}} atomic {{.*}} : !llvm.ptr<1> -> i16
+    // CHECK: llvm.load %{{.*}} atomic syncscope("workgroup") monotonic {alignment = 4 : i64} : !llvm.ptr<1> -> i32
+    // CHECK: llvm.bitcast %{{.*}} : i32 to vector<2xi16>
+    // CHECK: llvm.extractelement %{{.*}}[%{{.*}} : i32] : vector<2xi16>
+    // CHECK: llvm.fence syncscope("workgroup") acquire
+    %0 = tt.atomic_poll acquire, cta, %ptr, %expected : !tt.ptr<i16, 1>, i16 -> i1
+    tt.return
+  }
+}
+
+// -----
+
+// COM: 32-bit polls defer to the upstream lowering: native 32-bit atomic load.
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @poll_i32
+  tt.func @poll_i32(%ptr: !tt.ptr<i32, 1>, %expected: i32) {
+    // CHECK-NOT: llvm.bitcast %{{.*}} : i32 to vector<2xi16>
+    // CHECK: %[[LOADED:.*]] = llvm.load %arg0 atomic syncscope("device") monotonic {alignment = 4 : i64} : !llvm.ptr<1> -> i32
+    // CHECK: %{{.*}} = llvm.icmp "eq" %[[LOADED]], %arg1 : i32
+    %0 = tt.atomic_poll relaxed, gpu, %ptr, %expected : !tt.ptr<i32, 1>, i32 -> i1
+    tt.return
+  }
+}
+
+// -----
+
+// COM: With ttig.support_16bit_atomics the override defers to upstream: native i16.
+module attributes {ttig.support_16bit_atomics = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @poll_i16_hw_support
+  tt.func @poll_i16_hw_support(%ptr: !tt.ptr<i16, 1>, %expected: i16) {
+    // CHECK-NOT: llvm.bitcast %{{.*}} : i32 to vector<2xi16>
+    // CHECK: %[[LOADED:.*]] = llvm.load %arg0 atomic syncscope("device") monotonic {alignment = 2 : i64} : !llvm.ptr<1> -> i16
+    // CHECK: %{{.*}} = llvm.icmp "eq" %[[LOADED]], %arg1 : i16
+    %0 = tt.atomic_poll relaxed, gpu, %ptr, %expected : !tt.ptr<i16, 1>, i16 -> i1
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/CMakeLists.txt
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/CMakeLists.txt
@@ -19,6 +19,7 @@ add_triton_library(TritonIntelGPUToLLVM
     Fp4ToFpOpToLLVM.cpp
     HistogramOpToLLVM.cpp
     LoadStoreOpToLLVM.cpp
+    MemoryOpToLLVM.cpp
     PrintOpToLLVM.cpp
     ReduceOpToLLVM.cpp
     SPMDOpToLLVM.cpp

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/MemoryOpToLLVM.cpp
@@ -1,0 +1,181 @@
+//===- MemoryOpToLLVM.cpp - Intel memory-op lowering overrides ------------===//
+//
+// Intel override of the shared `tt.atomic_poll` lowering: the upstream pattern
+// polls with a native atomic load of the operand type, but 16-bit atomics are
+// unsupported on Intel GPUs and crash in ocloc/IGC (GitHub issue #7390). This
+// widens the 16-bit case to a 4-byte-aligned 32-bit atomic load; every other
+// case defers to the upstream pattern via a lower PatternBenefit.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dialect/TritonIntelGPU/IR/Dialect.h"
+
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/IR/PatternMatch.h"
+
+#include "PatternTritonGPUOpToLLVM.h"
+
+#include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+namespace {
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::gpu;
+namespace ttgi = mlir::triton::gpu::intel;
+
+struct AtomicPollOpConversion
+    : public ConvertOpToLLVMPattern<triton::AtomicPollOp> {
+  AtomicPollOpConversion(LLVMTypeConverter &converter,
+                         const TargetInfoBase &targetInfo,
+                         PatternBenefit benefit)
+      : ConvertOpToLLVMPattern<triton::AtomicPollOp>(converter, benefit),
+        targetInfo(targetInfo) {}
+
+  LogicalResult
+  matchAndRewrite(triton::AtomicPollOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto moduleOp = op->getParentOfType<ModuleOp>();
+    assert(moduleOp && "Parent ModuleOp not found for AtomicPollOp");
+
+    unsigned bitWidth = adaptor.getExpected().getType().getIntOrFloatBitWidth();
+    bool support16BitAtomics = moduleOp->hasAttr(
+        ttgi::TritonIntelGPUDialect::getSupport16BitAtomicsAttrName());
+    if (bitWidth != 16 || support16BitAtomics)
+      return rewriter.notifyMatchFailure(
+          op, "defer to upstream atomic_poll lowering");
+
+    int numCTAs = TritonGPUDialect::getNumCTAs(moduleOp);
+    if (numCTAs != 1 && !targetInfo.isCuda())
+      return rewriter.notifyMatchFailure(
+          op, "multi-CTA atomic_poll requires cross-CTA shared memory");
+
+    insertAtomicOrderingBarriers(op, op.getSem(),
+                                 /*emitBarrierAfter=*/false, rewriter,
+                                 targetInfo);
+
+    auto freeVarMasks = getFreeVariableMasks(op.getPtr().getType());
+    Value threadPred =
+        emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
+    StringRef syncScope = targetInfo.getAtomicSyncScope(op.getScope());
+
+    Block *currentBlock = rewriter.getInsertionBlock();
+    Block *doneBlock = currentBlock->splitBlock(rewriter.getInsertionPoint());
+    Region *region = currentBlock->getParent();
+    Block *pollInitBlock =
+        rewriter.createBlock(region, Region::iterator(doneBlock));
+    Block *pollLoopBlock =
+        rewriter.createBlock(region, Region::iterator(doneBlock));
+    Block *pollSuccessBlock =
+        rewriter.createBlock(region, Region::iterator(doneBlock));
+    Block *timeoutCheckBlock =
+        adaptor.getTimeout()
+            ? rewriter.createBlock(region, Region::iterator(doneBlock))
+            : nullptr;
+    BlockArgument matched = doneBlock->addArgument(i1_ty, loc);
+
+    rewriter.setInsertionPointToEnd(currentBlock);
+    LLVM::CondBrOp::create(rewriter, loc, threadPred, pollInitBlock,
+                           ValueRange{}, doneBlock, ValueRange{b.false_val()});
+
+    rewriter.setInsertionPointToEnd(pollInitBlock);
+    Value start;
+    if (adaptor.getTimeout())
+      start = targetInfo.getGlobalTimer(rewriter, loc);
+    LLVM::BrOp::create(rewriter, loc, pollLoopBlock);
+
+    rewriter.setInsertionPointToEnd(pollLoopBlock);
+    // Widen the unsupported 16-bit atomic load to a 4-byte-aligned 32-bit one
+    // and extract the target half (mirrors `emulate16BitsCAS` in
+    // LoadStoreOpToLLVM.cpp); ordering and sync scope match the upstream poll.
+    Value expected = adaptor.getExpected();
+    Value intPtr = b.ptrtoint(i64_ty, adaptor.getPtr());
+    Value lowPtrBits = b.and_(intPtr, b.i64_val(3));
+    Value elemIndex = b.trunc(i32_ty, b.lshr(lowPtrBits, b.i64_val(1)));
+    Value alignedPtr = b.inttoptr(adaptor.getPtr().getType(),
+                                  b.sub(intPtr, lowPtrBits).getResult());
+    Value word = LLVM::LoadOp::create(
+        rewriter, loc, i32_ty, alignedPtr, /*alignment=*/4,
+        /*isVolatile=*/false, /*isNonTemporal=*/false, /*isInvariant=*/false,
+        /*isInvariantGroup=*/false, LLVM::AtomicOrdering::monotonic, syncScope);
+    Value loaded =
+        b.extract_element(b.bitcast(word, vec_ty(i16_ty, 2)), elemIndex);
+    Value pollMatched = b.icmp_eq(loaded, expected);
+    if (adaptor.getTimeout()) {
+      LLVM::CondBrOp::create(rewriter, loc, pollMatched, pollSuccessBlock,
+                             timeoutCheckBlock);
+
+      rewriter.setInsertionPointToEnd(timeoutCheckBlock);
+      Value elapsed = b.sub(targetInfo.getGlobalTimer(rewriter, loc), start);
+      Value timedOut = b.icmp_uge(elapsed, adaptor.getTimeout());
+      LLVM::CondBrOp::create(rewriter, loc, timedOut, doneBlock,
+                             ValueRange{b.false_val()}, pollLoopBlock,
+                             ValueRange{});
+    } else {
+      LLVM::CondBrOp::create(rewriter, loc, pollMatched, pollSuccessBlock,
+                             pollLoopBlock);
+    }
+
+    rewriter.setInsertionPointToEnd(pollSuccessBlock);
+    if (op.getSem() == triton::MemSemantic::ACQUIRE)
+      LLVM::FenceOp::create(rewriter, loc, LLVM::AtomicOrdering::acquire,
+                            syncScope);
+    LLVM::BrOp::create(rewriter, loc, ValueRange{b.true_val()}, doneBlock);
+
+    rewriter.setInsertionPointToStart(doneBlock);
+    if (!adaptor.getTimeout()) {
+      if (numCTAs == 1)
+        targetInfo.barrier(loc, rewriter, AddrSpace::Local);
+      else
+        targetInfo.clusterBarrier(loc, rewriter, op);
+      rewriter.replaceOp(op, b.true_val());
+      return success();
+    }
+
+    if (op.getResult().use_empty()) {
+      if (numCTAs == 1)
+        targetInfo.barrier(loc, rewriter, AddrSpace::Local);
+      else
+        targetInfo.clusterBarrier(loc, rewriter, op);
+      rewriter.eraseOp(op);
+      return success();
+    }
+
+    Value atomPtr =
+        LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
+    atomPtr = b.bitcast(atomPtr, ptr_ty(rewriter.getContext(),
+                                        targetInfo.getSharedAddressSpace()));
+    targetInfo.storeShared(rewriter, loc, atomPtr, matched, threadPred);
+    if (numCTAs == 1)
+      targetInfo.barrier(loc, rewriter, AddrSpace::Local);
+    else
+      targetInfo.clusterBarrier(loc, rewriter, op);
+
+    Value result;
+    if (numCTAs == 1) {
+      result = b.load(i1_ty, atomPtr);
+    } else {
+      result = targetInfo.loadDShared(rewriter, loc, atomPtr, b.i32_val(0),
+                                      i1_ty, b.true_val());
+    }
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+
+private:
+  const TargetInfoBase &targetInfo;
+};
+
+} // namespace
+
+void mlir::triton::intel::populateMemoryOpToLLVMPattern(
+    LLVMTypeConverter &typeConverter, const TargetInfoBase &targetInfo,
+    RewritePatternSet &patterns, PatternBenefit benefit) {
+  patterns.add<AtomicPollOpConversion>(typeConverter, targetInfo,
+                                       benefit.getBenefit() + 1);
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -47,6 +47,11 @@ void populatePrintOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                   const TargetInfoBase &targetInfo,
                                   PatternBenefit benefit);
 
+void populateMemoryOpToLLVMPattern(LLVMTypeConverter &typeConverter,
+                                   const TargetInfoBase &targetInfo,
+                                   RewritePatternSet &patterns,
+                                   PatternBenefit benefit);
+
 void populateWarpIdOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                    RewritePatternSet &patterns,
                                    PatternBenefit benefit);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PipelineManager.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PipelineManager.h
@@ -237,6 +237,8 @@ public:
                                         benefit);
     mlir::ub::populateUBToLLVMConversionPatterns(typeConverter, patterns);
     populateAssertOpToLLVMPattern(typeConverter, patterns, targetInfo, benefit);
+    intel::populateMemoryOpToLLVMPattern(typeConverter, targetInfo, patterns,
+                                         benefit);
     mlir::triton::populateMemoryOpToLLVMPatterns(typeConverter, targetInfo,
                                                  patterns, benefit);
     intel::populateControlFlowOpToLLVMPattern(typeConverter, patterns,


### PR DESCRIPTION
Some Intel GPUs don't support 16-bit atomics (`has_16bit_atomics == False`), so on those targets the upstream poll's raw i16 atomic load crashes in ocloc/IGC. On them, override the lowering to poll via a 4-byte-aligned 32-bit atomic load and extract the target half; architectures that do support 16-bit atomics, and the 32/64-bit cases, stay on the upstream path.

Fixes #7390.