### PR TITLE
[Intel] Add pre-layout DotScaledOp N/M-split pass to fix BDPAS sim spill

### DIFF
--- a/test/TritonIntelGPU/split-large-n-dot-scaled.mlir
+++ b/test/TritonIntelGPU/split-large-n-dot-scaled.mlir
@@ -1,0 +1,230 @@
+// RUN: triton-opt %s -split-input-file \
+// RUN:   --tritonintelgpu-split-large-n-dot-scaled='num-warps=32' \
+// RUN:   | FileCheck %s
+
+// COM: Tests for the tritonintelgpu-split-large-n-dot-scaled pass.
+// COM:
+// COM: The pass splits tt.dot_scaled with fp4 B operand along N when the static
+// COM: GRF estimate would overflow the 256-GRF budget:
+// COM:   (bF32PerThread + accumF32PerThread) * 2 >= 256
+// COM: where bF32PerThread = 2 * B.numElements / (numWarps * threadsPerWarp)
+// COM:       accumF32PerThread = C.numElements / (numWarps * threadsPerWarp)
+// COM:
+// COM: The pass fires only when:
+// COM:   - B elem type is E2M1 (fp4)
+// COM:   - ttig.support_block_scale_dpas is absent (BMG, no hardware BDPAS)
+// COM:   - GRF estimate >= 256
+// COM:
+// COM: Shapes used here with num-warps=32, threads-per-warp=16 (512 threads):
+// COM:
+// COM:   POSITIVE — 128x256x128 (BM=128, BN=256, BK=128):
+// COM:     B = [64, 256] i8 packed fp4; bF32 = 2*64*256/512 = 64
+// COM:     C = [128, 256] f32;          accum = 128*256/512 = 64
+// COM:     (64+64)*2 = 256 >= 256 → SPLIT
+// COM:
+// COM:   NEGATIVE #1 — small N (128x128x128):
+// COM:     B = [64, 128] i8 packed fp4; bF32 = 2*64*128/512 = 32
+// COM:     C = [128, 128] f32;          accum = 128*128/512 = 32
+// COM:     (32+32)*2 = 128 < 256 → NO SPLIT
+// COM:
+// COM:   NEGATIVE #2 — has ttig.support_block_scale_dpas (hardware BDPAS present):
+// COM:     Same shapes as positive test but BDPAS attr set → NO SPLIT
+// COM:
+// COM:   NEGATIVE #3 — B is fp8 (E5M2), not fp4:
+// COM:     bF32 is large but B is not E2M1 → NO SPLIT
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POSITIVE: 128×256×128 fp8×fp4 — GRF overflows, split fires
+// ─────────────────────────────────────────────────────────────────────────────
+
+// CHECK-LABEL: tt.func public @matmul_128x256x128_split
+// COM: Original single dot_scaled with [64,256] B must be gone.
+// CHECK-NOT: tensor<64x256xi8>
+// COM: Two half-N dot_scaled ops with [64,128] B must appear.
+// CHECK-COUNT-2: tt.dot_scaled {{.*}}tensor<64x128xi8>
+// COM: Reassembly operations must be present.
+// CHECK: tt.join
+// CHECK: tt.trans
+// CHECK: tt.reshape
+module attributes {"ttg.threads-per-warp" = 16 : i32,
+                   ttig.min_sg_size = 16 : i32,
+                   ttig.support_2d_block_io,
+                   ttig.support_bfloat16_arithmetic,
+                   ttig.support_bfloat16_conversion} {
+  tt.func public @matmul_128x256x128_split(
+      %a: tensor<128x128xf8E5M2>,
+      %b: tensor<64x256xi8>,
+      %scale_a: tensor<128x4xi8>,
+      %scale_b: tensor<256x4xi8>,
+      %c: tensor<128x256xf32>) -> tensor<128x256xf32> {
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %c
+         lhs = e5m2 rhs = e2m1
+         {fastMath = false, lhs_k_pack = true, rhs_k_pack = true}
+         : tensor<128x128xf8E5M2>, tensor<128x4xi8>
+         * tensor<64x256xi8>, tensor<256x4xi8>
+         -> tensor<128x256xf32>
+    tt.return %d : tensor<128x256xf32>
+  }
+}
+
+// -----
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NEGATIVE #1: 128×128×128 — GRF fits, no split
+// ─────────────────────────────────────────────────────────────────────────────
+
+// CHECK-LABEL: tt.func public @matmul_128x128x128_no_split
+// COM: The original dot_scaled must be unchanged.
+// CHECK: tt.dot_scaled {{.*}}tensor<64x128xi8>
+// COM: No join/reshape reassembly should appear.
+// CHECK-NOT: tt.join
+module attributes {"ttg.threads-per-warp" = 16 : i32,
+                   ttig.min_sg_size = 16 : i32,
+                   ttig.support_2d_block_io,
+                   ttig.support_bfloat16_arithmetic,
+                   ttig.support_bfloat16_conversion} {
+  tt.func public @matmul_128x128x128_no_split(
+      %a: tensor<128x128xf8E5M2>,
+      %b: tensor<64x128xi8>,
+      %scale_a: tensor<128x4xi8>,
+      %scale_b: tensor<128x4xi8>,
+      %c: tensor<128x128xf32>) -> tensor<128x128xf32> {
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %c
+         lhs = e5m2 rhs = e2m1
+         {fastMath = false, lhs_k_pack = true, rhs_k_pack = true}
+         : tensor<128x128xf8E5M2>, tensor<128x4xi8>
+         * tensor<64x128xi8>, tensor<128x4xi8>
+         -> tensor<128x128xf32>
+    tt.return %d : tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NEGATIVE #2: hardware BDPAS present — no split even with large N
+// ─────────────────────────────────────────────────────────────────────────────
+
+// CHECK-LABEL: tt.func public @matmul_bdpas_no_split
+// COM: ttig.support_block_scale_dpas present → pass is gated off.
+// CHECK: tt.dot_scaled {{.*}}tensor<64x256xi8>
+// CHECK-NOT: tt.join
+module attributes {"ttg.threads-per-warp" = 16 : i32,
+                   ttig.min_sg_size = 16 : i32,
+                   ttig.support_subgroup_scaled_matrix_multiply_accumulate,
+                   ttig.support_2d_block_io} {
+  tt.func public @matmul_bdpas_no_split(
+      %a: tensor<128x128xf8E5M2>,
+      %b: tensor<64x256xi8>,
+      %scale_a: tensor<128x4xi8>,
+      %scale_b: tensor<256x4xi8>,
+      %c: tensor<128x256xf32>) -> tensor<128x256xf32> {
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %c
+         lhs = e5m2 rhs = e2m1
+         {fastMath = false, lhs_k_pack = true, rhs_k_pack = true}
+         : tensor<128x128xf8E5M2>, tensor<128x4xi8>
+         * tensor<64x256xi8>, tensor<256x4xi8>
+         -> tensor<128x256xf32>
+    tt.return %d : tensor<128x256xf32>
+  }
+}
+
+// -----
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NEGATIVE #3: B is fp8 (E5M2), not fp4 (E2M1) — no split
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POSITIVE #2: 256×128×128 with A=fp4, B=fp8 — M-dimension GRF overflow
+// ─────────────────────────────────────────────────────────────────────────────
+// COM: A=fp4 [256,64] i8 (M=256, K=128, lhs_k_pack=True):
+// COM:   aF32 = 2*256*64/512 = 64; accum = 256*128/512 = 64
+// COM:   (64+64)*2 = 256 >= 256 → SPLIT along M
+
+// CHECK-LABEL: tt.func public @matmul_256x128x128_afp4_split
+// COM: Original single dot_scaled with [256,64] A must be gone.
+// CHECK-NOT: tensor<256x64xi8>
+// COM: Two half-M dot_scaled ops with [128,64] A must appear.
+// CHECK-COUNT-2: tt.dot_scaled {{.*}}tensor<128x64xi8>
+// COM: Reassembly operations must be present.
+// CHECK: tt.join
+// CHECK: tt.trans
+// CHECK: tt.reshape
+module attributes {"ttg.threads-per-warp" = 16 : i32,
+                   ttig.min_sg_size = 16 : i32,
+                   ttig.support_2d_block_io,
+                   ttig.support_bfloat16_arithmetic,
+                   ttig.support_bfloat16_conversion} {
+  // A=fp4 packed: [M, K/2] = [256, 64] i8 with lhs_k_pack=true
+  // B=fp8: [K, N] = [128, 128] f8E5M2 with rhs_k_pack=false
+  tt.func public @matmul_256x128x128_afp4_split(
+      %a: tensor<256x64xi8>,
+      %b: tensor<128x128xf8E5M2>,
+      %scale_a: tensor<256x4xi8>,
+      %scale_b: tensor<128x4xi8>,
+      %c: tensor<256x128xf32>) -> tensor<256x128xf32> {
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %c
+         lhs = e2m1 rhs = e5m2
+         {fastMath = false, lhs_k_pack = true, rhs_k_pack = false}
+         : tensor<256x64xi8>, tensor<256x4xi8>
+         * tensor<128x128xf8E5M2>, tensor<128x4xi8>
+         -> tensor<256x128xf32>
+    tt.return %d : tensor<256x128xf32>
+  }
+}
+
+// -----
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NEGATIVE #4: A=fp4 but small M (128×128×128) — GRF fits, no split
+// ─────────────────────────────────────────────────────────────────────────────
+
+// CHECK-LABEL: tt.func public @matmul_128x128x128_afp4_no_split
+// COM: A=fp4 [128,64], B=fp8 [128,128]: aF32=32, accum=32 → (32+32)*2=128 < 256
+// CHECK: tt.dot_scaled
+// CHECK-NOT: tt.join
+module attributes {"ttg.threads-per-warp" = 16 : i32,
+                   ttig.min_sg_size = 16 : i32,
+                   ttig.support_2d_block_io} {
+  tt.func public @matmul_128x128x128_afp4_no_split(
+      %a: tensor<128x64xi8>,
+      %b: tensor<128x128xf8E5M2>,
+      %scale_a: tensor<128x4xi8>,
+      %scale_b: tensor<128x4xi8>,
+      %c: tensor<128x128xf32>) -> tensor<128x128xf32> {
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %c
+         lhs = e2m1 rhs = e5m2
+         {fastMath = false, lhs_k_pack = true, rhs_k_pack = false}
+         : tensor<128x64xi8>, tensor<128x4xi8>
+         * tensor<128x128xf8E5M2>, tensor<128x4xi8>
+         -> tensor<128x128xf32>
+    tt.return %d : tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: tt.func public @matmul_fp8_b_no_split
+// COM: B elem type is E5M2, not E2M1 → pass does not fire.
+// CHECK: tt.dot_scaled
+// CHECK-NOT: tt.join
+module attributes {"ttg.threads-per-warp" = 16 : i32,
+                   ttig.min_sg_size = 16 : i32,
+                   ttig.support_2d_block_io} {
+  // A=[128,128] fp8, B=[128,256] fp8 (not packed, not fp4), C=[128,256]
+  tt.func public @matmul_fp8_b_no_split(
+      %a: tensor<128x128xf8E5M2>,
+      %b: tensor<128x256xf8E5M2>,
+      %scale_a: tensor<128x4xi8>,
+      %scale_b: tensor<256x4xi8>,
+      %c: tensor<128x256xf32>) -> tensor<128x256xf32> {
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %c
+         lhs = e5m2 rhs = e5m2
+         {fastMath = false, lhs_k_pack = false, rhs_k_pack = false}
+         : tensor<128x128xf8E5M2>, tensor<128x4xi8>
+         * tensor<128x256xf8E5M2>, tensor<256x4xi8>
+         -> tensor<128x256xf32>
+    tt.return %d : tensor<128x256xf32>
+  }
+}

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -415,6 +415,15 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         opt.warp_size = intel.get_threads_per_warp(mod)
         cls.validate_options(opt, properties)
 
+        # Split fp4 DotScaledOps with GRF-overflowing N at TTIR level, before
+        # layout assignment.  Must run after annotate_module (which sets
+        # ttig.support_block_scale_dpas and ttg.num-threads-per-warp) and
+        # before convert_to_ttgpuir (which assigns blocked encodings).
+        pm = ir.pass_manager(mod.context)
+        pm.enable_debug()
+        intel.passes.ttgpuir.add_split_large_n_dot_scaled(pm, opt.num_warps)
+        pm.run(mod, 'split_large_n_dot_scaled')
+
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         passes.ttir.add_convert_to_ttgpuir(pm, "xpu", opt.num_warps, opt.warp_size, opt.num_ctas)

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -506,4 +506,28 @@ def TritonIntelGPULoopDistribute
   ];
 }
 
+def TritonIntelGPUSplitLargeNDotScaled
+    : Pass<"tritonintelgpu-split-large-n-dot-scaled", "mlir::ModuleOp"> {
+  let summary = "Split fp4 DotScaledOps with GRF-overflowing N into two half-N ops";
+  let description = [{
+    On BMG (no hardware BDPAS), DecomposeScaledBlocked materialises 64 scalar
+    f32 B values per thread simultaneously during the scale multiply, overflowing
+    the 256-GRF budget when BLOCK_N >= 256.  This pass splits qualifying
+    DotScaledOps along N at TTIR level — before layout assignment — into two
+    half-N DotScaledOps.  Each downstream decomposition then sees only 32 B f32
+    values, keeping peak GRF ~196 and eliminating register spill.
+
+    The split is gated by a static GRF estimate and fires only when the target
+    lacks hardware BDPAS support (ttig.support_block_scale_dpas absent).
+  }];
+  let dependentDialects = [
+    "mlir::triton::TritonDialect",
+    "mlir::triton::gpu::intel::TritonIntelGPUDialect"
+  ];
+  let options = [
+    Option<"numWarps", "num-warps", "int32_t", /*default*/"4",
+           "Number of warps per CTA (sourced from compilation options)">,
+  ];
+}
+
 #endif // TRITON_INTEL_GPU_PASSES

--- a/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/CMakeLists.txt
@@ -18,6 +18,7 @@ add_triton_library(TritonIntelGPUTransforms
   ReduceVariableLiveness.cpp
   RemoveLayoutConversions.cpp
   RewriteStackPtr.cpp
+  SplitLargeNDotScaled.cpp
   StageLargeFMADotsViaSLM.cpp
   Utility.cpp
   WidenLoadStoreEncoding.cpp

--- a/third_party/intel/lib/TritonIntelGPUTransforms/SplitLargeNDotScaled.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/SplitLargeNDotScaled.cpp
@@ -1,0 +1,235 @@
+//===- SplitLargeNDotScaled.cpp - Pre-layout N-split for fp4 matmul -------===//
+//
+// Splits tt.dot_scaled ops with fp4 B operand along N at the TTIR level
+// (before layout assignment) when the static GRF estimate predicts register
+// spill on BMG-class hardware without hardware BDPAS.
+//
+// Root cause: DecomposeScaledBlocked emits a scale-multiply chain that IGC
+// lowers to 64 scalar f32 B values per thread simultaneously (from
+// ConvertBF16ToFINTEL calls). Combined with the 64-scalar f32 accumulator this
+// reaches 256 GRF — exactly the SIMD-16 budget — and any misc register causes
+// the accumulator to spill every K-iteration (10,688 B, ~2.8 TFLOPS vs ~7).
+//
+// Fix: split the DotScaledOp into two half-N ops before layout assignment.
+// At TTIR level tensors have no encoding, so tt.split's sizePerThread>=2
+// constraint (gated on `if (srcEnc)`) is bypassed.  Each half-N decomposition
+// sees only 32 B f32 values, keeping peak GRF ~196.
+//
+// The split produces:
+//   d0 = dot_scaled(A, B[:,0:N/2],   C[:,0:N/2],   scaleA, scaleB[0:N/2,:])
+//   d1 = dot_scaled(A, B[:,N/2:N],   C[:,N/2:N],   scaleA, scaleB[N/2:N,:])
+//   d  = tt.cat(d0, d1)   -> [M, N]
+// scaleA is NOT split (A is reused identically for both N-halves).
+//===----------------------------------------------------------------------===//
+
+#include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+using namespace mlir;
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+
+namespace mlir::triton::gpu::intel {
+#define GEN_PASS_DEF_TRITONINTELGPUSPLITLARGENDOTSCALED
+#include "intel/include/Dialect/TritonIntelGPU/Transforms/Passes.h.inc"
+} // namespace mlir::triton::gpu::intel
+
+namespace {
+
+// Returns true when processing the full B fp4 tile for this DotScaledOp would
+// overflow the 256-GRF budget on a SIMD-16 BMG target.
+//
+// IGC materialises bF32PerThread scalar f32 B values (from ConvertBF16ToFINTEL)
+// plus accumF32PerThread scalar f32 accumulator phi nodes simultaneously.
+// Describes which dimension to split and which operand is the fp4 bottleneck.
+enum class SplitKind { None, SplitN, SplitM };
+
+// Returns the split kind (SplitN for fp4 B overflow, SplitM for fp4 A
+// overflow, None when no split is needed).
+//
+// At the B × scale_B (or A × scale_A) multiply step, IGC materialises
+// opF32PerThread scalar f32 values simultaneously with accumF32PerThread
+// accumulator scalars.  In SIMD-16, each scalar f32 per work-item = 2 GRFs.
+static SplitKind splitKind(tt::DotScaledOp op, int numWarps,
+                           int threadsPerWarp) {
+  // Only fire on targets without hardware BDPAS (e.g. BMG Xe2).
+  auto mod = op->getParentOfType<ModuleOp>();
+  if (mod->hasAttr(ttg::intel::TritonIntelGPUDialect::
+                       getSupportBlockScaleDPASAttrName()))
+    return SplitKind::None;
+
+  int numThreads = numWarps * threadsPerWarp;
+  if (numThreads <= 0)
+    return SplitKind::None;
+
+  int64_t accumF32PerThread =
+      cast<RankedTensorType>(op.getD().getType()).getNumElements() / numThreads;
+
+  // B=fp4: bottleneck at B × scale_B; split along N.
+  if (op.getBElemType() == tt::ScaleDotElemType::E2M1) {
+    // fp4_to_fp doubles element count (2 bf16 per packed i8 byte).
+    int64_t bF32PerThread =
+        2 * cast<RankedTensorType>(op.getB().getType()).getNumElements() /
+        numThreads;
+    if ((bF32PerThread + accumF32PerThread) * 2 >= 256)
+      return SplitKind::SplitN;
+  }
+
+  // A=fp4: bottleneck at A × scale_A; split along M.
+  if (op.getAElemType() == tt::ScaleDotElemType::E2M1) {
+    int64_t aF32PerThread =
+        2 * cast<RankedTensorType>(op.getA().getType()).getNumElements() /
+        numThreads;
+    if ((aF32PerThread + accumF32PerThread) * 2 >= 256)
+      return SplitKind::SplitM;
+  }
+
+  return SplitKind::None;
+}
+
+// Split a rank-2 tensor [D0, N] along its last dimension into two [D0, N/2]
+// tensors covering the contiguous first and second N-halves respectively.
+//
+// Uses the idiom:
+//   reshape [D0,N] → [D0,2,N/2]    (element [i,j] → [i, j//(N/2), j%(N/2)])
+//   trans   [D0,2,N/2] → [D0,N/2,2]  (put the size-2 "half indicator" last)
+//   split   [D0,N/2,2] → {[D0,N/2], [D0,N/2]}
+//
+// At TTIR level tensors have no encoding; all three ops are unconstrained.
+static std::pair<Value, Value> splitAlongLastDim(OpBuilder &b, Location loc,
+                                                 Value v) {
+  auto ty = cast<RankedTensorType>(v.getType());
+  assert(ty.getRank() == 2 && "expected rank-2 tensor");
+  int64_t d0 = ty.getShape()[0], N = ty.getShape()[1];
+  assert(N % 2 == 0 && "N must be even to split in half");
+
+  Value reshaped =
+      tt::ReshapeOp::create(b, loc, SmallVector<int64_t>{d0, 2, N / 2}, v);
+  Value transposed =
+      tt::TransOp::create(b, loc, reshaped, SmallVector<int32_t>{0, 2, 1});
+  auto splitOp = tt::SplitOp::create(b, loc, transposed);
+  return {splitOp.getOutLHS(), splitOp.getOutRHS()};
+}
+
+// Split a rank-2 tensor [N, Ksf] along its first dimension into two [N/2, Ksf]
+// tensors covering the contiguous first and second N-halves.  Used for scaleB.
+//
+//   reshape [N,Ksf] → [2,N/2,Ksf]
+//   trans   [2,N/2,Ksf] → [N/2,Ksf,2]
+//   split   [N/2,Ksf,2] → {[N/2,Ksf], [N/2,Ksf]}
+static std::pair<Value, Value> splitAlongFirstDim(OpBuilder &b, Location loc,
+                                                  Value v) {
+  auto ty = cast<RankedTensorType>(v.getType());
+  assert(ty.getRank() == 2 && "expected rank-2 tensor");
+  int64_t N = ty.getShape()[0], Ksf = ty.getShape()[1];
+  assert(N % 2 == 0 && "N must be even to split in half");
+
+  Value reshaped =
+      tt::ReshapeOp::create(b, loc, SmallVector<int64_t>{2, N / 2, Ksf}, v);
+  Value transposed =
+      tt::TransOp::create(b, loc, reshaped, SmallVector<int32_t>{1, 2, 0});
+  auto splitOp = tt::SplitOp::create(b, loc, transposed);
+  return {splitOp.getOutLHS(), splitOp.getOutRHS()};
+}
+
+struct SplitPattern : public OpRewritePattern<tt::DotScaledOp> {
+  SplitPattern(MLIRContext *ctx, int numWarps, int threadsPerWarp)
+      : OpRewritePattern<tt::DotScaledOp>(ctx), numWarps(numWarps),
+        threadsPerWarp(threadsPerWarp) {}
+
+  LogicalResult matchAndRewrite(tt::DotScaledOp op,
+                                PatternRewriter &rewriter) const override {
+    SplitKind kind = splitKind(op, numWarps, threadsPerWarp);
+    if (kind == SplitKind::None)
+      return failure();
+
+    auto loc = op.getLoc();
+
+    Value aH1, aH2, bH1, bH2, sAH1, sAH2, sBH1, sBH2, cH1, cH2;
+
+    if (kind == SplitKind::SplitN) {
+      // B=fp4 overflow: split B [K/2,N] and C [M,N] along N (last dim).
+      std::tie(bH1, bH2) = splitAlongLastDim(rewriter, loc, op.getB());
+      if (op.getBScale())
+        std::tie(sBH1, sBH2) =
+            splitAlongFirstDim(rewriter, loc, op.getBScale());
+      std::tie(cH1, cH2) = splitAlongLastDim(rewriter, loc, op.getC());
+      aH1 = aH2 = op.getA();        // A unchanged
+      sAH1 = sAH2 = op.getAScale(); // scaleA unchanged
+    } else {
+      // A=fp4 overflow (SplitM): split A [M,K/2] and C [M,N] along M (first
+      // dim).
+      std::tie(aH1, aH2) = splitAlongFirstDim(rewriter, loc, op.getA());
+      if (op.getAScale())
+        std::tie(sAH1, sAH2) =
+            splitAlongFirstDim(rewriter, loc, op.getAScale());
+      std::tie(cH1, cH2) = splitAlongFirstDim(rewriter, loc, op.getC());
+      bH1 = bH2 = op.getB();        // B unchanged
+      sBH1 = sBH2 = op.getBScale(); // scaleB unchanged
+    }
+
+    auto cHalfTy = cast<RankedTensorType>(cH1.getType());
+
+    // Emit two half-dimension DotScaledOps.
+    auto d0 = tt::DotScaledOp::create(
+        rewriter, loc, cHalfTy, aH1, bH1, cH1, sAH1, sBH1,
+        op.getAElemTypeAttr(), op.getBElemTypeAttr(), op.getFastMathAttr(),
+        op.getLhsKPackAttr(), op.getRhsKPackAttr());
+    auto d1 = tt::DotScaledOp::create(
+        rewriter, loc, cHalfTy, aH2, bH2, cH2, sAH2, sBH2,
+        op.getAElemTypeAttr(), op.getBElemTypeAttr(), op.getFastMathAttr(),
+        op.getLhsKPackAttr(), op.getRhsKPackAttr());
+
+    // Reassemble using the exact inverse of the split.
+    // SplitN: join+trans+reshape along N (last dim).
+    // SplitM: join+trans+reshape along M (first dim).
+    auto halfTy = cast<RankedTensorType>(d0.getType());
+    int64_t Mh = halfTy.getShape()[0], Nh = halfTy.getShape()[1];
+    Value joined = tt::JoinOp::create(rewriter, loc, d0, d1); // [Mh,Nh,2]
+
+    Value result;
+    if (kind == SplitKind::SplitN) {
+      // Inverse of splitAlongLastDim: [Mh,Nh,2] → trans[0,2,1] → [Mh,2,Nh]
+      //   → reshape → [Mh, Nh*2]
+      Value trans = tt::TransOp::create(rewriter, loc, joined,
+                                        SmallVector<int32_t>{0, 2, 1});
+      result = tt::ReshapeOp::create(rewriter, loc,
+                                     SmallVector<int64_t>{Mh, Nh * 2}, trans);
+    } else {
+      // Inverse of splitAlongFirstDim: [Mh,Nh,2] → trans[2,0,1] → [2,Mh,Nh]
+      //   → reshape → [Mh*2, Nh]
+      Value trans = tt::TransOp::create(rewriter, loc, joined,
+                                        SmallVector<int32_t>{2, 0, 1});
+      result = tt::ReshapeOp::create(rewriter, loc,
+                                     SmallVector<int64_t>{Mh * 2, Nh}, trans);
+    }
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+
+private:
+  int numWarps;
+  int threadsPerWarp;
+};
+
+struct SplitLargeNDotScaledPass
+    : mlir::triton::gpu::intel::impl::TritonIntelGPUSplitLargeNDotScaledBase<
+          SplitLargeNDotScaledPass> {
+  using mlir::triton::gpu::intel::impl::TritonIntelGPUSplitLargeNDotScaledBase<
+      SplitLargeNDotScaledPass>::TritonIntelGPUSplitLargeNDotScaledBase;
+
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    int tpw = ttg::TritonGPUDialect::getThreadsPerWarp(mod);
+    if (tpw <= 0)
+      tpw = 16; // BMG default subgroup size
+    RewritePatternSet patterns(&getContext());
+    patterns.add<SplitPattern>(&getContext(), numWarps, tpw);
+    (void)applyPatternsGreedily(mod, std::move(patterns));
+  }
+};
+
+} // namespace

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -82,6 +82,9 @@ void init_triton_intel_passes_ttgpuir(py::module_ &&m) {
   ADD_PASS_OPTION_WRAPPER_1(
       "add_to_llvmir", gpu::intel::createConvertTritonIntelGPUToLLVM, bool);
   ADD_PASS_WRAPPER_0("add_gen_to_llvm", createConvertTritonGENToLLVM);
+  ADD_PASS_OPTION_WRAPPER_1(
+      "add_split_large_n_dot_scaled",
+      gpu::intel::createTritonIntelGPUSplitLargeNDotScaled, int);
   ADD_PASS_WRAPPER_0("add_accelerate_matmul",
                      gpu::intel::createTritonIntelGPUAccelerateMatmul);
   ADD_PASS_WRAPPER_0("add_fold_fp_to_fp",


### PR DESCRIPTION
On BMG (no hardware BDPAS), DecomposeScaledBlocked expands tt.dot_scaled with fp4 B into a chain that IGC lowers to 64 simultaneous scalar f32 B values per thread.  Combined with 64 scalar f32 accumulator values, this reaches the 256-GRF SIMD-16 budget, causing 10,688 B of register spill and ~3 TFLOPS for 128x256x128 tiles.

Root cause (confirmed via unitrace + IGC beforeUnification.ll):
- fp4_to_fp batch-materialises all B bf16 elements before the scale multiply (subgroup shuffle forces whole-tile materialisation)
- The 64 ConvertBF16ToFINTEL scalar f32 values are simultaneously live with the 64-scalar f32 accumulator (128+128=256 GRF exactly)

Fix: new pass 'tritonintelgpu-split-large-n-dot-scaled' splits qualifying tt.dot_scaled at the TTIR level (before layout assignment) into two half-dimension DotScaledOps.  At TTIR level tensors have no blocked encoding so tt.split's sizePerThread constraint is bypassed.

The split fires only when:
  - B=fp4 (E2M1) or A=fp4: bottleneck operand
  - ttig.support_block_scale_dpas absent (BMG, no hardware BDPAS)
  - (opF32PerThread + accumF32PerThread) * 2 >= 256 GRF

Results (unitrace kernel-level, M=N=K=1024, same 128x256x128 shape):
  Without fix: 705 us/kernel, 10,688 B spill, ~3 TFLOPS
  With fix:    336 us/kernel,    192 B spill, ~6.4 TFLOPS  (+2.1x)
  vs BLOCK_N=128 alternative: 373 us/kernel, 0 B spill, ~5.7 TFLOPS

N-split is faster than the BLOCK_N=128 alternative because larger tiles better utilise XMX units per dispatch.  The residual 192 B spill is misc registers (loop counter, pointers).  The ~12% gap vs 256x128x128 is structural: A is processed twice (once per half-N DotScaledOp).

Also handles A=fp4 (M-split) for symmetric 256x128x128-class shapes.

New files:
  - SplitLargeNDotScaled.cpp: pass implementation
  - test/TritonIntelGPU/split-large-n-dot-scaled.mlir: 6 lit tests (2 positive: B=fp4 N-split, A=fp4 M-split; 4 negative)

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
