### PR TITLE
[AxisInfo] Clamp remainder divisibility to the result contiguity

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -521,7 +521,26 @@ private:
       // rhs: d_rhs * p = gcd(d_lhs, d_rhs) * p' * p = gcd(d_lhs, d_rhs) * p''
       // lhs = gcd(d_lhs, d_rhs) * k'' = gcd(d_lhs, d_rhs) * d + r
       // r must be divisible by gcd(d_lhs, d_rhs)
-      return gcd(lhs.getDivisibility(dim), rhs.getDivisibility(dim));
+      int64_t divisibility =
+          gcd(lhs.getDivisibility(dim), rhs.getDivisibility(dim));
+      // The argument above holds for a dividend element that d_lhs divides,
+      // i.e. for the first element of a dividend contiguity group. Divisibility
+      // is a claim about the first element of a *result* group, so when an
+      // operand has contiguity larger than the result contiguity, a result
+      // group can start inside an operand group, on d_lhs * k + t, which
+      // gcd(d_lhs, d_rhs) need not divide. Clamp to the result contiguity, as
+      // the add/sub visitor above does.
+      // For example, a dividend of [0, 1, 2, 3, 8, 9, 10, 11] modulo 4 has
+      // result contiguity 1, so every element is a group start - including the
+      // 1, which only 1 divides.
+      // Operands that are no coarser than the result need no clamping: every
+      // result group start is then also an operand group start, where d_lhs and
+      // d_rhs both apply.
+      int64_t contiguity = getContiguity(op, lhs, rhs, dim);
+      if (lhs.getContiguity(dim) > contiguity ||
+          rhs.getContiguity(dim) > contiguity)
+        return gcd(divisibility, contiguity);
+      return divisibility;
     }
     // Otherwise we shouldn't assume any divisibility.
     // For example:

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -270,6 +270,35 @@ tt.func @rem() {
   %15 = arith.remsi %12, %4 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %16 = arith.remsi %4, %12 : tensor<128xi32>
+  // COM: %5 is 0, 1, ..., 63, 0, 1, ..., 63, so only every 64th element is
+  // COM: divisible by 64 - which is exactly what contiguity 64 records. Feeding
+  // COM: it back into a remainder loses that contiguity, because the dividend is
+  // COM: no longer contiguous over the whole dimension, so every element becomes
+  // COM: the start of its own group and the divisibility claim would have to hold
+  // COM: for the 1 at index 1 as well. gcd(d_lhs, d_rhs) = 64 is only valid at
+  // COM: the group starts of the dividend; clamping to the result contiguity is
+  // COM: what brings it back to 1.
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  %17 = arith.remui %5, %4 : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  %18 = arith.remsi %5, %4 : tensor<128xi32>
+  // COM: A dividend with contiguity 1 is divisible by its divisibility in every
+  // COM: element, so no result group can start inside a dividend group and the
+  // COM: deduction needs no clamping.
+  // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [1], constant_value = <none>}}
+  %19 = arith.muli %0, %4 : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [1], constant_value = <none>}}
+  %20 = arith.remui %19, %4 : tensor<128xi32>
+  // COM: 256, 257, ..., 383 modulo 512 is unchanged, one group of 128 starting at
+  // COM: 256. The dividend is no coarser than the result, so its group starts and
+  // COM: the result group starts coincide and gcd(d_lhs, d_rhs) = 256 needs no
+  // COM: clamping - clamping to the result contiguity would report 128.
+  // expected-remark @below {{contiguity = [128], divisibility = [256], constancy = [1], constant_value = <none>}}
+  %21 = tt.make_range {end = 384 : i32, start = 256 : i32} : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [512], constancy = [128], constant_value = 512}}
+  %22 = arith.constant dense<512> : tensor<128xi32>
+  // expected-remark @below {{contiguity = [128], divisibility = [256], constancy = [1], constant_value = <none>}}
+  %23 = arith.remui %21, %22 : tensor<128xi32>
   tt.return
 }
 


### PR DESCRIPTION
`RemOpAxisInfoVisitor::getDivisibility` deduces gcd(d_lhs, d_rhs) from a dividend divisible by d_lhs and a divisor divisible by d_rhs. That argument only applies to a dividend element that d_lhs actually divides, i.e. to the first element of a dividend contiguity group, but divisibility is a claim about the first element of a *result* group. When the dividend has contiguity larger than the result contiguity, a result group starts inside a dividend group, on d_lhs * k + t, which the deduced value need not divide.

For example, a dividend of [0, 1, 2, 3, 8, 9, 10, 11] (contiguity 4, divisibility 4) modulo 4 was reported as divisibility 4 with contiguity 1, while the result is [0, 1, 2, 3, 0, ...]: every element is a group start and only 1 divides the 1.

Clamp the deduction to the result contiguity, exactly as the add/sub visitor already does for the same reason.