### PR TITLE
Increase timeout in spirvrunner-test.yml

### DIFF
--- a/.github/workflows/spirvrunner-test.yml
+++ b/.github/workflows/spirvrunner-test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on:
       - rolling
       - runner-0.0.22
-    timeout-minutes: 75 # equal to max + 3*std over the last 600 successful runs
+    timeout-minutes: 160
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7


### PR DESCRIPTION
For cases when PyTorch build has cache hit