### PR TITLE
[AxisInfo] Revert this incomplete fix to restore alignment with upstream

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -444,27 +444,11 @@ private:
     // the minimal constancy is gcd(d_lhs, d_rhs).
     // Since gcd(d_lhs, d_rhs) maybe > len(lhs),
     // we need to use another gcd to get the actual constancy.
-    //
-    // NOTE: This only holds when the division rounds consistently in one
-    // direction. For signed division (DivSIOp), truncation toward zero means
-    // the constancy pattern breaks at the zero crossing:
-    //   sdiv([-2, -1, 0, 1], 2) = [-1, 0, 0, 0]  (not pairwise constant)
-    // For signed division, we can still apply this optimization when the
-    // contiguous window is guaranteed not to cross zero. This is the case
-    // when divisibility >= contiguity: the window starts at k*div and has
-    // length cont <= div, so it stays within [k*div, (k+1)*div - 1] which
-    // never spans zero.
     if (AxisInfoVisitor::isContiguousDim(lhs, shape, dim) &&
         AxisInfoVisitor::isConstantDim(rhs, shape, dim)) {
-      if constexpr (!std::is_same_v<OpTy, arith::DivSIOp>) {
-        constancy = std::max(constancy, gcd(lhs.getContiguity(dim),
-                                            lhs.getDivisibility(dim),
-                                            rhs.getDivisibility(dim)));
-      } else if (lhs.getDivisibility(dim) >= lhs.getContiguity(dim)) {
-        constancy = std::max(constancy, gcd(lhs.getContiguity(dim),
-                                            lhs.getDivisibility(dim),
-                                            rhs.getDivisibility(dim)));
-      }
+      constancy = std::max(constancy,
+                           gcd(lhs.getContiguity(dim), lhs.getDivisibility(dim),
+                               rhs.getDivisibility(dim)));
     }
     return constancy;
   }
@@ -522,22 +506,10 @@ private:
     // The minimal contiguity is gcd(d_lhs, d_rhs).
     // Since gcd(d_lhs, d_rhs) maybe > len(lhs),
     // we need to use another gcd to get the actual contiguity.
-    //
-    // NOTE: For signed remainder (RemSIOp), the contiguity pattern breaks
-    // at the zero crossing because srem produces negative results for
-    // negative dividends: srem([-2, -1, 0, 1], 2) = [0, -1, 0, 1]
-    // For signed remainder, we can still apply this optimization when the
-    // contiguous window is guaranteed not to cross zero (divisibility >=
-    // contiguity ensures the window stays within one sign region).
     if (AxisInfoVisitor::isContiguousDim(lhs, shape, dim) &&
         AxisInfoVisitor::isConstantDim(rhs, shape, dim)) {
-      if constexpr (!std::is_same_v<OpTy, arith::RemSIOp>) {
-        contiguity = gcd(lhs.getContiguity(dim), lhs.getDivisibility(dim),
-                         rhs.getDivisibility(dim));
-      } else if (lhs.getDivisibility(dim) >= lhs.getContiguity(dim)) {
-        contiguity = gcd(lhs.getContiguity(dim), lhs.getDivisibility(dim),
-                         rhs.getDivisibility(dim));
-      }
+      contiguity = gcd(lhs.getContiguity(dim), lhs.getDivisibility(dim),
+                       rhs.getDivisibility(dim));
     }
     return contiguity;
   }

--- a/test/Analysis/intel/test-axis-info.mlir
+++ b/test/Analysis/intel/test-axis-info.mlir
@@ -160,10 +160,6 @@ tt.func @div() {
   %10 = tt.make_range {end = 8320 : i32, start = 8192 : i32} : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [64], constant_value = <none>
   %11 = arith.divsi %10, %4 : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [128], divisibility = [32], constancy = [1], constant_value = <none>
-  %12 = tt.make_range {end = 160 : i32, start = 32 : i32} : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
-  %13 = arith.divsi %12, %4 : tensor<128xi32>
   tt.return
 }
 

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -266,7 +266,7 @@ tt.func @rem() {
   %13 = arith.remsi %0, %12 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %14 = arith.remsi %12, %0 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [32], constancy = [1], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [32], divisibility = [32], constancy = [1], constant_value = <none>}}
   %15 = arith.remsi %12, %4 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %16 = arith.remsi %4, %12 : tensor<128xi32>


### PR DESCRIPTION
This reverts the AxisInfo changes from commit 9cfefec16a.

The `divisibility >= contiguity` guard is insufficient — truncation toward zero breaks constancy even within purely negative windows. Counterexample from https://github.com/intel/intel-xpu-backend-for-triton/pull/6896#discussion_r3395860198:
```
  lhs = [-64..-57], div=64, cont=8, rhs=32
  Guard passes (64 >= 8), predicts constancy=8
  Actual: sdiv = [-2,-1,-1,-1,-1,-1,-1,-1] — NOT constant-8
```