### PR TITLE
[StrideInfo] Disable stride preservation for DivSIOp and RemSIOp

### DIFF
--- a/test/Analysis/intel/test-stride-info.mlir
+++ b/test/Analysis/intel/test-stride-info.mlir
@@ -119,8 +119,8 @@ tt.func @div() {
   // stride(range) * 4 = 4, then 4 / 4 = 1
   // CHECK: arith.muli {{.*}} => stride = [4]
   %1 = arith.muli %0, %cst4 : tensor<128xi32>
-  // stride(4) / const(4) = 1
-  // CHECK: arith.divsi {{.*}} => stride = [1]
+  // stride(4) / const(4) — cannot prove non-negative for DivSIOp
+  // CHECK: arith.divsi {{.*}} => stride = [-1]
   %2 = arith.divsi %1, %cst4 : tensor<128xi32>
   // CHECK: arith.divui {{.*}} => stride = [1]
   %3 = arith.divui %1, %cst4 : tensor<128xi32>
@@ -159,8 +159,8 @@ tt.func @rem() {
   %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
   // CHECK: arith.constant {{.*}} => stride = [0]
   %cst_mod = arith.constant dense<512> : tensor<128xi32>
-  // Range span (127) < modulus (512): no wrap-around, stride preserved.
-  // CHECK: arith.remsi {{.*}} => stride = [1]
+  // Cannot prove non-negative for RemSIOp — conservatively unknown.
+  // CHECK: arith.remsi {{.*}} => stride = [-1]
   %1 = arith.remsi %0, %cst_mod : tensor<128xi32>
   // CHECK: arith.remui {{.*}} => stride = [1]
   %2 = arith.remui %0, %cst_mod : tensor<128xi32>
@@ -189,8 +189,8 @@ tt.func @rem_stride_wrap(%arg0: i32) {
   // CHECK: arith.remsi {{.*}} => stride = [-1]
   %rem_wrap = arith.remsi %range, %c8 : tensor<32xi32>
 
-  // Range span (31) < modulus (64): no wrap-around, stride preserved.
-  // CHECK: arith.remsi {{.*}} => stride = [1]
+  // Cannot prove non-negative for RemSIOp — conservatively unknown.
+  // CHECK: arith.remsi {{.*}} => stride = [-1]
   %rem_nowrap = arith.remsi %range, %c64 : tensor<32xi32>
 
   // Non-constant rhs (unknown stride): cannot reason about modulus.
@@ -382,17 +382,17 @@ tt.func @ptr_offset_pattern(%arg0: i32, %arg1: tensor<128x1xi32>) {
   // [0] + [1] = [1]
   // CHECK: arith.addi {{.*}} => stride = [1]
   %3 = arith.addi %1, %2 : tensor<128xi32>
-  // rem with constant modulus preserves stride
-  // CHECK: arith.remsi {{.*}} => stride = [1]
+  // Cannot prove non-negative for RemSIOp — conservatively unknown.
+  // CHECK: arith.remsi {{.*}} => stride = [-1]
   %4 = arith.remsi %3, %cst_1 : tensor<128xi32>
-  // expand_dims at axis=1: [1] -> [1, 0]
-  // CHECK: tt.expand_dims {{.*}} => stride = [1, 0]
+  // expand_dims at axis=1: [-1] -> [-1, 0]
+  // CHECK: tt.expand_dims {{.*}} => stride = [-1, 0]
   %5 = tt.expand_dims %4 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
-  // [1, 0] * splat(512) => stride = [512, 0]
-  // CHECK: arith.muli {{.*}} => stride = [512, 0]
+  // [-1, 0] * splat(512) => stride = [-1, 0]
+  // CHECK: arith.muli {{.*}} => stride = [-1, 0]
   %6 = arith.muli %5, %cst_0 : tensor<128x1xi32>
-  // broadcast preserves stride: [512, 0]
-  // CHECK: tt.broadcast {{.*}} => stride = [512, 0]
+  // broadcast preserves stride: [-1, 0]
+  // CHECK: tt.broadcast {{.*}} => stride = [-1, 0]
   %7 = tt.broadcast %6 : tensor<128x1xi32> -> tensor<128x64xi32>
   // muli with unknown stride input => [-1, -1]
   // CHECK: arith.muli {{.*}} => stride = [-1, -1]
@@ -545,8 +545,8 @@ tt.func @rem_stride_divisibility() {
   // CHECK: tt.make_range {{.*}} => stride = [1]
   %range_16_20 = tt.make_range {end = 20 : i32, start = 16 : i32} : tensor<4xi32>
 
-  // gcd(16, 4) = 4, maxVal=3 < 4 => no wrap
-  // CHECK: arith.remsi {{.*}} => stride = [1]
+  // Cannot prove non-negative for RemSIOp — conservatively unknown.
+  // CHECK: arith.remsi {{.*}} => stride = [-1]
   %rem3 = arith.remsi %range_16_20, %c4 : tensor<4xi32>
 
   // divisibility(start=0) = 2^62

--- a/third_party/intel/lib/Analysis/StrideInfo.cpp
+++ b/third_party/intel/lib/Analysis/StrideInfo.cpp
@@ -613,9 +613,17 @@ protected:
     stride.reserve(lhs.size());
     for (unsigned d = 0, rank = lhs.size(); d < rank; ++d) {
       if (lhs[d] > 0 && rhsConst.has_value() && rhsConst.value() > 0 &&
-          lhs[d] % rhsConst.value() == 0)
-        stride.push_back(lhs[d] / rhsConst.value());
-      else if (lhs[d] == 0 && rhsConst.has_value() && rhsConst.value() != 0)
+          lhs[d] % rhsConst.value() == 0) {
+        // For signed division (DivSIOp), truncation toward zero means
+        // the stride pattern breaks when the input window crosses zero:
+        //   divsi([-2,-1,0,1], 2) = [-1,0,0,0] (not evenly strided)
+        // Without range analysis we cannot prove inputs are non-negative
+        // for DivSIOp, so conservatively report unknown stride.
+        if constexpr (std::is_same_v<OpTy, arith::DivSIOp>)
+          stride.push_back(-1);
+        else
+          stride.push_back(lhs[d] / rhsConst.value());
+      } else if (lhs[d] == 0 && rhsConst.has_value() && rhsConst.value() != 0)
         stride.push_back(0);
       else
         stride.push_back(-1);
@@ -644,22 +652,33 @@ protected:
         // Stride preserved when range span doesn't cross a modulus boundary.
         // Effective period is gcd(divisibility, modulus) when AxisInfo is
         // available; falls back to modulus otherwise.
-        auto resTy = dyn_cast<RankedTensorType>(op.getType());
-        if (resTy) {
-          int64_t dimSize = resTy.getDimSize(d);
-          int64_t maxVal = lhs[d] * (dimSize - 1);
-          int64_t modulus = rhsConst.value();
-          int64_t g = modulus; // fallback when no AxisInfo
-          if (auto *ai = this->axisInfoLookup(op.getLhs())) {
-            int64_t divisibility = ai->getDivisibility(d);
-            g = std::gcd(divisibility, modulus);
-          }
-          if (maxVal < g)
-            stride.push_back(lhs[d]);
-          else
-            stride.push_back(-1);
-        } else {
+        //
+        // NOTE: For signed remainder (RemSIOp), this only holds when the
+        // input window starts at a non-negative value. For negative starts
+        // at multiples of M, truncation-toward-zero creates a discontinuity
+        // between x=kM and x=kM+1 (k<0), breaking stride. Without range
+        // analysis we cannot prove inputs are non-negative for RemSIOp, so
+        // conservatively report unknown stride.
+        if constexpr (std::is_same_v<OpTy, arith::RemSIOp>) {
           stride.push_back(-1);
+        } else {
+          auto resTy = dyn_cast<RankedTensorType>(op.getType());
+          if (resTy) {
+            int64_t dimSize = resTy.getDimSize(d);
+            int64_t maxVal = lhs[d] * (dimSize - 1);
+            int64_t modulus = rhsConst.value();
+            int64_t g = modulus; // fallback when no AxisInfo
+            if (auto *ai = this->axisInfoLookup(op.getLhs())) {
+              int64_t divisibility = ai->getDivisibility(d);
+              g = std::gcd(divisibility, modulus);
+            }
+            if (maxVal < g)
+              stride.push_back(lhs[d]);
+            else
+              stride.push_back(-1);
+          } else {
+            stride.push_back(-1);
+          }
         }
       } else {
         stride.push_back(-1);


### PR DESCRIPTION
For signed division and remainder, truncation-toward-zero semantics break the stride pattern when the input window crosses zero. For example:
```
  srem([-64, -63, ..., -57], 32) = [0, -31, -30, ..., -25] (not stride-1)
  sdiv([-2, -1, 0, 1], 2) = [-1, 0, 0, 0] (not evenly strided)
```

Without range analysis we cannot prove inputs are non-negative, so conservatively report unknown stride (-1) for DivSIOp and RemSIOp. The unsigned variants (DivUIOp, RemUIOp) are unaffected since unsigned values are always non-negative.