### PR TITLE
[vLLM] Skip MRV2 test that nondeterminstically fails with OOM error on B580

### DIFF
--- a/scripts/skiplist/xe2/vllm_mrv2.txt
+++ b/scripts/skiplist/xe2/vllm_mrv2.txt
@@ -54,3 +54,6 @@ tests/v1/kv_connector/unit/test_nixl_connector.py::test_abort_timeout_on_prefill
 # NIXL is not available: https://github.com/intel/intel-xpu-backend-for-triton/issues/7419
 tests/v1/kv_connector/unit/test_nixl_connector.py::test_kv_both_deprecation_warning
 tests/v1/kv_connector/unit/test_nixl_connector.py::test_explicit_kv_role_no_deprecation_warning
+
+# Nondeterministic OOM error on B580: https://github.com/intel/intel-xpu-backend-for-triton/issues/7714
+tests/v1/kv_connector/unit/test_nixl_connector.py::test_abort_timeout_on_prefiller[ray]


### PR DESCRIPTION
Created https://github.com/intel/intel-xpu-backend-for-triton/issues/7714.