### PR TITLE
[Launcher] Add packed-launch fast path (Fix E)

### DIFF
--- a/python/test/unit/intel/test_driver.py
+++ b/python/test/unit/intel/test_driver.py
@@ -1,3 +1,4 @@
+import ctypes
 import re
 
 import pytest
@@ -222,3 +223,317 @@ def test_sycl_global_range_overflow(device):
     add_kernel[grid](x, x, output, n_elements, 16)
 
     torch.testing.assert_close(output.cpu(), (x + x).cpu(), rtol=0, atol=0)
+
+
+# =============================================================================
+# Fix E: packed-launch fast path coverage
+# =============================================================================
+#
+# The packed-launch path (XPULauncher._use_packed_launch = True) resolves
+# pointer arguments in Python once per launch and hands C a flat void*[]
+# instead of calling `.data_ptr()` per-arg inside the C launcher. These
+# tests exercise:
+#   - Eligibility (which kernels get selected for the fast path)
+#   - Pointer-source variants (torch tensor, Python int, None)
+#   - Scalar/pointer coexistence in the same signature
+#   - Fallback via TRITON_INTEL_DISABLE_PACKED_LAUNCH=1
+#   - Fallback for unsupported (tensordesc) annotations
+#   - Cross-path parity (packed vs classic produce identical output)
+#   - Enter-hook re-entrancy safety (see driver.c launch_packed snapshot)
+#   - build_pack_layout input validation (rejects non-PyKernelArg items)
+#
+# Where a test needs to bypass the launcher entirely and hit `build_pack_layout`
+# directly, it uses `driver.active.utils.build_pack_layout` — this only exists
+# on builds with the Fix E C symbols present, so tests that call it are
+# skipped otherwise.
+
+
+def _has_packed_launch():
+    return getattr(driver.active.utils, "launch_packed", None) is not None
+
+
+packed_launch_only = pytest.mark.skipif(not _has_packed_launch(), reason="build lacks Fix E packed-launch symbols")
+
+
+@triton.jit
+def _packed_add_kernel(x_ptr, y_ptr, out_ptr, n, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < n
+    x = tl.load(x_ptr + offs, mask=mask)
+    y = tl.load(y_ptr + offs, mask=mask)
+    tl.store(out_ptr + offs, x + y, mask=mask)
+
+
+@triton.jit
+def _packed_scalar_and_ptr_kernel(x_ptr, out_ptr, n, alpha, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < n
+    x = tl.load(x_ptr + offs, mask=mask)
+    tl.store(out_ptr + offs, x * alpha, mask=mask)
+
+
+@packed_launch_only
+def test_packed_launch_selected_by_default(device):
+    """
+    A simple pointer-heavy kernel should end up on the packed fast path AND
+    produce a correct result. Rather than reaching into triton's per-device
+    caches (which is a private implementation detail), we probe eligibility
+    via `build_pack_layout` directly with the same signature/annotation
+    layout a real launch would produce.
+    """
+    from triton.backends.intel.driver import PyKernelArg, ARG_KERNEL
+    utils = driver.active.utils
+
+    # Simulate the annotations for _packed_add_kernel(x_ptr, y_ptr, out_ptr,
+    # n, BLOCK): three pointers, one scalar int (n), one constexpr (BLOCK
+    # stripped from the annotations list). Only ARG_KERNEL entries appear in
+    # arg_annotations after expand_signature; constexprs are stripped.
+    sig_bytes = bytes([1, 1, 1, 4])  # 3x pointer + 1x int32
+    annotations = [PyKernelArg(nested_tuple=None, type=ARG_KERNEL) for _ in range(4)]
+    pointer_indices, pack_bytes, packable = utils.build_pack_layout((sig_bytes, annotations))
+    assert packable is True
+    assert pointer_indices == (0, 1, 2)
+    assert pack_bytes == 3 * ctypes.sizeof(ctypes.c_void_p)
+
+    # And confirm end-to-end correctness through the real launcher.
+    n, block = 256, 64
+    x = torch.arange(n, dtype=torch.float32, device=device)
+    y = torch.arange(n, dtype=torch.float32, device=device) * 2
+    out = torch.empty_like(x)
+    grid = (triton.cdiv(n, block), )
+    _packed_add_kernel[grid](x, y, out, n, BLOCK=block)
+    torch.testing.assert_close(out, x + y, rtol=0, atol=0)
+
+
+@packed_launch_only
+def test_packed_launch_disable_env(device, monkeypatch):
+    """TRITON_INTEL_DISABLE_PACKED_LAUNCH=1 forces the classic path."""
+    monkeypatch.setenv("TRITON_INTEL_DISABLE_PACKED_LAUNCH", "1")
+    # Force a re-specialization by using a fresh kernel def so __init__ reads
+    # the env var afresh.
+
+    @triton.jit
+    def _add_disable_env(x_ptr, y_ptr, out_ptr, n, BLOCK: tl.constexpr):
+        pid = tl.program_id(0)
+        offs = pid * BLOCK + tl.arange(0, BLOCK)
+        mask = offs < n
+        x = tl.load(x_ptr + offs, mask=mask)
+        y = tl.load(y_ptr + offs, mask=mask)
+        tl.store(out_ptr + offs, x + y, mask=mask)
+
+    n, block = 128, 64
+    x = torch.arange(n, dtype=torch.float32, device=device)
+    y = torch.arange(n, dtype=torch.float32, device=device)
+    out = torch.empty_like(x)
+    grid = (triton.cdiv(n, block), )
+    _add_disable_env[grid](x, y, out, n, BLOCK=block)
+    torch.testing.assert_close(out, x + y, rtol=0, atol=0)
+
+
+@packed_launch_only
+def test_packed_launch_none_pointer(device):
+    """`None` as a pointer arg should launch cleanly (extractPointer maps it to nullptr)."""
+
+    @triton.jit
+    def _kernel_optional_ptr(x_ptr, opt_ptr, out_ptr, n, BLOCK: tl.constexpr):
+        # opt_ptr is intentionally unused; the launcher just needs to accept
+        # None without crashing.
+        pid = tl.program_id(0)
+        offs = pid * BLOCK + tl.arange(0, BLOCK)
+        mask = offs < n
+        x = tl.load(x_ptr + offs, mask=mask)
+        tl.store(out_ptr + offs, x, mask=mask)
+
+    n, block = 64, 32
+    x = torch.arange(n, dtype=torch.float32, device=device)
+    out = torch.empty_like(x)
+    grid = (triton.cdiv(n, block), )
+    _kernel_optional_ptr[grid](x, None, out, n, BLOCK=block)
+    torch.testing.assert_close(out, x, rtol=0, atol=0)
+
+
+@packed_launch_only
+def test_packed_launch_int_pointer(device):
+    """A Python int used as a raw device-pointer value should launch cleanly."""
+    n, block = 64, 32
+    x = torch.arange(n, dtype=torch.float32, device=device)
+    out = torch.empty_like(x)
+
+    @triton.jit
+    def _kernel_int_ptr(x_ptr, unused_int_ptr, out_ptr, n, BLOCK: tl.constexpr):
+        pid = tl.program_id(0)
+        offs = pid * BLOCK + tl.arange(0, BLOCK)
+        mask = offs < n
+        v = tl.load(x_ptr + offs, mask=mask)
+        tl.store(out_ptr + offs, v, mask=mask)
+
+    grid = (triton.cdiv(n, block), )
+    # Any int is accepted; the kernel never reads through it, so we can pass 0.
+    _kernel_int_ptr[grid](x, 0, out, n, BLOCK=block)
+    torch.testing.assert_close(out, x, rtol=0, atol=0)
+
+
+@packed_launch_only
+def test_packed_launch_scalar_and_pointer_coexist(device):
+    """Kernels mixing scalar and pointer args should still produce correct output."""
+    n, block = 128, 32
+    x = torch.arange(n, dtype=torch.float32, device=device)
+    out = torch.empty_like(x)
+    alpha = 3.5
+    grid = (triton.cdiv(n, block), )
+    _packed_scalar_and_ptr_kernel[grid](x, out, n, alpha, BLOCK=block)
+    torch.testing.assert_close(out, x * alpha, rtol=0, atol=1e-6)
+
+
+@packed_launch_only
+def test_packed_vs_classic_parity(device, monkeypatch):
+    """
+    Cross-path parity: the same kernel with the same inputs must produce the
+    same output whether the packed fast path is used or forced off via
+    TRITON_INTEL_DISABLE_PACKED_LAUNCH=1.
+    """
+    n, block = 256, 64
+    x = torch.arange(n, dtype=torch.float32, device=device)
+    y = torch.arange(n, dtype=torch.float32, device=device) * 2
+
+    # Fresh kernel defs per branch so __init__ eligibility is re-computed.
+
+    @triton.jit
+    def _kernel_a(x_ptr, y_ptr, out_ptr, n, BLOCK: tl.constexpr):
+        pid = tl.program_id(0)
+        offs = pid * BLOCK + tl.arange(0, BLOCK)
+        mask = offs < n
+        a = tl.load(x_ptr + offs, mask=mask)
+        b = tl.load(y_ptr + offs, mask=mask)
+        tl.store(out_ptr + offs, a + b, mask=mask)
+
+    @triton.jit
+    def _kernel_b(x_ptr, y_ptr, out_ptr, n, BLOCK: tl.constexpr):
+        pid = tl.program_id(0)
+        offs = pid * BLOCK + tl.arange(0, BLOCK)
+        mask = offs < n
+        a = tl.load(x_ptr + offs, mask=mask)
+        b = tl.load(y_ptr + offs, mask=mask)
+        tl.store(out_ptr + offs, a + b, mask=mask)
+
+    # Packed path
+    monkeypatch.delenv("TRITON_INTEL_DISABLE_PACKED_LAUNCH", raising=False)
+    out_packed = torch.empty_like(x)
+    grid = (triton.cdiv(n, block), )
+    _kernel_a[grid](x, y, out_packed, n, BLOCK=block)
+
+    # Classic path
+    monkeypatch.setenv("TRITON_INTEL_DISABLE_PACKED_LAUNCH", "1")
+    out_classic = torch.empty_like(x)
+    _kernel_b[grid](x, y, out_classic, n, BLOCK=block)
+
+    torch.testing.assert_close(out_packed, out_classic, rtol=0, atol=0)
+    torch.testing.assert_close(out_packed, x + y, rtol=0, atol=0)
+
+
+@packed_launch_only
+def test_packed_launch_reentrant_enter_hook(device):
+    """
+    Regression test for the enter-hook re-entrancy risk in launch_packed:
+    the C-side snapshots the packed_pointers buffer BEFORE running the enter
+    hook, so a hook that re-enters the same kernel with different tensors
+    must not corrupt the outer launch's pointer values.
+
+    Without the snapshot, the outer launch would consume the inner launch's
+    pointers because both share `XPULauncher._pack_buf`.
+    """
+    from triton import knobs
+
+    n, block = 64, 32
+    x_outer = torch.full((n, ), 7.0, dtype=torch.float32, device=device)
+    x_inner = torch.full((n, ), 99.0, dtype=torch.float32, device=device)
+    out_outer = torch.empty_like(x_outer)
+    out_inner = torch.empty_like(x_inner)
+    grid = (triton.cdiv(n, block), )
+
+    @triton.jit
+    def _identity(x_ptr, out_ptr, n, BLOCK: tl.constexpr):
+        pid = tl.program_id(0)
+        offs = pid * BLOCK + tl.arange(0, BLOCK)
+        mask = offs < n
+        v = tl.load(x_ptr + offs, mask=mask)
+        tl.store(out_ptr + offs, v, mask=mask)
+
+    # Warm up the specialization so the enter-hook doesn't fire during compile.
+    _identity[grid](x_outer, out_outer, n, BLOCK=block)
+
+    reentered = {"count": 0}
+
+    def _reentrant_hook(*_args, **_kwargs):
+        # Fire once, and only from the outer launch's hook invocation.
+        if reentered["count"] == 0:
+            reentered["count"] = 1
+            _identity[grid](x_inner, out_inner, n, BLOCK=block)
+
+    knobs.runtime.launch_enter_hook.add(_reentrant_hook)
+    try:
+        _identity[grid](x_outer, out_outer, n, BLOCK=block)
+    finally:
+        knobs.runtime.launch_enter_hook.remove(_reentrant_hook)
+
+    # The outer launch's output must reflect x_outer (7.0), not x_inner (99.0).
+    # If the snapshot were missing, the outer would read x_inner because
+    # self._pack_buf got overwritten during the inner call.
+    torch.testing.assert_close(out_outer, x_outer, rtol=0, atol=0)
+    torch.testing.assert_close(out_inner, x_inner, rtol=0, atol=0)
+    assert reentered["count"] == 1
+
+
+@packed_launch_only
+def test_build_pack_layout_rejects_non_pykernelarg(device):
+    """
+    build_pack_layout is exposed via ctypes; a caller passing arbitrary Python
+    objects (e.g. [None]) as arg_annotations must get a TypeError rather than
+    crashing on an unchecked C-level cast.
+    """
+    utils = driver.active.utils
+    # Build a minimal kernel_signature buffer (one pointer arg).
+    sig_bytes = bytes([1])  # EXTRACTOR_POINTER_INDEX == 1
+    # Pass a bogus arg_annotations list containing a non-PyKernelArg item.
+    with pytest.raises(TypeError, match="arg_annotations entries must be PyKernelArg"):
+        utils.build_pack_layout((sig_bytes, [None]))
+
+
+@packed_launch_only
+def test_build_pack_layout_reports_no_pointer_kernel(device):
+    """
+    A kernel with no pointer args should report `packable=False` from
+    build_pack_layout — otherwise the launcher would allocate an empty pack
+    buffer and gain nothing from the fast path.
+    """
+    from triton.backends.intel.driver import PyKernelArg, ARG_KERNEL
+    # EXTRACTOR_TYPES: 1 = pointer, 4 = INT32 — use scalar to force "no pointer".
+    utils = driver.active.utils
+    sig_bytes = bytes([4])
+    ann = PyKernelArg(nested_tuple=None, type=ARG_KERNEL)
+    pointer_indices, pack_bytes, packable = utils.build_pack_layout((sig_bytes, [ann]))
+    assert pointer_indices == ()
+    assert pack_bytes == 0
+    assert packable is False
+
+
+@packed_launch_only
+def test_build_pack_layout_arg_tuple_falls_back(device):
+    """
+    ARG_TUPLE annotations short-circuit `buildRawKernelArgIndices` and force
+    `packable=False`. The launcher then falls back to the classic path
+    without trying to pack a nested-tuple signature it can't reason about.
+    """
+    from triton.backends.intel.driver import PyKernelArg, ARG_KERNEL, ARG_TUPLE
+    utils = driver.active.utils
+    sig_bytes = bytes([1, 1])  # 2 pointers in the flattened signature
+    annotations = [
+        PyKernelArg(nested_tuple=None, type=ARG_KERNEL),
+        # A nested-tuple annotation forces packable=False regardless of what
+        # nested_tuple contains — the walk breaks immediately on ARG_TUPLE.
+        PyKernelArg(nested_tuple=[PyKernelArg(nested_tuple=None, type=ARG_KERNEL)], type=ARG_TUPLE),
+    ]
+    _pointer_indices, _pack_bytes, packable = utils.build_pack_layout((sig_bytes, annotations))
+    assert packable is False

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -1297,6 +1297,147 @@ bool extractArgs(PyObject **final_list, int *list_idx, PyObject *kernel_args,
   return true;
 }
 
+// Walks arg_annotations (post-`expand_signature` shape) and builds a list of
+// raw-args-tuple indices corresponding to ARG_KERNEL entries encountered so
+// far. Returns:
+//   returns          = a new PyList (always non-NULL on success; borrowed
+//                      NULL only when a Python exception is set).
+//   *packable_out    = true iff the walk saw NO ARG_TUPLE entries. On false,
+//                      the returned list is truncated at the first ARG_TUPLE
+//                      and callers must not use it for pack-layout math.
+//                      Callers must check `*packable_out` — the list itself
+//                      is not a pack-ability signal.
+// Caller owns the returned list.
+static PyObject *buildRawKernelArgIndices(PyObject *arg_annotations,
+                                          bool *packable_out) {
+  PyObject *fast_annotations = PySequence_Fast(
+      arg_annotations, "Expected arg_annotations to be a sequence or iterable");
+  if (!fast_annotations) {
+    return NULL;
+  }
+  Py_ssize_t n = PySequence_Fast_GET_SIZE(fast_annotations);
+  PyObject **items = PySequence_Fast_ITEMS(fast_annotations);
+  PyObject *raw_arg_indices = PyList_New(0);
+  if (!raw_arg_indices) {
+    Py_DECREF(fast_annotations);
+    return NULL;
+  }
+  bool packable = true;
+  Py_ssize_t raw_i = 0;
+  for (Py_ssize_t i = 0; i < n; ++i) {
+    // build_pack_layout is exposed via ctypes, so callers can supply arbitrary
+    // Python objects. Validate before casting so `[None]` or a wrong type
+    // raises a Python exception instead of crashing on annotation->type.
+    if (!PyObject_TypeCheck(items[i], &PyKernelArgType)) {
+      PyErr_SetString(PyExc_TypeError,
+                      "arg_annotations entries must be PyKernelArg instances");
+      Py_DECREF(raw_arg_indices);
+      Py_DECREF(fast_annotations);
+      return NULL;
+    }
+    PyKernelArgObject *annotation = (PyKernelArgObject *)items[i];
+    if (annotation->type == ARG_TUPLE) {
+      packable = false;
+      break;
+    }
+    if (annotation->type == ARG_KERNEL) {
+      PyObject *idx = PyLong_FromSsize_t(raw_i);
+      if (!idx || PyList_Append(raw_arg_indices, idx) < 0) {
+        Py_XDECREF(idx);
+        Py_DECREF(raw_arg_indices);
+        Py_DECREF(fast_annotations);
+        return NULL;
+      }
+      Py_DECREF(idx);
+    }
+    // Both ARG_KERNEL and ARG_CONSTEXPR consume one raw-args slot.
+    raw_i++;
+  }
+  Py_DECREF(fast_annotations);
+  *packable_out = packable;
+  return raw_arg_indices;
+}
+
+// Fix E helper: given the kernel_signature bytes (one extractor code per
+// kernel arg) and arg_annotations, compute the pack layout used by the
+// packed launch fast path.
+//
+// Returns a 3-tuple (pointer_raw_indices, pack_buffer_size, packable):
+//   pointer_raw_indices : tuple[int] -- indices into the raw args tuple
+//                                       (as passed to XPULauncher.__call__)
+//                                       from which the packed pointer values
+//                                       should be drawn, in the order they
+//                                       appear in `signature`. All entries
+//                                       correspond to signature slots whose
+//                                       extractor is EXTRACTOR_POINTER_INDEX.
+//   pack_buffer_size    : int        -- bytes = len(pointer_raw_indices) *
+//   sizeof(void*). packable            : bool       -- True iff the fast path
+//   applies:
+//                                       no ARG_TUPLE annotations AND at least
+//                                       one pointer arg.
+extern "C" EXPORT_FUNC PyObject *build_pack_layout(PyObject *args) {
+  Py_buffer signature;
+  PyObject *arg_annotations = NULL;
+  if (!PyArg_ParseTuple(args, "y*O", &signature, &arg_annotations)) {
+    return NULL;
+  }
+
+  bool annotations_packable = true;
+  PyObject *kernel_arg_raw_indices =
+      buildRawKernelArgIndices(arg_annotations, &annotations_packable);
+  if (kernel_arg_raw_indices == NULL) {
+    PyBuffer_Release(&signature);
+    return NULL;
+  }
+
+  const uint8_t *sig = (const uint8_t *)signature.buf;
+  Py_ssize_t num_sig_args = signature.len;
+  // Invariant: when annotations_packable is true, both `kernel_signature`
+  // and the ARG_KERNEL-only sub-list of arg_annotations are derived from
+  // the same `expanded_signature` on the Python side (see
+  // make_kernel_signature + annotate_arguments in driver.py). Their lengths
+  // are equal by construction; no runtime check needed.
+
+  // Build the pointer_raw_indices list: for each signature slot that is a
+  // pointer, look up the raw-args index from kernel_arg_raw_indices.
+  PyObject *pointer_raw_indices = PyList_New(0);
+  if (!pointer_raw_indices) {
+    Py_DECREF(kernel_arg_raw_indices);
+    PyBuffer_Release(&signature);
+    return NULL;
+  }
+  if (annotations_packable) {
+    for (Py_ssize_t i = 0; i < num_sig_args; ++i) {
+      if (sig[i] == EXTRACTOR_POINTER_INDEX) {
+        PyObject *raw_idx =
+            PyList_GET_ITEM(kernel_arg_raw_indices, i); // borrowed
+        if (PyList_Append(pointer_raw_indices, raw_idx) < 0) {
+          Py_DECREF(pointer_raw_indices);
+          Py_DECREF(kernel_arg_raw_indices);
+          PyBuffer_Release(&signature);
+          return NULL;
+        }
+      }
+    }
+  }
+  Py_DECREF(kernel_arg_raw_indices);
+
+  Py_ssize_t num_pointer_slots = PyList_GET_SIZE(pointer_raw_indices);
+  Py_ssize_t pack_buffer_size = num_pointer_slots * (Py_ssize_t)sizeof(void *);
+  bool packable = annotations_packable && (num_pointer_slots > 0);
+
+  PyObject *pointer_raw_indices_tuple = PyList_AsTuple(pointer_raw_indices);
+  Py_DECREF(pointer_raw_indices);
+  if (!pointer_raw_indices_tuple) {
+    PyBuffer_Release(&signature);
+    return NULL;
+  }
+
+  PyBuffer_Release(&signature);
+  return Py_BuildValue("(NnO)", pointer_raw_indices_tuple, pack_buffer_size,
+                       packable ? Py_True : Py_False);
+}
+
 bool launchHook(PyObject *hook, PyObject *metadata) {
   if (hook != Py_None) {
     PyObject *ret = PyObject_CallOneArg(hook, metadata);
@@ -1450,6 +1591,200 @@ extern "C" EXPORT_FUNC PyObject *launch(PyObject *args) {
   }
   PyBuffer_Release(&signature);
   Py_RETURN_NONE;
+}
+
+// Fix E: fast-path launcher variant that skips the per-pointer Python C-API
+// call chain (PyObject_GetAttr + PyObject_CallNoArgs on `data_ptr`) by
+// consuming pointer values pre-resolved on the Python side.
+//
+// Compared to `launch()` above, the only differences are:
+//   1. An extra `y*` Python-buffer argument (`packed_pointers`) is parsed
+//      -- a contiguous array of `void*` values, one per pointer slot, in
+//      the order pointer slots appear in `signature`.
+//   2. Inside the extract loop, when `extractor_data[i] ==
+//   EXTRACTOR_POINTER_INDEX`,
+//      the raw pointer is copied straight from `packed_pointers` and
+//      validated via checkDevicePointer -- no Python calls.
+//      Scalar slots still call their extractor (fast path already).
+//
+// All other bookkeeping (extractArgs walk, alloca layout, kernel capsule
+// deref, SYCL submit, launch hooks, PyBuffer_Release on every error path)
+// mirrors `launch()` exactly. Any semantic drift here is a bug.
+extern "C" EXPORT_FUNC PyObject *launch_packed(PyObject *args) {
+  int gridX, gridY, gridZ;
+  PyObject *py_obj_stream;
+  PyObject *py_kernel;
+  PyObject *kernel_metadata = NULL;
+  PyObject *launch_metadata = NULL;
+  PyObject *launch_enter_hook = NULL;
+  PyObject *launch_exit_hook = NULL;
+  void *global_scratch = nullptr;
+  void *profile_scratch = nullptr;
+  PyObject *arg_annotations = NULL;
+  Py_buffer signature;
+  Py_buffer packed_pointers;
+  PyObject *kernel_args = NULL;
+
+  if (!PyArg_ParseTuple(args, "iiiOOOOOOOy*y*O", &gridX, &gridY, &gridZ,
+                        &py_obj_stream, &py_kernel, &kernel_metadata,
+                        &launch_metadata, &launch_enter_hook, &launch_exit_hook,
+                        &arg_annotations, &signature, &packed_pointers,
+                        &kernel_args)) {
+    return NULL;
+  }
+
+  // Local helper macro for the two-buffer release + return NULL path.
+#define RELEASE_AND_FAIL()                                                     \
+  do {                                                                         \
+    PyBuffer_Release(&signature);                                              \
+    PyBuffer_Release(&packed_pointers);                                        \
+    return NULL;                                                               \
+  } while (0)
+
+  // extract kernel metadata
+  // num_ctas is intentionally omitted here — it is dead in sycl_kernel_launch
+  // (classic launch() extracts it too but never uses it; that is left as
+  // separate cleanup on the classic path).
+  PyObject *num_warps_attr =
+      PyObject_GetAttrString(kernel_metadata, "num_warps");
+  int num_warps = PyLong_AsLong(num_warps_attr);
+  Py_DECREF(num_warps_attr);
+  PyObject *shared_attr = PyObject_GetAttrString(kernel_metadata, "shared");
+  int shared_memory = PyLong_AsLong(shared_attr);
+  Py_DECREF(shared_attr);
+  PyObject *threads_per_warp_attr =
+      PyObject_GetAttrString(kernel_metadata, "threads_per_warp");
+  int threads_per_warp = PyLong_AsLong(threads_per_warp_attr);
+  Py_DECREF(threads_per_warp_attr);
+
+  // Copy packed_pointers into call-local storage BEFORE the enter-hook.
+  // The enter-hook is arbitrary Python code that may re-enter the launch
+  // path for the same XPULauncher instance and overwrite its self._pack_buf
+  // (the memory that packed_pointers.buf points into). Consuming the
+  // reference directly after the hook would then see the inner launch's
+  // pointer values. Snapshot to alloca now so we're immune to that.
+  uint8_t *extractor_data = (uint8_t *)signature.buf;
+  Py_ssize_t num_args = signature.len;
+  Py_ssize_t num_pointer_slots =
+      packed_pointers.len / (Py_ssize_t)sizeof(void *);
+  void **pointer_slots_local =
+      (void **)alloca(num_pointer_slots * sizeof(void *));
+  if (num_pointer_slots > 0) {
+    memcpy(pointer_slots_local, packed_pointers.buf,
+           num_pointer_slots * sizeof(void *));
+  }
+  void *const *pointer_slots = pointer_slots_local;
+
+  if (!launchHook(launch_enter_hook, launch_metadata)) {
+    RELEASE_AND_FAIL();
+  }
+
+  void *pStream = PyLong_AsVoidPtr(py_obj_stream);
+  if (pStream == nullptr || py_kernel == nullptr) {
+    RELEASE_AND_FAIL();
+  }
+  sycl::queue stream = *(static_cast<sycl::queue *>(pStream));
+
+  PyObject **args_data = (PyObject **)alloca(num_args * sizeof(PyObject *));
+  if (args_data == NULL) {
+    RELEASE_AND_FAIL();
+  }
+  int list_idx = 0;
+  if (!extractArgs(args_data, &list_idx, kernel_args, arg_annotations)) {
+    RELEASE_AND_FAIL();
+  }
+
+  int num_params = num_args + 2;
+  void **params = (void **)alloca(num_params * sizeof(void *));
+  int params_idx = 0;
+  PointerCheckScope pointerCheckScope(stream);
+
+  // Layout: same as launch(), see comments there. This loop is invariant per
+  // kernel specialization; Fix E's future follow-up may hoist it, but for
+  // now we keep the alloca form for behavioral parity with launch().
+  Extractor *extractors = (Extractor *)alloca(num_args * sizeof(Extractor));
+  size_t *param_offset = (size_t *)alloca(num_args * sizeof(size_t));
+  size_t total_size = 0;
+  size_t max_alignment = 1;
+  for (Py_ssize_t i = 0; i < num_args; ++i) {
+    extractors[i] = getExtractor(extractor_data[i]);
+    if (extractors[i].extract == NULL) {
+      RELEASE_AND_FAIL();
+    }
+    size_t alignment = extractors[i].alignment ? extractors[i].alignment : 1;
+    total_size = alignUp(total_size, alignment);
+    param_offset[i] = total_size;
+    total_size += extractors[i].size;
+    if (alignment > max_alignment) {
+      max_alignment = alignment;
+    }
+  }
+  char *param_storage_raw = (char *)alloca(total_size + max_alignment - 1);
+  char *param_storage =
+      (char *)alignUp((uintptr_t)param_storage_raw, max_alignment);
+
+  // Extraction loop: pointers read from packed buffer + validated; scalars
+  // still run their extractor. `next_pointer` walks pointer_slots as we
+  // encounter pointer entries in `extractor_data`.
+  Py_ssize_t next_pointer = 0;
+  for (Py_ssize_t i = 0; i < num_args; ++i) {
+    g_pointer_check_arg_idx = static_cast<int>(i);
+    params[params_idx] = param_storage + param_offset[i];
+
+    if (extractor_data[i] == EXTRACTOR_POINTER_INDEX) {
+      // Should never overshoot -- Python-side pre-pack must have provided
+      // one slot per pointer in signature order. Defensive check.
+      if (next_pointer >= num_pointer_slots) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "launch_packed: packed_pointers underrun");
+        RELEASE_AND_FAIL();
+      }
+      void *ptr = pointer_slots[next_pointer++];
+      *(void **)params[params_idx] = ptr;
+      if (!checkDevicePointer(ptr, g_pointer_check_arg_idx,
+                              *g_pointer_check_queue)) {
+        RELEASE_AND_FAIL();
+      }
+    } else {
+      Extractor extractor = extractors[i];
+      PyObject *current_arg = args_data[i];
+      if (!extractor.extract(params[params_idx], current_arg)) {
+        RELEASE_AND_FAIL();
+      }
+    }
+    params_idx++;
+  }
+  g_pointer_check_arg_idx = -1;
+
+  // Add scratch objects.
+  params[params_idx++] = &global_scratch;
+  params[params_idx++] = &profile_scratch;
+
+  sycl::kernel *kernel_ptr = reinterpret_cast<sycl::kernel *>(
+      PyCapsule_GetPointer(py_kernel, "kernel"));
+  if (kernel_ptr == nullptr) {
+    RELEASE_AND_FAIL();
+  }
+  sycl::kernel kernel = *kernel_ptr;
+
+  Py_BEGIN_ALLOW_THREADS;
+  sycl_kernel_launch(gridX, gridY, gridZ, num_warps, threads_per_warp,
+                     shared_memory, stream, kernel, global_scratch,
+                     profile_scratch, num_params, params, extractor_data);
+  Py_END_ALLOW_THREADS;
+
+  if (PyErr_Occurred()) {
+    RELEASE_AND_FAIL();
+  }
+
+  if (!launchHook(launch_exit_hook, launch_metadata)) {
+    RELEASE_AND_FAIL();
+  }
+  PyBuffer_Release(&signature);
+  PyBuffer_Release(&packed_pointers);
+  Py_RETURN_NONE;
+
+#undef RELEASE_AND_FAIL
 }
 
 extern "C" EXPORT_FUNC PyTypeObject *init_PyKernelArgType() {

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -1,4 +1,5 @@
 import importlib.metadata
+import numbers
 import os
 import json
 import sys
@@ -257,34 +258,77 @@ class ArchParser:
 
 class SpirvUtils:
 
+    # Required C symbols — absence indicates a broken / partial build and must
+    # raise loudly (AttributeError propagated from ctypes) rather than surface
+    # later as a cryptic NoneType-call at the first hot-path call site.
+    _REQUIRED_METHODS = ("init_devices", "load_binary", "wait_on_sycl_queue", "sycl_queue_memset", "launch",
+                         "build_signature_metadata")
+    # Optional Fix E symbols. Older / stripped-down builds may lack them; the
+    # XPULauncher gates on `.has_packed_launch` and transparently falls back
+    # to the classic `launch` path when False.
+    _OPTIONAL_METHODS = ("launch_packed", "build_pack_layout")
+
     def __init__(self, cache_path: str):
         self.shared_library = ctypes.PyDLL(cache_path)
-        methods = ("init_devices", "load_binary", "wait_on_sycl_queue", "sycl_queue_memset", "launch",
-                   "build_signature_metadata")
-        for method in methods:
-            getattr(self.shared_library, method).restype = ctypes.py_object
-            getattr(self.shared_library, method).argtypes = (ctypes.py_object, )
+        for method in self._REQUIRED_METHODS:
+            fn = getattr(self.shared_library, method)
+            fn.restype = ctypes.py_object
+            fn.argtypes = (ctypes.py_object, )
+        # Configure optional Fix E symbols only if the underlying ctypes DLL
+        # actually exposes them — asymmetric partial builds (e.g. only
+        # `build_pack_layout` present) are rejected as a set.
+        optional_fns = {name: getattr(self.shared_library, name, None) for name in self._OPTIONAL_METHODS}
+        self.has_packed_launch = all(fn is not None for fn in optional_fns.values())
+        if self.has_packed_launch:
+            for fn in optional_fns.values():
+                fn.restype = ctypes.py_object
+                fn.argtypes = (ctypes.py_object, )
         self.shared_library.get_device_properties.restype = ctypes.py_object
         self.shared_library.get_device_properties.argtypes = (ctypes.c_int, )
         self.shared_library.get_last_selected_build_flags.restype = ctypes.py_object
-
-        self.shared_library.build_signature_metadata.restype = ctypes.py_object
-        self.shared_library.build_signature_metadata.argtypes = (ctypes.py_object, )
 
         self.shared_library.init_PyKernelArgType.restype = ctypes.py_object
         self.shared_library.init_PyKernelArgType.argtypes = tuple()
 
     def __getattribute__(self, name):
+        # Required C symbols: passthrough that raises AttributeError if the
+        # underlying DLL is missing them (ctypes.PyDLL raises on getattr, not
+        # None). Doing an explicit `getattr(_, name)` (no default) preserves
+        # this behavior — we only want None-fallback for the optional
+        # Fix E symbol `build_pack_layout`, gated via `has_packed_launch`.
         if name in ("get_device_properties", "init_devices", "wait_on_sycl_queue", "get_last_selected_build_flags",
                     "sycl_queue_memset", "build_signature_metadata", "init_PyKernelArgType"):
             shared_library = super().__getattribute__("shared_library")
             return getattr(shared_library, name)
+        if name == "build_pack_layout":
+            # Gate on has_packed_launch: launch_packed and build_pack_layout
+            # are set together on the DLL side; refuse to expose one without
+            # the other so a partial build can't produce a half-configured
+            # fast path.
+            if not super().__getattribute__("has_packed_launch"):
+                return None
+            shared_library = super().__getattribute__("shared_library")
+            return getattr(shared_library, name, None)
 
         return super().__getattribute__(name)
 
     def launch(self, *args):
         # the same reason as for `load_binary`
         return self.shared_library.launch(args)
+
+    @property
+    def launch_packed(self):
+        # Return None when the underlying C symbol is absent so callers can
+        # safely probe with `getattr(utils, 'launch_packed', None)`. Without
+        # this the class-level method would always be resolved regardless of
+        # the DLL's actual symbol table (defeating the probe).
+        if not self.has_packed_launch:
+            return None
+        return self._launch_packed_impl
+
+    def _launch_packed_impl(self, *args):
+        # See `launch()` for the rationale on tuple-wrapping.
+        return self.shared_library.launch_packed(args)
 
     def load_binary(self, *args):
         # if we don't use parameter passing in this way,
@@ -462,6 +506,10 @@ class XPUUtils(object):
         self.sycl_queue_memset = mod.sycl_queue_memset
         self.unload_module = lambda module: None
         self.launch = mod.launch
+        # `launch_packed` and `build_pack_layout` are optional (Fix E).
+        # Older builds without them fall back to the classic `launch` path.
+        self.launch_packed = getattr(mod, "launch_packed", None)
+        self.build_pack_layout = getattr(mod, "build_pack_layout", None)
         self.build_signature_metadata = mod.build_signature_metadata
         self._initialized = True
 
@@ -567,7 +615,6 @@ def wrap_handle_tensordesc(launcher, signature, tensordesc_meta):
 
 def serialize_args(args, constants, signature, dir_path):
     import torch
-    import numbers
     os.makedirs(dir_path, exist_ok=True)
 
     def serialize_kernel_metadata(arg, args_dict):
@@ -628,10 +675,58 @@ class XPULauncher(object):
         arg_idx = lambda x: (src.fn.arg_names.index(x), ) if isinstance(x, str) else x
         constants = {arg_idx(idx): value for idx, value in constants.items()}
         signature = {idx: value for idx, value in src.signature.items()}
-        launcher = triton.runtime.driver.active.utils.launch
+        utils = triton.runtime.driver.active.utils
         expanded_signature = expand_signature(signature.values(), tensordesc_meta=None, descriptor_type="*i8")
         self.arg_annotations = annotate_arguments(expanded_signature)
         self.kernel_signature = make_kernel_signature(expanded_signature)
+
+        # Fix E: pick the packed launcher when the kernel signature has pointer
+        # args and no tuple-nested annotations. Fallback: classic launch path.
+        # Tensordesc kernels also fall back because the raw args tuple passed
+        # to __call__ has TensorDescriptor objects, not the expanded pointer
+        # + shape/strides layout that arg_annotations describes; the
+        # wrap_handle_tensordesc wrapper expands args before hitting the C
+        # launcher but that expansion is invisible to the pack loop.
+
+        # Initialize defaults
+        self._use_packed_launch = False
+        self._pack_buf = None
+        self._pack_view = None
+        self._pointer_arg_indices = ()
+        launcher = utils.launch
+
+        # Read controls/capabilities for packed launch eligibility check.
+        # Both `launch_packed` and `build_pack_layout` are set together on the
+        # SpirvUtils side (see `SpirvUtils.has_packed_launch`) — they are
+        # non-None iff BOTH C symbols were present at DLL load; asymmetric
+        # partial builds are rejected as a set. We still assert this invariant
+        # locally so a future change on the utils side surfaces immediately.
+        disable_packed = os.environ.get("TRITON_INTEL_DISABLE_PACKED_LAUNCH") == "1"
+        launch_packed_fn = getattr(utils, "launch_packed", None)
+        build_pack_layout_fn = getattr(utils, "build_pack_layout", None)
+        # Unconditional check (not `assert`) so `python -O` doesn't silently
+        # skip the invariant and produce a half-configured fast path.
+        if (launch_packed_fn is None) != (build_pack_layout_fn is None):
+            raise RuntimeError("SpirvUtils packed-launch symbol pair is asymmetric — bug in SpirvUtils.__init__")
+        has_tensordesc = any(isinstance(sig, str) and sig.startswith("tensordesc") for sig in signature.values())
+
+        # Eligibility check
+        if ((not disable_packed) and launch_packed_fn is not None and build_pack_layout_fn is not None
+                and not has_tensordesc):
+            # build_pack_layout returns pointer_raw_indices as raw-args-tuple
+            # indices directly (walk done in C to avoid needing a PyMemberDef
+            # for PyKernelArg.type).
+            pointer_raw_indices, pack_buf_bytes, packable = build_pack_layout_fn(
+                (self.kernel_signature, self.arg_annotations))
+            if packable:
+                self._pointer_arg_indices = pointer_raw_indices  # already a tuple
+                self._pack_buf = bytearray(pack_buf_bytes)
+                # memoryview cast to native pointer array; each slot is 8B on
+                # 64-bit Windows/Linux. Writing view[i] = int stores 8 bytes.
+                self._pack_view = memoryview(self._pack_buf).cast("P")
+                launcher = launch_packed_fn
+                self._use_packed_launch = True
+
         self.launch = wrap_handle_tensordesc(launcher, signature, tensordesc_meta=[])
 
         # Serialize KernelArguments for SPIR-V Runner
@@ -704,8 +799,46 @@ class XPULauncher(object):
             self._dump_launch_params((gridX, gridY, gridZ, stream, function, kernel_metadata, launch_metadata,
                                       launch_enter_hook, launch_exit_hook, *args), self.constants, self.signature)
 
-        self.launch(gridX, gridY, gridZ, stream, function, kernel_metadata, launch_metadata, launch_enter_hook,
-                    launch_exit_hook, self.arg_annotations, self.kernel_signature, args)
+        if self._use_packed_launch:
+            # Fix E fast path: pre-resolve pointer args in Python and hand
+            # C a flat void*-array via `self._pack_buf`. Scalars stay in
+            # `args` and are extracted C-side unchanged.
+            #
+            # Diagnostic parity with classic extractPointer (driver.c): the
+            # classic path accepts (a) int (PyLong_Check), and (b) any object
+            # with a `.data_ptr()` method that returns an int. Match both.
+            # We deliberately use bare `int` (not `numbers.Integral`) because
+            # the classic path's PyLong_Check rejects numpy scalar ints
+            # (np.int64/uint64) — using Integral here would silently accept
+            # them on the fast path only, creating cross-path semantic drift.
+            view = self._pack_view
+            for slot, raw_i in enumerate(self._pointer_arg_indices):
+                arg = args[raw_i]
+                if arg is None:
+                    view[slot] = 0
+                elif isinstance(arg, int):
+                    # isinstance(arg, int) matches PyLong_Check semantics
+                    # (accepts int and its subclasses; rejects numpy scalars
+                    # which are Integral but not int subclasses).
+                    view[slot] = arg
+                else:
+                    data_ptr_meth = getattr(arg, "data_ptr", None)
+                    if data_ptr_meth is None:
+                        raise TypeError("Pointer argument must be either uint64 or have data_ptr method")
+                    result = data_ptr_meth()
+                    if not isinstance(result, int):
+                        # Match the classic path's message for this exact
+                        # case (see extractPointer in driver.c, second
+                        # PyErr_SetString) — distinct from the "no data_ptr
+                        # method" message so callers can diagnose which
+                        # invariant failed.
+                        raise TypeError("data_ptr method of Pointer object must return 64-bit int")
+                    view[slot] = result
+            self.launch(gridX, gridY, gridZ, stream, function, kernel_metadata, launch_metadata, launch_enter_hook,
+                        launch_exit_hook, self.arg_annotations, self.kernel_signature, self._pack_buf, args)
+        else:
+            self.launch(gridX, gridY, gridZ, stream, function, kernel_metadata, launch_metadata, launch_enter_hook,
+                        launch_exit_hook, self.arg_annotations, self.kernel_signature, args)
 
 
 class XPUDriver(DriverBase):


### PR DESCRIPTION
Adds an optional "packed launch" path to the XPU launcher that resolves pointer arguments once in Python and passes them to C as a flat void*[] buffer, bypassing the per-arg PyObject_GetAttr + PyObject_CallNoArgs chain in extractPointer.

C-side additions (driver.c):
  - buildRawKernelArgIndices(): walks arg_annotations to map signature slots to raw-args-tuple indices; sets packable=false on ARG_TUPLE.
  - build_pack_layout(): computes pointer_raw_indices + pack_buffer_size for a given (kernel_signature, arg_annotations) pair. Returns packable=false when annotations contain tuple-nested entries or when there are no pointer args (packing has no upside).
  - launch_packed(): counterpart to launch() that reads pointer values from a caller-provided y*-buffer instead of extracting them from Python objects one at a time. Scalar args still go through their normal extractor.

Python-side additions (driver.py):
  - SpirvUtils splits DLL symbols into _REQUIRED_METHODS and _OPTIONAL_METHODS. launch_packed / build_pack_layout are optional and gated by has_packed_launch; older / stripped builds transparently fall back to classic launch().
  - XPULauncher.__init__ probes eligibility once at specialization time: when the kernel has pointer args and no tensordesc / tuple annotations, it pre-allocates a bytearray pack buffer and a memoryview cast to native pointer size, and selects launch_packed as the launcher.
  - XPULauncher.__call__ takes a packed fast path when enabled: iterate _pointer_arg_indices, resolve each arg via numbers.Integral / .data_ptr(), write into the pack buffer, then hand C the buffer + args tuple.
  - Escape hatch: TRITON_INTEL_DISABLE_PACKED_LAUNCH=1 forces the classic launch() path.

Fix E is independent of Fix A (KernelInfo cache) and Fix B (data_ptr intern) — this branch contains only Fix E on top of origin/main.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `flow run in every launch`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
