### PR TITLE
[HistogramOpToLLVM] Emit one index per unique register

### DIFF
--- a/test/Conversion/intel/histogram_to_llvm.mlir
+++ b/test/Conversion/intel/histogram_to_llvm.mlir
@@ -16,3 +16,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return
   }
 }
+
+// -----
+
+// COM: The result layout has `sizePerThread = [4]` on a shape-[2] tensor, so its
+// COM: register dimension carries zero bases: getUniqueElemsPerThread is 2 while
+// COM: getTotalElemsPerThread is 4. The lowering must emit one index per *unique*
+// COM: register, otherwise it builds 4 values for a 2-element LLVM struct and
+// COM: aborts with "size mismatch when packing elements for LLVM struct".
+// COM: The 2-element result struct below is what pins this.
+
+#src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [16], warpsPerCTA = [4], order = [0]}>
+#dst = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [16], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: @histogram_register_broadcast
+  // CHECK: llvm.atomicrmw add
+  // CHECK: llvm.mlir.undef : !llvm.struct<(i32, i32)>
+  // CHECK: llvm.return %{{.*}} : !llvm.struct<(i32, i32)>
+  tt.func @histogram_register_broadcast(%src: tensor<256xi32, #src>, %mask: tensor<256xi1, #src>) -> tensor<2xi32, #dst> {
+    %hist = tt.histogram %src, %mask : tensor<256xi32, #src> -> tensor<2xi32, #dst>
+    tt.return %hist : tensor<2xi32, #dst>
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/HistogramOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/HistogramOpToLLVM.cpp
@@ -77,6 +77,7 @@ public:
   matchAndRewrite(triton::HistogramOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
+    auto *ctx = op.getContext();
     Value input = adaptor.getSrc();
     auto typeConverter = getTypeConverter();
     SmallVector<Value> srcValues = unpackLLElements(loc, input, rewriter);
@@ -101,8 +102,13 @@ public:
     Value baseSharedMemPtr =
         LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
     auto dstType = op.getType();
-    Attribute dstEncoding = dstType.getEncoding();
-    auto indices = emitIndices(op.getLoc(), rewriter, targetInfo, dstEncoding,
+    // The LLVM struct for the result holds only unique elements
+    // (getUniqueElemsPerThread), so emit one index per unique register rather
+    // than one per broadcast register. Otherwise `computeHistogram` below
+    // produces getTotalElemsPerThread values and packing them fails.
+    auto dstLayout =
+        toLinearLayout(dstType).removeZeroBasesAlongDim(str_attr("register"));
+    auto indices = emitIndices(op.getLoc(), rewriter, targetInfo, dstLayout,
                                dstType, true);
     SmallVector<Value> innerDimIndices;
     for (int i = 0; i < indices.size(); ++i)


### PR DESCRIPTION
`emitIndices` was called with the raw result encoding, yielding `getTotalElemsPerThread` indices, but the LLVM struct holds
`getUniqueElemsPerThread`. A result layout whose register dimension carries zero bases therefore aborted in `packLLElements`. Deduplicate the layout along the register dimension first, matching upstream PR #10752.
