### PR TITLE
[LoopDistribute] Fix silent miscompiles, crash, and dropped loop attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ AGENTS.override.md
 /sglang/
 /Liger-Kernel/
 /wheels/
+.opencode

--- a/.gitignore
+++ b/.gitignore
@@ -117,4 +117,3 @@ AGENTS.override.md
 /sglang/
 /Liger-Kernel/
 /wheels/
-.opencode

--- a/python/test/unit/intel/test_loop_distribute.py
+++ b/python/test/unit/intel/test_loop_distribute.py
@@ -1,0 +1,232 @@
+"""End-to-end correctness test for the LoopDistribute pass
+(`tritonintelgpu-loop-distribute`, gated by the `loop_distribute` XPUOptions
+field / TRITON_INTEL_ENABLE_LOOP_DISTRIBUTION).
+
+The pass splits an scf.for loop containing exactly two tt.dot ops (sharing
+operand A) into two independent loops, each computing a single dot, to
+reduce register pressure. It is off by default.
+
+This test compiles and runs two kernel shapes with `loop_distribute` both
+disabled and enabled and checks that:
+  * both variants produce numerically correct results (vs. a torch reference)
+  * both variants agree with each other
+  * the pass actually fired when enabled, by counting `scf.for` occurrences
+    in the compiled TTIR (2 when enabled, 1 when disabled)
+
+Kernel A is a raw-pointer GEMM whose A/B operands are advanced every
+iteration via loop-carried `tt.addptr` (never re-derived from the loop
+index) -- the regression shape for the loop-carried-iter_arg-replication fix.
+Kernel B is a `tl.make_tensor_descriptor`-based GEMM mirroring the
+already-supported fast path used by `fused_gemm_swiglu_kernel` in
+benchmarks/triton_kernels_benchmark/fused_gemm_benchmark.py.
+"""
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton._internal_testing import is_xpu
+
+
+def _has_2d_block_io():
+    """Check if current device supports 2D block I/O."""
+    return triton.runtime.driver.active.get_current_target().arch.get('has_2d_block_io', False)
+
+
+@triton.jit
+def _dual_dot_ptr_kernel(
+    a_ptr,
+    wg_ptr,
+    wfc_ptr,
+    cg_ptr,
+    cfc_ptr,
+    K: tl.constexpr,
+    stride_am: tl.constexpr,
+    stride_ak: tl.constexpr,
+    stride_wgk: tl.constexpr,
+    stride_wgn: tl.constexpr,
+    stride_wfck: tl.constexpr,
+    stride_wfcn: tl.constexpr,
+    stride_cm: tl.constexpr,
+    stride_cn: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    offs_m = tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    wg_ptrs = wg_ptr + offs_k[:, None] * stride_wgk + offs_n[None, :] * stride_wgn
+    wfc_ptrs = wfc_ptr + offs_k[:, None] * stride_wfck + offs_n[None, :] * stride_wfcn
+
+    acc_g = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    acc_fc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for _ in range(0, K, BLOCK_K):
+        a = tl.load(a_ptrs)
+        w_g = tl.load(wg_ptrs)
+        w_fc = tl.load(wfc_ptrs)
+        acc_g = tl.dot(a, w_g, acc_g, input_precision="ieee")
+        acc_fc = tl.dot(a, w_fc, acc_fc, input_precision="ieee")
+        # Loop-carried pointers: advanced every iteration, never re-derived
+        # from the loop index.
+        a_ptrs += BLOCK_K * stride_ak
+        wg_ptrs += BLOCK_K * stride_wgk
+        wfc_ptrs += BLOCK_K * stride_wfck
+
+    cg_ptrs = cg_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    cfc_ptrs = cfc_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(cg_ptrs, acc_g.to(cg_ptr.dtype.element_ty))
+    tl.store(cfc_ptrs, acc_fc.to(cfc_ptr.dtype.element_ty))
+
+
+@triton.jit
+def _dual_dot_desc_kernel(
+    x_ptr,
+    wg_ptr,
+    wfc_ptr,
+    yg_ptr,
+    yfc_ptr,
+    M,
+    N,
+    K,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    desc_x = tl.make_tensor_descriptor(x_ptr, shape=[M, K], strides=[K, 1], block_shape=[BLOCK_M, BLOCK_K])
+    desc_wg = tl.make_tensor_descriptor(wg_ptr, shape=[K, N], strides=[N, 1], block_shape=[BLOCK_K, BLOCK_N])
+    desc_wfc = tl.make_tensor_descriptor(wfc_ptr, shape=[K, N], strides=[N, 1], block_shape=[BLOCK_K, BLOCK_N])
+
+    acc_g = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    acc_fc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k in range(0, K, BLOCK_K):
+        x = desc_x.load([0, k])
+        w_g = desc_wg.load([k, 0])
+        w_fc = desc_wfc.load([k, 0])
+        acc_g = tl.dot(x, w_g, acc_g)
+        acc_fc = tl.dot(x, w_fc, acc_fc)
+
+    desc_yg = tl.make_tensor_descriptor(yg_ptr, shape=[M, N], strides=[N, 1], block_shape=[BLOCK_M, BLOCK_N])
+    desc_yfc = tl.make_tensor_descriptor(yfc_ptr, shape=[M, N], strides=[N, 1], block_shape=[BLOCK_M, BLOCK_N])
+    desc_yg.store([0, 0], acc_g.to(yg_ptr.type.element_ty))
+    desc_yfc.store([0, 0], acc_fc.to(yfc_ptr.type.element_ty))
+
+
+@pytest.mark.skipif(not is_xpu(), reason="XPU-specific test")
+def test_dual_dot_ptr_gemm_loop_distribute(device):
+    """Regression test for the loop-carried-iter_arg-replication fix: A, W_g
+    and W_fc pointers are all loop-carried (advanced via `+=`, i.e. tt.addptr
+    chains) rather than re-derived from the loop index every iteration."""
+    M, N, K, BLOCK_K = 128, 128, 256, 64
+
+    torch.manual_seed(17)
+    a = torch.randn((M, K), dtype=torch.float16, device=device)
+    w_g = torch.randn((K, N), dtype=torch.float16, device=device)
+    w_fc = torch.randn((K, N), dtype=torch.float16, device=device)
+
+    ref_g = torch.matmul(a.float(), w_g.float())
+    ref_fc = torch.matmul(a.float(), w_fc.float())
+
+    results = {}
+    for loop_distribute in (False, True):
+        c_g = torch.empty((M, N), dtype=torch.float16, device=device)
+        c_fc = torch.empty((M, N), dtype=torch.float16, device=device)
+
+        kernel = _dual_dot_ptr_kernel[(1, 1)](
+            a,
+            w_g,
+            w_fc,
+            c_g,
+            c_fc,
+            K,
+            a.stride(0),
+            a.stride(1),
+            w_g.stride(0),
+            w_g.stride(1),
+            w_fc.stride(0),
+            w_fc.stride(1),
+            c_g.stride(0),
+            c_g.stride(1),
+            BLOCK_M=M,
+            BLOCK_N=N,
+            BLOCK_K=BLOCK_K,
+            num_warps=4,
+            loop_distribute=loop_distribute,
+        )
+
+        ttir = kernel.asm["ttir"]
+        expected_loops = 2 if loop_distribute else 1
+        assert ttir.count("scf.for") == expected_loops, (
+            f"loop_distribute={loop_distribute}: expected {expected_loops} scf.for in ttir, "
+            f"got {ttir.count('scf.for')}\n{ttir}")
+
+        err_g = (c_g.float() - ref_g).abs().max().item()
+        err_fc = (c_fc.float() - ref_fc).abs().max().item()
+        assert err_g < 2e-1, f"loop_distribute={loop_distribute}: acc_g max abs error {err_g} exceeds 2e-1"
+        assert err_fc < 2e-1, f"loop_distribute={loop_distribute}: acc_fc max abs error {err_fc} exceeds 2e-1"
+
+        results[loop_distribute] = (c_g.clone(), c_fc.clone())
+
+    # loop_distribute=False and loop_distribute=True must agree with each other.
+    torch.testing.assert_close(results[False][0].float(), results[True][0].float(), rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(results[False][1].float(), results[True][1].float(), rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.skipif(not is_xpu(), reason="XPU-specific test")
+@pytest.mark.xfail(not _has_2d_block_io(), reason="2D block I/O not supported", run=False)
+def test_dual_dot_desc_gemm_loop_distribute(device):
+    """Descriptor-based dual-dot GEMM (mirrors fused_gemm_swiglu_kernel's loop
+    body) -- guards that the already-supported descriptor fast path stays
+    correct with `loop_distribute` enabled."""
+    M, N, K, BLOCK_K = 128, 128, 256, 64
+
+    torch.manual_seed(17)
+    x = torch.randn((M, K), dtype=torch.bfloat16, device=device)
+    w_g = torch.randn((K, N), dtype=torch.bfloat16, device=device)
+    w_fc = torch.randn((K, N), dtype=torch.bfloat16, device=device)
+
+    ref_g = torch.matmul(x.float(), w_g.float())
+    ref_fc = torch.matmul(x.float(), w_fc.float())
+
+    results = {}
+    for loop_distribute in (False, True):
+        y_g = torch.empty((M, N), dtype=torch.bfloat16, device=device)
+        y_fc = torch.empty((M, N), dtype=torch.bfloat16, device=device)
+
+        kernel = _dual_dot_desc_kernel[(1, )](
+            x,
+            w_g,
+            w_fc,
+            y_g,
+            y_fc,
+            M,
+            N,
+            K,
+            BLOCK_M=M,
+            BLOCK_N=N,
+            BLOCK_K=BLOCK_K,
+            num_warps=4,
+            loop_distribute=loop_distribute,
+        )
+
+        ttir = kernel.asm["ttir"]
+        expected_loops = 2 if loop_distribute else 1
+        assert ttir.count("scf.for") == expected_loops, (
+            f"loop_distribute={loop_distribute}: expected {expected_loops} scf.for in ttir, "
+            f"got {ttir.count('scf.for')}\n{ttir}")
+
+        err_g = (y_g.float() - ref_g).abs().max().item()
+        err_fc = (y_fc.float() - ref_fc).abs().max().item()
+        # bf16 inputs accumulated over K=256 in fp32; generous absolute
+        # tolerance to accommodate bf16 rounding of the inputs.
+        assert err_g < 3.0, f"loop_distribute={loop_distribute}: acc_g max abs error {err_g} exceeds 3.0"
+        assert err_fc < 3.0, f"loop_distribute={loop_distribute}: acc_fc max abs error {err_fc} exceeds 3.0"
+
+        results[loop_distribute] = (y_g.clone(), y_fc.clone())
+
+    # loop_distribute=False and loop_distribute=True must agree with each other.
+    torch.testing.assert_close(results[False][0].float(), results[True][0].float(), rtol=1e-2, atol=5e-2)
+    torch.testing.assert_close(results[False][1].float(), results[True][1].float(), rtol=1e-2, atol=5e-2)

--- a/test/TritonIntelGPU/LoopDistribute/attrs.mlir
+++ b/test/TritonIntelGPU/LoopDistribute/attrs.mlir
@@ -1,27 +1,30 @@
 // RUN: triton-opt %s -split-input-file -tritonintelgpu-loop-distribute | FileCheck %s
 
-// Test: loop with two dots sharing operand A is distributed into two loops.
-// Each loop loads the shared A from %arg0 and only its own B operand. The
-// two scf.for results are wired back to the original op's results: result 0
-// comes from the first (dot0) loop, result 1 from the second (dot1) loop.
-// CHECK-LABEL: @dual_dot_distribute
-// CHECK: %[[LOOP1:.*]]:2 = scf.for
+// Test: discardable loop attributes (tt.num_stages, tt.loop_unroll_factor) on
+// the original loop must be copied onto BOTH distributed loops, not dropped.
+// CHECK-DAG directives are used since MLIR does not guarantee a fixed
+// printing order for a dictionary attribute.
+// CHECK-LABEL: @dual_dot_distribute_attrs
+// CHECK: scf.for
 // CHECK:   %[[X1:.*]] = tt.descriptor_load %arg0
 // CHECK:   %[[WG:.*]] = tt.descriptor_load %arg1
 // CHECK-NOT: tt.descriptor_load %arg2
 // CHECK:   tt.dot %[[X1]], %[[WG]]
 // CHECK-NOT: tt.dot
 // CHECK:   scf.yield
-// CHECK: %[[LOOP2:.*]]:2 = scf.for
+// CHECK-DAG: tt.num_stages = 3 : i32
+// CHECK-DAG: tt.loop_unroll_factor = 2 : i32
+// CHECK: scf.for
 // CHECK:   %[[X2:.*]] = tt.descriptor_load %arg0
 // CHECK-NOT: tt.descriptor_load %arg1
 // CHECK:   %[[WFC:.*]] = tt.descriptor_load %arg2
 // CHECK:   tt.dot %[[X2]], %[[WFC]]
 // CHECK-NOT: tt.dot
 // CHECK:   scf.yield
-// CHECK: tt.return %[[LOOP1]]#0, %[[LOOP2]]#1
+// CHECK-DAG: tt.num_stages = 3 : i32
+// CHECK-DAG: tt.loop_unroll_factor = 2 : i32
 module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  tt.func @dual_dot_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+  tt.func @dual_dot_distribute_attrs(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
     %c0_i32 = arith.constant 0 : i32
     %c64_i32 = arith.constant 64 : i32
@@ -33,7 +36,7 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
       %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
       %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
       scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
-    }
+    } {tt.num_stages = 3 : i32, tt.loop_unroll_factor = 2 : i32}
     tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
   }
 }

--- a/test/TritonIntelGPU/LoopDistribute/basic.mlir
+++ b/test/TritonIntelGPU/LoopDistribute/basic.mlir
@@ -45,14 +45,15 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // accumulator (which would read a frozen/dead pass-through slot in the
 // split loop), %acc_g evolves normally within the same new loop that
 // computes dot0, so the value read is identical to the original fused loop.
-// The loop must still be fully distributed. The accumulator iter_arg name is
-// captured from the loop header instead of hard-coded, since MLIR restarts
-// block-argument numbering per region: the SAME name (e.g. %arg3) prints as
-// the live accumulator in loop1, the frozen one in loop2, and also in the
-// un-distributed printing of this function, so a literal match would not
-// distinguish them.
+// The loop must still be fully distributed. The accumulator iter_arg and its
+// init value are matched through FileCheck variables captured from the IR
+// instead of literal SSA names: MLIR restarts block-argument numbering per
+// region, so the live accumulator in loop1, the frozen pass-through slot in
+// loop2 and the accumulator of the un-distributed loop all print under the
+// same name, and a literal match could not distinguish them.
 // CHECK-LABEL: @own_accumulator_dependency_distribute
-// CHECK: %[[LOOP1:.*]]:2 = scf.for {{.*}}iter_args(%[[ACC1:[^ ]+]] = %cst
+// CHECK: %[[CST:.*]] = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+// CHECK: %[[LOOP1:.*]]:2 = scf.for {{.*}}iter_args(%[[ACC1:[^ ]+]] = %[[CST]], %{{[^ ]+}} = %[[CST]])
 // CHECK:   %[[X1:.*]] = tt.descriptor_load %arg0
 // CHECK:   %[[WRAW1:.*]] = tt.descriptor_load %arg1
 // CHECK:   %[[WG:.*]] = arith.addf %[[WRAW1]], %[[ACC1]]

--- a/test/TritonIntelGPU/LoopDistribute/basic.mlir
+++ b/test/TritonIntelGPU/LoopDistribute/basic.mlir
@@ -37,3 +37,54 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
     tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
   }
 }
+
+// -----
+
+// Test: dot0's B operand depends on dot0's OWN accumulator (%acc_g) via a
+// pure arith.addf. This is safe -- unlike a dependency on the OTHER dot's
+// accumulator (which would read a frozen/dead pass-through slot in the
+// split loop), %acc_g evolves normally within the same new loop that
+// computes dot0, so the value read is identical to the original fused loop.
+// The loop must still be fully distributed. The accumulator iter_arg name is
+// captured from the loop header instead of hard-coded, since MLIR restarts
+// block-argument numbering per region: the SAME name (e.g. %arg3) prints as
+// the live accumulator in loop1, the frozen one in loop2, and also in the
+// un-distributed printing of this function, so a literal match would not
+// distinguish them.
+// CHECK-LABEL: @own_accumulator_dependency_distribute
+// CHECK: %[[LOOP1:.*]]:2 = scf.for {{.*}}iter_args(%[[ACC1:[^ ]+]] = %cst
+// CHECK:   %[[X1:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[WRAW1:.*]] = tt.descriptor_load %arg1
+// CHECK:   %[[WG:.*]] = arith.addf %[[WRAW1]], %[[ACC1]]
+// CHECK:   tt.dot %[[X1]], %[[WG]]
+// CHECK-NOT: tt.dot
+// CHECK:   scf.yield
+// CHECK: %[[LOOP2:.*]]:2 = scf.for
+// CHECK:   %[[X2:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[WRAW2:.*]] = tt.descriptor_load %arg1
+// The arith.addf belongs to dot0's operand slice only, so it must NOT be cloned
+// into loop2 (where %acc_g is the frozen pass-through slot).
+// CHECK-NOT: arith.addf
+// CHECK:   tt.dot %[[X2]], %[[WRAW2]]
+// CHECK-NOT: tt.dot
+// CHECK:   scf.yield
+// CHECK: tt.return %[[LOOP1]]#0, %[[LOOP2]]#1
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @own_accumulator_dependency_distribute(%arg0: !tt.tensordesc<128x128xf32>, %arg1: !tt.tensordesc<128x128xf32>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:2 = scf.for %k = %c0_i32 to %c512_i32 step %c128_i32 iter_args(%acc_g = %cst, %acc_fc = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x128xf32> -> tensor<128x128xf32>
+      %w_raw = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<128x128xf32> -> tensor<128x128xf32>
+      // dot0's B operand depends on dot0's OWN accumulator -- safe, since
+      // that accumulator evolves normally in the loop that computes dot0.
+      %wg = arith.addf %w_raw, %acc_g : tensor<128x128xf32>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x128xf32> * tensor<128x128xf32> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %w_raw, %acc_fc, inputPrecision = tf32 : tensor<128x128xf32> * tensor<128x128xf32> -> tensor<128x128xf32>
+      scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}

--- a/test/TritonIntelGPU/LoopDistribute/carried.mlir
+++ b/test/TritonIntelGPU/LoopDistribute/carried.mlir
@@ -4,15 +4,20 @@
 // offset advanced every iteration via arith.addi) must be replicated into
 // BOTH distributed loops, with its own cloned arith.addi and the incremented
 // value yielded -- not the stale %off passed through unchanged.
+// Both loops must also start from the ORIGINAL init values: neither is chained
+// onto the other's carried result, so the offset advances exactly once per
+// iteration in each loop.
 // CHECK-LABEL: @carried_offset
-// CHECK: scf.for
+// CHECK-DAG: %[[ACC_INIT:.*]] = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+// CHECK-DAG: %[[OFF_INIT:.*]] = arith.constant 0 : i32
+// CHECK: scf.for {{.*}}iter_args(%{{[^ ]+}} = %[[ACC_INIT]], %{{[^ ]+}} = %[[ACC_INIT]], %{{[^ ]+}} = %[[OFF_INIT]])
 // CHECK:   %[[X1:.*]] = tt.descriptor_load %arg0
 // CHECK:   %[[WG:.*]] = tt.descriptor_load %arg1
 // CHECK:   %[[D0:.*]] = tt.dot %[[X1]], %[[WG]]
 // CHECK-NOT: tt.dot
 // CHECK:   %[[OFFNEXT1:.*]] = arith.addi
 // CHECK:   scf.yield %[[D0]], %{{.*}}, %[[OFFNEXT1]]
-// CHECK: scf.for
+// CHECK: scf.for {{.*}}iter_args(%{{[^ ]+}} = %[[ACC_INIT]], %{{[^ ]+}} = %[[ACC_INIT]], %{{[^ ]+}} = %[[OFF_INIT]])
 // CHECK:   %[[X2:.*]] = tt.descriptor_load %arg0
 // CHECK:   %[[WFC:.*]] = tt.descriptor_load %arg2
 // CHECK:   %[[D1:.*]] = tt.dot %[[X2]], %[[WFC]]
@@ -47,8 +52,14 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // @carried_offset above, it must be replicated (cloned) into BOTH
 // distributed loops rather than frozen or rejected. Each new loop gets its
 // own copy of the inner scf.for and yields that copy's result at index 2.
+// Because the carried value (%s, a running sum) is also a function result, the
+// wiring is checked too: BOTH loops must start the sum from the original init
+// (neither is chained onto the other's result) and the returned sum must come
+// from the first loop -- i.e. the sum is accumulated once, not double counted.
 // CHECK-LABEL: @nested_pure_loop
-// CHECK: scf.for
+// CHECK-DAG: %[[ACC_INIT:.*]] = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+// CHECK-DAG: %[[S_INIT:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK: %[[LOOP1:.*]]:3 = scf.for {{.*}}iter_args(%{{[^ ]+}} = %[[ACC_INIT]], %{{[^ ]+}} = %[[ACC_INIT]], %{{[^ ]+}} = %[[S_INIT]])
 // CHECK:   %[[X1:.*]] = tt.descriptor_load %arg0
 // CHECK:   %[[WG:.*]] = tt.descriptor_load %arg1
 // CHECK:   %[[D0:.*]] = tt.dot %[[X1]], %[[WG]]
@@ -57,7 +68,7 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // CHECK:     arith.addf
 // CHECK:     scf.yield
 // CHECK:   scf.yield %[[D0]], %{{.*}}, %[[INNER1]]
-// CHECK: scf.for
+// CHECK: %[[LOOP2:.*]]:3 = scf.for {{.*}}iter_args(%{{[^ ]+}} = %[[ACC_INIT]], %{{[^ ]+}} = %[[ACC_INIT]], %{{[^ ]+}} = %[[S_INIT]])
 // CHECK:   %[[X2:.*]] = tt.descriptor_load %arg0
 // CHECK:   %[[WFC:.*]] = tt.descriptor_load %arg2
 // CHECK:   %[[D1:.*]] = tt.dot %[[X2]], %[[WFC]]
@@ -66,6 +77,7 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // CHECK:     arith.addf
 // CHECK:     scf.yield
 // CHECK:   scf.yield %{{.*}}, %[[D1]], %[[INNER2]]
+// CHECK: tt.return %[[LOOP1]]#0, %[[LOOP2]]#1, %[[LOOP1]]#2
 module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
   tt.func @nested_pure_loop(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>, f32) {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
@@ -100,15 +112,19 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // loop-carried tt.addptr (never re-derived from the induction variable, and
 // only consumed by the yield). Both distributed loops must contain their own
 // cloned tt.addptr and yield the advanced pointer, not the stale one.
+// Both loops must also start from the ORIGINAL base pointer tensor, so each
+// advances it exactly once per iteration.
 // CHECK-LABEL: @carried_ptr_gemm
-// CHECK: scf.for
+// CHECK-DAG: %[[ACC_INIT:.*]] = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+// CHECK-DAG: %[[PTR_INIT:.*]] = tt.splat %arg0
+// CHECK: scf.for {{.*}}iter_args(%{{[^ ]+}} = %[[ACC_INIT]], %{{[^ ]+}} = %[[ACC_INIT]], %{{[^ ]+}} = %[[PTR_INIT]])
 // CHECK:   %[[X1:.*]] = tt.load %{{.*}} : tensor<128x64x!tt.ptr<bf16>>
 // CHECK:   %[[WG:.*]] = tt.descriptor_load %arg1
 // CHECK:   %[[D0:.*]] = tt.dot %[[X1]], %[[WG]]
 // CHECK-NOT: tt.dot
 // CHECK:   %[[ANEXT1:.*]] = tt.addptr %{{.*}}, %{{.*}} : tensor<128x64x!tt.ptr<bf16>>
 // CHECK:   scf.yield %[[D0]], %{{.*}}, %[[ANEXT1]]
-// CHECK: scf.for
+// CHECK: scf.for {{.*}}iter_args(%{{[^ ]+}} = %[[ACC_INIT]], %{{[^ ]+}} = %[[ACC_INIT]], %{{[^ ]+}} = %[[PTR_INIT]])
 // CHECK:   %[[X2:.*]] = tt.load %{{.*}} : tensor<128x64x!tt.ptr<bf16>>
 // CHECK:   %[[WFC:.*]] = tt.descriptor_load %arg2
 // CHECK:   %[[D1:.*]] = tt.dot %[[X2]], %[[WFC]]

--- a/test/TritonIntelGPU/LoopDistribute/carried.mlir
+++ b/test/TritonIntelGPU/LoopDistribute/carried.mlir
@@ -1,0 +1,139 @@
+// RUN: triton-opt %s -split-input-file -tritonintelgpu-loop-distribute | FileCheck %s
+
+// Test: a loop-carried non-accumulator iter_arg (%off, a descriptor-load
+// offset advanced every iteration via arith.addi) must be replicated into
+// BOTH distributed loops, with its own cloned arith.addi and the incremented
+// value yielded -- not the stale %off passed through unchanged.
+// CHECK-LABEL: @carried_offset
+// CHECK: scf.for
+// CHECK:   %[[X1:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[WG:.*]] = tt.descriptor_load %arg1
+// CHECK:   %[[D0:.*]] = tt.dot %[[X1]], %[[WG]]
+// CHECK-NOT: tt.dot
+// CHECK:   %[[OFFNEXT1:.*]] = arith.addi
+// CHECK:   scf.yield %[[D0]], %{{.*}}, %[[OFFNEXT1]]
+// CHECK: scf.for
+// CHECK:   %[[X2:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[WFC:.*]] = tt.descriptor_load %arg2
+// CHECK:   %[[D1:.*]] = tt.dot %[[X2]], %[[WFC]]
+// CHECK-NOT: tt.dot
+// CHECK:   %[[OFFNEXT2:.*]] = arith.addi
+// CHECK:   scf.yield %{{.*}}, %[[D1]], %[[OFFNEXT2]]
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @carried_offset(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    // %off is a loop-carried offset (NOT an accumulator) advanced every iteration.
+    %0:3 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst, %off = %c0_i32) -> (tensor<128x128xf32>, tensor<128x128xf32>, i32) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %off] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg = tt.descriptor_load %arg1[%off, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%off, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %off_next = arith.addi %off, %c64_i32 : i32
+      scf.yield %d0, %d1, %off_next : tensor<128x128xf32>, tensor<128x128xf32>, i32
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: a pure but unrelated nested scf.for loop in the body is itself a
+// pure, dot-independent, accumulator-independent loop-carried chain (yielded
+// to the carried, non-accumulator index 2) -- just like %off_next in
+// @carried_offset above, it must be replicated (cloned) into BOTH
+// distributed loops rather than frozen or rejected. Each new loop gets its
+// own copy of the inner scf.for and yields that copy's result at index 2.
+// CHECK-LABEL: @nested_pure_loop
+// CHECK: scf.for
+// CHECK:   %[[X1:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[WG:.*]] = tt.descriptor_load %arg1
+// CHECK:   %[[D0:.*]] = tt.dot %[[X1]], %[[WG]]
+// CHECK-NOT: tt.dot
+// CHECK:   %[[INNER1:.*]] = scf.for
+// CHECK:     arith.addf
+// CHECK:     scf.yield
+// CHECK:   scf.yield %[[D0]], %{{.*}}, %[[INNER1]]
+// CHECK: scf.for
+// CHECK:   %[[X2:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[WFC:.*]] = tt.descriptor_load %arg2
+// CHECK:   %[[D1:.*]] = tt.dot %[[X2]], %[[WFC]]
+// CHECK-NOT: tt.dot
+// CHECK:   %[[INNER2:.*]] = scf.for
+// CHECK:     arith.addf
+// CHECK:     scf.yield
+// CHECK:   scf.yield %{{.*}}, %[[D1]], %[[INNER2]]
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @nested_pure_loop(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>, f32) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %f0 = arith.constant 0.000000e+00 : f32
+    %f1 = arith.constant 1.000000e+00 : f32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:3 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst, %s = %f0) -> (tensor<128x128xf32>, tensor<128x128xf32>, f32) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      // A pure inner loop, unrelated to either dot.
+      %inner = scf.for %j = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%t = %s) -> (f32) : i32 {
+        %n = arith.addf %t, %f1 : f32
+        scf.yield %n : f32
+      }
+      scf.yield %d0, %d1, %inner : tensor<128x128xf32>, tensor<128x128xf32>, f32
+    }
+    tt.return %0#0, %0#1, %0#2 : tensor<128x128xf32>, tensor<128x128xf32>, f32
+  }
+}
+
+// -----
+
+// Test: canonical pointer-advance GEMM shape. Operand A is shared by both
+// dots and its pointer tensor is carried across iterations via a
+// loop-carried tt.addptr (never re-derived from the induction variable, and
+// only consumed by the yield). Both distributed loops must contain their own
+// cloned tt.addptr and yield the advanced pointer, not the stale one.
+// CHECK-LABEL: @carried_ptr_gemm
+// CHECK: scf.for
+// CHECK:   %[[X1:.*]] = tt.load %{{.*}} : tensor<128x64x!tt.ptr<bf16>>
+// CHECK:   %[[WG:.*]] = tt.descriptor_load %arg1
+// CHECK:   %[[D0:.*]] = tt.dot %[[X1]], %[[WG]]
+// CHECK-NOT: tt.dot
+// CHECK:   %[[ANEXT1:.*]] = tt.addptr %{{.*}}, %{{.*}} : tensor<128x64x!tt.ptr<bf16>>
+// CHECK:   scf.yield %[[D0]], %{{.*}}, %[[ANEXT1]]
+// CHECK: scf.for
+// CHECK:   %[[X2:.*]] = tt.load %{{.*}} : tensor<128x64x!tt.ptr<bf16>>
+// CHECK:   %[[WFC:.*]] = tt.descriptor_load %arg2
+// CHECK:   %[[D1:.*]] = tt.dot %[[X2]], %[[WFC]]
+// CHECK-NOT: tt.dot
+// CHECK:   %[[ANEXT2:.*]] = tt.addptr %{{.*}}, %{{.*}} : tensor<128x64x!tt.ptr<bf16>>
+// CHECK:   scf.yield %{{.*}}, %[[D1]], %[[ANEXT2]]
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @carried_ptr_gemm(%a_ptr: !tt.ptr<bf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %a_off = arith.constant dense<64> : tensor<128x64xi32>
+    %a_splat = tt.splat %a_ptr : !tt.ptr<bf16> -> tensor<128x64x!tt.ptr<bf16>>
+    %0:3 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst, %a_ptrs = %a_splat) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x64x!tt.ptr<bf16>>) : i32 {
+      %x = tt.load %a_ptrs : tensor<128x64x!tt.ptr<bf16>>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      // %a_ptrs is only ever advanced here and consumed by the yield -- never
+      // re-derived from %k.
+      %a_next = tt.addptr %a_ptrs, %a_off : tensor<128x64x!tt.ptr<bf16>>, tensor<128x64xi32>
+      scf.yield %d0, %d1, %a_next : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x64x!tt.ptr<bf16>>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}

--- a/test/TritonIntelGPU/LoopDistribute/invalid.mlir
+++ b/test/TritonIntelGPU/LoopDistribute/invalid.mlir
@@ -58,6 +58,7 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // CHECK-LABEL: @non_direct_acc_no_distribute
 // CHECK: scf.for
 // CHECK:   tt.dot
+// CHECK-NOT: scf.for
 // CHECK:   tt.dot
 // CHECK:   scf.yield
 // CHECK-NOT: scf.for
@@ -88,6 +89,7 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // CHECK-LABEL: @dot_result_not_yielded_no_distribute
 // CHECK: scf.for
 // CHECK:   tt.dot
+// CHECK-NOT: scf.for
 // CHECK:   tt.dot
 // CHECK:   scf.yield
 // CHECK-NOT: scf.for
@@ -118,6 +120,7 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // CHECK-LABEL: @side_effecting_op_no_distribute
 // CHECK: scf.for
 // CHECK:   tt.dot
+// CHECK-NOT: scf.for
 // CHECK:   tt.dot
 // CHECK:   scf.yield
 // CHECK-NOT: scf.for
@@ -148,6 +151,7 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // CHECK-LABEL: @inter_dependent_dots_no_distribute
 // CHECK: scf.for
 // CHECK:   tt.dot
+// CHECK-NOT: scf.for
 // CHECK:   tt.dot
 // CHECK:   scf.yield
 // CHECK-NOT: scf.for
@@ -182,6 +186,7 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // CHECK-LABEL: @side_effecting_op_in_slice_no_distribute
 // CHECK: scf.for
 // CHECK:   tt.dot
+// CHECK-NOT: scf.for
 // CHECK:   tt.dot
 // CHECK:   scf.yield
 // CHECK-NOT: scf.for
@@ -218,6 +223,7 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // CHECK-LABEL: @carried_depends_on_acc_no_distribute
 // CHECK: scf.for
 // CHECK:   tt.dot
+// CHECK-NOT: scf.for
 // CHECK:   tt.dot
 // CHECK:   scf.yield
 // CHECK-NOT: scf.for
@@ -249,6 +255,7 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // CHECK-LABEL: @carried_depends_on_dot_result_no_distribute
 // CHECK: scf.for
 // CHECK:   tt.dot
+// CHECK-NOT: scf.for
 // CHECK:   tt.dot
 // CHECK:   scf.yield
 // CHECK-NOT: scf.for
@@ -283,6 +290,7 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // CHECK-LABEL: @unclassified_dead_op_no_distribute
 // CHECK: scf.for
 // CHECK:   tt.dot
+// CHECK-NOT: scf.for
 // CHECK:   tt.dot
 // CHECK:   scf.yield
 // CHECK-NOT: scf.for
@@ -301,6 +309,183 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
       // %dead is pure, but belongs to neither dot's slice nor any carried
       // chain, and has no further use.
       %dead = arith.addf %acc_g, %acc_g : tensor<128x128xf32>
+      scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: dot0's B operand secretly depends, via its backward slice, on dot1's
+// accumulator block argument (%acc_fc). In the distributed loop that
+// computes dot0, %acc_fc would be a frozen/dead pass-through slot (never
+// updated by dot1, since dot1 lives in the OTHER new loop) -- so cloning
+// this slice into that loop would compute a different %wg than the original
+// fused loop.
+// CHECK-LABEL: @cross_accumulator_dependency_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK-NOT: scf.for
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @cross_accumulator_dependency_no_distribute(%arg0: !tt.tensordesc<128x128xf32>, %arg1: !tt.tensordesc<128x128xf32>, %arg2: !tt.tensordesc<128x128xf32>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:2 = scf.for %k = %c0_i32 to %c512_i32 step %c128_i32 iter_args(%acc_g = %cst, %acc_fc = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x128xf32> -> tensor<128x128xf32>
+      %wg_raw = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<128x128xf32> -> tensor<128x128xf32>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<128x128xf32> -> tensor<128x128xf32>
+      // dot0's B operand secretly depends on dot1's accumulator.
+      %wg = arith.addf %wg_raw, %acc_fc : tensor<128x128xf32>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x128xf32> * tensor<128x128xf32> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x128xf32> * tensor<128x128xf32> -> tensor<128x128xf32>
+      scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: dot0's A operand IS dot1's accumulator block argument (%acc_fc),
+// used directly with no intervening op -- so it never even lands in dot0's
+// backward slice as a separate value to inspect; the direct-operand list
+// itself must be checked. Same frozen-slot hazard as above, reached via a
+// direct operand instead of a slice member.
+// CHECK-LABEL: @dot_operand_is_foreign_acc_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK-NOT: scf.for
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @dot_operand_is_foreign_acc_no_distribute(%arg0: !tt.tensordesc<128x128xf32>, %arg1: !tt.tensordesc<128x128xf32>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:2 = scf.for %k = %c0_i32 to %c512_i32 step %c128_i32 iter_args(%acc_g = %cst, %acc_fc = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %w = tt.descriptor_load %arg0[%k, %c0_i32] : !tt.tensordesc<128x128xf32> -> tensor<128x128xf32>
+      %x = tt.descriptor_load %arg1[%c0_i32, %k] : !tt.tensordesc<128x128xf32> -> tensor<128x128xf32>
+      // dot0's A operand IS dot1's accumulator block argument, used directly
+      // (no intervening op, so it never lands in dot0's backward slice).
+      %d0 = tt.dot %acc_fc, %w, %acc_g, inputPrecision = tf32 : tensor<128x128xf32> * tensor<128x128xf32> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %w, %acc_fc, inputPrecision = tf32 : tensor<128x128xf32> * tensor<128x128xf32> -> tensor<128x128xf32>
+      scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: mirror of cross_accumulator_dependency_no_distribute -- here dot1's
+// B operand secretly depends, via its backward slice, on dot0's accumulator
+// block argument (%acc_g). In the distributed loop that computes dot1,
+// %acc_g would be a frozen/dead pass-through slot, so cloning this slice
+// there would compute a different %wfc than the original fused loop.
+// CHECK-LABEL: @dot1_depends_on_dot0_acc_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK-NOT: scf.for
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @dot1_depends_on_dot0_acc_no_distribute(%arg0: !tt.tensordesc<128x128xf32>, %arg1: !tt.tensordesc<128x128xf32>, %arg2: !tt.tensordesc<128x128xf32>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:2 = scf.for %k = %c0_i32 to %c512_i32 step %c128_i32 iter_args(%acc_g = %cst, %acc_fc = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x128xf32> -> tensor<128x128xf32>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<128x128xf32> -> tensor<128x128xf32>
+      %wfc_raw = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<128x128xf32> -> tensor<128x128xf32>
+      // dot1's B operand secretly depends on dot0's accumulator.
+      %wfc = arith.addf %wfc_raw, %acc_g : tensor<128x128xf32>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x128xf32> * tensor<128x128xf32> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x128xf32> * tensor<128x128xf32> -> tensor<128x128xf32>
+      scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: mirror of dot_operand_is_foreign_acc_no_distribute -- here dot1's A
+// operand IS dot0's accumulator block argument (%acc_g), used directly. Same
+// frozen-slot hazard, reached via dot1's direct operand list instead of
+// dot0's.
+// CHECK-LABEL: @dot1_operand_is_foreign_acc_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK-NOT: scf.for
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @dot1_operand_is_foreign_acc_no_distribute(%arg0: !tt.tensordesc<128x128xf32>, %arg1: !tt.tensordesc<128x128xf32>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:2 = scf.for %k = %c0_i32 to %c512_i32 step %c128_i32 iter_args(%acc_g = %cst, %acc_fc = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %w = tt.descriptor_load %arg0[%k, %c0_i32] : !tt.tensordesc<128x128xf32> -> tensor<128x128xf32>
+      %x = tt.descriptor_load %arg1[%c0_i32, %k] : !tt.tensordesc<128x128xf32> -> tensor<128x128xf32>
+      %d0 = tt.dot %x, %w, %acc_g, inputPrecision = tf32 : tensor<128x128xf32> * tensor<128x128xf32> -> tensor<128x128xf32>
+      // dot1's A operand IS dot0's accumulator block argument, used directly
+      // (no intervening op, so it never lands in dot1's backward slice).
+      %d1 = tt.dot %acc_g, %w, %acc_fc, inputPrecision = tf32 : tensor<128x128xf32> * tensor<128x128xf32> -> tensor<128x128xf32>
+      scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: dot0's B operand is produced by an scf.if whose then-branch reads
+// dot1's accumulator (%acc_fc) as a plain SSA capture from the enclosing
+// scope, NOT as a formal top-level operand of the scf.if (whose only
+// top-level operand is %cond). Same hazard as
+// cross_accumulator_dependency_no_distribute, but reached via a
+// nested-region capture -- the safety check must walk into nested regions of
+// slice members, not just their top-level operands, to catch it.
+// CHECK-LABEL: @slice_captures_foreign_acc_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK-NOT: scf.for
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @slice_captures_foreign_acc_no_distribute(%arg0: !tt.tensordesc<128x128xf32>, %arg1: !tt.tensordesc<128x128xf32>, %arg2: !tt.tensordesc<128x128xf32>, %cond: i1) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:2 = scf.for %k = %c0_i32 to %c512_i32 step %c128_i32 iter_args(%acc_g = %cst, %acc_fc = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x128xf32> -> tensor<128x128xf32>
+      %wg_raw = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<128x128xf32> -> tensor<128x128xf32>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<128x128xf32> -> tensor<128x128xf32>
+      // %acc_fc (dot1's accumulator) is captured directly inside the
+      // scf.if's region body -- it is NOT a formal top-level operand of the
+      // scf.if (only %cond is).
+      %wg = scf.if %cond -> tensor<128x128xf32> {
+        %t = arith.addf %wg_raw, %acc_fc : tensor<128x128xf32>
+        scf.yield %t : tensor<128x128xf32>
+      } else {
+        scf.yield %wg_raw : tensor<128x128xf32>
+      }
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x128xf32> * tensor<128x128xf32> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x128xf32> * tensor<128x128xf32> -> tensor<128x128xf32>
       scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
     }
     tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>

--- a/test/TritonIntelGPU/LoopDistribute/invalid.mlir
+++ b/test/TritonIntelGPU/LoopDistribute/invalid.mlir
@@ -180,9 +180,9 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 
 // Test: a side-effecting op (tt.atomic_rmw) sits inside what would otherwise
 // be dot0's backward slice (its result feeds into computing dot0's B
-// operand), rather than floating free outside both slices. This must still
-// be rejected -- slice members must be side-effect free to be safely
-// replicated into both new loops.
+// operand), rather than floating free outside both slices. This must still be
+// rejected -- a slice member's memory effects must all be reads to be safely
+// replicated and reordered, and the atomic writes.
 // CHECK-LABEL: @side_effecting_op_in_slice_no_distribute
 // CHECK: scf.for
 // CHECK:   tt.dot

--- a/test/TritonIntelGPU/LoopDistribute/invalid.mlir
+++ b/test/TritonIntelGPU/LoopDistribute/invalid.mlir
@@ -171,3 +171,138 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
     tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x64xf32>
   }
 }
+
+// -----
+
+// Test: a side-effecting op (tt.atomic_rmw) sits inside what would otherwise
+// be dot0's backward slice (its result feeds into computing dot0's B
+// operand), rather than floating free outside both slices. This must still
+// be rejected -- slice members must be side-effect free to be safely
+// replicated into both new loops.
+// CHECK-LABEL: @side_effecting_op_in_slice_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @side_effecting_op_in_slice_no_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>, %rmw_ptr: tensor<64x128x!tt.ptr<f32>>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %cstf = arith.constant dense<0.000000e+00> : tensor<64x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:2 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg_raw = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      // Side-effecting atomic feeds into computing dot0's B operand.
+      %old = tt.atomic_rmw fadd, acq_rel, gpu, %rmw_ptr, %cstf : (tensor<64x128x!tt.ptr<f32>>, tensor<64x128xf32>) -> tensor<64x128xf32>
+      %old_bf16 = arith.truncf %old : tensor<64x128xf32> to tensor<64x128xbf16>
+      %wg = arith.addf %wg_raw, %old_bf16 : tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: a loop-carried chain (%carry) is updated from a dot accumulator's
+// block argument (%acc_g) directly, rather than from a value that is safe to
+// replicate identically into both new loops. Replicating this chain would
+// read a different (frozen or partial) %acc_g in each new loop, so
+// distribution must be rejected.
+// CHECK-LABEL: @carried_depends_on_acc_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @carried_depends_on_acc_no_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:3 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst, %carry = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      // %carry's update reads dot0's accumulator block-argument directly.
+      %bad = arith.addf %carry, %acc_g : tensor<128x128xf32>
+      scf.yield %d0, %d1, %bad : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: a loop-carried chain (%carry) is updated from a dot's RESULT (%d0)
+// directly, rather than the accumulator iter_arg. This must also be
+// rejected -- a carried chain may not depend on either dot's output.
+// CHECK-LABEL: @carried_depends_on_dot_result_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @carried_depends_on_dot_result_no_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:3 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst, %carry = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      // %carry's update derives from dot0's RESULT directly (not the
+      // accumulator iter_arg).
+      %bad = arith.addf %carry, %d0 : tensor<128x128xf32>
+      scf.yield %d0, %d1, %bad : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: a pure op that belongs to neither dot's slice nor any carried chain,
+// and whose result is not used anywhere (not a dot operand, not any yield
+// operand), is a genuinely unclassified op. It must be rejected. This only
+// survives as a standalone test case because we bypass the canonicalizer
+// that would normally dead-code-eliminate it in the real pipeline.
+// CHECK-LABEL: @unclassified_dead_op_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @unclassified_dead_op_no_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:2 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      // %dead is pure, but belongs to neither dot's slice nor any carried
+      // chain, and has no further use.
+      %dead = arith.addf %acc_g, %acc_g : tensor<128x128xf32>
+      scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}

--- a/test/TritonIntelGPU/LoopDistribute/region_capture.mlir
+++ b/test/TritonIntelGPU/LoopDistribute/region_capture.mlir
@@ -55,13 +55,73 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 
 // -----
 
-// Test: negative control for region_capture_pure. Here the value captured by
-// the scf.if (%wraw) is a *volatile* load, which isReplicable rejects
-// unconditionally -- unlike tt.descriptor_load/tt.descriptor_gather, which
-// have an unconditional allow-carve-out regardless of purity, a volatile
-// tt.load is never replicable. This must still be rejected (loop not
-// distributed) -- non-replicable captured chains are not cloned.
-// CHECK-LABEL: @region_capture
+// Test: the scf.if computing %wg is NOT pure -- its then-branch performs a
+// (non-volatile) tt.load -- but all of its memory effects, computed
+// recursively, are reads, so it is replicable: repeating a read is
+// observationally equivalent. The pointer tensor it loads from is itself a
+// loop-body value captured into the region (a pure tt.addptr, not an operand of
+// the scf.if), so the capture must be cloned along with it. Both feed dot0
+// only, so they land in the first distributed loop and nowhere else. Compare
+// region_capture_volatile_no_distribute below, where the same shape with a
+// volatile load is rejected.
+// CHECK-LABEL: @region_capture_read_only_load
+// CHECK: scf.for
+// CHECK:   %[[X1:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[PTRS:.*]] = tt.addptr
+// CHECK:   %[[WG:.*]] = scf.if
+// CHECK:     tt.load %[[PTRS]]
+// CHECK:   tt.dot %[[X1]], %[[WG]]
+// CHECK-NOT: tt.dot
+// CHECK:   scf.yield
+// CHECK: scf.for
+// CHECK:   %[[X2:.*]] = tt.descriptor_load %arg0
+// CHECK-NOT: scf.if
+// CHECK-NOT: tt.load
+// CHECK-NOT: tt.addptr
+// CHECK:   %[[WFC:.*]] = tt.descriptor_load %arg2
+// CHECK:   tt.dot %[[X2]], %[[WFC]]
+// CHECK-NOT: tt.dot
+// CHECK:   scf.yield
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @region_capture_read_only_load(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.tensordesc<64x128xbf16>, %cond: i1) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %cstb = arith.constant dense<1.000000e+00> : tensor<64x128xbf16>
+    %woff = arith.constant dense<64> : tensor<64x128xi32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %wbase = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<64x128x!tt.ptr<bf16>>
+    %0:2 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wraw_ptrs = tt.addptr %wbase, %woff : tensor<64x128x!tt.ptr<bf16>>, tensor<64x128xi32>
+      // %wraw_ptrs is captured by the scf.if region, it is NOT an operand of
+      // scf.if. The load inside the region gives the scf.if a Read effect.
+      %wg = scf.if %cond -> tensor<64x128xbf16> {
+        %t = tt.load %wraw_ptrs : tensor<64x128x!tt.ptr<bf16>>
+        scf.yield %t : tensor<64x128xbf16>
+      } else {
+        scf.yield %cstb : tensor<64x128xbf16>
+      }
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: negative control for region_capture_read_only_load. Here the value
+// captured by the scf.if (%wraw) is a *volatile* load. Note that %wg feeds
+// dot0 only, so the chain would be cloned into the first distributed loop
+// alone -- duplication is not what blocks this. A volatile tt.load declares a
+// Write effect (see LoadOp::getEffects) exactly so that it is neither
+// duplicated nor reordered, and distribution reorders it with respect to every
+// memory operation of the second loop, so isReplicable rejects it and the loop
+// must stay fused.
+// CHECK-LABEL: @region_capture_volatile_no_distribute
 // CHECK: scf.for
 // CHECK:   tt.dot
 // CHECK-NOT: scf.for
@@ -69,7 +129,7 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // CHECK:   scf.yield
 // CHECK-NOT: scf.for
 module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  tt.func @region_capture(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.tensordesc<64x128xbf16>, %cond: i1) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+  tt.func @region_capture_volatile_no_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.tensordesc<64x128xbf16>, %cond: i1) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
     %cstb = arith.constant dense<1.000000e+00> : tensor<64x128xbf16>
     %c0_i32 = arith.constant 0 : i32
@@ -102,11 +162,17 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // %acc_g is referenced directly from the then-branch, it is NOT passed as a
 // formal top-level operand of the scf.if (whose only top-level operand is
 // %cond). This is the same hazard as invalid.mlir's
-// carried_depends_on_acc_no_distribute (replicating this chain would read a
-// different/frozen %acc_g in each new loop), but reached via nested-region
-// capture rather than a direct top-level operand -- the safety check must
-// walk into nested regions, not just each slice member's top-level operands,
-// to catch it.
+// carried_depends_on_acc_no_distribute, but reached via nested-region capture
+// rather than a direct top-level operand -- the safety check must walk into
+// nested regions, not just each slice member's top-level operands, to catch it.
+//
+// Why it is rejected rather than placed in the loop that owns %acc_g: carried
+// chains are replicated into BOTH distributed loops and their result is taken
+// from the first one, so this chain would read the frozen pass-through %acc_g
+// slot in the second loop. Keeping it in the first loop only would need
+// per-iter_arg ownership (clone into the owning loop, freeze the slot in the
+// other, wire the result from the owner) plus a check that the other loop never
+// reads that iter_arg; see the follow-up issue.
 // CHECK-LABEL: @carried_captures_accumulator_no_distribute
 // CHECK: scf.for
 // CHECK:   tt.dot

--- a/test/TritonIntelGPU/LoopDistribute/region_capture.mlir
+++ b/test/TritonIntelGPU/LoopDistribute/region_capture.mlir
@@ -1,0 +1,139 @@
+// RUN: triton-opt %s -split-input-file -tritonintelgpu-loop-distribute | FileCheck %s
+
+// Test: %wg is computed by an scf.if whose then-branch captures a pure chain
+// (arith.sitofp/arith.truncf/tt.splat) defined earlier in the loop body via a
+// plain SSA reference into the nested region, not as an scf.if operand. Since
+// the scf.if is pure (no side effects) and everything it captures is pure,
+// it must be cloned -- together with the captured chain -- into the loop that
+// needs %wg (the loop computing dot0). No crash, correct distribution.
+// CHECK-LABEL: @region_capture_pure
+// CHECK: scf.for
+// CHECK:   %[[X1:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[KF:.*]] = arith.sitofp
+// CHECK:   %[[KB:.*]] = arith.truncf %[[KF]]
+// CHECK:   %[[SPLAT:.*]] = tt.splat %[[KB]]
+// CHECK:   %[[WG:.*]] = scf.if
+// CHECK:     arith.mulf %[[SPLAT]]
+// CHECK:   tt.dot %[[X1]], %[[WG]]
+// CHECK-NOT: tt.dot
+// CHECK:   scf.yield
+// CHECK: scf.for
+// CHECK:   %[[X2:.*]] = tt.descriptor_load %arg0
+// CHECK-NOT: scf.if
+// CHECK:   %[[WFC:.*]] = tt.descriptor_load %arg1
+// CHECK:   tt.dot %[[X2]], %[[WFC]]
+// CHECK-NOT: tt.dot
+// CHECK:   scf.yield
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @region_capture_pure(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %cond: i1) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %cstb = arith.constant dense<1.000000e+00> : tensor<64x128xbf16>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:2 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      // Pure chain, only used from *inside* the scf.if region below (a capture,
+      // not an operand of scf.if).
+      %kf = arith.sitofp %k : i32 to f32
+      %kb = arith.truncf %kf : f32 to bf16
+      %splat = tt.splat %kb : bf16 -> tensor<64x128xbf16>
+      %wg = scf.if %cond -> tensor<64x128xbf16> {
+        %t = arith.mulf %splat, %cstb : tensor<64x128xbf16>
+        scf.yield %t : tensor<64x128xbf16>
+      } else {
+        scf.yield %cstb : tensor<64x128xbf16>
+      }
+      %wfc = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: negative control for region_capture_pure. Here the value captured by
+// the scf.if (%wraw) is a *volatile* load, which isReplicable rejects
+// unconditionally -- unlike tt.descriptor_load/tt.descriptor_gather, which
+// have an unconditional allow-carve-out regardless of purity, a volatile
+// tt.load is never replicable. This must still be rejected (loop not
+// distributed) -- non-replicable captured chains are not cloned.
+// CHECK-LABEL: @region_capture
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @region_capture(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.tensordesc<64x128xbf16>, %cond: i1) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %cstb = arith.constant dense<1.000000e+00> : tensor<64x128xbf16>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %wraw_ptrs = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<64x128x!tt.ptr<bf16>>
+    %0:2 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wraw = tt.load %wraw_ptrs {isVolatile = true} : tensor<64x128x!tt.ptr<bf16>>
+      // %wraw is captured by the scf.if region, it is NOT an operand of scf.if.
+      %wg = scf.if %cond -> tensor<64x128xbf16> {
+        %t = arith.mulf %wraw, %cstb : tensor<64x128xbf16>
+        scf.yield %t : tensor<64x128xbf16>
+      } else {
+        scf.yield %cstb : tensor<64x128xbf16>
+      }
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: a carried, non-accumulator chain (%carry, index 2) reads dot0's
+// accumulator (%acc_g) only as a REGION CAPTURE inside an scf.if's body --
+// %acc_g is referenced directly from the then-branch, it is NOT passed as a
+// formal top-level operand of the scf.if (whose only top-level operand is
+// %cond). This is the same hazard as invalid.mlir's
+// carried_depends_on_acc_no_distribute (replicating this chain would read a
+// different/frozen %acc_g in each new loop), but reached via nested-region
+// capture rather than a direct top-level operand -- the safety check must
+// walk into nested regions, not just each slice member's top-level operands,
+// to catch it.
+// CHECK-LABEL: @carried_captures_accumulator_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @carried_captures_accumulator_no_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>, %cond: i1) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:3 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst, %carry = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      // %acc_g is captured directly inside the scf.if's region body -- it is
+      // NOT a formal top-level operand of the scf.if (only %cond is).
+      %new_carry = scf.if %cond -> tensor<128x128xf32> {
+        %t = arith.addf %acc_g, %acc_g : tensor<128x128xf32>
+        scf.yield %t : tensor<128x128xf32>
+      } else {
+        scf.yield %carry : tensor<128x128xf32>
+      }
+      scf.yield %d0, %d1, %new_carry : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}

--- a/test/TritonIntelGPU/LoopDistribute/region_capture.mlir
+++ b/test/TritonIntelGPU/LoopDistribute/region_capture.mlir
@@ -64,6 +64,7 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // CHECK-LABEL: @region_capture
 // CHECK: scf.for
 // CHECK:   tt.dot
+// CHECK-NOT: scf.for
 // CHECK:   tt.dot
 // CHECK:   scf.yield
 // CHECK-NOT: scf.for
@@ -109,6 +110,7 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // CHECK-LABEL: @carried_captures_accumulator_no_distribute
 // CHECK: scf.for
 // CHECK:   tt.dot
+// CHECK-NOT: scf.for
 // CHECK:   tt.dot
 // CHECK:   scf.yield
 // CHECK-NOT: scf.for

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LoopDistribute.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LoopDistribute.cpp
@@ -64,6 +64,22 @@ bool isReplicable(Operation *op) {
   return false;
 }
 
+/// Returns true if any op in `slice` -- including inside nested regions --
+/// has `val` among its operands.
+bool sliceUsesValue(const DenseSet<Operation *> &slice, Value val) {
+  return llvm::any_of(slice, [&](Operation *op) {
+    bool found = false;
+    op->walk([&](Operation *nested) {
+      if (llvm::is_contained(nested->getOperands(), val)) {
+        found = true;
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    return found;
+  });
+}
+
 /// Try to distribute a for loop with exactly two dot operations into two
 /// separate loops. Returns true if the transformation was applied.
 bool tryDistributeLoop(scf::ForOp forOp) {
@@ -144,15 +160,35 @@ bool tryDistributeLoop(scf::ForOp forOp) {
     return false;
   }
 
+  BlockArgument accArg0 = forOp.getRegionIterArgs()[*idx0];
+  BlockArgument accArg1 = forOp.getRegionIterArgs()[*idx1];
+
+  // A dot's operand slice is rooted *at* its A/B operands, so the dot itself
+  // is never a member of that slice -- check its operands directly too. Its C
+  // operand is its own accumulator, never the foreign one, so scanning all
+  // three operands cannot over-reject.
+  auto dependsOnForeignAcc = [](tt::DotOp dot,
+                                const DenseSet<Operation *> &slice,
+                                BlockArgument foreignAcc) {
+    return llvm::is_contained(dot->getOperands(), foreignAcc) ||
+           sliceUsesValue(slice, foreignAcc);
+  };
+
+  if (dependsOnForeignAcc(dot0, slice0, accArg1)) {
+    LDBG("Skipping loop: dot0 depends on dot1's accumulator block argument");
+    return false;
+  }
+  if (dependsOnForeignAcc(dot1, slice1, accArg0)) {
+    LDBG("Skipping loop: dot1 depends on dot0's accumulator block argument");
+    return false;
+  }
+
   // Every other (non-accumulator) iter_arg is either a true pass-through
   // (yielded unchanged) or a chain that must be safely replicable into both
   // new loops. Chains that depend on either dot's result, or that read a
   // dot's accumulator block argument directly, cannot be replicated
   // correctly (each new loop only computes one accumulator), so reject the
   // whole loop in that case.
-  BlockArgument accArg0 = forOp.getRegionIterArgs()[*idx0];
-  BlockArgument accArg1 = forOp.getRegionIterArgs()[*idx1];
-
   DenseSet<Operation *> carriedUnion;
   for (unsigned i = 0, e = forOp.getNumRegionIterArgs(); i < e; ++i) {
     if (i == *idx0 || i == *idx1)
@@ -183,19 +219,8 @@ bool tryDistributeLoop(scf::ForOp forOp) {
     // Walk into nested regions too: a region-holding op (e.g. `scf.if`) may
     // read the accumulator as a captured value inside its region without
     // passing it as one of the op's own top-level operands.
-    bool usesAcc = llvm::any_of(carriedSlice, [&](Operation *op) {
-      bool found = false;
-      op->walk([&](Operation *nested) {
-        if (llvm::is_contained(nested->getOperands(), accArg0) ||
-            llvm::is_contained(nested->getOperands(), accArg1)) {
-          found = true;
-          return WalkResult::interrupt();
-        }
-        return WalkResult::advance();
-      });
-      return found;
-    });
-    if (usesAcc) {
+    if (sliceUsesValue(carriedSlice, accArg0) ||
+        sliceUsesValue(carriedSlice, accArg1)) {
       LDBG("Skipping loop: carried iter_arg "
            << i << " depends on a dot accumulator block argument");
       return false;

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LoopDistribute.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LoopDistribute.cpp
@@ -1,6 +1,7 @@
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/IRMapping.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Debug.h"
 
@@ -54,14 +55,24 @@ void collectBackwardSlice(Value root, Block *loopBody,
 
 /// Returns true if `op` may be executed more than once without changing
 /// program behavior (i.e., it is safe to clone into both distributed loops).
+/// An op whose only memory effects are reads qualifies -- repeating a read is
+/// observationally equivalent -- and this is checked recursively, so a region
+/// op (e.g. an `scf.if`) that merely loads is replicable even though it is not
+/// pure. Writes, allocations and unknown effects are not replicable. Note that
+/// a volatile `tt.load` declares a Write effect (see `LoadOp::getEffects`)
+/// precisely so that it is neither duplicated nor reordered, so it is rejected
+/// here.
 bool isReplicable(Operation *op) {
   if (isPure(op))
     return true;
-  if (auto load = dyn_cast<tt::LoadOp>(op))
-    return !load.getIsVolatile();
-  if (isa<tt::DescriptorLoadOp, tt::DescriptorGatherOp>(op))
-    return true;
-  return false;
+  std::optional<SmallVector<MemoryEffects::EffectInstance>> effects =
+      getEffectsRecursively(op);
+  if (!effects)
+    return false;
+  return llvm::all_of(*effects,
+                      [](const MemoryEffects::EffectInstance &effect) {
+                        return isa<MemoryEffects::Read>(effect.getEffect());
+                      });
 }
 
 /// Returns true if any op in `slice` -- including inside nested regions --

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LoopDistribute.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LoopDistribute.cpp
@@ -1,5 +1,7 @@
+#include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/IRMapping.h"
+#include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Debug.h"
 
 #include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h"
@@ -17,27 +19,49 @@ namespace tt = mlir::triton;
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
+STATISTIC(NumLoopsDistributed, "Number of loops distributed");
+
 namespace {
 
-/// Walk backwards from a dot's operands to find all ops in the loop body
-/// that feed into it (excluding the induction variable and iter_args).
-void collectBackwardSlice(tt::DotOp dot, Block *loopBody,
+/// Computes the backward slice of `root` -- i.e. the ops it transitively
+/// depends on, including its own defining op -- following values captured
+/// from inside nested regions (e.g. an `scf.if` that reads a value defined
+/// earlier in the loop body via a plain SSA reference into its region,
+/// rather than as an explicit operand of the `scf.if` itself). Every op in
+/// the raw slice is mapped to its ancestor that is a direct child of
+/// `loopBody` (an op nested inside e.g. an `scf.if` maps to that `scf.if`
+/// itself, since that is what actually gets cloned at the top level). Ops
+/// defined above the loop are dropped -- there is nothing to clone for them.
+void collectBackwardSlice(Value root, Block *loopBody,
                           DenseSet<Operation *> &slice) {
-  SmallVector<Value> worklist;
-  // Add A and B operands (not C — that's the accumulator/iter_arg).
-  worklist.push_back(dot.getA());
-  worklist.push_back(dot.getB());
+  SetVector<Operation *> rawSlice;
+  BackwardSliceOptions options;
+  // The induction variable and iter_args are handled explicitly by the
+  // caller, not by walking into them here.
+  options.omitBlockArguments = true;
+  // Follow values captured from above by nested regions (e.g. an scf.if
+  // that reads a loop-body value without passing it as a region operand).
+  options.omitUsesFromAbove = false;
+  // Include root's own defining op, not just its transitive defs.
+  options.inclusive = true;
+  (void)getBackwardSlice(root, &rawSlice, options);
 
-  while (!worklist.empty()) {
-    Value val = worklist.pop_back_val();
-    Operation *defOp = val.getDefiningOp();
-    if (!defOp || defOp->getBlock() != loopBody)
-      continue;
-    if (!slice.insert(defOp).second)
-      continue;
-    for (Value operand : defOp->getOperands())
-      worklist.push_back(operand);
+  for (Operation *op : rawSlice) {
+    if (Operation *anchor = loopBody->findAncestorOpInBlock(*op))
+      slice.insert(anchor);
   }
+}
+
+/// Returns true if `op` may be executed more than once without changing
+/// program behavior (i.e., it is safe to clone into both distributed loops).
+bool isReplicable(Operation *op) {
+  if (isPure(op))
+    return true;
+  if (auto load = dyn_cast<tt::LoadOp>(op))
+    return !load.getIsVolatile();
+  if (isa<tt::DescriptorLoadOp, tt::DescriptorGatherOp>(op))
+    return true;
+  return false;
 }
 
 /// Try to distribute a for loop with exactly two dot operations into two
@@ -96,14 +120,20 @@ bool tryDistributeLoop(scf::ForOp forOp) {
     LDBG("Skipping loop: dot accumulators are not direct iter_args");
     return false;
   }
+  if (*idx0 == *idx1) {
+    LDBG("Skipping loop: both dots accumulate into the same iter_arg");
+    return false;
+  }
 
   LDBG("Found distributable loop with dots at iter_arg indices "
        << *idx0 << " and " << *idx1);
 
   // Compute the backward slice for each dot (ops that feed A/B operands).
   DenseSet<Operation *> slice0, slice1;
-  collectBackwardSlice(dot0, body, slice0);
-  collectBackwardSlice(dot1, body, slice1);
+  collectBackwardSlice(dot0.getA(), body, slice0);
+  collectBackwardSlice(dot0.getB(), body, slice0);
+  collectBackwardSlice(dot1.getA(), body, slice1);
+  collectBackwardSlice(dot1.getB(), body, slice1);
 
   // Check that the two slices don't have conflicting dependencies
   // (i.e., one dot's result feeds into the other dot's inputs).
@@ -114,16 +144,91 @@ bool tryDistributeLoop(scf::ForOp forOp) {
     return false;
   }
 
-  // Verify there are no other ops with side effects that we can't classify.
+  // Every other (non-accumulator) iter_arg is either a true pass-through
+  // (yielded unchanged) or a chain that must be safely replicable into both
+  // new loops. Chains that depend on either dot's result, or that read a
+  // dot's accumulator block argument directly, cannot be replicated
+  // correctly (each new loop only computes one accumulator), so reject the
+  // whole loop in that case.
+  BlockArgument accArg0 = forOp.getRegionIterArgs()[*idx0];
+  BlockArgument accArg1 = forOp.getRegionIterArgs()[*idx1];
+
+  DenseSet<Operation *> carriedUnion;
+  for (unsigned i = 0, e = forOp.getNumRegionIterArgs(); i < e; ++i) {
+    if (i == *idx0 || i == *idx1)
+      continue;
+
+    Value carriedVal = yieldOp.getOperand(i);
+    if (carriedVal == forOp.getRegionIterArgs()[i]) {
+      // True pass-through: nothing to clone, no slice needed.
+      continue;
+    }
+
+    if (carriedVal == accArg0 || carriedVal == accArg1) {
+      LDBG("Skipping loop: carried iter_arg "
+           << i << " is itself a dot accumulator block argument");
+      return false;
+    }
+
+    DenseSet<Operation *> carriedSlice;
+    collectBackwardSlice(carriedVal, body, carriedSlice);
+
+    if (carriedSlice.contains(dot0.getOperation()) ||
+        carriedSlice.contains(dot1.getOperation())) {
+      LDBG("Skipping loop: carried iter_arg " << i
+                                              << " depends on a dot result");
+      return false;
+    }
+
+    // Walk into nested regions too: a region-holding op (e.g. `scf.if`) may
+    // read the accumulator as a captured value inside its region without
+    // passing it as one of the op's own top-level operands.
+    bool usesAcc = llvm::any_of(carriedSlice, [&](Operation *op) {
+      bool found = false;
+      op->walk([&](Operation *nested) {
+        if (llvm::is_contained(nested->getOperands(), accArg0) ||
+            llvm::is_contained(nested->getOperands(), accArg1)) {
+          found = true;
+          return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+      });
+      return found;
+    });
+    if (usesAcc) {
+      LDBG("Skipping loop: carried iter_arg "
+           << i << " depends on a dot accumulator block argument");
+      return false;
+    }
+
+    carriedUnion.insert(carriedSlice.begin(), carriedSlice.end());
+  }
+
+  // Every top-level op must be classified: it is either one of the two
+  // dots, a member of a dot-operand slice, or a member of a carried chain.
+  // The canonicalizer already ran, so no dead ops should exist here -- an
+  // unclassified op means we cannot prove it is safe to drop, so reject.
+  DenseSet<Operation *> allSlices;
+  allSlices.insert(slice0.begin(), slice0.end());
+  allSlices.insert(slice1.begin(), slice1.end());
+  allSlices.insert(carriedUnion.begin(), carriedUnion.end());
+
   for (Operation &op : *body) {
-    if (&op == body->getTerminator())
+    if (&op == body->getTerminator() || &op == dot0.getOperation() ||
+        &op == dot1.getOperation())
       continue;
-    if (isa<tt::DotOp>(op))
-      continue;
-    if (slice0.contains(&op) || slice1.contains(&op))
-      continue;
-    if (!isPure(&op)) {
-      LDBG("Skipping loop: contains unclassified side-effecting op: " << op);
+    if (!allSlices.contains(&op)) {
+      LDBG("Skipping loop: unclassified op (neither a dot-operand slice nor "
+           "a carried chain member): "
+           << op);
+      return false;
+    }
+  }
+
+  // Every slice member must be safe to clone into both new loops.
+  for (Operation *op : allSlices) {
+    if (!isReplicable(op)) {
+      LDBG("Skipping loop: slice member is not safely replicable: " << *op);
       return false;
     }
   }
@@ -132,10 +237,12 @@ bool tryDistributeLoop(scf::ForOp forOp) {
 
   // Each distributed loop keeps all original iter_args but only computes
   // its target dot, yielding the iter_arg unchanged for the other position.
+  // Carried (non-accumulator) chains are replicated identically into both
+  // loops.
 
   auto buildDistributedLoop = [&](tt::DotOp targetDot, unsigned targetIdx,
                                   unsigned otherIdx,
-                                  DenseSet<Operation *> &targetSlice,
+                                  const DenseSet<Operation *> &targetSlice,
                                   ValueRange initArgs) {
     // Use the ForOp builder callback to construct the body inline.
     // This avoids issues with empty blocks and missing terminators.
@@ -153,28 +260,44 @@ bool tryDistributeLoop(scf::ForOp forOp) {
             mapping.map(oldArg, newArg);
           }
 
-          // Clone ops in original order, but only those in the target slice
-          // or the target dot.
+          // Clone ops in original order: this loop's own dot-operand slice
+          // plus every carried-chain op (carried chains are replicated
+          // identically into both distributed loops), plus the target dot.
           for (Operation &op : *body) {
             if (&op == body->getTerminator())
               continue;
-            if (targetSlice.contains(&op) || &op == targetDot.getOperation()) {
+            if (targetSlice.contains(&op) || carriedUnion.contains(&op) ||
+                &op == targetDot.getOperation()) {
               b.clone(op, mapping);
             }
           }
 
-          // Build yield: for the target iter_arg, yield the dot result;
-          // for all others, yield the iter_arg itself (pass-through).
+          // Build yield: for the target iter_arg, yield the dot result; for
+          // the other dot's accumulator, pass it through unchanged (its
+          // real value comes from the other distributed loop, this loop's
+          // copy is dead); for a true pass-through carried iter_arg, yield
+          // it unchanged; otherwise resolve the carried chain's cloned
+          // result through the mapping.
           SmallVector<Value> yieldOperands;
           for (unsigned i = 0; i < forOp.getNumRegionIterArgs(); ++i) {
             if (i == targetIdx) {
               yieldOperands.push_back(mapping.lookup(targetDot.getResult()));
-            } else {
+            } else if (i == otherIdx) {
               yieldOperands.push_back(iterArgs[i]);
+            } else if (yieldOp.getOperand(i) == forOp.getRegionIterArgs()[i]) {
+              yieldOperands.push_back(iterArgs[i]);
+            } else {
+              yieldOperands.push_back(
+                  mapping.lookupOrDefault(yieldOp.getOperand(i)));
             }
           }
           scf::YieldOp::create(b, loc, yieldOperands);
         });
+
+    // Both new loops have the same trip count as the original, so the same
+    // stage/unroll-factor intent (and any other discardable attributes)
+    // applies to each.
+    newForOp->setDiscardableAttrs(forOp->getDiscardableAttrDictionary());
 
     builder.setInsertionPointAfter(newForOp);
     return newForOp;
@@ -205,6 +328,7 @@ bool tryDistributeLoop(scf::ForOp forOp) {
   forOp.erase();
 
   LDBG("Successfully distributed loop into two loops");
+  ++NumLoopsDistributed;
   return true;
 }
 
@@ -218,9 +342,14 @@ public:
   void runOnOperation() override {
     ModuleOp mod = getOperation();
 
-    // Collect loops first to avoid modifying while walking.
+    // Collect loops first to avoid modifying while walking. Post-order
+    // (the default, made explicit here) visits inner loops before outer
+    // loops, so a nested loop is recorded before any outer loop that
+    // contains it gets erased -- avoiding stale handles into an erased
+    // outer loop's body.
     SmallVector<scf::ForOp> loops;
-    mod.walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
+    mod.walk<WalkOrder::PostOrder>(
+        [&](scf::ForOp forOp) { loops.push_back(forOp); });
 
     for (scf::ForOp forOp : loops) {
       tryDistributeLoop(forOp);


### PR DESCRIPTION
Replace the pass's ad-hoc backward-slice walker and isPure-based drop/clone
guard with mlir::getBackwardSlice + explicit classification of every loop
body op. Fixes: frozen (not replicated) loop-carried non-accumulator
iter_args producing wrong results; silent deletion of unrecognized pure ops
(now rejected instead); a crash on values captured into nested regions
(e.g. scf.if); dropped tt.num_stages/tt.loop_unroll_factor on output loops;
unchecked duplication of side-effecting slice members. Also closes a gap
found in review where a carried chain's accumulator dependency could be
missed if read only through a nested-region capture.

Add lit tests for each fixed defect and an end-to-end numerics test.

Fixes #7750