### PR TITLE
[TritonIntelGPUToLLVM] Vectorize masked StoreOp when mask isn't statically uniform

### DIFF
--- a/test/Conversion/intel/load_store_256b_to_llvm.mlir
+++ b/test/Conversion/intel/load_store_256b_to_llvm.mlir
@@ -106,11 +106,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttig.sup
 
 // -----
 
-// COM: Sanity-check the gate: a masked store with a runtime-derived mask has
-// COM: getMaskAlignment() == 1, which clamps the vectorization factor to 1
-// COM: regardless of whether ttig.support_256b_load_store is present. The
-// COM: emitted store must therefore be scalar-width (i32), NOT vector<8xi32>.
-// COM: This protects against an over-eager widening that ignores mask alignment.
+// COM: Sanity-check the mask-alignment gate: a masked store with a runtime-derived
+// COM: (non-statically-uniform) mask has getMaskAlignment() == 1. Pointer contiguity
+// COM: alone (bounded by tt.divisibility = 16 bytes = 4 f32 elements here) picks
+// COM: vec=4 per group, so each of the 2 groups (8 elements/thread total) gets a
+// COM: two-armed dynamic guard: a fast arm with a single wide vector<4xi32> store
+// COM: (taken when the group's 4 mask elements are all true at runtime), and a slow
+// COM: arm that falls back to the exact per-element scalar stores, preserving
+// COM: correctness at the boundary while still avoiding narrow partial-dword writes
+// COM: in the common, fully-valid-group case.
 
 #blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttig.support_256b_load_store} {
@@ -126,10 +130,24 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttig.sup
     %5 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>, #blocked0>
     %6 = tt.addptr %5, %4 : tensor<256x!tt.ptr<f32>, #blocked0>, tensor<256xi32, #blocked0>
     tt.store %6, %cst, %arg1 : tensor<256x!tt.ptr<f32>, #blocked0>
-    // COM: mask alignment is 1 -> per-element scalar stores (8 scalar stores per thread).
-    // CHECK-NOT:   vector<8xi32>
-    // CHECK-NOT:   vector<4xi32>
-    // CHECK:       llvm.store {{.*}} i32, !llvm.ptr<1>
+    // COM: Group 1: fast arm is a single wide vector<4xi32> store gated on the
+    // COM: dynamic AND of the group's 4 mask elements; slow arm is the exact
+    // COM: per-element scalar fallback (4 individually-predicated scalar stores).
+    // CHECK-COUNT-2: llvm.and {{.*}} : i1
+    // CHECK: %[[GROUPMASK0:.*]] = llvm.and {{.*}} : i1
+    // CHECK-NEXT: llvm.cond_br %[[GROUPMASK0]], ^[[BB_FAST0:bb[0-9]+]], ^[[BB_SLOW0:bb[0-9]+]]
+    // CHECK: ^[[BB_FAST0]]:
+    // CHECK:   llvm.store {{.*}} {alignment = 16 : i64} : vector<4xi32>, !llvm.ptr<1>
+    // CHECK: ^[[BB_SLOW0]]:
+    // CHECK-COUNT-4: llvm.store {{.*}} {alignment = 4 : i64} : f32, !llvm.ptr<1>
+    // COM: Group 2: same structure, second vec=4 group.
+    // CHECK-COUNT-2: llvm.and {{.*}} : i1
+    // CHECK: %[[GROUPMASK1:.*]] = llvm.and {{.*}} : i1
+    // CHECK-NEXT: llvm.cond_br %[[GROUPMASK1]], ^[[BB_FAST1:bb[0-9]+]], ^[[BB_SLOW1:bb[0-9]+]]
+    // CHECK: ^[[BB_FAST1]]:
+    // CHECK:   llvm.store {{.*}} {alignment = 16 : i64} : vector<4xi32>, !llvm.ptr<1>
+    // CHECK: ^[[BB_SLOW1]]:
+    // CHECK-COUNT-4: llvm.store {{.*}} {alignment = 4 : i64} : f32, !llvm.ptr<1>
     tt.return
   }
 }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -3231,6 +3231,30 @@ struct StoreOpConversion
         std::max<int>(1, valueElemTy.getIntOrFloatBitWidth() / 8);
     const size_t valueElemNBits = dtsize * 8;
 
+    // Widens an i1 element to i8 (stores don't support sub-byte types) and
+    // bitcasts it to the store's element type.
+    auto toElemTy = [&](Value elem) {
+      if (elem.getType().isInteger(1))
+        elem = b.sext(i8_ty, elem);
+      return b.bitcast(elem, valueElemTy);
+    };
+
+    // Dispatches a (possibly predicated) store of `value` to `addr`: an
+    // unconditional store if `pred` is null, a `TritonGEN::PredicatedStoreOp`
+    // if predicated instructions are available for `op`, or a branch-guarded
+    // plain store (via `storeFn`) otherwise.
+    auto emitPredicatedStore = [&](Value pred, Value addr, Value value,
+                                   auto storeFn) {
+      if (!pred)
+        (void)storeFn();
+      else if (canUsePredicatedInstructions(op)) {
+        auto cacheModifier = tritonToIntelCacheModifier(op);
+        TritonGEN::PredicatedStoreOp::create(rewriter, loc, addr, value, pred,
+                                             cacheModifier);
+      } else
+        LLVM::intel::createPredicatedBlock(rewriter, loc, pred, storeFn);
+    };
+
     unsigned elemsPerThread = getTotalElemsPerThread(valueTy);
     const int numVecs = elemsPerThread / vec;
     for (size_t vecStart = 0; vecStart < elemsPerThread; vecStart += vec) {
@@ -3262,10 +3286,7 @@ struct StoreOpConversion
         for (size_t elemIdx = 0; elemIdx < wordNElems; ++elemIdx) {
           const size_t elemOffset = vecStart + wordIdx * wordNElems + elemIdx;
           assert(elemOffset < valueElems.size());
-          Value elem = valueElems[elemOffset];
-          if (elem.getType().isInteger(1))
-            elem = b.sext(i8_ty, elem);
-          elem = b.bitcast(elem, valueElemTy);
+          Value elem = toElemTy(valueElems[elemOffset]);
 
           llWord = b.insert_element(wordTy, llWord, elem, b.i32_val(elemIdx));
         }
@@ -3300,10 +3321,7 @@ struct StoreOpConversion
       // here) and as the "slow" per-element arm when the mask isn't
       // statically uniform across the whole group.
       auto storeSingleElem = [&](size_t i) {
-        Value elem = valueElems[vecStart + i];
-        if (elem.getType().isInteger(1))
-          elem = b.sext(i8_ty, elem);
-        elem = b.bitcast(elem, valueElemTy);
+        Value elem = toElemTy(valueElems[vecStart + i]);
 
         Value addrElemI =
             b.bitcast(ptrElems[vecStart + i], ptr_ty(ctx, 1 /*global*/));
@@ -3319,15 +3337,7 @@ struct StoreOpConversion
         if (maskElems.size() > 0)
           predI = maybeAnd(rewriter, loc, threadPred, maskElems[vecStart + i]);
 
-        if (!predI)
-          auto _ = createSingleStoreWithAttrs();
-        else if (canUsePredicatedInstructions(op)) {
-          auto cacheModifier = tritonToIntelCacheModifier(op);
-          TritonGEN::PredicatedStoreOp::create(rewriter, loc, addrElemI, elem,
-                                               predI, cacheModifier);
-        } else
-          LLVM::intel::createPredicatedBlock(rewriter, loc, predI,
-                                             createSingleStoreWithAttrs);
+        emitPredicatedStore(predI, addrElemI, elem, createSingleStoreWithAttrs);
       };
 
       if (maskElems.empty() || maskAlignment >= vec) {
@@ -3337,15 +3347,7 @@ struct StoreOpConversion
         if (maskElems.size() > 0)
           maskVal = maybeAnd(rewriter, loc, threadPred, maskElems[vecStart]);
 
-        if (!maskVal)
-          auto _ = createStoreWithAttrs();
-        else if (canUsePredicatedInstructions(op)) {
-          auto cacheModifier = tritonToIntelCacheModifier(op);
-          TritonGEN::PredicatedStoreOp::create(rewriter, loc, addrElem, vecWord,
-                                               maskVal, cacheModifier);
-        } else
-          LLVM::intel::createPredicatedBlock(rewriter, loc, maskVal,
-                                             createStoreWithAttrs);
+        emitPredicatedStore(maskVal, addrElem, vecWord, createStoreWithAttrs);
       } else {
         // The mask isn't statically uniform across the group. Try a single
         // wide store gated on a dynamic AND of the group's mask elements

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -3199,8 +3199,13 @@ struct StoreOpConversion
     Type valueElemTy =
         typeConverter->convertType(getElementTypeOrSelf(valueTy));
     unsigned vec = getVectorSize(hasSupport256bLoadStore(op), ptr);
-    if (llMask)
-      vec = std::min<size_t>(vec, getMaskAlignment(op.getMask()));
+    // Statically-provable alignment of the mask (i.e. the mask is proven
+    // constant over blocks of this many elements). Unlike vec, this is no
+    // longer used to shrink the vectorization width: even when the mask
+    // isn't statically uniform across a vec-group, we still try a single
+    // wide store gated on a dynamic AND of the group's mask elements,
+    // falling back to the exact per-element behavior otherwise (see below).
+    unsigned maskAlignment = llMask ? getMaskAlignment(op.getMask()) : vec;
 
     Value llPtr = adaptor.getPtr();
     SmallVector<Value> ptrElems =
@@ -3270,12 +3275,6 @@ struct StoreOpConversion
         asmArgs.emplace_back(llWord, constraint);
       }
 
-      Value maskVal = threadPred;
-      if (maskElems.size() > 0) {
-        auto mask = maskElems[vecStart];
-        maskVal = maybeAnd(rewriter, loc, threadPred, mask);
-      }
-
       auto vecTy = vec_ty(valArgTy, nWords);
       Value vecWord = b.undef(vecTy);
       for (int index = 0; index < asmArgs.size(); ++index) {
@@ -3295,15 +3294,74 @@ struct StoreOpConversion
         return ArrayRef<Value>();
       };
 
-      if (!maskVal)
-        auto _ = createStoreWithAttrs();
-      else if (canUsePredicatedInstructions(op)) {
-        auto cacheModifier = tritonToIntelCacheModifier(op);
-        TritonGEN::PredicatedStoreOp::create(rewriter, loc, addrElem, vecWord,
-                                             maskVal, cacheModifier);
-      } else
-        LLVM::intel::createPredicatedBlock(rewriter, loc, maskVal,
-                                           createStoreWithAttrs);
+      // Emits the exact single-element fallback that today's code emits when
+      // vec == 1, applied to a single lane `i` of the current group. Used
+      // both for the statically-uniform-mask case (vec == 1 always falls
+      // here) and as the "slow" per-element arm when the mask isn't
+      // statically uniform across the whole group.
+      auto storeSingleElem = [&](size_t i) {
+        Value elem = valueElems[vecStart + i];
+        if (elem.getType().isInteger(1))
+          elem = b.sext(i8_ty, elem);
+        elem = b.bitcast(elem, valueElemTy);
+
+        Value addrElemI =
+            b.bitcast(ptrElems[vecStart + i], ptr_ty(ctx, 1 /*global*/));
+        uint32_t alignmentI = dtsize;
+        auto createSingleStoreWithAttrs = [&]() {
+          bool isVolatile = false;
+          b.store(elem, addrElemI, alignmentI, isVolatile,
+                  getNonTemporalFlag(op));
+          return ArrayRef<Value>();
+        };
+
+        Value predI = threadPred;
+        if (maskElems.size() > 0)
+          predI = maybeAnd(rewriter, loc, threadPred, maskElems[vecStart + i]);
+
+        if (!predI)
+          auto _ = createSingleStoreWithAttrs();
+        else if (canUsePredicatedInstructions(op)) {
+          auto cacheModifier = tritonToIntelCacheModifier(op);
+          TritonGEN::PredicatedStoreOp::create(rewriter, loc, addrElemI, elem,
+                                               predI, cacheModifier);
+        } else
+          LLVM::intel::createPredicatedBlock(rewriter, loc, predI,
+                                             createSingleStoreWithAttrs);
+      };
+
+      if (maskElems.empty() || maskAlignment >= vec) {
+        // Either unmasked, or the mask is statically provably uniform across
+        // this whole group: behavior identical to before this change.
+        Value maskVal = threadPred;
+        if (maskElems.size() > 0)
+          maskVal = maybeAnd(rewriter, loc, threadPred, maskElems[vecStart]);
+
+        if (!maskVal)
+          auto _ = createStoreWithAttrs();
+        else if (canUsePredicatedInstructions(op)) {
+          auto cacheModifier = tritonToIntelCacheModifier(op);
+          TritonGEN::PredicatedStoreOp::create(rewriter, loc, addrElem, vecWord,
+                                               maskVal, cacheModifier);
+        } else
+          LLVM::intel::createPredicatedBlock(rewriter, loc, maskVal,
+                                             createStoreWithAttrs);
+      } else {
+        // The mask isn't statically uniform across the group. Try a single
+        // wide store gated on a dynamic AND of the group's mask elements
+        // (the common case away from boundaries); otherwise fall back to
+        // the exact per-element behavior, preserving correctness.
+        Value groupMask = maskElems[vecStart];
+        for (size_t i = 1; i < vec; ++i)
+          groupMask = b.and_(groupMask, maskElems[vecStart + i]);
+        Value fastMaskVal = maybeAnd(rewriter, loc, threadPred, groupMask);
+
+        LLVM::intel::createTwoArmedPredicatedBlock(
+            rewriter, loc, fastMaskVal, createStoreWithAttrs, [&]() {
+              for (size_t i = 0; i < vec; ++i)
+                storeSingleElem(i);
+            });
+      }
     }
 
     rewriter.eraseOp(op);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
@@ -100,11 +100,11 @@ void createTwoArmedPredicatedBlock(RewriterBase &rewriter, Location loc,
   cf::CondBranchOp::create(rewriter, loc, cond, fastBlock, slowBlock);
 
   rewriter.setInsertionPointToStart(fastBlock);
-  (void)std::forward<FastFn>(fastFn)();
+  (void)fastFn();
   cf::BranchOp::create(rewriter, loc, endBlock);
 
   rewriter.setInsertionPointToStart(slowBlock);
-  (void)std::forward<SlowFn>(slowFn)();
+  (void)slowFn();
   cf::BranchOp::create(rewriter, loc, endBlock);
 
   rewriter.setInsertionPointToStart(endBlock);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Utility.h
@@ -76,6 +76,40 @@ Block &createPredicatedBlock(RewriterBase &rewriter, Location loc, Value cond,
   return createPredicatedBlock(rewriter, loc, cond, {}, thenOpsFn);
 }
 
+/// Create a two-armed predicated block, using \p cond to select between two
+/// side-effecting, result-less bodies:
+///   cf.cond_br %cond, ^fast, ^slow
+///   ^fast:
+///     `fastFn()`
+///     cf.br ^end
+///   ^slow:
+///     `slowFn()`
+///     cf.br ^end
+///   ^end:
+template <typename FastFn, typename SlowFn>
+void createTwoArmedPredicatedBlock(RewriterBase &rewriter, Location loc,
+                                   Value cond, FastFn &&fastFn,
+                                   SlowFn &&slowFn) {
+  Block *insertionBlock = rewriter.getInsertionBlock();
+  Block *fastBlock =
+      rewriter.splitBlock(insertionBlock, rewriter.getInsertionPoint());
+  Block *slowBlock = rewriter.splitBlock(fastBlock, fastBlock->begin());
+  Block *endBlock = rewriter.splitBlock(slowBlock, slowBlock->begin());
+
+  rewriter.setInsertionPointToEnd(insertionBlock);
+  cf::CondBranchOp::create(rewriter, loc, cond, fastBlock, slowBlock);
+
+  rewriter.setInsertionPointToStart(fastBlock);
+  (void)std::forward<FastFn>(fastFn)();
+  cf::BranchOp::create(rewriter, loc, endBlock);
+
+  rewriter.setInsertionPointToStart(slowBlock);
+  (void)std::forward<SlowFn>(slowFn)();
+  cf::BranchOp::create(rewriter, loc, endBlock);
+
+  rewriter.setInsertionPointToStart(endBlock);
+}
+
 LLVM::RoundingMode
 convertTritonRoundingModeToLLVM(const triton::RoundingMode rounding);
 


### PR DESCRIPTION
On reproducer from https://github.com/intel/intel-xpu-backend-for-triton/issues/7571 and PVC rolling I see the following numbers:
`28.152ms    8.590GB    305.12GB/s` -> `20.242ms    8.590GB    424.35GB/s`