### PR TITLE
[CI] Make vLLM tests reusable workflow rolling/lts aware on PVC

### DIFF
--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -48,9 +48,7 @@ env:
 jobs:
   setup:
     name: Setup
-    runs-on:
-      - linux
-      - ${{ inputs.runner_label || 'max1100' }}
+    runs-on: ${{ fromJSON((inputs.runner_label == '' || startsWith(inputs.runner_label, 'max')) && format('["linux", "rolling", "{0}"]', inputs.runner_label || 'max1100') || format('["linux", "{0}"]', inputs.runner_label)) }}
     timeout-minutes: 180
     defaults:
       run:
@@ -145,9 +143,7 @@ jobs:
           - vllm-kda
           - vllm-tdesc
           - vllm-rest
-    runs-on:
-      - linux
-      - ${{ inputs.runner_label || 'max1100' }}
+    runs-on: ${{ fromJSON((inputs.runner_label == '' || startsWith(inputs.runner_label, 'max')) && format('["linux", "rolling", "{0}"]', inputs.runner_label || 'max1100') || format('["linux", "{0}"]', inputs.runner_label)) }}
     timeout-minutes: 180
     defaults:
       run:


### PR DESCRIPTION
Fixes #7721 

✅ Test run: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/31430404203 (all jobs landed to rolling)