### PR TITLE
[Launcher] Drop the `local_accessor` shared memory argument

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -613,7 +613,8 @@ class intel_knobs(base_knobs):
     # SYCL compiler Triton needs to be compatible with when generating kernel launchers
     sycl_compiler: env_opt_str = env_opt_str("TRITON_INTEL_SYCL_COMPILER")
     # Allocate shared (work-group) memory dynamically, as an extra kernel argument bound
-    # with a `sycl::local_accessor`, instead of statically in the module. Legacy behavior.
+    # with a `sycl::local_accessor`, instead of statically in the module. Legacy behavior,
+    # kept as an escape hatch for driver issues with module scope work-group memory.
     dynamic_shared_memory: env_bool = env_bool("TRITON_INTEL_DYNAMIC_SHARED_MEMORY", False)
 
 

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -612,6 +612,9 @@ class intel_knobs(base_knobs):
     device_arch: env_opt_str = env_opt_str("TRITON_INTEL_DEVICE_ARCH")
     # SYCL compiler Triton needs to be compatible with when generating kernel launchers
     sycl_compiler: env_opt_str = env_opt_str("TRITON_INTEL_SYCL_COMPILER")
+    # Allocate shared (work-group) memory dynamically, as an extra kernel argument bound
+    # with a `sycl::local_accessor`, instead of statically in the module. Legacy behavior.
+    dynamic_shared_memory: env_bool = env_bool("TRITON_INTEL_DYNAMIC_SHARED_MEMORY", False)
 
 
 class amd_knobs(base_knobs):

--- a/test/TritonIntelGPU/atomic_cas.mlir
+++ b/test/TritonIntelGPU/atomic_cas.mlir
@@ -5,7 +5,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 
   // CHECK-DAG: llvm.func spir_funccc @_Z7barrierj(i32) attributes {convergent, no_unwind, will_return}
   // CHECK-DAG: llvm.func spir_funccc @_Z12get_local_idj(i32) -> i64 attributes {memory_effects = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none, errnoMem = none, targetMem0 = none, targetMem1 = none>, no_unwind, will_return}
-  // CHECK-DAG: llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+  // CHECK-DAG: llvm.mlir.global internal @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<4 x i8>
 
   // CHECK-LABEL: llvm.func spir_kernelcc @test_atomic_cas_i32_global
   // CHECK-SAME: (%arg0: !llvm.ptr<1> {tt.pointee_type = i32}, %arg1: i32, %arg2: i32, %arg3: !llvm.ptr<1>, %arg4: !llvm.ptr<1>) -> i32
@@ -44,7 +44,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 
   // CHECK-DAG: llvm.func spir_funccc @_Z7barrierj(i32) attributes {convergent, no_unwind, will_return}
   // CHECK-DAG: llvm.func spir_funccc @_Z12get_local_idj(i32) -> i64 attributes {memory_effects = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none, errnoMem = none, targetMem0 = none, targetMem1 = none>, no_unwind, will_return}
-  // CHECK-DAG: llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+  // CHECK-DAG: llvm.mlir.global internal @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<8 x i8>
 
   // CHECK-LABEL: llvm.func spir_kernelcc @test_atomic_cas_i64_global
   // CHECK-SAME: (%arg0: !llvm.ptr<1> {tt.pointee_type = i64}, %arg1: i64, %arg2: i64, %arg3: !llvm.ptr<1>, %arg4: !llvm.ptr<1>) -> i64
@@ -83,7 +83,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
 
   // CHECK-DAG: llvm.func spir_funccc @_Z12get_local_idj(i32) -> i64 attributes {memory_effects = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none, errnoMem = none, targetMem0 = none, targetMem1 = none>, no_unwind, will_return}
-  // CHECK-DAG: llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+  // CHECK-DAG: llvm.mlir.global internal @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
 
   // CHECK-LABEL: llvm.func spir_kernelcc @test_atomic_cas_tensor
   // CHECK-SAME: (%arg0: !llvm.struct<(ptr<1>)>, %arg1: !llvm.struct<(i32)>, %arg2: !llvm.struct<(i32)>, %arg3: !llvm.ptr<1>, %arg4: !llvm.ptr<1>) -> !llvm.struct<(i32)>
@@ -132,7 +132,7 @@ module attributes {ttig.support_16bit_atomics = true, "ttg.num-ctas" = 1 : i32, 
 
   // CHECK-DAG: llvm.func spir_funccc @_Z7barrierj(i32) attributes {convergent, no_unwind, will_return}
   // CHECK-DAG: llvm.func spir_funccc @_Z12get_local_idj(i32) -> i64 attributes {memory_effects = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none, errnoMem = none, targetMem0 = none, targetMem1 = none>, no_unwind, will_return}
-  // CHECK-DAG: llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+  // CHECK-DAG: llvm.mlir.global internal @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<2 x i8>
 
   // CHECK-LABEL: llvm.func spir_kernelcc @test_atomic_cas_i16_hw_support
   // CHECK-SAME: (%arg0: !llvm.ptr<1> {tt.pointee_type = i16}, %arg1: i16, %arg2: i16, %arg3: !llvm.ptr<1>, %arg4: !llvm.ptr<1>) -> i16
@@ -204,7 +204,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
   // CHECK-DAG: llvm.func spir_funccc @_Z7barrierj(i32) attributes {convergent, no_unwind, will_return}
   // CHECK-DAG: llvm.func spir_funccc @_Z12get_local_idj(i32) -> i64 attributes {memory_effects = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none, errnoMem = none, targetMem0 = none, targetMem1 = none>, no_unwind, will_return}
-  // CHECK-DAG: llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+  // CHECK-DAG: llvm.mlir.global internal @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<2 x i8>
 
   // CHECK-LABEL: llvm.func spir_kernelcc @test_atomic_cas_i16_emulated
   // CHECK-SAME: (%arg0: !llvm.ptr<1> {tt.pointee_type = i16}, %arg1: i16, %arg2: i16, %arg3: !llvm.ptr<1>, %arg4: !llvm.ptr<1>) -> i16
@@ -228,7 +228,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
   // CHECK-DAG: llvm.func spir_funccc @_Z7barrierj(i32) attributes {convergent, no_unwind, will_return}
   // CHECK-DAG: llvm.func spir_funccc @_Z12get_local_idj(i32) -> i64 attributes {memory_effects = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none, errnoMem = none, targetMem0 = none, targetMem1 = none>, no_unwind, will_return}
-  // CHECK-DAG: llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+  // CHECK-DAG: llvm.mlir.global internal @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<2 x i8>
 
   // CHECK-LABEL: llvm.func spir_kernelcc @test_atomic_cas_f16_emulated
   // CHECK-SAME: (%arg0: !llvm.ptr<1> {tt.pointee_type = f16}, %arg1: f16, %arg2: f16, %arg3: !llvm.ptr<1>, %arg4: !llvm.ptr<1>) -> f16
@@ -266,7 +266,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
   // CHECK-DAG: llvm.func spir_funccc @_Z7barrierj(i32) attributes {convergent, no_unwind, will_return}
   // CHECK-DAG: llvm.func spir_funccc @_Z12get_local_idj(i32) -> i64 attributes {memory_effects = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none, errnoMem = none, targetMem0 = none, targetMem1 = none>, no_unwind, will_return}
-  // CHECK-DAG: llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+  // CHECK-DAG: llvm.mlir.global internal @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<2 x i8>
 
   // CHECK-LABEL: llvm.func spir_kernelcc @test_atomic_cas_bf16_emulated
   // CHECK-SAME: (%arg0: !llvm.ptr<1> {tt.pointee_type = bf16}, %arg1: bf16, %arg2: bf16, %arg3: !llvm.ptr<1>, %arg4: !llvm.ptr<1>) -> bf16

--- a/test/TritonIntelGPU/tritonintelgpu-rewrite-stack-ptr.mlir
+++ b/test/TritonIntelGPU/tritonintelgpu-rewrite-stack-ptr.mlir
@@ -82,3 +82,34 @@ module attributes {"ttg.num-warps" = 1 : i32, ttg.shared = 1280 : i32, "ttg.thre
     tt.return
   }
 }
+
+// -----
+
+// `ttg.shared` is missing, so the shared memory size is unknown and the
+// conversion keeps the dynamic allocation in both modes: the base is appended as
+// a kernel argument. Only reachable when the passes are run standalone, i.e. in
+// tests: `intel-allocate-shared-memory` always sets `ttg.shared` in the
+// compilation pipeline.
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [16], warpsPerCTA = [1], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK: llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+  // CHECK: llvm.func spir_kernelcc @kernel_no_shared_attr(%arg0: !llvm.ptr<1> {tt.pointee_type = f32}, %arg1: !llvm.ptr<1>, %arg2: !llvm.ptr<1>, [[SHARED_MEM_PTR:%.*]]: !llvm.ptr<3>)
+  // DYNAMIC: llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+  // DYNAMIC: llvm.func spir_kernelcc @kernel_no_shared_attr(%arg0: !llvm.ptr<1> {tt.pointee_type = f32}, %arg1: !llvm.ptr<1>, %arg2: !llvm.ptr<1>, [[DYN_SHARED_MEM_PTR:%.*]]: !llvm.ptr<3>)
+  tt.func public @kernel_no_shared_attr(%arg0: !tt.ptr<f32>) {
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #blocked>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>, #blocked>
+    %2 = tt.addptr %1, %0 : tensor<16x!tt.ptr<f32>, #blocked>, tensor<16xi32, #blocked>
+    %3 = tt.load %2 : tensor<16x!tt.ptr<f32>, #blocked>
+    // CHECK-NOT: llvm.mlir.addressof @global_smem
+    // CHECK: llvm.getelementptr [[SHARED_MEM_PTR]]
+    // DYNAMIC-NOT: llvm.mlir.addressof @global_smem
+    // DYNAMIC: llvm.getelementptr [[DYN_SHARED_MEM_PTR]]
+    %4 = ttg.local_alloc %3 {allocation.offset = 0 : i32} : (tensor<16xf32, #blocked>) -> !ttg.memdesc<16xf32, #shared, #smem>
+    %5 = ttg.local_load %4 : !ttg.memdesc<16xf32, #shared, #smem> -> tensor<16xf32, #blocked>
+    tt.store %2, %5 : tensor<16x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/tritonintelgpu-rewrite-stack-ptr.mlir
+++ b/test/TritonIntelGPU/tritonintelgpu-rewrite-stack-ptr.mlir
@@ -1,8 +1,12 @@
 // RUN: triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm --tritonintelgpu-rewrite-stack-ptr | FileCheck %s
+// RUN: triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm=dynamic-shared-memory=true --tritonintelgpu-rewrite-stack-ptr | FileCheck %s --check-prefix=DYNAMIC
 
 module attributes {"ttg.num-warps" = 1 : i32, ttg.shared = 0 : i32} {
-  // CHECK-LABEL: llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+  // No shared memory: uses of `global_smem` are poison in both modes.
+  // CHECK-LABEL: llvm.mlir.global internal @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
   // CHECK: llvm.func spir_kernelcc @kernel(%arg0: !llvm.ptr<1> {tt.pointee_type = f32}, %arg1: !llvm.ptr<1> {tt.pointee_type = f32}, %arg2: !llvm.ptr<1> {tt.pointee_type = f32}, [[GLOBAL_PTR:%.*]]: !llvm.ptr<1>, [[PROFILE_PTR:%.*]]: !llvm.ptr<1>)
+  // DYNAMIC-LABEL: llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+  // DYNAMIC: llvm.func spir_kernelcc @kernel(%arg0: !llvm.ptr<1> {tt.pointee_type = f32}, %arg1: !llvm.ptr<1> {tt.pointee_type = f32}, %arg2: !llvm.ptr<1> {tt.pointee_type = f32}, [[GLOBAL_PTR:%.*]]: !llvm.ptr<1>, [[PROFILE_PTR:%.*]]: !llvm.ptr<1>)
   tt.func public @kernel(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>) {
     %0 = tt.load %arg0 : !tt.ptr<f32>
     %1 = tt.load %arg1 : !tt.ptr<f32>
@@ -10,6 +14,8 @@ module attributes {"ttg.num-warps" = 1 : i32, ttg.shared = 0 : i32} {
     // CHECK: [[LOAD1:%.*]] = llvm.bitcast {{.*}} : i32 to f32
     // CHECK: [[POISON:%.*]] = llvm.mlir.poison : !llvm.ptr<3>
     // CHECK: llvm.call spir_funccc @noinline_simple_fn__fp32_fp32_Pfp32__([[LOAD0]], [[LOAD1]], %arg2, [[POISON]], %arg3, %arg4)
+    // DYNAMIC: [[DYN_POISON:%.*]] = llvm.mlir.poison : !llvm.ptr<3>
+    // DYNAMIC: llvm.call spir_funccc @noinline_simple_fn__fp32_fp32_Pfp32__({{.*}}, {{.*}}, %arg2, [[DYN_POISON]], %arg3, %arg4)
     tt.call @noinline_simple_fn__fp32_fp32_Pfp32__(%0, %1, %arg2) : (f32, f32, !tt.ptr<f32>) -> ()
     tt.return
   }
@@ -28,19 +34,29 @@ module attributes {"ttg.num-warps" = 1 : i32, ttg.shared = 0 : i32} {
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 1 : i32, ttg.shared = 1280 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  // CHECK-LABEL: llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
-  // CHECK: llvm.func spir_kernelcc @kernel(%arg0: !llvm.ptr<1> {tt.pointee_type = f32}, %arg1: !llvm.ptr<1> {tt.pointee_type = f32}, %arg2: !llvm.ptr<1> {tt.pointee_type = f32}, [[GLOBAL_PTR:%.*]]: !llvm.ptr<1>, [[PROFILE_PTR:%.*]]: !llvm.ptr<1>, [[SHARED_MEM_PTR:%.*]]: !llvm.ptr<3>)
+  // Static allocation: `global_smem` is sized after `ttg.shared` and the kernel
+  // takes no shared memory argument.
+  // CHECK-LABEL: llvm.mlir.global internal @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<1280 x i8>
+  // CHECK: llvm.func spir_kernelcc @kernel(%arg0: !llvm.ptr<1> {tt.pointee_type = f32}, %arg1: !llvm.ptr<1> {tt.pointee_type = f32}, %arg2: !llvm.ptr<1> {tt.pointee_type = f32}, [[GLOBAL_PTR:%.*]]: !llvm.ptr<1>, [[PROFILE_PTR:%.*]]: !llvm.ptr<1>)
+  // Dynamic allocation: the base is a trailing kernel argument.
+  // DYNAMIC-LABEL: llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+  // DYNAMIC: llvm.func spir_kernelcc @kernel(%arg0: !llvm.ptr<1> {tt.pointee_type = f32}, %arg1: !llvm.ptr<1> {tt.pointee_type = f32}, %arg2: !llvm.ptr<1> {tt.pointee_type = f32}, [[DYN_GLOBAL_PTR:%.*]]: !llvm.ptr<1>, [[DYN_PROFILE_PTR:%.*]]: !llvm.ptr<1>, [[SHARED_MEM_PTR:%.*]]: !llvm.ptr<3>)
   tt.func public @kernel(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>) {
     %0 = tt.load %arg0 : !tt.ptr<f32>
     %1 = tt.load %arg1 : !tt.ptr<f32>
     // CHECK: [[LOAD0:%.*]] = llvm.bitcast {{.*}} : i32 to f32
     // CHECK: [[LOAD1:%.*]] = llvm.bitcast {{.*}} : i32 to f32
-    // CHECK: llvm.call spir_funccc @noinline_shared_fn([[LOAD0]], [[LOAD1]], %arg2, [[SHARED_MEM_PTR]], [[GLOBAL_PTR]], [[PROFILE_PTR]])
+    // CHECK: [[SMEM:%.*]] = llvm.mlir.addressof @global_smem : !llvm.ptr<3>
+    // CHECK: llvm.call spir_funccc @noinline_shared_fn([[LOAD0]], [[LOAD1]], %arg2, [[SMEM]], [[GLOBAL_PTR]], [[PROFILE_PTR]])
+    // DYNAMIC: llvm.call spir_funccc @noinline_shared_fn({{.*}}, {{.*}}, %arg2, [[SHARED_MEM_PTR]], [[DYN_GLOBAL_PTR]], [[DYN_PROFILE_PTR]])
     tt.call @noinline_shared_fn(%0, %1, %arg2) {allocation.offset = 0 : i32} : (f32, f32, !tt.ptr<f32>) -> ()
     tt.return
   }
+  // Non-kernel functions keep receiving the base as an argument in both modes.
   // CHECK: llvm.func internal spir_funccc @noinline_shared_fn(%arg0: f32, %arg1: f32, %arg2: !llvm.ptr<1> {tt.pointee_type = f32}, %arg3: !llvm.ptr<3>, %arg4: !llvm.ptr<1>, %arg5: !llvm.ptr<1>)
   // CHECK: llvm.getelementptr %arg3[{{.*}}]
+  // DYNAMIC: llvm.func internal spir_funccc @noinline_shared_fn(%arg0: f32, %arg1: f32, %arg2: !llvm.ptr<1> {tt.pointee_type = f32}, %arg3: !llvm.ptr<3>, %arg4: !llvm.ptr<1>, %arg5: !llvm.ptr<1>)
+  // DYNAMIC: llvm.getelementptr %arg3[{{.*}}]
   tt.func private @noinline_shared_fn(%arg0: f32, %arg1: f32, %arg2: !tt.ptr<f32>) attributes {noinline = true} {
     %cst = arith.constant dense<16> : tensor<16x1xi32, #blocked>
     %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 1, parent = #blocked}>>

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -47,6 +47,7 @@ class XPUOptions:
     loop_distribute: bool = knobs.intel.enable_loop_distribution
     code_sinking: bool = knobs.intel.enable_code_sinking
     sub_32_dpas: bool = knobs.intel.enable_sub_32_dpas
+    dynamic_shared_memory: bool = knobs.intel.dynamic_shared_memory
     use_barrier: bool = False
     max_num_imprecise_acc_default: int = 0  # `max_num_imprecise_acc` only applies to fp8 -> fp32 dot on sm_90 for cuda
     extern_libs: dict = None
@@ -500,7 +501,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         # instrumentation point here so we can override IRs above (e.g., ttir and ttgir)
         if cls.instrumentation:
             cls.instrumentation.patch("ttgpuir_to_llvmir", pm, mod.context)
-        intel.passes.ttgpuir.add_to_llvmir(pm)
+        intel.passes.ttgpuir.add_to_llvmir(pm, options.dynamic_shared_memory)
         intel.passes.ttgpuir.add_gen_to_llvm(pm)
         passes.common.add_canonicalizer(pm)
         intel.passes.ttgpuir.add_rewrite_stack_ptr(pm)

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -1075,7 +1075,7 @@ static void sycl_kernel_launch(uint32_t gridX, uint32_t gridY, uint32_t gridZ,
   RECORD_FUNCTION("XPU Triton kernel:" + kernel_name, {});
 #endif
 
-  uint32_t expected_num_params =
+  uint32_t kernel_num_args =
       kernel_ptr.get_info<sycl::info::kernel::num_args>();
   size_t global_range_x =
       static_cast<size_t>(gridX) * threads_per_warp * num_warps;
@@ -1087,9 +1087,14 @@ static void sycl_kernel_launch(uint32_t gridX, uint32_t gridY, uint32_t gridZ,
   sycl::range<3> global_range(global_range_z, global_range_y, global_range_x);
   sycl::range<3> local_range(local_range_z, local_range_y, local_range_x);
   sycl::nd_range<3> parallel_work_size(global_range, local_range);
-  if (shared_memory) {
-    expected_num_params -= 1;
-  }
+
+  // Shared memory is allocated statically in the kernel module, so it is not a
+  // kernel argument. Kernels compiled with TRITON_INTEL_DYNAMIC_SHARED_MEMORY=1
+  // do take a trailing shared memory argument, which is not part of `params`;
+  // detect that from the kernel so both flavors can be launched.
+  const bool bind_shared_memory =
+      shared_memory && (kernel_num_args == num_params + 1);
+  uint32_t expected_num_params = kernel_num_args - (bind_shared_memory ? 1 : 0);
 
   static bool launchDebug = getBoolEnv("TRITON_INTEL_LAUNCH_DEBUG");
   if (launchDebug) {
@@ -1142,7 +1147,7 @@ static void sycl_kernel_launch(uint32_t gridX, uint32_t gridY, uint32_t gridZ,
     // Set scratch memory arguments
     set_scalar_arg<void *>(cgh, num_params - 2, params[num_params - 2]);
     set_scalar_arg<void *>(cgh, num_params - 1, params[num_params - 1]);
-    if (shared_memory) {
+    if (bind_shared_memory) {
       using share_mem_t = sycl::local_accessor<int8_t, 1>;
       share_mem_t local_buffer = share_mem_t(shared_memory, cgh);
       cgh.set_arg(num_params, local_buffer);

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -1089,7 +1089,8 @@ static void sycl_kernel_launch(uint32_t gridX, uint32_t gridY, uint32_t gridZ,
   sycl::nd_range<3> parallel_work_size(global_range, local_range);
 
   // Shared memory is allocated statically in the kernel module, so it is not a
-  // kernel argument. Kernels compiled with TRITON_INTEL_DYNAMIC_SHARED_MEMORY=1
+  // kernel argument. Kernels that need a dynamic allocation (compiled with
+  // TRITON_INTEL_DYNAMIC_SHARED_MEMORY=1, or using a partitioned shared layout)
   // do take a trailing shared memory argument, which is not part of `params`;
   // detect that from the kernel so both flavors can be launched.
   const bool bind_shared_memory =

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -320,8 +320,17 @@ def TritonIntelGPURewriteStackPtr
   let summary = "rewrite the getStackPointer for Intel by addressofOp replacement";
 
   let description = [{
-    This pass searches for the global_smem symbol and replaces the addressOfOp with a newly inserted
-    SLM parameter or a PoisonOp to rewrite the getStackPointer for Intel.
+    This pass rewrites the addressOfOps referring to the `global_smem` symbol,
+    depending on how shared memory was allocated by the TritonIntelGPU to LLVM
+    conversion:
+
+    - statically (internal linkage): nothing to do, the address of `global_smem`
+      is a valid shared memory base.
+    - dynamically (external linkage): a shared memory pointer argument is
+      appended to every kernel and the addressOfOps are replaced by it.
+
+    In both cases, kernels not using shared memory (`ttg.shared` is 0) get a
+    PoisonOp instead, as a zero sized array cannot be materialized in SPIR-V.
   }];
 
   let dependentDialects = [

--- a/third_party/intel/include/TritonIntelGPUToLLVM/Passes.td
+++ b/third_party/intel/include/TritonIntelGPUToLLVM/Passes.td
@@ -12,6 +12,26 @@ def IntelAllocateSharedMemory
 def ConvertTritonIntelGPUToLLVM
     : Pass<"convert-triton-intel-gpu-to-llvm", "mlir::ModuleOp"> {
   let summary = "Convert TritonIntelGPU to LLVM";
+
+  let description = [{
+    Lowers TritonIntelGPU to LLVM. Shared (work-group) memory is allocated
+    statically in the module: `global_smem` is an internal array sized after the
+    `ttg.shared` module attribute, which the Level Zero runtime allocates
+    directly from the SPIR-V module, so no kernel argument is needed to pass the
+    shared memory base.
+
+    `dynamic-shared-memory` requests the legacy behavior instead: a zero sized
+    array with external linkage, allocated by the runtime and passed in as an
+    extra kernel argument (see `tritonintelgpu-rewrite-stack-ptr`).
+  }];
+
+  let options = [
+    Option<"dynamicSharedMemory", "dynamic-shared-memory", "bool",
+           /*default*/"false",
+           "Request shared memory dynamically (as a kernel argument bound by "
+           "the runtime) instead of allocating it statically in the module">
+  ];
+
   let dependentDialects = ["mlir::arith::ArithDialect",
                            "mlir::math::MathDialect",
                            "mlir::gpu::GPUDialect",

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVM.cpp
@@ -178,7 +178,9 @@ private:
     // Fall back to a dynamic allocation (size 0, external linkage, base passed
     // in as a kernel argument by `tritonintelgpu-rewrite-stack-ptr`) when:
     //  - requested explicitly via `dynamic-shared-memory`,
-    //  - `ttg.shared` is missing, so the size is unknown,
+    //  - `ttg.shared` is missing, so the size is unknown - in the compilation
+    //    pipeline `intel-allocate-shared-memory` always sets it, so this only
+    //    happens when this pass is run standalone (e.g. in lit tests),
     //  - the module uses partitioned shared memory: its per-partition bases
     //    would become constants, which LLVM folds into an `extractelement` from
     //    a constant vector of pointers - not expressible in SPIR-V without the

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/TritonGPUToLLVM.cpp
@@ -30,6 +30,23 @@ using namespace mlir;
 
 namespace {
 
+/// Returns true if the module allocates shared memory with a partitioned
+/// layout, i.e. one base pointer per physical shared memory partition.
+bool hasPartitionedSharedMemory(ModuleOp mod) {
+  auto isPartitioned = [](Type ty) {
+    auto memDescTy = dyn_cast<triton::gpu::MemDescType>(ty);
+    return memDescTy && isa<triton::gpu::PartitionedSharedEncodingAttr>(
+                            memDescTy.getEncoding());
+  };
+  WalkResult res = mod.walk([&](Operation *op) {
+    if (llvm::any_of(op->getResultTypes(), isPartitioned) ||
+        llvm::any_of(op->getOperandTypes(), isPartitioned))
+      return WalkResult::interrupt();
+    return WalkResult::advance();
+  });
+  return res.wasInterrupted();
+}
+
 class TritonLLVMFunctionConversionTarget : public ConversionTarget {
 public:
   explicit TritonLLVMFunctionConversionTarget(MLIRContext &ctx)
@@ -152,14 +169,31 @@ private:
     auto ctx = mod.getContext();
     auto loc = mod.getLoc();
     auto elemTy = typeConverter.convertType(b.getIntegerType(8));
-    // Set array size 0 and external linkage indicates that we use dynamic
-    // shared allocation to allow a larger shared memory size for each kernel.
+
+    // Shared memory is allocated statically: `global_smem` is an internal
+    // array sized after `ttg.shared` (a compile time constant computed by the
+    // `intel-allocate-shared-memory` pass), which the Level Zero runtime
+    // allocates directly from the module. No kernel argument is needed.
     //
+    // Fall back to a dynamic allocation (size 0, external linkage, base passed
+    // in as a kernel argument by `tritonintelgpu-rewrite-stack-ptr`) when:
+    //  - requested explicitly via `dynamic-shared-memory`,
+    //  - `ttg.shared` is missing, so the size is unknown,
+    //  - the module uses partitioned shared memory: its per-partition bases
+    //    would become constants, which LLVM folds into an `extractelement` from
+    //    a constant vector of pointers - not expressible in SPIR-V without the
+    //    SPV_INTEL_masked_gather_scatter extension (rejected by the driver).
+    auto sharedAttr = mod->getAttrOfType<IntegerAttr>("ttg.shared");
+    bool useDynamic =
+        dynamicSharedMemory || !sharedAttr || hasPartitionedSharedMemory(mod);
+    int64_t sharedMemSize = useDynamic ? 0 : sharedAttr.getInt();
+
     // Ask for 16B alignment on global_smem because that's the largest we should
     // ever need (4xi32).
-    auto arrayTy = LLVM::LLVMArrayType::get(elemTy, 0);
+    auto arrayTy = LLVM::LLVMArrayType::get(elemTy, sharedMemSize);
     auto global = LLVM::GlobalOp::create(
-        b, loc, arrayTy, /*isConstant=*/false, LLVM::Linkage::External,
+        b, loc, arrayTy, /*isConstant=*/false,
+        useDynamic ? LLVM::Linkage::External : LLVM::Linkage::Internal,
         "global_smem", /*value=*/Attribute(), /*alignment=*/16,
         // Add ROCm support.
         static_cast<unsigned>(TritonGEN::TritonGENMemorySpace::kWorkgroup));

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RewriteStackPtr.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RewriteStackPtr.cpp
@@ -33,9 +33,25 @@ public:
     if (!globalSmem) {
       return;
     }
-    CallGraph<Allocation> allocation(mod);
+
+    // The allocation strategy is encoded in `global_smem` (see
+    // `initSharedMemory` in the TritonIntelGPU to LLVM conversion): with
+    // internal linkage the shared memory is allocated statically in the module,
+    // so `addressof @global_smem` is already a valid base and kernels need no
+    // extra argument. With external linkage the base is allocated by the
+    // runtime and passed in as a trailing argument, appended here.
+    const bool dynamicSharedMemory =
+        globalSmem.getLinkage() == LLVM::Linkage::External;
+
+    // Kernels not using shared memory keep an unused zero sized `global_smem`,
+    // which cannot be materialized in SPIR-V: poison its uses instead.
     bool usePoison =
         (mod->getAttrOfType<IntegerAttr>("ttg.shared").getInt() == 0);
+
+    if (!dynamicSharedMemory && !usePoison)
+      return;
+
+    CallGraph<Allocation> allocation(mod);
 
     // 1: Process function arguments for root functions
     if (!usePoison) {

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RewriteStackPtr.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RewriteStackPtr.cpp
@@ -44,9 +44,12 @@ public:
         globalSmem.getLinkage() == LLVM::Linkage::External;
 
     // Kernels not using shared memory keep an unused zero sized `global_smem`,
-    // which cannot be materialized in SPIR-V: poison its uses instead.
-    bool usePoison =
-        (mod->getAttrOfType<IntegerAttr>("ttg.shared").getInt() == 0);
+    // which cannot be materialized in SPIR-V: poison its uses instead. A module
+    // without `ttg.shared` (the conversion pass run standalone, without
+    // `intel-allocate-shared-memory`) has an unknown shared memory size, which
+    // the conversion lowers as a dynamic allocation: append the argument.
+    auto sharedAttr = mod->getAttrOfType<IntegerAttr>("ttg.shared");
+    bool usePoison = sharedAttr && sharedAttr.getInt() == 0;
 
     if (!dynamicSharedMemory && !usePoison)
       return;

--- a/third_party/intel/tools/intel/compile.cpp
+++ b/third_party/intel/tools/intel/compile.cpp
@@ -140,7 +140,7 @@ int32_t {kernel_name}(sycl::queue &stream, {signature}) {{
   void* profile_scratch = nullptr;
   void *params[] = {{ {arg_pointers} }};
   uint32_t num_params = sizeof(params)/sizeof(params[0]);
-  uint32_t expected_num_params = sycl_kernel.get_info<sycl::info::kernel::num_args>();
+  uint32_t kernel_num_args = sycl_kernel.get_info<sycl::info::kernel::num_args>();
 
   size_t global_range_x = static_cast<size_t>({gridX}) * {threads_per_warp} * {num_warps};
   size_t global_range_y = {gridY};
@@ -153,9 +153,13 @@ int32_t {kernel_name}(sycl::queue &stream, {signature}) {{
   sycl::range<3> local_range(local_range_z, local_range_y, local_range_x);
   sycl::nd_range<3> parallel_work_size(global_range, local_range);
 
-  if (static_cast<bool>({shared})) {{
-    expected_num_params -= 1;
-  }}
+  // Shared memory is allocated statically in the kernel module (mirrors the JIT
+  // launcher in driver.c): bind a shared memory argument only for kernels
+  // compiled with TRITON_INTEL_DYNAMIC_SHARED_MEMORY=1, which have one extra
+  // argument.
+  const bool bind_shared_memory =
+      static_cast<bool>({shared}) && (kernel_num_args == num_params + 1);
+  uint32_t expected_num_params = kernel_num_args - (bind_shared_memory ? 1 : 0);
   assert(num_params == expected_num_params && "number of kernel param not matched");
   // Submit the imported kernel.
   auto cgf = [&](sycl::handler &cgh) {{
@@ -177,7 +181,7 @@ int32_t {kernel_name}(sycl::queue &stream, {signature}) {{
     // list, so they must be bound explicitly here (mirrors the JIT launcher in driver.c).
     set_scalar_arg<void *>(cgh, num_params - 2, params[num_params - 2]);
     set_scalar_arg<void *>(cgh, num_params - 1, params[num_params - 1]);
-    if (static_cast<bool>({shared})) {{
+    if (bind_shared_memory) {{
         using share_mem_t = sycl::local_accessor<int8_t, 1>;
         share_mem_t local_buffer = share_mem_t({shared}, cgh);
         cgh.set_arg(num_params, local_buffer);

--- a/third_party/intel/tools/intel/compile.cpp
+++ b/third_party/intel/tools/intel/compile.cpp
@@ -154,9 +154,10 @@ int32_t {kernel_name}(sycl::queue &stream, {signature}) {{
   sycl::nd_range<3> parallel_work_size(global_range, local_range);
 
   // Shared memory is allocated statically in the kernel module (mirrors the JIT
-  // launcher in driver.c): bind a shared memory argument only for kernels
-  // compiled with TRITON_INTEL_DYNAMIC_SHARED_MEMORY=1, which have one extra
-  // argument.
+  // launcher in driver.c): bind a shared memory argument only for kernels that
+  // need a dynamic allocation (compiled with
+  // TRITON_INTEL_DYNAMIC_SHARED_MEMORY=1, or using a partitioned shared
+  // layout), which have one extra argument.
   const bool bind_shared_memory =
       static_cast<bool>({shared}) && (kernel_num_args == num_params + 1);
   uint32_t expected_num_params = kernel_num_args - (bind_shared_memory ? 1 : 0);

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -79,8 +79,8 @@ void init_triton_intel_passes_ttir(py::module_ &&m) {
 }
 
 void init_triton_intel_passes_ttgpuir(py::module_ &&m) {
-  ADD_PASS_WRAPPER_0("add_to_llvmir",
-                     gpu::intel::createConvertTritonIntelGPUToLLVM);
+  ADD_PASS_OPTION_WRAPPER_1(
+      "add_to_llvmir", gpu::intel::createConvertTritonIntelGPUToLLVM, bool);
   ADD_PASS_WRAPPER_0("add_gen_to_llvm", createConvertTritonGENToLLVM);
   ADD_PASS_WRAPPER_0("add_accelerate_matmul",
                      gpu::intel::createTritonIntelGPUAccelerateMatmul);

--- a/utils/SPIRVRunner/SPIRVRunner.cpp
+++ b/utils/SPIRVRunner/SPIRVRunner.cpp
@@ -260,7 +260,7 @@ static void sycl_kernel_launch(sycl::queue &stream, sycl::kernel &kernel_ptr,
   std::string kernel_name =
       kernel_ptr.get_info<sycl::info::kernel::function_name>();
 
-  [[maybe_unused]] uint32_t expected_num_params =
+  uint32_t kernel_num_args =
       kernel_ptr.get_info<sycl::info::kernel::num_args>();
 
   size_t global_range_x = static_cast<size_t>(triton_args.gridX) *
@@ -275,9 +275,17 @@ static void sycl_kernel_launch(sycl::queue &stream, sycl::kernel &kernel_ptr,
   sycl::range<3> local_range(local_range_z, local_range_y, local_range_x);
   sycl::nd_range<3> parallel_work_size(global_range, local_range);
 
-  if (triton_args.shared_memory) {
-    expected_num_params -= 1;
-  }
+  // Kernel arguments are: the ones described by the JSON argument list,
+  // [global scratch], [profile scratch] and - only for kernels compiled with
+  // TRITON_INTEL_DYNAMIC_SHARED_MEMORY=1 - a trailing shared memory pointer.
+  // Shared memory is otherwise allocated statically in the kernel module, so
+  // bind it only if the kernel has an argument left over after the JSON
+  // arguments and the (at most two) scratch pointers.
+  const uint32_t num_json_args = triton_args.jsonData["argument_list"].size();
+  const bool bind_shared_memory =
+      triton_args.shared_memory != 0 && kernel_num_args > num_json_args + 2;
+  [[maybe_unused]] uint32_t expected_num_params =
+      kernel_num_args - (bind_shared_memory ? 1 : 0);
   int tensorIdx = 0;
   uint32_t narg = 0;
   // Submit the imported kernel.
@@ -304,7 +312,7 @@ static void sycl_kernel_launch(sycl::queue &stream, sycl::kernel &kernel_ptr,
       // profile scratch
       cgh.set_arg(narg++, nullptr);
     }
-    if (triton_args.shared_memory) {
+    if (bind_shared_memory) {
       using share_mem_t = sycl::local_accessor<int8_t, 1>;
       share_mem_t local_buffer = share_mem_t(triton_args.shared_memory, cgh);
       cgh.set_arg(narg, local_buffer);

--- a/utils/SPIRVRunner/SPIRVRunner.cpp
+++ b/utils/SPIRVRunner/SPIRVRunner.cpp
@@ -276,10 +276,11 @@ static void sycl_kernel_launch(sycl::queue &stream, sycl::kernel &kernel_ptr,
   sycl::nd_range<3> parallel_work_size(global_range, local_range);
 
   // A kernel allocating its shared memory statically in the module makes the
-  // driver report that size, and takes no shared memory argument. A kernel
-  // compiled with TRITON_INTEL_DYNAMIC_SHARED_MEMORY=1 (or by an older Triton)
-  // reports 0 and takes a trailing shared memory pointer instead, which the
-  // JSON argument list does not describe.
+  // driver report that size, and takes no shared memory argument. A kernel with
+  // a dynamic allocation (compiled with TRITON_INTEL_DYNAMIC_SHARED_MEMORY=1 or
+  // by an older Triton, or using a partitioned shared layout) reports 0 and
+  // takes a trailing shared memory pointer instead, which the JSON argument
+  // list does not describe.
   ze_kernel_properties_t kernel_props{};
   kernel_props.stype = ZE_STRUCTURE_TYPE_KERNEL_PROPERTIES;
   gpuAssert(zeKernelGetProperties(

--- a/utils/SPIRVRunner/SPIRVRunner.cpp
+++ b/utils/SPIRVRunner/SPIRVRunner.cpp
@@ -275,15 +275,18 @@ static void sycl_kernel_launch(sycl::queue &stream, sycl::kernel &kernel_ptr,
   sycl::range<3> local_range(local_range_z, local_range_y, local_range_x);
   sycl::nd_range<3> parallel_work_size(global_range, local_range);
 
-  // Kernel arguments are: the ones described by the JSON argument list,
-  // [global scratch], [profile scratch] and - only for kernels compiled with
-  // TRITON_INTEL_DYNAMIC_SHARED_MEMORY=1 - a trailing shared memory pointer.
-  // Shared memory is otherwise allocated statically in the kernel module, so
-  // bind it only if the kernel has an argument left over after the JSON
-  // arguments and the (at most two) scratch pointers.
-  const uint32_t num_json_args = triton_args.jsonData["argument_list"].size();
+  // A kernel allocating its shared memory statically in the module makes the
+  // driver report that size, and takes no shared memory argument. A kernel
+  // compiled with TRITON_INTEL_DYNAMIC_SHARED_MEMORY=1 (or by an older Triton)
+  // reports 0 and takes a trailing shared memory pointer instead, which the
+  // JSON argument list does not describe.
+  ze_kernel_properties_t kernel_props{};
+  kernel_props.stype = ZE_STRUCTURE_TYPE_KERNEL_PROPERTIES;
+  gpuAssert(zeKernelGetProperties(
+      sycl::get_native<sycl::backend::ext_oneapi_level_zero>(kernel_ptr),
+      &kernel_props));
   const bool bind_shared_memory =
-      triton_args.shared_memory != 0 && kernel_num_args > num_json_args + 2;
+      triton_args.shared_memory != 0 && kernel_props.localMemSize == 0;
   [[maybe_unused]] uint32_t expected_num_params =
       kernel_num_args - (bind_shared_memory ? 1 : 0);
   int tensorIdx = 0;


### PR DESCRIPTION
### Problem
`global_smem` is emitted as a zero sized array with _external linkage_, so the shared memory base has to be passed to every kernel as a trailing argument, bound with a `sycl::local_accessor`. That accessor is not device copyable and its constructor requires a `sycl::handler`, which blocks the handler-less submit APIs.
_*The construct is inherited from the CUDA path, where static `__shared__` is capped at 48 KB - Level Zero has no such cap._

### Why not the `work_group_scratch_memory` 
It does not remove the argument (it lowers to an implicit `__local` argument), and the runtime can only bind it from the device image property [SYCL/implicit local arg], which raw SPIR-V loaded by kernel name does not have - the launch property is rejected with `UR_RESULT_ERROR_UNSUPPORTED_FEATURE` on the Level Zero adapter. Since `ttg.shared` is a compile time constant, this PR emits what `work_group_static` lowers to (a fixed size work-group variable) directly in SPIR-V, without depending on any SYCL extension.

### Changes
 - `ConvertTritonIntelGPUToLLVM`: emit global_smem as an internal array sized after `ttg.shared`; the Level Zero runtime allocates it from the module. New pass option dynamic-shared-memory / `TRITON_INTEL_DYNAMIC_SHARED_MEMORY` restores the previous behavior.
 - `TritonIntelGPURewriteStackPtr`: infer the strategy from global_smem's linkage; nothing to rewrite for a static allocation.
 - `driver.c`, AOT `compile.cpp`, `SPIRVRunner.cpp`: drop the `local_accessor` binding and derive the kernel flavor from `sycl::info::kernel::num_args`, so both flavors can be launched.
 - Lit tests cover both modes.

 ### Limitation
 
 Modules using `PartitionedSharedLayout` (a gfx1250 layout) keep the dynamic allocation: their constant partition bases fold into an `extractelement` from a vector of pointers, which SPIR-V cannot express without `SPV_INTEL_masked_gather_scatter` (rejected by the driver).
 
 ### Performance
For kernels that use shared memory, submit cost drops from 4.45 to 4.21 us (-5.5 %): removing the binding makes them cost the same per launch as a kernel without shared memory. Kernels with no shared memory and device time are unaffected. In a full Python launch (~20 us) the same saving is ~1.5-3 %.

### Conclusion
This removes the last dependency on `sycl::handler` in the launch path, which is what #6209 needs to switch to the handler-less submit APIs.

@uditagarwal97 @gmlueck @etiotto 
