### PR TITLE
[vLLM] Add `batched_moe` tests to the `vllm-tdesc` test-suite

### DIFF
--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -134,15 +134,15 @@ jobs:
       fail-fast: false
       matrix:
         suite:
-          - vllm-spec-decode
-          - vllm-mrv2
-          - vllm-moe
-          - vllm-triton-attn
-          - vllm-mamba
-          - vllm-quant
-          - vllm-kda
+          # - vllm-spec-decode
+          # - vllm-mrv2
+          # - vllm-moe
+          # - vllm-triton-attn
+          # - vllm-mamba
+          # - vllm-quant
+          # - vllm-kda
           - vllm-tdesc
-          - vllm-rest
+          # - vllm-rest
     runs-on: ${{ fromJSON((inputs.runner_label == '' || startsWith(inputs.runner_label, 'max')) && format('["linux", "rolling", "{0}"]', inputs.runner_label || 'max1100') || format('["linux", "{0}"]', inputs.runner_label)) }}
     timeout-minutes: 180
     defaults:

--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -134,15 +134,15 @@ jobs:
       fail-fast: false
       matrix:
         suite:
-          # - vllm-spec-decode
-          # - vllm-mrv2
-          # - vllm-moe
-          # - vllm-triton-attn
-          # - vllm-mamba
-          # - vllm-quant
-          # - vllm-kda
+          - vllm-spec-decode
+          - vllm-mrv2
+          - vllm-moe
+          - vllm-triton-attn
+          - vllm-mamba
+          - vllm-quant
+          - vllm-kda
           - vllm-tdesc
-          # - vllm-rest
+          - vllm-rest
     runs-on: ${{ fromJSON((inputs.runner_label == '' || startsWith(inputs.runner_label, 'max')) && format('["linux", "rolling", "{0}"]', inputs.runner_label || 'max1100') || format('["linux", "{0}"]', inputs.runner_label)) }}
     timeout-minutes: 180
     defaults:

--- a/benchmarks/triton_kernels_benchmark/vllm/batched_moe/batched_moe.patch
+++ b/benchmarks/triton_kernels_benchmark/vllm/batched_moe/batched_moe.patch
@@ -1,3 +1,33 @@
+diff --git a/tests/kernels/moe/test_batched_moe.py b/tests/kernels/moe/test_batched_moe.py
+index 3c605ced6..be50a84a3 100644
+--- a/tests/kernels/moe/test_batched_moe.py
++++ b/tests/kernels/moe/test_batched_moe.py
+@@ -392,8 +392,13 @@ def _run_td(A, B, num_expert_tokens, use_td: bool):
+     max_tokens = A.shape[1]
+     K = A.shape[2]
+     N = B.shape[1]
+-    BM = BN = BK = 64
+-    grid = (E, triton.cdiv(max_tokens, BM) * triton.cdiv(N, BN))
++
++    def grid(meta):
++        return (
++            triton.cdiv(max_tokens, meta["BLOCK_M"]) * triton.cdiv(N, meta["BLOCK_N"]),
++            E,
++        )
++
+     batched_triton_kernel[grid](
+         A,
+         B,
+@@ -426,9 +431,6 @@ def _run_td(A, B, num_expert_tokens, use_td: bool):
+         False,
+         False,
+         False,
+-        BLOCK_M=BM,
+-        BLOCK_N=BN,
+-        BLOCK_K=BK,
+         USE_TD=use_td,
+     )
+     return out
 diff --git a/vllm/model_executor/layers/fused_moe/experts/fused_batched_moe.py b/vllm/model_executor/layers/fused_moe/experts/fused_batched_moe.py
 index 609b28a95..6ceb8d9ff 100644
 --- a/vllm/model_executor/layers/fused_moe/experts/fused_batched_moe.py

--- a/scripts/skiplist/default/vllm_tdesc.txt
+++ b/scripts/skiplist/default/vllm_tdesc.txt
@@ -883,7 +883,7 @@ tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_at
 tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_attn[8-q_dtype1-2048-50.0-dtype0-256-16-256-num_heads2-seq_lens0]
 tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_attn[8-q_dtype1-2048-50.0-dtype0-256-16-256-num_heads2-seq_lens1]
 
-# Tensor-likes are not close:
+# Tensor-likes are not close: https://github.com/intel/intel-xpu-backend-for-triton/issues/7753
 tests/kernels/moe/test_batched_moe.py::test_fused_moe_batched_experts[False-None-False-dtype0-2-8-222-128-2048]
 tests/kernels/moe/test_batched_moe.py::test_fused_moe_batched_experts[False-None-False-dtype0-6-8-45-1024-128]
 tests/kernels/moe/test_batched_moe.py::test_fused_moe_batched_experts[False-None-False-dtype0-6-8-64-512-512]

--- a/scripts/skiplist/default/vllm_tdesc.txt
+++ b/scripts/skiplist/default/vllm_tdesc.txt
@@ -882,3 +882,10 @@ tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_at
 tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_attn[8-q_dtype1-2048-50.0-dtype0-256-16-256-num_heads1-seq_lens1]
 tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_attn[8-q_dtype1-2048-50.0-dtype0-256-16-256-num_heads2-seq_lens0]
 tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_attn[8-q_dtype1-2048-50.0-dtype0-256-16-256-num_heads2-seq_lens1]
+
+# Tensor-likes are not close:
+tests/kernels/moe/test_batched_moe.py::test_fused_moe_batched_experts[False-None-False-dtype0-2-8-222-128-2048]
+tests/kernels/moe/test_batched_moe.py::test_fused_moe_batched_experts[False-None-False-dtype0-6-8-45-1024-128]
+tests/kernels/moe/test_batched_moe.py::test_fused_moe_batched_experts[False-None-False-dtype0-6-8-64-512-512]
+tests/kernels/moe/test_batched_moe.py::test_fused_moe_batched_experts[False-None-False-dtype0-6-8-64-1024-2048]
+tests/kernels/moe/test_batched_moe.py::test_fused_moe_batched_experts[False-None-False-dtype0-6-8-222-128-2048]

--- a/scripts/skiplist/xe2/vllm_tdesc.txt
+++ b/scripts/skiplist/xe2/vllm_tdesc.txt
@@ -885,3 +885,9 @@ tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_at
 
 # Nondeterministic tensor-likes are not close on B580: https://github.com/intel/intel-xpu-backend-for-triton/issues/7395
 tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_attn_fp16_input_fp8_output[8-32768-50.0-None-16-128-num_heads1-seq_lens3]
+
+# Tensor-likes are not close:
+tests/kernels/moe/test_batched_moe.py::test_fused_moe_batched_experts[False-None-False-dtype0-2-8-222-128-2048]
+tests/kernels/moe/test_batched_moe.py::test_fused_moe_batched_experts[False-None-False-dtype0-6-8-45-1024-128]
+tests/kernels/moe/test_batched_moe.py::test_fused_moe_batched_experts[False-None-False-dtype0-6-8-64-512-512]
+tests/kernels/moe/test_batched_moe.py::test_fused_moe_batched_experts[False-None-False-dtype0-6-8-222-128-2048]

--- a/scripts/skiplist/xe2/vllm_tdesc.txt
+++ b/scripts/skiplist/xe2/vllm_tdesc.txt
@@ -886,7 +886,7 @@ tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_at
 # Nondeterministic tensor-likes are not close on B580: https://github.com/intel/intel-xpu-backend-for-triton/issues/7395
 tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_attn_fp16_input_fp8_output[8-32768-50.0-None-16-128-num_heads1-seq_lens3]
 
-# Tensor-likes are not close:
+# Tensor-likes are not close: https://github.com/intel/intel-xpu-backend-for-triton/issues/7753
 tests/kernels/moe/test_batched_moe.py::test_fused_moe_batched_experts[False-None-False-dtype0-2-8-222-128-2048]
 tests/kernels/moe/test_batched_moe.py::test_fused_moe_batched_experts[False-None-False-dtype0-6-8-45-1024-128]
 tests/kernels/moe/test_batched_moe.py::test_fused_moe_batched_experts[False-None-False-dtype0-6-8-64-512-512]

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -1130,7 +1130,6 @@ run_vllm_tdesc_tests() {
     fi
   done
 
-  # Only run the tests if every patch applied cleanly.
   if [ "$exit_status" -eq 0 ]; then
       VLLM_TRITON_USE_TD=1 TRITON_TEST_SUITE=vllm_tdesc \
       run_pytest_command -vvv \
@@ -1139,7 +1138,6 @@ run_vllm_tdesc_tests() {
         || exit_status=$?
   fi
 
-  # Revert any patches this run applied, on both the success and error paths.
   local revert_patch
   for revert_patch in "${applied_patches[@]}"; do
     echo "Reverting tdesc patch: $revert_patch."

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -1132,7 +1132,7 @@ run_vllm_tdesc_tests() {
   done
 
   if [ "$exit_status" -eq 0 ]; then
-      VLLM_TRITON_USE_TD=1 TRITON_TEST_SUITE=vllm_tdesc \
+    VLLM_TRITON_USE_TD=1 TRITON_TEST_SUITE=vllm_tdesc \
       run_pytest_command -vvv \
         tests/kernels/moe/test_batched_moe.py \
         tests/kernels/attention/test_triton_unified_attention.py \

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -1114,6 +1114,7 @@ run_vllm_tdesc_tests() {
 
   local applied_patches=()
   local exit_status=0
+
   local patch_file
   for patch_file in "${PATCH_FILES[@]}"; do
     if git -C "$VLLM_PROJ" apply --check "$patch_file" 2>/dev/null; then

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -1112,10 +1112,10 @@ run_vllm_tdesc_tests() {
     "$TRITON_PROJ/benchmarks/triton_kernels_benchmark/vllm/unified_attention/unified_attention.patch"
   )
 
+  local patch_file
   local applied_patches=()
   local exit_status=0
 
-  local patch_file
   for patch_file in "${PATCH_FILES[@]}"; do
     if git -C "$VLLM_PROJ" apply --check "$patch_file" 2>/dev/null; then
       echo "Applying tdesc patch: $patch_file."
@@ -1139,11 +1139,10 @@ run_vllm_tdesc_tests() {
         || exit_status=$?
   fi
 
-  local revert_patch
-  for revert_patch in "${applied_patches[@]}"; do
-    echo "Reverting tdesc patch: $revert_patch."
-    if ! git -C "$VLLM_PROJ" apply -R "$revert_patch"; then
-      echo "WARNING: Failed to revert tdesc patch: $revert_patch." >&2
+  for patch_file in "${applied_patches[@]}"; do
+    echo "Reverting tdesc patch: $patch_file."
+    if ! git -C "$VLLM_PROJ" apply -R "$patch_file"; then
+      echo "WARNING: Failed to revert tdesc patch: $patch_file." >&2
     fi
   done
 

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -1107,31 +1107,48 @@ run_vllm_tdesc_tests() {
   enter_vllm_test_env
 
   local VLLM_PROJ="$TRITON_PROJ/vllm"
-  local PATCH_FILE="$TRITON_PROJ/benchmarks/triton_kernels_benchmark/vllm/unified_attention/unified_attention.patch"
+  local PATCH_FILES=(
+    "$TRITON_PROJ/benchmarks/triton_kernels_benchmark/vllm/batched_moe/batched_moe.patch"
+    "$TRITON_PROJ/benchmarks/triton_kernels_benchmark/vllm/unified_attention/unified_attention.patch"
+  )
 
-  if git -C "$VLLM_PROJ" apply --check "$PATCH_FILE" 2>/dev/null; then
-    echo "Applying tdesc patch: $PATCH_FILE."
-    git -C "$VLLM_PROJ" apply "$PATCH_FILE"
-  elif git -C "$VLLM_PROJ" apply --reverse --check "$PATCH_FILE" 2>/dev/null; then
-    echo "Patch already applied, skipping."
-  else
-    echo "ERROR: Failed to apply tdesc patch: $PATCH_FILE" >&2
-    echo "The vLLM tree may have an outdated patch or conflicting changes." >&2
-    return 1
+  local applied_patches=()
+  local exit_status=0
+  local patch_file
+  for patch_file in "${PATCH_FILES[@]}"; do
+    if git -C "$VLLM_PROJ" apply --check "$patch_file" 2>/dev/null; then
+      echo "Applying tdesc patch: $patch_file."
+      git -C "$VLLM_PROJ" apply "$patch_file"
+      applied_patches+=("$patch_file")
+    elif git -C "$VLLM_PROJ" apply --reverse --check "$patch_file" 2>/dev/null; then
+      echo "Patch already applied, skipping: $patch_file."
+    else
+      echo "ERROR: Failed to apply tdesc patch: $patch_file" >&2
+      echo "The vLLM tree may have an outdated patch or conflicting changes." >&2
+      exit_status=1
+      break
+    fi
+  done
+
+  # Only run the tests if every patch applied cleanly.
+  if [ "$exit_status" -eq 0 ]; then
+      VLLM_TRITON_USE_TD=1 TRITON_TEST_SUITE=vllm_tdesc \
+      run_pytest_command -vvv \
+        tests/kernels/moe/test_batched_moe.py \
+        tests/kernels/attention/test_triton_unified_attention.py \
+        || exit_status=$?
   fi
 
-  local EXIT_STATUS=0
-  TRITON_TEST_SUITE=vllm_tdesc \
-    run_pytest_command -vvv \
-      tests/kernels/attention/test_triton_unified_attention.py \
-      || EXIT_STATUS=$?
+  # Revert any patches this run applied, on both the success and error paths.
+  local revert_patch
+  for revert_patch in "${applied_patches[@]}"; do
+    echo "Reverting tdesc patch: $revert_patch."
+    if ! git -C "$VLLM_PROJ" apply -R "$revert_patch"; then
+      echo "WARNING: Failed to revert tdesc patch: $revert_patch." >&2
+    fi
+  done
 
-  echo "Reverting tdesc patch: $PATCH_FILE."
-  if ! git -C "$VLLM_PROJ" apply -R "$PATCH_FILE"; then
-    echo "WARNING: Failed to revert tdesc patch: $PATCH_FILE." >&2
-  fi
-
-  return $EXIT_STATUS
+  return $exit_status
 }
 
 


### PR DESCRIPTION
Closes https://github.com/intel/intel-xpu-backend-for-triton/issues/7742.

The `vllm-tdesc` test-suite now applies all enabled kernel patches, then runs all of the relevant tests.

Unlike `unified_attention`, which needs an additional wrapper argument to invoke the tdesc code path, `batched_moe` requires that the environment variable `VLLM_TRITON_USE_TD` is set.

Created https://github.com/intel/intel-xpu-backend-for-triton/issues/7753.

No impact on vLLM benchmark performance (verified on b580).