### PR TITLE
[Benchmarks] Don't use deprecated `tl.make_block_ptr` in `batched_flash_attention_benchmark` benchmark

### DIFF
--- a/benchmarks/triton_kernels_benchmark/batched_flash_attention_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/batched_flash_attention_benchmark.py
@@ -123,8 +123,8 @@ def fa_fwd_kernel(
         block_shape=[BLOCK_M, V_DIM],
     )
     desc_l = tl.make_tensor_descriptor(
-        l_ptr + q_start * q_head,
-        shape=[q_len, q_head],
+        l_ptr + q_start * q_head + start_qh,
+        shape=[q_len, 1],
         strides=[q_head, 1],
         block_shape=[BLOCK_M, 1],
     )
@@ -171,7 +171,7 @@ def fa_fwd_kernel(
     acc = acc / l[:, None]
     l = m * scale + tl.log(l)
     desc_o.store([start_m * BLOCK_M, 0], acc.to(dtype))
-    desc_l.store([start_m * BLOCK_M, start_qh], l[:, None])
+    desc_l.store([start_m * BLOCK_M, 0], l[:, None])
 
 
 def batched_attention(q, k, v, q_attn_arg, k_attn_arg, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, scale, mask_opt,

--- a/benchmarks/triton_kernels_benchmark/batched_flash_attention_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/batched_flash_attention_benchmark.py
@@ -15,32 +15,6 @@ def fwd_autotune_config() -> list[triton.Config]:
 
 
 @triton.jit
-def load_if(block_ptr, EVEN_M: tl.constexpr, EVEN_N: tl.constexpr):
-    if EVEN_M & EVEN_N:
-        return tl.load(block_ptr)
-    if EVEN_M:
-        return tl.load(block_ptr, boundary_check=(1, ), padding_option="zero")
-    if EVEN_N:
-        return tl.load(block_ptr, boundary_check=(0, ), padding_option="zero")
-
-    return tl.load(block_ptr, boundary_check=(0, 1), padding_option="zero")
-
-
-@triton.jit
-def store_if(block_ptr, value, EVEN_M: tl.constexpr, EVEN_N: tl.constexpr):
-    if EVEN_M & EVEN_N:
-        tl.store(block_ptr, value)
-        return
-    if EVEN_M:
-        tl.store(block_ptr, value, boundary_check=(1, ))
-        return
-    if EVEN_N:
-        tl.store(block_ptr, value, boundary_check=(0, ))
-    else:
-        tl.store(block_ptr, value, boundary_check=(0, 1))
-
-
-@triton.jit
 def mask_fn(q_attn_arg, k_attn_arg, q_offset, k_offset, TYPE: tl.constexpr):
     tril_causal = q_offset[:, None] >= k_offset[None, :]
     triu_causal = q_offset[:, None] <= k_offset[None, :]
@@ -148,8 +122,12 @@ def fa_fwd_kernel(
         strides=[q_head * V_DIM, 1],
         block_shape=[BLOCK_M, V_DIM],
     )
-    l_block_ptr = tl.make_block_ptr(base=l_ptr + q_start * q_head + start_qh, shape=(q_len, ), strides=(q_head, ),
-                                    offsets=(start_m * BLOCK_M, ), block_shape=(BLOCK_M, ), order=(0, ))
+    desc_l = tl.make_tensor_descriptor(
+        l_ptr + q_start * q_head,
+        shape=[q_len, q_head],
+        strides=[q_head, 1],
+        block_shape=[BLOCK_M, 1],
+    )
     desc_q_attn_arg = tl.make_tensor_descriptor(
         q_attn_arg_ptr + q_start,
         shape=[q_len],
@@ -193,7 +171,7 @@ def fa_fwd_kernel(
     acc = acc / l[:, None]
     l = m * scale + tl.log(l)
     desc_o.store([start_m * BLOCK_M, 0], acc.to(dtype))
-    store_if(l_block_ptr, l, False, True)
+    desc_l.store([start_m * BLOCK_M, start_qh], l[:, None])
 
 
 def batched_attention(q, k, v, q_attn_arg, k_attn_arg, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, scale, mask_opt,


### PR DESCRIPTION
To fix: `Block pointers have been removed in favor of the tensor descriptor API` like in https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/30208515393/job/89811918115?pr=7587#step:30:116