### PR TITLE
[XPU][DRIVER] Never unload `spirv_utils`: fixes GC segfault (#7682)

### DIFF
--- a/python/test/unit/intel/test_spirv_utils_no_unload_7682.py
+++ b/python/test/unit/intel/test_spirv_utils_no_unload_7682.py
@@ -19,9 +19,10 @@ Note the instances are deliberately *not* GC-tracked, and that does not help: th
 is the `Py_TYPE()` load that `visit_decref` performs before it can know whether the
 object is tracked.
 
-`ArchParser` and `ExtensionUtils` keep their unload on purpose. Their modules export no
-Python type, so unloading is safe there and still lets Windows delete the cached files
-(issue #3090, the reason the unload was introduced in #3230/#3251/#3455).
+`ArchParser` and `ExtensionUtils` keep their unload because they are out of scope here, not
+because they are proven safe: `ArchParser.__getattribute__` hands out a closure over the raw
+ctypes function that does not keep its owner alive, so a caller outliving the parser would
+call into an unloaded library.
 """
 import os
 import subprocess
@@ -29,14 +30,19 @@ import sys
 import textwrap
 
 import pytest
-import torch
 
 from triton.backends.intel import driver as intel_driver
 
-pytestmark = pytest.mark.skipif(
-    not (hasattr(torch, "xpu") and torch.xpu.is_available()),
-    reason="Intel XPU device not available",
-)
+
+def _xpu_available() -> bool:
+    # Imported lazily and defensively rather than at module scope: only the subprocess
+    # test needs a device, and the canary below must stay runnable wherever pytest runs
+    # -- including environments where `import torch` itself fails.
+    try:
+        import torch
+    except Exception:
+        return False
+    return hasattr(torch, "xpu") and torch.xpu.is_available()
 
 
 def test_spirv_utils_defines_no_destructor():
@@ -61,9 +67,38 @@ _CHILD = textwrap.dedent("""
 
     SO = "spirv_utils"
 
-    def mapped():
-        with open("/proc/self/maps") as fh:
-            return SO in fh.read()
+    if os.name == "nt":
+        # Windows counterpart of scanning /proc/self/maps: enumerate the modules mapped
+        # into this process and look for the same substring.
+        import ctypes
+        from ctypes import wintypes as w
+
+        _k32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        _psapi = ctypes.WinDLL("psapi", use_last_error=True)
+        _k32.GetCurrentProcess.restype = w.HANDLE
+        _psapi.EnumProcessModules.argtypes = [w.HANDLE, ctypes.POINTER(w.HMODULE), w.DWORD,
+                                              ctypes.POINTER(w.DWORD)]
+        _psapi.GetModuleFileNameExW.argtypes = [w.HANDLE, w.HMODULE, w.LPWSTR, w.DWORD]
+        _psapi.GetModuleFileNameExW.restype = w.DWORD
+
+        def mapped():
+            handle = _k32.GetCurrentProcess()
+            mods = (w.HMODULE * 8192)()
+            needed = w.DWORD()
+            if not _psapi.EnumProcessModules(handle, mods, ctypes.sizeof(mods),
+                                             ctypes.byref(needed)):
+                raise OSError("EnumProcessModules failed")
+            name = ctypes.create_unicode_buffer(32768)
+            count = min(needed.value // ctypes.sizeof(w.HMODULE), len(mods))
+            for i in range(count):
+                if _psapi.GetModuleFileNameExW(handle, mods[i], name, 32768) and SO in name.value:
+                    return True
+            return False
+    else:
+
+        def mapped():
+            with open("/proc/self/maps") as fh:
+                return SO in fh.read()
 
     @triton.jit
     def _add(x_ptr, y_ptr, o_ptr, n, BLOCK: tl.constexpr):
@@ -82,7 +117,8 @@ _CHILD = textwrap.dedent("""
     # Compile and launch on a thread that then exits. spirv_utils owns a non-POD
     # thread_local, so glibc pins the module against the thread that first touched it and
     # defers any unload until that thread is gone -- doing this on the main thread would
-    # mask a reintroduced unload and make this test silently green.
+    # mask a reintroduced unload and make this test silently green. Windows has no such
+    # deferral and unmaps immediately, so there the thread is merely harmless.
     worker = threading.Thread(target=workload)
     worker.start()
     worker.join()
@@ -116,12 +152,13 @@ _CHILD = textwrap.dedent("""
     """)
 
 
-@pytest.mark.skipif(sys.platform != "linux", reason="reads /proc/self/maps")
+@pytest.mark.skipif(not _xpu_available(), reason="Intel XPU device not available")
 def test_spirv_utils_survives_gc_after_teardown(tmp_path):
     """A GC pass after driver teardown must not fault: the module stays mapped.
 
-    Reintroducing `SpirvUtils.__del__` makes this child die with SIGSEGV (returncode
-    -11) instead of exiting cleanly -- verified on PVC against both revisions.
+    Reintroducing `SpirvUtils.__del__` makes this child die on a dangling `ob_type`
+    instead of exiting cleanly: SIGSEGV (returncode -11) on Linux, and an
+    `EXCEPTION_ACCESS_VIOLATION` (`0xC0000005`) on Windows -- verified on both.
     """
     script = tmp_path / "child.py"
     script.write_text(_CHILD)
@@ -130,6 +167,7 @@ def test_spirv_utils_survives_gc_after_teardown(tmp_path):
                             env={**os.environ, "PYTHONFAULTHANDLER": "1"})
 
     assert result.returncode == 0, (f"child exited with {result.returncode} "
-                                    f"(negative means a fatal signal; -11 is the #7682 SIGSEGV)\n"
+                                    f"(-11 is the #7682 SIGSEGV on Linux; "
+                                    f"{0xC0000005} / -1073741819 is the same fault on Windows)\n"
                                     f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
     assert "OK" in result.stdout, f"child did not reach the end:\n{result.stdout}\n{result.stderr}"

--- a/python/test/unit/intel/test_spirv_utils_no_unload_7682.py
+++ b/python/test/unit/intel/test_spirv_utils_no_unload_7682.py
@@ -1,0 +1,135 @@
+"""Regression test: `spirv_utils` must never be unloaded from the process.
+
+https://github.com/intel/intel-xpu-backend-for-triton/issues/7682
+
+`driver.c` defines `PyKernelArgType` as a *statically allocated* `PyTypeObject`
+(`Py_TPFLAGS_DEFAULT`, `PyType_Ready`), so the type object's storage is a data-segment
+address inside the JIT-compiled `spirv_utils` shared object. Instances of that type are
+created per compiled kernel by `annotate_arguments()` and kept alive for the lifetime of
+the kernel in `XPULauncher.arg_annotations`, and they travel inside the launch-args tuple.
+
+`SpirvUtils` used to define a `__del__` that `dlclose()`d (POSIX) / `FreeLibrary()`d
+(Windows) that shared object. Unloading it frees the type object's storage while
+instances remain reachable, so the next cyclic-GC pass over any tuple holding one runs
+`tupletraverse` -> `visit_decref` -> `_PyObject_IS_GC` -> `Py_TYPE(op)` and dereferences a
+dangling `ob_type`, killing the interpreter with
+`Fatal Python error: Segmentation fault`.
+
+Note the instances are deliberately *not* GC-tracked, and that does not help: the fault
+is the `Py_TYPE()` load that `visit_decref` performs before it can know whether the
+object is tracked.
+
+`ArchParser` and `ExtensionUtils` keep their unload on purpose. Their modules export no
+Python type, so unloading is safe there and still lets Windows delete the cached files
+(issue #3090, the reason the unload was introduced in #3230/#3251/#3455).
+"""
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+import torch
+
+from triton.backends.intel import driver as intel_driver
+
+pytestmark = pytest.mark.skipif(
+    not (hasattr(torch, "xpu") and torch.xpu.is_available()),
+    reason="Intel XPU device not available",
+)
+
+
+def test_spirv_utils_defines_no_destructor():
+    """The canary: catches anyone "restoring consistency" with the sibling classes.
+
+    The fix is a deletion, so this is the only check that runs on every platform and
+    fails fast if a `__del__` comes back. It also pins the deliberate asymmetry: the two
+    classes whose modules export no Python type still unload.
+    """
+    assert not hasattr(intel_driver.SpirvUtils,
+                       "__del__"), ("SpirvUtils must not define __del__: unloading spirv_utils frees PyKernelArgType "
+                                    "while its instances are still reachable. See issue #7682.")
+    assert hasattr(intel_driver.ArchParser, "__del__")
+    assert hasattr(intel_driver.ExtensionUtils, "__del__")
+
+
+# Runs in a subprocess because a regression here is a SIGSEGV, not an exception.
+_CHILD = textwrap.dedent("""
+    import gc, os, threading, sys
+    import torch, triton, triton.language as tl
+    from triton.backends.intel import driver as drv
+
+    SO = "spirv_utils"
+
+    def mapped():
+        with open("/proc/self/maps") as fh:
+            return SO in fh.read()
+
+    @triton.jit
+    def _add(x_ptr, y_ptr, o_ptr, n, BLOCK: tl.constexpr):
+        off = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+        m = off < n
+        tl.store(o_ptr + off, tl.load(x_ptr + off, mask=m) + tl.load(y_ptr + off, mask=m), mask=m)
+
+    def workload():
+        x = torch.randn(8192, device="xpu")
+        y = torch.randn(8192, device="xpu")
+        o = torch.empty_like(x)
+        _add[(8, )](x, y, o, x.numel(), BLOCK=1024)
+        torch.xpu.synchronize()
+        assert torch.allclose(o, x + y)
+
+    # Compile and launch on a thread that then exits. spirv_utils owns a non-POD
+    # thread_local, so glibc pins the module against the thread that first touched it and
+    # defers any unload until that thread is gone -- doing this on the main thread would
+    # mask a reintroduced unload and make this test silently green.
+    worker = threading.Thread(target=workload)
+    worker.start()
+    worker.join()
+
+    launchers = [o for o in gc.get_objects()
+                 if type(o) is drv.XPULauncher and getattr(o, "arg_annotations", None)]
+    assert launchers, "no XPULauncher with annotations -- test would prove nothing"
+
+    # A GC-tracked tuple standing in for the Triton/inductor caches that keep
+    # PyKernelArg instances alive in a long-running process. The list co-resident in the
+    # tuple is what keeps it tracked; a tuple of only untracked items gets untracked.
+    HOLDER = (0, [ln.arg_annotations for ln in launchers], drv.PyKernelArg)
+    assert gc.is_tracked(HOLDER)
+
+    assert mapped(), "spirv_utils should be mapped after running a kernel"
+
+    # Do what interpreter finalization does, then invoke any destructor that exists --
+    # CPython would run it at a moment of its own choosing, which is precisely why its
+    # existence is the bug.
+    spirv = triton.runtime.driver.active.utils.load_binary.__self__
+    destructor = getattr(type(spirv), "__del__", None)
+    drv.XPUUtils._instance = None
+    if destructor is not None:
+        destructor(spirv)
+
+    gc.collect()
+    gc.collect()
+
+    assert mapped(), "spirv_utils was unloaded while PyKernelArg instances were alive"
+    print("OK")
+    """)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="reads /proc/self/maps")
+def test_spirv_utils_survives_gc_after_teardown(tmp_path):
+    """A GC pass after driver teardown must not fault: the module stays mapped.
+
+    Reintroducing `SpirvUtils.__del__` makes this child die with SIGSEGV (returncode
+    -11) instead of exiting cleanly -- verified on PVC against both revisions.
+    """
+    script = tmp_path / "child.py"
+    script.write_text(_CHILD)
+
+    result = subprocess.run([sys.executable, str(script)], capture_output=True, text=True,
+                            env={**os.environ, "PYTHONFAULTHANDLER": "1"})
+
+    assert result.returncode == 0, (f"child exited with {result.returncode} "
+                                    f"(negative means a fatal signal; -11 is the #7682 SIGSEGV)\n"
+                                    f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+    assert "OK" in result.stdout, f"child did not reach the end:\n{result.stdout}\n{result.stderr}"

--- a/third_party/intel/backend/driver.py
+++ b/third_party/intel/backend/driver.py
@@ -318,20 +318,32 @@ class SpirvUtils:
             else:
                 raise e
 
-    if os.name != 'nt':
-
-        def __del__(self):
-            if hasattr(self, "shared_library"):
-                handle = self.shared_library._handle
-                self.shared_library.dlclose.argtypes = (ctypes.c_void_p, )
-                self.shared_library.dlclose(handle)
-    else:
-
-        def __del__(self):
-            if hasattr(self, "shared_library"):
-                handle = self.shared_library._handle
-                ctypes.windll.kernel32.FreeLibrary.argtypes = (ctypes.c_uint64, )
-                ctypes.windll.kernel32.FreeLibrary(handle)
+    # Deliberately no `__del__`: `spirv_utils` must never be unloaded.
+    #
+    # `driver.c` defines the statically allocated `PyKernelArgType`, and instances of it
+    # are cached for the lifetime of every compiled kernel (`XPULauncher.arg_annotations`).
+    # Unloading the module frees the storage of that type object while those instances are
+    # still reachable, so the next cyclic-GC pass dereferences a dangling `ob_type` and the
+    # interpreter dies with `Fatal Python error: Segmentation fault`
+    # (`tupletraverse` -> `visit_decref` -> `_PyObject_IS_GC` -> `Py_TYPE`).
+    # See https://github.com/intel/intel-xpu-backend-for-triton/issues/7682 and
+    # https://github.com/python/cpython/issues/114538.
+    #
+    # The type is not the only thing here that outlives an unload, so do not "fix" this by
+    # moving `PyKernelArgType` into Python and restoring the unload: `load_binary` returns
+    # capsules whose destructors (`freeKernel`, `freeKernelBundle`) and whose name strings
+    # live in this module, and every `XPULauncher` holds callables from it. Unloading is safe
+    # only once nothing reachable from Python can reference this module's code or storage.
+    #
+    # Windows is why this unload existed (#3090: a mapped `.pyd` cannot be deleted), so do not
+    # restore it for that reason either. Nothing here needs it any more: `runtime/cache.py`
+    # tolerates the `PermissionError` from `os.replace` on `nt`, and the `fresh_triton_cache`
+    # fixtures defer cache deletion past process exit (#7312).
+    #
+    # `ArchParser` and `ExtensionUtils` keep their unload because they are out of scope here,
+    # not because they are proven safe. `ArchParser.__getattribute__` returns a closure over
+    # the raw ctypes function that does not keep its owner alive, so a caller outliving the
+    # parser would call into an unloaded library.
 
 
 class ExtensionUtils:


### PR DESCRIPTION
## Fixes #7682: never unload `spirv_utils`

1. `spirv_utils` holds a statically-allocated `PyTypeObject`; unloading the module (`SpirvUtils.__del__`) frees that type while live instances still reference it → next GC pass dereferences a dangling `ob_type` → segfault. Exactly the reporter's crash.
2. Fix: stop unloading `spirv_utils`. Other backends already never unload their equivalents.
3. Narrow scope: `ArchParser`/`ExtensionUtils` export no Python types, so their unload is untouched.
4. Windows: net safety improvement, not a regression — turns a deterministic `0xC0000005` (699/699 on `main`) into a clean pass, at the cost of one leaked-but-already-tolerated `.pyd` temp file.
5. New regression test; validated on PVC (Linux) and BMG (Windows) + 3-iteration vLLM serving run.
6. Not reproduced: reporter's own multi-GPU loop (10× unfixed, 0 faults) — consistent with the deferred-unload mechanism explained below, not contradicting it.

<details>
<summary><b>The bug</b></summary>

`driver.c` defines `PyKernelArgType` as a **statically allocated** `PyTypeObject`
(`Py_TPFLAGS_DEFAULT`, `PyType_Ready`), so the type object's storage is a data-segment address inside
the JIT-compiled `spirv_utils` module. `annotate_arguments()` creates instances of it per compiled
kernel, they are cached for the kernel's lifetime in `XPULauncher.arg_annotations`, and they travel
inside the launch-args tuple.

`SpirvUtils.__del__` released that module — `dlclose()` on POSIX, `FreeLibrary()` on Windows. That
frees the type object while its instances are still reachable, so the next cyclic-GC pass over any
tuple holding one runs

```
tupletraverse -> visit_decref -> _PyObject_IS_GC -> Py_TYPE(op)
```

and dereferences a dangling `ob_type`. The interpreter dies with `Fatal Python error: Segmentation
fault` while `Garbage-collecting`, which is exactly the reporter's dump.

Worth stating explicitly because it is the counter-intuitive part: **`PyKernelArg` not being
GC-tracked does not help.** `visit_decref` loads `Py_TYPE(op)` *before* it can know whether `op` is
tracked. Adding `Py_TPFLAGS_HAVE_GC`/`tp_traverse`, heap-allocating the type, or immortalising it
would all leave this crash in place — `tp_dealloc`/`tp_traverse` are still function pointers into the
module's text. Only not unloading fixes it.

CPython documents this hazard for precisely this pattern in
[gh-114538](https://github.com/python/cpython/issues/114538): *"once the lib is closed, trying to use
any variables or functions defined in it will segfault … Likewise if … a reference to one of its
static types … is held outside the module. That may even impact GC."* NVIDIA (`CudaUtils`) and AMD
(`HIPUtils`) load their equivalent module as an ordinary extension module and never unload it.

</details>

<details>
<summary><b>How we got here</b></summary>

A commit pair, neither wrong on its own:

| PR | | |
|---|---|---|
| #3230 / #3251 / **#3455** | Jan–Feb 2025 | Made these helpers "pure DLLs" and added the unload — at a time when they exported **no Python types**. |
| **#6650** | Apr 2026 | "Switch to static launcher" put `PyKernelArgType` *inside* `spirv_utils`, silently breaking that precondition. |

</details>

<details>
<summary><b>Scope: why only <code>SpirvUtils</code></b></summary>

The rule the fix follows:

> Unloading is safe only once nothing reachable from Python can reference the module's code or storage — static types, native slot functions,
> capsule callbacks *and names*, FFI callables, borrowed buffers, TLS/global destructors.

Checked at `main`:

| source | module | `PyTypeObject` | `PyType_Ready` | unload kept? |
|---|---|---|---|---|
| `arch_parser.c` | `arch_utils` | 0 | 0 | ✅ kept |
| `extension_utils.c` | `extension_utils_impl` | 0 | 0 | ✅ kept |
| **`driver.c`** | **`spirv_utils`** | **2** | **1** | ❌ **removed** |

`__triton_launcher` — the module actually named in #3090's failure log — no longer exists as a
separate module; #6650 folded it into `spirv_utils`. That is what put "must be unloadable" and "must
never be unloaded" inside one module.

</details>

<details>
<summary><b>Windows: this is a net safety improvement, not a regression</b></summary>

The unload was added for Windows, where a loaded `.pyd` cannot be deleted and
`torch._inductor`'s cache teardown fails with `WinError 5` (#3090). Three findings say removing it
is nevertheless the right call:

1. **Triton's `__del__` is no longer what satisfies #3090.** PyTorch drives that cleanup itself in
   `torch._inductor.utils.unload_xpu_triton_pyds()`, called from `fresh_cache()` under
   `if is_windows() and torch.xpu.is_available()`.
2. **That torch function already performs the #7682 recipe.** It drops the singleton specifically to
   force the unload and then collects:
   ```python
   # unload spirv_utils.pyd
   if "triton.runtime.driver" in sys.modules:
       mod = sys.modules["triton.runtime.driver"]
       del type(mod.driver.active.utils).instance
       del mod.driver.active.utils
   gc.collect()
   ```
   With `__del__` present that is a *deterministic* #7682 crash on Windows XPU, not a rare one.
3. **It is inert on the pinned torch, live on torch main.** `del type(...).instance` targets
   `instance`, but this repo renamed the singleton to `_instance` in #6767 (`1f2d843ce`). On the pinned
   torch (`2.14.0a0+git23b1588`) that raises
   `AttributeError: type object 'XPUUtils' has no attribute 'instance'`, and `fresh_cache` re-raises
   it. On torch main, pytorch#189147 taught the lookup both names via `hasattr` guards, so the call
   succeeds there — and lands the unload, which is what intel/torch-xpu-ops#4950 reports as 339
   Windows inductor tests exiting `0xC0000005`. So #3090's cleanup path is pinned-vs-main, not
   uniformly dead.

The residual cost is that `spirv_utils.pyd` stays loaded, so a `fresh_cache()` teardown leaves that
one file behind. torch already accepts this: `shutil.rmtree(..., ignore_errors=is_windows())`, with
the comment *"for Windows, we can't delete the loaded modules because the module binaries are open."*
A leaked temp file plus a warning, against a hard interpreter crash.

Two follow-ups worth filing rather than folding in here:

- **Report the `instance`/`_instance` mismatch to PyTorch.** Note the ordering: fixing it *before*
  this lands would convert Windows XPU `fresh_cache` from "raises `AttributeError`" into "deterministic
  segfault". This PR should go first.
- **Optionally split `PyKernelArgType` out of `spirv_utils`** into its own never-unloaded module. Then
  `spirv_utils` could become unloadable again and #3090 would be fully restored on Windows.

</details>

<details>
<summary><b>Why it is intermittent (useful for anyone bisecting)</b></summary>

`dlclose()` here returns 0 and invalidates the handle **without unmapping**. `spirv_utils.so` imports
`__cxa_thread_atexit` because it owns a non-trivially-destructible `thread_local`
(`thread_local std::string g_last_module_build_log`, read at `driver.c:88`); glibc pins the module
against the thread that first touched it and defers the unload until that thread exits. Measured on a
Data Center GPU Max 1100:

| thread-local in module | touched by | unmapped at `dlclose` | crashes |
|---|---|---|---|
| none / POD | anyone | yes | yes |
| **non-POD** | **live thread** | **no** | **no** |
| non-POD | thread that has exited | yes | yes |

Not the loader refcount (it reaches 0), not `DF_1_NODELETE` (absent), not the TLS model
(global-dynamic and initial-exec both unmap). So the fault lands at an arbitrary later *thread exit*,
unrelated to any Python object's lifetime — hence a long multi-threaded vLLM run trips it and a short
script never does. It also means a test that compiles its kernel on the main thread is silently
green; the new test compiles on a worker thread that exits, for that reason.

</details>

<details>
<summary><b>Test</b></summary>

`python/test/unit/intel/test_spirv_utils_no_unload_7682.py`:

- `test_spirv_utils_defines_no_destructor` — cross-platform canary. The fix is a *deletion*, so this
  is what stops someone "restoring consistency" with `ArchParser`/`ExtensionUtils` later. It also pins
  the deliberate asymmetry.
- `test_spirv_utils_survives_gc_after_teardown` — subprocess (a regression is a signal, not an
  exception). Compiles on a worker thread that exits, parks the real `arg_annotations` in a GC-tracked
  tuple, invokes whatever destructor exists, collects, and asserts the module is still mapped.

Both fail before the change and pass after:

| | with fix | without fix |
|---|---|---|
| canary | PASSED | FAILED |
| subprocess GC test | PASSED | FAILED, child `returncode=-11` |

The failing child prints the reporter's signature verbatim:

```
Fatal Python error: Segmentation fault

Current thread 0x00007ff545762740 (most recent call first):
  Garbage-collecting
```

</details>

<details>
<summary><b>Validation</b></summary>

On a Data Center GPU Max 1100, CPython 3.12.13:

| | |
|---|---|
| `python/test/unit/intel/` | 1401 passed, 3 skipped, 344 xfailed, **0 failed** |
| `python/test/unit/runtime/` | 216 passed, 28 xfailed, **0 failed** |
| pre-commit (ruff, yapf, mypy, clang-format) | all pass |
| vLLM `tests/basic_correctness/test_cpu_offload.py`, 3 iterations **with** the fix | 4 passed each, no faults |

The vLLM run used the pinned commits from `scripts/vllm/{vllm,vllm-xpu-kernels}-pin.txt` with
`torch 2.13.0+xpu` — the reporter's exact torch version — so removing the destructor demonstrably does
not break vLLM serving, weight offloading, or `compare_two_settings`' dual-server comparison.

**What was not reproduced, and why the PR says so plainly:** the reporter's own failure. The issue's
loop was run 10× on the **unfixed** driver in that same vLLM environment and did not fault once
(`rc=0`, 4 passed, every iteration, ~2.5 h). That is consistent with the deferred-unload analysis
rather than at odds with it: on a single PVC the module stays pinned by the main thread's pending
thread-local destructor, so the `dlclose` never lands while `PyKernelArg` instances are alive. The
reporter's 4 × Arc Pro B60 differs in precisely the dimension that matters — which threads touch the
module and when they retire. Cheaper substitutes were tried first and are also insufficient
(`torch.compile` with 8 inductor compile threads, and plain interpreter shutdown after an exiting
compile thread: 0/10 each, unfixed).

Everything else is proven directly: the mechanism, that the unload happens and releases the module,
why it is deferred and therefore intermittent, and a real-Triton SIGSEGV that appears without the fix
and disappears with it. @chaojun-zhang — a confirmation run on your setup would close the last link.

Once this lands, vLLM can drop `VLLM_DISABLE_COMPILE_CACHE=1` from
`.buildkite/scripts/hardware_ci/run-intel-test.sh`, where the comment already names this issue.

</details>
