### PR TITLE
[vLLM][CI] Rewrite vllm scheduled workflow crons to re-direct email notifications

### DIFF
--- a/.github/workflows/vllm-benchmarks-bmg.yml
+++ b/.github/workflows/vllm-benchmarks-bmg.yml
@@ -15,7 +15,7 @@ on:
       - scripts/vllm/**
       - .github/pins/pytorch.txt
   schedule:
-    - cron: "0 8 * * *"
+    - cron: "0 8 * * 0-6"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}

--- a/.github/workflows/vllm-benchmarks-pvc.yml
+++ b/.github/workflows/vllm-benchmarks-pvc.yml
@@ -15,7 +15,7 @@ on:
       - scripts/vllm/**
       - .github/pins/pytorch.txt
   schedule:
-    - cron: "0 8 * * *"
+    - cron: "0 8 * * 0-6"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'ci' }}

--- a/.github/workflows/vllm-tests-bmg.yml
+++ b/.github/workflows/vllm-tests-bmg.yml
@@ -5,8 +5,8 @@ permissions: read-all
 on:
   schedule:
     # Thursday/Sunday 2:05AM PST (UTC-8) or 3:05AM PDT (UTC-7)
-    - cron: "5 10 * * THU"
-    - cron: "5 10 * * SUN"
+    - cron: "5 10 * * 4"
+    - cron: "5 10 * * 0"
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/vllm-tests-pvc.yml
+++ b/.github/workflows/vllm-tests-pvc.yml
@@ -5,8 +5,8 @@ permissions: read-all
 on:
   schedule:
     # Thursday/Sunday 2:05AM PST (UTC-8) or 3:05AM PDT (UTC-7)
-    - cron: "5 10 * * THU"
-    - cron: "5 10 * * SUN"
+    - cron: "5 10 * * 4"
+    - cron: "5 10 * * 0"
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
No functional change.

Reassigns scheduled-run failure notifications to myself.

Per GitHub's "last modified the cron syntax" rule: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/notifications-for-workflow-runs