### PR TITLE
[Analysis] Add `SignedDivRemDeduction` utility

### DIFF
--- a/third_party/intel/include/Analysis/SignedDivRemDeduction.h
+++ b/third_party/intel/include/Analysis/SignedDivRemDeduction.h
@@ -1,0 +1,29 @@
+#ifndef TRITON_INTEL_ANALYSIS_SIGNEDDIVREMDEDUCTION_H
+#define TRITON_INTEL_ANALYSIS_SIGNEDDIVREMDEDUCTION_H
+
+#include "mlir/IR/Operation.h"
+
+namespace mlir::triton {
+class AxisInfo;
+} // namespace mlir::triton
+
+namespace mlir::triton::intel {
+
+/// Returns true if `op` is an `arith.divsi` or `arith.remsi` that the AxisInfo
+/// deduction would have drawn a stronger conclusion from, were its dividend
+/// known to be non-negative.
+///
+/// The deduction is only sound for a non-negative dividend, so it is disabled
+/// for the signed operations (see DivOpAxisInfoVisitor::getConstancy and
+/// RemOpAxisInfoVisitor::getContiguity in lib/Analysis/AxisInfo.cpp). This
+/// query mirrors those two sites, and exists so
+/// TritonIntelSpeculateSignedDivRem can find the operations worth converting to
+/// their unsigned form under a runtime check.
+///
+/// `lhs` and `rhs` are the AxisInfo of the operands.
+bool signedDivRemDeductionApplies(Operation *op, const AxisInfo &lhs,
+                                  const AxisInfo &rhs);
+
+} // namespace mlir::triton::intel
+
+#endif // TRITON_INTEL_ANALYSIS_SIGNEDDIVREMDEDUCTION_H

--- a/third_party/intel/lib/Analysis/CMakeLists.txt
+++ b/third_party/intel/lib/Analysis/CMakeLists.txt
@@ -3,6 +3,7 @@ add_triton_library(TritonIntelAnalysis
     Allocation.cpp
     AxisInfoExt.cpp
     Liveness.cpp
+    SignedDivRemDeduction.cpp
     SpatialReuseAnalysis.cpp
     StrideInfo.cpp
     TemporalReuseAnalysis.cpp

--- a/third_party/intel/lib/Analysis/SignedDivRemDeduction.cpp
+++ b/third_party/intel/lib/Analysis/SignedDivRemDeduction.cpp
@@ -1,0 +1,74 @@
+#include "intel/include/Analysis/SignedDivRemDeduction.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "triton/Analysis/AxisInfo.h"
+
+#include <numeric>
+
+using namespace mlir;
+namespace tt = mlir::triton;
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// The deduction mirror
+//===----------------------------------------------------------------------===//
+//
+// The three helpers below mirror their counterparts in
+// lib/Analysis/AxisInfo.cpp
+// (`gcd`, `AxisInfoVisitor::isContiguousDim`, `AxisInfoVisitor::isConstantDim`)
+// so that signedDivRemDeductionApplies() can restate the disabled deduction
+// conditions verbatim.
+
+/// Greatest common divisor treating zero as the identity, matching the variadic
+/// `gcd` in lib/Analysis/AxisInfo.cpp.
+template <typename... Args> int64_t gcd(int64_t a, int64_t b, Args... args) {
+  if (a == 0)
+    return b;
+  if (b == 0)
+    return a;
+  if constexpr (sizeof...(args) == 0)
+    return std::gcd(a, b);
+  else
+    return gcd(std::gcd(a, b), args...);
+}
+
+bool isContiguousDim(const tt::AxisInfo &info, ArrayRef<int64_t> shape,
+                     int dim) {
+  return info.getContiguity(dim) == shape[dim];
+}
+
+bool isConstantDim(const tt::AxisInfo &info, ArrayRef<int64_t> shape, int dim) {
+  return info.getConstancy(dim) == shape[dim];
+}
+
+} // namespace
+
+namespace mlir::triton::intel {
+
+bool signedDivRemDeductionApplies(Operation *op, const AxisInfo &lhs,
+                                  const AxisInfo &rhs) {
+  if (!isa<arith::DivSIOp, arith::RemSIOp>(op))
+    return false;
+
+  auto resTy = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  if (!resTy)
+    return false;
+
+  // Mirrors DivOpAxisInfoVisitor::getConstancy and
+  // RemOpAxisInfoVisitor::getContiguity: both require a contiguous dividend and
+  // a constant divisor along the dimension, and both deduce
+  // gcd(contiguity, divisibility, divisibility). The sound value is 1 in either
+  // case (a contiguous dimension has constancy 1), so the deduction is only
+  // worth something when that gcd exceeds 1.
+  ArrayRef<int64_t> shape = resTy.getShape();
+  for (int d = 0, rank = shape.size(); d < rank; ++d) {
+    if (isContiguousDim(lhs, shape, d) && isConstantDim(rhs, shape, d) &&
+        gcd(lhs.getContiguity(d), lhs.getDivisibility(d),
+            rhs.getDivisibility(d)) > 1)
+      return true;
+  }
+
+  return false;
+}
+
+} // namespace mlir::triton::intel

--- a/third_party/intel/unittest/Analysis/CMakeLists.txt
+++ b/third_party/intel/unittest/Analysis/CMakeLists.txt
@@ -118,3 +118,20 @@ add_triton_ut(
     MLIRFuncDialect
     MLIRSCFDialect
 )
+
+add_triton_ut(
+  NAME SignedDivRemDeduction
+  SRCS SignedDivRemDeductionTest.cpp
+  LIBS
+    TritonAnalysis
+    TritonGPUIR
+    TritonGPUTransforms
+    TritonIR
+    TritonIntelAnalysis
+    TritonIntelGPUIR
+    TritonIntelGPUTransforms
+    TritonNvidiaGPUIR
+    TritonNvidiaGPUTransforms
+    MLIRArithDialect
+    MLIRFuncDialect
+)

--- a/third_party/intel/unittest/Analysis/SignedDivRemDeductionTest.cpp
+++ b/third_party/intel/unittest/Analysis/SignedDivRemDeductionTest.cpp
@@ -1,0 +1,151 @@
+//===- SignedDivRemDeductionTest.cpp --------------------------------------===//
+//
+// Unit tests for triton::intel::signedDivRemDeductionApplies, which mirrors the
+// two AxisInfo deduction sites that speculation can recover:
+//
+//   1. DivOpAxisInfoVisitor::getConstancy  - contiguous lhs, constant rhs
+//   2. RemOpAxisInfoVisitor::getContiguity - contiguous lhs, constant rhs
+//
+// These tests exist so the predicate cannot drift away from the conditions it
+// mirrors. Each covers both sides of every condition.
+//
+//===----------------------------------------------------------------------===//
+
+#include "intel/include/Analysis/SignedDivRemDeduction.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "triton/Analysis/AxisInfo.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include <gtest/gtest.h>
+
+using namespace mlir;
+using namespace mlir::triton;
+using mlir::triton::intel::signedDivRemDeductionApplies;
+
+namespace {
+
+class SignedDivRemDeductionTest : public ::testing::Test {
+public:
+  void SetUp() override {
+    ctx.getOrLoadDialect<arith::ArithDialect>();
+    ctx.getOrLoadDialect<func::FuncDialect>();
+    ctx.getOrLoadDialect<TritonDialect>();
+    module = ModuleOp::create(UnknownLoc::get(&ctx));
+  }
+
+  /// Builds `OpTy` over two fresh operands of type `ty`. The operation is kept
+  /// alive by `module` for the lifetime of the test.
+  template <typename OpTy> OpTy makeOp(Type ty) {
+    OpBuilder builder(&ctx);
+    builder.setInsertionPointToEnd(module->getBody());
+    Location loc = builder.getUnknownLoc();
+    auto funcOp = func::FuncOp::create(loc, "f" + std::to_string(numFuncs++),
+                                       builder.getFunctionType({ty, ty}, {ty}));
+    module->push_back(funcOp);
+    Block *entry = funcOp.addEntryBlock();
+    builder.setInsertionPointToEnd(entry);
+    auto op = OpTy::create(builder, loc, entry->getArgument(0),
+                           entry->getArgument(1));
+    func::ReturnOp::create(builder, loc, ValueRange{op.getResult()});
+    return op;
+  }
+
+  Type tensorTy(ArrayRef<int64_t> shape) {
+    return RankedTensorType::get(shape, IntegerType::get(&ctx, 32));
+  }
+
+  Type scalarTy() { return IntegerType::get(&ctx, 32); }
+
+protected:
+  MLIRContext ctx;
+  OwningOpRef<ModuleOp> module;
+  unsigned numFuncs = 0;
+};
+
+//===----------------------------------------------------------------------===//
+// Contiguous dividend, constant divisor, gcd > 1.
+//===----------------------------------------------------------------------===//
+
+TEST_F(SignedDivRemDeductionTest, DivContiguousLhsConstantRhs) {
+  auto op = makeOp<arith::DivSIOp>(tensorTy({128}));
+  AxisInfo lhs(/*contiguity=*/{128}, /*divisibility=*/{128}, /*constancy=*/{1});
+  AxisInfo rhs(/*contiguity=*/{1}, /*divisibility=*/{4}, /*constancy=*/{128});
+  EXPECT_TRUE(signedDivRemDeductionApplies(op, lhs, rhs));
+}
+
+TEST_F(SignedDivRemDeductionTest, RemContiguousLhsConstantRhs) {
+  auto op = makeOp<arith::RemSIOp>(tensorTy({128}));
+  AxisInfo lhs({128}, {128}, {1});
+  AxisInfo rhs({1}, {4}, {128});
+  EXPECT_TRUE(signedDivRemDeductionApplies(op, lhs, rhs));
+}
+
+TEST_F(SignedDivRemDeductionTest, DivNonContiguousLhs) {
+  auto op = makeOp<arith::DivSIOp>(tensorTy({128}));
+  AxisInfo lhs(/*contiguity=*/{1}, {128}, {1});
+  AxisInfo rhs({1}, {4}, {128});
+  EXPECT_FALSE(signedDivRemDeductionApplies(op, lhs, rhs));
+}
+
+TEST_F(SignedDivRemDeductionTest, DivNonConstantRhs) {
+  auto op = makeOp<arith::DivSIOp>(tensorTy({128}));
+  AxisInfo lhs({128}, {128}, {1});
+  AxisInfo rhs({1}, {4}, /*constancy=*/{1});
+  EXPECT_FALSE(signedDivRemDeductionApplies(op, lhs, rhs));
+}
+
+TEST_F(SignedDivRemDeductionTest, DivGcdIsOne) {
+  auto op = makeOp<arith::DivSIOp>(tensorTy({128}));
+  AxisInfo lhs({128}, /*divisibility=*/{1}, {1});
+  AxisInfo rhs({1}, /*divisibility=*/{1}, {128});
+  EXPECT_FALSE(signedDivRemDeductionApplies(op, lhs, rhs));
+}
+
+TEST_F(SignedDivRemDeductionTest, DivMatchesOnInnerDimensionOnly) {
+  auto op = makeOp<arith::DivSIOp>(tensorTy({1, 64}));
+  AxisInfo lhs(/*contiguity=*/{1, 64}, /*divisibility=*/{1, 64},
+               /*constancy=*/{1, 1});
+  AxisInfo rhs(/*contiguity=*/{1, 1}, /*divisibility=*/{1, 128},
+               /*constancy=*/{1, 64});
+  // Dimension 0 matches the shape but has contiguity 1, so its gcd is 1;
+  // dimension 1 is the one that carries the deduction.
+  EXPECT_TRUE(signedDivRemDeductionApplies(op, lhs, rhs));
+}
+
+TEST_F(SignedDivRemDeductionTest, DivUnitDimensionAloneIsNotEnough) {
+  auto op = makeOp<arith::DivSIOp>(tensorTy({1, 64}));
+  AxisInfo lhs(/*contiguity=*/{1, 1}, {1, 64}, {1, 1});
+  AxisInfo rhs(/*contiguity=*/{1, 1}, {1, 128}, /*constancy=*/{1, 64});
+  EXPECT_FALSE(signedDivRemDeductionApplies(op, lhs, rhs));
+}
+
+TEST_F(SignedDivRemDeductionTest, ScalarsNeverMatch) {
+  // Both sites index shape[dim], so they bail when the result is not a
+  // RankedTensorType.
+  AxisInfo lhs({1}, {64}, {1});
+  AxisInfo rhs({1}, {8}, /*constancy=*/{2});
+  EXPECT_FALSE(signedDivRemDeductionApplies(makeOp<arith::RemSIOp>(scalarTy()),
+                                            lhs, rhs));
+  EXPECT_FALSE(signedDivRemDeductionApplies(makeOp<arith::DivSIOp>(scalarTy()),
+                                            lhs, rhs));
+}
+
+//===----------------------------------------------------------------------===//
+// Only the signed operations are candidates.
+//===----------------------------------------------------------------------===//
+
+TEST_F(SignedDivRemDeductionTest, UnsignedOpsAreNotCandidates) {
+  AxisInfo lhs({128}, {128}, {1});
+  AxisInfo rhs({1}, {4}, {128});
+  EXPECT_FALSE(signedDivRemDeductionApplies(
+      makeOp<arith::DivUIOp>(tensorTy({128})), lhs, rhs));
+  EXPECT_FALSE(signedDivRemDeductionApplies(
+      makeOp<arith::RemUIOp>(tensorTy({128})), lhs, rhs));
+  EXPECT_FALSE(signedDivRemDeductionApplies(
+      makeOp<arith::AddIOp>(tensorTy({128})), lhs, rhs));
+}
+
+} // namespace


### PR DESCRIPTION
Introduces a utility function that identifies signed division and remainder operations where AxisInfo deductions could apply if the dividend were proven non-negative.

The AxisInfo analysis disables certain deductions for signed div/rem because they are only sound for non-negative dividends. This utility mirrors those deduction conditions so optimization passes can identify operations worth converting from signed to unsigned under a runtime assertion.

Specifically, it detects arith.divsi and arith.remsi operations where:
- The dividend dimension is contiguous in the AxisInfo
- The divisor dimension is constant in the AxisInfo
- gcd(contiguity, divisibility, divisibility) > 1

This indicates a deduction would improve the analysis if the dividend were non-negative.

Extracted from #7748.