### PR TITLE
Skip failing mrv2 and spec-decode tests

### DIFF
--- a/scripts/skiplist/default/vllm_mrv2.txt
+++ b/scripts/skiplist/default/vllm_mrv2.txt
@@ -42,6 +42,17 @@ tests/v1/sample/test_logprobs.py::test_spec_decode_logprobs[ngram-processed_logp
 # vLLM returns 6 logprob entries when 5 are expected: https://github.com/intel/intel-xpu-backend-for-triton/issues/7161
 tests/v1/sample/test_logprobs.py::test_get_logprobs_and_prompt_logprobs[False-0.0-BatchLogprobsComposition.SAMPLE]
 
+# oneCCL fails to start worker threads on Max 1550
+tests/v1/sample/test_logprobs.py::test_get_logprobs_and_prompt_logprobs[False-0.0-BatchLogprobsComposition.NONE]
+tests/v1/sample/test_logprobs.py::test_get_logprobs_and_prompt_logprobs[True-0.0-BatchLogprobsComposition.NONE]
+tests/v1/sample/test_logprobs.py::test_get_logprobs_and_prompt_logprobs[True-0.0-BatchLogprobsComposition.SAMPLE]
+tests/v1/sample/test_logprobs.py::test_get_logprobs_and_prompt_logprobs[True-0.0-BatchLogprobsComposition.PROMPT]
+tests/v1/sample/test_logprobs.py::test_get_logprobs_and_prompt_logprobs[True-0.0-BatchLogprobsComposition.SAMPLE_PROMPT]
+tests/v1/sample/test_logprobs.py::test_get_logprobs_and_prompt_logprobs[True-2.0-BatchLogprobsComposition.NONE]
+tests/v1/sample/test_logprobs.py::test_get_logprobs_and_prompt_logprobs[True-2.0-BatchLogprobsComposition.SAMPLE]
+tests/v1/sample/test_logprobs.py::test_get_logprobs_and_prompt_logprobs[True-2.0-BatchLogprobsComposition.PROMPT]
+tests/v1/kv_connector/unit/test_nixl_connector.py::test_abort_timeout_on_prefiller
+
 # NIXL is not available: https://github.com/intel/intel-xpu-backend-for-triton/issues/7419
 tests/v1/kv_connector/unit/test_nixl_connector.py::test_kv_both_deprecation_warning
 tests/v1/kv_connector/unit/test_nixl_connector.py::test_explicit_kv_role_no_deprecation_warning

--- a/scripts/skiplist/default/vllm_spec_decode.txt
+++ b/scripts/skiplist/default/vllm_spec_decode.txt
@@ -20,3 +20,6 @@ tests/v1/spec_decode/test_eagle.py::test_propose_stores_probabilistic_draft_prob
 
 # Model Runner V2 does not yet support: ngram/ngram_gpu speculative decoding:  https://github.com/intel/intel-xpu-backend-for-triton/issues/7166
 tests/v1/spec_decode/test_max_len.py::test_ngram_max_len
+
+# oneCCL fails to start worker threads on Max 1550
+tests/v1/spec_decode/test_speculators_eagle3.py::test_eagle3_speculators_model

--- a/scripts/skiplist/xe2/vllm_mrv2.txt
+++ b/scripts/skiplist/xe2/vllm_mrv2.txt
@@ -2,6 +2,24 @@
 tests/v1/worker/test_gpu_model_runner.py::test_hybrid_attention_mamba_tensor_shapes
 tests/v1/worker/test_gpu_model_runner.py::test_mamba_cache_raises_when_max_num_seqs_exceeds_blocks
 
+# torch.Event resolves to a dummy base class on B580
+tests/v1/worker/test_gpu_model_runner.py::test_reasoning_config_without_custom_logitsprocs_does_not_need_output_token_ids
+tests/v1/worker/test_gpu_model_runner.py::test_init_kv_cache_without_kv_sharing
+tests/v1/worker/test_gpu_model_runner.py::test_init_kv_cache_with_kv_sharing_valid
+tests/v1/worker/test_gpu_model_runner.py::test_hybrid_cache_integration
+tests/v1/worker/test_gpu_model_runner.py::test_update_states_new_request
+tests/v1/worker/test_gpu_model_runner.py::test_update_states_request_finished
+tests/v1/worker/test_gpu_model_runner.py::test_update_states_request_resumed
+tests/v1/worker/test_gpu_model_runner.py::test_get_nans_in_logits
+tests/v1/worker/test_gpu_model_runner.py::test_update_states_no_changes
+tests/v1/worker/test_gpu_model_runner.py::test_update_states_request_unscheduled
+tests/v1/worker/test_gpu_model_runner.py::test_update_states_pp_non_async_multi_request_keeps_token_buffers_consistent
+tests/v1/worker/test_gpu_model_runner.py::test_update_states_pp_async_multi_request_keeps_rank_state_consistent
+tests/v1/worker/test_gpu_model_runner.py::test_kv_cache_stride_order
+tests/v1/worker/test_gpu_model_runner.py::test_update_config
+tests/v1/worker/test_gpu_model_runner.py::test_load_model_weights_inplace
+tests/v1/worker/test_gpu_model_runner.py::test_reload_weights_before_load_model
+
 # compute_prompt_logprobs torch.cat incompatible shapes: https://github.com/intel/intel-xpu-backend-for-triton/issues/7159
 tests/v1/sample/test_logprobs.py::test_get_logprobs_and_prompt_logprobs[False-0.0-BatchLogprobsComposition.PROMPT]
 tests/v1/sample/test_logprobs.py::test_get_logprobs_and_prompt_logprobs[False-0.0-BatchLogprobsComposition.SAMPLE_PROMPT]
@@ -26,6 +44,9 @@ tests/v1/sample/test_logprobs.py::test_verify_tokens_integration
 tests/v1/sample/test_logprobs.py::test_utf8_edge_cases_with_real_model
 tests/v1/sample/test_logprobs.py::test_correct_decoded_token_preserves_valid_tokens
 tests/v1/sample/test_logprobs.py::test_prompt_logprobs_with_chunking_and_preemption
+
+# vLLM engine initialization fails on B580
+tests/v1/sample/test_logprobs.py::test_prompt_logprobs_mode
 
 # Pytest segmentation fault on B580: https://github.com/intel/intel-xpu-backend-for-triton/issues/7420
 tests/v1/kv_connector/unit/test_nixl_connector.py::test_abort_timeout_on_prefiller[None]


### PR DESCRIPTION
Failing mrv2 and spec-decode tests added to skiplist.
