### PR TITLE
[CRI] Skip 64-byte 2D block IO base-address alignment compensation on relaxed targets

### DIFF
--- a/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockload-to-llvm.mlir
@@ -811,3 +811,29 @@ llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_
   llvm.return
 }
 }
+
+// -----
+
+// COM: The ttig.2d_block_io_base_alignment attribute advertises a relaxed HW
+// COM: base-address alignment requirement (4 bytes, e.g. on CRI). Since
+// COM: MaterializeBlockPointer already guarantees a 4-byte aligned base, the
+// COM: 64-byte alignment compensation is skipped: the raw ptr, base_width and x
+// COM: are passed to the builtin unchanged.
+
+module attributes {ttig.2d_block_io_base_alignment = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+llvm.func @triton_gen.2Dblockload(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // CHECK:     llvm.func @triton_gen.2Dblockload(%arg0: !llvm.ptr<1>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
+  // CHECK-NOT:   llvm.ptrtoint
+  // CHECK-NOT:   llvm.mlir.constant(-64 : i64)
+  // CHECK-NOT:   llvm.mlir.constant(63 : i64)
+  // CHECK-NOT:   llvm.udiv
+  // CHECK-DAG:   [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
+  // CHECK-DAG:   [[ONE:%.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-DAG:   [[UNDEF:%.*]] = llvm.mlir.undef : vector<2xi32>
+  // CHECK-DAG:   [[COORD0:%.*]] = llvm.insertelement %arg4, [[UNDEF]][[[ZERO]] : i32] : vector<2xi32>
+  // CHECK-DAG:   [[COORD1:%.*]] = llvm.insertelement %arg5, [[COORD0]][[[ONE]] : i32] : vector<2xi32>
+  // CHECK:       llvm.call spir_funccc @_Z32__spirv_Subgroup2DBlockLoadINTELiiiiPU3AS1viiiDv2_iPv({{.*}}, %arg0, %arg1, %arg2, %arg3, [[COORD1]], {{.*}})
+  %0 = triton_gen.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=8, tile_width=8, tile_height=8, v_blocks=1, transpose=false, vnni_transform=false, cache_control=Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32) -> vector<2xi16>
+  llvm.return
+}
+}

--- a/test/TritonGEN/tritongen-2Dblockprefetch-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockprefetch-to-llvm.mlir
@@ -452,3 +452,29 @@ llvm.func @triton_gen.2Dblockprefetch_d16_genisa_fallback(%ptr : !llvm.ptr<1>, %
   triton_gen.2Dblockprefetch %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=16, tile_width=32, tile_height=8, v_blocks=1, cache_control=Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32)
   llvm.return
 }
+
+// -----
+
+// COM: The ttig.2d_block_io_base_alignment attribute advertises a relaxed HW
+// COM: base-address alignment requirement (4 bytes, e.g. on CRI). Since
+// COM: MaterializeBlockPointer already guarantees a 4-byte aligned base, the
+// COM: 64-byte alignment compensation is skipped: the raw ptr, base_width and x
+// COM: are passed to the builtin unchanged.
+
+module attributes {ttig.2d_block_io_base_alignment = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+llvm.func @triton_gen.2Dblockprefetch(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // CHECK:     llvm.func @triton_gen.2Dblockprefetch(%arg0: !llvm.ptr<1>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
+  // CHECK-NOT:   llvm.ptrtoint
+  // CHECK-NOT:   llvm.mlir.constant(-64 : i64)
+  // CHECK-NOT:   llvm.mlir.constant(63 : i64)
+  // CHECK-NOT:   llvm.udiv
+  // CHECK-DAG:   [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
+  // CHECK-DAG:   [[ONE:%.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-DAG:   [[UNDEF:%.*]] = llvm.mlir.undef : vector<2xi32>
+  // CHECK-DAG:   [[COORD0:%.*]] = llvm.insertelement %arg4, [[UNDEF]][[[ZERO]] : i32] : vector<2xi32>
+  // CHECK-DAG:   [[COORD1:%.*]] = llvm.insertelement %arg5, [[COORD0]][[[ONE]] : i32] : vector<2xi32>
+  // CHECK:       llvm.call spir_funccc @_Z36__spirv_Subgroup2DBlockPrefetchINTELiiiiPU3AS1viiiDv2_i({{.*}}, %arg0, %arg1, %arg2, %arg3, [[COORD1]])
+  triton_gen.2Dblockprefetch %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=8, tile_width=32, tile_height=8, v_blocks=1, cache_control=L1UC_L3UC} : (!llvm.ptr<1>, i32, i32, i32, i32, i32)
+  llvm.return
+}
+}

--- a/test/TritonGEN/tritongen-2Dblockstore-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockstore-to-llvm.mlir
@@ -221,3 +221,29 @@ llvm.func @triton_gen.2Dblockstore(%ptr : !llvm.ptr<1>, %base_width : i32, %base
   llvm.return
 }
 }
+
+// -----
+
+// COM: The ttig.2d_block_io_base_alignment attribute advertises a relaxed HW
+// COM: base-address alignment requirement (4 bytes, e.g. on CRI). Since
+// COM: MaterializeBlockPointer already guarantees a 4-byte aligned base, the
+// COM: 64-byte alignment compensation is skipped: the raw ptr, base_width and x
+// COM: are passed to the builtin unchanged.
+
+module attributes {ttig.2d_block_io_base_alignment = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+llvm.func @triton_gen.2Dblockstore(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<8xi16>) {
+  // CHECK:     llvm.func @triton_gen.2Dblockstore(%arg0: !llvm.ptr<1>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: vector<8xi16>) {
+  // CHECK-NOT:   llvm.ptrtoint
+  // CHECK-NOT:   llvm.mlir.constant(-64 : i64)
+  // CHECK-NOT:   llvm.mlir.constant(63 : i64)
+  // CHECK-NOT:   llvm.udiv
+  // CHECK-DAG:   [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
+  // CHECK-DAG:   [[ONE:%.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-DAG:   [[UNDEF:%.*]] = llvm.mlir.undef : vector<2xi32>
+  // CHECK-DAG:   [[COORD0:%.*]] = llvm.insertelement %arg4, [[UNDEF]][[[ZERO]] : i32] : vector<2xi32>
+  // CHECK-DAG:   [[COORD1:%.*]] = llvm.insertelement %arg5, [[COORD0]][[[ONE]] : i32] : vector<2xi32>
+  // CHECK:       llvm.call spir_funccc @_Z33__spirv_Subgroup2DBlockStoreINTELiiiiPvPU3AS1viiiDv2_i({{.*}}, {{.*}}, %arg0, %arg1, %arg2, %arg3, [[COORD1]])
+  triton_gen.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=8, tile_width=8, tile_height=8, v_blocks=1, cache_control=Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32, vector<8xi16>)
+  llvm.return
+}
+}

--- a/test/TritonIntelGPU/triton_annotate_module.mlir
+++ b/test/TritonIntelGPU/triton_annotate_module.mlir
@@ -3,8 +3,8 @@
 
 module {
   // COM: Ensure that the 'threads-per-warp' attribute is set according to the option.
-  // CHECK-NO-BDPAS: module attributes {"ttg.threads-per-warp" = 32 : i32, ttig.min_sg_size = 16 : i32, ttig.support_2d_block_io, ttig.support_subgroup_matrix_multiply_accumulate, ttig.target_arch = "spir64"}
-  // CHECK-BDPAS: module attributes {"ttg.threads-per-warp" = 32 : i32, ttig.min_sg_size = 16 : i32, ttig.support_2d_block_io, ttig.support_subgroup_matrix_multiply_accumulate, ttig.support_subgroup_scaled_matrix_multiply_accumulate, ttig.target_arch = "spir64"}
+  // CHECK-NO-BDPAS: module attributes {"ttg.threads-per-warp" = 32 : i32, ttig.2d_block_io_base_alignment = 64 : i32, ttig.min_sg_size = 16 : i32, ttig.support_2d_block_io, ttig.support_subgroup_matrix_multiply_accumulate, ttig.target_arch = "spir64"}
+  // CHECK-BDPAS: module attributes {"ttg.threads-per-warp" = 32 : i32, ttig.2d_block_io_base_alignment = 64 : i32, ttig.min_sg_size = 16 : i32, ttig.support_2d_block_io, ttig.support_subgroup_matrix_multiply_accumulate, ttig.support_subgroup_scaled_matrix_multiply_accumulate, ttig.target_arch = "spir64"}
 
   tt.func @kernel() {
     tt.return
@@ -16,8 +16,8 @@ module {
 module {
   // COM: Ensure that the 'threads-per-warp' attribute is overwritten when the kernel contains a 'tt.dot'
   //      operation that can be lowered to DPAS instructions.
-  // CHECK-NO-BDPAS: module attributes {"ttg.threads-per-warp" = 16 : i32, ttig.min_sg_size = 16 : i32, ttig.support_2d_block_io, ttig.support_subgroup_matrix_multiply_accumulate, ttig.target_arch = "spir64"}
-  // CHECK-BDPAS: module attributes {"ttg.threads-per-warp" = 16 : i32, ttig.min_sg_size = 16 : i32, ttig.support_2d_block_io, ttig.support_subgroup_matrix_multiply_accumulate, ttig.support_subgroup_scaled_matrix_multiply_accumulate, ttig.target_arch = "spir64"}
+  // CHECK-NO-BDPAS: module attributes {"ttg.threads-per-warp" = 16 : i32, ttig.2d_block_io_base_alignment = 64 : i32, ttig.min_sg_size = 16 : i32, ttig.support_2d_block_io, ttig.support_subgroup_matrix_multiply_accumulate, ttig.target_arch = "spir64"}
+  // CHECK-BDPAS: module attributes {"ttg.threads-per-warp" = 16 : i32, ttig.2d_block_io_base_alignment = 64 : i32, ttig.min_sg_size = 16 : i32, ttig.support_2d_block_io, ttig.support_subgroup_matrix_multiply_accumulate, ttig.support_subgroup_scaled_matrix_multiply_accumulate, ttig.target_arch = "spir64"}
 
   tt.func @kernel() {
     %a = arith.constant dense<1.00e+00> : tensor<128x32xf16>

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -221,6 +221,10 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         dev_prop['has_256b_load_store'] = tgt_prop.get('has_256b_prefetch', False)
         dev_prop['has_rounded_divide_sqrt'] = tgt_prop.get('has_rounded_divide_sqrt', not is_lts)
         dev_prop['has_sigmoid'] = tgt_prop.get('has_sigmoid', False)
+        # HW base-address alignment requirement (in bytes) for 2D block IO.
+        # Defaults to 64; targets with a relaxed requirement (e.g. CRI) override
+        # this so the downstream 64-byte alignment compensation is skipped.
+        dev_prop['block_io_base_alignment'] = tgt_prop.get('block_io_base_alignment', 64)
         dev_prop['core_clock_rate'] = self.core_clock_rate(tgt_prop)
 
         if '__intel_already_queried_extensions__' not in tgt_prop:
@@ -353,6 +357,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         module_opts.threads_per_warp = opt.warp_size
         module_opts.sub_32_dpas = opt.sub_32_dpas
         module_opts.target_arch = cls.target_arch
+        module_opts.block_io_base_alignment = properties["block_io_base_alignment"]
 
     @classmethod
     @track

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/Dialect.h
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/Dialect.h
@@ -21,6 +21,23 @@ namespace mlir::triton::gpu::intel {
 struct L2Cache : public SideEffects::Resource::Base<L2Cache> {
   StringRef getName() const final { return "<intel::L2Cache>"; }
 };
+
+/// Return true when the base address of a 2D block IO operation must be
+/// compensated to satisfy the HW base-address alignment requirement.
+///
+/// MaterializeBlockPointer guarantees a 4-byte aligned base address, so the
+/// compensation can be skipped when the target's requirement is at most 4 bytes
+/// (as advertised by the `ttig.2d_block_io_base_alignment` module attribute).
+/// Otherwise (e.g. the 64-byte requirement on BMG) the base address must be
+/// compensated. Absence of the attribute is conservatively treated as requiring
+/// compensation.
+inline bool needs2DBlockIOAlignmentCompensation(Operation *op) {
+  if (!isa<ModuleOp>(op))
+    op = op->getParentOfType<ModuleOp>();
+  auto alignment = op->getAttrOfType<IntegerAttr>(
+      TritonIntelGPUDialect::get2DBlockIOBaseAlignmentAttrName());
+  return !alignment || alignment.getInt() > 4;
+}
 } // namespace mlir::triton::gpu::intel
 
 #endif // TRITON_DIALECT_TRITON_INTEL_GPU_IR_DIALECT_H

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUDialect.td
@@ -167,6 +167,16 @@ def TritonIntelGPU_Dialect : Dialect {
     static constexpr llvm::StringRef getDescPaddingAttrName() {
       return "ttig.desc_padding";
     }
+
+    /// Get the name of the attribute conveying the HW base-address alignment
+    /// requirement (in bytes) for 2D block IO operations. MaterializeBlockPointer
+    /// guarantees a 4-byte aligned base, so when this value is <= 4 the base
+    /// address is already known to satisfy the HW requirement and the downstream
+    /// alignment compensation is skipped; otherwise (e.g. the 64-byte requirement
+    /// on BMG) the base address is compensated.
+    static constexpr llvm::StringRef get2DBlockIOBaseAlignmentAttrName() {
+      return "ttig.2d_block_io_base_alignment";
+    }
   }];
 
   let useDefaultAttributePrinterParser = 1;

--- a/third_party/intel/include/TritonAnnotateModule/Passes.td
+++ b/third_party/intel/include/TritonAnnotateModule/Passes.td
@@ -67,7 +67,9 @@ def TritonAnnotateModule: Pass<"triton-annotate-module", "mlir::ModuleOp"> {
     Option<"isFastMath", "is-fast-math", "bool", /*default*/"false",
            "whether fast-math approximations are allowed (set by TRITON_INTEL_FAST_MATH=1)">,
     Option<"sub32DPAS", "sub-32-dpas", "bool", /*default*/"false",
-           "whether to enable DPAS for 32 subgroup size kernels">
+           "whether to enable DPAS for 32 subgroup size kernels">,
+    Option<"blockIOBaseAlignment", "2d-block-io-base-alignment", "unsigned", /*default*/"64",
+           "HW base-address alignment requirement (in bytes) for 2D block IO">
   ];
 }
 

--- a/third_party/intel/lib/TritonAnnotateModule/TritonAnnotateModule.cpp
+++ b/third_party/intel/lib/TritonAnnotateModule/TritonAnnotateModule.cpp
@@ -61,6 +61,10 @@ struct TritonAnnotateModule
     mod->setAttr(ttgi::TritonIntelGPUDialect::getTargetArchAttrName(),
                  builder.getStringAttr(targetArch));
 
+    mod->setAttr(
+        ttgi::TritonIntelGPUDialect::get2DBlockIOBaseAlignmentAttrName(),
+        builder.getI32IntegerAttr(blockIOBaseAlignment));
+
     if (support16BitAtomics)
       mod->setAttr(
           ttgi::TritonIntelGPUDialect::getSupport16BitAtomicsAttrName(),

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -234,6 +234,11 @@ template <
 static std::tuple<Value, Value, Value>
 computeAlignedBasePtrWidthAndOffset(OpTy op,
                                     ConversionPatternRewriter &rewriter) {
+  // Skip compensation when the base address already satisfies the HW alignment
+  // requirement.
+  if (!intel::needs2DBlockIOAlignmentCompensation(op))
+    return {op.getPtr(), op.getBaseWidth(), op.getX()};
+
   Location loc = op->getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   Value baseAddr = b.ptrtoint(int_ty(64), op.getPtr());

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -4107,9 +4107,14 @@ struct Subgroup2DBlockLoadOpConversion
     // this, LLVM's CSE factors out (descIndex + delta) as a common
     // subexpression shared across different operand loads, producing a
     // suboptimal instruction schedule.
+    //
+    // The compensation is skipped entirely on targets whose base-address
+    // alignment requirement is already met by the 4-byte alignment that
+    // MaterializeBlockPointer guarantees.
     std::optional<int64_t> colConst =
         triton::intel::getFoldedConstantValue(baseOffsetX);
-    if (!colConst || *colConst != 0) {
+    if (needs2DBlockIOAlignmentCompensation(op) &&
+        (!colConst || *colConst != 0)) {
       constexpr int64_t ALIGNMENT_MASK = 0x3f;
       Value baseAddr = b.ptrtoint(int_ty(64), basePtr);
       Value alignedBaseAddr = b.and_(baseAddr, b.i64_val(~ALIGNMENT_MASK));

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -147,7 +147,9 @@ void init_triton_intel_passes_ttgpuir(py::module_ &&m) {
       .def_rw("is_fast_math",
               &gpu::intel::TritonAnnotateModuleOptions::isFastMath)
       .def_rw("sub_32_dpas",
-              &gpu::intel::TritonAnnotateModuleOptions::sub32DPAS);
+              &gpu::intel::TritonAnnotateModuleOptions::sub32DPAS)
+      .def_rw("block_io_base_alignment",
+              &gpu::intel::TritonAnnotateModuleOptions::blockIOBaseAlignment);
   ADD_PASS_OPTION_WRAPPER_1("add_triton_annotate_module",
                             gpu::intel::createTritonAnnotateModule,
                             gpu::intel::TritonAnnotateModuleOptions);


### PR DESCRIPTION
BMG requires 2D block IO base addresses to be 64-byte aligned, so the
lowering runs computeAlignedBasePtrWidthAndOffset() (and an equivalent
inline block in the Subgroup2DBlockLoadOp path) to mask the base pointer
and shift the width/x offset accordingly. CRI only requires 4-byte
alignment, which MaterializeBlockPointer already guarantees, so the
compensation is redundant there.