### PR TITLE
[Intel] Sync DecomposeScaledBlocked broadcastScale from upstream dc26…

### DIFF
--- a/test/TritonIntelGPU/accelerate-matmul-pvc.mlir
+++ b/test/TritonIntelGPU/accelerate-matmul-pvc.mlir
@@ -212,14 +212,7 @@ module attributes {"ttg.target" = "xpu", "ttg.num-ctas" = 1 : i32, "ttg.num-warp
   // CHECK-DAG: [[BLOCKED:#.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 2], order = [1, 0]}>
   // CHECK-DAG: [[BLOCKED1:#.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
   // CHECK-DAG: [[BLOCKED2:#.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [1, 4], order = [1, 0]}>
-  // CHECK-DAG: [[BLOCKED3:#.+]] = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [8, 2, 1], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
   // CHECK-DAG: [[BLOCKED4:#.+]] = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 16], warpsPerCTA = [2, 2], order = [1, 0]}>
-  // CHECK-DAG: [[BLOCKED5:#.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [1, 4], order = [0, 1]}>
-  // CHECK-DAG: [[BLOCKED6:#.+]] = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 16, 1], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
-  // CHECK-DAG: [[BLOCKED7:#.+]] = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 1, 16], warpsPerCTA = [1, 1, 4], order = [1, 2, 0]}>
-  // CHECK-DAG: [[LINEAR:#.+]] = #ttg.linear<{{.*}}>
-  // CHECK-DAG: [[LINEAR1:#.+]] = #ttg.linear<{{.*}}>
-  // CHECK-DAG: [[LINEAR2:#.+]] = #ttg.linear<{{.*}}>
   // CHECK-DAG: [[DPAS:#.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [2, 2], repCluster = [4, 2], A = [32, 16], B = [16, 32], C = [32, 32]}>
 
   // CHECK: tt.func @dot_scaled_fp8_bf16([[ARG0:%.*]]: tensor<128x64xf8E4M3FN, [[BLOCKED]]>, [[ARG1:%.*]]: tensor<128x2xi8, [[BLOCKED1]]>, [[ARG2:%.*]]: tensor<64x128xbf16, [[BLOCKED2]]>) -> tensor<128x128xf32, [[BLOCKED2]]> {
@@ -227,7 +220,7 @@ module attributes {"ttg.target" = "xpu", "ttg.num-ctas" = 1 : i32, "ttg.num-warp
     // CHECK: [[NAN:%.*]] = arith.constant dense<0x7FC0> : tensor<128x64xbf16, [[BLOCKED]]>
     // CHECK: [[CST:%.*]] = arith.constant dense<0.000000e+00> : tensor<128x128xf32, [[BLOCKED2]]>
     // CHECK: [[FPTOFP:%.*]] = tt.fp_to_fp [[ARG0]] : tensor<128x64xf8E4M3FN, #blocked> -> tensor<128x64xbf16, #blocked>
-    // CHECK: [[SCALE:%.*]] = ttg.convert_layout {{.*}} : tensor<128x64xbf16, [[LINEAR]]> -> tensor<128x64xbf16, [[BLOCKED]]>
+    // CHECK: [[SCALE:%.*]] = tt.reshape {{.*}} -> tensor<128x64xbf16, [[BLOCKED]]>
     // CHECK: [[UPCAST:%.*]] = arith.mulf [[FPTOFP]], [[SCALE]] : tensor<128x64xbf16, [[BLOCKED]]>
     // CHECK: [[MASKNAN:%.*]] = arith.select {{.*}}, [[NAN]], [[UPCAST]] : tensor<128x64xi1, [[BLOCKED]]>, tensor<128x64xbf16, [[BLOCKED]]>
     // CHECK: [[BLOCKED_A:%.*]] = ttg.convert_layout [[MASKNAN]] : tensor<128x64xbf16, [[BLOCKED]]> -> tensor<128x64xbf16, #ttg.dot_op<{opIdx = 0, parent = [[BLOCKED2]]}>>
@@ -246,7 +239,7 @@ module attributes {"ttg.target" = "xpu", "ttg.num-ctas" = 1 : i32, "ttg.num-warp
   tt.func @dot_scaled_fp4_fp8(%a: tensor<128x32xi8, #blocked2>, %scale: tensor<128x2xi8, #blocked1>, %b: tensor<64x128xf8E4M3FN, #blocked>) -> tensor<128x128xf32, #blocked> {
     // CHECK: [[CST:%.*]] = arith.constant dense<0.000000e+00> : tensor<128x128xf32, [[BLOCKED2]]>
     // CHECK: [[FP4TOFP:%.*]] = ttg.fp4_to_fp [[ARG0]] {axis = 1 : i32} : tensor<128x32xi8, [[BLOCKED]]> -> tensor<128x64xbf16, [[BLOCKED4]]>
-    // CHECK: [[SCALE:%.*]] = ttg.convert_layout {{.*}} : tensor<128x64xbf16, [[LINEAR]]> -> tensor<128x64xbf16, [[BLOCKED4]]>
+    // CHECK: [[SCALE:%.*]] = tt.reshape {{.*}} -> tensor<128x64xbf16, [[BLOCKED4]]>
     // CHECK: [[UPCAST:%.*]] = arith.mulf [[FP4TOFP]], [[SCALE]] : tensor<128x64xbf16, [[BLOCKED4]]>
     // CHECK: [[CVT_ARG0:%.*]] = ttg.convert_layout [[UPCAST]] : tensor<128x64xbf16, [[BLOCKED4]]> -> tensor<128x64xbf16, #ttg.dot_op<{opIdx = 0, parent = [[BLOCKED2]]}>>
     // CHECK: [[FPTOFP:%.*]] = tt.fp_to_fp [[ARG2]] : tensor<64x128xf8E4M3FN, [[BLOCKED2]]> -> tensor<64x128xbf16, [[BLOCKED2]]>
@@ -265,13 +258,13 @@ module attributes {"ttg.target" = "xpu", "ttg.num-ctas" = 1 : i32, "ttg.num-warp
   tt.func @dot_scaled_fp4_fp4(%a: tensor<128x32xi8, #blocked2>, %scale_a: tensor<128x2xi8, #blocked1>, %b: tensor<32x128xi8, #blocked>, %scale_b: tensor<128x2xi8, #blocked1>) -> tensor<128x128xf32, #blocked> {
     // CHECK: [[CST:%.*]] = arith.constant dense<0.000000e+00> : tensor<128x128xf32, [[BLOCKED2]]>
     // CHECK: [[FP4TOFP:%.*]] = ttg.fp4_to_fp [[ARG0]] {axis = 1 : i32} : tensor<128x32xi8, [[BLOCKED]]> -> tensor<128x64xbf16, [[BLOCKED4]]>
-    // CHECK: [[SCALE:%.*]] = ttg.convert_layout {{.*}} : tensor<128x64xbf16, [[LINEAR]]> -> tensor<128x64xbf16, [[BLOCKED4]]>
+    // CHECK: [[SCALE:%.*]] = tt.reshape {{.*}} -> tensor<128x64xbf16, [[BLOCKED4]]>
     // CHECK: [[UPCAST:%.*]] = arith.mulf [[FP4TOFP]], [[SCALE]] : tensor<128x64xbf16, [[BLOCKED4]]>
     // CHECK: [[CVT_ARG0:%.*]] = ttg.convert_layout [[UPCAST]] : tensor<128x64xbf16, [[BLOCKED4]]> -> tensor<128x64xbf16, #ttg.dot_op<{opIdx = 0, parent = [[BLOCKED2]]}>>
-    // CHECK: [[FP4TOFP1:%.*]] = ttg.fp4_to_fp [[ARG2]] {axis = 0 : i32} : tensor<32x128xi8, [[BLOCKED2]]> -> tensor<64x128xbf16, [[LINEAR1]]>
-    // CHECK: [[SCALE1:%.*]] = ttg.convert_layout {{.*}} : tensor<64x128xbf16, [[LINEAR2]]> -> tensor<64x128xbf16, [[LINEAR1]]>
-    // CHECK: [[UPCAST1:%.*]] = arith.mulf [[FP4TOFP1]], [[SCALE1]] : tensor<64x128xbf16, [[LINEAR1]]>
-    // CHECK: [[CVT_ARG2:%.*]] = ttg.convert_layout [[UPCAST1]] : tensor<64x128xbf16, [[LINEAR1]]> -> tensor<64x128xbf16, #ttg.dot_op<{opIdx = 1, parent = [[BLOCKED2]]}>>
+    // CHECK: [[FP4TOFP1:%.*]] = ttg.fp4_to_fp [[ARG2]] {axis = 0 : i32} : tensor<32x128xi8, [[BLOCKED2]]> -> tensor<64x128xbf16, {{.*}}>
+    // CHECK: [[SCALE1:%.*]] = tt.reshape {{.*}} -> tensor<64x128xbf16, {{.*}}>
+    // CHECK: [[UPCAST1:%.*]] = arith.mulf [[FP4TOFP1]], [[SCALE1]]
+    // CHECK: [[CVT_ARG2:%.*]] = ttg.convert_layout [[UPCAST1]] : tensor<64x128xbf16, {{.*}}> -> tensor<64x128xbf16, #ttg.dot_op<{opIdx = 1, parent = [[BLOCKED2]]}>>
     // CHECK: [[C:%.*]] = ttg.convert_layout [[CST]] : tensor<128x128xf32, [[BLOCKED2]]> -> tensor<128x128xf32, [[DPAS]]>
     // CHECK: [[A:%.*]] = ttg.convert_layout [[CVT_ARG0]] : tensor<128x64xbf16, #ttg.dot_op<{opIdx = 0, parent = [[BLOCKED2]]}>> -> tensor<128x64xbf16, #ttg.dot_op<{opIdx = 0, parent = [[DPAS]], kWidth = 1}>>
     // CHECK: [[B:%.*]] = ttg.convert_layout [[CVT_ARG2]] : tensor<64x128xbf16, #ttg.dot_op<{opIdx = 1, parent = [[BLOCKED2]]}>> -> tensor<64x128xbf16, #ttg.dot_op<{opIdx = 1, parent = [[DPAS]], kWidth = 2}>>
@@ -298,7 +291,6 @@ module attributes {ttg.target = "xpu", "ttg.num-ctas" = 1 : i32, "ttg.num-warps"
   // CHECK-DAG: [[BLOCKED3:#.+]] = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
   // CHECK-DAG: [[BLOCKED4:#.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
   // CHECK-DAG: [[BLOCKED5:#.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 1], warpsPerCTA = [2, 2], order = [0, 1]}>
-  // CHECK-DAG: [[BLOCKED6:#.+]] = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [8, 2, 1], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
   // CHECK-DAG: [[BLOCKED7:#.+]] = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [2, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
   // CHECK: [[LINEAR:#.*]] = #ttg.linear<{{.*}}>
   // CHECK-NEXT: [[LINEAR1:#.+]] = #ttg.linear<{{.*}}>
@@ -319,7 +311,7 @@ module attributes {ttg.target = "xpu", "ttg.num-ctas" = 1 : i32, "ttg.num-warps"
       // CHECK: [[TRANS_A:%.*]] = tt.trans [[ARG0]] {{.*}} : tensor<128x64xf8E4M3FN, [[BLOCKED]]> -> tensor<64x128xf8E4M3FN, [[BLOCKED5]]>
       // CHECK: [[TRANS_B:%.*]] = tt.trans [[ARG1]] {{.*}} : tensor<32x32xi8, [[BLOCKED1]]> -> tensor<32x32xi8, [[BLOCKED4]]>
       // CHECK: [[FP4TOFP:%.*]] = ttg.fp4_to_fp [[TRANS_B]] {axis = 1 : i32} : tensor<32x32xi8, [[BLOCKED4]]> -> tensor<32x64xbf16, [[LINEAR]]>
-      // CHECK: [[SCALE:%.*]] = ttg.convert_layout {{.*}} : tensor<32x64xbf16, [[LINEAR1]]> -> tensor<32x64xbf16, [[LINEAR]]>
+      // CHECK: [[SCALE:%.*]] = tt.reshape {{.*}} -> tensor<32x64xbf16, [[LINEAR]]>
       // CHECK: [[UPCAST:%.*]] = arith.mulf [[FP4TOFP]], [[SCALE]] : tensor<32x64xbf16, [[LINEAR]]>
       // CHECK: [[MASKNAN:%.*]] = arith.select {{.*}}, [[NAN]], [[UPCAST]] : tensor<32x64xi1, [[LINEAR]]>, tensor<32x64xbf16, [[LINEAR]]>
       // CHECK: [[CVT_ARG1:%.*]] = ttg.convert_layout [[MASKNAN]] : tensor<32x64xbf16, [[LINEAR]]> -> tensor<32x64xbf16, #ttg.dot_op<{opIdx = 0, parent = [[BLOCKED4]]}>>

--- a/test/TritonIntelGPU/decompose-scaled-blocked-non32-factor.mlir
+++ b/test/TritonIntelGPU/decompose-scaled-blocked-non32-factor.mlir
@@ -30,7 +30,7 @@ module attributes {ttig.min_sg_size = 16 : i32, ttig.support_2d_block_io, "ttg.n
   // CHECK-LABEL: tt.func public @kernel_scale_factor_16
   // CHECK-NOT: tt.dot_scaled
   // CHECK-DAG: tt.broadcast {{.*}} -> tensor<128x2x16x{{.*}}
-  // CHECK-DAG: tt.broadcast {{.*}} -> tensor<2x128x16x{{.*}}
+  // CHECK-DAG: tt.broadcast {{.*}} -> tensor<2x16x128x{{.*}}
   // CHECK: tt.dot
   tt.func public @kernel_scale_factor_16(%a: tensor<128x16xi8, #blocked2>, %scale_a: tensor<128x2xi8, #blocked1>, %b: tensor<16x128xi8, #blocked>, %scale_b: tensor<128x2xi8, #blocked1>) -> tensor<128x128xf32, #blocked> {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>

--- a/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeScaledBlocked.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeScaledBlocked.cpp
@@ -118,44 +118,62 @@ private:
   broadcastScale(PatternRewriter &rewriter, DotScaledOp scaledDotOp,
                  TypedValue<RankedTensorType> scale, int dim,
                  Attribute dstEncoding) const {
-    auto *ctx = rewriter.getContext();
     auto loc = scale.getLoc();
     auto scaleTy = scale.getType();
-    auto rank = scaleTy.getRank();
-    auto mod = scaledDotOp->getParentOfType<ModuleOp>();
-    // 1) Expand dims along the last dimension
-    {
-      auto shape = to_vector(scaleTy.getShape());
-      shape.insert(shape.end(), 1);
-      auto nWarps = lookupNumWarps(scaledDotOp);
-      auto threadsPerWarp = TritonGPUDialect::getThreadsPerWarp(mod);
-      auto numCTAs = TritonGPUDialect::getNumCTAs(mod);
-      auto blockedEnc = getDefaultBlockedEncoding(ctx, shape, nWarps,
-                                                  threadsPerWarp, numCTAs);
-      auto sliceEnc = SliceEncodingAttr::get(ctx, rank, blockedEnc);
-      RankedTensorType sliceType = scaleTy.cloneWithEncoding(sliceEnc);
-      scale = ConvertLayoutOp::create(rewriter, loc, sliceType, scale);
-    }
-    auto expandScale = ExpandDimsOp::create(rewriter, loc, scale, rank);
     int32_t scaleFactor = scaledDotOp.deduceScaleFactor();
-    // 2) Broadcast the dimension to the microscaling factor.
-    auto scaleShape = to_vector(scaleTy.getShape());
-    scaleShape.push_back(scaleFactor);
-    auto broadcastScale = BroadcastOp::create(
-        rewriter, loc, expandScale.getType().clone(scaleShape), expandScale);
-    // 3) Transpose the dimension to the scaled dimension
-    auto transposeOrder = llvm::to_vector(llvm::seq<int32_t>(rank));
-    transposeOrder.insert(transposeOrder.begin() + dim + 1, rank);
-    auto transposedScale =
-        TransOp::create(rewriter, loc, broadcastScale, transposeOrder);
-    // 4) Reshape to the result shape
-    scaleShape.pop_back();
-    scaleShape[dim] *= scaleFactor;
-    auto reshapeScale =
-        ReshapeOp::create(rewriter, loc, scaleShape, transposedScale);
+
+    // We want to broadcast the scales along dim. To do this:
+    //   1. Introduce a size 1 dimension right after dim
+    //   2. Broadcast the new dim to the scale factor
+    //   3. Reshape it to get the result shape.
+
+    // Compute the shape after each step.
+    auto expandedShape = to_vector(scaleTy.getShape());
+    expandedShape.insert(expandedShape.begin() + dim + 1, 1);
+    auto broadcastShape = expandedShape;
+    broadcastShape[dim + 1] = scaleFactor;
+    auto resultShape = to_vector(scaleTy.getShape());
+    resultShape[dim] *= scaleFactor;
+
+    // It is more efficient to perform a layout conversion before broadcasting,
+    // since there are fewer elements. Infer the source encoding that will
+    // produce dstEncoding after the broadcast and reshape.
+    auto interface =
+        cast<DialectInferLayoutInterface>(&dstEncoding.getDialect());
+    Attribute broadcastEncoding;
+    auto result = interface->inferReshapeOpEncoding(
+        resultShape, dstEncoding, broadcastShape, broadcastEncoding,
+        /*allowReorder=*/false, loc);
+    assert(succeeded(result));
+    Attribute srcEncoding;
+    result = interface->inferReshapeOpEncoding(expandedShape, broadcastEncoding,
+                                               scaleTy.getShape(), srcEncoding,
+                                               /*allowReorder=*/false, loc);
+    assert(succeeded(result));
+
+    auto srcType = scaleTy.cloneWithEncoding(srcEncoding);
+
+    // Convert the scales to the desired type.
+    scale = ConvertLayoutOp::create(rewriter, loc, srcType, scale);
+
+    // Introduce the new dimension.
+    auto expandType = RankedTensorType::get(
+        expandedShape, scaleTy.getElementType(), broadcastEncoding);
+    // We know this layout avoids having any layout conversions after we expand
+    // the scales, so mark the layout as efficient. Otherwise, forward layout
+    // propagation may try to sink the convert layout.
+    auto expandScale = ReshapeOp::create(
+        rewriter, loc, expandType, scale,
+        /*allow_reorder=*/nullptr, /*efficient_layout=*/rewriter.getUnitAttr());
+    // Broadcast the dimension to the microscaling factor.
+    auto broadcastType = RankedTensorType::get(
+        broadcastShape, scaleTy.getElementType(), broadcastEncoding);
+    auto broadcastScale =
+        BroadcastOp::create(rewriter, loc, broadcastType, expandScale);
     auto resultType = RankedTensorType::get(
-        scaleShape, scaleTy.getElementType(), dstEncoding);
-    return ConvertLayoutOp::create(rewriter, loc, resultType, reshapeScale);
+        resultShape, scaleTy.getElementType(), dstEncoding);
+    // Reshape to fold in the broadcasted dimension and get the final result.
+    return ReshapeOp::create(rewriter, loc, resultType, broadcastScale);
   }
 
   TypedValue<RankedTensorType>


### PR DESCRIPTION
Synced from upstream commit dc267ee15e.
Replace the ExpandDimsOp + SliceEncoding + TransOp approach with ReshapeOp + inferReshapeOpEncoding to broadcast scales. This avoids unnecessary layout conversions by inferring the correct intermediate encoding from the destination encoding upfront.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because `sync with upstream`.

- Select one of the following.
  - [X ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
