### PR TITLE
[TritonIntelGPU] Fix arith.bitcast on multi-element tensors in LLVM l…

### DIFF
--- a/test/Conversion/intel/arith_bitcast_tensor.mlir
+++ b/test/Conversion/intel/arith_bitcast_tensor.mlir
@@ -1,0 +1,59 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-intel-gpu-to-llvm | FileCheck %s
+
+// Regression test: arith.bitcast on a tensor whose per-thread register count > 1
+// must be lowered element-wise (one scalar llvm.bitcast per element).
+//
+// Root cause: mlir::arith::populateArithToLLVMConversionPatterns registers
+// BitcastOpLowering (benefit=1) which calls
+//   rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, llvmDstTy, adaptor.getIn())
+// When sizePerThread > 1 the tensor is represented as an LLVM struct, so
+// llvmDstTy is also a struct and the result is:
+//   llvm.bitcast !llvm.struct<(bf16,bf16)> to !llvm.struct<(i16,i16)>
+// LLVM rejects this with:
+//   error: 'llvm.bitcast' op operand #0 must be LLVM-compatible non-aggregate type
+//
+// The fix (ArithBitcastOpConversion, benefit=patternBenefitPrioritizeOverLLVMConversions)
+// overrides the upstream pattern and uses ElementwiseOpConversionBase to unpack
+// the struct, scalar-bitcast each element, and repack—producing:
+//   llvm.bitcast %elem : bf16 to i16   (repeated per element)
+
+// Two elements per thread → struct<(bf16, bf16)>
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttig.support_2d_block_io", "ttig.support_subgroup_matrix_multiply_accumulate", "ttig.support_bfloat16_conversion", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @bitcast_bf16_to_i16
+  // Input tensor lowers to struct<(bf16, bf16)>. The fix extracts each element,
+  // applies a scalar bitcast (valid in LLVM), then repacks.
+  // CHECK: llvm.extractvalue {{.*}} : !llvm.struct<(bf16, bf16)>
+  // CHECK: llvm.extractvalue {{.*}} : !llvm.struct<(bf16, bf16)>
+  // CHECK: llvm.bitcast {{.*}} : bf16 to i16
+  // CHECK: llvm.bitcast {{.*}} : bf16 to i16
+  // CHECK: llvm.insertvalue {{.*}} : !llvm.struct<(i16, i16)>
+  // CHECK: llvm.insertvalue {{.*}} : !llvm.struct<(i16, i16)>
+  // COM: No struct-level bitcast — that would fail LLVM verification.
+  // CHECK-NOT: llvm.bitcast {{.*}} : !llvm.struct
+  tt.func @bitcast_bf16_to_i16(%arg0: tensor<256xbf16, #blocked>) -> tensor<256xi16, #blocked> {
+    %0 = arith.bitcast %arg0 : tensor<256xbf16, #blocked> to tensor<256xi16, #blocked>
+    tt.return %0 : tensor<256xi16, #blocked>
+  }
+}
+
+// -----
+
+// Also verify the reverse direction (i16 → bf16) works correctly.
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttig.support_2d_block_io", "ttig.support_subgroup_matrix_multiply_accumulate", "ttig.support_bfloat16_conversion", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @bitcast_i16_to_bf16
+  // CHECK: llvm.extractvalue {{.*}} : !llvm.struct<(i16, i16)>
+  // CHECK: llvm.extractvalue {{.*}} : !llvm.struct<(i16, i16)>
+  // CHECK: llvm.bitcast {{.*}} : i16 to bf16
+  // CHECK: llvm.bitcast {{.*}} : i16 to bf16
+  // CHECK: llvm.insertvalue {{.*}} : !llvm.struct<(bf16, bf16)>
+  // CHECK: llvm.insertvalue {{.*}} : !llvm.struct<(bf16, bf16)>
+  // CHECK-NOT: llvm.bitcast {{.*}} : !llvm.struct
+  tt.func @bitcast_i16_to_bf16(%arg0: tensor<256xi16, #blocked>) -> tensor<256xbf16, #blocked> {
+    %0 = arith.bitcast %arg0 : tensor<256xi16, #blocked> to tensor<256xbf16, #blocked>
+    tt.return %0 : tensor<256xbf16, #blocked>
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1501,10 +1501,6 @@ struct ExtFOpConversion
   }
 };
 
-// Element-wise arith.bitcast lowering for tensor types.
-// The upstream arith→LLVM pattern emits a single llvm.bitcast on the whole
-// LLVM struct, which is invalid (structs are aggregate types). This override
-// has higher benefit and does a scalar llvm.bitcast per tensor element instead.
 struct ArithBitcastOpConversion
     : ElementwiseOpConversionBase<arith::BitcastOp, ArithBitcastOpConversion> {
   using Base =

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1501,6 +1501,25 @@ struct ExtFOpConversion
   }
 };
 
+// Element-wise arith.bitcast lowering for tensor types.
+// The upstream arith→LLVM pattern emits a single llvm.bitcast on the whole
+// LLVM struct, which is invalid (structs are aggregate types). This override
+// has higher benefit and does a scalar llvm.bitcast per tensor element instead.
+struct ArithBitcastOpConversion
+    : ElementwiseOpConversionBase<arith::BitcastOp, ArithBitcastOpConversion> {
+  using Base =
+      ElementwiseOpConversionBase<arith::BitcastOp, ArithBitcastOpConversion>;
+  using Base::Base;
+  using Adaptor = typename Base::OpAdaptor;
+
+  SmallVector<Value> createDestOps(arith::BitcastOp op, OpAdaptor adaptor,
+                                   ConversionPatternRewriter &rewriter,
+                                   Type elemTy, MultipleOperandsRange operands,
+                                   Location loc) const {
+    return {LLVM::BitcastOp::create(rewriter, loc, elemTy, operands[0][0])};
+  }
+};
+
 struct TruncFOpConversion
     : ElementwiseOpConversionBase<arith::TruncFOp, TruncFOpConversion> {
   using Base = ElementwiseOpConversionBase<arith::TruncFOp, TruncFOpConversion>;
@@ -1922,6 +1941,8 @@ void populateElementwiseOpToLLVMPatterns(
   patterns.add<ElementwiseOpConversion<arith::SubFOp, LLVM::FSubOp>>(
       typeConverter, axisInfoAnalysis, benefit);
 
+  patterns.add<ArithBitcastOpConversion>(typeConverter, axisInfoAnalysis,
+                                         benefit);
   patterns.add<ExtFOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<TruncFOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<FPToSIOpConversion>(typeConverter, axisInfoAnalysis, benefit);


### PR DESCRIPTION
When arith.bitcast is applied to a tensor with sizePerThread > 1, the tensor is represented in LLVM as a struct (e.g. !llvm.struct<(bf16, bf16)>). The upstream arith→LLVM BitcastOpLowering (benefit=1) emits a single llvm.bitcast on the whole struct, which the LLVM verifier rejects:

  error: 'llvm.bitcast' op operand #0 must be LLVM-compatible non-aggregate type,
         but got '!llvm.struct<(bf16, bf16)>'

Fix: add ArithBitcastOpConversion at patternBenefitPrioritizeOverLLVMConversions, using ElementwiseOpConversionBase to extract each struct element, emit a scalar llvm.bitcast per element (always valid), then repack. This matches how all other elementwise arith ops (mulf, extf, truncf, etc.) are lowered in the Intel backend.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
