### PR TITLE
[SGLANG] Split benchmark workflows into per-platform wrappers

### DIFF
--- a/.github/workflows/sglang-benchmarks-bmg.yml
+++ b/.github/workflows/sglang-benchmarks-bmg.yml
@@ -3,8 +3,6 @@ name: SGLang benchmarks, BMG
 permissions: read-all
 
 on:
-  # Explicit opt-in only: adding the label to a PR starts a run. There is no path
-  # based triggering, SGLang benchmarks are too expensive to run on every PR.
   pull_request:
     branches:
       - main
@@ -12,8 +10,8 @@ on:
   schedule:
     - cron: "0 11 * * *"
 
-# Adding any other label also starts a run whose jobs are all skipped. Give those a
-# separate lane so they cannot cancel a real run.
+# Runs from an unrelated label skip all jobs; keep them in a separate lane so they
+# cannot cancel a real run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}-${{ github.event.action == 'labeled' && github.event.label.name != 'run-sglang-benchmarks' && 'skip' || 'run' }}
   cancel-in-progress: true

--- a/.github/workflows/sglang-benchmarks-bmg.yml
+++ b/.github/workflows/sglang-benchmarks-bmg.yml
@@ -3,49 +3,35 @@ name: SGLang benchmarks, BMG
 permissions: read-all
 
 on:
+  # Explicit opt-in only: adding the label to a PR starts a run. There is no path
+  # based triggering, SGLang benchmarks are too expensive to run on every PR.
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened, labeled]
+    types: [labeled]
   schedule:
     - cron: "0 11 * * *"
 
-# Give unrelated-label skip runs a separate lane so they cannot cancel a real run.
+# Adding any other label also starts a run whose jobs are all skipped. Give those a
+# separate lane so they cannot cancel a real run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}-${{ github.event.action == 'labeled' && github.event.label.name != 'run-sglang-benchmarks' && 'skip' || 'run' }}
   cancel-in-progress: true
 
 jobs:
-  check-paths:
-    runs-on: ubuntu-latest
-    outputs:
-      benchmarks: ${{ steps.check.outputs.changed }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Check for SGLang benchmark changes
-        id: check
-        uses: ./.github/actions/check-path-changes
-        with:
-          patterns: '^(\.github/workflows/(sglang-benchmarks|build-benchmarks-wheel).*\.yml|\.github/actions/install-benchmarks/|benchmarks/triton_kernels_benchmark/sglang/|scripts/sglang/|\.github/pins/pytorch\.txt)'
-
   build-wheel:
-    needs: check-paths
     if: >-
       github.event_name == 'schedule' ||
-      (github.event.action != 'labeled' && needs.check-paths.outputs.benchmarks == 'true') ||
       github.event.label.name == 'run-sglang-benchmarks'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
 
   benchmarks:
-    needs: [check-paths, build-wheel]
+    needs: build-wheel
     if: >-
       always() && !cancelled() &&
       (github.event_name == 'schedule' ||
-       (github.event.action != 'labeled' && needs.check-paths.outputs.benchmarks == 'true') ||
        github.event.label.name == 'run-sglang-benchmarks')
     uses: ./.github/workflows/sglang-benchmarks.yml
     with:

--- a/.github/workflows/sglang-benchmarks-pvc.yml
+++ b/.github/workflows/sglang-benchmarks-pvc.yml
@@ -3,49 +3,35 @@ name: SGLang benchmarks, PVC
 permissions: read-all
 
 on:
+  # Explicit opt-in only: adding the label to a PR starts a run. There is no path
+  # based triggering, SGLang benchmarks are too expensive to run on every PR.
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened, labeled]
+    types: [labeled]
   schedule:
     - cron: "0 11 * * *"
 
-# Give unrelated-label skip runs a separate lane so they cannot cancel a real run.
+# Adding any other label also starts a run whose jobs are all skipped. Give those a
+# separate lane so they cannot cancel a real run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}-${{ github.event.action == 'labeled' && github.event.label.name != 'run-sglang-benchmarks' && 'skip' || 'run' }}
   cancel-in-progress: true
 
 jobs:
-  check-paths:
-    runs-on: ubuntu-latest
-    outputs:
-      benchmarks: ${{ steps.check.outputs.changed }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Check for SGLang benchmark changes
-        id: check
-        uses: ./.github/actions/check-path-changes
-        with:
-          patterns: '^(\.github/workflows/(sglang-benchmarks|build-benchmarks-wheel).*\.yml|\.github/actions/install-benchmarks/|benchmarks/triton_kernels_benchmark/sglang/|scripts/sglang/|\.github/pins/pytorch\.txt)'
-
   build-wheel:
-    needs: check-paths
     if: >-
       github.event_name == 'schedule' ||
-      (github.event.action != 'labeled' && needs.check-paths.outputs.benchmarks == 'true') ||
       github.event.label.name == 'run-sglang-benchmarks'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
 
   benchmarks:
-    needs: [check-paths, build-wheel]
+    needs: build-wheel
     if: >-
       always() && !cancelled() &&
       (github.event_name == 'schedule' ||
-       (github.event.action != 'labeled' && needs.check-paths.outputs.benchmarks == 'true') ||
        github.event.label.name == 'run-sglang-benchmarks')
     uses: ./.github/workflows/sglang-benchmarks.yml
     with:

--- a/.github/workflows/sglang-benchmarks-pvc.yml
+++ b/.github/workflows/sglang-benchmarks-pvc.yml
@@ -1,4 +1,4 @@
-name: SGLang benchmarks, BMG
+name: SGLang benchmarks, PVC
 
 permissions: read-all
 
@@ -49,5 +49,5 @@ jobs:
        github.event.label.name == 'run-sglang-benchmarks')
     uses: ./.github/workflows/sglang-benchmarks.yml
     with:
-      runner_label: b580
+      runner_label: max1550
     secrets: inherit

--- a/.github/workflows/sglang-benchmarks-pvc.yml
+++ b/.github/workflows/sglang-benchmarks-pvc.yml
@@ -3,8 +3,6 @@ name: SGLang benchmarks, PVC
 permissions: read-all
 
 on:
-  # Explicit opt-in only: adding the label to a PR starts a run. There is no path
-  # based triggering, SGLang benchmarks are too expensive to run on every PR.
   pull_request:
     branches:
       - main
@@ -12,8 +10,8 @@ on:
   schedule:
     - cron: "0 11 * * *"
 
-# Adding any other label also starts a run whose jobs are all skipped. Give those a
-# separate lane so they cannot cancel a real run.
+# Runs from an unrelated label skip all jobs; keep them in a separate lane so they
+# cannot cancel a real run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}-${{ github.event.action == 'labeled' && github.event.label.name != 'run-sglang-benchmarks' && 'skip' || 'run' }}
   cancel-in-progress: true

--- a/.github/workflows/sglang-benchmarks.yml
+++ b/.github/workflows/sglang-benchmarks.yml
@@ -15,8 +15,8 @@ on:
         description: SGLang pin (commit hash), keep empty for default
         type: string
         default: ""
-  # The BMG schedule runs through the sglang-benchmarks-bmg.yml wrapper (which
-  # builds the branch benchmarks wheel first). This workflow keeps its own PVC schedule.
+  # Both schedules run through the sglang-benchmarks-{pvc,bmg}.yml wrappers, which
+  # build the benchmarks wheel from the run's commit first.
   workflow_call:
     inputs:
       runner_label:
@@ -32,9 +32,6 @@ on:
         description: SGLang pin (commit hash), keep empty for default
         type: string
         default: ""
-
-  schedule:
-    - cron: "0 11 * * *"
 
 permissions: read-all
 

--- a/.github/workflows/sglang-benchmarks.yml
+++ b/.github/workflows/sglang-benchmarks.yml
@@ -15,8 +15,6 @@ on:
         description: SGLang pin (commit hash), keep empty for default
         type: string
         default: ""
-  # Both schedules run through the sglang-benchmarks-{pvc,bmg}.yml wrappers, which
-  # build the benchmarks wheel from the run's commit first.
   workflow_call:
     inputs:
       runner_label:
@@ -24,8 +22,8 @@ on:
         type: string
       tag:
         description: Tag for benchmark results
-        # Empty default so the TAG fallback below can resolve pr-<n>/ci from the
-        # caller's event. A non-empty default would short-circuit that expression.
+        # Empty default, so the TAG expression below can still resolve pr-<n>/ci
+        # from the caller's event.
         type: string
         default: ""
       sglang_pin:
@@ -86,10 +84,8 @@ jobs:
         id: setup-pytorch
         uses: ./.github/actions/setup-pytorch
 
-      # Every benchmark here imports sglang, and sglang/srt/utils/common.py imports
-      # torchvision.io at module level. install-sglang.sh strips torch* from
-      # pyproject.toml, so torchvision has to be installed here - built from the
-      # PyTorch pin, because a PyPI wheel would pull in its own torch build.
+      # sglang imports torchvision.io at module level and install-sglang.sh strips
+      # torch* from its pyproject, so it has to be installed here, from the PyTorch pin.
       - name: Identify torchvision pin
         run: |
           echo "TORCHVISION_COMMIT_ID=$(<pytorch/.github/ci_commit_pins/vision.txt)" | tee -a "$GITHUB_ENV"


### PR DESCRIPTION
Aligns the SGLang benchmark workflows with the vLLM/Triton layout: `sglang-benchmarks.yml` loses its own schedule and becomes a reusable engine (`workflow_dispatch` + `workflow_call`), while `sglang-benchmarks {pvc,bmg}.yml` own the cron, the label trigger, the `concurrency` group and the `build-wheel` job.

The PVC schedule used to run the engine directly, with no wheel in the run: it fell back to the last wheel built
 from `main`, logging `Artifact not found for name: benchmarks-wheel-py3.12` every time and occasionally picking up a stale one. The wheel now comes from the run's commit.

PR runs are gated on an explicit `run-sglang-benchmarks` label, **_which still has to be created in the repo settings_**. There is no path based triggering - these benchmarks are too expensive to run per PR for now (#7629).

The PVC nightly is now reported as "SGLang benchmarks, PVC".
