### PR TITLE
[CI] Upgrade triton-benchmarks to Python 3.12

### DIFF
--- a/.github/workflows/triton-benchmarks-bmg.yml
+++ b/.github/workflows/triton-benchmarks-bmg.yml
@@ -28,7 +28,7 @@ jobs:
     if: needs.check-paths.outputs.benchmarks == 'true' || github.event.label.name == 'run-benchmarks'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
-      python-version: "3.10"
+      python-version: "3.12"
 
   benchmarks:
     needs: [check-paths, build-wheel]

--- a/.github/workflows/triton-benchmarks-pvc.yml
+++ b/.github/workflows/triton-benchmarks-pvc.yml
@@ -28,7 +28,7 @@ jobs:
     if: needs.check-paths.outputs.benchmarks == 'true' || github.event.label.name == 'run-benchmarks'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
-      python-version: "3.10"
+      python-version: "3.12"
 
   benchmarks:
     needs: [check-paths, build-wheel]

--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -68,7 +68,7 @@ concurrency:
 permissions: read-all
 
 env:
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.12"
   BENCHMARKING_METHOD: ${{ inputs.benchmarking_method || 'UPSTREAM_PYTORCH_PROFILER' }}
   # FIXME: When https://github.com/pytorch/pytorch/issues/189144 will be addressed
   TORCHINDUCTOR_USE_EXPERIMENTAL_BENCHMARKER: '0'


### PR DESCRIPTION
Upgrades `triton-benchmarks.yml` and its platform wrappers from Python 3.10 to Python 3.12 for consistency, as all other benchmark workflows (vLLM, SGLang) already use Python 3.12.