### PR TITLE
[CI] Use max1100 runner for correctness test workflows

### DIFF
--- a/.github/workflows/third-party-tests.yml
+++ b/.github/workflows/third-party-tests.yml
@@ -44,7 +44,7 @@ jobs:
     if: ${{ !inputs.tests || contains(inputs.tests, 'sglang') }}
     runs-on:
       - linux
-      - ${{ inputs.runner_label || 'max1550' }}
+      - ${{ inputs.runner_label || 'max1100' }}
     timeout-minutes: 120
     defaults:
       run:
@@ -102,7 +102,7 @@ jobs:
     if: ${{ !inputs.tests || contains(inputs.tests, 'liger') }}
     runs-on:
       - linux
-      - ${{ inputs.runner_label || 'max1550' }}
+      - ${{ inputs.runner_label || 'max1100' }}
     timeout-minutes: 120
     defaults:
       run:

--- a/.github/workflows/vllm-tests-pvc.yml
+++ b/.github/workflows/vllm-tests-pvc.yml
@@ -24,5 +24,5 @@ jobs:
       github.event.label.name == 'run-vllm-tests'
     uses: ./.github/workflows/vllm-tests-reusable.yml
     with:
-      runner_label: max1550
+      runner_label: max1100
     secrets: inherit

--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -50,7 +50,7 @@ jobs:
     name: Setup
     runs-on:
       - linux
-      - ${{ inputs.runner_label || 'max1550' }}
+      - ${{ inputs.runner_label || 'max1100' }}
     timeout-minutes: 180
     defaults:
       run:
@@ -147,7 +147,7 @@ jobs:
           - vllm-rest
     runs-on:
       - linux
-      - ${{ inputs.runner_label || 'max1550' }}
+      - ${{ inputs.runner_label || 'max1100' }}
     timeout-minutes: 180
     defaults:
       run:


### PR DESCRIPTION
Switch default runner from `max1550` to `max1100` in vLLM tests, vLLM tests reusable, and third-party tests workflows. Since these workflows only track correctness and not performance, there is no need to use the `max1550` runner.
This should help reduce load on the max1550 runners, freeing them up for performance-sensitive workloads.