### PR TITLE
[CI] Fix triton-benchmarks concurrency group cancelling across GPU targets

### DIFF
--- a/.github/workflows/triton-benchmarks.yml
+++ b/.github/workflows/triton-benchmarks.yml
@@ -62,7 +62,7 @@ on:
 
 # Cancels in-progress PR runs when the PR is updated. Manual runs are never cancelled.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'keep-going') && github.run_id || github.event.pull_request.number) || github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.runner_label }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'keep-going') && github.run_id || github.event.pull_request.number) || github.ref }}
   cancel-in-progress: true
 
 permissions: read-all


### PR DESCRIPTION
When `on-label.yml` calls `triton-benchmarks.yml` twice (once for BMG, once for PVC), the reusable workflow's concurrency group resolved to the same value (`On label-<PR#>`) for both invocations, causing `cancel-in-progress: true` to kill whichever started first.

Add `inputs.runner_label` to the concurrency group key in `triton-benchmarks.yml` so each GPU target (b580, max1550) gets its own concurrency group.