### PR TITLE
Clamp the 2D block load base width to the HW minimum of 64 bytes

### DIFF
--- a/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
+++ b/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
@@ -83,6 +83,32 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
 
 // -----
 
+// COM: Test ttig.2d_block_load_from_ptr with a sub-64-byte base_width. The
+// COM: per-warp base_width (16 cols * 2 bytes = 32) is below the HW minimum,
+// COM: so the lowering must floor the adjusted base_width to 64 bytes via
+// COM: umax before emitting triton_gen.2Dblockload (see verifier constraint
+// COM: "base width should be >= 64").
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth=1}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: @block_load_from_ptr_small_base_width
+  tt.func public @block_load_from_ptr_small_base_width(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #dot0}>>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #dot0}>> -> tensor<1x16xi32, #dot0>
+    %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x16x!tt.ptr<f16>, #dot0>
+    %3 = tt.addptr %2, %1 : tensor<1x16x!tt.ptr<f16>, #dot0>, tensor<1x16xi32, #dot0>
+    %4 = tt.broadcast %3 : tensor<1x16x!tt.ptr<f16>, #dot0> -> tensor<64x16x!tt.ptr<f16>, #dot0>
+    %pitch = arith.constant 128 : i32
+    // CHECK: %[[C64:.*]] = llvm.mlir.constant(64 : i32) : i32
+    // CHECK: llvm.intr.umax(%{{.*}}, %[[C64]]) : (i32, i32) -> i32
+    // CHECK: triton_gen.2Dblockload
+    %5 = ttig.2d_block_load_from_ptr %4, %pitch {row_major} {base_height = 1 : i32, base_width = 32 : i32} : (tensor<64x16x!tt.ptr<f16>, #dot0>, i32) -> tensor<64x16xf16, #dot0>
+    tt.return
+  }
+}
+
+// -----
+
 // COM: Test ttig.2d_block_load_from_ptr with mask generates block loads
 // COM: with predicated out-of-bounds handling (select with other).
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -4326,6 +4326,8 @@ struct Subgroup2DBlockLoadFromPtrOpConversion
       addrElem = b.gep(ptr_ty(ctx, 1), eltTy, addrElem, negativeOffsetX);
       Value adjustedBaseWidth =
           b.add(baseWidth, b.mul(offsetX, b.i32_val(elemSizeInBits / 8)));
+      // The HW requires a base width of at least 64 bytes.
+      adjustedBaseWidth = b.umax(adjustedBaseWidth, b.i32_val(64));
 
       Value pred;
       if (maskElems.size())


### PR DESCRIPTION
`Subgroup2DBlockLoadFromPtrOpConversion` computes the adjusted `base_width` by
folding the column offset into the caller-supplied `base_width`. The result can
be below the HW minimum of 64 bytes (e.g. 16 columns of `f16` = 32 bytes), which
the `triton_gen.2Dblockload` verifier rejects with *"2nd operand (base width)
should be >= 64"*. This clamps the adjusted value with `umax` so the emitted
operation always satisfies the constraint.