### PR TITLE
[BLOCKIO] Fix issue for pitch < width

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -3117,7 +3117,6 @@ struct StoreOpToBlockIOConversion
       // by element bytes size.
       adjustedBaseWidth =
           b.add(baseWidth, b.mul(offsetX, b.i32_val(elemSizeInBits / 8)));
-      adjustedBaseWidth = b.umax(adjustedBaseWidth, b.i32_val(64));
 
       // Use the top-left address and mask of the block to store the data.
       // (The first value refer by the registerIdx.)


### PR DESCRIPTION
This PR addresses the base-width adjustment bug in Intel 2D block-store lowering where pointer misalignment and later TritonGEN alignment compensation could produce an incorrect minimum-width constraint.