### PR TITLE
[CRI][TEST] Fix two CPU/test issues

### DIFF
--- a/python/test/unit/language/test_subprocess.py
+++ b/python/test/unit/language/test_subprocess.py
@@ -27,7 +27,7 @@ FP32_HEX_CANONICAL = (
     "-inf",
     "0x1.8p+2",
 )
-HEX_FLOAT_RE = re.compile(r"-?0x[0-9a-f]+(?:\.[0-9a-f]*)?p[+-]?\d+|-?inf|-?nan", re.IGNORECASE)
+HEX_FLOAT_RE = re.compile(r"-?0x[0-9a-f]+(?:\.[0-9a-f]*)?p[+-]?\d+|-?\b(?:inf|nan)\b", re.IGNORECASE)
 
 
 def _hex_float_values(output: bytes) -> Counter:

--- a/python/triton_kernels/triton_kernels/tensor_details/bitmatrix.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/bitmatrix.py
@@ -160,7 +160,10 @@ def make_bitmatrix_metadata_torch(nonzero_indx, bitmatrix):
     pad = lambda x, total_size: torch.cat((x, torch.full((total_size - x.shape[0], ), -1, device=x.device)))
     col_sorted_indx = pad(torch.argsort(nonzero_indx[nonzero_indx != -1], stable=True), nonzero_indx.numel())
     row_sorted_indx = pad(torch.argsort(col_sorted_indx[col_sorted_indx != -1], stable=True), nonzero_indx.numel())
-    col_sum = torch.histc(nonzero_indx, bins=n_batches, max=n_batches - 1).int()
+    # PyTorch doesn't implement histc for integer types on CPU, so cast to
+    # float64 to keep this reference implementation usable on CPU as well.
+    nonzero_indx_fp64 = nonzero_indx.to(torch.float64)
+    col_sum = torch.histc(nonzero_indx_fp64, bins=n_batches, max=n_batches - 1).int()
     return BitmatrixMetadata(
         col_sum=col_sum,
         col_sorted_indx=col_sorted_indx,


### PR DESCRIPTION
1. **`test_subprocess.py`: anchor the `inf`/`nan` alternatives in
   `HEX_FLOAT_RE`** with word boundaries so they don't match inside longer
   identifiers.

2. **`bitmatrix.py`: cast to `float64` before `torch.histc`**, which has no
   integer CPU implementation, so the reference path also works on CPU.