### PR TITLE
[CI] Consolidate label-triggered workflows into a single dispatcher

### DIFF
--- a/.github/workflows/on-label.yml
+++ b/.github/workflows/on-label.yml
@@ -33,7 +33,10 @@ jobs:
   # ---- Build wheel ----
 
   build-wheel:
-    if: github.event.label.name != 'run-vllm-tests'
+    if: >-
+      github.event.label.name == 'run-benchmarks' ||
+      github.event.label.name == 'run-vllm-benchmarks' ||
+      github.event.label.name == 'run-sglang-benchmarks'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"

--- a/.github/workflows/on-label.yml
+++ b/.github/workflows/on-label.yml
@@ -30,18 +30,18 @@ jobs:
       runner_label: max1100
     secrets: inherit
 
-  # ---- vLLM benchmarks ----
+  # ---- Build wheel ----
 
-  build-wheel-vllm:
-    if: >-
-      github.event.label.name == 'run-vllm-benchmarks' ||
-      github.event.label.name == 'run-benchmarks'
+  build-wheel:
+    if: github.event.label.name != 'run-vllm-tests'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
 
+  # ---- vLLM benchmarks ----
+
   vllm-benchmarks-bmg:
-    needs: build-wheel-vllm
+    needs: build-wheel
     if: github.event.label.name == 'run-vllm-benchmarks'
     uses: ./.github/workflows/vllm-benchmarks.yml
     with:
@@ -49,7 +49,7 @@ jobs:
     secrets: inherit
 
   vllm-benchmarks-pvc:
-    needs: build-wheel-vllm
+    needs: build-wheel
     if: >-
       github.event.label.name == 'run-vllm-benchmarks' ||
       github.event.label.name == 'run-benchmarks'
@@ -60,14 +60,8 @@ jobs:
 
   # ---- Triton benchmarks ----
 
-  build-wheel-triton:
-    if: github.event.label.name == 'run-benchmarks'
-    uses: ./.github/workflows/build-benchmarks-wheel.yml
-    with:
-      python-version: "3.10"
-
   triton-benchmarks-bmg:
-    needs: build-wheel-triton
+    needs: build-wheel
     if: github.event.label.name == 'run-benchmarks'
     uses: ./.github/workflows/triton-benchmarks.yml
     with:
@@ -75,7 +69,7 @@ jobs:
       skip_benchmarks: '["flex-attention-causal-batch16"]'
 
   triton-benchmarks-pvc:
-    needs: build-wheel-triton
+    needs: build-wheel
     if: github.event.label.name == 'run-benchmarks'
     uses: ./.github/workflows/triton-benchmarks.yml
     with:
@@ -84,14 +78,8 @@ jobs:
 
   # ---- SGLang benchmarks ----
 
-  build-wheel-sglang:
-    if: github.event.label.name == 'run-sglang-benchmarks'
-    uses: ./.github/workflows/build-benchmarks-wheel.yml
-    with:
-      python-version: "3.12"
-
   sglang-benchmarks-bmg:
-    needs: build-wheel-sglang
+    needs: build-wheel
     if: github.event.label.name == 'run-sglang-benchmarks'
     uses: ./.github/workflows/sglang-benchmarks.yml
     with:
@@ -99,7 +87,7 @@ jobs:
     secrets: inherit
 
   sglang-benchmarks-pvc:
-    needs: build-wheel-sglang
+    needs: build-wheel
     if: github.event.label.name == 'run-sglang-benchmarks'
     uses: ./.github/workflows/sglang-benchmarks.yml
     with:

--- a/.github/workflows/on-label.yml
+++ b/.github/workflows/on-label.yml
@@ -1,0 +1,107 @@
+name: On label
+
+permissions: read-all
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
+  cancel-in-progress: true
+
+jobs:
+  # ---- vLLM tests ----
+
+  vllm-tests-bmg:
+    if: github.event.label.name == 'run-vllm-tests'
+    uses: ./.github/workflows/vllm-tests-reusable.yml
+    with:
+      runner_label: b580
+      skip_list: xe2
+    secrets: inherit
+
+  vllm-tests-pvc:
+    if: github.event.label.name == 'run-vllm-tests'
+    uses: ./.github/workflows/vllm-tests-reusable.yml
+    with:
+      runner_label: max1100
+    secrets: inherit
+
+  # ---- vLLM benchmarks ----
+
+  build-wheel-vllm:
+    if: >-
+      github.event.label.name == 'run-vllm-benchmarks' ||
+      github.event.label.name == 'run-benchmarks'
+    uses: ./.github/workflows/build-benchmarks-wheel.yml
+    with:
+      python-version: "3.12"
+
+  vllm-benchmarks-bmg:
+    needs: build-wheel-vllm
+    if: github.event.label.name == 'run-vllm-benchmarks'
+    uses: ./.github/workflows/vllm-benchmarks.yml
+    with:
+      runner_label: b580
+    secrets: inherit
+
+  vllm-benchmarks-pvc:
+    needs: build-wheel-vllm
+    if: >-
+      github.event.label.name == 'run-vllm-benchmarks' ||
+      github.event.label.name == 'run-benchmarks'
+    uses: ./.github/workflows/vllm-benchmarks.yml
+    with:
+      runner_label: max1550
+    secrets: inherit
+
+  # ---- Triton benchmarks ----
+
+  build-wheel-triton:
+    if: github.event.label.name == 'run-benchmarks'
+    uses: ./.github/workflows/build-benchmarks-wheel.yml
+    with:
+      python-version: "3.10"
+
+  triton-benchmarks-bmg:
+    needs: build-wheel-triton
+    if: github.event.label.name == 'run-benchmarks'
+    uses: ./.github/workflows/triton-benchmarks.yml
+    with:
+      runner_label: b580
+      skip_benchmarks: '["flex-attention-causal-batch16"]'
+
+  triton-benchmarks-pvc:
+    needs: build-wheel-triton
+    if: github.event.label.name == 'run-benchmarks'
+    uses: ./.github/workflows/triton-benchmarks.yml
+    with:
+      runner_label: max1550
+      skip_benchmarks: "[]"
+
+  # ---- SGLang benchmarks ----
+
+  build-wheel-sglang:
+    if: github.event.label.name == 'run-sglang-benchmarks'
+    uses: ./.github/workflows/build-benchmarks-wheel.yml
+    with:
+      python-version: "3.12"
+
+  sglang-benchmarks-bmg:
+    needs: build-wheel-sglang
+    if: github.event.label.name == 'run-sglang-benchmarks'
+    uses: ./.github/workflows/sglang-benchmarks.yml
+    with:
+      runner_label: b580
+    secrets: inherit
+
+  sglang-benchmarks-pvc:
+    needs: build-wheel-sglang
+    if: github.event.label.name == 'run-sglang-benchmarks'
+    uses: ./.github/workflows/sglang-benchmarks.yml
+    with:
+      runner_label: max1550
+    secrets: inherit

--- a/.github/workflows/on-label.yml
+++ b/.github/workflows/on-label.yml
@@ -53,9 +53,7 @@ jobs:
 
   vllm-benchmarks-pvc:
     needs: build-wheel
-    if: >-
-      github.event.label.name == 'run-vllm-benchmarks' ||
-      github.event.label.name == 'run-benchmarks'
+    if: github.event.label.name == 'run-vllm-benchmarks'
     uses: ./.github/workflows/vllm-benchmarks.yml
     with:
       runner_label: max1550

--- a/.github/workflows/sglang-benchmarks-bmg.yml
+++ b/.github/workflows/sglang-benchmarks-bmg.yml
@@ -6,13 +6,12 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
   schedule:
     - cron: "0 11 * * *"
 
-# Give unrelated-label skip runs a separate lane so they cannot cancel a real run.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}-${{ github.event.action == 'labeled' && github.event.label.name != 'run-sglang-benchmarks' && 'skip' || 'run' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}
   cancel-in-progress: true
 
 jobs:
@@ -34,8 +33,7 @@ jobs:
     needs: check-paths
     if: >-
       github.event_name == 'schedule' ||
-      (github.event.action != 'labeled' && needs.check-paths.outputs.benchmarks == 'true') ||
-      github.event.label.name == 'run-sglang-benchmarks'
+      needs.check-paths.outputs.benchmarks == 'true'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
@@ -45,8 +43,7 @@ jobs:
     if: >-
       always() && !cancelled() &&
       (github.event_name == 'schedule' ||
-       (github.event.action != 'labeled' && needs.check-paths.outputs.benchmarks == 'true') ||
-       github.event.label.name == 'run-sglang-benchmarks')
+       needs.check-paths.outputs.benchmarks == 'true')
     uses: ./.github/workflows/sglang-benchmarks.yml
     with:
       runner_label: b580

--- a/.github/workflows/sglang-benchmarks-pvc.yml
+++ b/.github/workflows/sglang-benchmarks-pvc.yml
@@ -6,13 +6,12 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
   schedule:
     - cron: "0 11 * * *"
 
-# Give unrelated-label skip runs a separate lane so they cannot cancel a real run.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}-${{ github.event.action == 'labeled' && github.event.label.name != 'run-sglang-benchmarks' && 'skip' || 'run' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}
   cancel-in-progress: true
 
 jobs:
@@ -34,8 +33,7 @@ jobs:
     needs: check-paths
     if: >-
       github.event_name == 'schedule' ||
-      (github.event.action != 'labeled' && needs.check-paths.outputs.benchmarks == 'true') ||
-      github.event.label.name == 'run-sglang-benchmarks'
+      needs.check-paths.outputs.benchmarks == 'true'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
@@ -45,8 +43,7 @@ jobs:
     if: >-
       always() && !cancelled() &&
       (github.event_name == 'schedule' ||
-       (github.event.action != 'labeled' && needs.check-paths.outputs.benchmarks == 'true') ||
-       github.event.label.name == 'run-sglang-benchmarks')
+       needs.check-paths.outputs.benchmarks == 'true')
     uses: ./.github/workflows/sglang-benchmarks.yml
     with:
       runner_label: max1550

--- a/.github/workflows/triton-benchmarks-bmg.yml
+++ b/.github/workflows/triton-benchmarks-bmg.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
 
 jobs:
   check-paths:
@@ -25,7 +25,7 @@ jobs:
 
   build-wheel:
     needs: check-paths
-    if: needs.check-paths.outputs.benchmarks == 'true' || github.event.label.name == 'run-benchmarks'
+    if: needs.check-paths.outputs.benchmarks == 'true'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
@@ -34,7 +34,7 @@ jobs:
     needs: [check-paths, build-wheel]
     if: >-
       always() && !cancelled() &&
-      (needs.check-paths.outputs.benchmarks == 'true' || github.event.label.name == 'run-benchmarks')
+      needs.check-paths.outputs.benchmarks == 'true'
     uses: ./.github/workflows/triton-benchmarks.yml
     with:
       runner_label: b580

--- a/.github/workflows/triton-benchmarks-pvc.yml
+++ b/.github/workflows/triton-benchmarks-pvc.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
 
 jobs:
   check-paths:
@@ -25,7 +25,7 @@ jobs:
 
   build-wheel:
     needs: check-paths
-    if: needs.check-paths.outputs.benchmarks == 'true' || github.event.label.name == 'run-benchmarks'
+    if: needs.check-paths.outputs.benchmarks == 'true'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
@@ -34,7 +34,7 @@ jobs:
     needs: [check-paths, build-wheel]
     if: >-
       always() && !cancelled() &&
-      (needs.check-paths.outputs.benchmarks == 'true' || github.event.label.name == 'run-benchmarks')
+      needs.check-paths.outputs.benchmarks == 'true'
     uses: ./.github/workflows/triton-benchmarks.yml
     with:
       runner_label: max1550

--- a/.github/workflows/vllm-benchmarks-bmg.yml
+++ b/.github/workflows/vllm-benchmarks-bmg.yml
@@ -6,13 +6,12 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
   schedule:
     - cron: "0 8 * * *"
 
-# Give unrelated-label skip runs a separate lane so they cannot cancel a real run.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}-${{ github.event.action == 'labeled' && github.event.label.name != 'run-vllm-benchmarks' && 'skip' || 'run' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}
   cancel-in-progress: true
 
 jobs:
@@ -34,8 +33,7 @@ jobs:
     needs: check-paths
     if: >-
       github.event_name == 'schedule' ||
-      (github.event.action != 'labeled' && needs.check-paths.outputs.benchmarks == 'true') ||
-      github.event.label.name == 'run-vllm-benchmarks'
+      needs.check-paths.outputs.benchmarks == 'true'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
@@ -45,8 +43,7 @@ jobs:
     if: >-
       always() && !cancelled() &&
       (github.event_name == 'schedule' ||
-       (github.event.action != 'labeled' && needs.check-paths.outputs.benchmarks == 'true') ||
-       github.event.label.name == 'run-vllm-benchmarks')
+       needs.check-paths.outputs.benchmarks == 'true')
     uses: ./.github/workflows/vllm-benchmarks.yml
     with:
       runner_label: b580

--- a/.github/workflows/vllm-benchmarks-pvc.yml
+++ b/.github/workflows/vllm-benchmarks-pvc.yml
@@ -6,13 +6,12 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
   schedule:
     - cron: "0 8 * * *"
 
-# Give unrelated-label skip runs a separate lane so they cannot cancel a real run.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}-${{ github.event.action == 'labeled' && github.event.label.name != 'run-benchmarks' && github.event.label.name != 'run-vllm-benchmarks' && 'skip' || 'run' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}
   cancel-in-progress: true
 
 jobs:
@@ -34,9 +33,7 @@ jobs:
     needs: check-paths
     if: >-
       github.event_name == 'schedule' ||
-      (github.event.action != 'labeled' && needs.check-paths.outputs.benchmarks == 'true') ||
-      github.event.label.name == 'run-benchmarks' ||
-      github.event.label.name == 'run-vllm-benchmarks'
+      needs.check-paths.outputs.benchmarks == 'true'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
@@ -46,9 +43,7 @@ jobs:
     if: >-
       always() && !cancelled() &&
       (github.event_name == 'schedule' ||
-       (github.event.action != 'labeled' && needs.check-paths.outputs.benchmarks == 'true') ||
-       github.event.label.name == 'run-benchmarks' ||
-       github.event.label.name == 'run-vllm-benchmarks')
+       needs.check-paths.outputs.benchmarks == 'true')
     uses: ./.github/workflows/vllm-benchmarks.yml
     with:
       runner_label: max1550

--- a/.github/workflows/vllm-tests-bmg.yml
+++ b/.github/workflows/vllm-tests-bmg.yml
@@ -9,7 +9,7 @@ on:
     - cron: "5 10 * * SUN"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}
+  group: ${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/vllm-tests-bmg.yml
+++ b/.github/workflows/vllm-tests-bmg.yml
@@ -3,25 +3,13 @@ name: vLLM tests, BMG
 permissions: read-all
 
 on:
-  pull_request:
-    branches:
-      - main
-    types: [labeled]
   schedule:
     # Thursday/Sunday 2:05AM PST (UTC-8) or 3:05AM PDT (UTC-7)
     - cron: "5 10 * * THU"
     - cron: "5 10 * * SUN"
 
-# Give unrelated-label skip runs a separate lane so they cannot cancel a real run.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}-${{ github.event.action == 'labeled' && github.event.label.name != 'run-vllm-tests' && 'skip' || 'run' }}
-  cancel-in-progress: true
-
 jobs:
   tests:
-    if: >-
-      github.event_name == 'schedule' ||
-      github.event.label.name == 'run-vllm-tests'
     uses: ./.github/workflows/vllm-tests-reusable.yml
     with:
       runner_label: b580

--- a/.github/workflows/vllm-tests-bmg.yml
+++ b/.github/workflows/vllm-tests-bmg.yml
@@ -8,6 +8,10 @@ on:
     - cron: "5 10 * * THU"
     - cron: "5 10 * * SUN"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     uses: ./.github/workflows/vllm-tests-reusable.yml

--- a/.github/workflows/vllm-tests-pvc.yml
+++ b/.github/workflows/vllm-tests-pvc.yml
@@ -3,25 +3,13 @@ name: vLLM tests, PVC
 permissions: read-all
 
 on:
-  pull_request:
-    branches:
-      - main
-    types: [labeled]
   schedule:
     # Thursday/Sunday 2:05AM PST (UTC-8) or 3:05AM PDT (UTC-7)
     - cron: "5 10 * * THU"
     - cron: "5 10 * * SUN"
 
-# Give unrelated-label skip runs a separate lane so they cannot cancel a real run.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}-${{ github.event.action == 'labeled' && github.event.label.name != 'run-vllm-tests' && 'skip' || 'run' }}
-  cancel-in-progress: true
-
 jobs:
   tests:
-    if: >-
-      github.event_name == 'schedule' ||
-      github.event.label.name == 'run-vllm-tests'
     uses: ./.github/workflows/vllm-tests-reusable.yml
     with:
       runner_label: max1100

--- a/.github/workflows/vllm-tests-pvc.yml
+++ b/.github/workflows/vllm-tests-pvc.yml
@@ -9,7 +9,7 @@ on:
     - cron: "5 10 * * SUN"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}
+  group: ${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/vllm-tests-pvc.yml
+++ b/.github/workflows/vllm-tests-pvc.yml
@@ -8,6 +8,10 @@ on:
     - cron: "5 10 * * THU"
     - cron: "5 10 * * SUN"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     uses: ./.github/workflows/vllm-tests-reusable.yml


### PR DESCRIPTION
## Summary
- Introduces a single `on-label.yml` workflow that handles all `pull_request: types: [labeled]` events and routes to the appropriate reusable workflows based on label name
- Removes the `labeled` trigger from all 8 individual wrapper workflows, simplifying their conditions and removing the concurrency skip-lane hacks
- vLLM test wrappers now only retain their `schedule` trigger; benchmark wrappers retain `[opened, synchronize, reopened]` for path-change detection

## Motivation
- **Cluttered PR checks**: Previously, applying any single label triggered all 8 workflows — 6+ would immediately skip, showing as noise in the PR status checks
- **Polluted Actions history**: Each individual workflow's Actions page was filled with 2-second no-op runs from unrelated labels
- **Lost results on push**: Workflows with `synchronize` + `labeled` would re-trigger and skip on new pushes, overwriting the real label-triggered run's status