### PR TITLE
[vLLM] Skip `test_mamba_ssm_ssd` tests that silently abort `pytest`

### DIFF
--- a/scripts/skiplist/default/vllm_mamba.txt
+++ b/scripts/skiplist/default/vllm_mamba.txt
@@ -1,4 +1,4 @@
-# Silent runtime failure:
+# Silent runtime failure: https://github.com/intel/intel-xpu-backend-for-triton/issues/7600
 tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-5-16-itype1]
 tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-5-32-itype1]
 tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-8-16-itype1]

--- a/scripts/skiplist/default/vllm_mamba.txt
+++ b/scripts/skiplist/default/vllm_mamba.txt
@@ -1,4 +1,4 @@
-# Silent runtime failure: https://github.com/intel/intel-xpu-backend-for-triton/issues/7600
+# Silent abort: https://github.com/intel/intel-xpu-backend-for-triton/issues/7600
 tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-5-16-itype1]
 tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-5-32-itype1]
 tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-8-16-itype1]

--- a/scripts/skiplist/default/vllm_mamba.txt
+++ b/scripts/skiplist/default/vllm_mamba.txt
@@ -1,0 +1,9 @@
+# Silent runtime failure:
+tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-5-16-itype1]
+tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-5-32-itype1]
+tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-8-16-itype1]
+tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-8-32-itype1]
+tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-32-16-itype1]
+tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-32-32-itype1]
+tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-128-16-itype1]
+tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-128-32-itype1]

--- a/scripts/skiplist/xe2/vllm_mamba.txt
+++ b/scripts/skiplist/xe2/vllm_mamba.txt
@@ -1,4 +1,4 @@
-# Silent runtime failure:
+# Silent runtime failure: https://github.com/intel/intel-xpu-backend-for-triton/issues/7600
 tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-5-16-itype1]
 tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-5-32-itype1]
 tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-8-16-itype1]

--- a/scripts/skiplist/xe2/vllm_mamba.txt
+++ b/scripts/skiplist/xe2/vllm_mamba.txt
@@ -1,4 +1,4 @@
-# Silent runtime failure: https://github.com/intel/intel-xpu-backend-for-triton/issues/7600
+# Silent abort: https://github.com/intel/intel-xpu-backend-for-triton/issues/7600
 tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-5-16-itype1]
 tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-5-32-itype1]
 tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-8-16-itype1]

--- a/scripts/skiplist/xe2/vllm_mamba.txt
+++ b/scripts/skiplist/xe2/vllm_mamba.txt
@@ -1,0 +1,9 @@
+# Silent runtime failure:
+tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-5-16-itype1]
+tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-5-32-itype1]
+tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-8-16-itype1]
+tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-8-32-itype1]
+tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-32-16-itype1]
+tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-32-32-itype1]
+tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-128-16-itype1]
+tests/kernels/mamba/test_mamba_ssm_ssd.py::test_mamba_chunk_scan_single_example[seq_len_chunk_size1-128-32-itype1]


### PR DESCRIPTION
Created https://github.com/intel/intel-xpu-backend-for-triton/issues/7600.