### PR TITLE
[SGLang] Install `torchvision` for SGLang benchmarks

### DIFF
--- a/.github/workflows/third-party-benchmarks.yml
+++ b/.github/workflows/third-party-benchmarks.yml
@@ -104,9 +104,6 @@ jobs:
         id: setup-pytorch
         uses: ./.github/actions/setup-pytorch
 
-      - name: Setup Triton
-        uses: ./.github/actions/setup-triton
-
       - name: Identify torchvision pin
         if: ${{ inputs.benchmarks == '' || contains(fromJson(inputs.benchmarks || '[]'), 'sglang') }}
         run: |
@@ -120,6 +117,9 @@ jobs:
           repository: pytorch/vision
           ref: ${{ env.TORCHVISION_COMMIT_ID }}
           extra-cache-key: ${{ steps.setup-pytorch.outputs.pytorch_cache_key }}
+
+      - name: Setup Triton
+        uses: ./.github/actions/setup-triton
 
       - name: Create reports dir
         run: |

--- a/.github/workflows/third-party-benchmarks.yml
+++ b/.github/workflows/third-party-benchmarks.yml
@@ -101,10 +101,25 @@ jobs:
           pip install cmake
 
       - name: Setup PyTorch
+        id: setup-pytorch
         uses: ./.github/actions/setup-pytorch
 
       - name: Setup Triton
         uses: ./.github/actions/setup-triton
+
+      - name: Identify torchvision pin
+        if: ${{ inputs.benchmarks == '' || contains(fromJson(inputs.benchmarks || '[]'), 'sglang') }}
+        run: |
+          echo "TORCHVISION_COMMIT_ID=$(<pytorch/.github/ci_commit_pins/vision.txt)" | tee -a "$GITHUB_ENV"
+
+      - name: Install torchvision package
+        if: ${{ inputs.benchmarks == '' || contains(fromJson(inputs.benchmarks || '[]'), 'sglang') }}
+        uses: ./.github/actions/install-dependency
+        with:
+          package: torchvision
+          repository: pytorch/vision
+          ref: ${{ env.TORCHVISION_COMMIT_ID }}
+          extra-cache-key: ${{ steps.setup-pytorch.outputs.pytorch_cache_key }}
 
       - name: Create reports dir
         run: |


### PR DESCRIPTION
This is also done in `vllm-tests-reusable.yml` for some test-suites.

Closes https://github.com/intel/intel-xpu-backend-for-triton/issues/7660.

SGLang benchmarks: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/30924722100
SGLang benchmarks BMG: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/30929436047