### PR TITLE
[SGLANG] Harden `install-sglang.sh` and drop dead code from the scaled_mm benchmark

### DIFF
--- a/.github/workflows/sglang-benchmarks.yml
+++ b/.github/workflows/sglang-benchmarks.yml
@@ -86,7 +86,24 @@ jobs:
           pip install cmake
 
       - name: Setup PyTorch
+        id: setup-pytorch
         uses: ./.github/actions/setup-pytorch
+
+      # Every benchmark here imports sglang, and sglang/srt/utils/common.py imports
+      # torchvision.io at module level. install-sglang.sh strips torch* from
+      # pyproject.toml, so torchvision has to be installed here - built from the
+      # PyTorch pin, because a PyPI wheel would pull in its own torch build.
+      - name: Identify torchvision pin
+        run: |
+          echo "TORCHVISION_COMMIT_ID=$(<pytorch/.github/ci_commit_pins/vision.txt)" | tee -a "$GITHUB_ENV"
+
+      - name: Install torchvision package
+        uses: ./.github/actions/install-dependency
+        with:
+          package: torchvision
+          repository: pytorch/vision
+          ref: ${{ env.TORCHVISION_COMMIT_ID }}
+          extra-cache-key: ${{ steps.setup-pytorch.outputs.pytorch_cache_key }}
 
       - name: Setup Triton
         uses: ./.github/actions/setup-triton

--- a/benchmarks/triton_kernels_benchmark/sglang/scaled_mm_benchmark.py
+++ b/benchmarks/triton_kernels_benchmark/sglang/scaled_mm_benchmark.py
@@ -2,7 +2,7 @@
 # https://github.com/sgl-project/sglang/blob/fdebc938f7f4d16fe6b9f55dcd9a767cf0899ea1/test/registered/quant/test_triton_scaled_mm.py
 # https://github.com/sgl-project/sglang/blob/fdebc938f7f4d16fe6b9f55dcd9a767cf0899ea1/python/sglang/kernels/ops/quantization/fp8_kernel.py
 import os
-from typing import Optional, List
+from typing import Optional
 
 import torch
 import triton
@@ -19,27 +19,6 @@ def is_weak_contiguous(x: torch.Tensor):
     is_not_transpose = strides[0] == 1 and (strides[1] >= max(1, sizes[0]))
     is_transpose = strides[1] == 1 and (strides[0] >= max(1, sizes[1]))
     return is_transpose or is_not_transpose
-
-
-def get_matmul_batched_autotune_configs() -> List[triton.Config]:
-    configs = [
-        triton.Config({'BLOCK_M': 256, 'BLOCK_N': 256, 'BLOCK_K': 32, 'grf_mode': '256'}, num_stages=s, num_warps=32)
-        for s in [2, 3]
-    ] + [
-        triton.Config({'BLOCK_M': 256, 'BLOCK_N': 128, 'BLOCK_K': 32, 'grf_mode': m}, num_stages=s, num_warps=w)
-        for s in [2]
-        for (m, w) in ([('256', 32), ('128', 64)])
-    ] + [
-        triton.Config({'BLOCK_M': 64, 'BLOCK_N': 128, 'BLOCK_K': 32, 'grf_mode': '256'}, num_stages=s, num_warps=32)
-        for s in [2]
-    ] + [
-        triton.Config({'BLOCK_M': 8, 'BLOCK_N': 512, 'BLOCK_K': 64, 'grf_mode': '256'}, num_stages=s, num_warps=32)
-        for s in [2]
-    ] + [
-        triton.Config({'BLOCK_M': 8, 'BLOCK_N': 128, 'BLOCK_K': 64, 'grf_mode': '256'}, num_stages=s, num_warps=4)
-        for s in [2]
-    ]
-    return configs
 
 
 @triton.jit
@@ -76,20 +55,9 @@ def scaled_mm_kernel_td(
     accumulator_dtype = ACCUMULATOR_DTYPE
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=accumulator_dtype)
 
-    # NOTE: Some tensor inputs are so large, they will cause int32 overflow
-    # so it is necessary to use tl.int64 for all the offsets, else SEGV will
-    # eventually occur.
-
-    # Offsets and masks.
-    # offsets_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
-    # masks_am = offsets_am < M
-
+    # NOTE: Some tensor inputs are so large that they would cause int32 overflow,
+    # so stride_am is tl.int64 and the N offsets below are computed in int64.
     offsets_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)
-    # masks_bn = offsets_bn < N
-
-    # offsets_k = tl.arange(0, BLOCK_SIZE_K).to(tl.int64)
-    # offsets_a = stride_am * offsets_am[:, None] + stride_ak * offsets_k[None, :]
-    # offsets_b = stride_bk * offsets_k[:, None] + stride_bn * offsets_bn[None, :]
 
     # NOTE: BLOCK_SIZE_SCALE_A could be 1 or BLOCK_SIZE_M, so need to create
     # appropriate offsets and masks for each case. Same goes for
@@ -105,32 +73,17 @@ def scaled_mm_kernel_td(
     b_desc = tl.make_tensor_descriptor(base=b_ptr, shape=(K, N), strides=(stride_bk, stride_bn),
                                        block_shape=(BLOCK_SIZE_K, BLOCK_SIZE_N))
 
-    # a_ptrs = a_ptr + offsets_a
-    # b_ptrs = b_ptr + offsets_b
-
     scale_a_ptrs = scale_a_ptr + offsets_scale_am
     scale_b_ptrs = scale_b_ptr + offsets_scale_bn
 
     off_k = 0
     for _ in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
-        # masks_k = offsets_k < K
-        # masks_a = masks_am[:, None] & masks_k[None, :]
-        # a = tl.load(a_ptrs, mask=masks_a)
-
-        # masks_b = masks_k[:, None] & masks_bn[None, :]
-        # b = tl.load(b_ptrs, mask=masks_b)
-
         a = a_desc.load([pid_m * BLOCK_SIZE_M, off_k])
         b = b_desc.load([off_k, pid_n * BLOCK_SIZE_N])
-        # accumulator += tl.dot(a, b)
 
         # Accumulate results.
         accumulator = tl.dot(a, b, accumulator, out_dtype=accumulator_dtype)
         off_k += BLOCK_SIZE_K
-
-        # offsets_k += BLOCK_SIZE_K
-        # a_ptrs += BLOCK_SIZE_K * stride_ak
-        # b_ptrs += BLOCK_SIZE_K * stride_bk
 
     # Apply scale at end.
     masks_scale_a = masks_scale_am[:, None] & (tl.arange(0, 1) < 1)[:, None]
@@ -158,14 +111,6 @@ def scaled_mm_kernel_td(
         c += bias
 
     # Save output
-    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
-    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)
-    offs_cm = offs_cm.to(tl.int64)
-    offs_cn = offs_cn.to(tl.int64)
-    # c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
-    # c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-
-    # tl.store(c_ptrs, c, mask=c_mask)
     c_desc = tl.make_tensor_descriptor(base=c_ptr, shape=(M, N), strides=(stride_cm, stride_cn),
                                        block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_N))
     c_desc.store([pid_m * BLOCK_SIZE_M, pid_n * BLOCK_SIZE_N], c)
@@ -181,10 +126,6 @@ def triton_scaled_mm_td(
     scale_b: torch.Tensor,
     out_dtype: type[torch.dtype],
     bias: Optional[torch.Tensor] = None,
-    block_size_m: int = 32,
-    block_size_n: int = 32,
-    block_size_k: int = 32,
-    use_heuristic=True,
 ) -> torch.Tensor:
     M, K = input.shape
     N = weight.shape[1]
@@ -210,19 +151,16 @@ def triton_scaled_mm_td(
 
     has_scalar = lambda x: x.shape[0] == 1 and x.shape[1] == 1
 
-    if use_heuristic:
-        is_small_N = N < 8192
-        next_power_of_2_M = max(32, triton.next_power_of_2(M))
-        if next_power_of_2_M <= 32:
-            tile_shape = (64, 64, 256) if is_small_N else (64, 128, 256)
-        elif next_power_of_2_M <= 64:
-            tile_shape = (64, 64, 256)
-        elif next_power_of_2_M <= 128:
-            tile_shape = (64, 128, 128)
-        else:
-            tile_shape = (128, 128, 128)
+    is_small_N = N < 8192
+    next_power_of_2_M = max(32, triton.next_power_of_2(M))
+    if next_power_of_2_M <= 32:
+        tile_shape = (64, 64, 256) if is_small_N else (64, 128, 256)
+    elif next_power_of_2_M <= 64:
+        tile_shape = (64, 64, 256)
+    elif next_power_of_2_M <= 128:
+        tile_shape = (64, 128, 128)
     else:
-        raise NotImplementedError('Only heuristic-based tile size selection is supported currently.')
+        tile_shape = (128, 128, 128)
 
     block_size_m, block_size_n, block_size_k = tile_shape
 

--- a/scripts/sglang/install-sglang.sh
+++ b/scripts/sglang/install-sglang.sh
@@ -6,6 +6,10 @@
 # XPU patches (sglang-test-fix.patch) and installs it in
 # editable mode. Torch/Triton dependencies are stripped from SGLang's
 # requirements so the repository's own (latest) torch and triton are kept.
+#
+# The source tree is always brought back to a pristine checkout of the pinned
+# commit before patching, so a run that failed half-way - or a bumped pin - cannot
+# leave behind a tree that is then silently reused in a wrong state.
 
 set -euo pipefail
 
@@ -13,6 +17,7 @@ OLD_DIR="$(pwd)"
 
 FORCE_REINSTALL=false
 SKIP_INSTALL=false
+REUSE_SOURCE=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -26,6 +31,11 @@ while [[ $# -gt 0 ]]; do
       SKIP_INSTALL=true
       shift
       ;;
+    -nc|--no-clean)
+      # Reuse an existing ./sglang as-is: skip the reset and the patching.
+      REUSE_SOURCE=true
+      shift
+      ;;
     --help)
       cat <<EOF
 Usage: ./install-sglang.sh [options]
@@ -33,6 +43,8 @@ Usage: ./install-sglang.sh [options]
 Options:
   --force-reinstall  Force reinstallation even if SGLang is already installed.
   --skip-install     Clone and patch only, skip pip install.
+  -nc, --no-clean    Reuse an existing ./sglang tree as-is (skip reset and patching).
+                     Use it to keep local modifications to the tree.
   --help             Show this help message and exit.
 EOF
       exit 0
@@ -52,6 +64,9 @@ ROOT="$(cd "$SGLANG_SCRIPTS_DIR/../.." && pwd)"
 # test-triton.sh's run_sglang_tests, which expect ./sglang there).
 cd "$ROOT"
 
+SGLANG_DIR="$ROOT/sglang"
+SGLANG_PATCH="$SGLANG_SCRIPTS_DIR/sglang-test-fix.patch"
+
 # Use SGLANG_PIN environment variable if set, otherwise read from file.
 if [ -z "${SGLANG_PIN:-}" ]; then
   SGLANG_PIN="$(<"$SGLANG_SCRIPTS_DIR/sglang-pin.txt")"
@@ -60,48 +75,123 @@ fi
 echo "**** SGLang pin: $SGLANG_PIN ****"
 
 ############################################################################
-# Check if already installed
+# Source preparation
 
-if pip show sglang >/dev/null 2>&1; then
-  if [ "$FORCE_REINSTALL" = false ]; then
-    echo "**** SGLang is already installed, skipping. ****"
-    echo "**** Use --force-reinstall to force reinstallation. ****"
-    echo "**** To get a clean install: rm -rf ./sglang && pip uninstall -y sglang ****"
-    exit 0
-  fi
-  echo "**** --force-reinstall: uninstalling existing SGLang. ****"
-  pip uninstall -y sglang
-  rm -rf ./sglang
-fi
+clone_sglang() {
+  rm -rf "$SGLANG_DIR"
+  git clone https://github.com/sgl-project/sglang.git "$SGLANG_DIR"
+  git -C "$SGLANG_DIR" checkout "$SGLANG_PIN"
+}
 
-############################################################################
-# Clone, checkout pinned commit and patch for XPU
-
-if [ -d "./sglang" ]; then
-  if [ "$FORCE_REINSTALL" = true ]; then
-    echo "**** Removing existing ./sglang ****"
-    rm -rf ./sglang
-  else
-    echo "**** Reusing existing ./sglang directory. ****"
-  fi
-fi
-
-if [ ! -d "./sglang" ]; then
-  git clone https://github.com/sgl-project/sglang.git
-  cd sglang
-  git checkout "$SGLANG_PIN"
-  echo "SGLang commit: '$(git rev-parse HEAD)'"
-  git apply "$SGLANG_SCRIPTS_DIR/sglang-test-fix.patch"
+# Apply the XPU-specific changes on top of a pristine checkout.
+patch_sglang() {
+  git -C "$SGLANG_DIR" apply "$SGLANG_PATCH"
 
   # That's how sglang assumes we'll pick out platform for now.
-  cp python/pyproject_xpu.toml python/pyproject.toml
+  # NOTE: python/pyproject.toml is tracked upstream, so the reset in prepare_source
+  # reverts this overwrite - it has to be redone on every preparation.
+  cp "$SGLANG_DIR/python/pyproject_xpu.toml" "$SGLANG_DIR/python/pyproject.toml"
   # Remove all torch libraries from requirements to avoid reinstalling triton & torch.
   # Remove sgl-kernel due to a bug in the current environment (newer torch); we don't use it here.
   # Remove timm because it depends on torchvision, which depends on a pinned torch.
-  sed -i '/pytorch\|torch\|sgl-kernel\|timm/d' python/pyproject.toml
-  cat python/pyproject.toml
-  cd ..
+  sed -i '/pytorch\|torch\|sgl-kernel\|timm/d' "$SGLANG_DIR/python/pyproject.toml"
+  cat "$SGLANG_DIR/python/pyproject.toml"
+}
+
+# True when $SGLANG_DIR is itself a git work tree. Without this check a corrupted
+# or leftover $SGLANG_DIR/.git makes git walk up and resolve to *this* repository,
+# so a reset/clean could operate on the Triton checkout instead of on SGLang.
+is_sglang_repo() {
+  [ -d "$SGLANG_DIR/.git" ] || return 1
+  local top
+  top="$(git -C "$SGLANG_DIR" rev-parse --show-toplevel 2>/dev/null)" || return 1
+  [ "$top" = "$SGLANG_DIR" ]
+}
+
+# Bring ./sglang to a pristine checkout of the pinned commit and patch it.
+# Re-clones when an existing tree cannot be reset, e.g. when a previous run failed
+# after cloning but before the checkout/patching finished.
+prepare_source() {
+  if is_sglang_repo; then
+    if [ "$REUSE_SOURCE" = true ]; then
+      echo "**** --no-clean: reusing existing $SGLANG_DIR as-is. ****"
+      echo "SGLang commit: '$(git -C "$SGLANG_DIR" rev-parse HEAD)'"
+      return
+    fi
+
+    # Only fetch when the pinned commit is not available locally yet, so that
+    # re-preparing an up-to-date checkout does not need the network.
+    if ! git -C "$SGLANG_DIR" rev-parse --verify --quiet "${SGLANG_PIN}^{commit}" >/dev/null; then
+      git -C "$SGLANG_DIR" fetch --tags origin || true
+    fi
+
+    if git -C "$SGLANG_DIR" reset --hard "$SGLANG_PIN" \
+      && git -C "$SGLANG_DIR" clean -xffd; then
+      echo "**** Reset existing $SGLANG_DIR to the pinned commit. ****"
+    else
+      echo "**** Could not reset $SGLANG_DIR to the pinned commit, re-cloning. ****"
+      clone_sglang
+    fi
+  else
+    clone_sglang
+  fi
+
+  echo "SGLang commit: '$(git -C "$SGLANG_DIR" rev-parse HEAD)'"
+  patch_sglang
+}
+
+############################################################################
+# Check whether the current installation already matches the pin
+
+# Resolve the pin (full or short SHA, tag or branch) to a full SHA via the checkout.
+resolve_pin() {
+  git -C "$SGLANG_DIR" rev-parse --verify --quiet "${SGLANG_PIN}^{commit}" 2>/dev/null
+}
+
+# True only when sglang is installed AND its (editable) source tree is present,
+# checked out at the pinned commit and patched.
+installed_at_pin() {
+  pip show sglang >/dev/null 2>&1 || return 1
+  # The install is editable, so a missing tree means a broken installation.
+  is_sglang_repo || return 1
+  [ -f "$SGLANG_DIR/python/pyproject.toml" ] || return 1
+
+  local want head
+  want="$(resolve_pin)" || return 1
+  [ -n "$want" ] || return 1
+  head="$(git -C "$SGLANG_DIR" rev-parse HEAD)"
+  [ "$head" = "$want" ] || return 1
+
+  # The patch has to be applied already, i.e. reverse-applying it must be possible.
+  git -C "$SGLANG_DIR" apply --reverse --check "$SGLANG_PATCH" 2>/dev/null || return 1
+}
+
+if [ "$FORCE_REINSTALL" = true ]; then
+  if pip show sglang >/dev/null 2>&1; then
+    echo "**** --force-reinstall: uninstalling existing SGLang. ****"
+    pip uninstall -y sglang
+  fi
+  echo "**** --force-reinstall: removing $SGLANG_DIR. ****"
+  rm -rf "$SGLANG_DIR"
+elif [ "$REUSE_SOURCE" = true ]; then
+  echo "**** --no-clean: not checking the installed commit against the pin. ****"
+elif installed_at_pin; then
+  echo "**** SGLang is already installed at the pinned commit, skipping. ****"
+  echo "**** Use --force-reinstall to force reinstallation. ****"
+  cd "$OLD_DIR"
+  exit 0
+elif pip show sglang >/dev/null 2>&1; then
+  # Never silently keep a stale installation: after a pin bump, or when the source
+  # tree is missing, unpatched or at a different commit, the tree is re-prepared
+  # and SGLang is reinstalled below.
+  echo "**** Installed SGLang does not match the pin: wrong commit, or a missing or ****"
+  echo "**** unpatched source tree. Re-preparing $SGLANG_DIR and reinstalling. ****"
 fi
+
+############################################################################
+# Clone/reset, checkout pinned commit and patch for XPU
+
+prepare_source
 
 ############################################################################
 # Install
@@ -112,7 +202,7 @@ if [ "$SKIP_INSTALL" = true ]; then
   exit 0
 fi
 
-pip install -e "./sglang/python"
+pip install -e "$SGLANG_DIR/python"
 # sglang imports xgrammar unconditionally, but pyproject_xpu.toml leaves it out because
 # it pulls in CUDA torch. Install without deps so our XPU torch and triton survive.
 # Versions match sglang's own pyproject.toml, so an upstream release cannot break us.

--- a/scripts/sglang/install-sglang.sh
+++ b/scripts/sglang/install-sglang.sh
@@ -227,4 +227,10 @@ pip install -e "$SGLANG_DIR/python"
 
 echo "**** SGLang installed successfully ****"
 
+if ! python -c 'import torchvision' 2>/dev/null; then
+  echo "**** WARNING: torchvision is not installed, any 'import sglang' will fail. ****" >&2
+  echo "**** WARNING: it ships with the PyTorch wheel set (scripts/install-pytorch.sh); ****" >&2
+  echo "**** WARNING: CI builds it from pytorch/.github/ci_commit_pins/vision.txt.     ****" >&2
+fi
+
 cd "$OLD_DIR"

--- a/scripts/sglang/install-sglang.sh
+++ b/scripts/sglang/install-sglang.sh
@@ -7,9 +7,9 @@
 # editable mode. Torch/Triton dependencies are stripped from SGLang's
 # requirements so the repository's own (latest) torch and triton are kept.
 #
-# The source tree is always brought back to a pristine checkout of the pinned
-# commit before patching, so a run that failed half-way - or a bumped pin - cannot
-# leave behind a tree that is then silently reused in a wrong state.
+# Whenever the source tree is prepared it is first brought back to a pristine
+# checkout of the pinned commit, so a run that failed half-way - or a bumped pin -
+# cannot leave behind a tree that is then silently reused in a wrong state.
 
 set -euo pipefail
 
@@ -102,23 +102,32 @@ patch_sglang() {
 # or leftover $SGLANG_DIR/.git makes git walk up and resolve to *this* repository,
 # so a reset/clean could operate on the Triton checkout instead of on SGLang.
 is_sglang_repo() {
-  [ -d "$SGLANG_DIR/.git" ] || return 1
-  local top
+  # A regular checkout has a .git directory, while a git worktree has a .git file.
+  [ -e "$SGLANG_DIR/.git" ] || return 1
+  local top dir
   top="$(git -C "$SGLANG_DIR" rev-parse --show-toplevel 2>/dev/null)" || return 1
-  [ "$top" = "$SGLANG_DIR" ]
+  dir="$(cd "$SGLANG_DIR" && pwd -P)" || return 1
+  [ "$top" = "$dir" ]
 }
 
 # Bring ./sglang to a pristine checkout of the pinned commit and patch it.
 # Re-clones when an existing tree cannot be reset, e.g. when a previous run failed
 # after cloning but before the checkout/patching finished.
 prepare_source() {
-  if is_sglang_repo; then
-    if [ "$REUSE_SOURCE" = true ]; then
-      echo "**** --no-clean: reusing existing $SGLANG_DIR as-is. ****"
-      echo "SGLang commit: '$(git -C "$SGLANG_DIR" rev-parse HEAD)'"
-      return
+  # --no-clean must never remove an existing path. Fail closed when it is not a
+  # valid standalone repository instead of falling through to clone_sglang's rm.
+  if [ "$REUSE_SOURCE" = true ] && { [ -e "$SGLANG_DIR" ] || [ -L "$SGLANG_DIR" ]; }; then
+    if ! is_sglang_repo; then
+      echo "ERROR: --no-clean requested, but $SGLANG_DIR is not a valid SGLang repository." >&2
+      echo "ERROR: Refusing to remove or modify the existing path." >&2
+      return 1
     fi
+    echo "**** --no-clean: reusing existing $SGLANG_DIR as-is. ****"
+    echo "SGLang commit: '$(git -C "$SGLANG_DIR" rev-parse HEAD)'"
+    return
+  fi
 
+  if is_sglang_repo; then
     # Only fetch when the pinned commit is not available locally yet, so that
     # re-preparing an up-to-date checkout does not need the network.
     if ! git -C "$SGLANG_DIR" rev-parse --verify --quiet "${SGLANG_PIN}^{commit}" >/dev/null; then
@@ -159,20 +168,31 @@ installed_at_pin() {
   local want head
   want="$(resolve_pin)" || return 1
   [ -n "$want" ] || return 1
-  head="$(git -C "$SGLANG_DIR" rev-parse HEAD)"
+  head="$(git -C "$SGLANG_DIR" rev-parse HEAD)" || return 1
   [ "$head" = "$want" ] || return 1
 
   # The patch has to be applied already, i.e. reverse-applying it must be possible.
   git -C "$SGLANG_DIR" apply --reverse --check "$SGLANG_PATCH" 2>/dev/null || return 1
 }
 
+# Dependencies SGLang needs at runtime but that pyproject_xpu.toml deliberately
+# leaves out. Installed before SGLang itself (as install-vllm.sh does), so a failure
+# here cannot leave an installed SGLang behind that makes the next run skip ahead.
+install_runtime_dependencies() {
+  # sglang imports xgrammar unconditionally, but pyproject_xpu.toml leaves it out because
+  # it pulls in CUDA torch. Install without deps so our XPU torch and triton survive.
+  # Versions match sglang's own pyproject.toml, so an upstream release cannot break us.
+  pip install --no-deps xgrammar==0.2.1 apache-tvm-ffi==0.1.11
+}
+
+# As in scripts/vllm/install-vllm.sh, --force-reinstall only drops the installed
+# package; the state of the source tree is left to prepare_source. That way it
+# composes with --no-clean instead of contradicting it.
 if [ "$FORCE_REINSTALL" = true ]; then
   if pip show sglang >/dev/null 2>&1; then
     echo "**** --force-reinstall: uninstalling existing SGLang. ****"
     pip uninstall -y sglang
   fi
-  echo "**** --force-reinstall: removing $SGLANG_DIR. ****"
-  rm -rf "$SGLANG_DIR"
 elif [ "$REUSE_SOURCE" = true ]; then
   echo "**** --no-clean: not checking the installed commit against the pin. ****"
 elif installed_at_pin; then
@@ -202,11 +222,8 @@ if [ "$SKIP_INSTALL" = true ]; then
   exit 0
 fi
 
+install_runtime_dependencies
 pip install -e "$SGLANG_DIR/python"
-# sglang imports xgrammar unconditionally, but pyproject_xpu.toml leaves it out because
-# it pulls in CUDA torch. Install without deps so our XPU torch and triton survive.
-# Versions match sglang's own pyproject.toml, so an upstream release cannot break us.
-pip install --no-deps xgrammar==0.2.1 apache-tvm-ffi==0.1.11
 
 echo "**** SGLang installed successfully ****"
 


### PR DESCRIPTION
Follow-up cleanup to #6789.

 `scripts/sglang/install-sglang.sh` - two robustness fixes, modelled on `install-vllm.sh`:
 - The source tree is now always reset to a pristine checkout of the pinned commit before patching (re-cloning if it cannot be reset), so a run that failed half-way is no longer silently reused. Previously patching only happened on a fresh clone, while `pip install -e` ran regardless.
 - The installed commit is verified against the pin instead of only checking that sglang is installed, so a bumped pin or a missing/unpatched tree triggers a reinstall instead of reporting "already installed, skipping".
 - Adds `-nc`/`--no-clean` to keep local modifications, and refuses to touch the tree when a corrupted `./sglang/.git` would make git resolve to this repository.

 sglang/scaled_mm_benchmark.py - removes dead code: the never-called `get_matmul_batched_autotune_configs` (the kernel is not autotuned), the commented-out pointer-path code and the offsets that only fed it, and the `block_size_*`/`use_heuristic` arguments that were unconditionally overwritten by the tile-size heuristic.
 
 ------
 
 Also added `torchvision` install step for perf benchmarks as for sglang benchmarks https://github.com/intel/intel-xpu-backend-for-triton/pull/7659 