### PR TITLE
[NIT] Clean up redundant code in driver.c by unifying the rebuild path on failure and register spilling.

### DIFF
--- a/python/test/unit/intel/test_driver.py
+++ b/python/test/unit/intel/test_driver.py
@@ -33,7 +33,7 @@ def test_auto_grf(device, monkeypatch, capfd):
     outs = [line for line in capfd.readouterr().out.splitlines() if line]
 
     # The output should contain the recompiling information for large GRF mode.
-    assert re.search(r"recompiling the kernel using large GRF mode", outs[0])
+    assert "retrying with large GRF mode" in outs[0]
     # The spill size of returned kernel should be same kernel as the one compiled with large GRF mode.
     assert re.findall(r"\d+\.?\d*", outs[1])[0] == re.findall(r"\d+\.?\d*", outs[2])[0]
 
@@ -181,7 +181,7 @@ def test_auto_grf_on_build_failure(device, monkeypatch, capfd, grf_mode, expect_
     outs = capfd.readouterr().out
     if expect_retry and not generate_native_code:
         # load_binary path prints a retry message to stdout.
-        assert "retrying with large GRF mode" in outs or "recompiling the kernel using large GRF mode" in outs
+        assert "retrying with large GRF mode" in outs
     elif expect_retry and generate_native_code:
         # make_zebin path retries silently via ocloc — no stdout message.
         # Success without exception is sufficient verification.

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -333,18 +333,33 @@ compileLevelZeroObjects(uint8_t *binary_ptr, const size_t binary_size,
                         const std::string &kernel_name, L0_DEVICE l0_device,
                         L0_CONTEXT l0_context, const std::string &build_flags,
                         const bool is_spv) {
-  auto l0_module = checkZeCodeAndSetPyErr(
-      create_module(l0_context, l0_device, binary_ptr, binary_size,
-                    build_flags.data(), is_spv),
-      __FILE__, __LINE__);
+  ze_module_handle_t l0_module = nullptr;
+  ze_kernel_handle_t l0_kernel = nullptr;
+  auto cleanupPartialObjects = [&]() {
+    if (l0_kernel) {
+      zeKernelDestroy(l0_kernel);
+      l0_kernel = nullptr;
+    }
+    if (l0_module) {
+      zeModuleDestroy(l0_module);
+      l0_module = nullptr;
+    }
+  };
+
+  l0_module = checkZeCodeAndSetPyErr(create_module(l0_context, l0_device,
+                                                   binary_ptr, binary_size,
+                                                   build_flags.data(), is_spv),
+                                     __FILE__, __LINE__);
   if (PyErr_Occurred()) {
+    cleanupPartialObjects();
     return std::make_tuple(nullptr, nullptr, -1);
   }
 
   // Retrieve the kernel properties (e.g. register spills).
-  auto l0_kernel = checkZeCodeAndSetPyErr(
-      create_function(l0_module, kernel_name), __FILE__, __LINE__);
+  l0_kernel = checkZeCodeAndSetPyErr(create_function(l0_module, kernel_name),
+                                     __FILE__, __LINE__);
   if (PyErr_Occurred()) {
+    cleanupPartialObjects();
     return std::make_tuple(nullptr, nullptr, -1);
   }
 
@@ -356,6 +371,7 @@ compileLevelZeroObjects(uint8_t *binary_ptr, const size_t binary_size,
       std::make_tuple(NULL, zeKernelGetProperties(l0_kernel, &props)), __FILE__,
       __LINE__);
   if (PyErr_Occurred()) {
+    cleanupPartialObjects();
     return std::make_tuple(nullptr, nullptr, -1);
   }
 
@@ -476,105 +492,97 @@ extern "C" EXPORT_FUNC PyObject *load_binary(PyObject *args) {
   auto [l0_module, l0_kernel, n_spills] =
       compileLevelZeroObjects(binary_ptr, binary_size, kernel_name, l0_device,
                               l0_context, build_flags(), is_spv);
-
-  const bool debugEnabled = getBoolEnv("TRITON_DEBUG");
-
-  // If the initial compilation failed entirely (e.g., scratch space exceeds
-  // HW limit), and GRF mode was not explicitly set, retry with large GRF mode.
-  // This handles cases where the default GRF mode doesn't provide enough
-  // registers, causing the backend compiler to fail.
-  if (PyErr_Occurred() && is_spv && !build_flags.hasGRFSizeFlag()) {
-    // Save the original error before clearing it for the retry attempt.
-    PyObject *orig_type, *orig_value, *orig_tb;
-    PyErr_Fetch(&orig_type, &orig_value, &orig_tb);
-
-    if (debugEnabled)
-      std::cout << "(I): Build failed for \"" << kernel_name
-                << "\", retrying with large GRF mode" << std::endl;
-
-    build_flags.addLargeGRFSizeFlag();
-
-    auto [l0_module_retry, l0_kernel_retry, n_spills_retry] =
-        compileLevelZeroObjects(binary_ptr, binary_size, kernel_name, l0_device,
-                                l0_context, build_flags(), is_spv);
-    if (PyErr_Occurred()) {
-      // Retry also failed — propagate the original error.
-      PyErr_Restore(orig_type, orig_value, orig_tb);
-      return NULL;
-    }
-
-    // Retry succeeded — discard the saved original error.
-    Py_XDECREF(orig_type);
-    Py_XDECREF(orig_value);
-    Py_XDECREF(orig_tb);
-
-    l0_module = l0_module_retry;
-    l0_kernel = l0_kernel_retry;
-    n_spills = n_spills_retry;
-
-    // Always print recovery message to stderr to follow up on the
-    // "L0 build module failed" error that was already printed.
-    std::cerr << "(I): Build failure recovered by retrying with large GRF "
-                 "mode for \""
-              << kernel_name << "\"" << std::endl;
-
-    if (debugEnabled)
-      std::cout << "(I): Retry with large GRF succeeded, kernel has "
-                << n_spills << " spills" << std::endl;
-  } else if (PyErr_Occurred()) {
+  bool firstBuildFailed = PyErr_Occurred();
+  const bool canRetryWithLargeGRF = is_spv && !build_flags.hasGRFSizeFlag();
+  if (firstBuildFailed && !canRetryWithLargeGRF) {
     return NULL;
   }
 
-  if (is_spv) {
-    constexpr int32_t max_reg_spill = 1000;
-    const bool is_GRF_mode_specified = build_flags.hasGRFSizeFlag();
+  const bool debugEnabled = getBoolEnv("TRITON_DEBUG");
+  constexpr int32_t max_reg_spill = 1000;
 
-    // If the register mode isn't set, and the number of spills is greater
-    // than the threshold, recompile the kernel using large GRF mode.
-    if (!is_GRF_mode_specified && n_spills > max_reg_spill) {
-      if (debugEnabled)
-        std::cout << "(I): Detected " << n_spills
-                  << " spills, recompiling the kernel using large GRF mode"
-                  << std::endl;
+  if (canRetryWithLargeGRF && (firstBuildFailed || n_spills > max_reg_spill)) {
+    PyObject *orig_type = nullptr, *orig_value = nullptr, *orig_tb = nullptr;
+    // Save the original error before clearing it for the retry attempt.
+    if (firstBuildFailed)
+      PyErr_Fetch(&orig_type, &orig_value, &orig_tb);
 
-      build_flags.addLargeGRFSizeFlag();
+    if (debugEnabled)
+      std::cout << (firstBuildFailed ? "(I): Build failed for \""
+                                     : "(I): Detected spills for \"")
+                << kernel_name << "\", retrying with large GRF mode"
+                << std::endl;
 
-      try {
-        auto [l0_module_dgrf, l0_kernel_dgrf, n_spills_dgrf] =
-            compileLevelZeroObjects(binary_ptr, binary_size, kernel_name,
-                                    l0_device, l0_context, build_flags(),
-                                    is_spv);
+    build_flags.addLargeGRFSizeFlag();
+
+    try {
+      auto [l0_module_retry, l0_kernel_retry, n_spills_retry] =
+          compileLevelZeroObjects(binary_ptr, binary_size, kernel_name,
+                                  l0_device, l0_context, build_flags(), is_spv);
+
+      if (PyErr_Occurred()) {
+        if (firstBuildFailed) {
+          // Retry also failed — propagate the original error.
+          PyErr_Restore(orig_type, orig_value, orig_tb);
+          return NULL;
+        } else {
+          // retry failed but got good kernel at first time.
+          // Just clear the build error log.
+          PyErr_Clear();
+          if (debugEnabled)
+            std::cout << "(I): Rebuild failed. Just use previous kernel"
+                      << std::endl;
+          // construct previous working version
+          build_flags = BuildFlags(build_flags_ptr);
+        }
+      } else {
+        if (firstBuildFailed) {
+          // Retry succeeded — discard the saved original error.
+          Py_XDECREF(orig_type);
+          Py_XDECREF(orig_value);
+          Py_XDECREF(orig_tb);
+
+          // Always print recovery message to stderr to follow up on the
+          // "L0 build module failed" error that was already printed.
+          std::cerr
+              << "(I): Build failure recovered by retrying with large GRF "
+                 "mode for \""
+              << kernel_name << "\"" << std::endl;
+        } else {
+          // clean up the unused module and kernel.
+          auto error_no = zeKernelDestroy(l0_kernel);
+          if (error_no != ZE_RESULT_SUCCESS) {
+            PyErr_WarnEx(
+                PyExc_RuntimeWarning,
+                "[Ignoring] Intel - Error during destroy unused L0 kernel", 1);
+          }
+          error_no = zeModuleDestroy(l0_module);
+          if (error_no != ZE_RESULT_SUCCESS) {
+            PyErr_WarnEx(
+                PyExc_RuntimeWarning,
+                "[Ignoring] Intel - Error during destroy unused L0 module", 1);
+          }
+        }
+        l0_module = l0_module_retry;
+        l0_kernel = l0_kernel_retry;
+        n_spills = n_spills_retry;
 
         if (debugEnabled)
-          std::cout << "(I): Kernel has now " << n_spills_dgrf << " spills"
-                    << std::endl;
-
-        std::swap(l0_module, l0_module_dgrf);
-        std::swap(l0_kernel, l0_kernel_dgrf);
-        std::swap(n_spills, n_spills_dgrf);
-
-        // clean up the unused module and kernel.
-        auto error_no = zeKernelDestroy(l0_kernel_dgrf);
-        if (error_no != ZE_RESULT_SUCCESS) {
-          PyErr_WarnEx(
-              PyExc_RuntimeWarning,
-              "[Ignoring] Intel - Error during destroy unused L0 kernel", 1);
-        }
-        error_no = zeModuleDestroy(l0_module_dgrf);
-        if (error_no != ZE_RESULT_SUCCESS) {
-          PyErr_WarnEx(
-              PyExc_RuntimeWarning,
-              "[Ignoring] Intel - Error during destroy unused L0 module", 1);
-        }
-      } catch (const std::exception &e) {
-        char buf[1024] = {0};
-        strcat(buf, "[Ignoring] Intel - Error during Intel loadBinary with "
-                    "large registers: ");
-        strcat(buf, e.what());
-        PyErr_WarnEx(PyExc_RuntimeWarning, buf, 1);
-        // construct previous working version
-        build_flags = BuildFlags(build_flags_ptr);
+          std::cout << "(I): Retry with large GRF succeeded, kernel has "
+                    << n_spills << " spills" << std::endl;
       }
+    } catch (const std::exception &e) {
+      if (firstBuildFailed) {
+        // Retry also failed — propagate the original error.
+        PyErr_Restore(orig_type, orig_value, orig_tb);
+        return NULL;
+      }
+      PyErr_WarnFormat(PyExc_RuntimeWarning, 1,
+                       "[Ignoring] Intel - Error during Intel loadBinary with "
+                       "large registers: %s",
+                       e.what());
+      // construct previous working version
+      build_flags = BuildFlags(build_flags_ptr);
     }
   }
 


### PR DESCRIPTION
This PR refactors the Intel Level Zero kernel/module compilation path to reduce duplicated logic by (1) adding centralized cleanup for partially-created objects and (2) unifying the “retry with large GRF” rebuild logic for both initial build failures and excessive register spilling.