### PR TITLE
[HostTensorDescriptor] Cap shape divisibility specialization at 4

### DIFF
--- a/python/test/unit/intel/test_tensordesc_specialization.py
+++ b/python/test/unit/intel/test_tensordesc_specialization.py
@@ -1,8 +1,8 @@
 """Unit tests for TensorDescriptor specialization key generation and parsing.
 
 Tests the round-trip encoding and decoding of host-side TensorDescriptor
-specialization keys, which encode max power-of-2 divisibility for shape
-dimensions to enable bounded specialization.
+specialization keys, which encode max power-of-2 divisibility (capped at 4)
+for shape dimensions to enable bounded specialization.
 """
 
 from triton.backends.intel.compiler import XPUBackend
@@ -12,7 +12,7 @@ class TestTensorDescSpecialization:
     """Test XPUBackend.get_tensordesc_specialization and parse_attr."""
 
     def test_shape_divisibility_encoding(self):
-        """Shape dimensions encode max power-of-2 divisibility."""
+        """Shape dimensions encode max power-of-2 divisibility, capped at 4."""
 
         # Mock tensor descriptor with various shape divisibilities
         class MockArg:
@@ -22,11 +22,11 @@ class TestTensorDescSpecialization:
                 self.strides = strides
                 self.padding = padding
 
-        # shape=[128, 64, 17] → S0D128S1D64S2D1
+        # shape=[128, 64, 17] → S0D4S1D4S2D1 (128 and 64 capped at 4)
         arg = MockArg(shape=[128, 64, 17], strides=[64, 1])
         key = XPUBackend.get_tensordesc_specialization(arg)
-        assert "S0D128" in key, f"Expected S0D128 in {key}"
-        assert "S1D64" in key, f"Expected S1D64 in {key}"
+        assert "S0D4" in key, f"Expected S0D4 in {key}"
+        assert "S1D4" in key, f"Expected S1D4 in {key}"
         assert "S2D1" in key, f"Expected S2D1 in {key}"
 
     def test_padding_encoding(self):
@@ -51,16 +51,17 @@ class TestTensorDescSpecialization:
 
     def test_parse_attr_shape_divisibility(self):
         """parse_attr correctly decodes shape divisibility."""
-        key = "S0D128S1D64S2D1"
+        # Test parsing with capped values (max 4)
+        key = "S0D4S1D2S2D1"
         attrs = XPUBackend.parse_attr(key)
 
         # Convert to dict for easier lookup
         attr_dict = {attr[0]: attr[1] for attr in attrs}
 
         assert "tt.shape.0.divisibility" in attr_dict
-        assert attr_dict["tt.shape.0.divisibility"] == 128
+        assert attr_dict["tt.shape.0.divisibility"] == 4
         assert "tt.shape.1.divisibility" in attr_dict
-        assert attr_dict["tt.shape.1.divisibility"] == 64
+        assert attr_dict["tt.shape.1.divisibility"] == 2
         assert "tt.shape.2.divisibility" in attr_dict
         assert attr_dict["tt.shape.2.divisibility"] == 1
 
@@ -85,6 +86,7 @@ class TestTensorDescSpecialization:
                 self.padding = padding
 
         # Rank-3 descriptor with NaN padding
+        # shape=[256, 128, 16] all capped at 4
         arg = MockArg(shape=[256, 128, 16], strides=[2048, 16, 1], padding="nan")
 
         # Encode
@@ -94,14 +96,14 @@ class TestTensorDescSpecialization:
         attrs = XPUBackend.parse_attr(key)
         attr_dict = {attr[0]: attr[1] for attr in attrs}
 
-        # Verify all expected attributes
+        # Verify all expected attributes (all capped at 4)
         assert attr_dict["tt.padding"] == 1
-        assert attr_dict["tt.shape.0.divisibility"] == 256
-        assert attr_dict["tt.shape.1.divisibility"] == 128
-        assert attr_dict["tt.shape.2.divisibility"] == 16
+        assert attr_dict["tt.shape.0.divisibility"] == 4
+        assert attr_dict["tt.shape.1.divisibility"] == 4
+        assert attr_dict["tt.shape.2.divisibility"] == 4
 
     def test_divisibility_power_of_2(self):
-        """Shape divisibility values are always powers of 2."""
+        """Shape divisibility values are always powers of 2, capped at 4."""
 
         class MockArg:
 
@@ -116,9 +118,9 @@ class TestTensorDescSpecialization:
         attrs = XPUBackend.parse_attr(key)
         attr_dict = {attr[0]: attr[1] for attr in attrs}
 
-        # Shape divisibility is power-of-2
-        # 96 = 32 * 3 → max divisor = 32
-        assert attr_dict["tt.shape.0.divisibility"] == 32
+        # Shape divisibility is power-of-2, capped at 4
+        # 96 = 32 * 3 → max divisor = 32, capped at 4
+        assert attr_dict["tt.shape.0.divisibility"] == 4
         # 100 = 4 * 25 → max divisor = 4
         assert attr_dict["tt.shape.1.divisibility"] == 4
         # 1023 = odd → max divisor = 1
@@ -141,3 +143,24 @@ class TestTensorDescSpecialization:
 
         # Zero should get divisibility 1
         assert attr_dict["tt.shape.0.divisibility"] == 1
+
+    def test_divisibility_cap_at_4(self):
+        """Divisibility is capped at 4 for MaterializeBlockPointer alignment."""
+
+        class MockArg:
+
+            def __init__(self, shape, strides, padding=None):
+                self.shape = shape
+                self.strides = strides
+                self.padding = padding
+
+        # Large power-of-2 values should be capped at 4
+        arg = MockArg(shape=[1024, 2048, 512], strides=[1048576, 512, 1])
+        key = XPUBackend.get_tensordesc_specialization(arg)
+        attrs = XPUBackend.parse_attr(key)
+        attr_dict = {attr[0]: attr[1] for attr in attrs}
+
+        # All should be capped at 4 (max requirement for fp8)
+        assert attr_dict["tt.shape.0.divisibility"] == 4
+        assert attr_dict["tt.shape.1.divisibility"] == 4
+        assert attr_dict["tt.shape.2.divisibility"] == 4

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -257,12 +257,16 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
 
     @staticmethod
     def _get_max_divisibility(value):
-        """Get the highest power-of-2 divisor of value.
+        """Get the highest power-of-2 divisor of value, capped at 4.
+
+        Cap rationale: MaterializeBlockPointer's alignment check requires
+        divisibility by at most 4 (for fp8 with 8-bit elements). Higher
+        divisibilities provide no additional benefit for 2D block I/O.
         """
         if value == 0:
             return 1
         div = 1
-        while value % (div * 2) == 0:
+        while div < 4 and value % (div * 2) == 0:
             div *= 2
         return div
 


### PR DESCRIPTION
The 2D block I/O fast path requires shape divisibility checks in `MaterializeBlockPointer::satisfies2DBlockReadAlignment()`:

```cpp
unsigned divisor = std::max(2u, llvm::divideCeil(32u, elementWidth));
if (!ttgi::isDivisible(baseWidth, divisor))
    return false;  // Reject 2D block I/O
```

Maximum divisor needed across all element types:
- **fp8/int8** (8 bits): divisor = **4** ← highest requirement
- **bf16/fp16** (16 bits): divisor = 2
- **fp32+** (≥32 bits): divisor = 2

**Higher divisibilities provide no additional benefit for 2D block I/O.**

Fixes #7691