### PR TITLE
[TritonIntelGPU] Implement getGlobalTimer for atomic_poll timeout

### DIFF
--- a/scripts/skiplist/a770/language.txt
+++ b/scripts/skiplist/a770/language.txt
@@ -102,9 +102,6 @@ python/test/unit/language/test_tensor_descriptor.py::test_tensor_descriptor_batc
 python/test/unit/language/test_tensor_descriptor.py::test_tensor_descriptor_batched_gemm_3d_tma
 # test_tensor_atomic_add_access_patterns
 python/test/unit/language/test_core.py::test_tensor_atomic_add_access_patterns[shape128-random_no_duplication-3-1-float32]
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
-python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
-python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/7504
 # Windows: no NVIDIA/AMD toolchain (ptxas-blackwell, hipcc) on Intel-only CI.
 python/test/unit/language/test_compile_only.py::test_compile_only_sm100

--- a/scripts/skiplist/arl-h/language.txt
+++ b/scripts/skiplist/arl-h/language.txt
@@ -89,6 +89,3 @@ python/test/unit/language/test_core.py::test_strided_store[float64]
 python/test/unit/language/test_tensor_descriptor.py::test_tensor_descriptor_store
 python/test/unit/language/test_tensor_descriptor.py::test_make_tensor_descriptor_matmul
 python/test/unit/language/test_tensor_descriptor.py::test_tensor_descriptor_rank_reducing_matmul
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
-python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
-python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]

--- a/scripts/skiplist/arl-s/language.txt
+++ b/scripts/skiplist/arl-s/language.txt
@@ -83,6 +83,3 @@ python/test/unit/language/test_core.py::test_strided_store[float64]
 python/test/unit/language/test_tensor_descriptor.py::test_tensor_descriptor_store
 python/test/unit/language/test_tensor_descriptor.py::test_make_tensor_descriptor_matmul
 python/test/unit/language/test_tensor_descriptor.py::test_tensor_descriptor_rank_reducing_matmul
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
-python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
-python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]

--- a/scripts/skiplist/default/language.txt
+++ b/scripts/skiplist/default/language.txt
@@ -55,6 +55,3 @@ python/test/unit/language/test_standard.py::test_sort[int32-False-1-8-64]
 python/test/unit/language/test_standard.py::test_sort[int32-True-1-256-16]
 python/test/unit/language/test_standard.py::test_sort[int32-True-1-512-8]
 python/test/unit/language/test_standard.py::test_sort[int32-True-1-8-64]
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
-python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
-python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]

--- a/scripts/skiplist/lts/language.txt
+++ b/scripts/skiplist/lts/language.txt
@@ -8,6 +8,3 @@ python/test/unit/language/test_tensor_descriptor.py::test_tensor_descriptor_redu
 # Below tests require AGAMA 1208 or above
 python/test/unit/language/test_core.py::test_side_effectful_reduction
 python/test/unit/language/test_core.py::test_side_effectful_reduction_2d
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
-python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
-python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]

--- a/scripts/skiplist/mtl/language.txt
+++ b/scripts/skiplist/mtl/language.txt
@@ -65,6 +65,3 @@ python/test/unit/language/test_core.py::test_dot[1-64-128-128-4-False-False-none
 python/test/unit/language/test_core.py::test_dot[1-64-128-128-4-False-False-none-tf32-float32-float32-1-None1]
 python/test/unit/language/test_core.py::test_dot[1-128-128-64-4-False-False-chain-dot-ieee-float8e5-float32-1-None]
 python/test/unit/language/test_core.py::test_dot[1-128-128-64-4-False-False-chain-dot-ieee-float8e4nv-float32-1-None]
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
-python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
-python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]

--- a/scripts/skiplist/ptl/language.txt
+++ b/scripts/skiplist/ptl/language.txt
@@ -1,3 +1,0 @@
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
-python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
-python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]

--- a/scripts/skiplist/xe2/language.txt
+++ b/scripts/skiplist/xe2/language.txt
@@ -1,6 +1,3 @@
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7391
-python/test/unit/language/test_core.py::test_atomic_poll_timeout[1-True]
-python/test/unit/language/test_core.py::test_atomic_poll_timeout[0-False]
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/7504
 # Windows: no NVIDIA/AMD toolchain (ptxas-blackwell, hipcc) on Intel-only CI.
 python/test/unit/language/test_compile_only.py::test_compile_only_sm100

--- a/test/Conversion/intel/atomic_poll.mlir
+++ b/test/Conversion/intel/atomic_poll.mlir
@@ -1,0 +1,56 @@
+// RUN: split-file %s %t
+// RUN: triton-opt %t/rate.mlir -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %t/rate.mlir
+// RUN: not --crash triton-opt %t/no-rate.mlir --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm 2>&1 | FileCheck %t/no-rate.mlir --check-prefix=NO-RATE
+
+//--- rate.mlir
+
+// COM: The clock is read twice and the two reads must not be merged. Cycles are
+//      converted to ns with ttig.core_clock_rate_khz, 1600000 kHz gives 5/8.
+
+// CHECK: llvm.func spir_funccc @_Z27__spirv_ReadClockKHR_Rulongi(i32) -> i64
+// CHECK-LABEL: llvm.func spir_kernelcc @poll_timeout
+// CHECK: llvm.call spir_funccc @_Z27__spirv_ReadClockKHR_Rulongi
+// CHECK-DAG: %[[DIV:.*]] = llvm.mlir.constant(8 : i64) : i64
+// CHECK-DAG: %[[MUL:.*]] = llvm.mlir.constant(5 : i64) : i64
+// CHECK: %[[T1:.*]] = llvm.mul %{{.*}}, %[[MUL]] : i64
+// CHECK: llvm.udiv %[[T1]], %[[DIV]] : i64
+// CHECK: llvm.call spir_funccc @_Z27__spirv_ReadClockKHR_Rulongi
+// CHECK: %[[T2:.*]] = llvm.mul %{{.*}}, %{{.*}} : i64
+// CHECK: llvm.udiv %[[T2]], %{{.*}} : i64
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32, "ttig.core_clock_rate_khz" = 1600000 : i32} {
+  tt.func public @poll_timeout(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i1>, %timeout: i64) {
+    %expected = arith.constant 1 : i32
+    %matched = tt.atomic_poll relaxed, gpu, %arg0, %expected timeout %timeout : !tt.ptr<i32>, i32 -> i1
+    tt.store %arg1, %matched : !tt.ptr<i1>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Without a timeout there is no clock read at all.
+
+// CHECK-LABEL: llvm.func spir_kernelcc @poll_no_timeout
+// CHECK-NOT: __spirv_ReadClockKHR
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32, "ttig.core_clock_rate_khz" = 1600000 : i32} {
+  tt.func public @poll_no_timeout(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i1>) {
+    %expected = arith.constant 1 : i32
+    %matched = tt.atomic_poll relaxed, gpu, %arg0, %expected : !tt.ptr<i32>, i32 -> i1
+    tt.store %arg1, %matched : !tt.ptr<i1>
+    tt.return
+  }
+}
+
+//--- no-rate.mlir
+
+// COM: A timeout without ttig.core_clock_rate_khz cannot be expressed in ns.
+
+// NO-RATE: getGlobalTimer needs a positive ttig.core_clock_rate_khz
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32} {
+  tt.func public @poll_timeout_no_core_clock_rate(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i1>, %timeout: i64) {
+    %expected = arith.constant 1 : i32
+    %matched = tt.atomic_poll relaxed, gpu, %arg0, %expected timeout %timeout : !tt.ptr<i32>, i32 -> i1
+    tt.store %arg1, %matched : !tt.ptr<i1>
+    tt.return
+  }
+}

--- a/test/Conversion/intel/atomic_poll.mlir
+++ b/test/Conversion/intel/atomic_poll.mlir
@@ -41,6 +41,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   }
 }
 
+// -----
+
+// COM: The LTS driver has no SPIR-V shader clock, so read the cycle counter.
+
+// CHECK: llvm.func spir_funccc @__builtin_IB_read_cycle_counter() -> i64
+// CHECK-LABEL: llvm.func spir_kernelcc @poll_timeout_lts
+// CHECK: llvm.call spir_funccc @__builtin_IB_read_cycle_counter()
+// CHECK-NOT: __spirv_ReadClockKHR
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32, "ttig.core_clock_rate_khz" = 1600000 : i32, ttig.is_lts} {
+  tt.func public @poll_timeout_lts(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i1>, %timeout: i64) {
+    %expected = arith.constant 1 : i32
+    %matched = tt.atomic_poll relaxed, gpu, %arg0, %expected timeout %timeout : !tt.ptr<i32>, i32 -> i1
+    tt.store %arg1, %matched : !tt.ptr<i1>
+    tt.return
+  }
+}
+
 //--- no-rate.mlir
 
 // COM: A timeout without ttig.core_clock_rate_khz cannot be expressed in ns.

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -168,6 +168,17 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
     def is_lts(ver) -> bool:
         return is_lts(ver)
 
+    @staticmethod
+    def core_clock_rate(tgt_prop) -> int:
+        if (rate := tgt_prop.get('core_clock_rate')) is None:
+            from triton.runtime import driver
+            # Not `driver.active.utils`: creating it initializes the device, which raises
+            # when compiling in a forked process.
+            if (utils := driver.active.__dict__.get('utils')) is None:
+                return 0
+            rate = utils.get_device_properties(driver.active.get_current_device()).get('sm_clock_rate', 0)
+        return rate or 0
+
     def parse_target(self, tgt_prop) -> dict:
         dev_prop = {}
         dev_prop['name'] = tgt_prop.get('name', 'xpu')
@@ -201,6 +212,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         dev_prop['has_256b_load_store'] = tgt_prop.get('has_256b_prefetch', False)
         dev_prop['has_rounded_divide_sqrt'] = tgt_prop.get('has_rounded_divide_sqrt', not is_lts)
         dev_prop['has_sigmoid'] = tgt_prop.get('has_sigmoid', False)
+        dev_prop['core_clock_rate'] = self.core_clock_rate(tgt_prop)
 
         if '__intel_already_queried_extensions__' not in tgt_prop:
             # All GPUs with the same device_id have the same extensions, so we just
@@ -486,6 +498,10 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         driver_version = metadata["target"].arch.get("driver_version")
         if cls.is_lts(driver_version):
             intel.set_is_lts(mod)
+
+        # `getGlobalTimer` counts core clock cycles and needs the rate to report
+        # nanoseconds.
+        intel.set_core_clock_rate(mod, cls.core_clock_rate(metadata["target"].arch))
 
         # TritonGPU -> LLVM-IR (MLIR)
         pm = ir.pass_manager(mod.context)

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -787,6 +787,7 @@ class XPUDriver(DriverBase):
         extensions = query_device_extensions(device_id)
         dev_property.update(extensions)
         dev_property["__intel_already_queried_extensions__"] = True
+        dev_property["core_clock_rate"] = self.utils.get_device_properties(device).get("sm_clock_rate", 0)
         update_device_arch(dev_property)
 
         return GPUTarget("xpu", dev_property, warp_size=32)

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
@@ -117,6 +117,12 @@ def TritonIntelGPU_Dialect : Dialect {
       return "ttig.is_lts";
     }
 
+    /// Get the name of the attribute holding the core clock rate in kHz, used
+    /// to convert cycles to nanoseconds.
+    static constexpr llvm::StringRef getCoreClockRateAttrName() {
+      return "ttig.core_clock_rate_khz";
+    }
+
     /// Get the name of the attribute used to indicate whether prefetching 256
     /// bytes is supported.
     static constexpr llvm::StringRef getSupportPrefetch256BAttrName() {

--- a/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
+++ b/third_party/intel/lib/Target/SPIRV/SPIRVTranslation.cpp
@@ -107,7 +107,7 @@ public:
 
 static SPIRV::TranslatorOpts getSPIRVOpts() {
   SPIRV::TranslatorOpts SPIRVOpts{SPIRV::VersionNumber::SPIRV_1_4};
-  static constexpr std::array<SPIRV::ExtensionID, 30> AllowedExtensions{
+  static constexpr std::array<SPIRV::ExtensionID, 31> AllowedExtensions{
       SPIRV::ExtensionID::SPV_EXT_shader_atomic_float_add,
       SPIRV::ExtensionID::SPV_EXT_shader_atomic_float16_add,
       SPIRV::ExtensionID::SPV_EXT_float8,
@@ -137,7 +137,8 @@ static SPIRV::TranslatorOpts getSPIRVOpts() {
       SPIRV::ExtensionID::SPV_INTEL_vector_compute,
       SPIRV::ExtensionID::SPV_KHR_bfloat16,
       SPIRV::ExtensionID::SPV_KHR_bit_instructions,
-      SPIRV::ExtensionID::SPV_KHR_non_semantic_info};
+      SPIRV::ExtensionID::SPV_KHR_non_semantic_info,
+      SPIRV::ExtensionID::SPV_KHR_shader_clock};
 
   SPIRVOpts.setMemToRegEnabled(true);
   SPIRVOpts.setPreserveOCLKernelArgTypeMetadataThroughString(true);

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.cpp
@@ -10,7 +10,11 @@
 #include "Dialect/TritonIntelGPU/IR/Utils.h"
 #include "SPIRVTargetInfo.h"
 #include "Utility.h"
+#include "Utils/LLVMIntr.h"
+#include "Utils/Mangling.h"
 #include "intel/include/Dialect/TritonGEN/IR/TritonGENMemorySpace.h"
+
+#include <numeric>
 
 #if defined(_MSC_VER) && !defined(__clang__)
 // from https://gist.github.com/pps83/3210a2f980fd02bb2ba2e5a1fc4a2ef0
@@ -46,9 +50,36 @@ Value TargetInfo::ballot(RewriterBase &rewriter, Location loc, Type type,
 }
 
 Value TargetInfo::getGlobalTimer(RewriterBase &rewriter, Location loc) const {
-  // No nanosecond wall-clock builtin is wired up for the SPIR-V target.
-  llvm::report_fatal_error(
-      "getGlobalTimer is not implemented for the Intel SPIR-V target");
+  // There is no real time counter, so count core clock cycles instead.
+  auto mod = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
+  auto clockRateAttr = mod->getAttrOfType<IntegerAttr>(
+      triton::gpu::intel::TritonIntelGPUDialect::getCoreClockRateAttrName());
+  if (!clockRateAttr || clockRateAttr.getInt() <= 0)
+    llvm::report_fatal_error(
+        Twine("getGlobalTimer needs a positive ") +
+        triton::gpu::intel::TritonIntelGPUDialect::getCoreClockRateAttrName() +
+        " to report nanoseconds");
+
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  Value scope = b.i32_val(/*Device=*/1);
+  std::string funcName =
+      mlir::triton::gpu::intel::mangle("__spirv_ReadClockKHR_Rulong", {i32_ty});
+  Value ticks = mlir::triton::gpu::intel::createDeviceFunctionCall(
+                    rewriter, funcName, /*retType=*/i64_ty,
+                    /*argTypes=*/{i32_ty},
+                    /*args=*/{scope}, /*paramAttrs=*/{},
+                    gpu::intel::noUnwindWillReturnAttrs)
+                    .getResult();
+
+  // kHz is cycles per millisecond. The rate is nominal and the core clock
+  // scales with DVFS, so a downclocked GPU makes a timeout fire late, never
+  // early. Reduce by the GCD so the multiplication does not overflow after a
+  // few hours of GPU uptime.
+  int64_t coreClockRate = clockRateAttr.getInt();
+  int64_t nsPerMs = 1000000;
+  int64_t g = std::gcd(nsPerMs, coreClockRate);
+  return b.udiv(b.mul(ticks, b.i64_val(nsPerMs / g)),
+                b.i64_val(coreClockRate / g));
 }
 
 StringRef TargetInfo::getAtomicSyncScope(MemSyncScope scope) const {

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TargetInfo.cpp
@@ -61,14 +61,21 @@ Value TargetInfo::getGlobalTimer(RewriterBase &rewriter, Location loc) const {
         " to report nanoseconds");
 
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  Value scope = b.i32_val(/*Device=*/1);
-  std::string funcName =
-      mlir::triton::gpu::intel::mangle("__spirv_ReadClockKHR_Rulong", {i32_ty});
+  // The LTS driver does not implement the SPIR-V shader clock builtin.
+  bool isLTS = mod->hasAttr(
+      triton::gpu::intel::TritonIntelGPUDialect::getIsLTSAttrName());
+  std::string funcName = isLTS ? "__builtin_IB_read_cycle_counter"
+                               : mlir::triton::gpu::intel::mangle(
+                                     "__spirv_ReadClockKHR_Rulong", {i32_ty});
+  SmallVector<Type> argTypes;
+  SmallVector<Value> args;
+  if (!isLTS) {
+    argTypes.push_back(i32_ty);
+    args.push_back(b.i32_val(/*Device=*/1));
+  }
   Value ticks = mlir::triton::gpu::intel::createDeviceFunctionCall(
-                    rewriter, funcName, /*retType=*/i64_ty,
-                    /*argTypes=*/{i32_ty},
-                    /*args=*/{scope}, /*paramAttrs=*/{},
-                    gpu::intel::noUnwindWillReturnAttrs)
+                    rewriter, funcName, /*retType=*/i64_ty, argTypes, args,
+                    /*paramAttrs=*/{}, gpu::intel::noUnwindWillReturnAttrs)
                     .getResult();
 
   // kHz is cycles per millisecond. The rate is nominal and the core clock

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -370,6 +370,16 @@ void init_triton_intel(py::module_ &m) {
     }
   });
 
+  m.def("set_core_clock_rate", [](mlir::ModuleOp &mod, unsigned clockRate) {
+    using namespace mlir::triton::gpu::intel;
+    if (clockRate &&
+        !mod->hasAttr(TritonIntelGPUDialect::getCoreClockRateAttrName())) {
+      mlir::Builder builder(mod.getContext());
+      mod->setAttr(TritonIntelGPUDialect::getCoreClockRateAttrName(),
+                   builder.getI32IntegerAttr(clockRate));
+    }
+  });
+
   // Set fast-math flags on floating-point instructions.
   // The fastMath parameter is resolved by the Python layer from
   // TRITON_INTEL_FAST_MATH and TORCHINDUCTOR_USE_FAST_MATH env vars.


### PR DESCRIPTION
atomic_poll with a timeout crashed on XPU because getGlobalTimer was not implemented. Implement it with the SPIR-V shader clock (OpReadClockKHR) and enable SPV_KHR_shader_clock so it translates.

The clock returns ticks, not nanoseconds, but the timeout path only needs a monotonic counter, so that's good enough. Re-enable the timeout tests and add a lowering test.

Fixes #7391.
