### PR TITLE
Fix regression that the transpose block IO is not used for column major matrix.

### DIFF
--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
@@ -171,3 +171,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     tt.return %0 : tensor<32x64xf16, #dot1>
   }
 }
+
+// -----
+
+// COM: Test case for regression where column_major of tt.descriptor_load with dot_op A encoding was not
+// COM: generating the correct triton_gen.2Dblockload instruction.
+#mma = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 1], repCluster = [2, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @descriptor_load_column_major_dota
+  tt.func @descriptor_load_column_major_dota(%k: !tt.ptr<bf16>, %T_3: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c0 = arith.constant 0 : index
+    %c2 = arith.constant 2 : index
+    %c1 = arith.constant 1 : index
+    %c64_i32 = arith.constant 64 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %c4096_i64 = arith.constant 4096 : i64
+
+    %k_desc = tt.make_tensor_descriptor %k, [%T_3, %c128_i32], [%c4096_i64, %c1_i64] : <bf16>, <64x64xbf16>
+    // CHECK: ttig.2d_block_load
+    // CHECK-SAME: {column_major}
+    %b_k = tt.descriptor_load %k_desc[%c0_i32, %c0_i32] {ttig.block_io = "column_major", ttig.desc_padding = 1 : i32} : !tt.tensordesc<64x64xbf16> -> tensor<64x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -498,7 +498,7 @@ bool transposeWithBitcast(MLIRContext *ctx, const LinearLayout &srcLayout,
                           const LinearLayout &dstLayout) {
   StringAttr kRegister = StringAttr::get(ctx, "register");
   StringAttr kLane = StringAttr::get(ctx, "lane");
-  // Conservatively check the bit cast layout changes limitation.
+  // Conservatively check the bitcast layout changes limitation.
   // 1st: No lane to reg mapping or vise versa.
   // 2nd: lane to lane mapping has to be identical.
   // 3rc: reg to reg mapping has to be identical.

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -494,6 +494,23 @@ DpasEncodingAttr getDpasLayout(RankedTensorType tensorTy) {
           : cast<triton::gpu::DotOperandEncodingAttr>(encoding).getParent());
 }
 
+bool transposeWithBitcast(MLIRContext *ctx, const LinearLayout &srcLayout,
+                          const LinearLayout &dstLayout) {
+  StringAttr kRegister = StringAttr::get(ctx, "register");
+  StringAttr kLane = StringAttr::get(ctx, "lane");
+  // Conservatively check the bit cast layout changes limitation.
+  // 1st: No lane to reg mapping or vise versa.
+  // 2nd: lane to lane mapping has to be identical.
+  // 3rc: reg to reg mapping has to be identical.
+  LinearLayout comp = srcLayout.invertAndCompose(dstLayout);
+  if (!comp.sublayout({kLane}, {kLane}).isIdentityOnOutDim(kLane) ||
+      !comp.sublayout({kRegister}, {kRegister}).isIdentityOnOutDim(kRegister) ||
+      !comp.sublayoutIsZero({kLane}, {kRegister}) ||
+      !comp.sublayoutIsZero({kRegister}, {kLane}))
+    return false;
+  return true;
+}
+
 FailureOr<LinearLayout> computeTransposeShuffleMapping(
     RankedTensorType tensorType, const LinearLayout &regMapping,
     int64_t numElemsPerLoad, const BlockIOTileSizeInfo &sizeInfo,
@@ -571,6 +588,11 @@ FailureOr<LinearLayout> computeTransposeShuffleMapping(
                                            dims[sizeInfo.colDim]};
     LinearLayout blockLoadLayoutWithInSubgroup =
         llEncoding->sublayout({kRegister, kLane}, loadDimName);
+
+    auto comp =
+        regMapping * LinearLayout::identity1D(threadsPerWarp, kLane, kLane);
+    blockLoadLayoutWithInSubgroup = comp.compose(blockLoadLayoutWithInSubgroup);
+
     LinearLayout expectedLoadUnpackLayout =
         blockLoadLayoutWithInSubgroup
             .resizeOutDim(dims[sizeInfo.rowDim],
@@ -621,7 +643,8 @@ FailureOr<LinearLayout> computeTransposeShuffleMapping(
       std::swap(loadDimName[0], loadDimName[1]);
       transPackedLayout = transPackedLayout.transposeOuts(loadDimName);
     }
-    if (transPackedLayout != expectedLoadUnpackLayout) {
+    if (!transposeWithBitcast(ctx, transPackedLayout,
+                              expectedLoadUnpackLayout)) {
       // Improve this. The current 2D block load only transposes the matrix at
       // i32 granularity. We still need to perform an additional in-register
       // transpose from i32 -> (N × ElemSizeInBits) tiles, using the tile width.


### PR DESCRIPTION
Fix regression that the transpose block IO is not used for column major matrix.