### PR TITLE
[MaterializeBlockPointer] Fix 1D reshape block I/O tile geometry for W > threadsPerWarp (#6578)

### DIFF
--- a/python/test/unit/intel/test_1d_reshape_store_correctness.py
+++ b/python/test/unit/intel/test_1d_reshape_store_correctness.py
@@ -226,3 +226,123 @@ def test_1d_reshape_strided_load(W, S, dtype_str, device):
         atol=1e-3,
         err_msg=f"Strided load mismatch for W={W}, S={S}",
     )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the W > threadsPerWarp correctness bug.
+#
+# When W > threadsPerWarp the hand-built BlockIOTileSizeInfo hardcoded
+# numElemPerPackedVal=1 / tileWidth=W, which mis-described the tile to the
+# hardware (lane l was given cols l and l+tpw, while it held cols 2l and
+# 2l+1). The shared getBlockIOTileSize helper packs the adjacent per-lane
+# columns into a wider element, producing the correct tile.
+#
+# On BMG (threadsPerWarp=32), the only reachable W>tpw case via
+# matchStridedPattern is 8-bit elements with W=64 (the payload restriction
+# caps 16-bit at W=32 = tpw). The test uses int8 to hit this path.
+# ---------------------------------------------------------------------------
+@triton.jit
+def _wgt_store_kernel(
+    src_ptr,
+    dst_ptr,
+    W: tl.constexpr,
+    S: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Single-instance strided store.  BLOCK = W*H, H <= maxPerWarpHeight=8.
+
+    The offset MUST be computed as a single expression before adding to the
+    pointer.  'dst_ptr + off_a + off_b' generates two chained addptr ops;
+    matchStridedPattern requires one addptr(splat, addi(remui, muli)).
+    """
+    i = tl.arange(0, BLOCK)
+    v = tl.load(src_ptr + i)
+    offset = (i % W) + (i // W) * S
+    mask = tl.full([BLOCK], True, tl.int1)
+    tl.store(dst_ptr + offset, v, mask=mask)
+
+
+@triton.jit
+def _wgt_load_kernel(
+    src_ptr,
+    dst_ptr,
+    W: tl.constexpr,
+    S: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Single-instance strided load.  BLOCK = W*H, H <= maxPerWarpHeight=32."""
+    i = tl.arange(0, BLOCK)
+    offset = (i % W) + (i // W) * S
+    mask = tl.full([BLOCK], True, tl.int1)
+    v = tl.load(src_ptr + offset, mask=mask)
+    tl.store(dst_ptr + i, v)
+
+
+@pytest.mark.skipif(not is_xpu(), reason="XPU-specific test")
+@pytest.mark.parametrize(
+    "W, S, H, dtype_str",
+    [
+        # i8 / W=64 > tpw=32 / H=1 (store is gated at H=1 anyway).
+        # BLOCK=W*H=64. Single instance, pure arange — matchStridedPattern fires.
+        # Before the fix: tile_width=64, elem_size=8 → lane l stores to
+        #   dst[l] and dst[l+32] but holds cols 2l and 2l+1 → wrong columns.
+        # After the fix:  tile_width=32, elem_size=16 → packed correctly.
+        (64, 128, 1, "int8"),
+        (64, 192, 1, "int8"),
+    ],
+    ids=["H1_W64_S128_i8_wgt_tpw", "H1_W64_S192_i8_wgt_tpw"],
+)
+def test_1d_reshape_strided_store_w_gt_tpw(W, S, H, dtype_str, device):
+    """Regression test: 1D strided store with W > threadsPerWarp must produce correct data."""
+    BLOCK = W * H
+    rs = RandomState(17)
+    x_np = numpy_random((BLOCK, ), dtype_str=dtype_str, rs=rs)
+
+    out_size = (H - 1) * S + W
+    out_ref = np.zeros(out_size, dtype=x_np.dtype)
+    for idx in range(BLOCK):
+        out_ref[idx % W + (idx // W) * S] = x_np[idx]
+
+    x_tri = to_triton(x_np, device=device)
+    out_tri = torch.zeros(out_size, dtype=x_tri.dtype, device=device)
+
+    _wgt_store_kernel[(1, )](x_tri, out_tri, W=W, S=S, BLOCK=BLOCK, num_warps=1)
+
+    np.testing.assert_array_equal(
+        to_numpy(out_tri),
+        out_ref,
+        err_msg=f"Store mismatch W={W} S={S} H={H} (W > threadsPerWarp bug)",
+    )
+
+
+@pytest.mark.skipif(not is_xpu(), reason="XPU-specific test")
+@pytest.mark.parametrize(
+    "W, S, H, dtype_str",
+    [
+        # i8 / W=64 > tpw=32 / H=8 (load allows up to H=32*numWarps=32).
+        # BLOCK=W*H=512. Single instance.
+        # Before the fix: tile_width=64, elem_size=8 tile_height=8 →
+        #   each lane reads the wrong columns (interleaved instead of adjacent).
+        # After the fix:  tile_width=32, elem_size=16 → packed correctly.
+        (64, 128, 8, "int8"),
+        (64, 192, 8, "int8"),
+    ],
+    ids=["H8_W64_S128_i8_wgt_tpw", "H8_W64_S192_i8_wgt_tpw"],
+)
+def test_1d_reshape_strided_load_w_gt_tpw(W, S, H, dtype_str, device):
+    """Regression test: 1D strided load with W > threadsPerWarp must read correct data."""
+    BLOCK = W * H
+    rs = RandomState(17)
+    in_full = numpy_random((H, S), dtype_str=dtype_str, rs=rs)
+    out_ref = np.array([in_full[i // W, i % W] for i in range(BLOCK)], dtype=in_full.dtype)
+
+    in_tri = to_triton(in_full.flatten(), device=device)
+    out_tri = torch.zeros(BLOCK, dtype=in_tri.dtype, device=device)
+
+    _wgt_load_kernel[(1, )](in_tri, out_tri, W=W, S=S, BLOCK=BLOCK, num_warps=1)
+
+    np.testing.assert_array_equal(
+        to_numpy(out_tri),
+        out_ref,
+        err_msg=f"Load mismatch W={W} S={S} H={H} (W > threadsPerWarp bug)",
+    )

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-w-gt-tpw.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-w-gt-tpw.mlir
@@ -1,0 +1,179 @@
+// RUN: env TRITON_INTEL_ENABLE_BLOCK_IO_ALL_LAYOUTS=1 triton-opt %s -split-input-file \
+// RUN:   -tritonintelgpu-materialize-block-pointer \
+// RUN:   --tritonintelgpu-lower-to-2d-block-load \
+// RUN:   --intel-allocate-shared-memory \
+// RUN:   --convert-triton-intel-gpu-to-llvm | FileCheck %s
+
+// Regression tests for the W > threadsPerWarp correctness bug in the 1D→2D
+// reshape paths.
+//
+// Root cause: the hand-built BlockIOTileSizeInfo in LoadStoreOpToLLVM.cpp
+// hardcoded numElemPerPackedVal=1 / tileWidth=W. When W > threadsPerWarp,
+// each lane owns W/tpw adjacent columns in the encoding; the hardware delivers
+// packed values at intervals of threadsPerWarp, so the tile must pack those
+// adjacent columns into a wider element type. The shared getBlockIOTileSize
+// helper does this via packRegister; the hand-built path did not.
+//
+// For i8 / W=64 / tpw=32, the correct tile packs two adjacent i8 into one i16:
+//   WRONG: elem_size_in_bits=8,  tile_width=64  (lane l gets cols l and l+32)
+//   RIGHT: elem_size_in_bits=16, tile_width=32  (lane l gets cols 2l,2l+1 as i16)
+//
+// The tests below were FAILING before the fix (wrong elem_size/tile_width
+// asserted) and PASSING after it.
+
+// ============================================================
+// Test 1: STORE i8, W=64 > tpw=32, H=1, BMG.
+//
+// matchStridedPattern: W=64 clears check2DBlockAddressPayloadRestriction(8,64).
+// reshape1DStridedStore: H=1 ≤ maxPerWarpHeight=8, numWarps=1.
+// Reshaped encoding: sizePerThread=[1,2], threadsPerWarp=[1,32].
+// Expected: two adjacent i8 packed → elem_size=16, tile_width=32.
+// ============================================================
+
+// CHECK-LABEL: llvm.func spir_kernelcc @store_i8_w64_h1_tpw32
+// CHECK:       triton_gen.2Dblockstore
+// CHECK-SAME:      {elem_size_in_bits = 16, tile_width = 32, tile_height = 1
+// CHECK-NOT:   {elem_size_in_bits = 8, tile_width = 64
+
+#blocked1d_t1 = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  tt.func @store_i8_w64_h1_tpw32(%arg0: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+                                   %arg1: tensor<64xi8, #blocked1d_t1>) {
+    %idx = tt.make_range {start = 0 : i32, end = 64 : i32} : tensor<64xi32, #blocked1d_t1>
+    %cW  = arith.constant dense<64>  : tensor<64xi32, #blocked1d_t1>
+    %cS  = arith.constant dense<128> : tensor<64xi32, #blocked1d_t1>
+    %r   = arith.remui %idx, %cW : tensor<64xi32, #blocked1d_t1>
+    %d   = arith.divui %idx, %cW : tensor<64xi32, #blocked1d_t1>
+    %m   = arith.muli  %d,   %cS : tensor<64xi32, #blocked1d_t1>
+    %off = arith.addi  %r,   %m  : tensor<64xi32, #blocked1d_t1>
+    %bp  = tt.splat %arg0 : !tt.ptr<i8> -> tensor<64x!tt.ptr<i8>, #blocked1d_t1>
+    %p   = tt.addptr %bp, %off : tensor<64x!tt.ptr<i8>, #blocked1d_t1>, tensor<64xi32, #blocked1d_t1>
+    tt.store %p, %arg1 : tensor<64x!tt.ptr<i8>, #blocked1d_t1>
+    tt.return
+  }
+}
+
+// -----
+
+// ============================================================
+// Test 2: STORE f16, W=32 > tpw=16, H=1, PVC (16-wide subgroup).
+//
+// Same tested shape as test_1d_reshape_h1_blockstore (W=32, f16) but on a
+// 16-wide subgroup. W=32 > tpw=16, so sizePerThread=[1,2] again.
+// Expected: two adjacent f16 packed → elem_size=32, tile_width=16.
+// ============================================================
+
+// CHECK-LABEL: llvm.func spir_kernelcc @store_f16_w32_h1_tpw16
+// CHECK:       triton_gen.2Dblockstore
+// CHECK-SAME:      {elem_size_in_bits = 32, tile_width = 16, tile_height = 1
+// CHECK-NOT:   {elem_size_in_bits = 16, tile_width = 32, tile_height = 1
+
+#blocked1d_t2 = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [16], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  tt.func @store_f16_w32_h1_tpw16(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                    %arg1: tensor<32xf16, #blocked1d_t2>) {
+    %idx = tt.make_range {start = 0 : i32, end = 32 : i32} : tensor<32xi32, #blocked1d_t2>
+    %cW  = arith.constant dense<32> : tensor<32xi32, #blocked1d_t2>
+    %cS  = arith.constant dense<96> : tensor<32xi32, #blocked1d_t2>
+    %r   = arith.remui %idx, %cW : tensor<32xi32, #blocked1d_t2>
+    %d   = arith.divui %idx, %cW : tensor<32xi32, #blocked1d_t2>
+    %m   = arith.muli  %d,   %cS : tensor<32xi32, #blocked1d_t2>
+    %off = arith.addi  %r,   %m  : tensor<32xi32, #blocked1d_t2>
+    %bp  = tt.splat %arg0 : !tt.ptr<f16> -> tensor<32x!tt.ptr<f16>, #blocked1d_t2>
+    %p   = tt.addptr %bp, %off : tensor<32x!tt.ptr<f16>, #blocked1d_t2>, tensor<32xi32, #blocked1d_t2>
+    tt.store %p, %arg1 : tensor<32x!tt.ptr<f16>, #blocked1d_t2>
+    tt.return
+  }
+}
+
+// -----
+
+// ============================================================
+// Test 3: LOAD i8, W=64 > tpw=32, H=8, BMG.
+//
+// The load path is NOT gated on H=1 (maxPerWarpHeight=32), so this tests
+// the more common multi-row case. reshape1DStridedLoad builds
+// loadEnc = sizePerThread=[8,2], threadsPerWarp=[1,32].
+// Expected: elem_size=16, tile_width=32, tile_height=8.
+// ============================================================
+
+// CHECK-LABEL: llvm.func spir_kernelcc @load_i8_w64_h8_tpw32
+// CHECK:       triton_gen.2Dblockload
+// CHECK-SAME:      {elem_size_in_bits = 16, tile_width = 32, tile_height = 8
+// CHECK-NOT:   {elem_size_in_bits = 8, tile_width = 64
+
+#blocked1d_t3 = #ttg.blocked<{sizePerThread = [16], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  tt.func @load_i8_w64_h8_tpw32(%arg0: !tt.ptr<i8> {tt.divisibility = 16 : i32})
+      -> tensor<512xi8, #blocked1d_t3> {
+    %idx = tt.make_range {start = 0 : i32, end = 512 : i32} : tensor<512xi32, #blocked1d_t3>
+    %cW  = arith.constant dense<64>  : tensor<512xi32, #blocked1d_t3>
+    %cS  = arith.constant dense<128> : tensor<512xi32, #blocked1d_t3>
+    %r   = arith.remui %idx, %cW : tensor<512xi32, #blocked1d_t3>
+    %d   = arith.divui %idx, %cW : tensor<512xi32, #blocked1d_t3>
+    %m   = arith.muli  %d,   %cS : tensor<512xi32, #blocked1d_t3>
+    %off = arith.addi  %r,   %m  : tensor<512xi32, #blocked1d_t3>
+    %bp  = tt.splat %arg0 : !tt.ptr<i8> -> tensor<512x!tt.ptr<i8>, #blocked1d_t3>
+    %p   = tt.addptr %bp, %off : tensor<512x!tt.ptr<i8>, #blocked1d_t3>, tensor<512xi32, #blocked1d_t3>
+    %v   = tt.load %p : tensor<512x!tt.ptr<i8>, #blocked1d_t3>
+    tt.return %v : tensor<512xi8, #blocked1d_t3>
+  }
+}
+
+// -----
+
+// ============================================================
+// Control 1: STORE i8, W=32 == tpw=32, H=1 — existing passing case.
+// Should still emit elem_size=8, tile_width=32 (no packing needed).
+// ============================================================
+
+// CHECK-LABEL: llvm.func spir_kernelcc @store_i8_w32_h1_tpw32_control
+// CHECK:       triton_gen.2Dblockstore
+// CHECK-SAME:      {elem_size_in_bits = 8, tile_width = 32, tile_height = 1
+
+#blocked1d_c1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  tt.func @store_i8_w32_h1_tpw32_control(%arg0: !tt.ptr<i8> {tt.divisibility = 16 : i32},
+                                           %arg1: tensor<32xi8, #blocked1d_c1>) {
+    %idx = tt.make_range {start = 0 : i32, end = 32 : i32} : tensor<32xi32, #blocked1d_c1>
+    %cW  = arith.constant dense<32> : tensor<32xi32, #blocked1d_c1>
+    %cS  = arith.constant dense<128> : tensor<32xi32, #blocked1d_c1>
+    %r   = arith.remui %idx, %cW : tensor<32xi32, #blocked1d_c1>
+    %d   = arith.divui %idx, %cW : tensor<32xi32, #blocked1d_c1>
+    %m   = arith.muli  %d,   %cS : tensor<32xi32, #blocked1d_c1>
+    %off = arith.addi  %r,   %m  : tensor<32xi32, #blocked1d_c1>
+    %bp  = tt.splat %arg0 : !tt.ptr<i8> -> tensor<32x!tt.ptr<i8>, #blocked1d_c1>
+    %p   = tt.addptr %bp, %off : tensor<32x!tt.ptr<i8>, #blocked1d_c1>, tensor<32xi32, #blocked1d_c1>
+    tt.store %p, %arg1 : tensor<32x!tt.ptr<i8>, #blocked1d_c1>
+    tt.return
+  }
+}
+
+// -----
+
+// ============================================================
+// Control 2: LOAD f16, W=32 == tpw=32, H=32 — existing passing case.
+// Should still emit elem_size=16, tile_width=32, tile_height=8.
+// ============================================================
+
+// CHECK-LABEL: llvm.func spir_kernelcc @load_f16_w32_h32_tpw32_control
+// CHECK:       triton_gen.2Dblockload
+// CHECK-SAME:      {elem_size_in_bits = 16, tile_width = 32, tile_height = 8
+
+#blocked1d_c2 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  tt.func @load_f16_w32_h32_tpw32_control(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32})
+      -> tensor<1024xf16, #blocked1d_c2> {
+    %idx = tt.make_range {start = 0 : i32, end = 1024 : i32} : tensor<1024xi32, #blocked1d_c2>
+    %cW  = arith.constant dense<32> : tensor<1024xi32, #blocked1d_c2>
+    %cS  = arith.constant dense<96> : tensor<1024xi32, #blocked1d_c2>
+    %r   = arith.remui %idx, %cW : tensor<1024xi32, #blocked1d_c2>
+    %d   = arith.divui %idx, %cW : tensor<1024xi32, #blocked1d_c2>
+    %m   = arith.muli  %d,   %cS : tensor<1024xi32, #blocked1d_c2>
+    %off = arith.addi  %r,   %m  : tensor<1024xi32, #blocked1d_c2>
+    %bp  = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked1d_c2>
+    %p   = tt.addptr %bp, %off : tensor<1024x!tt.ptr<f16>, #blocked1d_c2>, tensor<1024xi32, #blocked1d_c2>
+    %v   = tt.load %p : tensor<1024x!tt.ptr<f16>, #blocked1d_c2>
+    tt.return %v : tensor<1024xf16, #blocked1d_c2>
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -633,15 +633,6 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
            enableBlockIOForAllLayout.value() || hasDpas;
   }
 
-  /// Check whether an op was annotated by the 1D→2D reshape in
-  /// MaterializeBlockPointer.
-  template <typename OpTy> static bool hasAnnotated1DReshapeStride(OpTy op) {
-    if constexpr (std::is_same_v<OpTy, triton::StoreOp> ||
-                  std::is_same_v<OpTy, triton::LoadOp>)
-      return op->hasAttr(TritonIntelGPUDialect::getBlockIOStrideAttrName());
-    return false;
-  }
-
   /// Return the pitch (in bytes) for an op annotated by the 1D→2D reshape.
   /// The stride attribute is in elements; this converts to bytes.
   /// Returns std::nullopt if the attribute is absent, non-positive, or if
@@ -2917,52 +2908,10 @@ struct StoreOpToBlockIOConversion
     BlockIOTileSizeInfo sizeInfo = BlockIOTileSizeInfo::unknown();
     MLIRContext *ctx = rewriter.getContext();
 
-    if (hasAnnotated1DReshapeStride(op)) {
-      // For stores annotated by the 1D→2D reshape, the encoding was inferred
-      // by tt.reshape and may not satisfy getBlockIOTileSize constraints.
-      // Specifically, the reshape produces a blocked encoding with
-      // sizePerThread > maxElemPackedVal (e.g., sizePerThread[1]=8 vs
-      // maxElemPackedVal=4 for f16). This creates a gap between the
-      // register-packed extent and the first lane base that
-      // getBlockIOTileSize cannot bridge.
-      // TODO: extend getBlockIOTileSize to handle register bases in the
-      // contiguous dimension beyond the packing limit, so this special case
-      // can be removed.
-      auto blockedEnc = dyn_cast<BlockedEncodingAttr>(encoding);
-      assert(blockedEnc && "1D reshape store must have BlockedEncodingAttr");
-      assert(rank == 2 && "1D reshape always produces rank-2 tensors");
-      unsigned numWarpsRow = blockedEnc.getWarpsPerCTA()[0];
-      int height = tensorType.getDimSize(0) / numWarpsRow;
-      int width = tensorType.getDimSize(rank - 1);
-      // Build register bases as identity mapping — every register holds one
-      // element (numPackedVals=1), so all bases are included.
-      StringAttr kRegister = str_attr("register");
-      unsigned regDimSize = llEncoding->getInDimSize(kRegister);
-      SetVector<unsigned> regPackBases;
-      for (unsigned i = 1; i < regDimSize; i <<= 1)
-        regPackBases.insert(i);
-      sizeInfo = BlockIOTileSizeInfo(height, width, /*numElemPerPackedVal=*/1,
-                                     /*vBlocks=*/1, /*rowDim=*/0,
-                                     /*colDim=*/rank - 1, /*transpose=*/false,
-                                     /*vnni=*/false, std::move(regPackBases));
-      // The reshape path bypasses getBlockIOTileSize (and thus
-      // validate2DBlockStoreTile), so apply the HW address payload restriction
-      // here; vBlocks and transpose are already fixed (1 / false) above.
-      if (!sizeInfo.isValid())
-        return failure();
-      if (!check2DBlockAddressPayloadRestriction(
-              elemSizeInBits * sizeInfo.numElemPerPackedVal,
-              sizeInfo.tileWidth))
-        return failure();
-    } else {
-      // Validate through the shared helper (the single source of truth for 2D
-      // block store eligibility): tile geometry, HW address payload
-      // restriction, no transpose, vBlocks forced to 1.
-      if (!validate2DBlockStoreTile(llEncoding.value(), contiguousDim,
-                                    elemSizeInBits, tensorType, maskAxisInfo,
-                                    sizeInfo))
-        return failure();
-    }
+    if (!validate2DBlockStoreTile(llEncoding.value(), contiguousDim,
+                                  elemSizeInBits, tensorType, maskAxisInfo,
+                                  sizeInfo))
+      return failure();
 
     auto [tileHeight, tileWidth, numPackedVals, vBlocks, rowDim, colDim,
           isTransposeRequired, useVNNIFormat, regPackedBases] =
@@ -4240,28 +4189,9 @@ struct Subgroup2DBlockLoadFromPtrOpConversion
           const_cast<triton::intel::ModuleAxisInfoAnalysis &>(axisAnalysisPass)
               .getAxisInfo(op.getMask());
 
-    BlockIOTileSizeInfo sizeInfo = BlockIOTileSizeInfo::unknown();
-    bool has1DReshapeStride =
-        op->hasAttr(TritonIntelGPUDialect::getBlockIOStrideAttrName());
-    auto blockedEnc = dyn_cast<BlockedEncodingAttr>(encoding);
-    if (has1DReshapeStride && blockedEnc && rank == 2) {
-      unsigned numWarpsRow = blockedEnc.getWarpsPerCTA()[0];
-      int height = tensorType.getDimSize(0) / numWarpsRow;
-      int width = tensorType.getDimSize(rank - 1);
-      StringAttr kReg = S("register");
-      unsigned regDimSize = llEncoding->getInDimSize(kReg);
-      SetVector<unsigned> regPackBases;
-      for (unsigned i = 1; i < regDimSize; i <<= 1)
-        regPackBases.insert(i);
-      sizeInfo = BlockIOTileSizeInfo(height, width, /*numElemPerPackedVal=*/1,
-                                     /*vBlocks=*/1, /*rowDim=*/0,
-                                     /*colDim=*/rank - 1, /*transpose=*/false,
-                                     /*vnni=*/false, std::move(regPackBases));
-    } else {
-      sizeInfo =
-          getBlockIOLoadTileSize(*llEncoding, contiguousDim, elemSizeInBits,
-                                 maskAxisInfo, oneMatrixPerLoadForBT);
-    }
+    BlockIOTileSizeInfo sizeInfo =
+        getBlockIOLoadTileSize(*llEncoding, contiguousDim, elemSizeInBits,
+                               maskAxisInfo, oneMatrixPerLoadForBT);
     if (!sizeInfo.isValid())
       return failure();
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/BlockIOUtils.cpp
@@ -206,8 +206,15 @@ getBlockIOTileSize(const LinearLayout &ll, unsigned memContiguousDim,
   }
 
   const unsigned numLanes = 1 << basesOfLane.size();
-  // The slice of a name is not distributed densely across the lane. It is not
-  // supported by block io.
+  // Density check: every lane must own exactly one packed value.  This
+  // enforces the hardware's fixed delivery rule (lane = packedFlatIndex %
+  // threadsPerWarp, register = packedFlatIndex / threadsPerWarp).  A register
+  // basis that sits below full lane coverage — e.g. at packed-flat stride 1
+  // when threadsPerWarp = 32 — means one lane's values are interleaved with
+  // another's and cannot be expressed as a valid 2D block tile.  The
+  // packing loop must absorb all per-lane register bases before the lane
+  // walk reaches them; if it cannot (due to the MAX_BITS cap), the layout
+  // is unsupported and this check rejects it.
   if ((product<unsigned>(tileShape) / numElemPerPackedVal) != numLanes)
     return BlockIOTileSizeInfo::unknown();
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -347,8 +347,9 @@ private:
     if (op.getMask())
       maskAxisInfo = axisInfoAnalysis.getAxisInfo(op.getMask());
 
-    // For 1D->2D reshape loads, skip tile validation and use the stride
-    // attribute directly for pitch.
+    // Whether this load was annotated by the 1D→2D reshape in
+    // MaterializeBlockPointer. Used for pitch and base-height computation
+    // below.
     bool has1DReshapeStride =
         op->hasAttr(ttgi::TritonIntelGPUDialect::getBlockIOStrideAttrName());
 
@@ -360,31 +361,26 @@ private:
     int tileHeight = -1;
     int numPackedVals = -1;
     bool isTranspose = false;
-    if (has1DReshapeStride) {
-      // 1D reshape: conventional dims, no tile validation needed.
-      rowDim = memoryRowMajor ? rank - 2 : rank - 1;
-      colDim = memoryRowMajor ? rank - 1 : rank - 2;
-    } else {
-      Attribute encoding = tensorTy.getEncoding();
-      LinearLayout llEncoding =
-          cast<ttg::DistributedEncodingTrait>(encoding).toLinearLayout(
-              tensorTy.getShape());
-      if (!ttgi::validate2DBlockLoadTile(llEncoding, contiguousDim,
-                                         elemSizeInBits, tensorTy,
-                                         oneMatrixPerLoadForBT, maskAxisInfo)) {
-        LDBG("Tile validation failed for load: " << *op);
-        return;
-      }
-      auto sizeInfo = ttgi::getBlockIOLoadTileSize(llEncoding, contiguousDim,
-                                                   elemSizeInBits, maskAxisInfo,
-                                                   oneMatrixPerLoadForBT);
-      rowDim = sizeInfo.rowDim;
-      colDim = sizeInfo.colDim;
-      tileWidth = sizeInfo.tileWidth;
-      tileHeight = sizeInfo.tileHeight;
-      isTranspose = sizeInfo.transpose;
-      numPackedVals = sizeInfo.numElemPerPackedVal;
+
+    Attribute encoding = tensorTy.getEncoding();
+    LinearLayout llEncoding =
+        cast<ttg::DistributedEncodingTrait>(encoding).toLinearLayout(
+            tensorTy.getShape());
+    if (!ttgi::validate2DBlockLoadTile(llEncoding, contiguousDim,
+                                       elemSizeInBits, tensorTy,
+                                       oneMatrixPerLoadForBT, maskAxisInfo)) {
+      LDBG("Tile validation failed for load: " << *op);
+      return;
     }
+    auto sizeInfo =
+        ttgi::getBlockIOLoadTileSize(llEncoding, contiguousDim, elemSizeInBits,
+                                     maskAxisInfo, oneMatrixPerLoadForBT);
+    rowDim = sizeInfo.rowDim;
+    colDim = sizeInfo.colDim;
+    tileWidth = sizeInfo.tileWidth;
+    tileHeight = sizeInfo.tileHeight;
+    isTranspose = sizeInfo.transpose;
+    numPackedVals = sizeInfo.numElemPerPackedVal;
 
     // For the 2D block load surface, the pitch dimension is always the
     // non-contiguous memory direction. For transposed loads, rowDim is the

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -417,11 +417,7 @@ private:
       isBroadcast = (rowStride == 0);
     }
 
-    int64_t perWarpWidth;
-    if (has1DReshapeStride)
-      perWarpWidth = tensorTy.getDimSize(surfaceWidthDim);
-    else
-      perWarpWidth = tileWidth * numPackedVals;
+    int64_t perWarpWidth = tileWidth * numPackedVals;
     int64_t baseWidthBytes = perWarpWidth * elemSizeInBits / 8;
 
     if (!has1DReshapeStride) {

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -417,7 +417,11 @@ private:
       isBroadcast = (rowStride == 0);
     }
 
-    int64_t perWarpWidth = tileWidth * numPackedVals;
+    int64_t perWarpWidth;
+    if (has1DReshapeStride)
+      perWarpWidth = tensorTy.getDimSize(surfaceWidthDim);
+    else
+      perWarpWidth = tileWidth * numPackedVals;
     int64_t baseWidthBytes = perWarpWidth * elemSizeInBits / 8;
 
     if (!has1DReshapeStride) {

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -646,10 +646,10 @@ private:
     if (!info)
       return;
 
-    // TODO: 2D block store does not support hardware transpose. With H > 1,
-    // the encoding inference puts registers in columns while the store
-    // hardware expects registers in rows. Fixing this requires inserting a
-    // ConvertLayoutOp before the store.
+    // With H > 1, tt.reshape infers a blocked encoding that does not match the
+    // 2D block store's hardware delivery pattern: the hardware places each
+    // lane's values at intervals of threadsPerWarp in the packed-flat tile, but
+    // the inferred encoding places them in adjacent positions.
     if (info->H != 1) {
       LDBG("H=" << info->H
                 << " > 1 not yet supported for store, skip 1D reshape");

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -549,8 +549,6 @@ private:
     }
 
     // Tile width must satisfy HW limits per element size.
-    // The reshape always produces numElemPerPackedVal == 1, so
-    // packedElemSizeInBits == elemBits.
     if (!ttgi::check2DBlockAddressPayloadRestriction(elemBits, W)) {
       LDBG("Tile width " << W << " invalid for " << elemBits
                          << "-bit elements, skip 1D reshape");


### PR DESCRIPTION
The 1D→2D reshape paths in LoadStoreOpToLLVM.cpp hand-built a BlockIOTileSizeInfo with numElemPerPackedVal=1 / tileWidth=W instead of calling the shared getBlockIOTileSize helper. This was correct when W == threadsPerWarp (the only tested configuration) but silently produced wrong data when W > threadsPerWarp: each lane holds W/tpw adjacent columns, but the hand-built tile told the hardware to deliver non-adjacent columns (l and l+tpw instead of 2l and 2l+1).

On BMG (tpw=32) the reachable trigger is i8/W=64; on a 16-wide subgroup f16/W=32 also hits it. The corruption is silent — no compile error, wrong numerics at runtime, similar to the densenet/ghostnet accuracy failures from

Fix: delete both hand-built BlockIOTileSizeInfo constructions (store in LoadStoreOpToLLVM.cpp ~2884, load ~4207) so getBlockIOTileSize is called for all annotated ops. The helper's packRegister correctly folds W/tpw adjacent columns into one packed element (i8×2 → i16, tileWidth=32 instead of 64), matching the hardware delivery pattern exactly.

Also remove the tile-validation bypass in LowerTo2DBlockLoad.cpp that skipped validate2DBlockLoadTile for annotated ops; hasAnnotated1DReshapeStride is now unused and deleted. getAnnotated1DReshapePitch is kept — it recovers the row stride S from ttig.block_io_stride for pitch computation, which is not derivable from the encoding alone.

The W == tpw paths are unchanged: the helper returns the same geometry as the old hand-built path for those cases (verified by differential assert). All existing reshape lit tests pass byte-identical.

Add regression tests:
- materialize-block-pointer-1d-reshape-w-gt-tpw.mlir: GPU-free lit test pinning the correct packed geometry (elem_size=16, tile_width=32) for all three bug cases; FAILS before the fix, PASSES after.
- test_1d_reshape_store_correctness.py: four new GPU accuracy tests (test_1d_reshape_strided_{store,load}_w_gt_tpw) using single-instance kernels with a canonical linear index so matchStridedPattern fires.

Fixes wrong-data corruption for 1D strided block I/O when W > threadsPerWarp. Related: #6578.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
