### PR TITLE
[CI] Benchmark floordiv XOR bypass on BMG flex-attn-masks

### DIFF
--- a/.github/workflows/triton-benchmarks-bmg.yml
+++ b/.github/workflows/triton-benchmarks-bmg.yml
@@ -9,33 +9,15 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  check-paths:
-    runs-on: linux
-    outputs:
-      benchmarks: ${{ steps.check.outputs.changed }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Check for benchmark changes
-        id: check
-        uses: ./.github/actions/check-path-changes
-        with:
-          patterns: '^(\.github/workflows/(triton-benchmarks|build-benchmarks-wheel).*\.yml|\.github/actions/install-benchmarks/|benchmarks/|\.github/pins/pytorch\.txt)'
-
   build-wheel:
-    needs: check-paths
-    if: needs.check-paths.outputs.benchmarks == 'true'
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"
 
   benchmarks:
-    needs: [check-paths, build-wheel]
-    if: >-
-      always() && !cancelled() &&
-      needs.check-paths.outputs.benchmarks == 'true'
+    needs: build-wheel
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/triton-benchmarks.yml
     with:
       runner_label: b580
-      skip_benchmarks: '["flex-attention-causal-batch16"]'
+      skip_benchmarks: '["softmax","gemm","gemm-tensor-of-ptr","gemm_bt","gemm_at","gemm-streamk","gemm-splitk","gemm-preop-exp","gemm-postop-gelu","gemm-postop-addmatrix","gemm-postop-addmatrix-int8","fused-gemm","gemm-grouped","gemm-grouped-batched","flash_attention","flash_attention_fp8","flash_attention_bwd","batched-flash-attention","flex-attention-causal","flex-attention-causal-batch4","flex-attention-causal-batch16","flex-attention-causal-bwd","prefix-sums","micro_benchmarks"]'

--- a/scripts/patch-pytorch.sh
+++ b/scripts/patch-pytorch.sh
@@ -36,3 +36,4 @@ echo "Applying PyTorch patches in $REPO_ROOT"
 
 # put your patch applies here
 apply_patch patch/skip-test-topk-xpu.patch
+apply_patch patch/175168-floordiv-xpu.patch

--- a/scripts/patch/175168-floordiv-xpu.patch
+++ b/scripts/patch/175168-floordiv-xpu.patch
@@ -1,0 +1,19 @@
+diff --git a/torch/_inductor/codegen/triton.py b/torch/_inductor/codegen/triton.py
+index fe7b1c7d865..e09bbe79af1 100644
+--- a/torch/_inductor/codegen/triton.py
++++ b/torch/_inductor/codegen/triton.py
+@@ -2319,6 +2319,14 @@ class TritonOverrides(OpOverrides):
+         # See the comment in lowering.div_mode. a and b are integer type.
+         # Notice that // in triton behaves as truncdiv instead of floordiv.
+         #
++        # The XPU backend fixes the Triton AxisInfo bug for signed division
++        # and converts provably non-negative divsi to divui early, so use
++        # the simple floordiv lowering without the bitwise workaround.
++        if V.graph.get_current_device_or_throw().type == "xpu":
++            quot = f"{a} // {b}"
++            rem = f"{a} % {b}"
++            return f"tl.where(({a} < 0) != ({b} < 0), tl.where({rem} != 0, {quot} - 1, {quot}), {quot})"
++        #
+         # We avoid feeding negative values into Triton's // operator because
+         # Triton's AxisInfo analysis incorrectly deduplicates signed division
+         # results for contiguous inputs (triton-lang/triton#XXXX). Instead we


### PR DESCRIPTION
## Summary
- Cherry-picks `16a5140c72` ([PyTorch] Patch floordiv to bypass XOR workaround for XPU) onto main
- Runs only `flex-attention-custom-masks` benchmark on BMG to measure performance impact
- Temporary benchmarking PR — not intended to merge