### PR TITLE
[XPU] Fix fp4_to_fp to produce correct amount of outputs when lowering to llvm

### DIFF
--- a/test/TritonIntelGPU/fp4tofp-linear-fallback.mlir
+++ b/test/TritonIntelGPU/fp4tofp-linear-fallback.mlir
@@ -1,0 +1,33 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm -canonicalize | FileCheck %s
+
+// Regression test: fp4_to_fp fallback path when the input tensor is loaded
+// as packed i32 words (sizePerThread=8 forces a vector<2xi32> descriptor load).
+// Each i32 holds 4 packed i8 values; the lowering must extract all 4 nibbles
+// per element (not 2), producing 16 bf16 outputs for 8 input bytes.
+
+#blocked = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [16], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+module attributes {triton_intel_gpu.support_bfloat16_conversion, triton_intel_gpu.support_subgroup_matrix_multiply_accumulate, triton_intel_gpu.support_2d_block_io, triton_intel_gpu.target_arch = "spir64", ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 16384 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @fp4_vec2xi32_path(%src_ptr: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %dst_ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32}) {
+    %c1_i64 = arith.constant 1 : i64
+    %c8_i32 = arith.constant 8 : i32
+    %c16_i32 = arith.constant 16 : i32
+    %c1024_i32 = arith.constant 1024 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c8_i32 : i32
+    %2 = tt.make_tensor_descriptor %src_ptr, [%c1024_i32], [%c1_i64] : <i8>, !tt.tensordesc<8xi8, #blocked>
+    %3 = tt.descriptor_load %2[%1] : !tt.tensordesc<8xi8, #blocked> -> tensor<8xi8, #blocked>
+    %4 = ttg.fp4_to_fp %3 {axis = 0 : i32} : tensor<8xi8, #blocked> -> tensor<16xbf16, #blocked1>
+    %5 = arith.muli %0, %c16_i32 : i32
+    %6 = tt.make_tensor_descriptor %dst_ptr, [%c1024_i32], [%c1_i64] : <bf16>, !tt.tensordesc<16xbf16, #blocked1>
+    tt.descriptor_store %6[%5], %4 : !tt.tensordesc<16xbf16, #blocked1>, tensor<16xbf16, #blocked1>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: llvm.func {{.*}}@fp4_vec2xi32_path
+// COM: Table-lookup fallback used (hardware builtin requires explicit capability).
+// CHECK-NOT: __builtin_spirv_ConvertE2M1ToBF16INTEL
+// COM: 16 bf16 results written (8 i8 inputs x 2 nibbles each):
+// CHECK-COUNT-16: llvm.extractelement {{.*}} : vector<16xbf16>

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/Fp4ToFpOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/Fp4ToFpOpToLLVM.cpp
@@ -113,7 +113,8 @@ public:
         results.push_back(b.extract_element(table, idx1));
         results.push_back(b.extract_element(table, idx2));
       } else if (vecTy.getElementType() == b.builder->getI32Type()) {
-        ShapedType i8VecTy = VectorType::get(4, i8Ty);
+        VectorType i8VecTy = VectorType::get(4, i8Ty);
+        int32_t numI8Elements = i8VecTy.getNumElements();
         Value andVect =
             b.dense_val(vecTy, b.builder->getI32IntegerAttr(0x0F0F0F0F));
         Value shVec = b.dense_val(vecTy, b.builder->getI32IntegerAttr(4));
@@ -126,8 +127,7 @@ public:
           Value i2 = b.extract_element(i32IdxVec2, idx);
           Value idxVec1 = b.bitcast(i1, i8VecTy);
           Value idxVec2 = b.bitcast(i2, i8VecTy);
-          extractFloats(b, idxVec1, idxVec2, vecTy.getNumElements(), results,
-                        table);
+          extractFloats(b, idxVec1, idxVec2, numI8Elements, results, table);
         }
       } else {
         assert(vecTy.getElementType() == i8Ty);


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)


This PR fixes a latent FP4 lowering bug in the Intel fallback path for Fp4ToFpOp where the vec<Nxi32> branch passed the wrong element count into extractFloats, using the parent i32 vector width (for example, 2) instead of the actual bitcast vec<4xi8> width (4). Under the upstream "broadcastScale" flow that propagates LinearEncodingAttr, this caused fp4_to_fp to emit only half of the required unpacked values (128 instead of 256), which then triggered the packLLElements fatal size-mismatch during TTGIR→LLVM lowering. The fix is a one-line correction to derive the size from i8VecTy plus a lit test that exercises this code path directly.

