### PR TITLE
[NIT] Rebuild the kernel with large GRF size to reduce the register spilling size aggressively.

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -79,7 +79,7 @@ class XPUOptions:
 
 
 # Aligned with max_reg_spill in third_party/intel/backend/driver.c
-MAX_REG_SPILL = 1000
+MAX_REG_SPILL = 0
 
 SPILL_SIZE_RE = re.compile(r'spill_size\s*[:=]\s*(\d+)')
 PTSS_OVERFLOW_RE = re.compile(

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -511,7 +511,7 @@ extern "C" EXPORT_FUNC PyObject *load_binary(PyObject *args) {
   }
 
   const bool debugEnabled = getBoolEnv("TRITON_DEBUG");
-  constexpr int32_t max_reg_spill = 1000;
+  constexpr int32_t max_reg_spill = 0;
 
   if (canRetryWithLargeGRF && (firstBuildFailed || n_spills > max_reg_spill)) {
     PyObject *orig_type = nullptr, *orig_value = nullptr, *orig_tb = nullptr;


### PR DESCRIPTION
Rebuild the kernel with large GRF size to reduce the register spilling size aggressively.