### PR TITLE
[HostTensorDescriptor] Use max divisibility for bounded specialization

### DIFF
--- a/python/test/unit/intel/test_tensordesc_specialization.py
+++ b/python/test/unit/intel/test_tensordesc_specialization.py
@@ -1,8 +1,8 @@
 """Unit tests for TensorDescriptor specialization key generation and parsing.
 
 Tests the round-trip encoding and decoding of host-side TensorDescriptor
-specialization keys, which encode max power-of-2 divisibility for shape and
-stride dimensions to enable bounded specialization.
+specialization keys, which encode max power-of-2 divisibility for shape
+dimensions to enable bounded specialization.
 """
 
 from triton.backends.intel.compiler import XPUBackend
@@ -28,37 +28,6 @@ class TestTensorDescSpecialization:
         assert "S0D128" in key, f"Expected S0D128 in {key}"
         assert "S1D64" in key, f"Expected S1D64 in {key}"
         assert "S2D1" in key, f"Expected S2D1 in {key}"
-
-    def test_stride_exact_values_rank3(self):
-        """Stride exact values encoded for rank-3+ descriptors."""
-
-        class MockArg:
-
-            def __init__(self, shape, strides, padding=None):
-                self.shape = shape
-                self.strides = strides
-                self.padding = padding
-
-        # Rank-3: encode non-last strides as exact values
-        # strides=[256, 16, 1] → T256,16 (last stride omitted)
-        arg = MockArg(shape=[32, 32, 32], strides=[256, 16, 1])
-        key = XPUBackend.get_tensordesc_specialization(arg)
-        assert "T256,16" in key, f"Expected T256,16 in {key}"
-
-    def test_stride_not_encoded_rank2(self):
-        """Stride values not encoded for rank-2 descriptors."""
-
-        class MockArg:
-
-            def __init__(self, shape, strides, padding=None):
-                self.shape = shape
-                self.strides = strides
-                self.padding = padding
-
-        # Rank-2: no stride encoding
-        arg = MockArg(shape=[128, 64], strides=[64, 1])
-        key = XPUBackend.get_tensordesc_specialization(arg)
-        assert "T" not in key, f"Rank-2 should not encode strides, got {key}"
 
     def test_padding_encoding(self):
         """NaN padding encodes as 'N' prefix."""
@@ -95,18 +64,6 @@ class TestTensorDescSpecialization:
         assert "tt.shape.2.divisibility" in attr_dict
         assert attr_dict["tt.shape.2.divisibility"] == 1
 
-    def test_parse_attr_stride_exact_values(self):
-        """parse_attr correctly decodes stride exact values."""
-        key = "T256,16"
-        attrs = XPUBackend.parse_attr(key)
-
-        attr_dict = {attr[0]: attr[1] for attr in attrs}
-
-        assert "tt.stride.0" in attr_dict
-        assert attr_dict["tt.stride.0"] == 256
-        assert "tt.stride.1" in attr_dict
-        assert attr_dict["tt.stride.1"] == 16
-
     def test_parse_attr_padding(self):
         """parse_attr correctly decodes padding flag."""
         key = "N"
@@ -142,8 +99,6 @@ class TestTensorDescSpecialization:
         assert attr_dict["tt.shape.0.divisibility"] == 256
         assert attr_dict["tt.shape.1.divisibility"] == 128
         assert attr_dict["tt.shape.2.divisibility"] == 16
-        assert attr_dict["tt.stride.0"] == 2048
-        assert attr_dict["tt.stride.1"] == 16
 
     def test_divisibility_power_of_2(self):
         """Shape divisibility values are always powers of 2."""
@@ -168,12 +123,6 @@ class TestTensorDescSpecialization:
         assert attr_dict["tt.shape.1.divisibility"] == 4
         # 1023 = odd → max divisor = 1
         assert attr_dict["tt.shape.2.divisibility"] == 1
-
-        # Stride values are exact (not divisibility)
-        # 10000 encoded as exact value
-        assert attr_dict["tt.stride.0"] == 10000
-        # 1023 encoded as exact value
-        assert attr_dict["tt.stride.1"] == 1023
 
     def test_zero_value_divisibility(self):
         """Zero values have divisibility of 1."""

--- a/python/test/unit/intel/test_tensordesc_specialization.py
+++ b/python/test/unit/intel/test_tensordesc_specialization.py
@@ -1,0 +1,194 @@
+"""Unit tests for TensorDescriptor specialization key generation and parsing.
+
+Tests the round-trip encoding and decoding of host-side TensorDescriptor
+specialization keys, which encode max power-of-2 divisibility for shape and
+stride dimensions to enable bounded specialization.
+"""
+
+from triton.backends.intel.compiler import XPUBackend
+
+
+class TestTensorDescSpecialization:
+    """Test XPUBackend.get_tensordesc_specialization and parse_attr."""
+
+    def test_shape_divisibility_encoding(self):
+        """Shape dimensions encode max power-of-2 divisibility."""
+
+        # Mock tensor descriptor with various shape divisibilities
+        class MockArg:
+
+            def __init__(self, shape, strides, padding=None):
+                self.shape = shape
+                self.strides = strides
+                self.padding = padding
+
+        # shape=[128, 64, 17] → S0D128S1D64S2D1
+        arg = MockArg(shape=[128, 64, 17], strides=[64, 1])
+        key = XPUBackend.get_tensordesc_specialization(arg)
+        assert "S0D128" in key, f"Expected S0D128 in {key}"
+        assert "S1D64" in key, f"Expected S1D64 in {key}"
+        assert "S2D1" in key, f"Expected S2D1 in {key}"
+
+    def test_stride_exact_values_rank3(self):
+        """Stride exact values encoded for rank-3+ descriptors."""
+
+        class MockArg:
+
+            def __init__(self, shape, strides, padding=None):
+                self.shape = shape
+                self.strides = strides
+                self.padding = padding
+
+        # Rank-3: encode non-last strides as exact values
+        # strides=[256, 16, 1] → T256,16 (last stride omitted)
+        arg = MockArg(shape=[32, 32, 32], strides=[256, 16, 1])
+        key = XPUBackend.get_tensordesc_specialization(arg)
+        assert "T256,16" in key, f"Expected T256,16 in {key}"
+
+    def test_stride_not_encoded_rank2(self):
+        """Stride values not encoded for rank-2 descriptors."""
+
+        class MockArg:
+
+            def __init__(self, shape, strides, padding=None):
+                self.shape = shape
+                self.strides = strides
+                self.padding = padding
+
+        # Rank-2: no stride encoding
+        arg = MockArg(shape=[128, 64], strides=[64, 1])
+        key = XPUBackend.get_tensordesc_specialization(arg)
+        assert "T" not in key, f"Rank-2 should not encode strides, got {key}"
+
+    def test_padding_encoding(self):
+        """NaN padding encodes as 'N' prefix."""
+
+        class MockArg:
+
+            def __init__(self, shape, strides, padding=None):
+                self.shape = shape
+                self.strides = strides
+                self.padding = padding
+
+        # With NaN padding
+        arg = MockArg(shape=[128, 64], strides=[64, 1], padding="nan")
+        key = XPUBackend.get_tensordesc_specialization(arg)
+        assert key.startswith("N"), f"Expected 'N' prefix for NaN padding, got {key}"
+
+        # Without padding
+        arg = MockArg(shape=[128, 64], strides=[64, 1], padding=None)
+        key = XPUBackend.get_tensordesc_specialization(arg)
+        assert not key.startswith("N"), f"Should not have 'N' prefix without padding, got {key}"
+
+    def test_parse_attr_shape_divisibility(self):
+        """parse_attr correctly decodes shape divisibility."""
+        key = "S0D128S1D64S2D1"
+        attrs = XPUBackend.parse_attr(key)
+
+        # Convert to dict for easier lookup
+        attr_dict = {attr[0]: attr[1] for attr in attrs}
+
+        assert "tt.shape.0.divisibility" in attr_dict
+        assert attr_dict["tt.shape.0.divisibility"] == 128
+        assert "tt.shape.1.divisibility" in attr_dict
+        assert attr_dict["tt.shape.1.divisibility"] == 64
+        assert "tt.shape.2.divisibility" in attr_dict
+        assert attr_dict["tt.shape.2.divisibility"] == 1
+
+    def test_parse_attr_stride_exact_values(self):
+        """parse_attr correctly decodes stride exact values."""
+        key = "T256,16"
+        attrs = XPUBackend.parse_attr(key)
+
+        attr_dict = {attr[0]: attr[1] for attr in attrs}
+
+        assert "tt.stride.0" in attr_dict
+        assert attr_dict["tt.stride.0"] == 256
+        assert "tt.stride.1" in attr_dict
+        assert attr_dict["tt.stride.1"] == 16
+
+    def test_parse_attr_padding(self):
+        """parse_attr correctly decodes padding flag."""
+        key = "N"
+        attrs = XPUBackend.parse_attr(key)
+
+        attr_dict = {attr[0]: attr[1] for attr in attrs}
+
+        assert "tt.padding" in attr_dict
+        assert attr_dict["tt.padding"] == 1
+
+    def test_roundtrip_full_example(self):
+        """Full round-trip: encode → key → parse → attrs."""
+
+        class MockArg:
+
+            def __init__(self, shape, strides, padding=None):
+                self.shape = shape
+                self.strides = strides
+                self.padding = padding
+
+        # Rank-3 descriptor with NaN padding
+        arg = MockArg(shape=[256, 128, 16], strides=[2048, 16, 1], padding="nan")
+
+        # Encode
+        key = XPUBackend.get_tensordesc_specialization(arg)
+
+        # Parse
+        attrs = XPUBackend.parse_attr(key)
+        attr_dict = {attr[0]: attr[1] for attr in attrs}
+
+        # Verify all expected attributes
+        assert attr_dict["tt.padding"] == 1
+        assert attr_dict["tt.shape.0.divisibility"] == 256
+        assert attr_dict["tt.shape.1.divisibility"] == 128
+        assert attr_dict["tt.shape.2.divisibility"] == 16
+        assert attr_dict["tt.stride.0"] == 2048
+        assert attr_dict["tt.stride.1"] == 16
+
+    def test_divisibility_power_of_2(self):
+        """Shape divisibility values are always powers of 2."""
+
+        class MockArg:
+
+            def __init__(self, shape, strides, padding=None):
+                self.shape = shape
+                self.strides = strides
+                self.padding = padding
+
+        # Test various non-power-of-2 values
+        arg = MockArg(shape=[96, 100, 1023], strides=[10000, 1023, 1])
+        key = XPUBackend.get_tensordesc_specialization(arg)
+        attrs = XPUBackend.parse_attr(key)
+        attr_dict = {attr[0]: attr[1] for attr in attrs}
+
+        # Shape divisibility is power-of-2
+        # 96 = 32 * 3 → max divisor = 32
+        assert attr_dict["tt.shape.0.divisibility"] == 32
+        # 100 = 4 * 25 → max divisor = 4
+        assert attr_dict["tt.shape.1.divisibility"] == 4
+        # 1023 = odd → max divisor = 1
+        assert attr_dict["tt.shape.2.divisibility"] == 1
+
+        # Stride values are exact (not divisibility)
+        # 10000 encoded as exact value
+        assert attr_dict["tt.stride.0"] == 10000
+        # 1023 encoded as exact value
+        assert attr_dict["tt.stride.1"] == 1023
+
+    def test_zero_value_divisibility(self):
+        """Zero values have divisibility of 1."""
+
+        class MockArg:
+
+            def __init__(self, shape, strides, padding=None):
+                self.shape = shape
+                self.strides = strides
+                self.padding = padding
+
+        arg = MockArg(shape=[0, 128], strides=[0, 1])
+        key = XPUBackend.get_tensordesc_specialization(arg)
+        attrs = XPUBackend.parse_attr(key)
+        attr_dict = {attr[0]: attr[1] for attr in attrs}
+
+        # Zero should get divisibility 1
+        assert attr_dict["tt.shape.0.divisibility"] == 1

--- a/test/Triton/Intel/host-tensordesc-specialization.mlir
+++ b/test/Triton/Intel/host-tensordesc-specialization.mlir
@@ -35,48 +35,6 @@ module {
 
 // -----
 
-// Test that stride constant folding (rank-3+) replaces stride args with constants.
-// Frontend flattened layout: descriptor, shape[0..rank-1], stride[0..rank-1]
-module {
-  tt.func public @stride_constant_folding_rank3(
-      %arg0: !tt.tensordesc<32x32x32xf32>
-             {tt.stride.0 = 1024 : i32, tt.stride.1 = 32 : i32},
-      %arg1: i32, %arg2: i32, %arg3: i32,
-      %arg4: i64, %arg5: i64, %arg6: i64)
-      -> tensor<32x32x32xf32> {
-    %c0 = arith.constant 0 : i32
-    %0 = tt.descriptor_load %arg0[%c0, %c0, %c0] : !tt.tensordesc<32x32x32xf32> -> tensor<32x32x32xf32>
-    tt.return %0 : tensor<32x32x32xf32>
-  }
-}
-
-// CHECK-LABEL: @stride_constant_folding_rank3
-// Descriptor expands to (ptr, 2*rank i64 args, 2 i1 args) = (ptr, 6 i64, 2 i1).
-// CHECK-SAME: %[[PTR:[^:]*]]: !tt.ptr<f32> {tt.divisibility = 16 : i32}
-// CHECK-SAME: %[[SHAPE0:[^:]*]]: i64
-// CHECK-SAME: %[[SHAPE1:[^:]*]]: i64
-// CHECK-SAME: %[[SHAPE2:[^:]*]]: i64
-// CHECK-SAME: %[[STRIDE0:[^:]*]]: i64
-// CHECK-SAME: %[[STRIDE1:[^:]*]]: i64
-// CHECK-SAME: %[[STRIDE2:[^:]*]]: i64
-// CHECK-SAME: %[[PAD:[^:]*]]: i1
-// CHECK-SAME: %[[ROUND:[^:]*]]: i1
-// Preserved original shape args (3) and stride args (3).
-// CHECK-SAME: %[[ORIG_SHAPE0:[^:]*]]: i32
-// CHECK-SAME: %[[ORIG_SHAPE1:[^:]*]]: i32
-// CHECK-SAME: %[[ORIG_SHAPE2:[^:]*]]: i32
-// Frontend stride args - still present but NOT used by MakeTensorDescOp (replaced by constants).
-// CHECK-SAME: %[[ORIG_STRIDE0:[^:]*]]: i64
-// CHECK-SAME: %[[ORIG_STRIDE1:[^:]*]]: i64
-// CHECK-SAME: %[[ORIG_STRIDE2:[^:]*]]: i64
-// Strides are replaced by constants from tt.stride.N attributes.
-// CHECK-DAG: %[[C1024:.*]] = arith.constant 1024 : i64
-// CHECK-DAG: %[[C32:.*]] = arith.constant 32 : i64
-// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : i64
-// CHECK: tt.make_tensor_descriptor %{{.*}}, [%[[ORIG_SHAPE0]], %[[ORIG_SHAPE1]], %[[ORIG_SHAPE2]]], [%[[C1024]], %[[C32]], %[[C1]]]
-
-// -----
-
 // Test that NaN padding attribute is correctly handled.
 module {
   tt.func public @padding(
@@ -109,37 +67,3 @@ module {
 // CHECK-LABEL: @base_ptr_divisibility
 // Base pointer always gets 16-byte divisibility.
 // CHECK-SAME: %[[PTR:[^:]*]]: !tt.ptr<f16> {tt.divisibility = 16 : i32}
-
-// -----
-
-// Test combined shape divisibility and stride constant folding (rank-3).
-module {
-  tt.func public @combined_shape_and_stride(
-      %arg0: !tt.tensordesc<256x128x16xf32>
-             {tt.shape.0.divisibility = 256 : i32, tt.shape.1.divisibility = 128 : i32, tt.shape.2.divisibility = 16 : i32,
-              tt.stride.0 = 2048 : i32, tt.stride.1 = 16 : i32},
-      %arg1: i32, %arg2: i32, %arg3: i32,
-      %arg4: i64, %arg5: i64, %arg6: i64)
-      -> tensor<256x128x16xf32> {
-    %c0 = arith.constant 0 : i32
-    %0 = tt.descriptor_load %arg0[%c0, %c0, %c0] : !tt.tensordesc<256x128x16xf32> -> tensor<256x128x16xf32>
-    tt.return %0 : tensor<256x128x16xf32>
-  }
-}
-
-// CHECK-LABEL: @combined_shape_and_stride
-// CHECK-SAME: %[[PTR:[^:]*]]: !tt.ptr<f32> {tt.divisibility = 16 : i32}
-// CHECK-SAME: %{{[^,)]*}}: i64, %{{[^,)]*}}: i64, %{{[^,)]*}}: i64
-// CHECK-SAME: %{{[^,)]*}}: i64, %{{[^,)]*}}: i64, %{{[^,)]*}}: i64
-// CHECK-SAME: %{{[^,)]*}}: i1, %{{[^,)]*}}: i1
-// Shape args get divisibility from specialization.
-// CHECK-SAME: %[[ORIG_SHAPE0:[^:]*]]: i32 {tt.divisibility = 256 : i32}
-// CHECK-SAME: %[[ORIG_SHAPE1:[^:]*]]: i32 {tt.divisibility = 128 : i32}
-// CHECK-SAME: %[[ORIG_SHAPE2:[^:]*]]: i32 {tt.divisibility = 16 : i32}
-// Stride args - no divisibility for rank-3+ with stride constant folding.
-// CHECK-SAME: %[[ORIG_STRIDE0:[^:]*]]: i64, %[[ORIG_STRIDE1:[^:]*]]: i64, %[[ORIG_STRIDE2:[^:]*]]: i64
-// Strides replaced by constants from tt.stride.N.
-// CHECK-DAG: %[[C2048:.*]] = arith.constant 2048 : i64
-// CHECK-DAG: %[[C16:.*]] = arith.constant 16 : i64
-// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : i64
-// CHECK: tt.make_tensor_descriptor %{{.*}}, [%[[ORIG_SHAPE0]], %[[ORIG_SHAPE1]], %[[ORIG_SHAPE2]]], [%[[C2048]], %[[C16]], %[[C1]]]

--- a/test/Triton/Intel/host-tensordesc-specialization.mlir
+++ b/test/Triton/Intel/host-tensordesc-specialization.mlir
@@ -1,0 +1,145 @@
+// RUN: triton-opt %s --triton-intel-rewrite-tensor-descriptor-to-pointer --split-input-file | FileCheck %s
+
+// Test that shape divisibility attributes from specialization are correctly
+// propagated to tt.divisibility on shape block arguments.
+// Frontend flattened layout: descriptor, shape[0..rank-1], stride[0..rank-1]
+module {
+  tt.func public @shape_divisibility(
+      %arg0: !tt.tensordesc<128x64xf16>
+             {tt.shape.0.divisibility = 128 : i32, tt.shape.1.divisibility = 64 : i32},
+      %arg1: i32, %arg2: i32,
+      %arg3: i64, %arg4: i64) -> tensor<128x64xf16> {
+    %c0 = arith.constant 0 : i32
+    %0 = tt.descriptor_load %arg0[%c0, %c0] : !tt.tensordesc<128x64xf16> -> tensor<128x64xf16>
+    tt.return %0 : tensor<128x64xf16>
+  }
+}
+
+// CHECK-LABEL: @shape_divisibility
+// Descriptor expands to (ptr, 2*rank i64 args, 2 i1 args).
+// CHECK-SAME: %[[PTR:[^:]*]]: !tt.ptr<f16> {tt.divisibility = 16 : i32}
+// CHECK-SAME: %[[SHAPE0:[^:]*]]: i64
+// CHECK-SAME: %[[SHAPE1:[^:]*]]: i64
+// CHECK-SAME: %[[STRIDE0:[^:]*]]: i64
+// CHECK-SAME: %[[STRIDE1:[^:]*]]: i64
+// CHECK-SAME: %[[PAD:[^:]*]]: i1
+// CHECK-SAME: %[[ROUND:[^:]*]]: i1
+// Frontend shape args (i32) become block arguments shifted by descriptor expansion.
+// CHECK-SAME: %[[ORIG_SHAPE0:[^:]*]]: i32 {tt.divisibility = 128 : i32}
+// CHECK-SAME: %[[ORIG_SHAPE1:[^:]*]]: i32 {tt.divisibility = 64 : i32}
+// Frontend stride args (i64) follow shape args.
+// CHECK-SAME: %[[ORIG_STRIDE0:[^:]*]]: i64 {tt.divisibility = 8 : i32}
+// CHECK-SAME: %[[ORIG_STRIDE1:[^:]*]]: i64
+// CHECK: %[[C1:.*]] = arith.constant 1 : i64
+// CHECK: tt.make_tensor_descriptor %[[PTR]], [%[[ORIG_SHAPE0]], %[[ORIG_SHAPE1]]], [%[[ORIG_STRIDE0]], %[[C1]]]
+
+// -----
+
+// Test that stride constant folding (rank-3+) replaces stride args with constants.
+// Frontend flattened layout: descriptor, shape[0..rank-1], stride[0..rank-1]
+module {
+  tt.func public @stride_constant_folding_rank3(
+      %arg0: !tt.tensordesc<32x32x32xf32>
+             {tt.stride.0 = 1024 : i32, tt.stride.1 = 32 : i32},
+      %arg1: i32, %arg2: i32, %arg3: i32,
+      %arg4: i64, %arg5: i64, %arg6: i64)
+      -> tensor<32x32x32xf32> {
+    %c0 = arith.constant 0 : i32
+    %0 = tt.descriptor_load %arg0[%c0, %c0, %c0] : !tt.tensordesc<32x32x32xf32> -> tensor<32x32x32xf32>
+    tt.return %0 : tensor<32x32x32xf32>
+  }
+}
+
+// CHECK-LABEL: @stride_constant_folding_rank3
+// Descriptor expands to (ptr, 2*rank i64 args, 2 i1 args) = (ptr, 6 i64, 2 i1).
+// CHECK-SAME: %[[PTR:[^:]*]]: !tt.ptr<f32> {tt.divisibility = 16 : i32}
+// CHECK-SAME: %[[SHAPE0:[^:]*]]: i64
+// CHECK-SAME: %[[SHAPE1:[^:]*]]: i64
+// CHECK-SAME: %[[SHAPE2:[^:]*]]: i64
+// CHECK-SAME: %[[STRIDE0:[^:]*]]: i64
+// CHECK-SAME: %[[STRIDE1:[^:]*]]: i64
+// CHECK-SAME: %[[STRIDE2:[^:]*]]: i64
+// CHECK-SAME: %[[PAD:[^:]*]]: i1
+// CHECK-SAME: %[[ROUND:[^:]*]]: i1
+// Preserved original shape args (3) and stride args (3).
+// CHECK-SAME: %[[ORIG_SHAPE0:[^:]*]]: i32
+// CHECK-SAME: %[[ORIG_SHAPE1:[^:]*]]: i32
+// CHECK-SAME: %[[ORIG_SHAPE2:[^:]*]]: i32
+// Frontend stride args - still present but NOT used by MakeTensorDescOp (replaced by constants).
+// CHECK-SAME: %[[ORIG_STRIDE0:[^:]*]]: i64
+// CHECK-SAME: %[[ORIG_STRIDE1:[^:]*]]: i64
+// CHECK-SAME: %[[ORIG_STRIDE2:[^:]*]]: i64
+// Strides are replaced by constants from tt.stride.N attributes.
+// CHECK-DAG: %[[C1024:.*]] = arith.constant 1024 : i64
+// CHECK-DAG: %[[C32:.*]] = arith.constant 32 : i64
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : i64
+// CHECK: tt.make_tensor_descriptor %{{.*}}, [%[[ORIG_SHAPE0]], %[[ORIG_SHAPE1]], %[[ORIG_SHAPE2]]], [%[[C1024]], %[[C32]], %[[C1]]]
+
+// -----
+
+// Test that NaN padding attribute is correctly handled.
+module {
+  tt.func public @padding(
+      %arg0: !tt.tensordesc<128x64xf16> {tt.padding = 1 : i32},
+      %arg1: i32, %arg2: i32,
+      %arg3: i64, %arg4: i64) -> tensor<128x64xf16> {
+    %c0 = arith.constant 0 : i32
+    %0 = tt.descriptor_load %arg0[%c0, %c0] : !tt.tensordesc<128x64xf16> -> tensor<128x64xf16>
+    tt.return %0 : tensor<128x64xf16>
+  }
+}
+
+// CHECK-LABEL: @padding
+// CHECK: tt.make_tensor_descriptor %{{.*}}, [%{{.*}}, %{{.*}}], [%{{.*}}, %{{.*}}] {padding = 2 : i32}
+
+// -----
+
+// Test that base pointer divisibility is always 16 bytes.
+module {
+  tt.func public @base_ptr_divisibility(
+      %arg0: !tt.tensordesc<128x64xf16>,
+      %arg1: i32, %arg2: i32,
+      %arg3: i64, %arg4: i64) -> tensor<128x64xf16> {
+    %c0 = arith.constant 0 : i32
+    %0 = tt.descriptor_load %arg0[%c0, %c0] : !tt.tensordesc<128x64xf16> -> tensor<128x64xf16>
+    tt.return %0 : tensor<128x64xf16>
+  }
+}
+
+// CHECK-LABEL: @base_ptr_divisibility
+// Base pointer always gets 16-byte divisibility.
+// CHECK-SAME: %[[PTR:[^:]*]]: !tt.ptr<f16> {tt.divisibility = 16 : i32}
+
+// -----
+
+// Test combined shape divisibility and stride constant folding (rank-3).
+module {
+  tt.func public @combined_shape_and_stride(
+      %arg0: !tt.tensordesc<256x128x16xf32>
+             {tt.shape.0.divisibility = 256 : i32, tt.shape.1.divisibility = 128 : i32, tt.shape.2.divisibility = 16 : i32,
+              tt.stride.0 = 2048 : i32, tt.stride.1 = 16 : i32},
+      %arg1: i32, %arg2: i32, %arg3: i32,
+      %arg4: i64, %arg5: i64, %arg6: i64)
+      -> tensor<256x128x16xf32> {
+    %c0 = arith.constant 0 : i32
+    %0 = tt.descriptor_load %arg0[%c0, %c0, %c0] : !tt.tensordesc<256x128x16xf32> -> tensor<256x128x16xf32>
+    tt.return %0 : tensor<256x128x16xf32>
+  }
+}
+
+// CHECK-LABEL: @combined_shape_and_stride
+// CHECK-SAME: %[[PTR:[^:]*]]: !tt.ptr<f32> {tt.divisibility = 16 : i32}
+// CHECK-SAME: %{{[^,)]*}}: i64, %{{[^,)]*}}: i64, %{{[^,)]*}}: i64
+// CHECK-SAME: %{{[^,)]*}}: i64, %{{[^,)]*}}: i64, %{{[^,)]*}}: i64
+// CHECK-SAME: %{{[^,)]*}}: i1, %{{[^,)]*}}: i1
+// Shape args get divisibility from specialization.
+// CHECK-SAME: %[[ORIG_SHAPE0:[^:]*]]: i32 {tt.divisibility = 256 : i32}
+// CHECK-SAME: %[[ORIG_SHAPE1:[^:]*]]: i32 {tt.divisibility = 128 : i32}
+// CHECK-SAME: %[[ORIG_SHAPE2:[^:]*]]: i32 {tt.divisibility = 16 : i32}
+// Stride args - no divisibility for rank-3+ with stride constant folding.
+// CHECK-SAME: %[[ORIG_STRIDE0:[^:]*]]: i64, %[[ORIG_STRIDE1:[^:]*]]: i64, %[[ORIG_STRIDE2:[^:]*]]: i64
+// Strides replaced by constants from tt.stride.N.
+// CHECK-DAG: %[[C2048:.*]] = arith.constant 2048 : i64
+// CHECK-DAG: %[[C16:.*]] = arith.constant 16 : i64
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : i64
+// CHECK: tt.make_tensor_descriptor %{{.*}}, [%[[ORIG_SHAPE0]], %[[ORIG_SHAPE1]], %[[ORIG_SHAPE2]]], [%[[C2048]], %[[C16]], %[[C1]]]

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -245,40 +245,67 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
     @staticmethod
     def parse_attr(desc):
         ret = BaseBackend.parse_attr(desc)
-        if "L" in desc:
-            ret += [["tt.last_dim_divisibility", 8]]
+
+        # Parse padding
         if "N" in desc:
             ret += [["tt.padding", 1]]
-        # "S<val>,<val>,..." encodes non-last stride values for rank-3+
-        # descriptors (enables constexpr stride optimization for FuseReshape).
-        if "S" in desc:
-            idx = desc.index("S") + 1
-            stride_str = desc[idx:]
-            try:
-                strides = [int(x) for x in stride_str.split(",") if x]
-                for i, s in enumerate(strides):
-                    ret += [[f"tt.stride.{i}", s]]
-            except ValueError:
-                pass
+
+        # Parse shape divisibility: S<dim>D<divisor>
+        # Format: S0D128 means shape[0] is divisible by 128
+        import re
+        for match in re.finditer(r'S(\d+)D(\d+)', desc):
+            dim = int(match.group(1))
+            divisor = int(match.group(2))
+            ret += [[f"tt.shape.{dim}.divisibility", divisor]]
+
+        # Parse stride divisibility: T<dim>D<divisor>
+        # Format: T0D64 means stride[0] is divisible by 64
+        for match in re.finditer(r'T(\d+)D(\d+)', desc):
+            dim = int(match.group(1))
+            divisor = int(match.group(2))
+            ret += [[f"tt.stride.{dim}.divisibility", divisor]]
+
         return ret
 
     @staticmethod
+    def _get_max_divisibility(value):
+        """Get the highest power-of-2 divisor of value.
+        """
+        if value == 0:
+            return 1
+        div = 1
+        while value % (div * 2) == 0:
+            div *= 2
+        return div
+
+    @staticmethod
     def get_tensordesc_specialization(arg, **kwargs):
-        # "L" = last-dim shape satisfies 2D block IO surface width alignment
-        #   (needed for satisfies2DBlockReadAlignment in MaterializeBlockPointer).
-        #   HW requires 4-byte (DW) alignment; combined with minimum 2 elements
-        #   for the stride-one dim this means shape[-1] * elem_bytes % 8 == 0.
-        # "N" = NaN padding (enables tt.padding attribute).
-        # "S<val>,..." = non-last stride values for rank-3+ (enables constexpr
-        #   stride optimization for FuseReshape).
+        """Encode max power-of-2 divisibility for specialization.
+
+        Format:
+          N = NaN padding
+          S<dim>D<divisor> = shape[dim] is divisible by <divisor> (max power of 2)
+          T<dim>D<divisor> = stride[dim] is divisible by <divisor> (max power of 2)
+
+        Example: "NS0D128S1D16" = NaN padding, shape[0] divisible by 128, shape[1] divisible by 16
+        """
         key = ""
-        elem_bytes = arg.base.dtype.itemsize
-        if (arg.shape[-1] * elem_bytes) % 8 == 0:
-            key += "L"
+
+        # Padding (bounded: 2 values)
         if getattr(arg, "padding", None) == "nan":
             key += "N"
+
+        # Shape maximum divisibility (naturally bounded by power-of-2 structure)
+        for i, shape_val in enumerate(arg.shape):
+            div = XPUBackend._get_max_divisibility(shape_val)
+            key += f"S{i}D{div}"
+
+        # Stride maximum divisibility for rank-3+ (naturally bounded)
         if len(arg.strides) >= 3:
-            key += "S" + ",".join(str(s) for s in arg.strides[:-1])
+            for i, stride_val in enumerate(arg.strides[:-1]):
+                div = XPUBackend._get_max_divisibility(stride_val)
+                key += f"T{i}D{div}"
+
         return key
 
     def pack_metadata(self, metadata):

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -245,26 +245,29 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
     @staticmethod
     def parse_attr(desc):
         ret = BaseBackend.parse_attr(desc)
-
-        # Parse padding
         if "N" in desc:
             ret += [["tt.padding", 1]]
-
-        # Parse shape divisibility: S<dim>D<divisor>
-        # Format: S0D128 means shape[0] is divisible by 128
+        # Shape divisibility: S<dim>D<divisor> (e.g., S0D128)
         import re
         for match in re.finditer(r'S(\d+)D(\d+)', desc):
             dim = int(match.group(1))
             divisor = int(match.group(2))
             ret += [[f"tt.shape.{dim}.divisibility", divisor]]
-
-        # Parse stride divisibility: T<dim>D<divisor>
-        # Format: T0D64 means stride[0] is divisible by 64
-        for match in re.finditer(r'T(\d+)D(\d+)', desc):
-            dim = int(match.group(1))
-            divisor = int(match.group(2))
-            ret += [[f"tt.stride.{dim}.divisibility", divisor]]
-
+        # Stride values: T<stride0>,<stride1>,... (e.g., T256,16)
+        if "T" in desc:
+            idx = desc.index("T") + 1
+            t_str = desc[idx:]
+            try:
+                stride_end = len(t_str)
+                for i, c in enumerate(t_str):
+                    if c.isalpha():
+                        stride_end = i
+                        break
+                strides = [int(x) for x in t_str[:stride_end].split(",") if x]
+                for i, s in enumerate(strides):
+                    ret += [[f"tt.stride.{i}", s]]
+            except (ValueError, IndexError):
+                pass
         return ret
 
     @staticmethod
@@ -280,32 +283,16 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
 
     @staticmethod
     def get_tensordesc_specialization(arg, **kwargs):
-        """Encode max power-of-2 divisibility for specialization.
-
-        Format:
-          N = NaN padding
-          S<dim>D<divisor> = shape[dim] is divisible by <divisor> (max power of 2)
-          T<dim>D<divisor> = stride[dim] is divisible by <divisor> (max power of 2)
-
-        Example: "NS0D128S1D16" = NaN padding, shape[0] divisible by 128, shape[1] divisible by 16
-        """
+        # Format: "N" (padding) + "S<dim>D<divisor>" (shape divisibility) + "T<strides>" (exact values)
         key = ""
-
-        # Padding (bounded: 2 values)
         if getattr(arg, "padding", None) == "nan":
             key += "N"
-
-        # Shape maximum divisibility (naturally bounded by power-of-2 structure)
         for i, shape_val in enumerate(arg.shape):
             div = XPUBackend._get_max_divisibility(shape_val)
             key += f"S{i}D{div}"
-
-        # Stride maximum divisibility for rank-3+ (naturally bounded)
         if len(arg.strides) >= 3:
-            for i, stride_val in enumerate(arg.strides[:-1]):
-                div = XPUBackend._get_max_divisibility(stride_val)
-                key += f"T{i}D{div}"
-
+            strides_str = ",".join(str(s) for s in arg.strides[:-1])
+            key += "T" + strides_str
         return key
 
     def pack_metadata(self, metadata):

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -245,42 +245,40 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
     @staticmethod
     def parse_attr(desc):
         ret = BaseBackend.parse_attr(desc)
+        if "L" in desc:
+            ret += [["tt.last_dim_divisibility", 8]]
         if "N" in desc:
             ret += [["tt.padding", 1]]
-        # "S" section: encodes shape and stride values as constexpr.
-        # Format: "S<shape0>,<shape1>,...;<stride0>,<stride1>,..."
-        # Enables isDivisible checks to pass trivially on constants.
+        # "S<val>,<val>,..." encodes non-last stride values for rank-3+
+        # descriptors (enables constexpr stride optimization for FuseReshape).
         if "S" in desc:
             idx = desc.index("S") + 1
-            s_str = desc[idx:]
+            stride_str = desc[idx:]
             try:
-                parts = s_str.split(";")
-                shapes = [int(x) for x in parts[0].split(",") if x]
-                for i, s in enumerate(shapes):
-                    ret += [[f"tt.shape.{i}", s]]
-                if len(parts) > 1:
-                    strides = [int(x) for x in parts[1].split(",") if x]
-                    for i, s in enumerate(strides):
-                        ret += [[f"tt.stride.{i}", s]]
-            except (ValueError, IndexError):
+                strides = [int(x) for x in stride_str.split(",") if x]
+                for i, s in enumerate(strides):
+                    ret += [[f"tt.stride.{i}", s]]
+            except ValueError:
                 pass
         return ret
 
     @staticmethod
     def get_tensordesc_specialization(arg, **kwargs):
+        # "L" = last-dim shape satisfies 2D block IO surface width alignment
+        #   (needed for satisfies2DBlockReadAlignment in MaterializeBlockPointer).
+        #   HW requires 4-byte (DW) alignment; combined with minimum 2 elements
+        #   for the stride-one dim this means shape[-1] * elem_bytes % 8 == 0.
         # "N" = NaN padding (enables tt.padding attribute).
-        # "S<shapes>;<strides>" = shape and stride values as constexpr.
-        #   Shapes: enables satisfies2DBlockReadAlignment and FuseReshape checks.
-        #   Strides (rank-3+ only): enables FuseReshape stride divisibility.
+        # "S<val>,..." = non-last stride values for rank-3+ (enables constexpr
+        #   stride optimization for FuseReshape).
         key = ""
+        elem_bytes = arg.base.dtype.itemsize
+        if (arg.shape[-1] * elem_bytes) % 8 == 0:
+            key += "L"
         if getattr(arg, "padding", None) == "nan":
             key += "N"
-        # Encode all shapes and non-last strides (rank-3+ only) as constants.
-        shapes_str = ",".join(str(s) for s in arg.shape)
-        strides_str = ",".join(str(s) for s in arg.strides[:-1]) if len(arg.strides) >= 3 else ""
-        key += "S" + shapes_str
-        if strides_str:
-            key += ";" + strides_str
+        if len(arg.strides) >= 3:
+            key += "S" + ",".join(str(s) for s in arg.strides[:-1])
         return key
 
     def pack_metadata(self, metadata):

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -253,21 +253,6 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
             dim = int(match.group(1))
             divisor = int(match.group(2))
             ret += [[f"tt.shape.{dim}.divisibility", divisor]]
-        # Stride values: T<stride0>,<stride1>,... (e.g., T256,16)
-        if "T" in desc:
-            idx = desc.index("T") + 1
-            t_str = desc[idx:]
-            try:
-                stride_end = len(t_str)
-                for i, c in enumerate(t_str):
-                    if c.isalpha():
-                        stride_end = i
-                        break
-                strides = [int(x) for x in t_str[:stride_end].split(",") if x]
-                for i, s in enumerate(strides):
-                    ret += [[f"tt.stride.{i}", s]]
-            except (ValueError, IndexError):
-                pass
         return ret
 
     @staticmethod
@@ -283,16 +268,13 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
 
     @staticmethod
     def get_tensordesc_specialization(arg, **kwargs):
-        # Format: "N" (padding) + "S<dim>D<divisor>" (shape divisibility) + "T<strides>" (exact values)
+        # Format: "N" (padding) + "S<dim>D<divisor>" (shape divisibility)
         key = ""
         if getattr(arg, "padding", None) == "nan":
             key += "N"
         for i, shape_val in enumerate(arg.shape):
             div = XPUBackend._get_max_divisibility(shape_val)
             key += f"S{i}D{div}"
-        if len(arg.strides) >= 3:
-            strides_str = ",".join(str(s) for s in arg.strides[:-1])
-            key += "T" + strides_str
         return key
 
     def pack_metadata(self, metadata):

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
@@ -1225,20 +1225,6 @@ static void synthesizeDescriptorsFromFuncArgs(Operation *moduleOp) {
         }
       }
 
-      // For rank-3+, replace non-last strides with constants from tt.stride.N
-      // attributes. This enables FuseReshape to prove stride divisibility.
-      if (rank >= 3 && descArgAttrs) {
-        for (unsigned d = 0; d < rank - 1; ++d) {
-          std::string attrName = "tt.stride." + std::to_string(d);
-          if (auto attr =
-                  dyn_cast_or_null<IntegerAttr>(descArgAttrs.get(attrName))) {
-            strideArgs[d] = arith::ConstantOp::create(
-                builder, loc, builder.getI64Type(),
-                builder.getI64IntegerAttr(attr.getValue().getSExtValue()));
-          }
-        }
-      }
-
       // Determine padding from the tt.padding attribute on the descriptor arg
       // (set by the specialization system for NaN-padded host descriptors).
       auto paddingOpt = triton::PaddingOption::PAD_ZERO;

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
@@ -1208,22 +1208,9 @@ static void synthesizeDescriptorsFromFuncArgs(Operation *moduleOp) {
                                            builder.getI64IntegerAttr(1));
       strideArgs.back() = c1;
 
-      // Replace shapes with constants from tt.shape.N attributes (set by
-      // specialization). This enables satisfies2DBlockReadAlignment and
-      // FuseReshape's shape divisibility checks to pass.
-      for (unsigned d = 0; d < rank; ++d) {
-        std::string attrName = "tt.shape." + std::to_string(d);
-        if (auto attr = funcOp.getArgAttrOfType<IntegerAttr>(
-                idx, StringRef(attrName))) {
-          shapeArgs[d] = arith::ConstantOp::create(
-              builder, loc, builder.getI32Type(),
-              builder.getI32IntegerAttr(
-                  static_cast<int32_t>(attr.getValue().getSExtValue())));
-        }
-      }
-
       // For rank-3+, replace non-last strides with constants from tt.stride.N
-      // attributes. This enables FuseReshape to prove stride divisibility.
+      // attributes. This enables FuseReshape to prove stride divisibility for
+      // rank-reducing loads.
       if (rank >= 3) {
         for (unsigned d = 0; d < rank - 1; ++d) {
           std::string attrName = "tt.stride." + std::to_string(d);
@@ -1264,10 +1251,22 @@ static void synthesizeDescriptorsFromFuncArgs(Operation *moduleOp) {
       unsigned strideDivisibility = 16 / std::max(1u, elemBytes);
 
       pendingAttrs.push_back({basePtr, 16});
-      // Frontend stride args: only add BlockArgument strides (not constants).
+      // Frontend stride args used by MakeTensorDescOp (guaranteed by
+      // TensorDescriptor: stride * elem_bytes % 16 == 0).
+      // Only need to add to BlockArgument strides (not constants).
       for (unsigned d = 0; d < rank - 1; ++d)
         if (isa<BlockArgument>(strideArgs[d]))
           pendingAttrs.push_back({strideArgs[d], strideDivisibility});
+
+      // Last-dim shape divisibility (set by "L" specialization key when
+      // shape[-1] * elem_bytes % 8 == 0). Required by
+      // satisfies2DBlockReadAlignment.
+      if (auto lastDimAttr = funcOp.getArgAttrOfType<IntegerAttr>(
+              idx, "tt.last_dim_divisibility")) {
+        unsigned lastDimDiv =
+            lastDimAttr.getValue().getZExtValue() / std::max(1u, elemBytes);
+        pendingAttrs.push_back({shapeArgs.back(), lastDimDiv});
+      }
 
       // Refresh for next iteration.
       funcType = funcOp.getFunctionType();

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
@@ -1208,14 +1208,30 @@ static void synthesizeDescriptorsFromFuncArgs(Operation *moduleOp) {
                                            builder.getI64IntegerAttr(1));
       strideArgs.back() = c1;
 
+      // Read attributes from descriptor arg at original position (idx), before
+      // arg_attrs array is updated by expansion.
+      DictionaryAttr descArgAttrs = funcOp.getArgAttrDict(idx);
+
+      // Collect shape divisibility from specialization.
+      SmallVector<std::pair<unsigned, unsigned>> shapeDivAttrs;
+      if (descArgAttrs) {
+        for (unsigned d = 0; d < rank; ++d) {
+          std::string attrName =
+              "tt.shape." + std::to_string(d) + ".divisibility";
+          if (auto attr =
+                  dyn_cast_or_null<IntegerAttr>(descArgAttrs.get(attrName))) {
+            shapeDivAttrs.push_back({d, attr.getValue().getZExtValue()});
+          }
+        }
+      }
+
       // For rank-3+, replace non-last strides with constants from tt.stride.N
-      // attributes. This enables FuseReshape to prove stride divisibility for
-      // rank-reducing loads.
-      if (rank >= 3) {
+      // attributes. This enables FuseReshape to prove stride divisibility.
+      if (rank >= 3 && descArgAttrs) {
         for (unsigned d = 0; d < rank - 1; ++d) {
           std::string attrName = "tt.stride." + std::to_string(d);
-          if (auto attr = funcOp.getArgAttrOfType<IntegerAttr>(
-                  idx, StringRef(attrName))) {
+          if (auto attr =
+                  dyn_cast_or_null<IntegerAttr>(descArgAttrs.get(attrName))) {
             strideArgs[d] = arith::ConstantOp::create(
                 builder, loc, builder.getI64Type(),
                 builder.getI64IntegerAttr(attr.getValue().getSExtValue()));
@@ -1226,10 +1242,12 @@ static void synthesizeDescriptorsFromFuncArgs(Operation *moduleOp) {
       // Determine padding from the tt.padding attribute on the descriptor arg
       // (set by the specialization system for NaN-padded host descriptors).
       auto paddingOpt = triton::PaddingOption::PAD_ZERO;
-      if (auto padAttr =
-              funcOp.getArgAttrOfType<IntegerAttr>(idx, "tt.padding"))
-        if (padAttr.getValue().getZExtValue() != 0)
-          paddingOpt = triton::PaddingOption::PAD_NAN;
+      if (descArgAttrs) {
+        if (auto padAttr =
+                dyn_cast_or_null<IntegerAttr>(descArgAttrs.get("tt.padding")))
+          if (padAttr.getValue().getZExtValue() != 0)
+            paddingOpt = triton::PaddingOption::PAD_NAN;
+      }
       auto paddingAttr = triton::PaddingOptionAttr::get(ctx, paddingOpt);
 
       auto syntheticDesc = triton::MakeTensorDescOp::create(
@@ -1251,26 +1269,15 @@ static void synthesizeDescriptorsFromFuncArgs(Operation *moduleOp) {
       unsigned strideDivisibility = 16 / std::max(1u, elemBytes);
 
       pendingAttrs.push_back({basePtr, 16});
-      // Frontend stride args used by MakeTensorDescOp (guaranteed by
-      // TensorDescriptor: stride * elem_bytes % 16 == 0).
-      // Only need to add to BlockArgument strides (not constants).
+      // Frontend stride args: only add BlockArgument strides (not constants).
       for (unsigned d = 0; d < rank - 1; ++d)
         if (isa<BlockArgument>(strideArgs[d]))
           pendingAttrs.push_back({strideArgs[d], strideDivisibility});
 
-      // Shape divisibility from specialization attributes (set by
-      // get_tensordesc_specialization for non-constant shape dimensions).
-      // Enables FuseReshape and other passes to prove divisibility properties.
-      for (unsigned d = 0; d < rank; ++d) {
-        if (isa<BlockArgument>(shapeArgs[d])) {
-          std::string attrName =
-              "tt.shape." + std::to_string(d) + ".divisibility";
-          if (auto attr = funcOp.getArgAttrOfType<IntegerAttr>(
-                  idx, StringRef(attrName))) {
-            unsigned shapeDivisibility = attr.getValue().getZExtValue();
-            pendingAttrs.push_back({shapeArgs[d], shapeDivisibility});
-          }
-        }
+      // Shape divisibility from specialization.
+      for (auto &[d, div] : shapeDivAttrs) {
+        if (isa<BlockArgument>(shapeArgs[d]))
+          pendingAttrs.push_back({shapeArgs[d], div});
       }
 
       // Refresh for next iteration.

--- a/third_party/intel/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
@@ -1258,14 +1258,19 @@ static void synthesizeDescriptorsFromFuncArgs(Operation *moduleOp) {
         if (isa<BlockArgument>(strideArgs[d]))
           pendingAttrs.push_back({strideArgs[d], strideDivisibility});
 
-      // Last-dim shape divisibility (set by "L" specialization key when
-      // shape[-1] * elem_bytes % 8 == 0). Required by
-      // satisfies2DBlockReadAlignment.
-      if (auto lastDimAttr = funcOp.getArgAttrOfType<IntegerAttr>(
-              idx, "tt.last_dim_divisibility")) {
-        unsigned lastDimDiv =
-            lastDimAttr.getValue().getZExtValue() / std::max(1u, elemBytes);
-        pendingAttrs.push_back({shapeArgs.back(), lastDimDiv});
+      // Shape divisibility from specialization attributes (set by
+      // get_tensordesc_specialization for non-constant shape dimensions).
+      // Enables FuseReshape and other passes to prove divisibility properties.
+      for (unsigned d = 0; d < rank; ++d) {
+        if (isa<BlockArgument>(shapeArgs[d])) {
+          std::string attrName =
+              "tt.shape." + std::to_string(d) + ".divisibility";
+          if (auto attr = funcOp.getArgAttrOfType<IntegerAttr>(
+                  idx, StringRef(attrName))) {
+            unsigned shapeDivisibility = attr.getValue().getZExtValue();
+            pendingAttrs.push_back({shapeArgs[d], shapeDivisibility});
+          }
+        }
       }
 
       // Refresh for next iteration.


### PR DESCRIPTION
Host tensor descriptors cause excessive JIT compilation, as it used exact shape values as constexpr, causing unbounded specialization where every unique shape value creates a new kernel variant.

This PR encodes maximum power-of-2 divisibility for **shape dimensions only**. Stride specialization removed as it caused unbounded compilation without benefit.

Fixes #7691