### PR TITLE
Improve AccelerateMatmul.cpp for the cases of the chained dot operations.

### DIFF
--- a/test/TritonIntelGPU/accelerate-matmul-pvc.mlir
+++ b/test/TritonIntelGPU/accelerate-matmul-pvc.mlir
@@ -459,6 +459,7 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
 
 // COM: For the chained dot(dot(dot(X, Y), Z), W)... cases, we only aggressively to assigned the warps when the chained dot on the same operands.
 // CHECK: #[[$DPAS_A:.+]] = #ttig.dpas<{{.*}}warpsPerCTA = [8, 1]{{.*}}>
+// CHECK-NOT: #ttig.dpas
 #blocked = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [8, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [16, 1], warpsPerCTA = [1, 8], order = [0, 1]}>
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.min_sg_size" = 16 : i32, "ttig.support_subgroup_matrix_multiply_accumulate"} {
@@ -492,7 +493,6 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
 // COM: For the mixed chained dot like dot(W, dot(dot(X, Y), Z))... cases, falling back to normal tiling pattern.
 // CHECK: #[[$DPAS_0:.+]] = #ttig.dpas<{{.*}}warpsPerCTA = [4, 2]{{.*}}>
 // CHECK: #[[$DPAS_1:.+]] = #ttig.dpas<{{.*}}warpsPerCTA = [2, 4]{{.*}}>
-// CHECK: #[[$DPAS_2:.+]] = #ttig.dpas<{{.*}}warpsPerCTA = [1, 8]{{.*}}>
 #blocked = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [8, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [16, 1], warpsPerCTA = [1, 8], order = [0, 1]}>
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.min_sg_size" = 16 : i32, "ttig.support_subgroup_matrix_multiply_accumulate"} {
@@ -515,9 +515,69 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
       tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked1}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked1}>> -> tensor<64x128xf32, #blocked1>
     %u = arith.truncf %r : tensor<64x128xf32, #blocked1> to tensor<64x128xf16, #blocked1>
     %b = ttg.convert_layout %u : tensor<64x128xf16, #blocked1> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>
-    // CHECK: tt.dot {{.*}} -> tensor<64x128xf32, #[[$DPAS_2]]>
+    // CHECK: tt.dot {{.*}} -> tensor<64x128xf32, #[[$DPAS_1]]>
     %s = tt.dot %arg3, %b, %cst_2 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} :
       tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x128xf32, #blocked>
     tt.return %s : tensor<64x128xf32, #blocked>
+  }
+}
+
+// -----
+
+// COM: For the chained dot(dot(dot(X, Y), Z), W)... cases, if the num-warps is larger than needed, we will assigned the extra num-warps on the N dimenssion to reduce register space sizes.
+// CHECK: #[[$DPAS_A_0:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [8, 4], repCluster = [1, 1]
+// CHECK: #[[$DPAS_A_1:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [8, 4], repCluster = [1, 2]
+#blocked = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [8, 2], warpsPerCTA = [4, 8], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [16, 1], warpsPerCTA = [4, 8], order = [0, 1]}>
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.min_sg_size" = 16 : i32, "ttig.support_subgroup_matrix_multiply_accumulate"} {
+  // CHECK-LABEL: chained_dot_three_level
+  tt.func public @chained_dot_three_level(
+    %arg0: tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+    %arg1: tensor<128x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+    %arg2: tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked1}>>,
+    %arg3: tensor<128x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<64x64xf32, #blocked> {
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked>
+    %cst_1 = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #blocked1>
+    // CHECK: tt.dot {{.*}} -> tensor<64x64xf32, #[[$DPAS_A]]>
+    %d = tt.dot %arg0, %arg1, %cst_0 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} :
+      tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<128x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x64xf32, #blocked>
+    %t = arith.truncf %d : tensor<64x64xf32, #blocked> to tensor<64x64xf16, #blocked>
+    %c = ttg.convert_layout %t : tensor<64x64xf16, #blocked> -> tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked1}>>
+    // CHECK: tt.dot {{.*}} -> tensor<64x128xf32, #[[$DPAS_A_1]]>
+    %r = tt.dot %c, %arg2, %cst_1 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} :
+      tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked1}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked1}>> -> tensor<64x128xf32, #blocked1>
+    %u = arith.truncf %r : tensor<64x128xf32, #blocked1> to tensor<64x128xf16, #blocked1>
+    %e = ttg.convert_layout %u : tensor<64x128xf16, #blocked1> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    // CHECK: tt.dot {{.*}} -> tensor<64x64xf32, #[[$DPAS_A_0]]>
+    %s = tt.dot %e, %arg3, %cst_0 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} :
+      tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<128x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x64xf32, #blocked>
+    tt.return %s : tensor<64x64xf32, #blocked>
+  }
+}
+
+// -----
+
+// COM: For the chained dot(X, dot(Y, Z)) case, if the num-warps is larger than needed, we will assigned the extra num-warps on the N dimenssion to reduce register space sizes.
+// CHECK: #[[$DPAS_B_0:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 8], repCluster = [2, 1]
+// CHECK: #[[$DPAS_B_1:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 8], repCluster = [4, 1]
+#blocked = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [8, 2], warpsPerCTA = [4, 8], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [16, 1], warpsPerCTA = [4, 8], order = [0, 1]}>
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.min_sg_size" = 16 : i32, "ttig.support_subgroup_matrix_multiply_accumulate"} {
+  // CHECK-LABEL: chained_dot_operand_b
+  tt.func public @chained_dot_operand_b(
+    %arg0: tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+    %arg1: tensor<128x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+    %arg2: tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked1}>>) -> tensor<128x128xf32, #blocked1> {
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #blocked>
+    %cst_1 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
+    // CHECK: tt.dot {{.*}} -> tensor<64x128xf32, #[[$DPAS_B_0]]>
+    %d = tt.dot %arg0, %arg1, %cst_0 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} :
+      tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<128x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x128xf32, #blocked>
+    %t = arith.truncf %d : tensor<64x128xf32, #blocked> to tensor<64x128xf16, #blocked>
+    %c = ttg.convert_layout %t : tensor<64x128xf16, #blocked> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked1}>>
+    // CHECK: tt.dot {{.*}} -> tensor<128x128xf32, #[[$DPAS_B_1]]>
+    %r = tt.dot %arg2, %c, %cst_1 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} :
+      tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked1}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked1}>> -> tensor<128x128xf32, #blocked1>
+    tt.return %r : tensor<128x128xf32, #blocked1>
   }
 }

--- a/test/TritonIntelGPU/accelerate-matmul-pvc.mlir
+++ b/test/TritonIntelGPU/accelerate-matmul-pvc.mlir
@@ -412,7 +412,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
 // -----
 
-// CHECK: #[[$DPAS:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 1, 1], repCluster = [1, 4, 2], A = [1, 32, 16], B = [1, 16, 32], C = [1, 32, 32]}>
+// CHECK: #[[$DPAS:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4, 1], repCluster = [1, 2, 2], A = [1, 16, 16], B = [1, 16, 32], C = [1, 16, 32]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 4, 4], threadsPerWarp = [1, 1, 16], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.min_sg_size" = 16 : i32, ttig.support_subgroup_matrix_multiply_accumulate} {
   tt.func public @_helion_repro_baddbmm_kernel(%A: tensor<1x64x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, %B: tensor<1x64x64xbf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>, %C: tensor<1x64x64x!tt.ptr<bf16>, #blocked>) {
@@ -426,5 +426,98 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %43 = arith.truncf %42 : tensor<1x64x64xf32, #blocked> to tensor<1x64x64xbf16, #blocked>
     tt.store %C, %43 : tensor<1x64x64x!tt.ptr<bf16>, #blocked>
     tt.return
+  }
+}
+
+// -----
+
+// COM: For the chained dot(X, dot(Y, Z)) case, the numwarps is assigned to the N dimension to reduce the D -> B convert layout cost.
+// CHECK: #[[$DPAS_B:.+]] = #ttig.dpas<{{.*}}warpsPerCTA = [1, 8]{{.*}}>
+#blocked = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [8, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [16, 1], warpsPerCTA = [1, 8], order = [0, 1]}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.min_sg_size" = 16 : i32, "ttig.support_subgroup_matrix_multiply_accumulate"} {
+  // CHECK-LABEL: chained_dot_operand_b
+  tt.func public @chained_dot_operand_b(
+    %arg0: tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+    %arg1: tensor<128x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+    %arg2: tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked1}>>) -> tensor<128x128xf32, #blocked1> {
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #blocked>
+    %cst_1 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
+    // CHECK: tt.dot {{.*}} -> tensor<64x128xf32, #[[$DPAS_B]]>
+    %d = tt.dot %arg0, %arg1, %cst_0 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} :
+      tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<128x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x128xf32, #blocked>
+    %t = arith.truncf %d : tensor<64x128xf32, #blocked> to tensor<64x128xf16, #blocked>
+    %c = ttg.convert_layout %t : tensor<64x128xf16, #blocked> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked1}>>
+    // CHECK: tt.dot {{.*}} -> tensor<128x128xf32, #[[$DPAS_B]]>
+    %r = tt.dot %arg2, %c, %cst_1 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} :
+      tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked1}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked1}>> -> tensor<128x128xf32, #blocked1>
+    tt.return %r : tensor<128x128xf32, #blocked1>
+  }
+}
+
+// -----
+
+// COM: For the chained dot(dot(dot(X, Y), Z), W)... cases, we only aggressively to assigned the warps when the chained dot on the same operands.
+// CHECK: #[[$DPAS_A:.+]] = #ttig.dpas<{{.*}}warpsPerCTA = [8, 1]{{.*}}>
+#blocked = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [8, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [16, 1], warpsPerCTA = [1, 8], order = [0, 1]}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.min_sg_size" = 16 : i32, "ttig.support_subgroup_matrix_multiply_accumulate"} {
+  // CHECK-LABEL: chained_dot_three_level
+  tt.func public @chained_dot_three_level(
+    %arg0: tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+    %arg1: tensor<128x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+    %arg2: tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked1}>>,
+    %arg3: tensor<128x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<64x64xf32, #blocked> {
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked>
+    %cst_1 = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #blocked1>
+    // CHECK: tt.dot {{.*}} -> tensor<64x64xf32, #[[$DPAS_A]]>
+    %d = tt.dot %arg0, %arg1, %cst_0 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} :
+      tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<128x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x64xf32, #blocked>
+    %t = arith.truncf %d : tensor<64x64xf32, #blocked> to tensor<64x64xf16, #blocked>
+    %c = ttg.convert_layout %t : tensor<64x64xf16, #blocked> -> tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked1}>>
+    // CHECK: tt.dot {{.*}} -> tensor<64x128xf32, #[[$DPAS_A]]>
+    %r = tt.dot %c, %arg2, %cst_1 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} :
+      tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked1}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked1}>> -> tensor<64x128xf32, #blocked1>
+    %u = arith.truncf %r : tensor<64x128xf32, #blocked1> to tensor<64x128xf16, #blocked1>
+    %e = ttg.convert_layout %u : tensor<64x128xf16, #blocked1> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    // CHECK: tt.dot {{.*}} -> tensor<64x64xf32, #[[$DPAS_A]]>
+    %s = tt.dot %e, %arg3, %cst_0 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} :
+      tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<128x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x64xf32, #blocked>
+    tt.return %s : tensor<64x64xf32, #blocked>
+  }
+}
+
+// -----
+
+// COM: For the mixed chained dot like dot(W, dot(dot(X, Y), Z))... cases, falling back to normal tiling pattern.
+// CHECK: #[[$DPAS_0:.+]] = #ttig.dpas<{{.*}}warpsPerCTA = [4, 2]{{.*}}>
+// CHECK: #[[$DPAS_1:.+]] = #ttig.dpas<{{.*}}warpsPerCTA = [2, 4]{{.*}}>
+// CHECK: #[[$DPAS_2:.+]] = #ttig.dpas<{{.*}}warpsPerCTA = [1, 8]{{.*}}>
+#blocked = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [8, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [16, 1], warpsPerCTA = [1, 8], order = [0, 1]}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.min_sg_size" = 16 : i32, "ttig.support_subgroup_matrix_multiply_accumulate"} {
+  // CHECK-LABEL: chained_dot_mixed_operands
+  tt.func public @chained_dot_mixed_operands(
+    %arg0: tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+    %arg1: tensor<128x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+    %arg2: tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked1}>>,
+    %arg3: tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<64x128xf32, #blocked> {
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked>
+    %cst_1 = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #blocked1>
+    %cst_2 = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #blocked>
+    // CHECK: tt.dot {{.*}} -> tensor<64x64xf32, #[[$DPAS_0]]>
+    %d = tt.dot %arg0, %arg1, %cst_0 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} :
+      tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<128x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x64xf32, #blocked>
+    %t = arith.truncf %d : tensor<64x64xf32, #blocked> to tensor<64x64xf16, #blocked>
+    %a = ttg.convert_layout %t : tensor<64x64xf16, #blocked> -> tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked1}>>
+    // CHECK: tt.dot {{.*}} -> tensor<64x128xf32, #[[$DPAS_1]]>
+    %r = tt.dot %a, %arg2, %cst_1 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} :
+      tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked1}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked1}>> -> tensor<64x128xf32, #blocked1>
+    %u = arith.truncf %r : tensor<64x128xf32, #blocked1> to tensor<64x128xf16, #blocked1>
+    %b = ttg.convert_layout %u : tensor<64x128xf16, #blocked1> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>
+    // CHECK: tt.dot {{.*}} -> tensor<64x128xf32, #[[$DPAS_2]]>
+    %s = tt.dot %arg3, %b, %cst_2 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} :
+      tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x128xf32, #blocked>
+    tt.return %s : tensor<64x128xf32, #blocked>
   }
 }

--- a/test/TritonIntelGPU/accelerate-matmul-pvc.mlir
+++ b/test/TritonIntelGPU/accelerate-matmul-pvc.mlir
@@ -431,7 +431,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
-// COM: For the chained dot(X, dot(Y, Z)) case, the numwarps is assigned to the N dimension to reduce the D -> B convert layout cost.
+// COM: For chained dot(X, dot(Y, Z)), assign num-warps to N to reduce the D->B convert_layout cost.
 // CHECK: #[[$DPAS_B:.+]] = #ttig.dpas<{{.*}}warpsPerCTA = [1, 8]{{.*}}>
 #blocked = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [8, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [16, 1], warpsPerCTA = [1, 8], order = [0, 1]}>
@@ -457,7 +457,7 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
 
 // -----
 
-// COM: For the chained dot(dot(dot(X, Y), Z), W)... cases, we only aggressively to assigned the warps when the chained dot on the same operands.
+// COM: For chained dot(dot(dot(X, Y), Z), W), aggressively assign warps only when chaining stays on the same operand.
 // CHECK: #[[$DPAS_A:.+]] = #ttig.dpas<{{.*}}warpsPerCTA = [8, 1]{{.*}}>
 // CHECK-NOT: #ttig.dpas
 #blocked = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [8, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
@@ -490,7 +490,7 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
 
 // -----
 
-// COM: For the mixed chained dot like dot(W, dot(dot(X, Y), Z))... cases, falling back to normal tiling pattern.
+// COM: For mixed chains such as dot(W, dot(dot(X, Y), Z)), apply directional chaining per DotOp instead of a global fallback.
 // CHECK: #[[$DPAS_0:.+]] = #ttig.dpas<{{.*}}warpsPerCTA = [4, 2]{{.*}}>
 // CHECK: #[[$DPAS_1:.+]] = #ttig.dpas<{{.*}}warpsPerCTA = [2, 4]{{.*}}>
 #blocked = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [8, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
@@ -524,21 +524,21 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
 
 // -----
 
-// COM: For the chained dot(dot(dot(X, Y), Z), W)... cases, if the num-warps is larger than needed, we will assigned the extra num-warps on the N dimenssion to reduce register space sizes.
+// COM: Chained dot(dot(dot(X, Y), Z), W) with 32 warps. The expected layouts are validated below.
 // CHECK: #[[$DPAS_A_0:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [8, 4], repCluster = [1, 1]
 // CHECK: #[[$DPAS_A_1:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [8, 4], repCluster = [1, 2]
 #blocked = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [8, 2], warpsPerCTA = [4, 8], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [16, 1], warpsPerCTA = [4, 8], order = [0, 1]}>
 module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.min_sg_size" = 16 : i32, "ttig.support_subgroup_matrix_multiply_accumulate"} {
-  // CHECK-LABEL: chained_dot_three_level
-  tt.func public @chained_dot_three_level(
+  // CHECK-LABEL: chained_dot_three_level_32warps
+  tt.func public @chained_dot_three_level_32warps(
     %arg0: tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
     %arg1: tensor<128x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
     %arg2: tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked1}>>,
     %arg3: tensor<128x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<64x64xf32, #blocked> {
     %cst_0 = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked>
     %cst_1 = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #blocked1>
-    // CHECK: tt.dot {{.*}} -> tensor<64x64xf32, #[[$DPAS_A]]>
+    // CHECK: tt.dot {{.*}} -> tensor<64x64xf32, #[[$DPAS_A_0]]>
     %d = tt.dot %arg0, %arg1, %cst_0 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} :
       tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<128x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x64xf32, #blocked>
     %t = arith.truncf %d : tensor<64x64xf32, #blocked> to tensor<64x64xf16, #blocked>
@@ -557,14 +557,41 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 
 // -----
 
-// COM: For the chained dot(X, dot(Y, Z)) case, if the num-warps is larger than needed, we will assigned the extra num-warps on the N dimenssion to reduce register space sizes.
+// COM: Cover the rank-3 extra-warps path where remaining warps are assigned to dim-0.
+// CHECK: #[[$DPAS_EXTRA_0:.+]] = #ttig.dpas<{{.*}}warpsPerCTA = [2, 8, 2]{{.*}}>
+// CHECK: #[[$DPAS_EXTRA_1:.+]] = #ttig.dpas<{{.*}}warpsPerCTA = [1, 8, 4]{{.*}}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 8, 4], threadsPerWarp = [1, 8, 2], warpsPerCTA = [4, 8, 1], order = [2, 1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8, 4], threadsPerWarp = [1, 16, 1], warpsPerCTA = [4, 8, 1], order = [2, 1, 0]}>
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.min_sg_size" = 16 : i32, "ttig.support_subgroup_matrix_multiply_accumulate"} {
+  // CHECK-LABEL: chained_dot_rank3_extra_warps
+  tt.func public @chained_dot_rank3_extra_warps(
+    %arg0: tensor<2x64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+    %arg1: tensor<2x128x32xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+    %arg2: tensor<2x32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked1}>>) -> tensor<2x64x64xf32, #blocked1> {
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<2x64x32xf32, #blocked>
+    %cst_1 = arith.constant dense<0.000000e+00> : tensor<2x64x64xf32, #blocked1>
+    // CHECK: tt.dot {{.*}} -> tensor<2x64x32xf32, #[[$DPAS_EXTRA_0]]>
+    %d = tt.dot %arg0, %arg1, %cst_0 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} :
+      tensor<2x64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<2x128x32xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<2x64x32xf32, #blocked>
+    %t = arith.truncf %d : tensor<2x64x32xf32, #blocked> to tensor<2x64x32xf16, #blocked>
+    %c = ttg.convert_layout %t : tensor<2x64x32xf16, #blocked> -> tensor<2x64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked1}>>
+    // CHECK: tt.dot {{.*}} -> tensor<2x64x64xf32, #[[$DPAS_EXTRA_1]]>
+    %r = tt.dot %c, %arg2, %cst_1 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} :
+      tensor<2x64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked1}>> * tensor<2x32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked1}>> -> tensor<2x64x64xf32, #blocked1>
+    tt.return %r : tensor<2x64x64xf32, #blocked1>
+  }
+}
+
+// -----
+
+// COM: Chained dot(X, dot(Y, Z)) with 32 warps. The expected layouts are validated below.
 // CHECK: #[[$DPAS_B_0:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 8], repCluster = [2, 1]
 // CHECK: #[[$DPAS_B_1:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 8], repCluster = [4, 1]
 #blocked = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [8, 2], warpsPerCTA = [4, 8], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [8, 4], threadsPerWarp = [16, 1], warpsPerCTA = [4, 8], order = [0, 1]}>
 module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.min_sg_size" = 16 : i32, "ttig.support_subgroup_matrix_multiply_accumulate"} {
-  // CHECK-LABEL: chained_dot_operand_b
-  tt.func public @chained_dot_operand_b(
+  // CHECK-LABEL: chained_dot_operand_b_32warps
+  tt.func public @chained_dot_operand_b_32warps(
     %arg0: tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
     %arg1: tensor<128x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
     %arg2: tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked1}>>) -> tensor<128x128xf32, #blocked1> {

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
@@ -162,6 +162,12 @@ def TritonIntelGPU_Dialect : Dialect {
       return "ttig.one_matrix_per_load";
     }
 
+    /// Get the name of the attribute used to record chained dot
+    /// classification for warp-tiling decisions.
+    static constexpr llvm::StringRef getChainedDotKindAttrName() {
+      return "ttig.chained_dot_kind";
+    }
+
     /// Get the name of the attribute used to propagate the padding option
     /// from MakeTensorDescOp to descriptor load/store operations.
     static constexpr llvm::StringRef getDescPaddingAttrName() {

--- a/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
@@ -130,7 +130,6 @@ static unsigned clampToPowerOfTwo(unsigned value) {
 }
 
 using ChainedDotKindMap = llvm::DenseMap<Operation *, ChainedDotKind>;
-constexpr StringLiteral kChainedDotKindAttrName = "ttig.chained_dot_kind";
 
 ChainedDotKind computeChainedDotKindFromSlices(Operation *dotOp,
                                                ChainedDotKindMap &cache);
@@ -139,14 +138,14 @@ ChainedDotKind computeChainedDotKind(Operation *dotOp,
                                      ChainedDotKindMap &cache);
 
 void setChainedDotKindAttr(Operation *op, ChainedDotKind kind) {
-  op->setAttr(kChainedDotKindAttrName,
+  op->setAttr(ttgi::TritonIntelGPUDialect::getChainedDotKindAttrName(),
               IntegerAttr::get(IntegerType::get(op->getContext(), 32),
                                static_cast<int32_t>(kind)));
 }
 
 std::optional<ChainedDotKind> getChainedDotKindAttr(Operation *op) {
-  auto kindAttr =
-      dyn_cast_or_null<IntegerAttr>(op->getAttr(kChainedDotKindAttrName));
+  auto kindAttr = dyn_cast_or_null<IntegerAttr>(
+      op->getAttr(ttgi::TritonIntelGPUDialect::getChainedDotKindAttrName()));
   if (!kindAttr)
     return std::nullopt;
   int64_t raw = kindAttr.getInt();
@@ -488,7 +487,8 @@ public:
         scaledDotOp.getC(), scaledDotOp.getAScale(), scaledDotOp.getBScale(),
         precA, precB, scaledDotOp.getFastMath(), scaledDotOp.getLhsKPack(),
         scaledDotOp.getRhsKPack());
-    newDot->setAttrs(scaledDotOp->getAttrs());
+    if (auto chainedDotKind = getChainedDotKindAttr(scaledDotOp))
+      setChainedDotKindAttr(newDot, *chainedDotKind);
 
     rewriter.replaceOp(scaledDotOp, newDot);
     return success();

--- a/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
@@ -18,6 +18,7 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
 #include <optional>
+#include <utility>
 
 using namespace mlir;
 namespace tt = mlir::triton;
@@ -61,6 +62,57 @@ unsigned getOpsPerChannel(Type elemType, ModuleOp m) {
          dpasElemBitWidths;
 }
 
+SetVector<Operation *> getChainedDotOps(Value operand) {
+  auto filter = [&operand](Operation *op) {
+    return op->getParentRegion() == operand.getParentRegion();
+  };
+  SetVector<Operation *> slice;
+  if (getBackwardSlice(operand, &slice, {filter}).succeeded()) {
+    SetVector<Operation *> dotOps;
+    for (Operation *op : slice) {
+      if (isa<tt::DotOp, tt::DotScaledOp>(op)) {
+        dotOps.insert(op);
+      }
+    }
+    return dotOps;
+  }
+  return {};
+}
+
+std::pair<Value, Value> getDotOperands(Operation *dotOp) {
+  return llvm::TypeSwitch<Operation *, std::pair<Value, Value>>(dotOp)
+      .Case<tt::DotOp, tt::DotScaledOp>(
+          [](auto op) { return std::make_pair(op.getA(), op.getB()); })
+      .Default([](Operation *) { return std::pair<Value, Value>{}; });
+}
+
+// Improve the tiling pattern for chained `tt.dot`/`tt.scaled_dot` operations.
+//
+// Consider the following chained dot operations on operands A and B:
+//
+// clang-format off
+//                dot      dot
+//                  \      /
+//                   \    /
+//            C = dot(A, B)  <- The dot operation to be tiled.
+//           /\
+//          /  \-------\
+//         /            \
+//    dot(A, B)   dot(A, B)
+// clang-format on
+//
+// First, check whether there is a dot operation in the backward slice of A or
+// B. If the dot operations are chained only along A or only along B,
+// aggressively assign parallelism to the M dimension or the N dimension,
+// respectively, to reduce the cost of the C -> A or C -> B layout conversion.
+//
+// Next, check whether the current dot operation is part of a forward chain
+// (that is, its result is used as operand A or B of another dot operation). If
+// so, similarly assign parallelism to the corresponding M or N dimension.
+//
+// If the dot operation is chained along both A and B, fall back to the default
+// tiling pattern.
+
 SmallVector<unsigned>
 getWarpsPerTile(Operation *dotOp,
                 const ttgi::DpasEncodingAttr::DPASCapability &dpasCap,
@@ -80,10 +132,62 @@ getWarpsPerTile(Operation *dotOp,
         setAttrOnBOperand(dotOp, attrName, UnitAttr::get(ctx));
         setAttrOnBOperand(op, attrName, UnitAttr::get(ctx));
       }
-      SmallVector<unsigned> ret(shape.size(), 1);
-      ret[0] = numWarps;
-      return ret;
     }
+  }
+
+  auto [A, B] = getDotOperands(dotOp);
+
+  auto dotOpsA = getChainedDotOps(A);
+  bool chainedDotA = !dotOpsA.empty();
+  auto dotOpsB = getChainedDotOps(B);
+  bool chainedDotB = !dotOpsB.empty();
+  if (!(chainedDotA && chainedDotB)) {
+    SetVector<Operation *> forwardSlice;
+    getForwardSlice(dotOp, &forwardSlice, {filter});
+    for (Operation *op : forwardSlice) {
+      if (isa<tt::DotOp, tt::DotScaledOp>(op)) {
+        auto [A, B] = getDotOperands(op);
+        auto dotOpsA = getChainedDotOps(A);
+        chainedDotA |= dotOpsA.contains(dotOp);
+        auto dotOpsB = getChainedDotOps(B);
+        chainedDotB |= dotOpsB.contains(dotOp);
+      }
+    }
+  }
+
+  if (chainedDotA ^ chainedDotB) {
+    unsigned rank = shape.size();
+    SmallVector<unsigned> ret(rank, 1);
+    unsigned maxNumWarpsAlongM =
+        mlir::ceil<unsigned>(shape[rank - 2], dpasCap.repeatCount);
+    unsigned maxNumWarpsAlongN =
+        mlir::ceil<unsigned>(shape[rank - 1], dpasCap.executionSize);
+    if (chainedDotA) {
+      ret[rank - 2] = std::min(maxNumWarpsAlongM, numWarps);
+      ret[rank - 1] = std::min(maxNumWarpsAlongN,
+                               mlir::ceil<unsigned>(numWarps, ret[rank - 2]));
+    } else {
+      ret[rank - 1] = std::min(maxNumWarpsAlongN, numWarps);
+      ret[rank - 2] = std::min(maxNumWarpsAlongM,
+                               mlir::ceil<unsigned>(numWarps, ret[rank - 1]));
+    }
+
+    unsigned numWarpsUsed = ret[rank - 1] * ret[rank - 2];
+    if (numWarpsUsed < numWarps) {
+      unsigned remainingWarps = numWarps / numWarpsUsed;
+      if (rank > 2) {
+        ret[0] = remainingWarps;
+      } else {
+        // Put the remaining parallelism on the other dim to reduce the costs.
+        if (chainedDotA) {
+          ret[rank - 1] *= remainingWarps;
+        } else {
+          ret[rank - 2] *= remainingWarps;
+        }
+      }
+    }
+
+    return ret;
   }
 
   return ttgi::calculateWarpsPerTile(dpasCap.repeatCount, dpasCap.executionSize,

--- a/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
@@ -16,8 +16,13 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/ADT/bit.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+#include <algorithm>
 #include <optional>
 #include <utility>
 
@@ -33,6 +38,9 @@ namespace mlir::triton::gpu::intel {
 } // namespace mlir::triton::gpu::intel
 
 namespace {
+
+#define DEBUG_TYPE "tritonintelgpu-accelerate-matmul"
+#define LDBG(X) LLVM_DEBUG(llvm::dbgs() << X << "\n")
 
 // FIXME: Remove once IGC can split large 2D block loads.
 static void setAttrOnBOperand(Operation *op, StringRef attrName,
@@ -77,6 +85,7 @@ SetVector<Operation *> getChainedDotOps(Value operand) {
     }
     return dotOps;
   }
+  LDBG("getBackwardSlice failed for operand: " << operand);
   return {};
 }
 
@@ -88,6 +97,10 @@ std::pair<Value, Value> getDotOperands(Operation *dotOp) {
 }
 
 enum class ChainedDotKind {
+  // Chained dots are classified per-dot to bias warp placement:
+  // - ChainedAlongA: prioritize M warps to reduce A-path convert_layout costs.
+  // - ChainedAlongB: prioritize N warps to reduce B-path convert_layout costs.
+  // - ChainedMixedAB: dot participates on both A/B chains; use default tiling.
   NoChained,
   ChainedAlongA,
   ChainedAlongB,
@@ -111,23 +124,52 @@ bool mergeChainedDotFlags(ChainedDotKind chainedDotKind, bool &chainedDotA,
   return false;
 }
 
+static unsigned clampToPowerOfTwo(unsigned value) {
+  // DPAS layout construction expects power-of-two warp counts per dimension.
+  return value == 0 ? 1 : llvm::bit_floor(value);
+}
+
 using ChainedDotKindMap = llvm::DenseMap<Operation *, ChainedDotKind>;
+constexpr StringLiteral kChainedDotKindAttrName = "ttig.chained_dot_kind";
 
-ChainedDotKind updateChainedDotFlagsFromForwardSlice(Operation *dotOp,
-                                                     ChainedDotKindMap &cache);
+ChainedDotKind computeChainedDotKindFromSlices(Operation *dotOp,
+                                               ChainedDotKindMap &cache);
 
-ChainedDotKind getChainedDotKind(Operation *dotOp, ChainedDotKindMap &cache) {
-  if (cache.count(dotOp)) {
-    return cache[dotOp];
-  }
-  ChainedDotKind dotChainedType =
-      updateChainedDotFlagsFromForwardSlice(dotOp, cache);
+ChainedDotKind computeChainedDotKind(Operation *dotOp,
+                                     ChainedDotKindMap &cache);
+
+void setChainedDotKindAttr(Operation *op, ChainedDotKind kind) {
+  op->setAttr(kChainedDotKindAttrName,
+              IntegerAttr::get(IntegerType::get(op->getContext(), 32),
+                               static_cast<int32_t>(kind)));
+}
+
+std::optional<ChainedDotKind> getChainedDotKindAttr(Operation *op) {
+  auto kindAttr =
+      dyn_cast_or_null<IntegerAttr>(op->getAttr(kChainedDotKindAttrName));
+  if (!kindAttr)
+    return std::nullopt;
+  int64_t raw = kindAttr.getInt();
+  if (raw < static_cast<int64_t>(ChainedDotKind::NoChained) ||
+      raw > static_cast<int64_t>(ChainedDotKind::ChainedMixedAB))
+    return std::nullopt;
+  return static_cast<ChainedDotKind>(raw);
+}
+
+ChainedDotKind computeChainedDotKind(Operation *dotOp,
+                                     ChainedDotKindMap &cache) {
+  if (!dotOp || !isa<tt::DotOp, tt::DotScaledOp>(dotOp))
+    return ChainedDotKind::NoChained;
+  if (auto it = cache.find(dotOp); it != cache.end())
+    return it->second;
+
+  ChainedDotKind dotChainedType = computeChainedDotKindFromSlices(dotOp, cache);
   cache.try_emplace(dotOp, dotChainedType);
   return dotChainedType;
 }
 
-ChainedDotKind updateChainedDotFlagsFromForwardSlice(Operation *dotOp,
-                                                     ChainedDotKindMap &cache) {
+ChainedDotKind computeChainedDotKindFromSlices(Operation *dotOp,
+                                               ChainedDotKindMap &cache) {
   auto filter = [&dotOp](Operation *op) {
     return op->getParentRegion() == dotOp->getParentRegion();
   };
@@ -140,10 +182,11 @@ ChainedDotKind updateChainedDotFlagsFromForwardSlice(Operation *dotOp,
   bool chainedDotB = !chainedDotOpsB.empty();
   if (!(chainedDotA && chainedDotB)) {
     // Not mixed yet: merge chained kinds from backward-slice DotOps.
-    // Recursion is bounded because it only walks backward slices.
+    // Recursion is bounded by the in-progress sentinel in
+    // computeChainedDotKind.
     auto updateChainedDotFlags = [&](auto &chainedDotOps) {
       for (Operation *op : chainedDotOps) {
-        if (mergeChainedDotFlags(getChainedDotKind(op, cache), chainedDotA,
+        if (mergeChainedDotFlags(computeChainedDotKind(op, cache), chainedDotA,
                                  chainedDotB))
           return true;
       }
@@ -179,14 +222,13 @@ ChainedDotKind updateChainedDotFlagsFromForwardSlice(Operation *dotOp,
   return ChainedDotKind::NoChained;
 }
 
-ChainedDotKindMap buildChainedDotKindMap(ModuleOp mod) {
+void annotateChainedDotKinds(ModuleOp mod) {
   ChainedDotKindMap chainedDotKinds;
   mod.walk([&](Operation *op) {
     if (!isa<tt::DotOp, tt::DotScaledOp>(op))
       return;
-    getChainedDotKind(op, chainedDotKinds);
+    setChainedDotKindAttr(op, computeChainedDotKind(op, chainedDotKinds));
   });
-  return chainedDotKinds;
 }
 
 template <typename OpTy, typename = std::enable_if_t<llvm::is_one_of<
@@ -195,10 +237,8 @@ class BlockedToDPAS : public OpRewritePattern<OpTy> {
   using TensorValue = TypedValue<RankedTensorType>;
 
 public:
-  BlockedToDPAS(MLIRContext *context, int benefit,
-                ChainedDotKindMap *chainedDotKinds)
-      : OpRewritePattern<OpTy>(context, benefit),
-        chainedDotKinds(chainedDotKinds) {}
+  BlockedToDPAS(MLIRContext *context, int benefit)
+      : OpRewritePattern<OpTy>(context, benefit) {}
 
   LogicalResult matchAndRewrite(OpTy op,
                                 PatternRewriter &rewriter) const override {
@@ -352,15 +392,20 @@ private:
       }
     }
 
-    ChainedDotKind chainedDotKind = getChainedDotKind(dotOp, *chainedDotKinds);
+    ChainedDotKind chainedDotKind = ChainedDotKind::NoChained;
+    if (auto kind = getChainedDotKindAttr(dotOp)) {
+      chainedDotKind = *kind;
+    }
+
     if (chainedDotKind == ChainedDotKind::ChainedAlongA ||
         chainedDotKind == ChainedDotKind::ChainedAlongB) {
       unsigned rank = shape.size();
+      assert((rank == 2 || rank == 3) && "expecting a 2D or 3D dot operation");
       SmallVector<unsigned> ret(rank, 1);
-      unsigned maxNumWarpsAlongM =
-          mlir::ceil<unsigned>(shape[rank - 2], dpasCap.repeatCount);
-      unsigned maxNumWarpsAlongN =
-          mlir::ceil<unsigned>(shape[rank - 1], dpasCap.executionSize);
+      unsigned maxNumWarpsAlongM = clampToPowerOfTwo(
+          mlir::ceil<unsigned>(shape[rank - 2], dpasCap.repeatCount));
+      unsigned maxNumWarpsAlongN = clampToPowerOfTwo(
+          mlir::ceil<unsigned>(shape[rank - 1], dpasCap.executionSize));
       if (chainedDotKind == ChainedDotKind::ChainedAlongA) {
         ret[rank - 2] = std::min(maxNumWarpsAlongM, numWarps);
         ret[rank - 1] = std::min(maxNumWarpsAlongN,
@@ -373,16 +418,19 @@ private:
 
       unsigned numWarpsUsed = ret[rank - 1] * ret[rank - 2];
       if (numWarpsUsed < numWarps) {
-        unsigned remainingWarps = numWarps / numWarpsUsed;
+        unsigned remainingWarps = mlir::ceil<unsigned>(numWarps, numWarpsUsed);
         if (rank > 2) {
-          ret[0] = remainingWarps;
+          unsigned batch =
+              static_cast<unsigned>(std::max<int64_t>(shape[0], 1));
+          ret[0] = std::min(clampToPowerOfTwo(batch), remainingWarps);
+          remainingWarps = mlir::ceil<unsigned>(remainingWarps, ret[0]);
+        }
+
+        // Put remaining parallelism on the non-chained dot dimension.
+        if (chainedDotKind == ChainedDotKind::ChainedAlongA) {
+          ret[rank - 1] *= remainingWarps;
         } else {
-          // Put remaining parallelism on the other dimension to reduce cost.
-          if (chainedDotKind == ChainedDotKind::ChainedAlongA) {
-            ret[rank - 1] *= remainingWarps;
-          } else {
-            ret[rank - 2] *= remainingWarps;
-          }
+          ret[rank - 2] *= remainingWarps;
         }
       }
 
@@ -393,8 +441,6 @@ private:
         dpasCap.repeatCount, dpasCap.executionSize, shape, numWarps);
     return ret;
   }
-
-  ChainedDotKindMap *chainedDotKinds;
 };
 
 class UpcastScaledBlocked : public OpRewritePattern<tt::DotScaledOp> {
@@ -439,6 +485,7 @@ public:
         scaledDotOp.getC(), scaledDotOp.getAScale(), scaledDotOp.getBScale(),
         precA, precB, scaledDotOp.getFastMath(), scaledDotOp.getLhsKPack(),
         scaledDotOp.getRhsKPack());
+    newDot->setAttrs(scaledDotOp->getAttrs());
 
     rewriter.replaceOp(scaledDotOp, newDot);
     return success();
@@ -790,16 +837,14 @@ public:
     if (!supportBlockScaleDPAS)
       transposeDotScaledOp(mod);
 
-    ChainedDotKindMap chainedDotKinds = buildChainedDotKindMap(mod);
+    annotateChainedDotKinds(mod);
 
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
     constexpr int benefitDefault = 1;
-    patterns.add<BlockedToDPAS<tt::DotOp>>(context, benefitDefault + 1,
-                                           &chainedDotKinds);
+    patterns.add<BlockedToDPAS<tt::DotOp>>(context, benefitDefault + 1);
     if (supportBlockScaleDPAS) {
-      patterns.add<BlockedToDPAS<tt::DotScaledOp>>(context, benefitDefault + 1,
-                                                   &chainedDotKinds);
+      patterns.add<BlockedToDPAS<tt::DotScaledOp>>(context, benefitDefault + 1);
       patterns.add<UpcastScaledBlocked>(context, benefitDefault + 1);
     }
     ttgi::populateDecomposeScaledBlockedPatterns(patterns, benefitDefault);

--- a/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
@@ -164,6 +164,9 @@ ChainedDotKind computeChainedDotKind(Operation *dotOp,
     return it->second;
 
   ChainedDotKind dotChainedType = computeChainedDotKindFromSlices(dotOp, cache);
+  // Recursion computeChainedDotKind -> computeChainedDotKindFromSlices ->
+  // computeChainedDotKind is bounded by the backward-slice. No re-entering of
+  // DotOp. DotOp output cannot be used by same DotOp.
   cache.try_emplace(dotOp, dotChainedType);
   return dotChainedType;
 }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
@@ -16,7 +16,6 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/ADT/bit.h"
 #include "llvm/Support/Casting.h"
@@ -184,8 +183,7 @@ ChainedDotKind computeChainedDotKindFromSlices(Operation *dotOp,
   bool chainedDotB = !chainedDotOpsB.empty();
   if (!(chainedDotA && chainedDotB)) {
     // Not mixed yet: merge chained kinds from backward-slice DotOps.
-    // Recursion is bounded by the in-progress sentinel in
-    // computeChainedDotKind.
+    // Termination relies on backward-slice acyclicity.
     auto updateChainedDotFlags = [&](auto &chainedDotOps) {
       for (Operation *op : chainedDotOps) {
         if (mergeChainedDotFlags(computeChainedDotKind(op, cache), chainedDotA,
@@ -230,6 +228,15 @@ void annotateChainedDotKinds(ModuleOp mod) {
     if (!isa<tt::DotOp, tt::DotScaledOp>(op))
       return;
     setChainedDotKindAttr(op, computeChainedDotKind(op, chainedDotKinds));
+  });
+}
+
+void clearChainedDotKindAttrs(ModuleOp mod) {
+  StringRef attrName = ttgi::TritonIntelGPUDialect::getChainedDotKindAttrName();
+  mod.walk([&](Operation *op) {
+    if (!isa<tt::DotOp, tt::DotScaledOp>(op))
+      return;
+    op->removeAttr(attrName);
   });
 }
 
@@ -853,6 +860,9 @@ public:
     ttgi::populateDecomposeScaledBlockedPatterns(patterns, benefitDefault);
     if (applyPatternsGreedily(mod, std::move(patterns)).failed())
       signalPassFailure();
+
+    // Chained-dot kind is temporary analysis metadata and should not leak.
+    clearChainedDotKindAttrs(mod);
 
     decomposeMixedModeDotOp(mod);
   }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/AccelerateMatmul.cpp
@@ -15,6 +15,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
 #include <optional>
@@ -86,112 +87,106 @@ std::pair<Value, Value> getDotOperands(Operation *dotOp) {
       .Default([](Operation *) { return std::pair<Value, Value>{}; });
 }
 
-// Improve the tiling pattern for chained `tt.dot`/`tt.scaled_dot` operations.
-//
-// Consider the following chained dot operations on operands A and B:
-//
-// clang-format off
-//                dot      dot
-//                  \      /
-//                   \    /
-//            C = dot(A, B)  <- The dot operation to be tiled.
-//           /\
-//          /  \-------\
-//         /            \
-//    dot(A, B)   dot(A, B)
-// clang-format on
-//
-// First, check whether there is a dot operation in the backward slice of A or
-// B. If the dot operations are chained only along A or only along B,
-// aggressively assign parallelism to the M dimension or the N dimension,
-// respectively, to reduce the cost of the C -> A or C -> B layout conversion.
-//
-// Next, check whether the current dot operation is part of a forward chain
-// (that is, its result is used as operand A or B of another dot operation). If
-// so, similarly assign parallelism to the corresponding M or N dimension.
-//
-// If the dot operation is chained along both A and B, fall back to the default
-// tiling pattern.
+enum class ChainedDotKind {
+  NoChained,
+  ChainedAlongA,
+  ChainedAlongB,
+  ChainedMixedAB,
+};
 
-SmallVector<unsigned>
-getWarpsPerTile(Operation *dotOp,
-                const ttgi::DpasEncodingAttr::DPASCapability &dpasCap,
-                const ArrayRef<int64_t> shape, unsigned numWarps) {
+bool mergeChainedDotFlags(ChainedDotKind chainedDotKind, bool &chainedDotA,
+                          bool &chainedDotB) {
+  switch (chainedDotKind) {
+  case ChainedDotKind::ChainedMixedAB:
+    return true;
+  case ChainedDotKind::ChainedAlongA:
+    chainedDotA = true;
+    break;
+  case ChainedDotKind::ChainedAlongB:
+    chainedDotB = true;
+    break;
+  case ChainedDotKind::NoChained:
+    break;
+  }
+  return false;
+}
+
+using ChainedDotKindMap = llvm::DenseMap<Operation *, ChainedDotKind>;
+
+ChainedDotKind updateChainedDotFlagsFromForwardSlice(Operation *dotOp,
+                                                     ChainedDotKindMap &cache);
+
+ChainedDotKind getChainedDotKind(Operation *dotOp, ChainedDotKindMap &cache) {
+  if (cache.count(dotOp)) {
+    return cache[dotOp];
+  }
+  ChainedDotKind dotChainedType =
+      updateChainedDotFlagsFromForwardSlice(dotOp, cache);
+  cache.try_emplace(dotOp, dotChainedType);
+  return dotChainedType;
+}
+
+ChainedDotKind updateChainedDotFlagsFromForwardSlice(Operation *dotOp,
+                                                     ChainedDotKindMap &cache) {
   auto filter = [&dotOp](Operation *op) {
     return op->getParentRegion() == dotOp->getParentRegion();
   };
 
-  SetVector<Operation *> slices = getSlice(dotOp, {filter});
-  for (Operation *op : slices) {
-    if (isa<tt::DotOp, tt::DotScaledOp>(op) && (op != dotOp)) {
-      if (auto forOp = op->getParentOfType<scf::ForOp>()) {
-        // FIXME: Remove once IGC can split large 2D block loads.
-        MLIRContext *ctx = forOp->getContext();
-        StringRef attrName =
-            ttgi::TritonIntelGPUDialect::getOneMatrixPerLoadAttrName();
-        setAttrOnBOperand(dotOp, attrName, UnitAttr::get(ctx));
-        setAttrOnBOperand(op, attrName, UnitAttr::get(ctx));
-      }
-    }
-  }
+  auto [operandA, operandB] = getDotOperands(dotOp);
 
-  auto [A, B] = getDotOperands(dotOp);
-
-  auto dotOpsA = getChainedDotOps(A);
-  bool chainedDotA = !dotOpsA.empty();
-  auto dotOpsB = getChainedDotOps(B);
-  bool chainedDotB = !dotOpsB.empty();
+  auto chainedDotOpsA = getChainedDotOps(operandA);
+  bool chainedDotA = !chainedDotOpsA.empty();
+  auto chainedDotOpsB = getChainedDotOps(operandB);
+  bool chainedDotB = !chainedDotOpsB.empty();
   if (!(chainedDotA && chainedDotB)) {
+    // Not mixed yet: merge chained kinds from backward-slice DotOps.
+    // Recursion is bounded because it only walks backward slices.
+    auto updateChainedDotFlags = [&](auto &chainedDotOps) {
+      for (Operation *op : chainedDotOps) {
+        if (mergeChainedDotFlags(getChainedDotKind(op, cache), chainedDotA,
+                                 chainedDotB))
+          return true;
+      }
+      return false;
+    };
+
+    if (updateChainedDotFlags(chainedDotOpsA) ||
+        updateChainedDotFlags(chainedDotOpsB))
+      return ChainedDotKind::ChainedMixedAB;
+
     SetVector<Operation *> forwardSlice;
     getForwardSlice(dotOp, &forwardSlice, {filter});
-    for (Operation *op : forwardSlice) {
-      if (isa<tt::DotOp, tt::DotScaledOp>(op)) {
-        auto [A, B] = getDotOperands(op);
-        auto dotOpsA = getChainedDotOps(A);
-        chainedDotA |= dotOpsA.contains(dotOp);
-        auto dotOpsB = getChainedDotOps(B);
-        chainedDotB |= dotOpsB.contains(dotOp);
-      }
+    for (Operation *forwardOp : forwardSlice) {
+      if (!isa<tt::DotOp, tt::DotScaledOp>(forwardOp))
+        continue;
+
+      auto [forwardOperandA, forwardOperandB] = getDotOperands(forwardOp);
+      auto forwardChainedDotOpsA = getChainedDotOps(forwardOperandA);
+      chainedDotA |= forwardChainedDotOpsA.contains(dotOp);
+      auto forwardChainedDotOpsB = getChainedDotOps(forwardOperandB);
+      chainedDotB |= forwardChainedDotOpsB.contains(dotOp);
+      if (chainedDotA && chainedDotB)
+        break;
     }
   }
 
-  if (chainedDotA ^ chainedDotB) {
-    unsigned rank = shape.size();
-    SmallVector<unsigned> ret(rank, 1);
-    unsigned maxNumWarpsAlongM =
-        mlir::ceil<unsigned>(shape[rank - 2], dpasCap.repeatCount);
-    unsigned maxNumWarpsAlongN =
-        mlir::ceil<unsigned>(shape[rank - 1], dpasCap.executionSize);
-    if (chainedDotA) {
-      ret[rank - 2] = std::min(maxNumWarpsAlongM, numWarps);
-      ret[rank - 1] = std::min(maxNumWarpsAlongN,
-                               mlir::ceil<unsigned>(numWarps, ret[rank - 2]));
-    } else {
-      ret[rank - 1] = std::min(maxNumWarpsAlongN, numWarps);
-      ret[rank - 2] = std::min(maxNumWarpsAlongM,
-                               mlir::ceil<unsigned>(numWarps, ret[rank - 1]));
-    }
+  if (chainedDotA && chainedDotB)
+    return ChainedDotKind::ChainedMixedAB;
+  if (chainedDotA)
+    return ChainedDotKind::ChainedAlongA;
+  if (chainedDotB)
+    return ChainedDotKind::ChainedAlongB;
+  return ChainedDotKind::NoChained;
+}
 
-    unsigned numWarpsUsed = ret[rank - 1] * ret[rank - 2];
-    if (numWarpsUsed < numWarps) {
-      unsigned remainingWarps = numWarps / numWarpsUsed;
-      if (rank > 2) {
-        ret[0] = remainingWarps;
-      } else {
-        // Put the remaining parallelism on the other dim to reduce the costs.
-        if (chainedDotA) {
-          ret[rank - 1] *= remainingWarps;
-        } else {
-          ret[rank - 2] *= remainingWarps;
-        }
-      }
-    }
-
-    return ret;
-  }
-
-  return ttgi::calculateWarpsPerTile(dpasCap.repeatCount, dpasCap.executionSize,
-                                     shape, numWarps);
+ChainedDotKindMap buildChainedDotKindMap(ModuleOp mod) {
+  ChainedDotKindMap chainedDotKinds;
+  mod.walk([&](Operation *op) {
+    if (!isa<tt::DotOp, tt::DotScaledOp>(op))
+      return;
+    getChainedDotKind(op, chainedDotKinds);
+  });
+  return chainedDotKinds;
 }
 
 template <typename OpTy, typename = std::enable_if_t<llvm::is_one_of<
@@ -200,8 +195,10 @@ class BlockedToDPAS : public OpRewritePattern<OpTy> {
   using TensorValue = TypedValue<RankedTensorType>;
 
 public:
-  BlockedToDPAS(MLIRContext *context, int benefit)
-      : OpRewritePattern<OpTy>(context, benefit) {}
+  BlockedToDPAS(MLIRContext *context, int benefit,
+                ChainedDotKindMap *chainedDotKinds)
+      : OpRewritePattern<OpTy>(context, benefit),
+        chainedDotKinds(chainedDotKinds) {}
 
   LogicalResult matchAndRewrite(OpTy op,
                                 PatternRewriter &rewriter) const override {
@@ -214,12 +211,12 @@ public:
     ModuleOp mod = funcOp->template getParentOfType<ModuleOp>();
     auto dpasAnalysis = ttgi::DPASAnalysisFactory::createDPASAnalysis(mod);
 
-    // Ensure function wide DPAS applicability.
+    // Ensure function-wide DPAS applicability.
     if (ttgi::DPASAnalysisFactory::canUseDPAS(funcOp, dpasAnalysis) !=
         ttgi::DPASAnalysisResult::True)
       return failure();
 
-    // Ensure operation DPAS applicability.
+    // Ensure operation-level DPAS applicability.
     if (ttgi::DPASAnalysisFactory::canUseDPAS(op, dpasAnalysis) !=
         ttgi::DPASAnalysisResult::True)
       return failure();
@@ -230,7 +227,7 @@ public:
     if (!dpasCap.has_value())
       return failure();
 
-    // Create DPAS encoding for the given number of warps
+    // Create a DPAS encoding for the requested number of warps.
     ArrayRef<int64_t> retShape = oldRetType.getShape();
     unsigned numWarps = ttg::lookupNumWarps(funcOp);
 
@@ -276,11 +273,12 @@ public:
 
     RankedTensorType newRetType = oldRetType.cloneWithEncoding(dpasEnc);
 
-    // convert accumulator
+    // Convert accumulator.
     TensorValue oldAcc = op.getC();
     auto newAcc = ttg::ConvertLayoutOp::create(rewriter, oldAcc.getLoc(),
                                                newRetType, oldAcc);
-    // opA are packed to i16 for scalar type < 16 bits. opB are packed to i32.
+    // Operand A is packed to i16 for scalar types < 16 bits.
+    // Operand B is packed to i32.
     auto newAEncoding = ttg::DotOperandEncodingAttr::get(
         oldAType.getContext(), 0, newRetType.getEncoding(),
         opsPerChan == 1 ? opsPerChan : opsPerChan / 2);
@@ -330,6 +328,73 @@ public:
 
     return success();
   }
+
+private:
+  SmallVector<unsigned>
+  getWarpsPerTile(Operation *dotOp,
+                  const ttgi::DpasEncodingAttr::DPASCapability &dpasCap,
+                  const ArrayRef<int64_t> shape, unsigned numWarps) const {
+    auto filter = [&dotOp](Operation *op) {
+      return op->getParentRegion() == dotOp->getParentRegion();
+    };
+
+    SetVector<Operation *> slices = getSlice(dotOp, {filter});
+    for (Operation *op : slices) {
+      if (isa<tt::DotOp, tt::DotScaledOp>(op) && (op != dotOp)) {
+        if (auto forOp = op->getParentOfType<scf::ForOp>()) {
+          // FIXME: Remove once IGC can split large 2D block loads.
+          MLIRContext *ctx = forOp->getContext();
+          StringRef attrName =
+              ttgi::TritonIntelGPUDialect::getOneMatrixPerLoadAttrName();
+          setAttrOnBOperand(dotOp, attrName, UnitAttr::get(ctx));
+          setAttrOnBOperand(op, attrName, UnitAttr::get(ctx));
+        }
+      }
+    }
+
+    ChainedDotKind chainedDotKind = getChainedDotKind(dotOp, *chainedDotKinds);
+    if (chainedDotKind == ChainedDotKind::ChainedAlongA ||
+        chainedDotKind == ChainedDotKind::ChainedAlongB) {
+      unsigned rank = shape.size();
+      SmallVector<unsigned> ret(rank, 1);
+      unsigned maxNumWarpsAlongM =
+          mlir::ceil<unsigned>(shape[rank - 2], dpasCap.repeatCount);
+      unsigned maxNumWarpsAlongN =
+          mlir::ceil<unsigned>(shape[rank - 1], dpasCap.executionSize);
+      if (chainedDotKind == ChainedDotKind::ChainedAlongA) {
+        ret[rank - 2] = std::min(maxNumWarpsAlongM, numWarps);
+        ret[rank - 1] = std::min(maxNumWarpsAlongN,
+                                 mlir::ceil<unsigned>(numWarps, ret[rank - 2]));
+      } else {
+        ret[rank - 1] = std::min(maxNumWarpsAlongN, numWarps);
+        ret[rank - 2] = std::min(maxNumWarpsAlongM,
+                                 mlir::ceil<unsigned>(numWarps, ret[rank - 1]));
+      }
+
+      unsigned numWarpsUsed = ret[rank - 1] * ret[rank - 2];
+      if (numWarpsUsed < numWarps) {
+        unsigned remainingWarps = numWarps / numWarpsUsed;
+        if (rank > 2) {
+          ret[0] = remainingWarps;
+        } else {
+          // Put remaining parallelism on the other dimension to reduce cost.
+          if (chainedDotKind == ChainedDotKind::ChainedAlongA) {
+            ret[rank - 1] *= remainingWarps;
+          } else {
+            ret[rank - 2] *= remainingWarps;
+          }
+        }
+      }
+
+      return ret;
+    }
+
+    SmallVector<unsigned> ret = ttgi::calculateWarpsPerTile(
+        dpasCap.repeatCount, dpasCap.executionSize, shape, numWarps);
+    return ret;
+  }
+
+  ChainedDotKindMap *chainedDotKinds;
 };
 
 class UpcastScaledBlocked : public OpRewritePattern<tt::DotScaledOp> {
@@ -402,7 +467,7 @@ private:
   std::optional<std::tuple<tt::ScaleDotElemType, tt::ScaleDotElemType>>
   getComputeType(tt::ScaleDotElemType aType, tt::ScaleDotElemType bType,
                  PatternRewriter &rewriter) const {
-    if (aType == bType) // Skip the dot_scaled which is not mixed precision.
+    if (aType == bType) // Skip dot_scaled when it is not mixed precision.
       return std::nullopt;
     std::optional<unsigned> aBitWidth = getScaleDotElemTypeBitWidth(aType);
     std::optional<unsigned> bBitWidth = getScaleDotElemTypeBitWidth(bType);
@@ -541,8 +606,8 @@ static void decomposeMixedModeDotOp(ModuleOp mod) {
 
     Type promoteType;
     if (dpasLayout) {
-      // fp8 is not always natively supported by the the DPAS instruction,
-      // promote it to fp16 when necessary.
+      // FP8 is not always natively supported by the DPAS instruction.
+      // Promote to FP16 when needed.
       bool isNativeFP8 = isa<Float8E5M2Type, Float8E4M3FNType>(AElType);
       auto mod = dotOp->getParentOfType<ModuleOp>();
       bool supportsFP8 = mod->hasAttr(
@@ -725,12 +790,16 @@ public:
     if (!supportBlockScaleDPAS)
       transposeDotScaledOp(mod);
 
+    ChainedDotKindMap chainedDotKinds = buildChainedDotKindMap(mod);
+
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
     constexpr int benefitDefault = 1;
-    patterns.add<BlockedToDPAS<tt::DotOp>>(context, benefitDefault + 1);
+    patterns.add<BlockedToDPAS<tt::DotOp>>(context, benefitDefault + 1,
+                                           &chainedDotKinds);
     if (supportBlockScaleDPAS) {
-      patterns.add<BlockedToDPAS<tt::DotScaledOp>>(context, benefitDefault + 1);
+      patterns.add<BlockedToDPAS<tt::DotScaledOp>>(context, benefitDefault + 1,
+                                                   &chainedDotKinds);
       patterns.add<UpcastScaledBlocked>(context, benefitDefault + 1);
     }
     ttgi::populateDecomposeScaledBlockedPatterns(patterns, benefitDefault);

--- a/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeScaledBlocked.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeScaledBlocked.cpp
@@ -60,6 +60,7 @@ public:
     auto newDot =
         DotOp::create(rewriter, scaledDotOp.getLoc(), scaledA, scaledB,
                       scaledDotOp.getC(), InputPrecision::TF32, 0);
+    newDot->setAttrs(scaledDotOp->getAttrs());
 
     rewriter.replaceOpWithNewOp<ConvertLayoutOp>(scaledDotOp,
                                                  scaledDotOp.getType(), newDot);

--- a/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeScaledBlocked.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeScaledBlocked.cpp
@@ -61,10 +61,8 @@ public:
         DotOp::create(rewriter, scaledDotOp.getLoc(), scaledA, scaledB,
                       scaledDotOp.getC(), InputPrecision::TF32, 0);
     if (auto chainedDotKind = scaledDotOp->getAttr(
-            mlir::triton::gpu::intel::TritonIntelGPUDialect::
-                getChainedDotKindAttrName()))
-      newDot->setAttr(mlir::triton::gpu::intel::TritonIntelGPUDialect::
-                          getChainedDotKindAttrName(),
+            intel::TritonIntelGPUDialect::getChainedDotKindAttrName()))
+      newDot->setAttr(intel::TritonIntelGPUDialect::getChainedDotKindAttrName(),
                       chainedDotKind);
 
     rewriter.replaceOpWithNewOp<ConvertLayoutOp>(scaledDotOp,

--- a/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeScaledBlocked.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/DecomposeScaledBlocked.cpp
@@ -60,7 +60,12 @@ public:
     auto newDot =
         DotOp::create(rewriter, scaledDotOp.getLoc(), scaledA, scaledB,
                       scaledDotOp.getC(), InputPrecision::TF32, 0);
-    newDot->setAttrs(scaledDotOp->getAttrs());
+    if (auto chainedDotKind = scaledDotOp->getAttr(
+            mlir::triton::gpu::intel::TritonIntelGPUDialect::
+                getChainedDotKindAttrName()))
+      newDot->setAttr(mlir::triton::gpu::intel::TritonIntelGPUDialect::
+                          getChainedDotKindAttrName(),
+                      chainedDotKind);
 
     rewriter.replaceOpWithNewOp<ConvertLayoutOp>(scaledDotOp,
                                                  scaledDotOp.getType(), newDot);


### PR DESCRIPTION
Improve AccelerateMatmul.cpp for the cases of the chained dot operations.

Get the best performance of chunk_gated_delta_rule_fwd_kernel_h_blockdim64 to 155.520us which has the chained dot operation `dot(A', dot(A, B))`