### PR TITLE
Improve prefetching op lowering to support column major B matrix prefetching

### DIFF
--- a/test/TritonGEN/tritongen-2Dblockprefetch-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockprefetch-to-llvm.mlir
@@ -347,11 +347,11 @@ llvm.func @triton_gen.2Dblockprefetch(%ptr : !llvm.ptr<1>, %base_width : i32, %b
 
 llvm.func @triton_gen.2Dblockprefetch(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
   // CHECK-COUNT-2: llvm.mlir.constant(1 : i32) : i32
-  // CHECK:         [[ElemSize:%.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK:         [[ElemSize:%.*]] = llvm.mlir.constant(8 : i32) : i32
   // CHECK-NEXT:    [[TileWidth:%.*]] = llvm.mlir.constant(16 : i32) : i32
   // CHECK-NEXT:    [[TileHeight:%.*]] = llvm.mlir.constant(32 : i32) : i32
   // CHECK-NEXT:    [[VBlocks:%.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK-NEXT:    llvm.call spir_funccc @_Z36__spirv_Subgroup2DBlockPrefetchINTELiiiiPU3AS1viiiDv2_i([[ElemSize]], [[TileWidth]], [[TileHeight]], [[VBlocks]], {{.*}}, %arg2, %arg3, {{.*}}) {{.*}} : (i32, i32, i32, i32, !llvm.ptr<1>{{.*}}, i32, i32, i32, vector<2xi32>) -> ()
+  // CHECK:    llvm.call spir_funccc @llvm.genx.GenISA.LSC2DBlockPrefetch.isVoid({{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %arg5, [[ElemSize]], [[TileWidth]], [[TileHeight]], [[VBlocks]], {{.*}}) {{.*}} : (i64, i32, i32, i32, i32, i32, i32, i32, i32, i32, i1, i1, i32) -> ()
   triton_gen.2Dblockprefetch %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=8, tile_width=16, tile_height=32, v_blocks=1, cache_control=Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32)
   llvm.return
 }

--- a/test/TritonIntelGPU/prefetch-to-llvm.mlir
+++ b/test/TritonIntelGPU/prefetch-to-llvm.mlir
@@ -22,55 +22,95 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
     // CHECK: %[[ADDR_16:.*]] = llvm.extractvalue {{.*}}[16] : !llvm.struct<(ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>)>
     // CHECK: %[[ADDR_32:.*]] = llvm.extractvalue {{.*}}[32] : !llvm.struct<(ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>)>
     // CHECK: %[[ADDR_48:.*]] = llvm.extractvalue {{.*}}[48] : !llvm.struct<(ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>, ptr<1>)>
+    // CHECK: %[[MASK_0:.*]] = llvm.extractvalue {{.*}}[0] : !llvm.struct<(i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1)>
+    // CHECK: %[[MASK_16:.*]] = llvm.extractvalue {{.*}}[16] : !llvm.struct<(i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1)>
+    // CHECK: %[[MASK_32:.*]] = llvm.extractvalue {{.*}}[32] : !llvm.struct<(i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1)>
+    // CHECK: %[[MASK_48:.*]] = llvm.extractvalue {{.*}}[48] : !llvm.struct<(i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1)>
     // CHECK: %[[PITCH:.*]] = llvm.mlir.constant(128 : i32) : i32
     // CHECK: %[[BASE_HEIGHT:.*]] = llvm.mlir.constant(8 : i32) : i32
     // CHECK: %[[BASE_WIDTH:.*]] = llvm.mlir.constant(64 : i32) : i32
-    // CHECK: %[[CST_0_:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: llvm.mlir.constant(0 : i32) : i32
 
-    // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: %[[UNIFIED_MASK:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflecj(%{{.*}}, %[[CST_0]]) {convergent, no_unwind, will_return} : (i8, i32) -> i8
-    // CHECK: %[[UNIFIED_MASK_I1:.*]] = llvm.trunc %[[UNIFIED_MASK]] : i8 to i1
-    // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: %[[OFFSET_Y:.*]] = llvm.select %[[UNIFIED_MASK_I1]], %[[CST_0]], %[[BASE_HEIGHT]] : i1, i32
-    // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: %[[VAL_13:.*]] = llvm.ptrtoint %[[ADDR_0]] : !llvm.ptr<1> to i64
-    // CHECK: %[[UNIFIED_BASE:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[VAL_13]], %[[CST_0]]) {convergent, no_unwind, will_return} : (i64, i32) -> i64
+    // CHECK: %[[WARP_ID:.*]] = llvm.call spir_funccc @_Z16get_sub_group_id() {no_unwind, will_return} : () -> i32
+    // CHECK: llvm.xor {{.*}}, {{.*}} : i32
+    // CHECK: %[[OFFSET_X_TO_TILE:.*]] = llvm.xor {{.*}}, {{.*}} : i32
+    // CHECK: %[[EXTRACTED_BASE:.*]] = llvm.ptrtoint %[[ADDR_0]] : !llvm.ptr<1> to i64
+    // CHECK: %[[UNIFIED_BASE:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[EXTRACTED_BASE]], {{.*}}) {convergent, no_unwind, will_return} : (i64, i32) -> i64
     // CHECK: %[[VAL_26:.*]] = llvm.inttoptr %[[UNIFIED_BASE]] : i64 to !llvm.ptr<1>
-    // CHECK: triton_gen.2Dblockprefetch %[[VAL_26]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[OFFSET_Y]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
+    // CHECK: %[[NEG_OFFSET_X:.*]] = llvm.sub {{.*}}, %[[OFFSET_X_TO_TILE]] : i32
+    // CHECK: %[[ADJUSTED_BASE:.*]] = llvm.getelementptr %[[VAL_26]]{{\[}}%[[NEG_OFFSET_X]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, f16
 
-    // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: %[[VAL_29:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflecj(%{{.*}}, %[[CST_0]]) {convergent, no_unwind, will_return} : (i8, i32) -> i8
-    // CHECK: %[[VAL_30:.*]] = llvm.trunc %[[VAL_29]] : i8 to i1
-    // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: %[[VAL_31:.*]] = llvm.select %[[VAL_30]], %[[CST_0]], %[[BASE_HEIGHT]] : i1, i32
-    // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: %[[VAL_32:.*]] = llvm.ptrtoint %[[ADDR_16]] : !llvm.ptr<1> to i64
-    // CHECK: %[[VAL_33:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[VAL_32]], %[[CST_0]]) {convergent, no_unwind, will_return} : (i64, i32) -> i64
-    // CHECK: %[[VAL_34:.*]] = llvm.inttoptr %[[VAL_33]] : i64 to !llvm.ptr<1>
-    // CHECK: triton_gen.2Dblockprefetch %[[VAL_34]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[VAL_31]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
+    // CHECK: %[[MUL_32:.*]] = llvm.mul %[[OFFSET_X_TO_TILE]], {{.*}} : i32
+    // CHECK: %[[ADD_98:.*]] = llvm.add %[[BASE_WIDTH]], %[[MUL_32]] : i32
+    // CHECK: %[[MIN_BASE_WIDTH:.*]] = llvm.mlir.constant(64 : i32) : i32
+    // CHECK: %[[ADJUSTED_BASE_WIDTH:.*]] = llvm.intr.umax(%[[ADD_98]], %[[MIN_BASE_WIDTH]]) : (i32, i32) -> i32
 
-    // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: %[[VAL_36:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflecj(%{{.*}}, %[[CST_0]]) {convergent, no_unwind, will_return} : (i8, i32) -> i8
-    // CHECK: %[[VAL_37:.*]] = llvm.trunc %[[VAL_36]] : i8 to i1
-    // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: %[[VAL_38:.*]] = llvm.select %[[VAL_37]], %[[CST_0]], %[[BASE_HEIGHT]] : i1, i32
-    // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: %[[VAL_39:.*]] = llvm.ptrtoint %[[ADDR_32]] : !llvm.ptr<1> to i64
-    // CHECK: %[[VAL_40:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[VAL_39]], %[[CST_0]]) {convergent, no_unwind, will_return} : (i64, i32) -> i64
-    // CHECK: %[[VAL_41:.*]] = llvm.inttoptr %[[VAL_40]] : i64 to !llvm.ptr<1>
-    // CHECK: triton_gen.2Dblockprefetch %[[VAL_41]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[VAL_38]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
+    // CHECK: %[[EXTRACTED_MASK:.*]] = llvm.zext %[[MASK_0]] : i1 to i8
+    // CHECK: %[[UNIFIED_MASK:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflecj(%[[EXTRACTED_MASK]], {{.*}}) {convergent, no_unwind, will_return} : (i8, i32) -> i8
+    // CHECK: %[[UNIFIED_MASK_I1:.*]] = llvm.trunc %[[UNIFIED_MASK]] : i8 to i1
+    // CHECK: %[[OFFSET_Y:.*]] = llvm.select %[[UNIFIED_MASK_I1]], {{.*}}, %[[BASE_HEIGHT]] : i1, i32
+    // CHECK: %[[OFFSET_IN_PACKEDELEM_SIZE:.*]] = llvm.udiv %[[OFFSET_X_TO_TILE]], {{.*}} : i32
+    // CHECK: triton_gen.2Dblockprefetch %[[ADJUSTED_BASE]], %[[ADJUSTED_BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[OFFSET_IN_PACKEDELEM_SIZE]], %[[OFFSET_Y]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
 
-    // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: %[[VAL_43:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflecj(%{{.*}}, %[[CST_0]]) {convergent, no_unwind, will_return} : (i8, i32) -> i8
-    // CHECK: %[[VAL_44:.*]] = llvm.trunc %[[VAL_43]] : i8 to i1
-    // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: %[[VAL_45:.*]] = llvm.select %[[VAL_44]], %[[CST_0]], %[[BASE_HEIGHT]] : i1, i32
-    // CHECK: %[[CST_0:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK: %[[VAL_46:.*]] = llvm.ptrtoint %[[ADDR_48]] : !llvm.ptr<1> to i64
-    // CHECK: %[[VAL_47:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[VAL_46]], %[[CST_0]]) {convergent, no_unwind, will_return} : (i64, i32) -> i64
-    // CHECK: %[[VAL_48:.*]] = llvm.inttoptr %[[VAL_47]] : i64 to !llvm.ptr<1>
-    // CHECK: triton_gen.2Dblockprefetch %[[VAL_48]], %[[BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[CST_0_]], %[[VAL_45]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
+    // CHECK: llvm.xor {{.*}}, {{.*}} : i32
+    // CHECK: %[[OFFSET_X_TO_TILE:.*]] = llvm.xor {{.*}}, {{.*}} : i32
+    // CHECK: %[[EXTRACTED_BASE:.*]] = llvm.ptrtoint %[[ADDR_16]] : !llvm.ptr<1> to i64
+    // CHECK: %[[UNIFIED_BASE:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[EXTRACTED_BASE]], {{.*}}) {convergent, no_unwind, will_return} : (i64, i32) -> i64
+    // CHECK: %[[VAL_26:.*]] = llvm.inttoptr %[[UNIFIED_BASE]] : i64 to !llvm.ptr<1>
+    // CHECK: %[[NEG_OFFSET_X:.*]] = llvm.sub {{.*}}, %[[OFFSET_X_TO_TILE]] : i32
+    // CHECK: %[[ADJUSTED_BASE:.*]] = llvm.getelementptr %[[VAL_26]]{{\[}}%[[NEG_OFFSET_X]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, f16
+
+    // CHECK: %[[MUL_32:.*]] = llvm.mul %[[OFFSET_X_TO_TILE]], {{.*}} : i32
+    // CHECK: %[[ADD_98:.*]] = llvm.add %[[BASE_WIDTH]], %[[MUL_32]] : i32
+    // CHECK: %[[MIN_BASE_WIDTH:.*]] = llvm.mlir.constant(64 : i32) : i32
+    // CHECK: %[[ADJUSTED_BASE_WIDTH:.*]] = llvm.intr.umax(%[[ADD_98]], %[[MIN_BASE_WIDTH]]) : (i32, i32) -> i32
+
+    // CHECK: %[[EXTRACTED_MASK:.*]] = llvm.zext %[[MASK_16]] : i1 to i8
+    // CHECK: %[[UNIFIED_MASK:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflecj(%[[EXTRACTED_MASK]], {{.*}}) {convergent, no_unwind, will_return} : (i8, i32) -> i8
+    // CHECK: %[[UNIFIED_MASK_I1:.*]] = llvm.trunc %[[UNIFIED_MASK]] : i8 to i1
+    // CHECK: %[[OFFSET_Y:.*]] = llvm.select %[[UNIFIED_MASK_I1]], {{.*}}, %[[BASE_HEIGHT]] : i1, i32
+    // CHECK: %[[OFFSET_IN_PACKEDELEM_SIZE:.*]] = llvm.udiv %[[OFFSET_X_TO_TILE]], {{.*}} : i32
+    // CHECK: triton_gen.2Dblockprefetch %[[ADJUSTED_BASE]], %[[ADJUSTED_BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[OFFSET_IN_PACKEDELEM_SIZE]], %[[OFFSET_Y]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
+
+    // CHECK: llvm.xor {{.*}}, {{.*}} : i32
+    // CHECK: %[[OFFSET_X_TO_TILE:.*]] = llvm.xor {{.*}}, {{.*}} : i32
+    // CHECK: %[[EXTRACTED_BASE:.*]] = llvm.ptrtoint %[[ADDR_32]] : !llvm.ptr<1> to i64
+    // CHECK: %[[UNIFIED_BASE:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[EXTRACTED_BASE]], {{.*}}) {convergent, no_unwind, will_return} : (i64, i32) -> i64
+    // CHECK: %[[VAL_26:.*]] = llvm.inttoptr %[[UNIFIED_BASE]] : i64 to !llvm.ptr<1>
+    // CHECK: %[[NEG_OFFSET_X:.*]] = llvm.sub {{.*}}, %[[OFFSET_X_TO_TILE]] : i32
+    // CHECK: %[[ADJUSTED_BASE:.*]] = llvm.getelementptr %[[VAL_26]]{{\[}}%[[NEG_OFFSET_X]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, f16
+
+    // CHECK: %[[MUL_32:.*]] = llvm.mul %[[OFFSET_X_TO_TILE]], {{.*}} : i32
+    // CHECK: %[[ADD_98:.*]] = llvm.add %[[BASE_WIDTH]], %[[MUL_32]] : i32
+    // CHECK: %[[MIN_BASE_WIDTH:.*]] = llvm.mlir.constant(64 : i32) : i32
+    // CHECK: %[[ADJUSTED_BASE_WIDTH:.*]] = llvm.intr.umax(%[[ADD_98]], %[[MIN_BASE_WIDTH]]) : (i32, i32) -> i32
+
+    // CHECK: %[[EXTRACTED_MASK:.*]] = llvm.zext %[[MASK_32]] : i1 to i8
+    // CHECK: %[[UNIFIED_MASK:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflecj(%[[EXTRACTED_MASK]], {{.*}}) {convergent, no_unwind, will_return} : (i8, i32) -> i8
+    // CHECK: %[[UNIFIED_MASK_I1:.*]] = llvm.trunc %[[UNIFIED_MASK]] : i8 to i1
+    // CHECK: %[[OFFSET_Y:.*]] = llvm.select %[[UNIFIED_MASK_I1]], {{.*}}, %[[BASE_HEIGHT]] : i1, i32
+    // CHECK: %[[OFFSET_IN_PACKEDELEM_SIZE:.*]] = llvm.udiv %[[OFFSET_X_TO_TILE]], {{.*}} : i32
+    // CHECK: triton_gen.2Dblockprefetch %[[ADJUSTED_BASE]], %[[ADJUSTED_BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[OFFSET_IN_PACKEDELEM_SIZE]], %[[OFFSET_Y]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
+
+
+    // CHECK: llvm.xor {{.*}}, {{.*}} : i32
+    // CHECK: %[[OFFSET_X_TO_TILE:.*]] = llvm.xor {{.*}}, {{.*}} : i32
+    // CHECK: %[[EXTRACTED_BASE:.*]] = llvm.ptrtoint %[[ADDR_48]] : !llvm.ptr<1> to i64
+    // CHECK: %[[UNIFIED_BASE:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[EXTRACTED_BASE]], {{.*}}) {convergent, no_unwind, will_return} : (i64, i32) -> i64
+    // CHECK: %[[VAL_26:.*]] = llvm.inttoptr %[[UNIFIED_BASE]] : i64 to !llvm.ptr<1>
+    // CHECK: %[[NEG_OFFSET_X:.*]] = llvm.sub {{.*}}, %[[OFFSET_X_TO_TILE]] : i32
+    // CHECK: %[[ADJUSTED_BASE:.*]] = llvm.getelementptr %[[VAL_26]]{{\[}}%[[NEG_OFFSET_X]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, f16
+
+    // CHECK: %[[MUL_32:.*]] = llvm.mul %[[OFFSET_X_TO_TILE]], {{.*}} : i32
+    // CHECK: %[[ADD_98:.*]] = llvm.add %[[BASE_WIDTH]], %[[MUL_32]] : i32
+    // CHECK: %[[MIN_BASE_WIDTH:.*]] = llvm.mlir.constant(64 : i32) : i32
+    // CHECK: %[[ADJUSTED_BASE_WIDTH:.*]] = llvm.intr.umax(%[[ADD_98]], %[[MIN_BASE_WIDTH]]) : (i32, i32) -> i32
+
+    // CHECK: %[[EXTRACTED_MASK:.*]] = llvm.zext %[[MASK_48]] : i1 to i8
+    // CHECK: %[[UNIFIED_MASK:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflecj(%[[EXTRACTED_MASK]], {{.*}}) {convergent, no_unwind, will_return} : (i8, i32) -> i8
+    // CHECK: %[[UNIFIED_MASK_I1:.*]] = llvm.trunc %[[UNIFIED_MASK]] : i8 to i1
+    // CHECK: %[[OFFSET_Y:.*]] = llvm.select %[[UNIFIED_MASK_I1]], {{.*}}, %[[BASE_HEIGHT]] : i1, i32
+    // CHECK: %[[OFFSET_IN_PACKEDELEM_SIZE:.*]] = llvm.udiv %[[OFFSET_X_TO_TILE]], {{.*}} : i32
+    // CHECK: triton_gen.2Dblockprefetch %[[ADJUSTED_BASE]], %[[ADJUSTED_BASE_WIDTH]], %[[BASE_HEIGHT]], %[[PITCH]], %[[OFFSET_IN_PACKEDELEM_SIZE]], %[[OFFSET_Y]] {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = L1C_L3C}
 
     %mask_tensor = arith.constant dense<1> : tensor<64x32xi1, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
     ttig.prefetch %tensor_of_ptr, %mask_tensor {boundaryCheck = array<i32>, cache = 1 : i32, evict = 1 : i32, isVolatile = false, operandSegmentSizes = array<i32: 1, 1, 1>, ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
@@ -136,6 +176,171 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32}
   // CHECK-NOT: triton_gen.2Dblockprefetch
   tt.func public @prefetch_unknown_stride(%arg0: tensor<64x32x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>) {
     ttig.prefetch %arg0 {cache = 1 : i32, evict = 1 : i32, isVolatile = false, ttig.block_io = "row_major"} : tensor<64x32x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Prefetch of a column-major tensor-of-pointers with affine pointer
+// COM: arithmetic. This should lower to 2D block prefetch ops.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [2, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_column_major
+  // CHECK: %[[PITCH:.*]] = llvm.mlir.constant(128 : i32) : i32
+  // CHECK-COUNT-2: triton_gen.2Dblockprefetch {{.*}} {elem_size_in_bits = 32, tile_width = 16, tile_height = 16, v_blocks = 1, cache_control = L1C_L3C}
+  tt.func public @prefetch_column_major(%arg0: !tt.ptr<f16>) {
+    %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>}>> -> tensor<64x1xi32, #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>>
+    %2 = tt.broadcast %1 : tensor<64x1xi32, #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>> -> tensor<64x32xi32, #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>>
+    %3 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>}>>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>}>> -> tensor<1x32xi32, #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>>
+    %5 = arith.constant dense<64> : tensor<1x32xi32, #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>>
+    %6 = arith.muli %4, %5 : tensor<1x32xi32, #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>>
+    %7 = tt.broadcast %6 : tensor<1x32xi32, #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>> -> tensor<64x32xi32, #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>>
+    %8 = arith.addi %2, %7 : tensor<64x32xi32, #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>>
+    %9 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x32x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>>
+    %10 = tt.addptr %9, %8 : tensor<64x32x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>>, tensor<64x32xi32, #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>>
+    ttig.prefetch %10 {cache = 1 : i32, evict = 1 : i32, isVolatile = false, ttig.block_io = "column_major"} : tensor<64x32x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Column-major fp8 tensor-of-pointers prefetch.
+#mma = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_column_major_fp8
+  // COM: The prefetch only supports <= 64 bytes or 256 bytes. 128 bytes per row are split into two 64 bytes prefetches.
+  // COM: The redundant prefetches are dummy prefetches as hit on miss.
+  // COM: Check the prefetch tile of
+  // COM:                      even Warp            odd Warp         even Warp             odd Warp
+  // COM:
+  // COM:                 addr0──────────────┬──────────────────addr256────────────┬──────────────────┐
+  // COM:                 │                  │                  │                  │                  │
+  // COM:                 │                  │                  │                  │                  │
+  // COM:                 │                  │                  │                  │                  │
+  // COM:       64 bytes  │                  │                  │                  │                  │
+  // COM:                 │                  │                  │                  │                  │
+  // COM:                 │                  │                  │                  │                  │
+  // COM:                 │                  │                  │                  │                  │
+  // COM:                 addr128────────────┼──────────────────addr384────────────┼──────────────────┤
+  // COM:                 │                  │                  │                  │                  │
+  // COM:                 │                  │                  │                  │                  │
+  // COM:                 │                  │                  │                  │                  │
+  // COM:       64 bytes  │                  │                  │                  │                  │
+  // COM:                 │                  │                  │                  │                  │
+  // COM:                 │                  │                  │                  │                  │
+  // COM:                 │                  │                  │                  │                  │
+  // COM:                 └──────────────────┴──────────────────┴──────────────────┴──────────────────┘
+  // COM:                        32 row             32 row             32 row              32 row
+  // CHECK: llvm.extractvalue {{.*}}[0] : !llvm.struct<(ptr<1>
+  // CHECK: %[[ADDR_0:.*]] = llvm.extractvalue {{.*}}[0] : !llvm.struct<(ptr<1>,
+  // CHECK: %[[ADDR_128:.*]] = llvm.extractvalue {{.*}}[128] : !llvm.struct<(ptr<1>,
+  // CHECK: %[[ADDR_256:.*]] = llvm.extractvalue {{.*}}[256] : !llvm.struct<(ptr<1>,
+  // CHECK: %[[ADDR_384:.*]] = llvm.extractvalue {{.*}}[384] : !llvm.struct<(ptr<1>,
+  // CHECK: %[[BASE_I64:.*]] = llvm.ptrtoint %[[ADDR_0]] : !llvm.ptr<1> to i64
+  // CHECK: %[[SHUF_BASE:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[BASE_I64]], {{.*}})
+  // CHECK: %[[BASE_PTR:.*]] = llvm.inttoptr %[[SHUF_BASE]] : i64 to !llvm.ptr<1>
+  // CHECK: %[[NEG_X:.*]] = llvm.sub {{.*}}, {{.*}} : i32
+  // CHECK: %[[ADJ_BASE:.*]] = llvm.getelementptr %[[BASE_PTR]]{{\[}}%[[NEG_X]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>
+  // CHECK: %[[X_PACKED:.*]] = llvm.udiv {{.*}}, {{.*}} : i32
+  // CHECK: triton_gen.2Dblockprefetch %[[ADJ_BASE]], {{.*}}, {{.*}}, {{.*}}, %[[X_PACKED]], {{.*}} {elem_size_in_bits = 32, tile_width = 16, tile_height = 32, v_blocks = 1, cache_control = L1C_L3C}
+  // CHECK: %[[BASE_I64:.*]] = llvm.ptrtoint %[[ADDR_128]] : !llvm.ptr<1> to i64
+  // CHECK: %[[SHUF_BASE:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[BASE_I64]], {{.*}})
+  // CHECK: %[[BASE_PTR:.*]] = llvm.inttoptr %[[SHUF_BASE]] : i64 to !llvm.ptr<1>
+  // CHECK: %[[NEG_X:.*]] = llvm.sub {{.*}}, {{.*}} : i32
+  // CHECK: %[[ADJ_BASE:.*]] = llvm.getelementptr %[[BASE_PTR]]{{\[}}%[[NEG_X]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>
+  // CHECK: %[[X_PACKED:.*]] = llvm.udiv {{.*}}, {{.*}} : i32
+  // CHECK: triton_gen.2Dblockprefetch %[[ADJ_BASE]], {{.*}}, {{.*}}, {{.*}}, %[[X_PACKED]], {{.*}} {elem_size_in_bits = 32, tile_width = 16, tile_height = 32, v_blocks = 1, cache_control = L1C_L3C}
+  // CHECK: %[[BASE_I64:.*]] = llvm.ptrtoint %[[ADDR_256]] : !llvm.ptr<1> to i64
+  // CHECK: %[[SHUF_BASE:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[BASE_I64]], {{.*}})
+  // CHECK: %[[BASE_PTR:.*]] = llvm.inttoptr %[[SHUF_BASE]] : i64 to !llvm.ptr<1>
+  // CHECK: %[[NEG_X:.*]] = llvm.sub {{.*}}, {{.*}} : i32
+  // CHECK: %[[ADJ_BASE:.*]] = llvm.getelementptr %[[BASE_PTR]]{{\[}}%[[NEG_X]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>
+  // CHECK: %[[X_PACKED:.*]] = llvm.udiv {{.*}}, {{.*}} : i32
+  // CHECK: triton_gen.2Dblockprefetch %[[ADJ_BASE]], {{.*}}, {{.*}}, {{.*}}, %[[X_PACKED]], {{.*}} {elem_size_in_bits = 32, tile_width = 16, tile_height = 32, v_blocks = 1, cache_control = L1C_L3C}
+  // CHECK: %[[BASE_I64:.*]] = llvm.ptrtoint %[[ADDR_384]] : !llvm.ptr<1> to i64
+  // CHECK: %[[SHUF_BASE:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[BASE_I64]], {{.*}})
+  // CHECK: %[[BASE_PTR:.*]] = llvm.inttoptr %[[SHUF_BASE]] : i64 to !llvm.ptr<1>
+  // CHECK: %[[NEG_X:.*]] = llvm.sub {{.*}}, {{.*}} : i32
+  // CHECK: %[[ADJ_BASE:.*]] = llvm.getelementptr %[[BASE_PTR]]{{\[}}%[[NEG_X]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>
+  // CHECK: %[[X_PACKED:.*]] = llvm.udiv {{.*}}, {{.*}} : i32
+  // CHECK: triton_gen.2Dblockprefetch %[[ADJ_BASE]], {{.*}}, {{.*}}, {{.*}}, %[[X_PACKED]], {{.*}} {elem_size_in_bits = 32, tile_width = 16, tile_height = 32, v_blocks = 1, cache_control = L1C_L3C}
+  tt.func public @prefetch_column_major_fp8(%arg0: !tt.ptr<f8E4M3FN>, %arg1: !tt.ptr<f8E4M3FN>, %pred: i1) {
+    %cst = arith.constant dense<256> : tensor<1x128xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %k = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>>
+    %k2d = tt.expand_dims %k {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>> -> tensor<128x1xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %kBc = tt.broadcast %k2d : tensor<128x1xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x128xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %n = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>>
+    %n2d = tt.expand_dims %n {axis = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>> -> tensor<1x128xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %nScaled = arith.muli %n2d, %cst : tensor<1x128xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %nScaledBc = tt.broadcast %nScaled : tensor<1x128xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x128xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %offsets = arith.addi %kBc, %nScaledBc : tensor<128x128xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %base = tt.splat %arg0 : !tt.ptr<f8E4M3FN> -> tensor<128x128x!tt.ptr<f8E4M3FN>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %ptrs = tt.addptr %base, %offsets : tensor<128x128x!tt.ptr<f8E4M3FN>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>, tensor<128x128xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+
+    ttig.prefetch %ptrs {cache = 1 : i32, evict = 1 : i32, isVolatile = false, ttig.block_io = "column_major"} : tensor<128x128x!tt.ptr<f8E4M3FN>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+
+    tt.return
+  }
+}
+
+
+// -----
+
+// COM: Column-major fp8 tensor-of-pointers prefetch.
+#mma = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_prefetch_256b"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @prefetch_column_major_fp8
+  // COM: The prefetch only supports <= 64 bytes or 256 bytes. 128 bytes per row are split into two 64 bytes prefetches.
+  // COM: The redundant prefetches are dummy prefetches as hit on miss.
+  // COM: Check the prefetch tile of
+  // COM:                      even Warp            odd Warp         even Warp             odd Warp
+  // COM:
+  // COM:                 addr0──────────────┬──────────────────addr512────────────┬──────────────────┐
+  // COM:                 │                  │                  │                  │                  │
+  // COM:                 │                  │                  │                  │                  │
+  // COM:                 │                  │                  │                  │                  │
+  // COM:      256 bytes  │                  │                  │                  │                  │
+  // COM:                 │                  │                  │                  │                  │
+  // COM:                 │                  │                  │                  │                  │
+  // COM:                 │                  │                  │                  │                  │
+  // COM:                 └──────────────────┴──────────────────┴──────────────────┴──────────────────┘
+  // COM:                        32 row             32 row             32 row              32 row
+  // CHECK: llvm.extractvalue {{.*}}[0] : !llvm.struct<(ptr<1>
+  // CHECK: %[[ADDR_0:.*]] = llvm.extractvalue {{.*}}[0] : !llvm.struct<(ptr<1>,
+  // CHECK: %[[ADDR_512:.*]] = llvm.extractvalue {{.*}}[512] : !llvm.struct<(ptr<1>,
+  // CHECK: %[[BASE_I64:.*]] = llvm.ptrtoint %[[ADDR_0]] : !llvm.ptr<1> to i64
+  // CHECK: %[[SHUF_BASE:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[BASE_I64]], {{.*}})
+  // CHECK: %[[BASE_PTR:.*]] = llvm.inttoptr %[[SHUF_BASE]] : i64 to !llvm.ptr<1>
+  // CHECK: %[[NEG_X:.*]] = llvm.sub {{.*}}, {{.*}} : i32
+  // CHECK: %[[ADJ_BASE:.*]] = llvm.getelementptr %[[BASE_PTR]]{{\[}}%[[NEG_X]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>
+  // CHECK: %[[X_PACKED:.*]] = llvm.udiv {{.*}}, {{.*}} : i32
+  // CHECK: triton_gen.2Dblockprefetch %[[ADJ_BASE]], {{.*}}, {{.*}}, {{.*}}, %[[X_PACKED]], {{.*}} {elem_size_in_bits = 32, tile_width = 64, tile_height = 32, v_blocks = 1, cache_control = L1C_L3C}
+  // CHECK: %[[BASE_I64:.*]] = llvm.ptrtoint %[[ADDR_512]] : !llvm.ptr<1> to i64
+  // CHECK: %[[SHUF_BASE:.*]] = llvm.call spir_funccc @_Z17sub_group_shufflelj(%[[BASE_I64]], {{.*}})
+  // CHECK: %[[BASE_PTR:.*]] = llvm.inttoptr %[[SHUF_BASE]] : i64 to !llvm.ptr<1>
+  // CHECK: %[[NEG_X:.*]] = llvm.sub {{.*}}, {{.*}} : i32
+  // CHECK: %[[ADJ_BASE:.*]] = llvm.getelementptr %[[BASE_PTR]]{{\[}}%[[NEG_X]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>
+  // CHECK: %[[X_PACKED:.*]] = llvm.udiv {{.*}}, {{.*}} : i32
+  // CHECK: triton_gen.2Dblockprefetch %[[ADJ_BASE]], {{.*}}, {{.*}}, {{.*}}, %[[X_PACKED]], {{.*}} {elem_size_in_bits = 32, tile_width = 64, tile_height = 32, v_blocks = 1, cache_control = L1C_L3C}
+  tt.func public @prefetch_column_major_fp8(%arg0: !tt.ptr<f8E4M3FN>, %arg1: !tt.ptr<f8E4M3FN>, %pred: i1) {
+    %cst = arith.constant dense<256> : tensor<1x128xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %k = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>>
+    %k2d = tt.expand_dims %k {axis = 1 : i32} : tensor<256xi32, #ttg.slice<{dim = 1, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>> -> tensor<256x1xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %kBc = tt.broadcast %k2d : tensor<256x1xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<256x128xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %n = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>>
+    %n2d = tt.expand_dims %n {axis = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>}>> -> tensor<1x128xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %nScaled = arith.muli %n2d, %cst : tensor<1x128xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %nScaledBc = tt.broadcast %nScaled : tensor<1x128xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<256x128xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %offsets = arith.addi %kBc, %nScaledBc : tensor<256x128xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %base = tt.splat %arg0 : !tt.ptr<f8E4M3FN> -> tensor<256x128x!tt.ptr<f8E4M3FN>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %ptrs = tt.addptr %base, %offsets : tensor<256x128x!tt.ptr<f8E4M3FN>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>, tensor<256x128xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+
+    ttig.prefetch %ptrs {cache = 1 : i32, evict = 1 : i32, isVolatile = false, ttig.block_io = "column_major"} : tensor<256x128x!tt.ptr<f8E4M3FN>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+
     tt.return
   }
 }

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
@@ -52,20 +52,27 @@ struct BlockIOTileSizeInfo {
 /// Compute the 2D block I/O tile shape from a LinearLayout.
 /// Returns BlockIOTileSizeInfo::unknown() if the layout does not support
 /// 2D block I/O.
-template <bool isLoad>
-BlockIOTileSizeInfo
-getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
-                   unsigned elemSizeInBits, AxisInfo *maskAxisInfo,
-                   bool oneMatrixPerLoadForBT);
+// template <bool isLoad>
+// BlockIOTileSizeInfo
+// getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
+//                    unsigned elemSizeInBits, AxisInfo *maskAxisInfo,
+//                    bool oneMatrixPerLoadForBT);
+//
+// // Explicit instantiation declarations.
+// extern template BlockIOTileSizeInfo
+// getBlockIOTileSize<true>(const LinearLayout &, unsigned, unsigned, AxisInfo
+// *,
+//                          bool);
+// extern template BlockIOTileSizeInfo
+// getBlockIOTileSize<false>(const LinearLayout &, unsigned, unsigned, AxisInfo
+// *,
+//                           bool);
 
-// Explicit instantiation declarations.
-extern template BlockIOTileSizeInfo
-getBlockIOTileSize<true>(const LinearLayout &, unsigned, unsigned, AxisInfo *,
-                         bool);
-extern template BlockIOTileSizeInfo
-getBlockIOTileSize<false>(const LinearLayout &, unsigned, unsigned, AxisInfo *,
-                          bool);
-
+BlockIOTileSizeInfo getBlockIOLoadTileSize(const LinearLayout &, unsigned,
+                                           unsigned, AxisInfo *, bool);
+BlockIOTileSizeInfo getBlockIOPrefetchTileSize(const LinearLayout &, unsigned,
+                                               unsigned, AxisInfo *,
+                                               bool allow256Bytes);
 /// Return the tensor dimension along which consecutive lanes (the fastest-
 /// varying lane bit) advance in `ll` -- the dimension the hardware vectorizes
 /// for 2D block I/O. This is the dimension getBlockIOTileSize uses to decide

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/BlockIOUtils.h
@@ -49,25 +49,6 @@ struct BlockIOTileSizeInfo {
   }
 };
 
-/// Compute the 2D block I/O tile shape from a LinearLayout.
-/// Returns BlockIOTileSizeInfo::unknown() if the layout does not support
-/// 2D block I/O.
-// template <bool isLoad>
-// BlockIOTileSizeInfo
-// getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
-//                    unsigned elemSizeInBits, AxisInfo *maskAxisInfo,
-//                    bool oneMatrixPerLoadForBT);
-//
-// // Explicit instantiation declarations.
-// extern template BlockIOTileSizeInfo
-// getBlockIOTileSize<true>(const LinearLayout &, unsigned, unsigned, AxisInfo
-// *,
-//                          bool);
-// extern template BlockIOTileSizeInfo
-// getBlockIOTileSize<false>(const LinearLayout &, unsigned, unsigned, AxisInfo
-// *,
-//                           bool);
-
 BlockIOTileSizeInfo getBlockIOLoadTileSize(const LinearLayout &, unsigned,
                                            unsigned, AxisInfo *, bool);
 BlockIOTileSizeInfo getBlockIOPrefetchTileSize(const LinearLayout &, unsigned,

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -206,6 +206,11 @@ static bool isSPVBuiltinAvailableImpl(TritonGEN::Matrix2DBlockPrefetchOp op) {
       op.getVBlocks() == 1)
     return false;
 
+  // intel_sub_group_2d_block_prefetch_8b_?r16x1c
+  if (op.getElemSizeInBits() == 8 && op.getTileWidth() == 16 &&
+      op.getVBlocks() == 1)
+    return false;
+
   return true;
 }
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1607,7 +1607,7 @@ struct PrefetchOpConversion
           /*tile_width*/ tileWidth,
           /*tile_height*/ tileHeight,
           /*v_blocks*/ vBlocks,
-          /*cache_opt*/ TritonGEN::LoadCacheControl::L1C_L3C);
+          /*cache_opt*/ prefetchCacheControl(op.getCache()));
       if (failed(newOp.verify())) {
         // delete the op so that the verifier will not abort the pass
         // pipeline later, as we can fail this path and try a different

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1437,108 +1437,56 @@ struct PrefetchOpConversion
     if (!blockIOAttr)
       return failure();
 
-    const bool memoryRowMajor = isMemoryRowMajor(op);
-    // TODO: To support more layouts on memory.
-    if (!memoryRowMajor)
-      return failure();
-
     auto tensorOfPointers = cast<RankedTensorType>(op.getPtr().getType());
-    std::optional<DotOperandEncodingAttr> encoding =
-        getDotEncoding(tensorOfPointers);
-    if (!encoding)
-      return failure();
-
-    auto dpasLayout = cast<DpasEncodingAttr>(encoding->getParent());
-    SmallVector<unsigned> warpsPerCTA(dpasLayout.getWarpsPerCTA());
-    ArrayRef<unsigned> cluster = dpasLayout.getRepCluster();
-    SmallVector<unsigned> repCluster{cluster.begin(), cluster.end()};
     ArrayRef<int64_t> tensorShape = tensorOfPointers.getShape();
     unsigned rank = tensorShape.size();
-    DpasEncodingAttr::OpIdx opIdx = getOpIdx(tensorOfPointers);
-    SmallVector<int64_t> repetitions =
-        dpasLayout.getDPASRepetitions(tensorShape, opIdx);
-    // getDPASRepetitions prepends a batch dimension; strip it.
-    SmallVector<unsigned> numReps;
-    for (size_t i = 1; i < repetitions.size(); ++i)
-      numReps.push_back(repetitions[i]);
 
-    SmallVector<int64_t> shardTensorShape(tensorShape.begin(),
-                                          tensorShape.end());
-    switch (opIdx) {
-    case DpasEncodingAttr::OpIdx::OperandA: {
-      shardTensorShape[rank - 2] =
-          std::min<int64_t>(tensorShape[rank - 2], dpasLayout.getShapeA()[0]);
-      // K dim (last) not distributed across warps.
-      warpsPerCTA[rank - 1] = 1;
-      repCluster[rank - 1] = 1;
-      numReps[rank - 1] = 1;
-    } break;
-    case DpasEncodingAttr::OpIdx::OperandB: {
-      shardTensorShape[rank - 1] =
-          std::min<int64_t>(tensorShape[rank - 1], dpasLayout.getShapeB()[1]);
-      // K dim (second-to-last) not distributed across warps.
-      warpsPerCTA[rank - 2] = 1;
-      repCluster[rank - 2] = 1;
-      numReps[rank - 2] = 1;
-    } break;
-    case DpasEncodingAttr::OpIdx::OperandC: {
-      llvm_unreachable("unexpected OpIdx::OperandC");
-    } break;
-    }
+    unsigned contiguousDim;
+    const bool memoryRowMajor = isMemoryRowMajor(op);
+    contiguousDim = memoryRowMajor ? rank - 1 : rank - 2;
+
+    std::optional<LinearLayout> llEncoding =
+        cast<DistributedEncodingTrait>(tensorOfPointers.getEncoding())
+            .toLinearLayout(tensorShape);
+    assert(llEncoding.has_value() &&
+           "unexpected failure when getting linear layout");
 
     auto ptrType = cast<PointerType>(tensorOfPointers.getElementType());
-    Type elementType = ptrType.getPointeeType();
-    auto tensorType = RankedTensorType::get(shardTensorShape, elementType,
-                                            tensorOfPointers.getEncoding());
-
-    Value mask = op.getMask();
-    unsigned maskConstancyHor = std::numeric_limits<unsigned>::max(),
-             maskConstancyVer = std::numeric_limits<unsigned>::max();
-    if (mask) {
-      // No need to check the constancy of scalar mask.
-      if (auto maskTy = dyn_cast_or_null<RankedTensorType>(mask.getType())) {
-        maskConstancyHor = maskConstancyVer = 1;
-        AxisInfo *axisInfo =
-            const_cast<triton::intel::ModuleAxisInfoAnalysis &>(
-                axisAnalysisPass)
-                .getAxisInfo(mask);
-        if (axisInfo) {
-          maskConstancyHor = axisInfo->getConstancy(rank - 1);
-          maskConstancyVer = axisInfo->getConstancy(rank - 2);
-        }
-      }
-    }
-
-    SmallVector<unsigned, 2> prefetchShape =
-        get2DPrefetchShapePerWarp(tensorType);
-    prefetchShape = {std::min<unsigned>(prefetchShape[0], maskConstancyVer),
-                     std::min<unsigned>(prefetchShape[1], maskConstancyHor)};
-
-    SmallVector<int64_t> numPrefetchsPerRep = {
-        mlir::ceil<int64_t>(shardTensorShape[rank - 2], prefetchShape[0]),
-        mlir::ceil<int64_t>(shardTensorShape[rank - 1], prefetchShape[1])};
-
-    Type eltTy = getTypeConverter()->convertType(tensorType.getElementType());
+    Type eltTy = getTypeConverter()->convertType(ptrType.getPointeeType());
     unsigned elemSizeInBits = eltTy.getIntOrFloatBitWidth();
-    unsigned tileWidthInElem = prefetchShape[1];
-    unsigned tileHeightInElem = prefetchShape[0];
-    unsigned vBlocks = 1;
-    switch (elemSizeInBits) {
-    case 8:
-      if (tileWidthInElem == 64) {
-        // OCL interface supports 8b_?r32x2c for 64 bytes per row of 8 bits
-        // element.
-        vBlocks = 2;
-        tileWidthInElem = 32;
-      }
-      break;
+
+    // Get the maximum tile shapes for the given mask constancy.
+    AxisInfo *maskAxisInfo = nullptr;
+    if (op.getMask()) {
+      maskAxisInfo =
+          const_cast<triton::intel::ModuleAxisInfoAnalysis &>(axisAnalysisPass)
+              .getAxisInfo(op.getMask());
     }
 
-    auto mod = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
+    auto m = op->template getParentOfType<mlir::ModuleOp>();
+    bool isPrefetch256BSupported =
+        m->hasAttr(TritonIntelGPUDialect::getSupportPrefetch256BAttrName());
+    BlockIOTileSizeInfo sizeInfo = getBlockIOPrefetchTileSize(
+        llEncoding.value(), contiguousDim, elemSizeInBits, maskAxisInfo,
+        isPrefetch256BSupported);
+    if (!sizeInfo.isValid())
+      return failure();
+    // Extract members to regular variables for C++17 compatibility
+    // (capturing structured bindings in lambdas requires C++20)
+    int tileHeight = sizeInfo.tileHeight;
+    int tileWidth = sizeInfo.tileWidth;
+    int numPackedVals = sizeInfo.numElemPerPackedVal;
+    int vBlocks = sizeInfo.vBlocks;
+    int rowDim = sizeInfo.rowDim;
+    int colDim = sizeInfo.colDim;
+    bool isTransposeRequired = sizeInfo.transpose;
+    std::optional<SetVector<unsigned>> regPackedBases =
+        std::move(sizeInfo.regPackedBases);
+    unsigned packedElemSizeInBits = elemSizeInBits * numPackedVals;
+
     Location loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-    std::map<SmallVector<unsigned>, Value> baseAddrs, masks;
     Value llPtr = adaptor.getPtr();
     Value llMask = adaptor.getMask();
 
@@ -1548,24 +1496,13 @@ struct PrefetchOpConversion
     if (llMask)
       maskElems = unpackLLElements(loc, llMask, rewriter);
 
-    // re-arrange the baseAddrs and masks to for large 2D block IO.
-    // Layout is unrelated to the scalar type.
-    SmallVector<SmallVector<unsigned>> offsets =
-        emitOffsetForLayout(*encoding, tensorOfPointers);
-    for (size_t i = 0; i < ptrElems.size(); ++i) {
-      SmallVector<unsigned> offset = offsets[i];
-      baseAddrs[offset] = ptrElems[i];
-      if (llMask && maskElems.size() > 1)
-        masks[offset] = maskElems[i];
-    }
-
-    unsigned pitchDim = memoryRowMajor ? 0 : 1;
+    unsigned pitchDim = isTransposeRequired ? colDim : rowDim;
     Value rowStrideInBytes =
         getPitch(rewriter, op.getPtr(), elemSizeInBits, pitchDim);
     if (!rowStrideInBytes) {
       // No constant pitch: a prefetch may use a runtime stride. The full row
       // width is the contiguous tensor dimension.
-      int64_t fullRowElems = tensorShape[memoryRowMajor ? rank - 1 : rank - 2];
+      int64_t fullRowElems = tensorShape[rowDim];
       rowStrideInBytes = getRuntimePitch(rewriter, op.getPtr(), elemSizeInBits,
                                          pitchDim, fullRowElems);
     }
@@ -1573,87 +1510,110 @@ struct PrefetchOpConversion
       return failure();
 
     // If the stride is 0, we want to load only the first row.
-    int64_t stride = getStride(op.getPtr(), rank - 2);
-    Value baseHeight = b.i32_val(stride == 0 ? 1 : tileHeightInElem);
-    Value baseWidth = b.i32_val(
-        std::max(64u, vBlocks * tileWidthInElem * (elemSizeInBits / 8)));
-    Value offsetBaseX = b.i32_val(0);
-    Value offsetBaseY = b.i32_val(0);
+    int64_t stride = getStride(op.getPtr(), pitchDim);
+    Value baseHeight = b.i32_val(stride == 0 ? 1 : tileHeight);
+    Value baseWidth =
+        b.i32_val(vBlocks * tileWidth * (packedElemSizeInBits / 8));
 
-    // Compute total batch repetitions for dims beyond the inner 2.
-    int64_t totalBatchReps = 1;
-    for (unsigned d = 0; d < rank - 2; ++d)
-      totalBatchReps *= numReps[d];
+    unsigned threadsPerWarp =
+        TritonGPUDialect::getThreadsPerWarp(op->getParentOfType<ModuleOp>());
+    unsigned numElemsPerPrefetch =
+        mlir::ceil((unsigned)tileWidth * tileHeight * numPackedVals * vBlocks,
+                   threadsPerWarp);
+    int64_t numElems = getTotalElemsPerThread(tensorOfPointers);
 
-    for (int64_t batchIdx = 0; batchIdx < totalBatchReps; ++batchIdx) {
-      // Decompose batchIdx into per-dim batch indices.
-      SmallVector<unsigned> batchOffsets(rank - 2);
-      int64_t remaining = batchIdx;
-      for (int d = static_cast<int>(rank) - 3; d >= 0; --d) {
-        batchOffsets[d] = remaining % numReps[d];
-        remaining /= numReps[d];
+    MLIRContext *ctx = op->getContext();
+    StringAttr kRegister = S("register");
+    StringAttr kLane = S("lane");
+    StringAttr kWarp = S("warp");
+    StringAttr kBlock = S("block");
+    assert(regPackedBases.has_value() &&
+           "invalid register bases for packing elems.");
+    std::vector<std::vector<int>> bases(regPackedBases->size());
+    llvm::transform(*regPackedBases, bases.begin(),
+                    [&](int base) { return std::vector<int>{base}; });
+    LinearLayout regMapping({{kRegister, bases}},
+                            {{kRegister, llEncoding->getInDimSize(kRegister)}},
+                            /*requireSurjective=*/true);
+
+    Value warpId = arith::IndexCastOp::create(
+        rewriter, loc, i32_ty,
+        mlir::gpu::SubgroupIdOp::create(rewriter, loc,
+                                        /*upperBound=*/nullptr));
+
+    static constexpr unsigned MIN_BASE_WIDTH_BYTES = 64;
+    for (size_t elemIdx = 0; elemIdx < numElems;
+         elemIdx += numElemsPerPrefetch) {
+      unsigned registerIdx = regMapping.apply({{kRegister, elemIdx}})[0].second;
+
+      // Need to apply the linear layout to get the offsets to the base of the
+      // block pointer.
+      // TODO: add annotation uniform to the offsets. Make sure the IGC detect
+      // the offsets as uniform.
+      auto offsets = applyLinearLayout(loc, rewriter, *llEncoding,
+                                       {{kRegister, b.i32_val(registerIdx)},
+                                        {kLane, b.i32_val(0)},
+                                        {kWarp, warpId},
+                                        {kBlock, b.i32_val(0)}});
+
+      // Use the top-left address of the block to load the data.
+      Value addrElem = ptrElems[registerIdx];
+      Value offsetX, offsetY;
+      Value adjustedBaseWidth = baseWidth;
+      Value pred;
+
+      addrElem = targetInfo.shuffleIdx(rewriter, loc, addrElem, 0);
+
+      // Adjust the baseWidth, offsetX and base address use the original base
+      // of the BLOCK.
+      offsetX = offsets[isTransposeRequired ? rowDim : colDim].second;
+      offsetY = b.i32_val(0);
+      Value negativeOffsetX = b.sub(b.i32_val(0), offsetX);
+      addrElem = b.gep(ptr_ty(ctx, 1), eltTy, addrElem, negativeOffsetX);
+      // The offset is in number of original elements. So we need to scale it
+      // by element bytes size.
+      adjustedBaseWidth =
+          b.add(baseWidth, b.mul(offsetX, b.i32_val(elemSizeInBits / 8)));
+      adjustedBaseWidth =
+          b.umax(adjustedBaseWidth, b.i32_val(MIN_BASE_WIDTH_BYTES));
+      // Use the top-left address and mask of the block to load the data.
+      // (The first value referred to by the registerIdx.)
+      if (maskElems.size()) {
+        pred = targetInfo.shuffleIdx(rewriter, loc, maskElems[registerIdx], 0);
       }
-      assert(remaining == 0 &&
-             "batchIdx decomposition inconsistent with totalBatchReps");
 
-      for (unsigned row = 0; row < numReps[rank - 2]; ++row) {
-        for (unsigned col = 0; col < numReps[rank - 1]; ++col) {
-          // Prefetch the data for each repetition.
-          for (int64_t i = 0; i < numPrefetchsPerRep[0]; ++i)
-            for (int64_t j = 0; j < numPrefetchsPerRep[1]; ++j) {
-              unsigned offsetN =
-                  col * warpsPerCTA[rank - 1] * shardTensorShape[rank - 1] +
-                  j * prefetchShape[1];
-              unsigned offsetM =
-                  row * warpsPerCTA[rank - 2] * shardTensorShape[rank - 2] +
-                  i * prefetchShape[0];
+      if (pred) {
+        // We leverage the GPU block I/O hardware out-of-bound protection
+        // feature by setting the offset to an invalid value when 'pred'
+        // is false (the HW will not read out-of-bounds values). Later on,
+        // after issuing the 2d block read operation, we will select the
+        // result of the load only if the mask evaluate to true, otherwise
+        // we will use 'other'.
+        offsetY = b.select(pred, offsetY, baseHeight);
+      }
 
-              // Build the full offset key for the baseAddrs/masks map.
-              SmallVector<unsigned> key;
-              for (unsigned d = 0; d < rank - 2; ++d)
-                key.push_back(batchOffsets[d] * warpsPerCTA[d] *
-                              shardTensorShape[d]);
-              key.push_back(offsetM);
-              key.push_back(offsetN);
-
-              Value pred;
-              if (llMask)
-                pred = (maskElems.size() > 1)
-                           ? targetInfo.shuffleIdx(rewriter, loc, masks[key], 0)
-                           : maskElems[0];
-              else
-                pred = b.int_val(1, 1);
-
-              // If the mask exists and evaluates to false, we set offsetY to be
-              // equal to baseHeight, which causes the HW to ignore the
-              // generated prefetch operation (given that the block to be
-              // prefetched would be outside the baseWidth X baseHeight shape).
-              Value offsetY = b.select(pred, b.i32_val(0), baseHeight);
-              Value addr =
-                  targetInfo.shuffleIdx(rewriter, loc, baseAddrs[key], 0);
-
-              auto newOp = TritonGEN::Matrix2DBlockPrefetchOp::create(
-                  rewriter, loc,
-                  /*ptr*/ addr,
-                  /*base_width*/ baseWidth,
-                  /*base_height*/ baseHeight,
-                  /*base_pitch*/ rowStrideInBytes,
-                  /*x*/ offsetBaseX,
-                  /*y*/ offsetY,
-                  /*elem_size_in_bits*/ elemSizeInBits,
-                  /*tile_width*/ tileWidthInElem,
-                  /*tile_height*/ tileHeightInElem,
-                  /*v_blocks*/ vBlocks,
-                  /*cache_opt*/ prefetchCacheControl(op.getCache()));
-              if (failed(newOp.verify())) {
-                // delete the op so that the verifier will not abort the pass
-                // pipeline later, as we can fail this path and try a different
-                // approach.
-                rewriter.eraseOp(newOp);
-                return failure();
-              }
-            }
-        }
+      assert(numPackedVals > 0 && "numPackedVals should be greater than zero.");
+      auto newOp = TritonGEN::Matrix2DBlockPrefetchOp::create(
+          rewriter, loc,
+          /*ptr*/ addrElem,
+          /*base_width*/ adjustedBaseWidth,
+          /*base_height*/ baseHeight,
+          /*base_pitch*/ rowStrideInBytes,
+          // offsetX was in terms of original elements. The 2d block io
+          // requires offsetX to be in terms of packed elements.
+          /*x*/ b.udiv(offsetX, b.i32_val(numPackedVals)),
+          /*y*/ offsetY,
+          /*elem_size_in_bits*/ packedElemSizeInBits,
+          /*tile_width*/ tileWidth,
+          /*tile_height*/ tileHeight,
+          /*v_blocks*/ vBlocks,
+          /*cache_opt*/ TritonGEN::LoadCacheControl::L1C_L3C);
+      if (failed(newOp.verify())) {
+        // delete the op so that the verifier will not abort the pass
+        // pipeline later, as we can fail this path and try a different
+        // approach.
+        rewriter.eraseOp(newOp);
+        return failure();
       }
     }
 
@@ -4072,7 +4032,7 @@ struct Subgroup2DBlockLoadOpConversion
     // FIXME: Remove once IGC can split large 2D block loads.
     bool oneMatrixPerLoadForBT =
         op->hasAttr(TritonIntelGPUDialect::getOneMatrixPerLoadAttrName());
-    BlockIOTileSizeInfo sizeInfo = getBlockIOTileSize<true /*load*/>(
+    BlockIOTileSizeInfo sizeInfo = getBlockIOLoadTileSize(
         llEncoding.value(), contiguousDim, elemSizeInBits,
         /*maskAxisInfo=*/nullptr, oneMatrixPerLoadForBT);
     assert(sizeInfo.isValid() && "expected valid tile size");
@@ -4258,8 +4218,8 @@ struct Subgroup2DBlockLoadFromPtrOpConversion
                                      /*vnni=*/false, std::move(regPackBases));
     } else {
       sizeInfo =
-          getBlockIOTileSize<true>(*llEncoding, contiguousDim, elemSizeInBits,
-                                   maskAxisInfo, oneMatrixPerLoadForBT);
+          getBlockIOLoadTileSize(*llEncoding, contiguousDim, elemSizeInBits,
+                                 maskAxisInfo, oneMatrixPerLoadForBT);
     }
     if (!sizeInfo.isValid())
       return failure();

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -50,7 +50,7 @@ std::optional<unsigned> getLaneFastChangeDim(const LinearLayout &ll,
   if (!ll.hasInDim(kLane))
     return std::nullopt;
   // First lane basis vector (fastest-varying lane bit). Mirrors the gate in
-  // getBlockIOTileSize<false>: the lane base must move along exactly one tensor
+  // getBlockIOTileSize: the lane base must move along exactly one tensor
   // dimension, else the layout is not a clean 2D block-I/O tile.
   ArrayRef<int32_t> laneBase0 = ll.getBasis(kLane, /*pos=*/0);
   if (llvm::count_if(laneBase0, [](int32_t x) { return x > 0; }) != 1)
@@ -122,9 +122,9 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
   const BaseType &basesOfRegister = getBase("register");
   int numElemPerPackedVal = 1;
   constexpr unsigned MAX_BITS_NORMAL = 64;
-  // // Hardware supports the d64 for transposing. But for packing
-  // // transpose, we'd prefer smaller d32 type cause hardware could
-  // // transpose more to reduce the number of mov operation in register.
+  // Hardware supports the d64 for transposing. But for packing
+  // transpose, we'd prefer smaller d32 type cause hardware could
+  // transpose more to reduce the number of mov operation in register.
   constexpr unsigned MAX_BITS_TRANSPOSE = 32;
   constexpr unsigned MAX_BITS_VNNI = 32;
   constexpr unsigned MAX_BITS_WIDTH_NORMAL = 64 * 8; // 64 bytes.
@@ -496,7 +496,7 @@ BlockIOTileSizeInfo getBlockIOPrefetchTileSize(const LinearLayout &ll,
   sizeInfo.tileWidth *= vBlocks;
   sizeInfo.vBlocks = 1;
 
-  // Workaround fo OCL interface supports 8b_?r32x2c for 64 bytes per row of 8
+  // Workaround for OCL interface supports 8b_?r32x2c for 64 bytes per row of 8
   // bits element.
   switch (packedElemSizeInBits) {
   case 8:
@@ -744,7 +744,7 @@ bool validate2DBlockLoadTile(const LinearLayout &ll, unsigned memContiguousDim,
     return false;
 
   // For transposed loads, verify computeTransposeShuffleMapping will succeed.
-  // sizeInfo.vBlocks is already capped by getBlockIOTileSize<true>.
+  // sizeInfo.vBlocks is already capped by getBlockIOTileSize.
   if (sizeInfo.transpose && sizeInfo.regPackedBases.has_value()) {
     MLIRContext *ctx = ll.getBases().begin()->first.getContext();
     StringAttr kRegister = StringAttr::get(ctx, "register");

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -61,14 +61,11 @@ std::optional<unsigned> getLaneFastChangeDim(const LinearLayout &ll,
 
 // Return the tileHeight, tileWidth, numElemPerPackedVal, vBlocks, row Dim and
 // column Dim.
-template <bool isLoad>
+template <unsigned MAX_TILE_HEIGHT, unsigned MAX_BITS_WIDTH_TRANSPOSE>
 BlockIOTileSizeInfo
 getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
                    unsigned elemSizeInBits, AxisInfo *maskAxisInfo,
                    bool oneMatrixPerLoadForBT) {
-  assert((isLoad || !oneMatrixPerLoadForBT) &&
-         "oneMatrixPerLoadForBT must be false for stores");
-
   if (elemSizeInBits > 64)
     return BlockIOTileSizeInfo::unknown();
 
@@ -125,24 +122,17 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
   const BaseType &basesOfRegister = getBase("register");
   int numElemPerPackedVal = 1;
   constexpr unsigned MAX_BITS_NORMAL = 64;
-  // Hardware supports the d64 for transposing. But for packing
-  // transpose, we'd prefer smaller d32 type cause hardware could
-  // transpose more to reduce the number of mov operation in register.
+  // // Hardware supports the d64 for transposing. But for packing
+  // // transpose, we'd prefer smaller d32 type cause hardware could
+  // // transpose more to reduce the number of mov operation in register.
   constexpr unsigned MAX_BITS_TRANSPOSE = 32;
   constexpr unsigned MAX_BITS_VNNI = 32;
-  constexpr unsigned MAX_BITS_WIDTH_NORMAL = 64 * 8;       // 64 bytes.
-  constexpr unsigned MAX_BITS_WIDTH_TRANSPOSE = 8 * 4 * 8; // 8xd32. (and 4xd64)
+  constexpr unsigned MAX_BITS_WIDTH_NORMAL = 64 * 8; // 64 bytes.
   constexpr unsigned TRANSPOSE_LOAD_D64_HEIGHT = 8;
-  constexpr unsigned MAX_TILE_HEIGHT_STORE = 8;
-  constexpr unsigned MAX_TILE_HEIGHT_LOAD = 32;
-  unsigned MAX_TILE_HEIGHT;
-  if constexpr (isLoad) {
-    MAX_TILE_HEIGHT = (transpose && elemSizeInBits == 64)
-                          ? TRANSPOSE_LOAD_D64_HEIGHT
-                          : MAX_TILE_HEIGHT_LOAD;
-  } else {
-    MAX_TILE_HEIGHT = MAX_TILE_HEIGHT_STORE;
-  }
+  unsigned maxTileHeight = (transpose && elemSizeInBits == 64)
+                               ? TRANSPOSE_LOAD_D64_HEIGHT
+                               : MAX_TILE_HEIGHT;
+  unsigned MAX_BITS = transpose ? MAX_BITS_TRANSPOSE : MAX_BITS_NORMAL;
   unsigned MAX_BITS_WIDTH =
       transpose ? MAX_BITS_WIDTH_TRANSPOSE : MAX_BITS_WIDTH_NORMAL;
 
@@ -169,14 +159,12 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
     }
   };
 
-  packRegister(
-      memContiguousDim,
-      mlir::ceil<unsigned>(transpose ? MAX_BITS_TRANSPOSE : MAX_BITS_NORMAL,
-                           elemSizeInBits));
+  packRegister(memContiguousDim,
+               mlir::ceil<unsigned>(MAX_BITS, elemSizeInBits));
 
   // For the transpose case, elements up to d32 must be packed to d32.
-  if (transpose && elemSizeInBits <= MAX_BITS_TRANSPOSE &&
-      (numElemPerPackedVal * elemSizeInBits) != MAX_BITS_TRANSPOSE)
+  if (transpose && elemSizeInBits <= MAX_BITS &&
+      (numElemPerPackedVal * elemSizeInBits) != MAX_BITS)
     return BlockIOTileSizeInfo::unknown();
 
   // We already get the basic tile shape in packing values.
@@ -246,9 +234,9 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
 
   // The tile shape sizes should not exceed the hardware limit.
   unsigned fastChangeDimLimit =
-      !transpose ? MAX_BITS_WIDTH / elemSizeInBits : MAX_TILE_HEIGHT;
+      !transpose ? MAX_BITS_WIDTH / elemSizeInBits : maxTileHeight;
   unsigned rowDimLimit =
-      !transpose ? MAX_TILE_HEIGHT : MAX_BITS_WIDTH / elemSizeInBits;
+      !transpose ? maxTileHeight : MAX_BITS_WIDTH / elemSizeInBits;
 
   // The tile shape sizes should not exceed the mask constancy limit.
   fastChangeDimLimit =
@@ -286,7 +274,7 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
       if (dim != fastChangeDim ||
           tileShape[fastChangeDim] != base[fastChangeDim])
         continue; // Skip the register not mapped to the row dim.
-      if ((tileShape[fastChangeDim] << 1) > MAX_TILE_HEIGHT)
+      if ((tileShape[fastChangeDim] << 1) > maxTileHeight)
         break; // The col dim is the height.
       if ((tileShape[fastChangeDim] << 1) > maskConstancyFastChangeDimLimit)
         break; // Should not exceed the mask constancy limit.
@@ -351,7 +339,7 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
     if (dim != rowDim || tileShape[rowDim] != base[rowDim])
       continue; // Skip the register not mapped to the row dim.
     if (!transpose) {
-      if ((tileShape[rowDim] << 1) > MAX_TILE_HEIGHT)
+      if ((tileShape[rowDim] << 1) > maxTileHeight)
         break; // If the tile height is limited, we stop here.
     } else {
       if (((tileShape[rowDim] << 1) * elemSizeInBits) > MAX_BITS_WIDTH)
@@ -384,25 +372,26 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
   }
 
   unsigned vBlocks = 1;
-  if (!transpose) {
-    // Increase the tile shape along the column dimension. (Increase the
-    // vBlocks.)
-    for (unsigned regBaseIter = 0; regBaseIter < basesOfRegister.size();
-         ++regBaseIter) {
-      if (regPackBases.contains(1 << regBaseIter))
-        continue; // Skip the register already packed.
-      const std::vector<int> &base = basesOfRegister[regBaseIter];
-      if (!validateBase(base))
-        continue; // Skip as the bases are not trivial.
-      int dim = getFirstNonZeroDim(base);
-      if (dim != fastChangeDim || (tileShape[dim] * vBlocks) != base[dim])
-        continue;
-      if ((tileShape[fastChangeDim] * (vBlocks << 1)) >
-          maskConstancyFastChangeDimLimit)
-        break; // Should not exceed the mask constancy limit.
-      vBlocks <<= 1;
-      regPackBases.insert(1 << regBaseIter);
-    }
+  // Increase the tile shape along the tile width dimension. (Increase the
+  // vBlocks.)
+  // For the transpose case, increase the vBlocks along row dim to increase the
+  // size of the tile width for prefetch.
+  unsigned vBlocksDim = transpose ? rowDim : fastChangeDim;
+  for (unsigned regBaseIter = 0; regBaseIter < basesOfRegister.size();
+       ++regBaseIter) {
+    if (regPackBases.contains(1 << regBaseIter))
+      continue; // Skip the register already packed.
+    const std::vector<int> &base = basesOfRegister[regBaseIter];
+    if (!validateBase(base))
+      continue; // Skip as the bases are not trivial.
+    int dim = getFirstNonZeroDim(base);
+    if (dim != vBlocksDim || (tileShape[dim] * vBlocks) != base[dim])
+      continue;
+    if ((tileShape[vBlocksDim] * (vBlocks << 1)) >
+        maskConstancyFastChangeDimLimit)
+      break; // Should not exceed the mask constancy limit.
+    vBlocks <<= 1;
+    regPackBases.insert(1 << regBaseIter);
   }
   for (unsigned regBaseIter = 0; regBaseIter < basesOfRegister.size();
        ++regBaseIter) {
@@ -420,11 +409,33 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
   int tileWidth =
       tileShape[transpose ? rowDim : fastChangeDim] / packedValueNumber;
 
+  return BlockIOTileSizeInfo(tileHeight, tileWidth, packedValueNumber, vBlocks,
+                             rowDim, fastChangeDim, transpose, vnni,
+                             std::move(regPackBases));
+}
+
+BlockIOTileSizeInfo getBlockIOLoadTileSize(const LinearLayout &ll,
+                                           unsigned memContiguousDim,
+                                           unsigned elemSizeInBits,
+                                           AxisInfo *maskAxisInfo,
+                                           bool oneMatrixPerLoadForBT) {
+  constexpr unsigned MAX_TILE_HEIGHT_LOAD = 32;
+  constexpr unsigned MAX_BITS_WIDTH_TRANSPOSE = 8 * 4 * 8; // 8xd32. (and 4xd64)
+  auto sizeInfo =
+      getBlockIOTileSize<MAX_TILE_HEIGHT_LOAD, MAX_BITS_WIDTH_TRANSPOSE>(
+          ll, memContiguousDim, elemSizeInBits, maskAxisInfo,
+          oneMatrixPerLoadForBT);
+
   // Cap vBlocks for loads based on HW constraints.
-  if constexpr (isLoad) {
+  unsigned vBlocks = sizeInfo.vBlocks;
+  if (sizeInfo.transpose) {
+    vBlocks = 1;
+  } else {
     constexpr int MAX_WIDTH_BYTES = 64;
-    unsigned packedElemSizeInBits = elemSizeInBits * numElemPerPackedVal;
-    unsigned totalBytesPerRowPerMatrix = tileWidth * packedElemSizeInBits / 8;
+    unsigned packedElemSizeInBits =
+        elemSizeInBits * sizeInfo.numElemPerPackedVal;
+    unsigned totalBytesPerRowPerMatrix =
+        sizeInfo.tileWidth * packedElemSizeInBits / 8;
     if (totalBytesPerRowPerMatrix > 0) {
       vBlocks =
           std::min(vBlocks, static_cast<unsigned>(MAX_WIDTH_BYTES /
@@ -432,22 +443,72 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
     }
     vBlocks = std::min(vBlocks, 4u);
     constexpr unsigned GRF_SIZE = 64;
-    if (tileHeight * tileWidth * packedElemSizeInBits / 8 < GRF_SIZE)
+    if (sizeInfo.tileHeight * sizeInfo.tileWidth * packedElemSizeInBits / 8 <
+        GRF_SIZE)
       vBlocks = 1;
   }
-
-  return BlockIOTileSizeInfo(tileHeight, tileWidth, packedValueNumber, vBlocks,
-                             rowDim, fastChangeDim, transpose, vnni,
-                             std::move(regPackBases));
+  sizeInfo.vBlocks = vBlocks;
+  return sizeInfo;
 }
 
-// Explicit instantiations.
-template BlockIOTileSizeInfo getBlockIOTileSize<true>(const LinearLayout &,
-                                                      unsigned, unsigned,
-                                                      AxisInfo *, bool);
-template BlockIOTileSizeInfo getBlockIOTileSize<false>(const LinearLayout &,
-                                                       unsigned, unsigned,
-                                                       AxisInfo *, bool);
+BlockIOTileSizeInfo getBlockIOStoreTileSize(const LinearLayout &ll,
+                                            unsigned memContiguousDim,
+                                            unsigned elemSizeInBits,
+                                            AxisInfo *maskAxisInfo) {
+  constexpr unsigned MAX_TILE_HEIGHT_STORE = 8;
+  constexpr unsigned MAX_BITS_WIDTH_TRANSPOSE =
+      8 * 4 * 8; // the transpose store is not supported. This is a dummy input
+  return getBlockIOTileSize<MAX_TILE_HEIGHT_STORE, MAX_BITS_WIDTH_TRANSPOSE>(
+      ll, memContiguousDim, elemSizeInBits, maskAxisInfo, false);
+}
+
+BlockIOTileSizeInfo getBlockIOPrefetchTileSize(const LinearLayout &ll,
+                                               unsigned memContiguousDim,
+                                               unsigned elemSizeInBits,
+                                               AxisInfo *maskAxisInfo,
+                                               bool allow256Bytes) {
+  constexpr unsigned MAX_TILE_HEIGHT_LOAD = 32;
+  constexpr unsigned MAX_BITS_WIDTH_TRANSPOSE =
+      64 * 8; // for prefetching, still 64 bytes for transpose case.
+  auto sizeInfo =
+      getBlockIOTileSize<MAX_TILE_HEIGHT_LOAD, MAX_BITS_WIDTH_TRANSPOSE>(
+          ll, memContiguousDim, elemSizeInBits, maskAxisInfo, false);
+
+  // Cap vBlocks for prefetches based on HW constraints.
+  unsigned vBlocks = sizeInfo.vBlocks;
+  constexpr int MAX_WIDTH_BYTES = 64;
+  constexpr int MAX_WIDTH_256_BYTES = 256;
+  unsigned packedElemSizeInBits = elemSizeInBits * sizeInfo.numElemPerPackedVal;
+  unsigned totalBytesPerRowPerMatrix =
+      mlir::ceil<unsigned>(sizeInfo.tileWidth * packedElemSizeInBits, 8);
+  if (allow256Bytes &&
+      totalBytesPerRowPerMatrix * vBlocks >= MAX_WIDTH_256_BYTES) {
+    // Change it to 256 bytes.
+    vBlocks =
+        mlir::ceil<unsigned>(MAX_WIDTH_256_BYTES, totalBytesPerRowPerMatrix);
+  } else {
+    // Change it to <=64 bytes.
+    vBlocks =
+        std::min(vBlocks, static_cast<unsigned>(MAX_WIDTH_BYTES /
+                                                totalBytesPerRowPerMatrix));
+  }
+  // Adjust for tileHeight, tileWidth for prefetching.
+  sizeInfo.tileWidth *= vBlocks;
+  sizeInfo.vBlocks = 1;
+
+  // Workaround fo OCL interface supports 8b_?r32x2c for 64 bytes per row of 8
+  // bits element.
+  switch (packedElemSizeInBits) {
+  case 8:
+    if (sizeInfo.tileWidth == 64) {
+      sizeInfo.vBlocks = 2;
+      sizeInfo.tileWidth = 32;
+    }
+    break;
+  }
+
+  return sizeInfo;
+}
 
 bool check2DBlockAddressPayloadRestriction(unsigned packedElemSizeInBits,
                                            unsigned tileWidth) {
@@ -666,8 +727,8 @@ bool validate2DBlockLoadTile(const LinearLayout &ll, unsigned memContiguousDim,
                              RankedTensorType tensorType,
                              bool oneMatrixPerLoadForBT,
                              AxisInfo *maskAxisInfo) {
-  auto sizeInfo = getBlockIOTileSize<true>(ll, memContiguousDim, elemSizeInBits,
-                                           maskAxisInfo, oneMatrixPerLoadForBT);
+  auto sizeInfo = getBlockIOLoadTileSize(ll, memContiguousDim, elemSizeInBits,
+                                         maskAxisInfo, oneMatrixPerLoadForBT);
   if (!sizeInfo.isValid())
     return false;
 
@@ -735,9 +796,8 @@ bool validate2DBlockStoreTile(const LinearLayout &ll, unsigned memContiguousDim,
   // store cannot express. This mirrors the checks the store lowering applies;
   // keeping them here (rather than duplicated inline in each store lowering
   // pattern) makes this the single source of truth for store eligibility.
-  BlockIOTileSizeInfo sizeInfo = getBlockIOTileSize</*isLoad=*/false>(
-      ll, memContiguousDim, elemSizeInBits, maskAxisInfo,
-      /*oneMatrixPerLoadForBT=*/false);
+  BlockIOTileSizeInfo sizeInfo = getBlockIOStoreTileSize(
+      ll, memContiguousDim, elemSizeInBits, maskAxisInfo);
   if (!sizeInfo.isValid())
     return false;
 
@@ -827,8 +887,8 @@ unsigned estimateLoadHWCost(RankedTensorType type, Operation *loadOp) {
     return estimateGatherCost(type);
 
   BlockIOTileSizeInfo info =
-      getBlockIOTileSize<true>(ll, contiguousDim, elemSizeInBits,
-                               /*maskAxisInfo=*/nullptr, oneMatrixPerLoadForBT);
+      getBlockIOLoadTileSize(ll, contiguousDim, elemSizeInBits,
+                             /*maskAxisInfo=*/nullptr, oneMatrixPerLoadForBT);
   if (!info.isValid())
     return estimateGatherCost(type);
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -182,7 +182,7 @@ private:
     // For descriptor loads, the 2D block I/O tile must use only the inner 2
     // dims. Reject if rowDim or colDim falls in a batch dimension.
     if (rank > 2) {
-      auto sizeInfo = ttgi::getBlockIOTileSize<true>(
+      auto sizeInfo = ttgi::getBlockIOLoadTileSize(
           llEncoding, contiguousDim, elemSizeInBits,
           /*maskAxisInfo=*/nullptr, oneMatrixPerLoadForBT);
       int innerDimStart = static_cast<int>(rank - 2);
@@ -375,9 +375,9 @@ private:
         LDBG("Tile validation failed for load: " << *op);
         return;
       }
-      auto sizeInfo = ttgi::getBlockIOTileSize<true>(
-          llEncoding, contiguousDim, elemSizeInBits, maskAxisInfo,
-          oneMatrixPerLoadForBT);
+      auto sizeInfo = ttgi::getBlockIOLoadTileSize(llEncoding, contiguousDim,
+                                                   elemSizeInBits, maskAxisInfo,
+                                                   oneMatrixPerLoadForBT);
       rowDim = sizeInfo.rowDim;
       colDim = sizeInfo.colDim;
       tileWidth = sizeInfo.tileWidth;


### PR DESCRIPTION
This PR updates Intel XPU prefetch lowering and 2D block-I/O tile-size utilities to better support column-major (notably operand-B) prefetching by deriving tile shapes from LinearLayout and emitting triton_gen.2Dblockprefetch with appropriate packed element geometry.

Changes:

- Split/clarified Block I/O tile-size computation into load/store/prefetch-specific helpers and updated call sites accordingly.
- Reworked ttig.prefetch lowering to derive prefetch tile shapes from LinearLayout (including column-major) and to adjust base pointer/width for block prefetch emission.
- Extended/updated MLIR tests for row-major + new column-major prefetch lowering and updated GEN-to-LLVM expectations.