### PR TITLE
[vLLM] Trigger BMG benchmarks on the `run-benchmarks` label

### DIFF
--- a/.github/workflows/vllm-benchmarks-bmg.yml
+++ b/.github/workflows/vllm-benchmarks-bmg.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
   schedule:
     - cron: "0 8 * * *"
 
@@ -34,7 +34,8 @@ jobs:
     needs: check-paths
     if: >-
       github.event_name == 'schedule' ||
-      needs.check-paths.outputs.benchmarks == 'true'
+      needs.check-paths.outputs.benchmarks == 'true' ||
+      github.event.label.name == 'run-benchmarks'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
@@ -44,7 +45,8 @@ jobs:
     if: >-
       always() && !cancelled() &&
       (github.event_name == 'schedule' ||
-       needs.check-paths.outputs.benchmarks == 'true')
+       needs.check-paths.outputs.benchmarks == 'true' ||
+       github.event.label.name == 'run-benchmarks')
     uses: ./.github/workflows/vllm-benchmarks.yml
     with:
       runner_label: b580


### PR DESCRIPTION
Labelling a PR with `run-benchmarks` started the PVC vLLM benchmarks but not the BMG ones. 
#7567 added the `pull_request` trigger for BMG but did not carry over the label handling from the PVC workflow.