### PR TITLE
Improve the remove layout in handling loop op.

### DIFF
--- a/test/TritonIntelGPU/RemoveLayoutConversions/remove_layout_conversions_7625.mlir
+++ b/test/TritonIntelGPU/RemoveLayoutConversions/remove_layout_conversions_7625.mlir
@@ -1,0 +1,56 @@
+// RUN: triton-opt %s -split-input-file -tritonintelgpu-remove-layout-conversions 2>&1 | FileCheck %s
+
+// COM: https://github.com/intel/intel-xpu-backend-for-triton/issues/7625
+// COM: There is an inefficient issue in the RemoveLayout optimization for the loop.
+// COM: The structured loop return values and loop iteration arguments are duplicated during backward rematerialization,
+// COM: which causes the loop body to be duplicated in the final result.a
+
+// CHECK: #[[$ATTR_0:.+]] = #ttg.linear<{register = {{\[\[0, 1\], \[0, 2\], \[0, 4\], \[0, 8\]\],}} lane = {{\[\[1, 0\], \[2, 0\], \[4, 0\], \[8, 0\]\],}} warp = {{\[\[0, 16\], \[0, 32\]\],}}
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 2], warpsPerCTA = [1, 4], order = [0, 1]}>
+#mma = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 1], repCluster = [2, 1], A = [16, 16], B = [16, 16], C = [16, 16]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io, ttig.support_subgroup_matrix_multiply_accumulate} {
+  // CHECK-LABEL: chunk_gated_delta_rule_fwd_kernel_h_blockdim64
+  tt.func public @chunk_gated_delta_rule_fwd_kernel_h_blockdim64(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.tensordesc<64x64xbf16>, %arg3: !tt.tensordesc<64x16xbf16>, %arg4: !tt.tensordesc<64x64xbf16>) attributes {noinline = false} {
+    %cst = arith.constant dense<0.000000e+00> : tensor<16x64xf32, #blocked>
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<64x16xf32, #mma>
+    %c32_i32 = arith.constant 32 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c128_i64 = arith.constant 128 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    // CHECK:  scf.for %[[VAL_0:.*]] = {{.*}} to {{.*}} step {{.*}} iter_args(%[[VAL_1:.*]] = {{.*}}) -> (tensor<16x64xf32, {{.*}}>)  : i32 {
+    %0 = scf.for %arg5 = %c0_i32 to %c32_i32 step %c1_i32 iter_args(%arg6 = %cst) -> (tensor<16x64xf32, #blocked>)  : i32 {
+      %2 = tt.make_tensor_descriptor %arg0, [%c128_i32, %c128_i32], [%c128_i64, %c1_i64] : <bf16>, <16x64xbf16>
+      %3 = arith.truncf %arg6 : tensor<16x64xf32, #blocked> to tensor<16x64xbf16, #blocked>
+      tt.descriptor_store %2[%c0_i32, %c0_i32], %3 {ttig.block_io = "row_major", ttig.desc_padding = 1 : i32} : !tt.tensordesc<16x64xbf16>, tensor<16x64xbf16, #blocked>
+      %4 = arith.muli %arg5, %c64_i32 : i32
+      // CHECK: tt.descriptor_store {{.*}} : !tt.tensordesc<16x64xbf16>, tensor<16x64xbf16, #[[$ATTR_0]]>
+      %5 = tt.descriptor_load %arg2[%4, %c0_i32] {ttig.block_io = "row_major", ttig.desc_padding = 1 : i32} : !tt.tensordesc<64x64xbf16> -> tensor<64x64xbf16, #blocked1>
+      %6 = tt.trans %arg6 {order = array<i32: 1, 0>} : tensor<16x64xf32, #blocked> -> tensor<64x16xf32, #blocked2>
+      %7 = arith.truncf %6 : tensor<64x16xf32, #blocked2> to tensor<64x16xbf16, #blocked2>
+      %8 = ttg.convert_layout %5 : tensor<64x64xbf16, #blocked1> -> tensor<64x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+      %9 = ttg.convert_layout %7 : tensor<64x16xbf16, #blocked2> -> tensor<64x16xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+      %10 = tt.dot %8, %9, %cst_0, inputPrecision = tf32 : tensor<64x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<64x16xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<64x16xf32, #mma>
+      %11 = ttg.convert_layout %10 : tensor<64x16xf32, #mma> -> tensor<64x16xf32, #blocked3>
+      %12 = arith.truncf %11 : tensor<64x16xf32, #blocked3> to tensor<64x16xbf16, #blocked3>
+      %13 = tt.descriptor_load %arg4[%4, %c0_i32] {ttig.block_io = "row_major", ttig.desc_padding = 1 : i32} : !tt.tensordesc<64x64xbf16> -> tensor<64x64xbf16, #blocked1>
+      %14 = tt.trans %13 {order = array<i32: 1, 0>} : tensor<64x64xbf16, #blocked1> -> tensor<64x64xbf16, #blocked4>
+      %15 = ttg.convert_layout %14 : tensor<64x64xbf16, #blocked4> -> tensor<64x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+      %16 = ttg.convert_layout %12 : tensor<64x16xbf16, #blocked3> -> tensor<64x16xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+      %17 = tt.dot %15, %16, %cst_0, inputPrecision = tf32 : tensor<64x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<64x16xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<64x16xf32, #mma>
+      %18 = ttg.convert_layout %17 : tensor<64x16xf32, #mma> -> tensor<64x16xf32, #blocked2>
+      %19 = tt.trans %18 {order = array<i32: 1, 0>} : tensor<64x16xf32, #blocked2> -> tensor<16x64xf32, #blocked>
+      scf.yield %19 : tensor<16x64xf32, #blocked>
+    }
+    %1 = tt.make_tensor_descriptor %arg1, [%c128_i32, %c128_i32], [%c128_i64, %c1_i64] : <f32>, <16x64xf32>
+    // CHECK: tt.descriptor_store {{.*}} : !tt.tensordesc<16x64xf32>, tensor<16x64xf32, #[[$ATTR_0]]>
+    tt.descriptor_store %1[%c0_i32, %c0_i32], %0 {ttig.block_io = "row_major", ttig.desc_padding = 1 : i32} : !tt.tensordesc<16x64xf32>, tensor<16x64xf32, #blocked>
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/RemoveLayoutConversions/remove_layout_conversions_7625.mlir
+++ b/test/TritonIntelGPU/RemoveLayoutConversions/remove_layout_conversions_7625.mlir
@@ -24,13 +24,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %c1_i64 = arith.constant 1 : i64
     %c0_i32 = arith.constant 0 : i32
     %c64_i32 = arith.constant 64 : i32
-    // CHECK:  scf.for %[[VAL_0:.*]] = {{.*}} to {{.*}} step {{.*}} iter_args(%[[VAL_1:.*]] = {{.*}}) -> (tensor<16x64xf32, {{.*}}>)  : i32 {
+    // CHECK-COUNT-1:  scf.for %[[VAL_0:.*]] = {{.*}} to {{.*}} step {{.*}} iter_args(%[[VAL_1:.*]] = {{.*}}) -> (tensor<16x64xf32, {{.*}}>)  : i32 {
+    // CHECK-NOT: scf.for
     %0 = scf.for %arg5 = %c0_i32 to %c32_i32 step %c1_i32 iter_args(%arg6 = %cst) -> (tensor<16x64xf32, #blocked>)  : i32 {
       %2 = tt.make_tensor_descriptor %arg0, [%c128_i32, %c128_i32], [%c128_i64, %c1_i64] : <bf16>, <16x64xbf16>
       %3 = arith.truncf %arg6 : tensor<16x64xf32, #blocked> to tensor<16x64xbf16, #blocked>
+      // CHECK: tt.descriptor_store {{.*}} : !tt.tensordesc<16x64xbf16>, tensor<16x64xbf16, #[[$ATTR_0]]>
       tt.descriptor_store %2[%c0_i32, %c0_i32], %3 {ttig.block_io = "row_major", ttig.desc_padding = 1 : i32} : !tt.tensordesc<16x64xbf16>, tensor<16x64xbf16, #blocked>
       %4 = arith.muli %arg5, %c64_i32 : i32
-      // CHECK: tt.descriptor_store {{.*}} : !tt.tensordesc<16x64xbf16>, tensor<16x64xbf16, #[[$ATTR_0]]>
+      // CHECK-COUNT-1: tt.descriptor_load
+      // CHECK-COUNT-1: tt.dot
       %5 = tt.descriptor_load %arg2[%4, %c0_i32] {ttig.block_io = "row_major", ttig.desc_padding = 1 : i32} : !tt.tensordesc<64x64xbf16> -> tensor<64x64xbf16, #blocked1>
       %6 = tt.trans %arg6 {order = array<i32: 1, 0>} : tensor<16x64xf32, #blocked> -> tensor<64x16xf32, #blocked2>
       %7 = arith.truncf %6 : tensor<64x16xf32, #blocked2> to tensor<64x16xbf16, #blocked2>
@@ -39,6 +42,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
       %10 = tt.dot %8, %9, %cst_0, inputPrecision = tf32 : tensor<64x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<64x16xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<64x16xf32, #mma>
       %11 = ttg.convert_layout %10 : tensor<64x16xf32, #mma> -> tensor<64x16xf32, #blocked3>
       %12 = arith.truncf %11 : tensor<64x16xf32, #blocked3> to tensor<64x16xbf16, #blocked3>
+      // CHECK-COUNT-1: tt.descriptor_load
+      // CHECK-COUNT-1: tt.dot
+      // CHECK-NOT: tt.descriptor_load
+      // CHECK-NOT: tt.dot
       %13 = tt.descriptor_load %arg4[%4, %c0_i32] {ttig.block_io = "row_major", ttig.desc_padding = 1 : i32} : !tt.tensordesc<64x64xbf16> -> tensor<64x64xbf16, #blocked1>
       %14 = tt.trans %13 {order = array<i32: 1, 0>} : tensor<64x64xbf16, #blocked1> -> tensor<64x64xbf16, #blocked4>
       %15 = ttg.convert_layout %14 : tensor<64x64xbf16, #blocked4> -> tensor<64x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
@@ -46,6 +53,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
       %17 = tt.dot %15, %16, %cst_0, inputPrecision = tf32 : tensor<64x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<64x16xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<64x16xf32, #mma>
       %18 = ttg.convert_layout %17 : tensor<64x16xf32, #mma> -> tensor<64x16xf32, #blocked2>
       %19 = tt.trans %18 {order = array<i32: 1, 0>} : tensor<64x16xf32, #blocked2> -> tensor<16x64xf32, #blocked>
+      // CHECK: scf.yield {{.*}} : tensor<16x64xf32, #[[$ATTR_0]]>
       scf.yield %19 : tensor<16x64xf32, #blocked>
     }
     %1 = tt.make_tensor_descriptor %arg1, [%c128_i32, %c128_i32], [%c128_i64, %c1_i64] : <f32>, <16x64xf32>

--- a/test/TritonIntelGPU/RemoveLayoutConversions/remove_layout_conversions_7625.mlir
+++ b/test/TritonIntelGPU/RemoveLayoutConversions/remove_layout_conversions_7625.mlir
@@ -3,7 +3,7 @@
 // COM: https://github.com/intel/intel-xpu-backend-for-triton/issues/7625
 // COM: There is an inefficient issue in the RemoveLayout optimization for the loop.
 // COM: The structured loop return values and loop iteration arguments are duplicated during backward rematerialization,
-// COM: which causes the loop body to be duplicated in the final result.a
+// COM: which causes the loop body to be duplicated in the final result.
 
 // CHECK: #[[$ATTR_0:.+]] = #ttg.linear<{register = {{\[\[0, 1\], \[0, 2\], \[0, 4\], \[0, 8\]\],}} lane = {{\[\[1, 0\], \[2, 0\], \[4, 0\], \[8, 0\]\],}} warp = {{\[\[0, 16\], \[0, 32\]\],}}
 #blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 4], warpsPerCTA = [1, 4], order = [0, 1]}>

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
@@ -699,8 +699,34 @@ struct TritonIntelGPUInferLayoutInterface
                        ArrayRef<int32_t> order, // trans order
                        Attribute &resultEncoding,
                        std::optional<Location> loc) const override {
-    // Not support TransOp on DPAS layout.
-    return failure();
+    auto *ctx = getDialect()->getContext();
+
+    if (shape.size() != order.size()) {
+      return emitOptionalError(loc, "shape and order rank do not match: ",
+                               shape.size(), " vs ", order.size());
+    }
+    auto checkRank = [&](unsigned rank) {
+      if (rank != order.size()) {
+        return emitOptionalError(loc, "rank of encoding does not match order: ",
+                                 rank, " vs ", order.size());
+      }
+      return success();
+    };
+
+    auto ll = toLinearLayout(shape, operandEncoding);
+    if (failed(checkRank(ll.getNumOutDims())))
+      return failure();
+    auto transposedLl = transposeLinearLayout(ll, order);
+    if (isa<DistributedEncodingTrait>(operandEncoding)) {
+      resultEncoding = inferEncodingFromLinearLayout(
+          ctx, std::move(transposedLl), operandEncoding);
+    } else {
+      return emitOptionalError(
+          loc,
+          "unsupported transpose encoding type of TritonIntelGPU dialect: ",
+          operandEncoding);
+    }
+    return success();
   }
 
   LogicalResult

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Dialect.cpp
@@ -699,6 +699,12 @@ struct TritonIntelGPUInferLayoutInterface
                        ArrayRef<int32_t> order, // trans order
                        Attribute &resultEncoding,
                        std::optional<Location> loc) const override {
+    // transpose(x, order=[0, 1, ...]) preserves the operand encoding.
+    if (isIota(order)) {
+      resultEncoding = operandEncoding;
+      return success();
+    }
+
     auto *ctx = getDialect()->getContext();
 
     if (shape.size() != order.size()) {

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -1402,6 +1402,9 @@ void LayoutRematerialization::propagateLayout(
              << ", which has layout:\n";
       DBGS() << "  " << layout << "\n";
       DBGS() << "changed: " << changed.size() << "\n";
+      for (auto &v : changed) {
+        DBGS().indent(2) << "value: " << v << "\n";
+      }
     });
 
     queue.insert(queue.end(), changed.begin(), changed.end());
@@ -1478,10 +1481,6 @@ void LayoutRematerialization::forwardPropagateRemat(
     Region *currentRegion = regQueue.front();
     regQueue.pop_front();
     for (Operation &op : currentRegion->getOps()) {
-      // The scf::ForOp and scf::IfOp are handled separately in
-      // rewriteSlice. Just skip those two ops here.
-      if (isa<scf::ForOp, scf::IfOp>(op))
-        continue;
 
       bool needRewrite = false;
       for (Value result : op.getResults()) {
@@ -1511,6 +1510,13 @@ void LayoutRematerialization::forwardPropagateRemat(
           continue;
         Value newOperand = getRematValue(operand, valuesToPropagate[operand]);
         assertOp->setOperand(0, newOperand);
+      } else if (auto descStore = dyn_cast<tt::DescriptorStoreOp>(&op)) {
+        // Only need to deal with the store value
+        Value operand = descStore.getSrc();
+        if (!valuesToPropagate.contains(operand))
+          continue;
+        Value newOperand = getRematValue(operand, valuesToPropagate[operand]);
+        descStore.getSrcMutable().assign(newOperand);
       }
 
       for (Region &R : op.getRegions())
@@ -1909,23 +1915,63 @@ void LayoutRematerialization::backwardRematerialization(
 
   // Build forward propagation candidates using pre-rewrite analysis.
   DenseMap<Value, Attribute> forwardPropagateCandidates;
-  for (Operation *op : sliceOps) {
-    bool isOpUsedOutsideSlice = llvm::any_of(op->getResults(), [&](Value v) {
-      return nonSliceOnlyValues.contains(v);
-    });
-    if (!isOpUsedOutsideSlice)
-      continue;
-    for (Value result : op->getResults()) {
-      for (Operation *user : result.getUsers()) {
-        if (user == convertOp)
-          continue;
-        Attribute encoding = layout[result];
-        if (encoding)
-          forwardPropagateCandidates[result] = encoding;
-        break;
+  for (Value v : slice) {
+    Operation *op = v.getDefiningOp();
+    if (!op) {
+      if (isa<BlockArgument>(v)) {
+        for (Operation *user : v.getUsers()) {
+          if (user == convertOp)
+            continue;
+          Attribute encoding = layout[v];
+          if (encoding)
+            forwardPropagateCandidates[v] = encoding;
+          break;
+        }
+
+        BlockArgument blockArg = cast<BlockArgument>(v);
+        Operation *parentOp = blockArg.getOwner()->getParentOp();
+        if (auto loopOp = dyn_cast<LoopLikeOpInterface>(parentOp)) {
+          OpOperand *operand = loopOp.getTiedLoopYieldedValue(blockArg);
+          if (!operand)
+            continue;
+          unsigned iterOpIdx = operand->getOperandNumber();
+          Value loopResult = loopOp->getResult(iterOpIdx);
+          for (Operation *user : loopResult.getUsers()) {
+            if (user == convertOp)
+              continue;
+            // Use the layout same as the block arg.
+            Attribute encoding = layout[v];
+            if (encoding)
+              forwardPropagateCandidates[loopResult] = encoding;
+            break;
+          }
+        }
+      }
+    } else {
+      bool isOpUsedOutsideSlice = llvm::any_of(op->getResults(), [&](Value v) {
+        return nonSliceOnlyValues.contains(v);
+      });
+      if (!isOpUsedOutsideSlice)
+        continue;
+      for (Value result : op->getResults()) {
+        for (Operation *user : result.getUsers()) {
+          if (user == convertOp)
+            continue;
+          Attribute encoding = layout[result];
+          if (encoding)
+            forwardPropagateCandidates[result] = encoding;
+          break;
+        }
       }
     }
   }
+
+  LLVM_DEBUG({
+    DBGS() << "  forwardPropagateCandidates: "
+           << forwardPropagateCandidates.size() << "\n";
+    for (const auto &[candidate, encoding] : forwardPropagateCandidates)
+      DBGS() << "    " << candidate << " -> " << encoding << "\n";
+  });
 
   // 5. Forward propagate remat values created during backward propagation.
   forwardPropagateRemat(forwardPropagateCandidates);

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -1520,7 +1520,16 @@ void LayoutRematerialization::forwardPropagateRemat(
         if (!valuesToPropagate.contains(operand))
           continue;
         Value newOperand = getRematValue(operand, valuesToPropagate[operand]);
-        assert(newOperand && "the value of the new layout couldn't be null");
+        if (!newOperand) {
+          LLVM_DEBUG({
+            DBGS()
+                << "forwardPropagateRemat no remet src value for desc store:\n";
+            DBGS().indent(2) << "origin src: " << operand << "\n";
+            DBGS().indent(2)
+                << "to layout:" << valuesToPropagate[operand] << "\n";
+          });
+          continue;
+        }
         descStore.getSrcMutable().assign(newOperand);
       }
 
@@ -1910,10 +1919,6 @@ void LayoutRematerialization::backwardRematerialization(
 
   // Compute external-use analysis before rewriteSlice mutates slice.
   auto nonSliceOnlyValues = getNonSliceOnlyValues(slice, convertOp);
-  SetVector<Operation *> sliceOps;
-  for (Value v : slice)
-    if (Operation *op = v.getDefiningOp())
-      sliceOps.insert(op);
 
   // 4. Rewrite the slice.
   rewriteSlice(slice, layout, convertOp);

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -1500,8 +1500,12 @@ void LayoutRematerialization::forwardPropagateRemat(
       }
 
       if (needRewrite) {
-        // Create the op with the new layout.
-        rewriteOp(&op, valuesToPropagate[op.getResult(0)]);
+        // The scf::ForOp and scf::IfOp are handled separately in
+        // rewriteSlice. Just skip those two ops here.
+        if (!isa<scf::ForOp, scf::IfOp>(op)) {
+          // Create the op with the new layout.
+          rewriteOp(&op, valuesToPropagate[op.getResult(0)]);
+        }
       } else if (auto assertOp = dyn_cast<tt::AssertOp>(&op)) {
         // Only need to deal with the first operand which is the condition
         // tensor.
@@ -1516,6 +1520,7 @@ void LayoutRematerialization::forwardPropagateRemat(
         if (!valuesToPropagate.contains(operand))
           continue;
         Value newOperand = getRematValue(operand, valuesToPropagate[operand]);
+        assert(newOperand && "the value of the new layout couldn't be null");
         descStore.getSrcMutable().assign(newOperand);
       }
 
@@ -1930,7 +1935,7 @@ void LayoutRematerialization::backwardRematerialization(
 
         BlockArgument blockArg = cast<BlockArgument>(v);
         Operation *parentOp = blockArg.getOwner()->getParentOp();
-        if (auto loopOp = dyn_cast<LoopLikeOpInterface>(parentOp)) {
+        if (auto loopOp = dyn_cast<scf::ForOp>(parentOp)) {
           OpOperand *operand = loopOp.getTiedLoopYieldedValue(blockArg);
           if (!operand)
             continue;


### PR DESCRIPTION
This PR improves the Intel GPU RemoveLayoutConversions pass to better handle loop-related values during backward/forward rematerialization, aiming to avoid duplicated loop bodies and improve kernel performance (referenced in issue https://github.com/intel/intel-xpu-backend-for-triton/issues/7604).

chunk_gated_delta_rule_fwd_kernel_h_blockdim64 kernel time 207us vs 235us in https://github.com/intel/intel-xpu-backend-for-triton/issues/7604