### PR TITLE
[SimplifySignedArithmetic] Extend non-negative analysis to catch more signed→unsigned conversions

### DIFF
--- a/test/Triton/Intel/SimplifySignedArithmetic/simplify-signed-arithmetic.mlir
+++ b/test/Triton/Intel/SimplifySignedArithmetic/simplify-signed-arithmetic.mlir
@@ -338,8 +338,9 @@ tt.func public @remsi_nonneg_dividend_nonconst_divisor(%arg0: i32) -> i32 {
 
 // -----
 
-// Test 18: divsi with non-negative dividend and non-negative (non-constant)
-// divisor produces non-negative result. Downstream remsi should be converted.
+// Test 18: divsi with non-negative dividend and get_num_programs divisor.
+// get_num_programs is strictly positive, so the divsi converts to divui; its
+// non-negative result then lets the downstream remsi convert to remui.
 module {
 tt.func public @divsi_nonneg_both_operands() -> i32 {
   %pid = tt.get_program_id x : i32
@@ -352,7 +353,7 @@ tt.func public @divsi_nonneg_both_operands() -> i32 {
 // CHECK-LABEL: @divsi_nonneg_both_operands
 // CHECK: %[[PID:.*]] = tt.get_program_id x
 // CHECK: %[[NP:.*]] = tt.get_num_programs x
-// CHECK: %[[DIV:.*]] = arith.divsi %[[PID]], %[[NP]]
+// CHECK: %[[DIV:.*]] = arith.divui %[[PID]], %[[NP]]
 // CHECK: %[[C16:.*]] = arith.constant 16
 // CHECK: %[[REM:.*]] = arith.remui %[[DIV]], %[[C16]]
 // CHECK: tt.return %[[REM]]
@@ -609,4 +610,421 @@ tt.func public @no_convert_maxsi_both_unknown(%arg0: i32, %arg1: i32) -> i32 {
 // CHECK: arith.maxsi
 // CHECK: arith.divsi
 // CHECK-NOT: arith.divui
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// andi widening tests
+//===----------------------------------------------------------------------===//
+
+// Test 22: andi with non-negative first operand and non-constant second -> convert
+module {
+tt.func public @andi_nonneg_nonconstant_operand(%arg0: i32) -> i32 {
+  %pid = tt.get_program_id x : i32
+  %m = arith.andi %pid, %arg0 : i32
+  %c128 = arith.constant 128 : i32
+  %rem = arith.remsi %m, %c128 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @andi_nonneg_nonconstant_operand
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[M:.*]] = arith.andi %[[PID]], %arg0
+// CHECK: %[[C128:.*]] = arith.constant 128
+// CHECK: %[[REM:.*]] = arith.remui %[[M]], %[[C128]]
+// CHECK: tt.return %[[REM]]
+}
+
+// -----
+
+// Negative Test 13: andi with both operands unknown -> do NOT convert
+module {
+tt.func public @no_convert_andi_both_unknown(%arg0: i32, %arg1: i32) -> i32 {
+  %m = arith.andi %arg0, %arg1 : i32
+  %c128 = arith.constant 128 : i32
+  %rem = arith.remsi %m, %c128 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @no_convert_andi_both_unknown
+// CHECK: arith.andi
+// CHECK: arith.remsi
+// CHECK-NOT: arith.remui
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// extui / extsi tests
+//===----------------------------------------------------------------------===//
+
+// Test 23: extui always produces non-negative result -> convert
+module {
+tt.func public @extui_always_nonneg(%arg0: i16) -> i32 {
+  %e = arith.extui %arg0 : i16 to i32
+  %c128 = arith.constant 128 : i32
+  %div = arith.divsi %e, %c128 : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @extui_always_nonneg
+// CHECK: %[[E:.*]] = arith.extui %arg0
+// CHECK: %[[C128:.*]] = arith.constant 128
+// CHECK: %[[DIV:.*]] = arith.divui %[[E]], %[[C128]]
+// CHECK: tt.return %[[DIV]]
+}
+
+// -----
+
+// Test 24: extsi with non-negative input -> convert
+module {
+tt.func public @extsi_nonneg_input() -> i32 {
+  %c5 = arith.constant 5 : i16
+  %e = arith.extsi %c5 : i16 to i32
+  %c8 = arith.constant 8 : i32
+  %div = arith.divsi %e, %c8 : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @extsi_nonneg_input
+// CHECK: %[[C5:.*]] = arith.constant 5
+// CHECK: %[[E:.*]] = arith.extsi %[[C5]]
+// CHECK: %[[C8:.*]] = arith.constant 8
+// CHECK: %[[DIV:.*]] = arith.divui %[[E]], %[[C8]]
+// CHECK: tt.return %[[DIV]]
+}
+
+// -----
+
+// Negative Test 14: extsi with unknown input -> do NOT convert
+module {
+tt.func public @no_convert_extsi_unknown_input(%arg0: i16) -> i32 {
+  %e = arith.extsi %arg0 : i16 to i32
+  %c8 = arith.constant 8 : i32
+  %div = arith.divsi %e, %c8 : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @no_convert_extsi_unknown_input
+// CHECK: arith.extsi
+// CHECK: arith.divsi
+// CHECK-NOT: arith.divui
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// shrui / shrsi tests
+//===----------------------------------------------------------------------===//
+
+// Negative Test 15: shrui does not guarantee non-negativity -> do NOT convert
+module {
+tt.func public @no_convert_shrui_shift_zero(%arg0: i32) -> i32 {
+  %c0 = arith.constant 0 : i32
+  %s = arith.shrui %arg0, %c0 : i32
+  %c128 = arith.constant 128 : i32
+  %div = arith.divsi %s, %c128 : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @no_convert_shrui_shift_zero
+// CHECK: arith.shrui
+// CHECK: arith.divsi
+// CHECK-NOT: arith.divui
+}
+
+// -----
+
+// Test 25: shrsi with non-negative LHS -> convert
+module {
+tt.func public @shrsi_nonneg_lhs() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c2 = arith.constant 2 : i32
+  %s = arith.shrsi %pid, %c2 : i32
+  %c64 = arith.constant 64 : i32
+  %rem = arith.remsi %s, %c64 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @shrsi_nonneg_lhs
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[C2:.*]] = arith.constant 2
+// CHECK: %[[S:.*]] = arith.shrsi %[[PID]], %[[C2]]
+// CHECK: %[[C64:.*]] = arith.constant 64
+// CHECK: %[[REM:.*]] = arith.remui %[[S]], %[[C64]]
+// CHECK: tt.return %[[REM]]
+}
+
+// -----
+
+// Negative Test 16: shrsi with unknown LHS -> do NOT convert
+module {
+tt.func public @no_convert_shrsi_unknown_lhs(%arg0: i32) -> i32 {
+  %c2 = arith.constant 2 : i32
+  %s = arith.shrsi %arg0, %c2 : i32
+  %c64 = arith.constant 64 : i32
+  %rem = arith.remsi %s, %c64 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @no_convert_shrsi_unknown_lhs
+// CHECK: arith.shrsi
+// CHECK: arith.remsi
+// CHECK-NOT: arith.remui
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// trunci test
+//===----------------------------------------------------------------------===//
+
+// Negative Test 17: trunci is unsafe (can truncate sign bit) -> do NOT convert
+module {
+tt.func public @no_convert_trunci() -> i16 {
+  %pid = tt.get_program_id x : i32
+  %t = arith.trunci %pid : i32 to i16
+  %c8 = arith.constant 8 : i16
+  %rem = arith.remsi %t, %c8 : i16
+  tt.return %rem : i16
+}
+// CHECK-LABEL: @no_convert_trunci
+// CHECK: arith.trunci
+// CHECK: arith.remsi
+// CHECK-NOT: arith.remui
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// minui / maxui tests
+//===----------------------------------------------------------------------===//
+
+// Negative Test 18: minui does not guarantee non-negativity -> do NOT convert
+module {
+tt.func public @no_convert_minui(%arg0: i32, %arg1: i32) -> i32 {
+  %m = arith.minui %arg0, %arg1 : i32
+  %c128 = arith.constant 128 : i32
+  %div = arith.divsi %m, %c128 : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @no_convert_minui
+// CHECK: arith.minui
+// CHECK: arith.divsi
+// CHECK-NOT: arith.divui
+}
+
+// -----
+
+// Negative Test 19: maxui does not guarantee non-negativity -> do NOT convert
+module {
+tt.func public @no_convert_maxui(%arg0: i32, %arg1: i32) -> i32 {
+  %m = arith.maxui %arg0, %arg1 : i32
+  %c128 = arith.constant 128 : i32
+  %div = arith.divsi %m, %c128 : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @no_convert_maxui
+// CHECK: arith.maxui
+// CHECK: arith.divsi
+// CHECK-NOT: arith.divui
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// minsi tests
+//===----------------------------------------------------------------------===//
+
+// Test 26: minsi with both operands non-negative -> convert
+module {
+tt.func public @minsi_both_nonneg() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c5 = arith.constant 5 : i32
+  %m = arith.minsi %pid, %c5 : i32
+  %c128 = arith.constant 128 : i32
+  %div = arith.divsi %m, %c128 : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @minsi_both_nonneg
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[C5:.*]] = arith.constant 5
+// CHECK: %[[M:.*]] = arith.minsi %[[PID]], %[[C5]]
+// CHECK: %[[C128:.*]] = arith.constant 128
+// CHECK: %[[DIV:.*]] = arith.divui %[[M]], %[[C128]]
+// CHECK: tt.return %[[DIV]]
+}
+
+// -----
+
+// Negative Test 20: minsi with one unknown operand -> do NOT convert
+module {
+tt.func public @no_convert_minsi_one_unknown(%arg0: i32) -> i32 {
+  %pid = tt.get_program_id x : i32
+  %m = arith.minsi %pid, %arg0 : i32
+  %c128 = arith.constant 128 : i32
+  %div = arith.divsi %m, %c128 : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @no_convert_minsi_one_unknown
+// CHECK: arith.minsi
+// CHECK: arith.divsi
+// CHECK-NOT: arith.divui
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// select tests
+//===----------------------------------------------------------------------===//
+
+// Test 27: select with both operands non-negative -> convert
+module {
+tt.func public @select_both_nonneg(%cond: i1) -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c5 = arith.constant 5 : i32
+  %s = arith.select %cond, %pid, %c5 : i32
+  %c64 = arith.constant 64 : i32
+  %rem = arith.remsi %s, %c64 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @select_both_nonneg
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[C5:.*]] = arith.constant 5
+// CHECK: %[[S:.*]] = arith.select %arg0, %[[PID]], %[[C5]]
+// CHECK: %[[C64:.*]] = arith.constant 64
+// CHECK: %[[REM:.*]] = arith.remui %[[S]], %[[C64]]
+// CHECK: tt.return %[[REM]]
+}
+
+// -----
+
+// Negative Test 21: select with false operand unknown -> do NOT convert
+module {
+tt.func public @no_convert_select_false_unknown(%cond: i1, %arg0: i32) -> i32 {
+  %pid = tt.get_program_id x : i32
+  %s = arith.select %cond, %pid, %arg0 : i32
+  %c64 = arith.constant 64 : i32
+  %rem = arith.remsi %s, %c64 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @no_convert_select_false_unknown
+// CHECK: arith.select
+// CHECK: arith.remsi
+// CHECK-NOT: arith.remui
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// isStrictlyPositive divisor gate tests
+//===----------------------------------------------------------------------===//
+
+// Test 28: divsi by get_num_programs (strictly positive) -> convert
+module {
+tt.func public @divsi_by_num_programs() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %np = tt.get_num_programs x : i32
+  %div = arith.divsi %pid, %np : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @divsi_by_num_programs
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[NP:.*]] = tt.get_num_programs x
+// CHECK: %[[DIV:.*]] = arith.divui %[[PID]], %[[NP]]
+// CHECK: tt.return %[[DIV]]
+}
+
+// -----
+
+// Negative Test 22: divsi by program_id (can be 0) -> do NOT convert
+module {
+tt.func public @no_convert_divsi_by_program_id() -> i32 {
+  %pid0 = tt.get_program_id x : i32
+  %pid1 = tt.get_program_id y : i32
+  %div = arith.divsi %pid0, %pid1 : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @no_convert_divsi_by_program_id
+// CHECK: arith.divsi
+// CHECK-NOT: arith.divui
+}
+
+// -----
+
+// Test 29: divsi by maxsi with positive constant (strictly positive) -> convert
+module {
+tt.func public @divsi_by_maxsi_positive_const(%arg0: i32) -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c1 = arith.constant 1 : i32
+  %mx = arith.maxsi %arg0, %c1 : i32
+  %div = arith.divsi %pid, %mx : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @divsi_by_maxsi_positive_const
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[C1:.*]] = arith.constant 1
+// CHECK: %[[MX:.*]] = arith.maxsi %arg0, %[[C1]]
+// CHECK: %[[DIV:.*]] = arith.divui %[[PID]], %[[MX]]
+// CHECK: tt.return %[[DIV]]
+}
+
+// -----
+
+// Negative Test 23: divsi by maxsi with zero constant (non-neg but not strictly positive) -> do NOT convert
+module {
+tt.func public @no_convert_divsi_by_maxsi_zero_const(%arg0: i32) -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c0 = arith.constant 0 : i32
+  %mx = arith.maxsi %arg0, %c0 : i32
+  %div = arith.divsi %pid, %mx : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @no_convert_divsi_by_maxsi_zero_const
+// CHECK: arith.maxsi
+// CHECK: arith.divsi
+// CHECK-NOT: arith.divui
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// ceildivsi tests
+//===----------------------------------------------------------------------===//
+
+// Test 30: ceildivsi with non-negative dividend and positive divisor -> convert to ceildivui
+module {
+tt.func public @ceildivsi_from_program_id() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c128 = arith.constant 128 : i32
+  %cdiv = arith.ceildivsi %pid, %c128 : i32
+  tt.return %cdiv : i32
+}
+// CHECK-LABEL: @ceildivsi_from_program_id
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[C128:.*]] = arith.constant 128
+// CHECK: %[[CDIV:.*]] = arith.ceildivui %[[PID]], %[[C128]]
+// CHECK: tt.return %[[CDIV]]
+}
+
+// -----
+
+// Negative Test 24: ceildivsi with unknown dividend -> do NOT convert
+module {
+tt.func public @no_convert_ceildivsi_unknown_dividend(%arg0: i32) -> i32 {
+  %c128 = arith.constant 128 : i32
+  %cdiv = arith.ceildivsi %arg0, %c128 : i32
+  tt.return %cdiv : i32
+}
+// CHECK-LABEL: @no_convert_ceildivsi_unknown_dividend
+// CHECK: arith.ceildivsi
+// CHECK-NOT: arith.ceildivui
+}
+
+// -----
+
+// Negative Test 25: ceildivsi with negative divisor -> do NOT convert
+module {
+tt.func public @no_convert_ceildivsi_negative_divisor() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %cn128 = arith.constant -128 : i32
+  %cdiv = arith.ceildivsi %pid, %cn128 : i32
+  tt.return %cdiv : i32
+}
+// CHECK-LABEL: @no_convert_ceildivsi_negative_divisor
+// CHECK: arith.ceildivsi
+// CHECK-NOT: arith.ceildivui
 }

--- a/test/Triton/Intel/SimplifySignedArithmetic/simplify-signed-arithmetic.mlir
+++ b/test/Triton/Intel/SimplifySignedArithmetic/simplify-signed-arithmetic.mlir
@@ -425,6 +425,177 @@ tt.func public @maxsi_in_chain(%arg0: i32) -> i32 {
 
 // -----
 
+// Test 22: andi with non-negative first operand and non-constant second -> convert
+module {
+tt.func public @andi_nonneg_nonconstant_operand(%arg0: i32) -> i32 {
+  %pid = tt.get_program_id x : i32
+  %m = arith.andi %pid, %arg0 : i32
+  %c128 = arith.constant 128 : i32
+  %rem = arith.remsi %m, %c128 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @andi_nonneg_nonconstant_operand
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[M:.*]] = arith.andi %[[PID]], %arg0
+// CHECK: %[[C128:.*]] = arith.constant 128
+// CHECK: %[[REM:.*]] = arith.remui %[[M]], %[[C128]]
+// CHECK: tt.return %[[REM]]
+}
+
+// -----
+
+// Test 23: extui always produces non-negative result -> convert
+module {
+tt.func public @extui_always_nonneg(%arg0: i16) -> i32 {
+  %e = arith.extui %arg0 : i16 to i32
+  %c128 = arith.constant 128 : i32
+  %div = arith.divsi %e, %c128 : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @extui_always_nonneg
+// CHECK: %[[E:.*]] = arith.extui %arg0
+// CHECK: %[[C128:.*]] = arith.constant 128
+// CHECK: %[[DIV:.*]] = arith.divui %[[E]], %[[C128]]
+// CHECK: tt.return %[[DIV]]
+}
+
+// -----
+
+// Test 24: extsi with non-negative input -> convert
+module {
+tt.func public @extsi_nonneg_input() -> i32 {
+  %c5 = arith.constant 5 : i16
+  %e = arith.extsi %c5 : i16 to i32
+  %c8 = arith.constant 8 : i32
+  %div = arith.divsi %e, %c8 : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @extsi_nonneg_input
+// CHECK: %[[C5:.*]] = arith.constant 5
+// CHECK: %[[E:.*]] = arith.extsi %[[C5]]
+// CHECK: %[[C8:.*]] = arith.constant 8
+// CHECK: %[[DIV:.*]] = arith.divui %[[E]], %[[C8]]
+// CHECK: tt.return %[[DIV]]
+}
+
+// -----
+
+// Test 25: shrsi with non-negative LHS -> convert
+module {
+tt.func public @shrsi_nonneg_lhs() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c2 = arith.constant 2 : i32
+  %s = arith.shrsi %pid, %c2 : i32
+  %c64 = arith.constant 64 : i32
+  %rem = arith.remsi %s, %c64 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @shrsi_nonneg_lhs
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[C2:.*]] = arith.constant 2
+// CHECK: %[[S:.*]] = arith.shrsi %[[PID]], %[[C2]]
+// CHECK: %[[C64:.*]] = arith.constant 64
+// CHECK: %[[REM:.*]] = arith.remui %[[S]], %[[C64]]
+// CHECK: tt.return %[[REM]]
+}
+
+// -----
+
+// Test 26: minsi with both operands non-negative -> convert
+module {
+tt.func public @minsi_both_nonneg() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c5 = arith.constant 5 : i32
+  %m = arith.minsi %pid, %c5 : i32
+  %c128 = arith.constant 128 : i32
+  %div = arith.divsi %m, %c128 : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @minsi_both_nonneg
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[C5:.*]] = arith.constant 5
+// CHECK: %[[M:.*]] = arith.minsi %[[PID]], %[[C5]]
+// CHECK: %[[C128:.*]] = arith.constant 128
+// CHECK: %[[DIV:.*]] = arith.divui %[[M]], %[[C128]]
+// CHECK: tt.return %[[DIV]]
+}
+
+// -----
+
+// Test 27: select with both operands non-negative -> convert
+module {
+tt.func public @select_both_nonneg(%cond: i1) -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c5 = arith.constant 5 : i32
+  %s = arith.select %cond, %pid, %c5 : i32
+  %c64 = arith.constant 64 : i32
+  %rem = arith.remsi %s, %c64 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @select_both_nonneg
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[C5:.*]] = arith.constant 5
+// CHECK: %[[S:.*]] = arith.select %arg0, %[[PID]], %[[C5]]
+// CHECK: %[[C64:.*]] = arith.constant 64
+// CHECK: %[[REM:.*]] = arith.remui %[[S]], %[[C64]]
+// CHECK: tt.return %[[REM]]
+}
+
+// -----
+
+// Test 28: divsi by get_num_programs (strictly positive) -> convert
+module {
+tt.func public @divsi_by_num_programs() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %np = tt.get_num_programs x : i32
+  %div = arith.divsi %pid, %np : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @divsi_by_num_programs
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[NP:.*]] = tt.get_num_programs x
+// CHECK: %[[DIV:.*]] = arith.divui %[[PID]], %[[NP]]
+// CHECK: tt.return %[[DIV]]
+}
+
+// -----
+
+// Test 29: divsi by maxsi with positive constant (strictly positive) -> convert
+module {
+tt.func public @divsi_by_maxsi_positive_const(%arg0: i32) -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c1 = arith.constant 1 : i32
+  %mx = arith.maxsi %arg0, %c1 : i32
+  %div = arith.divsi %pid, %mx : i32
+  tt.return %div : i32
+}
+// CHECK-LABEL: @divsi_by_maxsi_positive_const
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[C1:.*]] = arith.constant 1
+// CHECK: %[[MX:.*]] = arith.maxsi %arg0, %[[C1]]
+// CHECK: %[[DIV:.*]] = arith.divui %[[PID]], %[[MX]]
+// CHECK: tt.return %[[DIV]]
+}
+
+// -----
+
+// Test 30: ceildivsi with non-negative dividend and positive divisor -> convert to ceildivui
+module {
+tt.func public @ceildivsi_from_program_id() -> i32 {
+  %pid = tt.get_program_id x : i32
+  %c128 = arith.constant 128 : i32
+  %cdiv = arith.ceildivsi %pid, %c128 : i32
+  tt.return %cdiv : i32
+}
+// CHECK-LABEL: @ceildivsi_from_program_id
+// CHECK: %[[PID:.*]] = tt.get_program_id x
+// CHECK: %[[C128:.*]] = arith.constant 128
+// CHECK: %[[CDIV:.*]] = arith.ceildivui %[[PID]], %[[C128]]
+// CHECK: tt.return %[[CDIV]]
+}
+
+// -----
+
 //===----------------------------------------------------------------------===//
 // Negative Tests - Should NOT convert
 //===----------------------------------------------------------------------===//
@@ -614,29 +785,6 @@ tt.func public @no_convert_maxsi_both_unknown(%arg0: i32, %arg1: i32) -> i32 {
 
 // -----
 
-//===----------------------------------------------------------------------===//
-// andi widening tests
-//===----------------------------------------------------------------------===//
-
-// Test 22: andi with non-negative first operand and non-constant second -> convert
-module {
-tt.func public @andi_nonneg_nonconstant_operand(%arg0: i32) -> i32 {
-  %pid = tt.get_program_id x : i32
-  %m = arith.andi %pid, %arg0 : i32
-  %c128 = arith.constant 128 : i32
-  %rem = arith.remsi %m, %c128 : i32
-  tt.return %rem : i32
-}
-// CHECK-LABEL: @andi_nonneg_nonconstant_operand
-// CHECK: %[[PID:.*]] = tt.get_program_id x
-// CHECK: %[[M:.*]] = arith.andi %[[PID]], %arg0
-// CHECK: %[[C128:.*]] = arith.constant 128
-// CHECK: %[[REM:.*]] = arith.remui %[[M]], %[[C128]]
-// CHECK: tt.return %[[REM]]
-}
-
-// -----
-
 // Negative Test 13: andi with both operands unknown -> do NOT convert
 module {
 tt.func public @no_convert_andi_both_unknown(%arg0: i32, %arg1: i32) -> i32 {
@@ -649,46 +797,6 @@ tt.func public @no_convert_andi_both_unknown(%arg0: i32, %arg1: i32) -> i32 {
 // CHECK: arith.andi
 // CHECK: arith.remsi
 // CHECK-NOT: arith.remui
-}
-
-// -----
-
-//===----------------------------------------------------------------------===//
-// extui / extsi tests
-//===----------------------------------------------------------------------===//
-
-// Test 23: extui always produces non-negative result -> convert
-module {
-tt.func public @extui_always_nonneg(%arg0: i16) -> i32 {
-  %e = arith.extui %arg0 : i16 to i32
-  %c128 = arith.constant 128 : i32
-  %div = arith.divsi %e, %c128 : i32
-  tt.return %div : i32
-}
-// CHECK-LABEL: @extui_always_nonneg
-// CHECK: %[[E:.*]] = arith.extui %arg0
-// CHECK: %[[C128:.*]] = arith.constant 128
-// CHECK: %[[DIV:.*]] = arith.divui %[[E]], %[[C128]]
-// CHECK: tt.return %[[DIV]]
-}
-
-// -----
-
-// Test 24: extsi with non-negative input -> convert
-module {
-tt.func public @extsi_nonneg_input() -> i32 {
-  %c5 = arith.constant 5 : i16
-  %e = arith.extsi %c5 : i16 to i32
-  %c8 = arith.constant 8 : i32
-  %div = arith.divsi %e, %c8 : i32
-  tt.return %div : i32
-}
-// CHECK-LABEL: @extsi_nonneg_input
-// CHECK: %[[C5:.*]] = arith.constant 5
-// CHECK: %[[E:.*]] = arith.extsi %[[C5]]
-// CHECK: %[[C8:.*]] = arith.constant 8
-// CHECK: %[[DIV:.*]] = arith.divui %[[E]], %[[C8]]
-// CHECK: tt.return %[[DIV]]
 }
 
 // -----
@@ -709,10 +817,6 @@ tt.func public @no_convert_extsi_unknown_input(%arg0: i16) -> i32 {
 
 // -----
 
-//===----------------------------------------------------------------------===//
-// shrui / shrsi tests
-//===----------------------------------------------------------------------===//
-
 // Negative Test 15: shrui does not guarantee non-negativity -> do NOT convert
 module {
 tt.func public @no_convert_shrui_shift_zero(%arg0: i32) -> i32 {
@@ -726,27 +830,6 @@ tt.func public @no_convert_shrui_shift_zero(%arg0: i32) -> i32 {
 // CHECK: arith.shrui
 // CHECK: arith.divsi
 // CHECK-NOT: arith.divui
-}
-
-// -----
-
-// Test 25: shrsi with non-negative LHS -> convert
-module {
-tt.func public @shrsi_nonneg_lhs() -> i32 {
-  %pid = tt.get_program_id x : i32
-  %c2 = arith.constant 2 : i32
-  %s = arith.shrsi %pid, %c2 : i32
-  %c64 = arith.constant 64 : i32
-  %rem = arith.remsi %s, %c64 : i32
-  tt.return %rem : i32
-}
-// CHECK-LABEL: @shrsi_nonneg_lhs
-// CHECK: %[[PID:.*]] = tt.get_program_id x
-// CHECK: %[[C2:.*]] = arith.constant 2
-// CHECK: %[[S:.*]] = arith.shrsi %[[PID]], %[[C2]]
-// CHECK: %[[C64:.*]] = arith.constant 64
-// CHECK: %[[REM:.*]] = arith.remui %[[S]], %[[C64]]
-// CHECK: tt.return %[[REM]]
 }
 
 // -----
@@ -768,10 +851,6 @@ tt.func public @no_convert_shrsi_unknown_lhs(%arg0: i32) -> i32 {
 
 // -----
 
-//===----------------------------------------------------------------------===//
-// trunci test
-//===----------------------------------------------------------------------===//
-
 // Negative Test 17: trunci is unsafe (can truncate sign bit) -> do NOT convert
 module {
 tt.func public @no_convert_trunci() -> i16 {
@@ -788,10 +867,6 @@ tt.func public @no_convert_trunci() -> i16 {
 }
 
 // -----
-
-//===----------------------------------------------------------------------===//
-// minui / maxui tests
-//===----------------------------------------------------------------------===//
 
 // Negative Test 18: minui does not guarantee non-negativity -> do NOT convert
 module {
@@ -825,31 +900,6 @@ tt.func public @no_convert_maxui(%arg0: i32, %arg1: i32) -> i32 {
 
 // -----
 
-//===----------------------------------------------------------------------===//
-// minsi tests
-//===----------------------------------------------------------------------===//
-
-// Test 26: minsi with both operands non-negative -> convert
-module {
-tt.func public @minsi_both_nonneg() -> i32 {
-  %pid = tt.get_program_id x : i32
-  %c5 = arith.constant 5 : i32
-  %m = arith.minsi %pid, %c5 : i32
-  %c128 = arith.constant 128 : i32
-  %div = arith.divsi %m, %c128 : i32
-  tt.return %div : i32
-}
-// CHECK-LABEL: @minsi_both_nonneg
-// CHECK: %[[PID:.*]] = tt.get_program_id x
-// CHECK: %[[C5:.*]] = arith.constant 5
-// CHECK: %[[M:.*]] = arith.minsi %[[PID]], %[[C5]]
-// CHECK: %[[C128:.*]] = arith.constant 128
-// CHECK: %[[DIV:.*]] = arith.divui %[[M]], %[[C128]]
-// CHECK: tt.return %[[DIV]]
-}
-
-// -----
-
 // Negative Test 20: minsi with one unknown operand -> do NOT convert
 module {
 tt.func public @no_convert_minsi_one_unknown(%arg0: i32) -> i32 {
@@ -863,31 +913,6 @@ tt.func public @no_convert_minsi_one_unknown(%arg0: i32) -> i32 {
 // CHECK: arith.minsi
 // CHECK: arith.divsi
 // CHECK-NOT: arith.divui
-}
-
-// -----
-
-//===----------------------------------------------------------------------===//
-// select tests
-//===----------------------------------------------------------------------===//
-
-// Test 27: select with both operands non-negative -> convert
-module {
-tt.func public @select_both_nonneg(%cond: i1) -> i32 {
-  %pid = tt.get_program_id x : i32
-  %c5 = arith.constant 5 : i32
-  %s = arith.select %cond, %pid, %c5 : i32
-  %c64 = arith.constant 64 : i32
-  %rem = arith.remsi %s, %c64 : i32
-  tt.return %rem : i32
-}
-// CHECK-LABEL: @select_both_nonneg
-// CHECK: %[[PID:.*]] = tt.get_program_id x
-// CHECK: %[[C5:.*]] = arith.constant 5
-// CHECK: %[[S:.*]] = arith.select %arg0, %[[PID]], %[[C5]]
-// CHECK: %[[C64:.*]] = arith.constant 64
-// CHECK: %[[REM:.*]] = arith.remui %[[S]], %[[C64]]
-// CHECK: tt.return %[[REM]]
 }
 
 // -----
@@ -909,27 +934,6 @@ tt.func public @no_convert_select_false_unknown(%cond: i1, %arg0: i32) -> i32 {
 
 // -----
 
-//===----------------------------------------------------------------------===//
-// isStrictlyPositive divisor gate tests
-//===----------------------------------------------------------------------===//
-
-// Test 28: divsi by get_num_programs (strictly positive) -> convert
-module {
-tt.func public @divsi_by_num_programs() -> i32 {
-  %pid = tt.get_program_id x : i32
-  %np = tt.get_num_programs x : i32
-  %div = arith.divsi %pid, %np : i32
-  tt.return %div : i32
-}
-// CHECK-LABEL: @divsi_by_num_programs
-// CHECK: %[[PID:.*]] = tt.get_program_id x
-// CHECK: %[[NP:.*]] = tt.get_num_programs x
-// CHECK: %[[DIV:.*]] = arith.divui %[[PID]], %[[NP]]
-// CHECK: tt.return %[[DIV]]
-}
-
-// -----
-
 // Negative Test 22: divsi by program_id (can be 0) -> do NOT convert
 module {
 tt.func public @no_convert_divsi_by_program_id() -> i32 {
@@ -941,25 +945,6 @@ tt.func public @no_convert_divsi_by_program_id() -> i32 {
 // CHECK-LABEL: @no_convert_divsi_by_program_id
 // CHECK: arith.divsi
 // CHECK-NOT: arith.divui
-}
-
-// -----
-
-// Test 29: divsi by maxsi with positive constant (strictly positive) -> convert
-module {
-tt.func public @divsi_by_maxsi_positive_const(%arg0: i32) -> i32 {
-  %pid = tt.get_program_id x : i32
-  %c1 = arith.constant 1 : i32
-  %mx = arith.maxsi %arg0, %c1 : i32
-  %div = arith.divsi %pid, %mx : i32
-  tt.return %div : i32
-}
-// CHECK-LABEL: @divsi_by_maxsi_positive_const
-// CHECK: %[[PID:.*]] = tt.get_program_id x
-// CHECK: %[[C1:.*]] = arith.constant 1
-// CHECK: %[[MX:.*]] = arith.maxsi %arg0, %[[C1]]
-// CHECK: %[[DIV:.*]] = arith.divui %[[PID]], %[[MX]]
-// CHECK: tt.return %[[DIV]]
 }
 
 // -----
@@ -977,27 +962,6 @@ tt.func public @no_convert_divsi_by_maxsi_zero_const(%arg0: i32) -> i32 {
 // CHECK: arith.maxsi
 // CHECK: arith.divsi
 // CHECK-NOT: arith.divui
-}
-
-// -----
-
-//===----------------------------------------------------------------------===//
-// ceildivsi tests
-//===----------------------------------------------------------------------===//
-
-// Test 30: ceildivsi with non-negative dividend and positive divisor -> convert to ceildivui
-module {
-tt.func public @ceildivsi_from_program_id() -> i32 {
-  %pid = tt.get_program_id x : i32
-  %c128 = arith.constant 128 : i32
-  %cdiv = arith.ceildivsi %pid, %c128 : i32
-  tt.return %cdiv : i32
-}
-// CHECK-LABEL: @ceildivsi_from_program_id
-// CHECK: %[[PID:.*]] = tt.get_program_id x
-// CHECK: %[[C128:.*]] = arith.constant 128
-// CHECK: %[[CDIV:.*]] = arith.ceildivui %[[PID]], %[[C128]]
-// CHECK: tt.return %[[CDIV]]
 }
 
 // -----

--- a/third_party/intel/lib/Dialect/Triton/Transforms/SimplifySignedArithmetic.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/SimplifySignedArithmetic.cpp
@@ -21,6 +21,7 @@ public:
   void run(ModuleOp moduleOp) {
     SmallVector<arith::RemSIOp> remOpsToConvert;
     SmallVector<arith::DivSIOp> divOpsToConvert;
+    SmallVector<arith::CeilDivSIOp> ceilDivOpsToConvert;
 
     // Collect divsi operations first (order matters for tracking)
     moduleOp.walk([&](arith::DivSIOp divOp) {
@@ -44,6 +45,17 @@ public:
       return WalkResult::advance();
     });
 
+    // Collect ceildivsi operations
+    moduleOp.walk([&](arith::CeilDivSIOp ceilDivOp) {
+      if (!isCandidate(ceilDivOp))
+        return WalkResult::skip();
+
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Converting ceildivsi to ceildivui: " << ceilDivOp << "\n");
+      ceilDivOpsToConvert.push_back(ceilDivOp);
+      return WalkResult::advance();
+    });
+
     // Convert divsi to divui
     for (arith::DivSIOp divOp : divOpsToConvert) {
       OpBuilder builder(divOp);
@@ -62,19 +74,31 @@ public:
       remOp.erase();
     }
 
+    // Convert ceildivsi to ceildivui
+    for (arith::CeilDivSIOp ceilDivOp : ceilDivOpsToConvert) {
+      OpBuilder builder(ceilDivOp);
+      auto newOp = arith::CeilDivUIOp::create(
+          builder, ceilDivOp.getLoc(), ceilDivOp.getLhs(), ceilDivOp.getRhs());
+      ceilDivOp.replaceAllUsesWith(newOp.getResult());
+      ceilDivOp.erase();
+    }
+
     LLVM_DEBUG(llvm::dbgs()
-               << "Converted " << divOpsToConvert.size() << " divsi and "
-               << remOpsToConvert.size() << " remsi operations\n");
+               << "Converted " << divOpsToConvert.size() << " divsi, "
+               << remOpsToConvert.size() << " remsi, and "
+               << ceilDivOpsToConvert.size() << " ceildivsi operations\n");
   }
 
 private:
   /// Returns true if a signed div/rem operation can be converted to unsigned:
   /// - dividend must be provably non-negative
-  /// - divisor must be a positive constant
-  template <typename OpTy, typename = std::enable_if_t<llvm::is_one_of<
-                               OpTy, arith::DivSIOp, arith::RemSIOp>::value>>
+  /// - divisor must be strictly positive
+  template <
+      typename OpTy,
+      typename = std::enable_if_t<llvm::is_one_of<
+          OpTy, arith::DivSIOp, arith::RemSIOp, arith::CeilDivSIOp>::value>>
   bool isCandidate(OpTy op) const {
-    return isNonNegative(op.getLhs()) && isPositiveConstant(op.getRhs());
+    return isNonNegative(op.getLhs()) && isStrictlyPositive(op.getRhs());
   }
 
   /// Returns true if value is provably non-negative (>= 0).
@@ -116,8 +140,9 @@ private:
     if (auto mulOp = dyn_cast<arith::MulIOp>(defOp))
       return isNonNegative(mulOp.getLhs()) && isNonNegative(mulOp.getRhs());
 
-    // arith.remui/divui always produce non-negative results
-    if (isa<arith::RemUIOp, arith::DivUIOp>(defOp))
+    // arith.remui/divui/extui produce non-negative results. extui zero-extends
+    // into a wider type, so the result MSB is always clear.
+    if (isa<arith::RemUIOp, arith::DivUIOp, arith::ExtUIOp>(defOp))
       return true;
 
     // arith.divsi with non-negative dividend and non-negative divisor.
@@ -132,16 +157,33 @@ private:
     if (auto remOp = dyn_cast<arith::RemSIOp>(defOp))
       return isNonNegative(remOp.getLhs());
 
+    // arith.extsi preserves the signed value, hence its sign.
+    if (auto extOp = dyn_cast<arith::ExtSIOp>(defOp))
+      return isNonNegative(extOp.getIn());
+
+    // arith.shrsi (arithmetic right shift) replicates the sign bit; the result
+    // is non-negative iff the shifted value is non-negative.
+    if (auto shrOp = dyn_cast<arith::ShRSIOp>(defOp))
+      return isNonNegative(shrOp.getLhs());
+
     // arith.maxsi: non-negative if either operand is non-negative.
     if (auto maxOp = dyn_cast<arith::MaxSIOp>(defOp))
       return isNonNegative(maxOp.getLhs()) || isNonNegative(maxOp.getRhs());
 
-    // arith.andi with non-negative constant mask
-    if (auto andOp = dyn_cast<arith::AndIOp>(defOp)) {
-      if (isNonNegativeConstant(andOp.getLhs()) ||
-          isNonNegativeConstant(andOp.getRhs()))
-        return true;
-    }
+    // arith.minsi: non-negative iff BOTH operands are non-negative.
+    if (auto minOp = dyn_cast<arith::MinSIOp>(defOp))
+      return isNonNegative(minOp.getLhs()) && isNonNegative(minOp.getRhs());
+
+    // arith.select yields one of its two value operands; non-negative iff both
+    // candidate values are non-negative.
+    if (auto selOp = dyn_cast<arith::SelectOp>(defOp))
+      return isNonNegative(selOp.getTrueValue()) &&
+             isNonNegative(selOp.getFalseValue());
+
+    // arith.andi is non-negative if EITHER operand is non-negative, since
+    // MSB(a & b) = MSB(a) & MSB(b). Subsumes the constant-mask case.
+    if (auto andOp = dyn_cast<arith::AndIOp>(defOp))
+      return isNonNegative(andOp.getLhs()) || isNonNegative(andOp.getRhs());
 
     // tt.splat preserves non-negativity
     if (auto splatOp = dyn_cast<tt::SplatOp>(defOp))
@@ -155,16 +197,6 @@ private:
     if (auto broadcastOp = dyn_cast<tt::BroadcastOp>(defOp))
       return isNonNegative(broadcastOp.getSrc());
 
-    return false;
-  }
-
-  /// Returns true if value is a non-negative constant.
-  bool isNonNegativeConstant(Value value) const {
-    auto constOp = value.getDefiningOp<arith::ConstantOp>();
-    if (!constOp)
-      return false;
-    if (auto intAttr = dyn_cast<IntegerAttr>(constOp.getValue()))
-      return intAttr.getValue().isNonNegative();
     return false;
   }
 
@@ -189,6 +221,32 @@ private:
     // Splat of positive constant
     if (auto splatOp = dyn_cast<tt::SplatOp>(defOp))
       return isPositiveConstant(splatOp.getSrc());
+
+    return false;
+  }
+
+  /// Returns true if value is provably strictly positive (> 0). Superset of
+  /// isPositiveConstant.
+  bool isStrictlyPositive(Value value) const {
+    if (isPositiveConstant(value))
+      return true;
+
+    Operation *defOp = value.getDefiningOp();
+    if (!defOp)
+      return false;
+
+    // tt.get_num_programs is a grid dimension, always >= 1.
+    if (isa<tt::GetNumProgramsOp>(defOp))
+      return true;
+
+    // arith.maxsi(x, c) >= c; strictly positive if either operand is.
+    if (auto maxOp = dyn_cast<arith::MaxSIOp>(defOp))
+      return isStrictlyPositive(maxOp.getLhs()) ||
+             isStrictlyPositive(maxOp.getRhs());
+
+    // tt.splat preserves strict positivity (tensor divisors).
+    if (auto splatOp = dyn_cast<tt::SplatOp>(defOp))
+      return isStrictlyPositive(splatOp.getSrc());
 
     return false;
   }


### PR DESCRIPTION
Following up on #7667, the `TritonIntelSimplifySignedArithmetic` pass still misses a number of patterns that show up all the time in tiled kernels — masking, tile-coordinate extraction, and dividing by `num_programs`. In these cases the dividend is clearly non-negative and the divisor is clearly positive, but the pass leaves the more expensive signed `divsi`/`remsi` in place because its analysis doesn't recognize the shape.

This PR teaches the pass to see through a few more operations:

- Widen `isNonNegative` to handle `andi` (non-negative if either operand is), `extui`, `extsi`, `shrsi`, `minsi`, and `select`.
- Add an `isStrictlyPositive` divisor gate that accepts any provably-positive value, not just a constant — e.g. `tt.get_num_programs` (always ≥ 1) or `maxsi(x, c>0)`. This is what unlocks the common `divsi(pid, num_programs)` pattern.
- Convert `ceildivsi` → `ceildivui` under the same conditions.

Closes #7675

