### PR TITLE
[Launcher] Intern data_ptr string in extractPointer

### DIFF
--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -928,9 +928,6 @@ bool extractPointer(void *ptr, PyObject *obj) {
                               *g_pointer_check_queue);
   }
 
-  if (data_ptr_str == NULL) {
-    data_ptr_str = PyUnicode_InternFromString("data_ptr");
-  }
   PyObject *data_ptr = PyObject_GetAttr(obj, data_ptr_str);
 
   if (data_ptr) {
@@ -1466,6 +1463,10 @@ extern "C" EXPORT_FUNC PyTypeObject *init_PyKernelArgType() {
   PyKernelArgType.tp_new = PyType_GenericNew;
 
   if (PyType_Ready(&PyKernelArgType) < 0)
+    return NULL;
+
+  data_ptr_str = PyUnicode_InternFromString("data_ptr");
+  if (data_ptr_str == NULL)
     return NULL;
 
   Py_INCREF(&PyKernelArgType);

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -928,7 +928,10 @@ bool extractPointer(void *ptr, PyObject *obj) {
                               *g_pointer_check_queue);
   }
 
-  PyObject *data_ptr = PyObject_GetAttrString(obj, "data_ptr");
+  if (data_ptr_str == NULL) {
+    data_ptr_str = PyUnicode_InternFromString("data_ptr");
+  }
+  PyObject *data_ptr = PyObject_GetAttr(obj, data_ptr_str);
 
   if (data_ptr) {
     PyObject *ret = PyObject_CallNoArgs(data_ptr);


### PR DESCRIPTION
The static data_ptr_str was declared but never assigned. Complete the lazy init to save a per-pointer-arg PyUnicode hash on every launch.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because `no functionality change`.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
