### PR TITLE
[LoopDistribute] Allow carried chains that depend on a single accumulator

### DIFF
--- a/python/test/unit/intel/test_loop_distribute.py
+++ b/python/test/unit/intel/test_loop_distribute.py
@@ -19,6 +19,10 @@ index) -- the regression shape for the loop-carried-iter_arg-replication fix.
 Kernel B is a `tl.make_tensor_descriptor`-based GEMM mirroring the
 already-supported fast path used by `fused_gemm_swiglu_kernel` in
 benchmarks/triton_kernels_benchmark/fused_gemm_benchmark.py.
+Kernel C adds a loop-carried value that reads one dot's accumulator, which
+exercises the per-iter_arg ownership path: the chain is computed only in the
+loop owning that accumulator, its slot is frozen in the other loop, and its
+result is wired from the owner.
 """
 
 import pytest
@@ -113,6 +117,61 @@ def _dual_dot_desc_kernel(
     desc_yfc = tl.make_tensor_descriptor(yfc_ptr, shape=[M, N], strides=[N, 1], block_shape=[BLOCK_M, BLOCK_N])
     desc_yg.store([0, 0], acc_g.to(yg_ptr.type.element_ty))
     desc_yfc.store([0, 0], acc_fc.to(yfc_ptr.type.element_ty))
+
+
+@triton.jit
+def _dual_dot_carry_reads_acc_kernel(
+    a_ptr,
+    wg_ptr,
+    wfc_ptr,
+    cg_ptr,
+    cfc_ptr,
+    carry_ptr,
+    K: tl.constexpr,
+    stride_am: tl.constexpr,
+    stride_ak: tl.constexpr,
+    stride_wgk: tl.constexpr,
+    stride_wgn: tl.constexpr,
+    stride_wfck: tl.constexpr,
+    stride_wfcn: tl.constexpr,
+    stride_cm: tl.constexpr,
+    stride_cn: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    offs_m = tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    wg_ptrs = wg_ptr + offs_k[:, None] * stride_wgk + offs_n[None, :] * stride_wgn
+    wfc_ptrs = wfc_ptr + offs_k[:, None] * stride_wfck + offs_n[None, :] * stride_wfcn
+
+    acc_g = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    acc_fc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    carry = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for _ in range(0, K, BLOCK_K):
+        a = tl.load(a_ptrs)
+        w_g = tl.load(wg_ptrs)
+        w_fc = tl.load(wfc_ptrs)
+        # Read acc_g BEFORE the tl.dot below rebinds it, so this reads the
+        # accumulator's *iter_arg* (its value at the top of the iteration) and
+        # not the dot's result. That makes `carry` a loop-carried chain owned by
+        # acc_g's distributed loop.
+        carry = carry + acc_g
+        acc_g = tl.dot(a, w_g, acc_g, input_precision="ieee")
+        acc_fc = tl.dot(a, w_fc, acc_fc, input_precision="ieee")
+        a_ptrs += BLOCK_K * stride_ak
+        wg_ptrs += BLOCK_K * stride_wgk
+        wfc_ptrs += BLOCK_K * stride_wfck
+
+    cg_ptrs = cg_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    cfc_ptrs = cfc_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    carry_ptrs = carry_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(cg_ptrs, acc_g.to(cg_ptr.dtype.element_ty))
+    tl.store(cfc_ptrs, acc_fc.to(cfc_ptr.dtype.element_ty))
+    tl.store(carry_ptrs, carry)
 
 
 @pytest.mark.skipif(not is_xpu(), reason="XPU-specific test")
@@ -230,3 +289,81 @@ def test_dual_dot_desc_gemm_loop_distribute(device):
     # loop_distribute=False and loop_distribute=True must agree with each other.
     torch.testing.assert_close(results[False][0].float(), results[True][0].float(), rtol=1e-2, atol=5e-2)
     torch.testing.assert_close(results[False][1].float(), results[True][1].float(), rtol=1e-2, atol=5e-2)
+
+
+@pytest.mark.skipif(not is_xpu(), reason="XPU-specific test")
+def test_dual_dot_carry_reads_acc_loop_distribute(device):
+    """A loop-carried, non-accumulator value (`carry`) reads acc_g's iter_arg, so
+    it can only be computed in the loop that keeps acc_g live.
+
+    This exercises per-iter_arg ownership end to end: `carry`'s chain is cloned
+    into acc_g's loop only, its slot is frozen (yielded unchanged) in acc_fc's
+    loop, and the returned value is taken from the owning loop. Getting any of
+    those three wrong changes `carry` numerically -- it would come out as the
+    frozen init (all zeros) or be accumulated twice -- while acc_g and acc_fc
+    stay correct, so `carry` is the value that actually discriminates here.
+    """
+    M, N, K, BLOCK_K = 128, 128, 256, 64
+
+    torch.manual_seed(17)
+    a = torch.randn((M, K), dtype=torch.float16, device=device)
+    w_g = torch.randn((K, N), dtype=torch.float16, device=device)
+    w_fc = torch.randn((K, N), dtype=torch.float16, device=device)
+
+    ref_g = torch.matmul(a.float(), w_g.float())
+    ref_fc = torch.matmul(a.float(), w_fc.float())
+    # carry accumulates acc_g as seen at the TOP of each iteration, i.e. the sum
+    # of the partial products over all but the last k-block, prefix by prefix.
+    ref_carry = torch.zeros((M, N), dtype=torch.float32, device=device)
+    running = torch.zeros((M, N), dtype=torch.float32, device=device)
+    for k in range(0, K, BLOCK_K):
+        ref_carry += running
+        running = running + torch.matmul(a[:, k:k + BLOCK_K].float(), w_g[k:k + BLOCK_K, :].float())
+
+    results = {}
+    for loop_distribute in (False, True):
+        c_g = torch.empty((M, N), dtype=torch.float16, device=device)
+        c_fc = torch.empty((M, N), dtype=torch.float16, device=device)
+        c_carry = torch.empty((M, N), dtype=torch.float32, device=device)
+
+        kernel = _dual_dot_carry_reads_acc_kernel[(1, 1)](
+            a,
+            w_g,
+            w_fc,
+            c_g,
+            c_fc,
+            c_carry,
+            K,
+            a.stride(0),
+            a.stride(1),
+            w_g.stride(0),
+            w_g.stride(1),
+            w_fc.stride(0),
+            w_fc.stride(1),
+            c_g.stride(0),
+            c_g.stride(1),
+            BLOCK_M=M,
+            BLOCK_N=N,
+            BLOCK_K=BLOCK_K,
+            num_warps=4,
+            loop_distribute=loop_distribute,
+        )
+
+        ttir = kernel.asm["ttir"]
+        expected_loops = 2 if loop_distribute else 1
+        assert ttir.count("scf.for") == expected_loops, (
+            f"loop_distribute={loop_distribute}: expected {expected_loops} scf.for in ttir, "
+            f"got {ttir.count('scf.for')}\n{ttir}")
+
+        err_g = (c_g.float() - ref_g).abs().max().item()
+        err_fc = (c_fc.float() - ref_fc).abs().max().item()
+        err_carry = (c_carry - ref_carry).abs().max().item()
+        assert err_g < 2e-1, f"loop_distribute={loop_distribute}: acc_g max abs error {err_g} exceeds 2e-1"
+        assert err_fc < 2e-1, f"loop_distribute={loop_distribute}: acc_fc max abs error {err_fc} exceeds 2e-1"
+        assert err_carry < 5e-1, f"loop_distribute={loop_distribute}: carry max abs error {err_carry} exceeds 5e-1"
+
+        results[loop_distribute] = (c_g.clone(), c_fc.clone(), c_carry.clone())
+
+    # loop_distribute=False and loop_distribute=True must agree with each other.
+    for i in range(3):
+        torch.testing.assert_close(results[False][i].float(), results[True][i].float(), rtol=1e-2, atol=1e-2)

--- a/test/TritonIntelGPU/LoopDistribute/carried.mlir
+++ b/test/TritonIntelGPU/LoopDistribute/carried.mlir
@@ -153,3 +153,205 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
     tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
   }
 }
+
+// -----
+
+// Test: a carried, non-accumulator chain (%carry, index 2) reads dot0's
+// accumulator block argument (%acc_g). Since it reads exactly ONE
+// accumulator, index 2 is OWNED by dot0's loop rather than rejected: the
+// chain is cloned into the first loop only, the second loop FREEZES index 2
+// (yields its own block argument unchanged so the slot is inert there), and
+// the function result for index 2 is wired from the first loop.
+//
+// Replicating the chain into both loops -- the treatment every other carried
+// chain in this file gets -- would be wrong here: the second loop's %acc_g
+// slot is a frozen pass-through, so its copy would read the init value.
+// CHECK-LABEL: @carried_reads_own_acc_distribute
+// CHECK: %[[ACC_INIT:.*]] = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+// CHECK: %[[LOOP1:.*]]:3 = scf.for {{.*}}iter_args(%[[L1_ACCG:[^ ]+]] = %[[ACC_INIT]], %[[L1_ACCFC:[^ ]+]] = %[[ACC_INIT]], %[[L1_CARRY:[^ ]+]] = %[[ACC_INIT]])
+// CHECK:   %[[X1:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[WG:.*]] = tt.descriptor_load %arg1
+// CHECK:   %[[D0:.*]] = tt.dot %[[X1]], %[[WG]], %[[L1_ACCG]]
+// CHECK-NOT: tt.dot
+// CHECK:   %[[NEXT:.*]] = arith.addf %[[L1_CARRY]], %[[L1_ACCG]]
+// CHECK:   scf.yield %[[D0]], %[[L1_ACCFC]], %[[NEXT]]
+// CHECK: %[[LOOP2:.*]]:3 = scf.for {{.*}}iter_args(%[[L2_ACCG:[^ ]+]] = %[[ACC_INIT]], %[[L2_ACCFC:[^ ]+]] = %[[ACC_INIT]], %[[L2_CARRY:[^ ]+]] = %[[ACC_INIT]])
+// CHECK:   %[[X2:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[WFC:.*]] = tt.descriptor_load %arg2
+// CHECK:   %[[D1:.*]] = tt.dot %[[X2]], %[[WFC]], %[[L2_ACCFC]]
+// CHECK-NOT: tt.dot
+// The owned chain is NOT replicated here; index 2 is frozen instead.
+// CHECK-NOT: arith.addf
+// CHECK:   scf.yield %[[L2_ACCG]], %[[D1]], %[[L2_CARRY]]
+// CHECK: tt.return %[[LOOP1]]#0, %[[LOOP2]]#1, %[[LOOP1]]#2
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @carried_reads_own_acc_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:3 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst, %carry = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      // %carry's update reads dot0's accumulator block argument directly.
+      %next = arith.addf %carry, %acc_g : tensor<128x128xf32>
+      scf.yield %d0, %d1, %next : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1, %0#2 : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: the mirror image of @carried_reads_own_acc_distribute -- the carried
+// chain reads dot1's accumulator (%acc_fc), so index 2 is owned by the SECOND
+// loop. This direction is the one that actually catches a broken ownership
+// analysis: the pre-existing wiring took every carried result from the first
+// loop, so index 2 must now be taken from %[[LOOP2]], not %[[LOOP1]].
+// CHECK-LABEL: @carried_reads_dot1_acc_distribute
+// CHECK: %[[ACC_INIT:.*]] = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+// CHECK: %[[LOOP1:.*]]:3 = scf.for {{.*}}iter_args(%[[L1_ACCG:[^ ]+]] = %[[ACC_INIT]], %[[L1_ACCFC:[^ ]+]] = %[[ACC_INIT]], %[[L1_CARRY:[^ ]+]] = %[[ACC_INIT]])
+// CHECK:   %[[X1:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[WG:.*]] = tt.descriptor_load %arg1
+// CHECK:   %[[D0:.*]] = tt.dot %[[X1]], %[[WG]], %[[L1_ACCG]]
+// CHECK-NOT: tt.dot
+// Index 2 is frozen in this loop -- no cloned arith.addf.
+// CHECK-NOT: arith.addf
+// CHECK:   scf.yield %[[D0]], %[[L1_ACCFC]], %[[L1_CARRY]]
+// CHECK: %[[LOOP2:.*]]:3 = scf.for {{.*}}iter_args(%[[L2_ACCG:[^ ]+]] = %[[ACC_INIT]], %[[L2_ACCFC:[^ ]+]] = %[[ACC_INIT]], %[[L2_CARRY:[^ ]+]] = %[[ACC_INIT]])
+// CHECK:   %[[X2:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[WFC:.*]] = tt.descriptor_load %arg2
+// CHECK:   %[[D1:.*]] = tt.dot %[[X2]], %[[WFC]], %[[L2_ACCFC]]
+// CHECK-NOT: tt.dot
+// CHECK:   %[[NEXT:.*]] = arith.addf %[[L2_CARRY]], %[[L2_ACCFC]]
+// CHECK:   scf.yield %[[L2_ACCG]], %[[D1]], %[[NEXT]]
+// CHECK: tt.return %[[LOOP1]]#0, %[[LOOP2]]#1, %[[LOOP2]]#2
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @carried_reads_dot1_acc_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:3 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst, %carry = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      // %carry's update reads dot1's accumulator block argument directly.
+      %next = arith.addf %carry, %acc_fc : tensor<128x128xf32>
+      scf.yield %d0, %d1, %next : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1, %0#2 : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: the carried slot's yielded value IS an accumulator block argument, with
+// no intervening op -- %lag holds dot1's accumulator delayed by one iteration.
+// There is no chain to slice here (a backward slice rooted at a block argument
+// is empty), so ownership must be decided from the yielded value itself:
+// index 2 is owned by dot1's loop.
+//
+// This is the case that a slice-only test cannot see, and getting it wrong is
+// silently wrong rather than a crash: classifying index 2 as replicable would
+// take its result from the FIRST loop, where the %acc_fc slot is a frozen
+// pass-through, so the function would return the init value instead of the
+// second-to-last accumulator. Hence dot1 -- not dot0 -- is the one to use.
+// CHECK-LABEL: @carried_is_dot1_acc_distribute
+// CHECK: %[[ACC_INIT:.*]] = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+// CHECK: %[[LOOP1:.*]]:3 = scf.for {{.*}}iter_args(%[[L1_ACCG:[^ ]+]] = %[[ACC_INIT]], %[[L1_ACCFC:[^ ]+]] = %[[ACC_INIT]], %[[L1_LAG:[^ ]+]] = %[[ACC_INIT]])
+// CHECK:   %[[X1:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[WG:.*]] = tt.descriptor_load %arg1
+// CHECK:   %[[D0:.*]] = tt.dot %[[X1]], %[[WG]], %[[L1_ACCG]]
+// CHECK-NOT: tt.dot
+// Index 2 is frozen here: it yields its OWN block argument, not %[[L1_ACCFC]].
+// CHECK:   scf.yield %[[D0]], %[[L1_ACCFC]], %[[L1_LAG]]
+// CHECK: %[[LOOP2:.*]]:3 = scf.for {{.*}}iter_args(%[[L2_ACCG:[^ ]+]] = %[[ACC_INIT]], %[[L2_ACCFC:[^ ]+]] = %[[ACC_INIT]], %[[L2_LAG:[^ ]+]] = %[[ACC_INIT]])
+// CHECK:   %[[X2:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[WFC:.*]] = tt.descriptor_load %arg2
+// CHECK:   %[[D1:.*]] = tt.dot %[[X2]], %[[WFC]], %[[L2_ACCFC]]
+// CHECK-NOT: tt.dot
+// Index 2 is live here: it yields THIS loop's live %acc_fc block argument.
+// CHECK:   scf.yield %[[L2_ACCG]], %[[D1]], %[[L2_ACCFC]]
+// CHECK: tt.return %[[LOOP1]]#0, %[[LOOP2]]#1, %[[LOOP2]]#2
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @carried_is_dot1_acc_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:3 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst, %lag = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      // No op in between: the yielded value IS dot1's accumulator block argument.
+      scf.yield %d0, %d1, %acc_fc : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1, %0#2 : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: an OWNED carried chain (index 2, reads %acc_g) and a REPLICABLE one
+// (index 3, reads only its own slot) coexist and share a pure sub-chain
+// (arith.sitofp/tt.splat). The shared ops go into both loops because the
+// replicable chain needs them there; only the acc-reading arith.addf is
+// confined to the first loop. Index 2's result comes from its owner and index
+// 3's from the first loop as before.
+// CHECK-LABEL: @carried_mixed_owners_distribute
+// CHECK: %[[ACC_INIT:.*]] = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+// CHECK: %[[LOOP1:.*]]:4 = scf.for {{.*}}iter_args(%[[L1_ACCG:[^ ]+]] = %[[ACC_INIT]], %[[L1_ACCFC:[^ ]+]] = %[[ACC_INIT]], %[[L1_OWNED:[^ ]+]] = %[[ACC_INIT]], %[[L1_SHARED:[^ ]+]] = %[[ACC_INIT]])
+// CHECK:   %[[X1:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[WG:.*]] = tt.descriptor_load %arg1
+// CHECK:   %[[D0:.*]] = tt.dot %[[X1]], %[[WG]], %[[L1_ACCG]]
+// CHECK-NOT: tt.dot
+// CHECK:   %[[KF1:.*]] = arith.sitofp
+// CHECK:   %[[SPLAT1:.*]] = tt.splat %[[KF1]]
+// CHECK:   %[[OWNED:.*]] = arith.addf %[[SPLAT1]], %[[L1_ACCG]]
+// CHECK:   %[[SHARED1:.*]] = arith.subf %[[SPLAT1]], %[[L1_SHARED]]
+// CHECK:   scf.yield %[[D0]], %[[L1_ACCFC]], %[[OWNED]], %[[SHARED1]]
+// CHECK: %[[LOOP2:.*]]:4 = scf.for {{.*}}iter_args(%[[L2_ACCG:[^ ]+]] = %[[ACC_INIT]], %[[L2_ACCFC:[^ ]+]] = %[[ACC_INIT]], %[[L2_OWNED:[^ ]+]] = %[[ACC_INIT]], %[[L2_SHARED:[^ ]+]] = %[[ACC_INIT]])
+// CHECK:   %[[X2:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[WFC:.*]] = tt.descriptor_load %arg2
+// CHECK:   %[[D1:.*]] = tt.dot %[[X2]], %[[WFC]], %[[L2_ACCFC]]
+// CHECK-NOT: tt.dot
+// The shared pure sub-chain IS replicated here, for index 3's sake...
+// CHECK:   %[[KF2:.*]] = arith.sitofp
+// CHECK:   %[[SPLAT2:.*]] = tt.splat %[[KF2]]
+// ...but the acc-reading arith.addf is not, and index 2 is frozen.
+// CHECK-NOT: arith.addf
+// CHECK:   %[[SHARED2:.*]] = arith.subf %[[SPLAT2]], %[[L2_SHARED]]
+// CHECK:   scf.yield %[[L2_ACCG]], %[[D1]], %[[L2_OWNED]], %[[SHARED2]]
+// CHECK: tt.return %[[LOOP1]]#0, %[[LOOP2]]#1, %[[LOOP1]]#2, %[[LOOP1]]#3
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @carried_mixed_owners_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:4 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst, %owned = %cst, %shared_carry = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      // Pure sub-chain feeding BOTH carried chains below.
+      %kf = arith.sitofp %k : i32 to f32
+      %shared = tt.splat %kf : f32 -> tensor<128x128xf32>
+      // Index 2: reads %acc_g, so owned by dot0's loop.
+      %next_owned = arith.addf %shared, %acc_g : tensor<128x128xf32>
+      // Index 3: reads no accumulator, so replicable into both loops.
+      %next_shared = arith.subf %shared, %shared_carry : tensor<128x128xf32>
+      scf.yield %d0, %d1, %next_owned, %next_shared : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1, %0#2, %0#3 : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}

--- a/test/TritonIntelGPU/LoopDistribute/invalid.mlir
+++ b/test/TritonIntelGPU/LoopDistribute/invalid.mlir
@@ -215,40 +215,6 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 
 // -----
 
-// Test: a loop-carried chain (%carry) is updated from a dot accumulator's
-// block argument (%acc_g) directly, rather than from a value that is safe to
-// replicate identically into both new loops. Replicating this chain would
-// read a different (frozen or partial) %acc_g in each new loop, so
-// distribution must be rejected.
-// CHECK-LABEL: @carried_depends_on_acc_no_distribute
-// CHECK: scf.for
-// CHECK:   tt.dot
-// CHECK-NOT: scf.for
-// CHECK:   tt.dot
-// CHECK:   scf.yield
-// CHECK-NOT: scf.for
-module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  tt.func @carried_depends_on_acc_no_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
-    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
-    %c0_i32 = arith.constant 0 : i32
-    %c64_i32 = arith.constant 64 : i32
-    %c512_i32 = arith.constant 512 : i32
-    %0:3 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst, %carry = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
-      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
-      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
-      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
-      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
-      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
-      // %carry's update reads dot0's accumulator block-argument directly.
-      %bad = arith.addf %carry, %acc_g : tensor<128x128xf32>
-      scf.yield %d0, %d1, %bad : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
-    }
-    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
-  }
-}
-
-// -----
-
 // Test: a loop-carried chain (%carry) is updated from a dot's RESULT (%d0)
 // directly, rather than the accumulator iter_arg. This must also be
 // rejected -- a carried chain may not depend on either dot's output.
@@ -487,6 +453,194 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
       %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x128xf32> * tensor<128x128xf32> -> tensor<128x128xf32>
       %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x128xf32> * tensor<128x128xf32> -> tensor<128x128xf32>
       scf.yield %d0, %d1 : tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: a carried chain reads BOTH dot accumulators (%acc_g via %sum, and
+// %acc_fc via %sum). A carried chain that reads exactly one accumulator can be
+// given to that accumulator's loop, but this one can be given to neither: each
+// distributed loop keeps only one accumulator live and freezes the other, so
+// wherever the chain is placed it would read a frozen slot. Reject.
+// CHECK-LABEL: @carried_depends_on_both_accs_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK-NOT: scf.for
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @carried_depends_on_both_accs_no_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:3 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst, %carry = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      // Reads both accumulator block arguments.
+      %sum = arith.addf %acc_g, %acc_fc : tensor<128x128xf32>
+      %bad = arith.addf %carry, %sum : tensor<128x128xf32>
+      scf.yield %d0, %d1, %bad : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: %carry (index 2) reads %acc_g, so it is owned by dot0's loop and its
+// slot is frozen in dot1's loop -- but dot1's own operand slice reads %carry
+// too (via %wfc). dot1 would then consume the frozen pass-through slot, i.e.
+// the init value rather than the advanced one, so distribution must be
+// rejected. Ownership is only sound when the loop that freezes a slot never
+// reads it.
+// CHECK-LABEL: @dot1_slice_reads_owned_carry_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK-NOT: scf.for
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @dot1_slice_reads_owned_carry_no_distribute(%arg0: !tt.tensordesc<128x128xbf16>, %arg1: !tt.tensordesc<128x128xbf16>, %arg2: !tt.tensordesc<128x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %cstb = arith.constant dense<0.000000e+00> : tensor<128x128xbf16>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:3 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst, %carry = %cstb) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xbf16>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x128xbf16> -> tensor<128x128xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<128x128xbf16> -> tensor<128x128xbf16>
+      %wfc_raw = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<128x128xbf16> -> tensor<128x128xbf16>
+      // dot1's B operand is derived from %carry -- an indirect read, not a
+      // direct dot operand.
+      %wfc = arith.addf %wfc_raw, %carry : tensor<128x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x128xbf16> * tensor<128x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x128xbf16> * tensor<128x128xbf16> -> tensor<128x128xf32>
+      // Makes index 2 owned by dot0's loop.
+      %accg_bf = arith.truncf %acc_g : tensor<128x128xf32> to tensor<128x128xbf16>
+      %next = arith.addf %carry, %accg_bf : tensor<128x128xbf16>
+      scf.yield %d0, %d1, %next : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xbf16>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: the same hazard as @dot1_slice_reads_owned_carry_no_distribute, but the
+// reader of the frozen slot is another CARRIED CHAIN rather than a dot. %owned
+// (index 2) reads %acc_g so it is owned by dot0's loop; %other (index 3) reads
+// no accumulator so it is replicated into both loops -- and its copy in dot1's
+// loop would read the frozen index-2 slot. Note that index 3's own backward
+// slice stops at the %owned block argument and so never reaches %acc_g: the
+// check must look at which iter_args a chain reads, not just which
+// accumulators.
+// CHECK-LABEL: @carried_reads_owned_carry_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK-NOT: scf.for
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @carried_reads_owned_carry_no_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:4 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst, %owned = %cst, %other = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      // Index 2: reads %acc_g, so owned by dot0's loop.
+      %next_owned = arith.addf %owned, %acc_g : tensor<128x128xf32>
+      // Index 3: replicable on its own, but reads the owned index-2 slot.
+      %next_other = arith.addf %other, %owned : tensor<128x128xf32>
+      scf.yield %d0, %d1, %next_owned, %next_other : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: index 3 does not merely read the owned index-2 slot through an op, its
+// yielded value IS %owned, the index-2 block argument, with nothing in between.
+// A backward slice rooted at a block argument is empty, so the slice carries no
+// evidence of the read at all -- the check must compare the yielded value
+// itself against the frozen block argument, not only walk the slice. Without
+// that comparison this loop distributes and index 3 silently returns the frozen
+// init value.
+// CHECK-LABEL: @both_slot_aliases_owned_carry_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK-NOT: scf.for
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @both_slot_aliases_owned_carry_no_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:4 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst, %owned = %cst, %alias = %cst) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x64xbf16> -> tensor<128x64xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      %d1 = tt.dot %x, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x64xbf16> * tensor<64x128xbf16> -> tensor<128x128xf32>
+      // Index 2: reads %acc_g, so owned by dot0's loop.
+      %next_owned = arith.addf %owned, %acc_g : tensor<128x128xf32>
+      // Index 3 yields the index-2 block argument verbatim.
+      scf.yield %d0, %d1, %next_owned, %owned : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
+    }
+    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+  }
+}
+
+// -----
+
+// Test: the frozen owned slot is read as a DIRECT operand of dot1, not through
+// an op in dot1's slice. %carry (index 2) reads %acc_g so it is owned by dot0's
+// loop, and it is also dot1's A operand -- so dot1's loop, which freezes index
+// 2, would multiply the init value every iteration. The check must inspect the
+// dot's own operands as well as its backward slice.
+// CHECK-LABEL: @dot1_operand_is_owned_carry_no_distribute
+// CHECK: scf.for
+// CHECK:   tt.dot
+// CHECK-NOT: scf.for
+// CHECK:   tt.dot
+// CHECK:   scf.yield
+// CHECK-NOT: scf.for
+module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @dot1_operand_is_owned_carry_no_distribute(%arg0: !tt.tensordesc<128x128xbf16>, %arg1: !tt.tensordesc<128x128xbf16>, %arg2: !tt.tensordesc<128x128xbf16>) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+    %cstb = arith.constant dense<0.000000e+00> : tensor<128x128xbf16>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c512_i32 = arith.constant 512 : i32
+    %0:3 = scf.for %k = %c0_i32 to %c512_i32 step %c64_i32 iter_args(%acc_g = %cst, %acc_fc = %cst, %carry = %cstb) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xbf16>) : i32 {
+      %x = tt.descriptor_load %arg0[%c0_i32, %k] : !tt.tensordesc<128x128xbf16> -> tensor<128x128xbf16>
+      %wg = tt.descriptor_load %arg1[%k, %c0_i32] : !tt.tensordesc<128x128xbf16> -> tensor<128x128xbf16>
+      %wfc = tt.descriptor_load %arg2[%k, %c0_i32] : !tt.tensordesc<128x128xbf16> -> tensor<128x128xbf16>
+      %d0 = tt.dot %x, %wg, %acc_g, inputPrecision = tf32 : tensor<128x128xbf16> * tensor<128x128xbf16> -> tensor<128x128xf32>
+      // %carry is dot1's A operand directly.
+      %d1 = tt.dot %carry, %wfc, %acc_fc, inputPrecision = tf32 : tensor<128x128xbf16> * tensor<128x128xbf16> -> tensor<128x128xf32>
+      // Makes index 2 owned by dot0's loop.
+      %accg_bf = arith.truncf %acc_g : tensor<128x128xf32> to tensor<128x128xbf16>
+      %next = arith.addf %carry, %accg_bf : tensor<128x128xbf16>
+      scf.yield %d0, %d1, %next : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xbf16>
     }
     tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
   }

--- a/test/TritonIntelGPU/LoopDistribute/region_capture.mlir
+++ b/test/TritonIntelGPU/LoopDistribute/region_capture.mlir
@@ -161,27 +161,38 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
 // accumulator (%acc_g) only as a REGION CAPTURE inside an scf.if's body --
 // %acc_g is referenced directly from the then-branch, it is NOT passed as a
 // formal top-level operand of the scf.if (whose only top-level operand is
-// %cond). This is the same hazard as invalid.mlir's
-// carried_depends_on_acc_no_distribute, but reached via nested-region capture
-// rather than a direct top-level operand -- the safety check must walk into
-// nested regions, not just each slice member's top-level operands, to catch it.
+// %cond). The ownership analysis must walk into nested regions, not just each
+// slice member's top-level operands, to see the read: the chain reads exactly
+// one accumulator, so index 2 is OWNED by dot0's loop.
 //
-// Why it is rejected rather than placed in the loop that owns %acc_g: carried
-// chains are replicated into BOTH distributed loops and their result is taken
-// from the first one, so this chain would read the frozen pass-through %acc_g
-// slot in the second loop. Keeping it in the first loop only would need
-// per-iter_arg ownership (clone into the owning loop, freeze the slot in the
-// other, wire the result from the owner) plus a check that the other loop never
-// reads that iter_arg; see the follow-up issue.
-// CHECK-LABEL: @carried_captures_accumulator_no_distribute
-// CHECK: scf.for
-// CHECK:   tt.dot
-// CHECK-NOT: scf.for
-// CHECK:   tt.dot
-// CHECK:   scf.yield
-// CHECK-NOT: scf.for
+// Consequently the scf.if is cloned into the FIRST loop only; the second loop
+// freezes index 2 (yields its own block argument unchanged), and the function
+// result for index 2 is wired from the first loop. Replicating the chain into
+// both loops instead would make the second copy read that loop's frozen
+// pass-through %acc_g slot.
+// CHECK-LABEL: @carried_captures_accumulator_distribute
+// CHECK: %[[ACC_INIT:.*]] = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
+// CHECK: %[[LOOP1:.*]]:3 = scf.for {{.*}}iter_args(%[[L1_ACCG:[^ ]+]] = %[[ACC_INIT]], %[[L1_ACCFC:[^ ]+]] = %[[ACC_INIT]], %[[L1_CARRY:[^ ]+]] = %[[ACC_INIT]])
+// CHECK:   %[[X1:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[WG:.*]] = tt.descriptor_load %arg1
+// CHECK:   %[[D0:.*]] = tt.dot %[[X1]], %[[WG]], %[[L1_ACCG]]
+// CHECK-NOT: tt.dot
+// CHECK:   %[[NEW_CARRY:.*]] = scf.if
+// CHECK:     arith.addf %[[L1_ACCG]], %[[L1_ACCG]]
+// CHECK:     scf.yield %[[L1_CARRY]]
+// CHECK:   scf.yield %[[D0]], %[[L1_ACCFC]], %[[NEW_CARRY]]
+// CHECK: %[[LOOP2:.*]]:3 = scf.for {{.*}}iter_args(%[[L2_ACCG:[^ ]+]] = %[[ACC_INIT]], %[[L2_ACCFC:[^ ]+]] = %[[ACC_INIT]], %[[L2_CARRY:[^ ]+]] = %[[ACC_INIT]])
+// The owned chain's scf.if is NOT replicated here.
+// CHECK-NOT: scf.if
+// CHECK:   %[[X2:.*]] = tt.descriptor_load %arg0
+// CHECK:   %[[WFC:.*]] = tt.descriptor_load %arg2
+// CHECK:   %[[D1:.*]] = tt.dot %[[X2]], %[[WFC]], %[[L2_ACCFC]]
+// CHECK-NOT: tt.dot
+// Index 2 is frozen here: yielded unchanged.
+// CHECK:   scf.yield %[[L2_ACCG]], %[[D1]], %[[L2_CARRY]]
+// CHECK: tt.return %[[LOOP1]]#0, %[[LOOP2]]#1, %[[LOOP1]]#2
 module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
-  tt.func @carried_captures_accumulator_no_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>, %cond: i1) -> (tensor<128x128xf32>, tensor<128x128xf32>) {
+  tt.func @carried_captures_accumulator_distribute(%arg0: !tt.tensordesc<128x64xbf16>, %arg1: !tt.tensordesc<64x128xbf16>, %arg2: !tt.tensordesc<64x128xbf16>, %cond: i1) -> (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>) {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
     %c0_i32 = arith.constant 0 : i32
     %c64_i32 = arith.constant 64 : i32
@@ -202,6 +213,6 @@ module attributes {"ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32
       }
       scf.yield %d0, %d1, %new_carry : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
     }
-    tt.return %0#0, %0#1 : tensor<128x128xf32>, tensor<128x128xf32>
+    tt.return %0#0, %0#1, %0#2 : tensor<128x128xf32>, tensor<128x128xf32>, tensor<128x128xf32>
   }
 }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LoopDistribute.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LoopDistribute.cpp
@@ -91,6 +91,29 @@ bool sliceUsesValue(const DenseSet<Operation *> &slice, Value val) {
   });
 }
 
+/// Returns true if the chain feeding a loop-carried `iter_arg` reads `arg`:
+/// either the yielded value *is* `arg`, or some op in the chain's backward
+/// `slice` -- including inside nested regions -- has `arg` as an operand.
+///
+/// The first disjunct is load bearing twice over. A slot that yields a block
+/// argument directly has no defining op in the loop body, so
+/// `collectBackwardSlice` returns nothing for it: the value-rooted
+/// `getBackwardSlice` re-roots at the block argument's parent op (i.e. the
+/// `scf.for` itself) and every op it reaches is then dropped as being outside
+/// the loop body. A slice-only test would see such a chain as dependency free.
+/// It is also what catches a slot that aliases another carried slot by yielding
+/// its block argument unchanged.
+bool chainReadsArg(Value carriedVal, const DenseSet<Operation *> &slice,
+                   BlockArgument arg) {
+  return carriedVal == arg || sliceUsesValue(slice, arg);
+}
+
+/// Which distributed loop may compute a loop-carried `iter_arg`. `Both` means
+/// the slot is computed identically in the two new loops; `Dot0`/`Dot1` mean
+/// only the loop computing that dot can compute it, because the chain feeding
+/// the slot reads that dot's accumulator -- which is live in that loop alone.
+enum class Owner { Both, Dot0, Dot1 };
+
 /// Try to distribute a for loop with exactly two dot operations into two
 /// separate loops. Returns true if the transformation was applied.
 bool tryDistributeLoop(scf::ForOp forOp) {
@@ -176,48 +199,58 @@ bool tryDistributeLoop(scf::ForOp forOp) {
 
   // A dot's operand slice is rooted *at* its A/B operands, so the dot itself
   // is never a member of that slice -- check its operands directly too. Its C
-  // operand is its own accumulator, never the foreign one, so scanning all
-  // three operands cannot over-reject.
-  auto dependsOnForeignAcc = [](tt::DotOp dot,
-                                const DenseSet<Operation *> &slice,
-                                BlockArgument foreignAcc) {
-    return llvm::is_contained(dot->getOperands(), foreignAcc) ||
-           sliceUsesValue(slice, foreignAcc);
+  // operand is its own accumulator, which is never frozen in its own loop, so
+  // scanning all three operands cannot over-reject.
+  auto dotReadsArg = [](tt::DotOp dot, const DenseSet<Operation *> &slice,
+                        BlockArgument arg) {
+    return llvm::is_contained(dot->getOperands(), arg) ||
+           sliceUsesValue(slice, arg);
   };
 
-  if (dependsOnForeignAcc(dot0, slice0, accArg1)) {
-    LDBG("Skipping loop: dot0 depends on dot1's accumulator block argument");
-    return false;
-  }
-  if (dependsOnForeignAcc(dot1, slice1, accArg0)) {
-    LDBG("Skipping loop: dot1 depends on dot0's accumulator block argument");
-    return false;
-  }
+  // Classify each iter_arg by which new loop may compute it. Each accumulator
+  // is owned by its own dot's loop by construction.
+  SmallVector<Owner> owners(forOp.getNumRegionIterArgs(), Owner::Both);
+  owners[*idx0] = Owner::Dot0;
+  owners[*idx1] = Owner::Dot1;
 
-  // Every other (non-accumulator) iter_arg is either a true pass-through
-  // (yielded unchanged) or a chain that must be safely replicable into both
-  // new loops. Chains that depend on either dot's result, or that read a
-  // dot's accumulator block argument directly, cannot be replicated
-  // correctly (each new loop only computes one accumulator), so reject the
-  // whole loop in that case.
-  DenseSet<Operation *> carriedUnion;
-  for (unsigned i = 0, e = forOp.getNumRegionIterArgs(); i < e; ++i) {
+  // Every other (non-accumulator) iter_arg is a true pass-through (yielded
+  // unchanged), a chain safe to replicate into both new loops, or a chain that
+  // reads exactly one dot's accumulator and therefore belongs to that dot's
+  // loop only. A chain that depends on a dot's *result*, or that reads *both*
+  // accumulators, fits in neither loop, so reject the whole loop.
+  //
+  // Ownership is seeded from the two accumulators and deliberately *not*
+  // propagated transitively through other iter_args: this is one-hop ownership
+  // plus the frozen-slot rejection below, not a general ownership analysis.
+  // A fixpoint would distribute strictly more loops, but it would also
+  // invalidate the overlap invariant below -- an op in a `Both` slice would no
+  // longer be provably accumulator free, so an op shared between a `Dot0`- and
+  // a `Dot1`-owned chain would become a new hazard needing a new check. That is
+  // a soundness rewrite, not a refactor. `owners` is structured so a worklist
+  // could later produce it without disturbing anything downstream.
+  //
+  // Overlap between chains is benign. Backward slices are transitively closed
+  // within the body, so if any op in a chain's slice transitively reads an
+  // accumulator, the op that reads it directly is *also* in that slice -- as
+  // itself, or as the top-level anchor (e.g. the `scf.if`) that
+  // `sliceUsesValue` descends into. Hence every op reached through a `Both`
+  // chain is provably accumulator free, and two chains sharing an op agree on
+  // ownership unless the accumulator read comes from a non-shared op -- in
+  // which case the shared op is safe in both loops.
+  //
+  // The slices are kept per index rather than merged: the frozen-slot check
+  // below is per chain, so a union would not be enough.
+  SmallVector<DenseSet<Operation *>> carriedSlices(
+      forOp.getNumRegionIterArgs());
+  for (unsigned i = 0, e = forOp.getNumRegionIterArgs(); i != e; ++i) {
     if (i == *idx0 || i == *idx1)
       continue;
 
     Value carriedVal = yieldOp.getOperand(i);
-    if (carriedVal == forOp.getRegionIterArgs()[i]) {
-      // True pass-through: nothing to clone, no slice needed.
-      continue;
-    }
+    if (carriedVal == forOp.getRegionIterArgs()[i])
+      continue; // True pass-through: nothing to clone, no slice needed.
 
-    if (carriedVal == accArg0 || carriedVal == accArg1) {
-      LDBG("Skipping loop: carried iter_arg "
-           << i << " is itself a dot accumulator block argument");
-      return false;
-    }
-
-    DenseSet<Operation *> carriedSlice;
+    DenseSet<Operation *> &carriedSlice = carriedSlices[i];
     collectBackwardSlice(carriedVal, body, carriedSlice);
 
     if (carriedSlice.contains(dot0.getOperation()) ||
@@ -227,27 +260,85 @@ bool tryDistributeLoop(scf::ForOp forOp) {
       return false;
     }
 
-    // Walk into nested regions too: a region-holding op (e.g. `scf.if`) may
-    // read the accumulator as a captured value inside its region without
-    // passing it as one of the op's own top-level operands.
-    if (sliceUsesValue(carriedSlice, accArg0) ||
-        sliceUsesValue(carriedSlice, accArg1)) {
+    bool readsAcc0 = chainReadsArg(carriedVal, carriedSlice, accArg0);
+    bool readsAcc1 = chainReadsArg(carriedVal, carriedSlice, accArg1);
+    if (readsAcc0 && readsAcc1) {
       LDBG("Skipping loop: carried iter_arg "
-           << i << " depends on a dot accumulator block argument");
+           << i
+           << " depends on both dot accumulators, so neither new loop "
+              "can compute it");
       return false;
     }
+    // A slot that *is* an accumulator block argument is owned too, not
+    // rejected: the original semantics are `iter_arg(k+1) = acc(k)`, a
+    // one-iteration lag that the owner loop reproduces bit for bit, since the
+    // accumulator evolves there through exactly the original sequence.
+    if (readsAcc0)
+      owners[i] = Owner::Dot0;
+    else if (readsAcc1)
+      owners[i] = Owner::Dot1;
+  }
 
-    carriedUnion.insert(carriedSlice.begin(), carriedSlice.end());
+  // A slot is frozen in a new loop exactly when the *other* loop owns it: this
+  // loop yields it unchanged, so it holds the loop-invariant init value here.
+  auto isFrozenIn = [&owners](unsigned i, Owner loopOwner) {
+    return owners[i] != Owner::Both && owners[i] != loopOwner;
+  };
+
+  // Nothing placed in a new loop may read a slot that is frozen there: it would
+  // see the init value instead of the value the original fused loop computed.
+  // This covers the dot itself, its operand slice, and every carried chain
+  // cloned into that loop -- including a chain that merely yields the frozen
+  // block argument unchanged, which has an empty slice and so is invisible to
+  // any scan of op operands. It subsumes the old foreign-accumulator check,
+  // since each accumulator is frozen in the other dot's loop.
+  for (unsigned j = 0, e = forOp.getNumRegionIterArgs(); j != e; ++j) {
+    if (owners[j] == Owner::Both)
+      continue;
+    bool readerIsDot0 = owners[j] == Owner::Dot1;
+    Owner reader = readerIsDot0 ? Owner::Dot0 : Owner::Dot1;
+    BlockArgument arg = forOp.getRegionIterArgs()[j];
+
+    if (dotReadsArg(readerIsDot0 ? dot0 : dot1, readerIsDot0 ? slice0 : slice1,
+                    arg)) {
+      LDBG("Skipping loop: dot " << (readerIsDot0 ? 0 : 1)
+                                 << " depends on iter_arg " << j
+                                 << ", which is frozen in its loop");
+      return false;
+    }
+    for (unsigned i = 0; i != e; ++i) {
+      if (isFrozenIn(i, reader))
+        continue;
+      if (chainReadsArg(yieldOp.getOperand(i), carriedSlices[i], arg)) {
+        LDBG("Skipping loop: carried iter_arg "
+             << i << " depends on iter_arg " << j
+             << ", which is frozen in a loop that must compute it");
+        return false;
+      }
+    }
+  }
+
+  // An owned chain is cloned only into its owner's loop; a `Both` chain is
+  // replicated into both.
+  DenseSet<Operation *> carriedForDot0, carriedForDot1;
+  for (unsigned i = 0, e = forOp.getNumRegionIterArgs(); i != e; ++i) {
+    if (owners[i] != Owner::Dot1)
+      carriedForDot0.insert(carriedSlices[i].begin(), carriedSlices[i].end());
+    if (owners[i] != Owner::Dot0)
+      carriedForDot1.insert(carriedSlices[i].begin(), carriedSlices[i].end());
   }
 
   // Every top-level op must be classified: it is either one of the two
   // dots, a member of a dot-operand slice, or a member of a carried chain.
   // The canonicalizer already ran, so no dead ops should exist here -- an
   // unclassified op means we cannot prove it is safe to drop, so reject.
+  // Every carried chain lands in at least one of the two clone sets, so their
+  // union has the same contents as a single merged set over all chains.
   DenseSet<Operation *> allSlices;
   allSlices.insert(slice0.begin(), slice0.end());
   allSlices.insert(slice1.begin(), slice1.end());
-  allSlices.insert(carriedUnion.begin(), carriedUnion.end());
+  allSlices.insert(carriedForDot0.begin(), carriedForDot0.end());
+  allSlices.insert(carriedForDot1.begin(), carriedForDot1.end());
 
   for (Operation &op : *body) {
     if (&op == body->getTerminator() || &op == dot0.getOperation() ||
@@ -261,7 +352,13 @@ bool tryDistributeLoop(scf::ForOp forOp) {
     }
   }
 
-  // Every slice member must be safe to clone into both new loops.
+  // Every slice member must be safe to clone into both new loops. This applies
+  // to an owned chain as well, even though it is cloned into one loop only:
+  // duplication was never the sole hazard, because distribution also *reorders*
+  // the op against every memory operation of the other loop and this pass has
+  // no alias analysis. That is why a volatile `tt.load` -- which declares a
+  // Write effect precisely to prevent reordering -- must be rejected regardless
+  // of how many loops it lands in.
   for (Operation *op : allSlices) {
     if (!isReplicable(op)) {
       LDBG("Skipping loop: slice member is not safely replicable: " << *op);
@@ -271,15 +368,16 @@ bool tryDistributeLoop(scf::ForOp forOp) {
 
   OpBuilder builder(forOp);
 
-  // Each distributed loop keeps all original iter_args but only computes
-  // its target dot, yielding the iter_arg unchanged for the other position.
-  // Carried (non-accumulator) chains are replicated identically into both
-  // loops.
+  // Each distributed loop keeps all original iter_args but only computes its
+  // target dot and the slots it owns, yielding every slot owned by the other
+  // loop unchanged. Carried (non-accumulator) chains owned by neither loop are
+  // replicated identically into both.
 
   auto buildDistributedLoop = [&](tt::DotOp targetDot, unsigned targetIdx,
-                                  unsigned otherIdx,
                                   const DenseSet<Operation *> &targetSlice,
+                                  const DenseSet<Operation *> &carriedSet,
                                   ValueRange initArgs) {
+    Owner loopOwner = owners[targetIdx];
     // Use the ForOp builder callback to construct the body inline.
     // This avoids issues with empty blocks and missing terminators.
     scf::ForOp newForOp;
@@ -297,28 +395,34 @@ bool tryDistributeLoop(scf::ForOp forOp) {
           }
 
           // Clone ops in original order: this loop's own dot-operand slice
-          // plus every carried-chain op (carried chains are replicated
-          // identically into both distributed loops), plus the target dot.
+          // plus the carried-chain ops it must compute (chains owned by
+          // neither loop are replicated identically into both), plus the
+          // target dot.
           for (Operation &op : *body) {
             if (&op == body->getTerminator())
               continue;
-            if (targetSlice.contains(&op) || carriedUnion.contains(&op) ||
+            if (targetSlice.contains(&op) || carriedSet.contains(&op) ||
                 &op == targetDot.getOperation()) {
               b.clone(op, mapping);
             }
           }
 
-          // Build yield: for the target iter_arg, yield the dot result; for
-          // the other dot's accumulator, pass it through unchanged (its
-          // real value comes from the other distributed loop, this loop's
-          // copy is dead); for a true pass-through carried iter_arg, yield
-          // it unchanged; otherwise resolve the carried chain's cloned
-          // result through the mapping.
+          // Build yield: for the target iter_arg, yield the dot result; for a
+          // slot frozen here because the other loop owns it, pass it through
+          // unchanged (its real value comes from that loop, this loop's copy
+          // is dead); for a true pass-through carried iter_arg, yield it
+          // unchanged; otherwise resolve the carried chain's cloned result
+          // through the mapping.
           SmallVector<Value> yieldOperands;
           for (unsigned i = 0; i < forOp.getNumRegionIterArgs(); ++i) {
             if (i == targetIdx) {
               yieldOperands.push_back(mapping.lookup(targetDot.getResult()));
-            } else if (i == otherIdx) {
+            } else if (isFrozenIn(i, loopOwner)) {
+              // Must be tested *before* the mapping fallback below: an owned
+              // chain is not cloned into the loop that does not own it, so
+              // `mapping` has no entry for its yielded value and
+              // `lookupOrDefault` would hand back the original value, defined
+              // inside the loop we are about to erase.
               yieldOperands.push_back(iterArgs[i]);
             } else if (yieldOp.getOperand(i) == forOp.getRegionIterArgs()[i]) {
               yieldOperands.push_back(iterArgs[i]);
@@ -340,24 +444,20 @@ bool tryDistributeLoop(scf::ForOp forOp) {
   };
 
   // Build loop 1 (for dot0).
-  scf::ForOp loop1 =
-      buildDistributedLoop(dot0, *idx0, *idx1, slice0, forOp.getInitArgs());
+  scf::ForOp loop1 = buildDistributedLoop(dot0, *idx0, slice0, carriedForDot0,
+                                          forOp.getInitArgs());
 
   // Build loop 2 (for dot1).
-  scf::ForOp loop2 =
-      buildDistributedLoop(dot1, *idx1, *idx0, slice1, forOp.getInitArgs());
+  scf::ForOp loop2 = buildDistributedLoop(dot1, *idx1, slice1, carriedForDot1,
+                                          forOp.getInitArgs());
 
-  // Replace the original loop's results: idx0 from loop1, idx1 from loop2,
-  // others from either (they're pass-through in both).
+  // Each original result comes from the loop that owns its slot. A `Both` slot
+  // is computed identically in the two loops, so take it from the first. Note
+  // `loop1` computes dot0 and `loop2` computes dot1 -- the names are off by one
+  // from the `Owner` values.
   for (unsigned i = 0; i < forOp.getNumResults(); ++i) {
-    Value replacement;
-    if (i == *idx0)
-      replacement = loop1.getResult(i);
-    else if (i == *idx1)
-      replacement = loop2.getResult(i);
-    else
-      replacement = loop1.getResult(i); // pass-through, same in both
-    forOp.getResult(i).replaceAllUsesWith(replacement);
+    scf::ForOp ownerLoop = owners[i] == Owner::Dot1 ? loop2 : loop1;
+    forOp.getResult(i).replaceAllUsesWith(ownerLoop.getResult(i));
   }
 
   // Erase the original loop.


### PR DESCRIPTION
Instead of rejecting any loop-carried iter_arg chain that reads a dot
accumulator, give each iter_arg slot an owner. A chain reading exactly one
accumulator is computed only in that accumulator's loop, its slot is frozen
in the other loop, and the loop result is taken from the owner.

Still rejected: chains reading both accumulators, and ops that would read a
slot frozen in their own loop.

Closes #7784

Signed-off-by: Ettore Tiotto <ettore.tiotto@intel.com>