### PR TITLE
[LAYOUTS] Dispatch dot-operand and Gluon layouts through interfaces

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -1055,6 +1055,7 @@ w2 w2 w3 w3
     SmallVector<int64_t> getInstrShapeForOperand(int kWidth, int opIdx) const;
     SmallVector<int64_t> getRepForOperand(ArrayRef<int64_t> operandShape, int kWidth, int opIdx) const;
     SmallVector<unsigned> getRepOrderForOperand(int opIdx) const;
+    LinearLayout dotOperandToLinearLayout(Attribute dotOp, ArrayRef<int64_t> shape) const;
 
     // Check if tilesPerWarp is 1 in every dimension.
     bool hasUnitTilesPerWarp() const;
@@ -1247,6 +1248,7 @@ This simplifies both WMMA and dotOperand layouts lowering to linear layout.
 
   let extraClassDeclaration = extraDistributedDeclaration # [{
     SmallVector<unsigned> getRepOrderForOperand(int opIdx) const;
+    LinearLayout dotOperandToLinearLayout(Attribute dotOp, ArrayRef<int64_t> shape) const;
     LinearLayout getTileLayout(unsigned rank) const;
     static SmallVector<unsigned, 3> getDefaultInstrShape() {
       return {16, 16, 16};
@@ -1373,6 +1375,7 @@ For example, the matrix L corresponding to blockTileSize=[32,16] is:
                                           int bitwidth, int kWidth,
                                           int opIdx) const;
     SmallVector<unsigned> getRepOrderForOperand(int opIdx) const;
+    LinearLayout dotOperandToLinearLayout(Attribute dotOp, ArrayRef<int64_t> shape) const;
   }];
 
   let hasCustomAssemblyFormat = 1;

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrInterfaces.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrInterfaces.td
@@ -246,6 +246,16 @@ def MmaEncodingTrait : AttrInterface<"MmaEncodingTrait"> {
                     "SmallVector<unsigned>",
                     "getRepOrderForOperand",
                     (ins "int":$opIdx)>,
+    InterfaceMethod<"Convert a dot operand whose parent is this MMA layout to a LinearLayout.",
+                    "LinearLayout",
+                    "dotOperandToLinearLayout",
+                    (ins "::mlir::Attribute":$dotOp,
+                         "ArrayRef<int64_t>":$shape),
+                    /*methodBody=*/[{}],
+                    /*defaultImplementation=*/[{
+                      llvm::report_fatal_error(
+                          "this MMA layout is not a valid dot-operand parent");
+                    }]>,
   ];
 }
 

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2964,6 +2964,11 @@ LogicalResult DotOperandEncodingAttr::verify(
     return success();
   }
 
+  // Accept any MMA-like parent by interface, so an out-of-tree matmul layout
+  // can be a valid dot-operand parent without being enumerated here.
+  if (mlir::isa<MmaEncodingTrait>(parent))
+    return success();
+
   return emitError() << "ttg.dot_op unexpected parent layout: " << parent;
 }
 

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1,6 +1,5 @@
 #include <vector>
 
-#include "intel/include/Dialect/TritonIntelGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -1116,20 +1115,33 @@ LinearLayout nvidiaDotToLinearLayout(ArrayRef<int64_t> shape,
 }
 
 LinearLayout
+NvidiaMmaEncodingAttr::dotOperandToLinearLayout(Attribute dotOp,
+                                                ArrayRef<int64_t> shape) const {
+  return nvidiaDotToLinearLayout(shape, cast<DotOperandEncodingAttr>(dotOp));
+}
+
+LinearLayout
+AMDMfmaEncodingAttr::dotOperandToLinearLayout(Attribute dotOp,
+                                              ArrayRef<int64_t> shape) const {
+  return mfmaDotToLinearLayout(cast<DotOperandEncodingAttr>(dotOp), shape);
+}
+
+LinearLayout
+AMDWmmaEncodingAttr::dotOperandToLinearLayout(Attribute dotOp,
+                                              ArrayRef<int64_t> shape) const {
+  return wmmaDotOperandToLinearLayout(cast<DotOperandEncodingAttr>(dotOp),
+                                      shape);
+}
+
+LinearLayout
 DotOperandEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   auto parent = getParent();
-  if (auto blockedLayout = mlir::dyn_cast<BlockedEncodingAttr>(parent)) {
+  if (mlir::isa<BlockedEncodingAttr>(parent))
     return fmaDotToLinearLayout(*this, shape);
-  } else if (auto mfmaLayout = mlir::dyn_cast<AMDMfmaEncodingAttr>(parent)) {
-    return mfmaDotToLinearLayout(*this, shape);
-  } else if (auto wmmaLayout = mlir::dyn_cast<AMDWmmaEncodingAttr>(parent)) {
-    return wmmaDotOperandToLinearLayout(*this, shape);
-  } else if (auto dpasLayout =
-                 llvm::dyn_cast<intel::DpasEncodingAttr>(parent)) {
-    return dotOperandDpasToLinearLayout(*this, shape);
-  } else {
-    return nvidiaDotToLinearLayout(shape, *this);
-  }
+  if (auto mma = mlir::dyn_cast<MmaEncodingTrait>(parent))
+    return mma.dotOperandToLinearLayout(*this, shape);
+  llvm::report_fatal_error(
+      "unexpected parent layout in DotOperandEncodingAttr::toLinearLayout");
 }
 
 LinearLayout SliceEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -226,7 +226,8 @@ std::vector<llvm::ValueTypeFromRangeType<R>> toStdVector(R &&range) {
   return {range.begin(), range.end()};
 }
 
-py::object layoutToGluon(Attribute layout, bool isRubin = false) {
+py::object layoutToGluon(Attribute layout, bool isRubin = false,
+                         llvm::ArrayRef<int64_t> shape = {}) {
   static GluonLayouts layouts;
   if (auto blocked = dyn_cast<ttg::BlockedEncodingAttr>(layout)) {
     auto cgaBases = getCgaLayoutBases(blocked.getCGALayout());
@@ -351,6 +352,14 @@ py::object layoutToGluon(Attribute layout, bool isRubin = false) {
         std::vector<unsigned>{tmem.getBlockM(), tmem.getBlockN()},
         tmem.getColStride(), getCgaLayoutBases(tmem.getCGALayout()),
         tmem.getTwoCTAs(), tmem.getFp4Padded());
+  }
+
+  // A distributed layout not matched above (e.g. out-of-tree) still has a
+  // LinearLayout form. When the caller passed the tensor shape, expose it as
+  // one instead of failing.
+  if (!shape.empty()) {
+    if (auto dist = dyn_cast<ttg::DistributedEncodingTrait>(layout))
+      return layoutToGluon(ttg::toLinearEncoding(dist, shape), isRubin);
   }
 
   throw py::value_error("Unhandled encoding encountered");
@@ -659,7 +668,8 @@ void init_gluon_ir(py::module_ &m) {
            [](GluonOpBuilder &self, Value tensor) -> py::object {
              auto ty = dyn_cast<RankedTensorType>(tensor.getType());
              check(ty.getEncoding(), "expected a tensor with an encoding");
-             return layoutToGluon(ty.getEncoding(), self.isRubin());
+             return layoutToGluon(ty.getEncoding(), self.isRubin(),
+                                  ty.getShape());
            })
       .def("get_gluon_layout_from_memdesc",
            [](GluonOpBuilder &self, Value memdesc) -> py::object {

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUAttrDefs.td
@@ -286,6 +286,7 @@ The semantic of this `tt.dot` includes GEMM tiling configuration as:
     SmallVector<unsigned> getElemsPerThreadForOperands(ArrayRef<int64_t> shape, Type eltTy, OpIdx opIdx) const;
     SmallVector<unsigned> getRepOrderForOperand(OpIdx opIdx) const;
     unsigned getTotalElemsPerThreadForOperand(ArrayRef<int64_t> shape, Type eltTy, int kWidth, OpIdx opIdx) const;
+    LinearLayout dotOperandToLinearLayout(Attribute dotOp, ArrayRef<int64_t> shape) const;
 
     // Forwarder functions for casting unsigned to OpIdx.
     SmallVector<int64_t> getDPASRepetitions(ArrayRef<int64_t> shape, unsigned opIdx) const {

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
@@ -343,6 +343,13 @@ LinearLayout DpasEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   return DPAStoLinearLayout(shape, *this);
 }
 
+LinearLayout
+DpasEncodingAttr::dotOperandToLinearLayout(Attribute dotOp,
+                                           ArrayRef<int64_t> shape) const {
+  return dotOperandDpasToLinearLayout(cast<DotOperandEncodingAttr>(dotOp),
+                                      shape);
+}
+
 //===----------------------------------------------------------------------===//
 // WarpEncodingAttr
 //===----------------------------------------------------------------------===//

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -1,5 +1,7 @@
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/Location.h"
 #include "mlir/IR/MLIRContext.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -3663,6 +3665,97 @@ TEST_F(LinearLayoutConversionsTest,
           << dim0 << ", " << dim1 << "] with " << swizzleBytes << "B swizzle";
     }
   }
+}
+
+// A dot-operand parent may be any MmaEncodingTrait, including out-of-tree
+// layouts unknown to core. No such layout exists in-tree, so attach the
+// interface to a placeholder attribute (a test-only stand-in) and check both
+// seams. testExtMmaSentinel is what the stand-in returns, so the test can
+// confirm dispatch reached it.
+static LinearLayout testExtMmaSentinel(MLIRContext *ctx) {
+  auto S = [&](StringRef s) { return StringAttr::get(ctx, s); };
+  return LinearLayout(
+      {
+          {S("register"), {}},
+          {S("lane"), {{1}, {2}}},
+          {S("warp"), {}},
+          {S("block"), {}},
+      },
+      {S("dim0")});
+}
+
+// Test-only stand-in: MmaEncodingTrait attached to a placeholder attribute.
+struct TestExtMmaModel
+    : public MmaEncodingTrait::ExternalModel<TestExtMmaModel, StringAttr> {
+  SmallVector<unsigned> getRepOrderForOperand(Attribute attr, int opIdx) const {
+    return {0};
+  }
+  LinearLayout dotOperandToLinearLayout(Attribute attr, Attribute dotOp,
+                                        ArrayRef<int64_t> shape) const {
+    return testExtMmaSentinel(attr.getContext());
+  }
+};
+
+TEST_F(LinearLayoutConversionsTest, OutOfTreeMmaDotOperandExtensionPoint) {
+  StringAttr::attachInterface<TestExtMmaModel>(ctx);
+  Attribute parent = S("test_out_of_tree_mma");
+  ASSERT_TRUE(isa<MmaEncodingTrait>(parent));
+
+  // verify accepts an unknown MmaEncodingTrait parent.
+  auto emitError = [&]() {
+    return mlir::emitError(mlir::UnknownLoc::get(&ctx));
+  };
+  EXPECT_TRUE(succeeded(DotOperandEncodingAttr::verify(emitError, /*opIdx=*/0,
+                                                       parent, /*kWidth=*/0)));
+
+  // toLinearLayout dispatches through the interface, not a hardcoded type.
+  auto dotOperand = dot(parent, /*idx=*/0, /*kWidth=*/0);
+  EXPECT_EQ(dotOperand.toLinearLayout({4}), testExtMmaSentinel(&ctx));
+}
+
+// layoutToGluon (gluon_ir.cc) accepts an unrecognized distributed layout by
+// converting it via toLinearEncoding instead of throwing. That path is
+// pybind-only, so guard the core conversion here with an out-of-tree stand-in.
+static LinearLayout testExtDistSentinel(MLIRContext *ctx) {
+  auto S = [&](StringRef s) { return StringAttr::get(ctx, s); };
+  return LinearLayout(
+      {
+          {S("register"), {}},
+          {S("lane"), {{1}, {2}, {4}}},
+          {S("warp"), {}},
+          {S("block"), {}},
+      },
+      {S("dim0")});
+}
+
+struct TestExtDistModel
+    : public DistributedEncodingTrait::ExternalModel<TestExtDistModel,
+                                                     StringAttr> {
+  SmallVector<unsigned> getRepOrder(Attribute attr) const { return {0}; }
+  LinearLayout toLinearLayout(Attribute attr, ArrayRef<int64_t> shape) const {
+    return testExtDistSentinel(attr.getContext());
+  }
+  // FallbackModel requires these too (no auto-defaults); unused by this test.
+  unsigned getTotalElemsPerThread(Attribute attr,
+                                  ArrayRef<int64_t> shape) const {
+    return 1;
+  }
+  SmallVector<unsigned> getElemsPerThread(Attribute attr,
+                                          ArrayRef<int64_t> shape) const {
+    return SmallVector<unsigned>(shape.size(), 1);
+  }
+};
+
+TEST_F(LinearLayoutConversionsTest, OutOfTreeDistributedGluonFallback) {
+  StringAttr::attachInterface<TestExtDistModel>(ctx);
+  Attribute layout = S("test_out_of_tree_distributed");
+  ASSERT_TRUE(isa<DistributedEncodingTrait>(layout));
+
+  // The conversion the layoutToGluon fallback performs: succeeds and carries
+  // LL.
+  auto enc = toLinearEncoding(cast<DistributedEncodingTrait>(layout), {8});
+  ASSERT_TRUE(enc);
+  EXPECT_EQ(enc.getLinearLayout(), testExtDistSentinel(&ctx));
 }
 
 } // anonymous namespace


### PR DESCRIPTION
Aligned as in PR#11025 from upstream (still open)

------------

### Problem

   `DotOperandEncodingAttr::toLinearLayout` and Gluon's `layoutToGluon` each lower a layout by enumerating the concrete encodings they know about:

   - `toLinearLayout`: `dyn_cast<Blocked/MFMA/WMMA>`, otherwise assume NVIDIA
   - `layoutToGluon`: a `dyn_cast` chain, otherwise `throw "Unhandled encoding"`

   A distributed layout on neither list breaks: the first reaches `cast<NvidiaMmaEncodingAttr>`, the second raises.
Yet every MMA parent already implements `MmaEncodingTrait`, and every distributed layout already lowers to a `LinearLayout`.
These switches re-encode information the layouts already carry, and adding a layout means editing a switch instead of implementing an interface.

   ### Change

   Dispatch through those existing abstractions:

   - dot-operand lowering asks the parent through `MmaEncodingTrait`
   - `layoutToGluon` falls back to the layout's own `LinearLayout`

   This is the path the in-tree MMA backends already take - it just stops the two call sites from naming concrete types.
A layout core doesn't enumerate (a future in-tree encoding, or an out-of-tree one) then lowers without touching either switch.

   ### Compatibility & tests

 No behavior change for existing layouts: the NVIDIA/AMD paths run the same code as before, and the new Gluon fallback only triggers for encodings the chain didn't already handle (none in tree). Unit tests drive both seams with a stand-in layout: the dot-operand test runs end-to-end through the interface dispatch - the Gluon test covers the conversion the fallback relies on (`toLinearEncoding`), not the pybind wiring.