### PR TITLE
Revert "[SYCL][XPU] Avoid creating `sycl::event` when submitting kernels on rolling driver (#6361)"

### DIFF
--- a/python/test/unit/intel/test_core.py
+++ b/python/test/unit/intel/test_core.py
@@ -1135,7 +1135,7 @@ def test_silu_sigmoid_optimization(device, monkeypatch):
             return cap
 
         triton.backends.backends['intel'].driver._construct_target.cache_clear()
-        with mock.patch('triton.runtime.driver.active.utils._get_device_capability', new=mock_func):
+        with mock.patch('torch.xpu.get_device_capability', new=mock_func):
             meta = silu_kernel[(2, )](x_gpu, y_gpu, n, BLOCK=512)
             llir = meta.asm.get('llir')
             assert "__spirv_FSigmoidINTEL" in llir, f"Expected __spirv_FSigmoidINTEL in llir output, got:\n{llir}"

--- a/python/triton/tools/compile.py
+++ b/python/triton/tools/compile.py
@@ -218,18 +218,12 @@ def compile_kernel(args: CompileArgs):
             format_name = "native"
         else:
             format_name = "spirv"
-        # Eventless kernel submission requires a rolling (non-LTS) driver; the AOT
-        # stub is generated for this specific target, so bake the decision in now
-        # rather than deferring to a runtime check in the generated C++.
-        driver_version = target.arch.get("driver_version") if isinstance(target.arch, dict) else None
-        is_lts = backend.is_lts(driver_version)
         params |= {
             "arg_types": ", ".join(ty_to_cpp(arg) for arg in arg_types_not_1),
             "grf_mode": args.grf_mode,
             "build_flags": ccinfo.metadata.build_flags,
             "threads_per_warp": args.threads_per_warp,
             "format_name": format_name,
-            "eventless_submit_define": "" if is_lts else "#define ENABLE_EXPERIMENTAL_EVENTLESS_SUBMIT",
         }
     output_files = []
     template_dir = Path(__file__).parent / "extra" / backend_name

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -1,6 +1,6 @@
 from triton.backends.compiler import BaseBackend, GPUTarget, Language
 from triton._C.libtriton import ir, passes, llvm, intel
-from triton.backends.intel.driver import compile_module_from_src, is_lts
+from triton.backends.intel.driver import compile_module_from_src
 from triton.backends.intel.track import track
 from triton.backends.intel.extension_utils import query_device_extensions
 from triton import knobs
@@ -24,6 +24,8 @@ try:  # XPUBackend allows metaclasses injection
     from .meta import XPUBackendMeta
 except ImportError:
     XPUBackendMeta = type(BaseBackend)
+
+_VERSION_PATTERN = re.compile(r'(\d+)\.(\d+)\.(\d+)(?:\+(\d+))?')
 
 
 @dataclass
@@ -164,9 +166,14 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
     def get_target_name(self, options) -> str:
         return f"xpu:{self.device_arch}"
 
-    @staticmethod
-    def is_lts(ver) -> bool:
-        return is_lts(ver)
+    @classmethod
+    def is_lts(cls, ver) -> bool:
+        if not ver:
+            return True
+        m = _VERSION_PATTERN.match(ver)
+        if not m:
+            return True
+        return tuple(int(x) if x is not None else 0 for x in m.groups()) < (1, 6, 35096, 9)
 
     def parse_target(self, tgt_prop) -> dict:
         dev_prop = {}

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -14,14 +14,7 @@
 #include <vector>
 
 #include <level_zero/ze_api.h>
-
-#define __DPCPP_ENABLE_UNFINISHED_KHR_EXTENSIONS
 #include <sycl/sycl.hpp>
-
-#if __SYCL_COMPILER_VERSION >= 20260204
-#include <sycl/khr/free_function_commands.hpp>
-#endif
-
 #if defined(TRITON_INTEL_INJECT_PYTORCH)
 #include <ATen/record_function.h>
 #endif
@@ -1151,15 +1144,7 @@ static void sycl_kernel_launch(uint32_t gridX, uint32_t gridY, uint32_t gridZ,
       cgh.parallel_for(parallel_work_size, kernel_ptr);
     }
   };
-#if __SYCL_COMPILER_VERSION >= 20260204 &&                                     \
-    defined(ENABLE_EXPERIMENTAL_EVENTLESS_SUBMIT)
-  // Event-less kernel submission.
-  // Eventless submission fails with agama 1146 but passes with
-  // agama 1222 L0 driver and later.
-  sycl::ext::oneapi::experimental::submit(stream, cgf);
-#else
   auto event = stream.submit(cgf);
-#endif
 }
 // end sycl
 

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -2,7 +2,6 @@ import importlib.metadata
 import os
 import json
 import sys
-import re
 import hashlib
 import shutil
 import ctypes
@@ -356,20 +355,8 @@ class ExtensionUtils:
                 ctypes.windll.kernel32.FreeLibrary(handle)
 
 
-_VERSION_PATTERN = re.compile(r'(\d+)\.(\d+)\.(\d+)(?:\+(\d+))?')
-
-
-def is_lts(ver) -> bool:
-    if not ver:
-        return True
-    m = _VERSION_PATTERN.match(ver)
-    if not m:
-        return True
-    return tuple(int(x) if x is not None else 0 for x in m.groups()) < (1, 6, 35096, 9)
-
-
 @lru_cache
-def get_hasher_common(is_lts: bool = False):
+def get_hasher_common():
     hasher = hashlib.sha256((__CACHE_VERSION + platform_key()).encode("utf-8"))
     # Include libsycl_dir in the hash to prevent cache collisions across
     # environments with different oneAPI versions (e.g. 2025.3 vs 2026.0).
@@ -378,13 +365,11 @@ def get_hasher_common(is_lts: bool = False):
     # share the same cache entry and load an incompatible .so.
     if COMPILATION_HELPER.libsycl_dir:
         hasher.update(str(COMPILATION_HELPER.libsycl_dir).encode("utf-8"))
-    if is_lts:
-        hasher.update("is_lts=True".encode("utf-8"))
     return hasher
 
 
-def compile_module_from_src(src: str, name: str, is_lts: bool = False):
-    hasher = get_hasher_common(is_lts).copy()
+def compile_module_from_src(src: str, name: str):
+    hasher = get_hasher_common().copy()
     hasher.update(src.encode("utf-8"))
     key = hasher.hexdigest()
     cache = get_cache_manager(key)
@@ -407,12 +392,6 @@ def compile_module_from_src(src: str, name: str, is_lts: bool = False):
                     extra_compiler_args += ["/DTRITON_INTEL_INJECT_PYTORCH=1"]
                 else:
                     extra_compiler_args += ["-DTRITON_INTEL_INJECT_PYTORCH=1"]
-
-            if name == "spirv_utils" and not is_lts:
-                if os.name == "nt":
-                    extra_compiler_args += ["/DENABLE_EXPERIMENTAL_EVENTLESS_SUBMIT"]
-                else:
-                    extra_compiler_args += ["-DENABLE_EXPERIMENTAL_EVENTLESS_SUBMIT"]
 
             so = _build(name, src_path, tmpdir, COMPILATION_HELPER.library_dir, COMPILATION_HELPER.include_dir,
                         COMPILATION_HELPER.libraries, ccflags=extra_compiler_args)
@@ -459,9 +438,7 @@ class XPUUtils(object):
         dirname = os.path.dirname(os.path.realpath(__file__))
         # we save `spirv_utils` module so that the destructor is not called prematurely, which will unload the dll
         # and can cause `Fatal Python error: Segmentation fault`
-        is_lts = self._is_lts()
-        mod = compile_module_from_src(src=Path(os.path.join(dirname, "driver.c")).read_text(), name="spirv_utils",
-                                      is_lts=is_lts)
+        mod = compile_module_from_src(src=Path(os.path.join(dirname, "driver.c")).read_text(), name="spirv_utils")
         global PyKernelArg
         global ARG_CONSTEXPR
         global ARG_KERNEL
@@ -484,8 +461,7 @@ class XPUUtils(object):
         self.build_signature_metadata = mod.build_signature_metadata
         self._initialized = True
 
-    @classmethod
-    def get_current_device(cls):
+    def get_current_device(self):
         try:
             from torch._C import _xpu_getDevice
             return _xpu_getDevice()
@@ -496,19 +472,6 @@ class XPUUtils(object):
     def get_sycl_queue(self):
         import torch
         return torch.xpu.current_stream().sycl_queue
-
-    @classmethod
-    @lru_cache
-    def _get_device_capability(cls, device):
-        import torch
-        return torch.xpu.get_device_capability(device)
-
-    @classmethod
-    @lru_cache
-    def _is_lts(cls):
-        device = cls.get_current_device()
-        properties = cls._get_device_capability(device)
-        return is_lts(properties.get('driver_version'))
 
     def wait(self):
         self.wait_on_sycl_queue(self.get_sycl_queue())
@@ -769,9 +732,10 @@ class XPUDriver(DriverBase):
 
     @lru_cache
     def _construct_target(self, device):
+        import torch
         from triton.backends.intel.extension_utils import query_device_extensions
 
-        dev_property = self.utils._get_device_capability(device)
+        dev_property = torch.xpu.get_device_capability(device)
 
         def update_device_arch(dev_property):
             if not (arch := knobs.intel.device_arch):

--- a/third_party/intel/tools/intel/compile.cpp
+++ b/third_party/intel/tools/intel/compile.cpp
@@ -7,14 +7,6 @@
 #include <level_zero/ze_api.h>
 #include <sycl/sycl.hpp>
 
-// Eventless kernel submission requires a rolling (non-LTS) driver. Baked in
-// by compile.py based on the compile-time target's driver version.
-{eventless_submit_define}
-
-#if __SYCL_COMPILER_VERSION >= 20260204 && defined(ENABLE_EXPERIMENTAL_EVENTLESS_SUBMIT)
-#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
-#endif
-
 // helpers to check for ze errors
 #define ZE_CHECK(ans) {{\
     gpuAssert((ans), __FILE__, __LINE__);\
@@ -186,13 +178,7 @@ int32_t {kernel_name}(sycl::queue &stream, {signature}) {{
         cgh.parallel_for(parallel_work_size, sycl_kernel);
     }}
   }};
-#if __SYCL_COMPILER_VERSION >= 20260204 && defined(ENABLE_EXPERIMENTAL_EVENTLESS_SUBMIT)
-  // Use eventless kernel submission. queue::submit() creates SYCL event which
-  // is redundant for our use case.
-  sycl::ext::oneapi::experimental::submit(stream, cgf);
-#else
   stream.submit(cgf);
-#endif
   stream.wait_and_throw();
   return 0;
 }}

--- a/utils/SPIRVRunner/CMakeLists.txt
+++ b/utils/SPIRVRunner/CMakeLists.txt
@@ -43,18 +43,6 @@ set(TARGET_NAME SPIRVRunner)
 add_executable(${TARGET_NAME} ${TARGET_NAME}.cpp $<TARGET_OBJECTS:llvm_parser>)
 target_include_directories(${TARGET_NAME} PRIVATE
 	"${ONEAPI_ROOT}/compiler/latest/include" ${SYCL_FUNCTIONS_INCLUDE_DIR} ${JSON_INCLUDE_DIR})
-
-# Eventless kernel submission requires a rolling (non-LTS) driver. It's not
-# worth complicating this build with driver detection, so default to enabled
-# and let users on an LTS driver opt out via the environment.
-set(SPIRVRUNNER_ENABLE_EVENTLESS_SUBMIT "1")
-if(DEFINED ENV{SPIRVRUNNER_ENABLE_EVENTLESS_SUBMIT})
-  set(SPIRVRUNNER_ENABLE_EVENTLESS_SUBMIT "$ENV{SPIRVRUNNER_ENABLE_EVENTLESS_SUBMIT}")
-endif()
-if(NOT SPIRVRUNNER_ENABLE_EVENTLESS_SUBMIT STREQUAL "0")
-  target_compile_definitions(${TARGET_NAME} PRIVATE ENABLE_EXPERIMENTAL_EVENTLESS_SUBMIT)
-endif()
-
 set_target_properties(${TARGET_NAME} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS}")
 set_target_properties(${TARGET_NAME} PROPERTIES LINK_FLAGS "${LINK_FLAGS}")
 add_dependencies(${TARGET_NAME} json)

--- a/utils/SPIRVRunner/README.md
+++ b/utils/SPIRVRunner/README.md
@@ -37,12 +37,6 @@ CMAKE_PREFIX_PATH=/abs/path/to/TorchConfig.cmake/directory LLVM_DIR=/abs/path/to
 make -j
 ```
 
-Eventless kernel submission is enabled by default, but it requires a rolling (non-LTS) driver. If you are running on an LTS driver, disable it at configure time:
-
-```
-SPIRVRUNNER_ENABLE_EVENTLESS_SUBMIT=0 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-```
-
 ## Configuration
 
 ### Generate Data

--- a/utils/SPIRVRunner/SPIRVRunner.cpp
+++ b/utils/SPIRVRunner/SPIRVRunner.cpp
@@ -1,7 +1,4 @@
 #include <level_zero/ze_api.h>
-#if __SYCL_COMPILER_VERSION >= 20260204
-#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
-#endif
 #include <sycl/sycl.hpp>
 #include <torch/torch.h>
 
@@ -322,14 +319,7 @@ static void sycl_kernel_launch(sycl::queue &stream, sycl::kernel &kernel_ptr,
     double duration = static_cast<double>(end - start) / 1000000;
     std::cout << "Kernel execution time: " << duration << " ms" << std::endl;
   } else {
-#if __SYCL_COMPILER_VERSION >= 20260204 &&                                     \
-    defined(ENABLE_EXPERIMENTAL_EVENTLESS_SUBMIT)
-    // Use eventless kernel submission. queue::submit() creates SYCL event which
-    // is redundant for our use case.
-    sycl::ext::oneapi::experimental::submit(stream, cgf);
-#else
     stream.submit(cgf);
-#endif
   }
   stream.wait_and_throw();
 }
@@ -439,18 +429,12 @@ std::vector<TensorBuffer> launchKernel(sycl::queue stream, sycl::kernel kernel,
 
   // copy back the output tensors
   for (const auto &item : triton_args.host_outbuffers) {
-#if __SYCL_COMPILER_VERSION >= 20260204 &&                                     \
-    defined(ENABLE_EXPERIMENTAL_EVENTLESS_SUBMIT)
-    sycl::ext::oneapi::experimental::memcpy(
-        stream, tensor_ptr(item.buffer_ptr),
-        triton_args.dev_buffers.at(item.index), item.buffer_ptr.nbytes());
-#else
-    stream.memcpy(tensor_ptr(item.buffer_ptr),
-                  triton_args.dev_buffers.at(item.index),
-                  item.buffer_ptr.nbytes());
-#endif
+    stream
+        .memcpy(tensor_ptr(item.buffer_ptr),
+                triton_args.dev_buffers.at(item.index),
+                item.buffer_ptr.nbytes())
+        .wait_and_throw();
   }
-  stream.wait_and_throw();
 
   for (auto *dev_ptr : triton_args.dev_buffers) {
     if (dev_ptr)


### PR DESCRIPTION
This reverts commit afe31207fcf582a48260b117a36a325708edf531.