### PR TITLE
[XPU] Read the core clock rate from the target properties only

### DIFF
--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -174,14 +174,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
 
     @staticmethod
     def core_clock_rate(tgt_prop) -> int:
-        if (rate := tgt_prop.get('core_clock_rate')) is None:
-            from triton.runtime import driver
-            # Not `driver.active.utils`: creating it initializes the device, which raises
-            # when compiling in a forked process.
-            if (utils := driver.active.__dict__.get('utils')) is None:
-                return 0
-            rate = utils.get_device_properties(driver.active.get_current_device()).get('sm_clock_rate', 0)
-        return rate or 0
+        return tgt_prop.get('core_clock_rate') or 0
 
     def parse_target(self, tgt_prop) -> dict:
         dev_prop = {}


### PR DESCRIPTION
`parse_target()` runs on every `triton.compile()` and must stay driver-free, but the fallback read `driver.active`. The driver-built target already carries the rate, and a target that does not cannot support the in-kernel timer, which reports that explicitly. Fixes `test/inductor/test_triton_heuristics.py::TestCachingAutotunerPrecompileDriverSetup::test_warm_cache_only_precompile_skips_driver_setup_in_context`, currently failing on main.

Closes #7802