### PR TITLE
[CI] Replace check-paths jobs with paths: filter in benchmark workflows

### DIFF
--- a/.github/workflows/sglang-benchmarks-bmg.yml
+++ b/.github/workflows/sglang-benchmarks-bmg.yml
@@ -8,8 +8,11 @@ on:
       - main
     paths:
       - .github/workflows/sglang-benchmarks*.yml
+      - .github/workflows/build-benchmarks-wheel*.yml
+      - .github/actions/install-benchmarks/**
       - scripts/sglang/**
       - benchmarks/triton_kernels_benchmark/sglang/**
+      - .github/pins/pytorch.txt
   schedule:
     - cron: "0 11 * * *"
 

--- a/.github/workflows/sglang-benchmarks-bmg.yml
+++ b/.github/workflows/sglang-benchmarks-bmg.yml
@@ -6,7 +6,10 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened]
+    paths:
+      - .github/workflows/sglang-benchmarks*.yml
+      - scripts/sglang/**
+      - benchmarks/triton_kernels_benchmark/sglang/**
   schedule:
     - cron: "0 11 * * *"
 
@@ -15,35 +18,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-paths:
-    runs-on: linux
-    outputs:
-      benchmarks: ${{ steps.check.outputs.changed }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Check for SGLang benchmark changes
-        id: check
-        uses: ./.github/actions/check-path-changes
-        with:
-          patterns: '^(\.github/workflows/sglang-benchmarks(-pvc|-bmg)?\.yml|scripts/sglang/sglang-pin\.txt)'
-
   build-wheel:
-    needs: check-paths
-    if: >-
-      github.event_name == 'schedule' ||
-      needs.check-paths.outputs.benchmarks == 'true'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
 
   benchmarks:
-    needs: [check-paths, build-wheel]
-    if: >-
-      always() && !cancelled() &&
-      (github.event_name == 'schedule' ||
-       needs.check-paths.outputs.benchmarks == 'true')
+    needs: build-wheel
+    if: always() && !cancelled()
     uses: ./.github/workflows/sglang-benchmarks.yml
     with:
       runner_label: b580

--- a/.github/workflows/sglang-benchmarks-pvc.yml
+++ b/.github/workflows/sglang-benchmarks-pvc.yml
@@ -8,8 +8,11 @@ on:
       - main
     paths:
       - .github/workflows/sglang-benchmarks*.yml
+      - .github/workflows/build-benchmarks-wheel*.yml
+      - .github/actions/install-benchmarks/**
       - scripts/sglang/**
       - benchmarks/triton_kernels_benchmark/sglang/**
+      - .github/pins/pytorch.txt
   schedule:
     - cron: "0 11 * * *"
 

--- a/.github/workflows/sglang-benchmarks-pvc.yml
+++ b/.github/workflows/sglang-benchmarks-pvc.yml
@@ -6,7 +6,10 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened]
+    paths:
+      - .github/workflows/sglang-benchmarks*.yml
+      - scripts/sglang/**
+      - benchmarks/triton_kernels_benchmark/sglang/**
   schedule:
     - cron: "0 11 * * *"
 
@@ -15,35 +18,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-paths:
-    runs-on: linux
-    outputs:
-      benchmarks: ${{ steps.check.outputs.changed }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Check for SGLang benchmark changes
-        id: check
-        uses: ./.github/actions/check-path-changes
-        with:
-          patterns: '^(\.github/workflows/sglang-benchmarks(-pvc|-bmg)?\.yml|scripts/sglang/sglang-pin\.txt)'
-
   build-wheel:
-    needs: check-paths
-    if: >-
-      github.event_name == 'schedule' ||
-      needs.check-paths.outputs.benchmarks == 'true'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
 
   benchmarks:
-    needs: [check-paths, build-wheel]
-    if: >-
-      always() && !cancelled() &&
-      (github.event_name == 'schedule' ||
-       needs.check-paths.outputs.benchmarks == 'true')
+    needs: build-wheel
+    if: always() && !cancelled()
     uses: ./.github/workflows/sglang-benchmarks.yml
     with:
       runner_label: max1550

--- a/.github/workflows/triton-benchmarks-bmg.yml
+++ b/.github/workflows/triton-benchmarks-bmg.yml
@@ -6,35 +6,24 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened]
+    paths:
+      - .github/workflows/triton-benchmarks*.yml
+      - .github/workflows/build-benchmarks-wheel*.yml
+      - .github/actions/install-benchmarks/**
+      - benchmarks/**
+      - '!benchmarks/triton_kernels_benchmark/vllm/**'
+      - '!benchmarks/triton_kernels_benchmark/sglang/**'
+      - .github/pins/pytorch.txt
 
 jobs:
-  check-paths:
-    runs-on: linux
-    outputs:
-      benchmarks: ${{ steps.check.outputs.changed }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Check for benchmark changes
-        id: check
-        uses: ./.github/actions/check-path-changes
-        with:
-          patterns: '^(\.github/workflows/(triton-benchmarks|build-benchmarks-wheel).*\.yml|\.github/actions/install-benchmarks/|benchmarks/|\.github/pins/pytorch\.txt)'
-
   build-wheel:
-    needs: check-paths
-    if: needs.check-paths.outputs.benchmarks == 'true'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
 
   benchmarks:
-    needs: [check-paths, build-wheel]
-    if: >-
-      always() && !cancelled() &&
-      needs.check-paths.outputs.benchmarks == 'true'
+    needs: build-wheel
+    if: always() && !cancelled()
     uses: ./.github/workflows/triton-benchmarks.yml
     with:
       runner_label: b580

--- a/.github/workflows/triton-benchmarks-pvc.yml
+++ b/.github/workflows/triton-benchmarks-pvc.yml
@@ -6,35 +6,24 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened]
+    paths:
+      - .github/workflows/triton-benchmarks*.yml
+      - .github/workflows/build-benchmarks-wheel*.yml
+      - .github/actions/install-benchmarks/**
+      - benchmarks/**
+      - '!benchmarks/triton_kernels_benchmark/vllm/**'
+      - '!benchmarks/triton_kernels_benchmark/sglang/**'
+      - .github/pins/pytorch.txt
 
 jobs:
-  check-paths:
-    runs-on: linux
-    outputs:
-      benchmarks: ${{ steps.check.outputs.changed }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Check for benchmark changes
-        id: check
-        uses: ./.github/actions/check-path-changes
-        with:
-          patterns: '^(\.github/workflows/(triton-benchmarks|build-benchmarks-wheel).*\.yml|\.github/actions/install-benchmarks/|benchmarks/|\.github/pins/pytorch\.txt)'
-
   build-wheel:
-    needs: check-paths
-    if: needs.check-paths.outputs.benchmarks == 'true'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
 
   benchmarks:
-    needs: [check-paths, build-wheel]
-    if: >-
-      always() && !cancelled() &&
-      needs.check-paths.outputs.benchmarks == 'true'
+    needs: build-wheel
+    if: always() && !cancelled()
     uses: ./.github/workflows/triton-benchmarks.yml
     with:
       runner_label: max1550

--- a/.github/workflows/vllm-benchmarks-bmg.yml
+++ b/.github/workflows/vllm-benchmarks-bmg.yml
@@ -6,7 +6,14 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened]
+    paths:
+      - .github/workflows/vllm-benchmarks*.yml
+      - .github/workflows/build-benchmarks-wheel*.yml
+      - .github/actions/install-benchmarks/**
+      - .github/actions/install-vllm/**
+      - benchmarks/triton_kernels_benchmark/vllm/**
+      - scripts/vllm/**
+      - .github/pins/pytorch.txt
   schedule:
     - cron: "0 8 * * *"
 
@@ -15,35 +22,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-paths:
-    runs-on: linux
-    outputs:
-      benchmarks: ${{ steps.check.outputs.changed }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Check for vLLM benchmark changes
-        id: check
-        uses: ./.github/actions/check-path-changes
-        with:
-          patterns: '^(\.github/workflows/(vllm-benchmarks|build-benchmarks-wheel).*\.yml|\.github/actions/(install-benchmarks|install-vllm)/|benchmarks/triton_kernels_benchmark/vllm/|scripts/vllm/|\.github/pins/pytorch\.txt)'
-
   build-wheel:
-    needs: check-paths
-    if: >-
-      github.event_name == 'schedule' ||
-      needs.check-paths.outputs.benchmarks == 'true'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
 
   benchmarks:
-    needs: [check-paths, build-wheel]
-    if: >-
-      always() && !cancelled() &&
-      (github.event_name == 'schedule' ||
-       needs.check-paths.outputs.benchmarks == 'true')
+    needs: build-wheel
+    if: always() && !cancelled()
     uses: ./.github/workflows/vllm-benchmarks.yml
     with:
       runner_label: b580

--- a/.github/workflows/vllm-benchmarks-pvc.yml
+++ b/.github/workflows/vllm-benchmarks-pvc.yml
@@ -6,7 +6,14 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened]
+    paths:
+      - .github/workflows/vllm-benchmarks*.yml
+      - .github/workflows/build-benchmarks-wheel*.yml
+      - .github/actions/install-benchmarks/**
+      - .github/actions/install-vllm/**
+      - benchmarks/triton_kernels_benchmark/vllm/**
+      - scripts/vllm/**
+      - .github/pins/pytorch.txt
   schedule:
     - cron: "0 8 * * *"
 
@@ -15,35 +22,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-paths:
-    runs-on: linux
-    outputs:
-      benchmarks: ${{ steps.check.outputs.changed }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Check for vLLM benchmark changes
-        id: check
-        uses: ./.github/actions/check-path-changes
-        with:
-          patterns: '^(\.github/workflows/(vllm-benchmarks|build-benchmarks-wheel).*\.yml|\.github/actions/(install-benchmarks|install-vllm)/|benchmarks/triton_kernels_benchmark/vllm/|scripts/vllm/|\.github/pins/pytorch\.txt)'
-
   build-wheel:
-    needs: check-paths
-    if: >-
-      github.event_name == 'schedule' ||
-      needs.check-paths.outputs.benchmarks == 'true'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
 
   benchmarks:
-    needs: [check-paths, build-wheel]
-    if: >-
-      always() && !cancelled() &&
-      (github.event_name == 'schedule' ||
-       needs.check-paths.outputs.benchmarks == 'true')
+    needs: build-wheel
+    if: always() && !cancelled()
     uses: ./.github/workflows/vllm-benchmarks.yml
     with:
       runner_label: max1550


### PR DESCRIPTION
- Replace `check-paths` jobs with GitHub's native `paths:` filter in 6 benchmark workflows
- Since these are not required status checks, using `paths:` avoids triggering the workflow entirely (no runner overhead from the check-paths job)
- Triton benchmarks: exclude `benchmarks/triton_kernels_benchmark/vllm/` and `sglang/` subdirs so vLLM/SGLang-only changes don't trigger Triton benchmarks
- vLLM/SGLang benchmarks: use specific path patterns matching only their respective files