### PR TITLE
Bucket unified attention autotuning by Q and KV length

### DIFF
--- a/benchmarks/triton_kernels_benchmark/vllm/unified_attention/unified_attention.patch
+++ b/benchmarks/triton_kernels_benchmark/vllm/unified_attention/unified_attention.patch
@@ -61,7 +61,7 @@ index b2667935c..678d938b6 100644
      right = num_seqs
      while left < right:
 diff --git a/vllm/v1/attention/ops/triton_unified_attention.py b/vllm/v1/attention/ops/triton_unified_attention.py
-index 93622957b..431b24945 100644
+index 93622957b..3177aaa58 100644
 --- a/vllm/v1/attention/ops/triton_unified_attention.py
 +++ b/vllm/v1/attention/ops/triton_unified_attention.py
 @@ -7,8 +7,6 @@
@@ -73,7 +73,7 @@ index 93622957b..431b24945 100644
  import torch
  
  import vllm.envs as envs
-@@ -175,6 +173,62 @@ def _store_output_td(
+@@ -175,6 +173,85 @@ def _store_output_td(
      )
  
  
@@ -82,6 +82,27 @@ index 93622957b..431b24945 100644
 +    for block_m in (16, 32, 64)
 +]
 +
++
++def q_len_bucket(max_seqlen_q):
++    if max_seqlen_q <= 1:
++        return 0  # decode
++    if max_seqlen_q <= 16:
++        return 1  # chunk tail / tiny prefill
++    if max_seqlen_q <= 512:
++        return 2  # medium prefill
++    return 3  # large prefill
++
++
++def kv_len_bucket(max_seqlen_k):
++    if max_seqlen_k <= 256:
++        return 0
++    if max_seqlen_k <= 1024:
++        return 1
++    if max_seqlen_k <= 4096:
++        return 2
++    return 3
++
++
 +ATTENTION_AUTOTUNE_KEY = [
 +    "BLOCK_SIZE",
 +    "HEAD_SIZE",
@@ -89,6 +110,8 @@ index 93622957b..431b24945 100644
 +    "num_queries_per_kv",
 +    "USE_TD",
 +    "USE_TD_QO",
++    "Q_LEN_BUCKET",
++    "KV_LEN_BUCKET",
 +]
 +
 +
@@ -136,7 +159,14 @@ index 93622957b..431b24945 100644
  @triton.jit
  def kernel_unified_attention(
      # Output destination for the 2D path.  In 3D mode per-segment partials
-@@ -290,6 +344,9 @@ def kernel_unified_attention(
+@@ -285,11 +362,16 @@ def kernel_unified_attention(
+     USE_TD: tl.constexpr = False,
+     USE_TD_QO: tl.constexpr = False,
+     Q_IS_FP8: tl.constexpr = False,
++    Q_LEN_BUCKET: tl.constexpr = 0,
++    KV_LEN_BUCKET: tl.constexpr = 0,
+     # Gemma4: clamp mm_prefix bidirectional ranges by the sliding window
+     # instead of letting them override it. Default False preserves the
      # original (causal AND SW) OR mm_prefix behavior for all other models.
      MM_PREFIX_CLAMP_SW: tl.constexpr = False,
  ):
@@ -146,7 +176,7 @@ index 93622957b..431b24945 100644
      # Per-(token, head) scale caches: used iff KV_QUANT_MODE in {2, 3}.
      USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = (KV_QUANT_MODE >= 2) and (
          KV_QUANT_MODE <= 3
-@@ -534,12 +591,12 @@ def kernel_unified_attention(
+@@ -534,12 +616,12 @@ def kernel_unified_attention(
  
          # S : (BLOCK_M, TILE_SIZE)
          S = tl.zeros(shape=(BLOCK_M, TILE_SIZE), dtype=tl.float32)
@@ -163,7 +193,7 @@ index 93622957b..431b24945 100644
  
          if USE_SOFTCAP:
              S = apply_softcap(S, softcap)
-@@ -561,27 +618,14 @@ def kernel_unified_attention(
+@@ -561,27 +643,14 @@ def kernel_unified_attention(
          M, L, P, alpha = softmax_step(S, M, L)
          acc = acc * alpha[:, None]
  
@@ -195,7 +225,7 @@ index 93622957b..431b24945 100644
  
      # ---- Epilogue ---------------------------------------------------------
      if IS_3D:
-@@ -699,7 +743,6 @@ def reduce_segments(
+@@ -699,7 +768,6 @@ def reduce_segments(
      HEAD_SIZE: tl.constexpr,  # int, must be power of 2
      HEAD_SIZE_PADDED: tl.constexpr,  # int, must be power of 2
      query_start_len_ptr,  # [num_seqs+1]
@@ -203,7 +233,7 @@ index 93622957b..431b24945 100644
      NUM_SEGMENTS_PER_SEQ: tl.constexpr,  # int
      USE_FP8: tl.constexpr,  # bool
      FP8_MIN: tl.constexpr = float8_info.min,
-@@ -709,7 +752,7 @@ def reduce_segments(
+@@ -709,7 +777,7 @@ def reduce_segments(
      query_head_idx = tl.program_id(1)
  
      seq_idx = find_seq_idx(
@@ -212,7 +242,7 @@ index 93622957b..431b24945 100644
      )
  
      # sequence len for this particular sequence
-@@ -929,11 +972,6 @@ def unified_attention(
+@@ -929,11 +997,6 @@ def unified_attention(
      num_queries_per_kv = num_query_heads // num_kv_heads
      head_size = q.shape[2]
  
@@ -224,7 +254,7 @@ index 93622957b..431b24945 100644
      # Tuned launch parameters; ``None`` lets Triton pick its defaults.
      launch_num_warps: int | None = None
      launch_num_stages: int | None = None
-@@ -949,22 +987,9 @@ def unified_attention(
+@@ -949,22 +1012,9 @@ def unified_attention(
          and current_platform.is_device_capability_family(100)
      )
      if tuned_large_head:
@@ -247,7 +277,7 @@ index 93622957b..431b24945 100644
      sliding_window_val = 1 + window_size[0] if window_size[0] >= 0 else 0
  
      # Compute chunked block size from sliding window if needed.
-@@ -975,12 +1000,16 @@ def unified_attention(
+@@ -975,12 +1025,16 @@ def unified_attention(
      elif sliding_window_val <= 0:
          chunk_lookback = -1
  
@@ -270,7 +300,17 @@ index 93622957b..431b24945 100644
  
      # Wider KV tile for the tuned large-head path (see above). Only the 2D
      # path (used when max_seqlen_q > 1) reads TILE_SIZE_PREFILL.
-@@ -1036,18 +1065,11 @@ def unified_attention(
+@@ -994,7 +1048,8 @@ def unified_attention(
+     if use_td:
+         TILE_SIZE_PREFILL = min(TILE_SIZE_PREFILL, block_size)
+         TILE_SIZE_DECODE = min(TILE_SIZE_DECODE, block_size)
+-
++    q_len_bucket_val = q_len_bucket(max_seqlen_q)
++    kv_len_bucket_val = kv_len_bucket(max_seqlen_k)
+     # Tensor descriptors for Q load / output store require every element
+     # of ``block_shape`` to be a power of 2.  ``num_queries_per_kv`` is
+     # not always pow2 (e.g. Qwen2-7B: 28 / 4 = 7), so gate the Q/O paths
+@@ -1036,18 +1091,11 @@ def unified_attention(
      # Launch the 2D kernel if
      # 1. No intermediate tiled softmax buffers for the 3D kernel have been allocated, or
      # 2. The batch includes at least one prefill request, or
@@ -294,7 +334,7 @@ index 93622957b..431b24945 100644
  
      # The kernel signature is the same for 2D and 3D — only the launch
      # grid + a handful of constexpr toggles differ.  Per-token-head scale
-@@ -1068,17 +1090,57 @@ def unified_attention(
+@@ -1068,17 +1116,57 @@ def unified_attention(
          v_scale_ptr = None
      # 3D needs real segm tensors; 2D never touches them.  Pass ``None`` in
      # 2D mode so Triton can skip materialising these pointer arguments.
@@ -355,7 +395,7 @@ index 93622957b..431b24945 100644
          tile_size = TILE_SIZE_DECODE
  
      launch_kwargs: dict[str, int] = {}
-@@ -1150,9 +1212,7 @@ def unified_attention(
+@@ -1150,12 +1238,12 @@ def unified_attention(
          stride_vs_slot=vs_slot,
          stride_vs_head=vs_head,
          query_start_len_ptr=cu_seqlens_q,
@@ -365,7 +405,12 @@ index 93622957b..431b24945 100644
          NUM_SEGMENTS_PER_SEQ=num_segments,
          USE_FP8=output_scale is not None,
          IS_3D=use_3d,
-@@ -1183,7 +1243,6 @@ def unified_attention(
++        Q_LEN_BUCKET=q_len_bucket_val,
++        KV_LEN_BUCKET=kv_len_bucket_val,
+         KV_QUANT_MODE=kv_quant_mode,
+         Q_IS_FP8=(q.dtype == current_platform.fp8_dtype()),
+         CHUNK_LOOKBACK=chunk_lookback,
+@@ -1183,7 +1271,6 @@ def unified_attention(
              HEAD_SIZE=head_size,
              HEAD_SIZE_PADDED=head_size_padded,
              query_start_len_ptr=cu_seqlens_q,

--- a/benchmarks/triton_kernels_benchmark/vllm/unified_attention/unified_attention.patch
+++ b/benchmarks/triton_kernels_benchmark/vllm/unified_attention/unified_attention.patch
@@ -61,7 +61,7 @@ index b2667935c..678d938b6 100644
      right = num_seqs
      while left < right:
 diff --git a/vllm/v1/attention/ops/triton_unified_attention.py b/vllm/v1/attention/ops/triton_unified_attention.py
-index 93622957b..3177aaa58 100644
+index 93622957b..b3e348f71 100644
 --- a/vllm/v1/attention/ops/triton_unified_attention.py
 +++ b/vllm/v1/attention/ops/triton_unified_attention.py
 @@ -7,8 +7,6 @@
@@ -73,7 +73,7 @@ index 93622957b..3177aaa58 100644
  import torch
  
  import vllm.envs as envs
-@@ -175,6 +173,85 @@ def _store_output_td(
+@@ -175,6 +173,87 @@ def _store_output_td(
      )
  
  
@@ -100,7 +100,9 @@ index 93622957b..3177aaa58 100644
 +        return 1
 +    if max_seqlen_k <= 4096:
 +        return 2
-+    return 3
++    if max_seqlen_k <= 8192:
++        return 3
++    return 4
 +
 +
 +ATTENTION_AUTOTUNE_KEY = [
@@ -159,7 +161,7 @@ index 93622957b..3177aaa58 100644
  @triton.jit
  def kernel_unified_attention(
      # Output destination for the 2D path.  In 3D mode per-segment partials
-@@ -285,11 +362,16 @@ def kernel_unified_attention(
+@@ -285,11 +364,16 @@ def kernel_unified_attention(
      USE_TD: tl.constexpr = False,
      USE_TD_QO: tl.constexpr = False,
      Q_IS_FP8: tl.constexpr = False,
@@ -176,7 +178,7 @@ index 93622957b..3177aaa58 100644
      # Per-(token, head) scale caches: used iff KV_QUANT_MODE in {2, 3}.
      USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = (KV_QUANT_MODE >= 2) and (
          KV_QUANT_MODE <= 3
-@@ -534,12 +616,12 @@ def kernel_unified_attention(
+@@ -534,12 +618,12 @@ def kernel_unified_attention(
  
          # S : (BLOCK_M, TILE_SIZE)
          S = tl.zeros(shape=(BLOCK_M, TILE_SIZE), dtype=tl.float32)
@@ -193,7 +195,7 @@ index 93622957b..3177aaa58 100644
  
          if USE_SOFTCAP:
              S = apply_softcap(S, softcap)
-@@ -561,27 +643,14 @@ def kernel_unified_attention(
+@@ -561,27 +645,14 @@ def kernel_unified_attention(
          M, L, P, alpha = softmax_step(S, M, L)
          acc = acc * alpha[:, None]
  
@@ -225,7 +227,7 @@ index 93622957b..3177aaa58 100644
  
      # ---- Epilogue ---------------------------------------------------------
      if IS_3D:
-@@ -699,7 +768,6 @@ def reduce_segments(
+@@ -699,7 +770,6 @@ def reduce_segments(
      HEAD_SIZE: tl.constexpr,  # int, must be power of 2
      HEAD_SIZE_PADDED: tl.constexpr,  # int, must be power of 2
      query_start_len_ptr,  # [num_seqs+1]
@@ -233,7 +235,7 @@ index 93622957b..3177aaa58 100644
      NUM_SEGMENTS_PER_SEQ: tl.constexpr,  # int
      USE_FP8: tl.constexpr,  # bool
      FP8_MIN: tl.constexpr = float8_info.min,
-@@ -709,7 +777,7 @@ def reduce_segments(
+@@ -709,7 +779,7 @@ def reduce_segments(
      query_head_idx = tl.program_id(1)
  
      seq_idx = find_seq_idx(
@@ -242,7 +244,7 @@ index 93622957b..3177aaa58 100644
      )
  
      # sequence len for this particular sequence
-@@ -929,11 +997,6 @@ def unified_attention(
+@@ -929,11 +999,6 @@ def unified_attention(
      num_queries_per_kv = num_query_heads // num_kv_heads
      head_size = q.shape[2]
  
@@ -254,7 +256,7 @@ index 93622957b..3177aaa58 100644
      # Tuned launch parameters; ``None`` lets Triton pick its defaults.
      launch_num_warps: int | None = None
      launch_num_stages: int | None = None
-@@ -949,22 +1012,9 @@ def unified_attention(
+@@ -949,22 +1014,9 @@ def unified_attention(
          and current_platform.is_device_capability_family(100)
      )
      if tuned_large_head:
@@ -277,7 +279,7 @@ index 93622957b..3177aaa58 100644
      sliding_window_val = 1 + window_size[0] if window_size[0] >= 0 else 0
  
      # Compute chunked block size from sliding window if needed.
-@@ -975,12 +1025,16 @@ def unified_attention(
+@@ -975,12 +1027,16 @@ def unified_attention(
      elif sliding_window_val <= 0:
          chunk_lookback = -1
  
@@ -300,7 +302,7 @@ index 93622957b..3177aaa58 100644
  
      # Wider KV tile for the tuned large-head path (see above). Only the 2D
      # path (used when max_seqlen_q > 1) reads TILE_SIZE_PREFILL.
-@@ -994,7 +1048,8 @@ def unified_attention(
+@@ -994,7 +1050,8 @@ def unified_attention(
      if use_td:
          TILE_SIZE_PREFILL = min(TILE_SIZE_PREFILL, block_size)
          TILE_SIZE_DECODE = min(TILE_SIZE_DECODE, block_size)
@@ -310,7 +312,7 @@ index 93622957b..3177aaa58 100644
      # Tensor descriptors for Q load / output store require every element
      # of ``block_shape`` to be a power of 2.  ``num_queries_per_kv`` is
      # not always pow2 (e.g. Qwen2-7B: 28 / 4 = 7), so gate the Q/O paths
-@@ -1036,18 +1091,11 @@ def unified_attention(
+@@ -1036,18 +1093,11 @@ def unified_attention(
      # Launch the 2D kernel if
      # 1. No intermediate tiled softmax buffers for the 3D kernel have been allocated, or
      # 2. The batch includes at least one prefill request, or
@@ -334,7 +336,7 @@ index 93622957b..3177aaa58 100644
  
      # The kernel signature is the same for 2D and 3D — only the launch
      # grid + a handful of constexpr toggles differ.  Per-token-head scale
-@@ -1068,17 +1116,57 @@ def unified_attention(
+@@ -1068,17 +1118,57 @@ def unified_attention(
          v_scale_ptr = None
      # 3D needs real segm tensors; 2D never touches them.  Pass ``None`` in
      # 2D mode so Triton can skip materialising these pointer arguments.
@@ -395,7 +397,7 @@ index 93622957b..3177aaa58 100644
          tile_size = TILE_SIZE_DECODE
  
      launch_kwargs: dict[str, int] = {}
-@@ -1150,12 +1238,12 @@ def unified_attention(
+@@ -1150,12 +1240,12 @@ def unified_attention(
          stride_vs_slot=vs_slot,
          stride_vs_head=vs_head,
          query_start_len_ptr=cu_seqlens_q,
@@ -410,7 +412,7 @@ index 93622957b..3177aaa58 100644
          KV_QUANT_MODE=kv_quant_mode,
          Q_IS_FP8=(q.dtype == current_platform.fp8_dtype()),
          CHUNK_LOOKBACK=chunk_lookback,
-@@ -1183,7 +1271,6 @@ def unified_attention(
+@@ -1183,7 +1273,6 @@ def unified_attention(
              HEAD_SIZE=head_size,
              HEAD_SIZE_PADDED=head_size_padded,
              query_start_len_ptr=cu_seqlens_q,


### PR DESCRIPTION
## Summary

This PR adds query and KV-length buckets to the unified attention autotune key.

This better prevents different workloads from reusing a suboptimal `BLOCK_M` selected by an earlier tuned shape.

## Results

CI inputs benchmarked locally and with CI BMG B580, showing speedups. This branch was benchmarked against ua-autotune-fix branch, which directly precedes it in the PR stack.

BMG local testing: 
5.19% BF16 latency reduction (geomean)
~0% Fp8 latency reduction (geomean)
Total time spent autotuning increases from 29.49 to 48.69 seconds per one complete run through all 87 BF16 CI cases

BMG CI:
https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/34153609341/job/101860001305?pr=7619
