### PR TITLE
Speculate signed div/rem into unsigned under a runtime assertion

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -109,6 +109,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::intel::registerTritonIntelRemoveMasks();
   mlir::triton::intel::registerTritonIntelStrideVersioning();
   mlir::triton::intel::registerTritonIntelSimplifySignedArithmetic();
+  mlir::triton::intel::registerTritonIntelSpeculateSignedDivRem();
   mlir::triton::intel::registerTritonRewriteTensorDescriptorToPointer();
   mlir::triton::intel::registerTritonIntelGPUFoldTrueCmpI();
   mlir::triton::intel::registerTritonIntelGPUPrepareIfCombining();

--- a/test/Triton/Intel/SpeculateSignedDivRem/speculate-after-simplify.mlir
+++ b/test/Triton/Intel/SpeculateSignedDivRem/speculate-after-simplify.mlir
@@ -1,0 +1,42 @@
+// RUN: triton-opt %s -split-input-file -triton-intel-simplify-signed-arithmetic -triton-intel-speculate-signed-div-rem | FileCheck %s
+
+// COM: The pipeline order matters: triton-intel-simplify-signed-arithmetic proves
+// COM: what it can and converts without a check, so this pass only sees the
+// COM: operations that need one. A provably non-negative dividend must therefore
+// COM: end up unsigned with no assertion.
+module {
+tt.func public @provable_dividend_needs_no_assert() -> (tensor<128xi32>, tensor<128xi32>) {
+  %cst = arith.constant dense<16> : tensor<128xi32>
+  %range = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+  %rem = arith.remsi %range, %cst : tensor<128xi32>
+  %div = arith.divsi %range, %cst : tensor<128xi32>
+  tt.return %rem, %div : tensor<128xi32>, tensor<128xi32>
+}
+// CHECK-LABEL: @provable_dividend_needs_no_assert
+// CHECK-NOT:     tt.assert
+// CHECK:         arith.remui
+// CHECK:         arith.divui
+// CHECK-NOT:     tt.assert
+}
+
+// -----
+
+// COM: An unprovable dividend of the same shape does get an assertion, so the
+// COM: distinction above is drawn by the prover, not by the match conditions.
+// COM: The sign here depends on a kernel argument, which is the case the
+// COM: speculation exists for: neither provably non-negative nor provably
+// COM: negative.
+module {
+tt.func public @unprovable_dividend_gets_an_assert(%arg0: i32) -> tensor<128xi32> {
+  %cst = arith.constant dense<16> : tensor<128xi32>
+  %range = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+  %splat = tt.splat %arg0 : i32 -> tensor<128xi32>
+  %off = arith.muli %splat, %cst : tensor<128xi32>
+  %base = arith.addi %range, %off : tensor<128xi32>
+  %div = arith.divsi %base, %cst : tensor<128xi32>
+  tt.return %div : tensor<128xi32>
+}
+// CHECK-LABEL: @unprovable_dividend_gets_an_assert
+// CHECK:         tt.assert
+// CHECK:         arith.divui
+}

--- a/test/Triton/Intel/SpeculateSignedDivRem/speculate-signed-div-rem.mlir
+++ b/test/Triton/Intel/SpeculateSignedDivRem/speculate-signed-div-rem.mlir
@@ -169,10 +169,12 @@ tt.func public @nested_loops(%ub: i32, %ptr: !tt.ptr<i32>) -> tensor<1x64xi32> {
 // CHECK:           %[[INNER:.*]]:3 = scf.for {{.*}} iter_args(%[[IDX:.*]] = %{{.*}}, %{{.*}} = %{{.*}}, %[[IFLAG:.*]] = %{{.*}})
 // CHECK:             %[[COND:.*]] = arith.cmpi sge, %[[IDX]], %{{.*}} : tensor<1x64xi32>
 // CHECK:             arith.remui %[[IDX]], %{{.*}} : tensor<1x64xi32>
+// CHECK-NOT:         tt.assert
 // CHECK:             %[[IAND:.*]] = arith.andi %[[IFLAG]], %[[COND]] : tensor<1x64xi1>
 // CHECK:             scf.yield %{{.*}}, %{{.*}}, %[[IAND]]
 // CHECK:           }
 // CHECK:           %[[OAND:.*]] = arith.andi %[[OFLAG]], %[[INNER]]#2 : tensor<1x64xi1>
+// CHECK-NOT:       tt.assert
 // CHECK:           scf.yield %[[INNER]]#1, %[[OAND]]
 // CHECK:         }
 // CHECK:         tt.assert %[[OUTER]]#1

--- a/test/Triton/Intel/SpeculateSignedDivRem/speculate-signed-div-rem.mlir
+++ b/test/Triton/Intel/SpeculateSignedDivRem/speculate-signed-div-rem.mlir
@@ -1,0 +1,420 @@
+// RUN: triton-opt %s -split-input-file -triton-intel-speculate-signed-div-rem | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Positive tests - the AxisInfo deduction applies, so speculate.
+//===----------------------------------------------------------------------===//
+
+// COM: One contiguous dividend feeding both a division and a
+// COM: remainder by the same constant. Both are converted, and the assertion is
+// COM: emitted only once for the shared dividend.
+// COM:
+// COM: The dividend is non-negative as soon as the scalar offset is, so that is
+// COM: the fact the prover is left with and the fact that gets checked - one
+// COM: scalar comparison instead of a comparison over the whole index tensor.
+module {
+tt.func public @div_and_rem_share_one_assert(%arg0: i32) -> (tensor<1x64xi32>, tensor<1x64xi32>) {
+  %cst = arith.constant dense<128> : tensor<1x64xi32>
+  %c64_i32 = arith.constant 64 : i32
+  %scaled = arith.muli %arg0, %c64_i32 : i32
+  %off = tt.splat %scaled : i32 -> tensor<1x64xi32>
+  %range = tt.make_range {start = 0 : i32, end = 64 : i32} : tensor<64xi32>
+  %exp = tt.expand_dims %range {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
+  %idx = arith.addi %exp, %off : tensor<1x64xi32>
+  %rem = arith.remsi %idx, %cst : tensor<1x64xi32>
+  %div = arith.divsi %idx, %cst : tensor<1x64xi32>
+  tt.return %rem, %div : tensor<1x64xi32>, tensor<1x64xi32>
+}
+// CHECK-LABEL: @div_and_rem_share_one_assert
+// CHECK-SAME:    (%[[ARG0:.*]]: i32)
+// CHECK:         %[[CST:.*]] = arith.constant dense<128> : tensor<1x64xi32>
+// CHECK:         %[[IDX:.*]] = arith.addi
+// CHECK:         %[[ZERO:.*]] = arith.constant 0 : i32
+// CHECK:         %[[COND:.*]] = arith.cmpi sge, %[[ARG0]], %[[ZERO]] : i32
+// CHECK:         tt.assert %[[COND]]
+// CHECK-NOT:     tt.assert
+// CHECK:         %[[REM:.*]] = arith.remui %[[IDX]], %[[CST]] : tensor<1x64xi32>
+// CHECK:         %[[DIV:.*]] = arith.divui %[[IDX]], %[[CST]] : tensor<1x64xi32>
+// CHECK:         tt.return %[[REM]], %[[DIV]]
+}
+
+// -----
+
+// COM: The dividend is a bare range, so it is provably non-negative and there is
+// COM: nothing left for a runtime check to establish. It converts outright, with
+// COM: no assertion - checking a tautology would cost the whole benefit.
+module {
+tt.func public @provably_non_negative_dividend() -> tensor<1x64xi32> {
+  %cst = arith.constant dense<128> : tensor<1x64xi32>
+  %range = tt.make_range {start = 0 : i32, end = 64 : i32} : tensor<64xi32>
+  %idx = tt.expand_dims %range {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
+  %rem = arith.remsi %idx, %cst : tensor<1x64xi32>
+  tt.return %rem : tensor<1x64xi32>
+}
+// CHECK-LABEL: @provably_non_negative_dividend
+// CHECK-NOT:     arith.cmpi
+// CHECK-NOT:     tt.assert
+// CHECK:         arith.remui
+}
+
+// -----
+
+// COM: Same provable dividend, but used inside an scf.if nested in an scf.for -
+// COM: the one place an assertion cannot be hoisted to, so a speculated operation
+// COM: here would be left signed (see @dividend_in_conditional). This one still
+// COM: converts, because a proven dividend emits no assertion for a loop to
+// COM: contain. Pins that the hoistability bail-out gates the checks, not the
+// COM: conversion.
+module {
+tt.func public @provable_dividend_in_loop(%c: i1, %ub: i32) -> tensor<1x64xi32> {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %cst = arith.constant dense<128> : tensor<1x64xi32>
+  %range = tt.make_range {start = 0 : i32, end = 64 : i32} : tensor<64xi32>
+  %init = tt.expand_dims %range {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
+  %res = scf.for %i = %c0_i32 to %ub step %c1_i32 iter_args(%acc = %init) -> (tensor<1x64xi32>) : i32 {
+    %sum = scf.if %c -> (tensor<1x64xi32>) {
+      %rem = arith.remsi %init, %cst : tensor<1x64xi32>
+      %s = arith.addi %acc, %rem : tensor<1x64xi32>
+      scf.yield %s : tensor<1x64xi32>
+    } else {
+      scf.yield %acc : tensor<1x64xi32>
+    }
+    scf.yield %sum : tensor<1x64xi32>
+  }
+  tt.return %res : tensor<1x64xi32>
+}
+// CHECK-LABEL: @provable_dividend_in_loop
+// CHECK-NOT:     arith.cmpi
+// CHECK-NOT:     tt.assert
+// CHECK:         arith.remui
+}
+
+// -----
+
+// COM: The dividend is a loop-carried index advanced by
+// COM: `(load(next) - load(cur)) * 128 - 64`, so it stays non-negative only if
+// COM: the loaded block indices are in increasing order. That is a property of
+// COM: the data in the buffer, not of the IR, so no prover can show it.
+// COM:
+// COM: The check therefore has to happen at runtime, but a tt.assert in the body
+// COM: would stop IGC from optimizing the loop. So the check is folded into a
+// COM: loop-carried flag - one arith.andi per iteration - and asserted once
+// COM: after the loop.
+module {
+tt.func public @loop_carried_dividend(%ub: i32, %ptr: !tt.ptr<i32>) -> tensor<1x64xi32> {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c64_i32 = arith.constant 64 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %cst = arith.constant dense<128> : tensor<1x64xi32>
+  %range = tt.make_range {start = 0 : i32, end = 64 : i32} : tensor<64xi32>
+  %init = tt.expand_dims %range {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
+  %res:2 = scf.for %i = %c0_i32 to %ub step %c1_i32 iter_args(%idx = %init, %acc = %init)
+      -> (tensor<1x64xi32>, tensor<1x64xi32>) : i32 {
+    %rem = arith.remsi %idx, %cst : tensor<1x64xi32>
+    %sum = arith.addi %acc, %rem : tensor<1x64xi32>
+    %l = tt.load %ptr : !tt.ptr<i32>
+    %scaled = arith.muli %l, %c128_i32 : i32
+    %advance = arith.subi %scaled, %c64_i32 : i32
+    %splat = tt.splat %advance : i32 -> tensor<1x64xi32>
+    %next = arith.addi %idx, %splat : tensor<1x64xi32>
+    scf.yield %next, %sum : tensor<1x64xi32>, tensor<1x64xi32>
+  }
+  tt.return %res#1 : tensor<1x64xi32>
+}
+// CHECK-LABEL: @loop_carried_dividend
+// CHECK:         %[[TRUE:.*]] = arith.constant dense<true> : tensor<1x64xi1>
+// CHECK:         %[[RES:.*]]:3 = scf.for {{.*}} iter_args(%[[IDX:.*]] = %{{.*}}, %{{.*}} = %{{.*}}, %[[FLAG:.*]] = %[[TRUE]])
+// CHECK-SAME:        -> (tensor<1x64xi32>, tensor<1x64xi32>, tensor<1x64xi1>)
+// CHECK:           %[[COND:.*]] = arith.cmpi sge, %[[IDX]], %{{.*}} : tensor<1x64xi32>
+// CHECK:           arith.remui %[[IDX]], %{{.*}} : tensor<1x64xi32>
+// CHECK-NOT:       tt.assert
+// CHECK:           %[[AND:.*]] = arith.andi %[[FLAG]], %[[COND]] : tensor<1x64xi1>
+// CHECK:           scf.yield %{{.*}}, %{{.*}}, %[[AND]]
+// CHECK:         }
+// CHECK:         tt.assert %[[RES]]#2
+}
+
+// -----
+
+// COM: The flag is accumulated once per loop level, so the assertion ends up
+// COM: after the outermost loop and no loop body contains a tt.assert.
+module {
+tt.func public @nested_loops(%ub: i32, %ptr: !tt.ptr<i32>) -> tensor<1x64xi32> {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c64_i32 = arith.constant 64 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %cst = arith.constant dense<128> : tensor<1x64xi32>
+  %range = tt.make_range {start = 0 : i32, end = 64 : i32} : tensor<64xi32>
+  %init = tt.expand_dims %range {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
+  %outer = scf.for %j = %c0_i32 to %ub step %c1_i32 iter_args(%o = %init) -> (tensor<1x64xi32>) : i32 {
+    %inner:2 = scf.for %i = %c0_i32 to %ub step %c1_i32 iter_args(%idx = %init, %acc = %o)
+        -> (tensor<1x64xi32>, tensor<1x64xi32>) : i32 {
+      %rem = arith.remsi %idx, %cst : tensor<1x64xi32>
+      %sum = arith.addi %acc, %rem : tensor<1x64xi32>
+      %l = tt.load %ptr : !tt.ptr<i32>
+      %scaled = arith.muli %l, %c128_i32 : i32
+      %advance = arith.subi %scaled, %c64_i32 : i32
+      %splat = tt.splat %advance : i32 -> tensor<1x64xi32>
+      %next = arith.addi %idx, %splat : tensor<1x64xi32>
+      scf.yield %next, %sum : tensor<1x64xi32>, tensor<1x64xi32>
+    }
+    scf.yield %inner#1 : tensor<1x64xi32>
+  }
+  tt.return %outer : tensor<1x64xi32>
+}
+// CHECK-LABEL: @nested_loops
+// CHECK:         %[[OUTER:.*]]:2 = scf.for {{.*}} iter_args(%{{.*}} = %{{.*}}, %[[OFLAG:.*]] = %{{.*}})
+// CHECK:           %[[INNER:.*]]:3 = scf.for {{.*}} iter_args(%[[IDX:.*]] = %{{.*}}, %{{.*}} = %{{.*}}, %[[IFLAG:.*]] = %{{.*}})
+// CHECK:             %[[COND:.*]] = arith.cmpi sge, %[[IDX]], %{{.*}} : tensor<1x64xi32>
+// CHECK:             arith.remui %[[IDX]], %{{.*}} : tensor<1x64xi32>
+// CHECK:             %[[IAND:.*]] = arith.andi %[[IFLAG]], %[[COND]] : tensor<1x64xi1>
+// CHECK:             scf.yield %{{.*}}, %{{.*}}, %[[IAND]]
+// CHECK:           }
+// CHECK:           %[[OAND:.*]] = arith.andi %[[OFLAG]], %[[INNER]]#2 : tensor<1x64xi1>
+// CHECK:           scf.yield %[[INNER]]#1, %[[OAND]]
+// CHECK:         }
+// CHECK:         tt.assert %[[OUTER]]#1
+}
+
+// -----
+
+// COM: The remainder is nested in an scf.if, which cannot carry an accumulator
+// COM: the way an scf.for can, but no loop encloses it, so the assertion stays
+// COM: inside the conditional at no cost. Pins that the bail-out condition is
+// COM: "the assertion would land inside a loop", not "inside a region".
+// COM:
+// COM: The checked fact is defined outside the conditional, but the check is
+// COM: emitted at the division, so a launch that takes the other branch is not
+// COM: aborted for a fact no division depended on.
+module {
+tt.func public @conditional_outside_loop(%c: i1, %arg0: i32) -> tensor<1x64xi32> {
+  %cst = arith.constant dense<128> : tensor<1x64xi32>
+  %c64_i32 = arith.constant 64 : i32
+  %scaled = arith.muli %arg0, %c64_i32 : i32
+  %off = tt.splat %scaled : i32 -> tensor<1x64xi32>
+  %range = tt.make_range {start = 0 : i32, end = 64 : i32} : tensor<64xi32>
+  %exp = tt.expand_dims %range {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
+  %init = arith.addi %exp, %off : tensor<1x64xi32>
+  %res = scf.if %c -> (tensor<1x64xi32>) {
+    %rem = arith.remsi %init, %cst : tensor<1x64xi32>
+    scf.yield %rem : tensor<1x64xi32>
+  } else {
+    scf.yield %init : tensor<1x64xi32>
+  }
+  tt.return %res : tensor<1x64xi32>
+}
+// CHECK-LABEL: @conditional_outside_loop
+// CHECK-SAME:    (%{{.*}}: i1, %[[ARG1:.*]]: i32)
+// CHECK:         %[[IDX:.*]] = arith.addi
+// CHECK:         scf.if
+// CHECK:           %[[COND:.*]] = arith.cmpi sge, %[[ARG1]], %{{.*}} : i32
+// CHECK:           tt.assert %[[COND]]
+// CHECK:           arith.remui %[[IDX]], %{{.*}} : tensor<1x64xi32>
+}
+
+// -----
+
+// COM: The fact the dividend reduces to is an i1, reached through the
+// COM: arith.extsi rule. The check is built in the fact's own type, and a signed
+// COM: comparison there is exact: `%c` sign-extends to -128 when set, so
+// COM: `sge 0` on one bit holds exactly when the dividend is non-negative.
+module {
+tt.func public @narrow_fact(%arg0: i32) -> tensor<128xi32> {
+  %cst = arith.constant dense<128> : tensor<128xi32>
+  %c0_i32 = arith.constant 0 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c = arith.cmpi sgt, %arg0, %c0_i32 : i32
+  %ext = arith.extsi %c : i1 to i32
+  %scaled = arith.muli %ext, %c128_i32 : i32
+  %off = tt.splat %scaled : i32 -> tensor<128xi32>
+  %range = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+  %idx = arith.addi %range, %off : tensor<128xi32>
+  %rem = arith.remsi %idx, %cst : tensor<128xi32>
+  tt.return %rem : tensor<128xi32>
+}
+// CHECK-LABEL: @narrow_fact
+// CHECK:         %[[C:.*]] = arith.cmpi sgt
+// CHECK:         %[[FALSE:.*]] = arith.constant false
+// CHECK:         %[[COND:.*]] = arith.cmpi sge, %[[C]], %[[FALSE]] : i1
+// CHECK:         tt.assert %[[COND]]
+// CHECK:         arith.remui
+}
+
+//===----------------------------------------------------------------------===//
+// Negative tests - no deduction to recover, converting would be unsound, or the
+// assertion cannot be kept out of a loop body.
+//===----------------------------------------------------------------------===//
+
+// -----
+
+// COM: Same shape as @loop_carried_dividend, except the remainder is nested in
+// COM: an scf.if. An scf.if cannot carry the accumulator, so the assertion would
+// COM: have to stay in the loop body - which costs several times the kernel
+// COM: runtime, more than the deduction recovers. Leave the operation signed.
+module {
+tt.func public @dividend_in_conditional(%c: i1, %ub: i32, %ptr: !tt.ptr<i32>) -> tensor<1x64xi32> {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c64_i32 = arith.constant 64 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %cst = arith.constant dense<128> : tensor<1x64xi32>
+  %range = tt.make_range {start = 0 : i32, end = 64 : i32} : tensor<64xi32>
+  %init = tt.expand_dims %range {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
+  %res:2 = scf.for %i = %c0_i32 to %ub step %c1_i32 iter_args(%idx = %init, %acc = %init)
+      -> (tensor<1x64xi32>, tensor<1x64xi32>) : i32 {
+    %sum = scf.if %c -> (tensor<1x64xi32>) {
+      %rem = arith.remsi %idx, %cst : tensor<1x64xi32>
+      %s = arith.addi %acc, %rem : tensor<1x64xi32>
+      scf.yield %s : tensor<1x64xi32>
+    } else {
+      scf.yield %acc : tensor<1x64xi32>
+    }
+    %l = tt.load %ptr : !tt.ptr<i32>
+    %scaled = arith.muli %l, %c128_i32 : i32
+    %advance = arith.subi %scaled, %c64_i32 : i32
+    %splat = tt.splat %advance : i32 -> tensor<1x64xi32>
+    %next = arith.addi %idx, %splat : tensor<1x64xi32>
+    scf.yield %next, %sum : tensor<1x64xi32>, tensor<1x64xi32>
+  }
+  tt.return %res#1 : tensor<1x64xi32>
+}
+// CHECK-LABEL: @dividend_in_conditional
+// CHECK-NOT:     tt.assert
+// CHECK:         arith.remsi
+}
+
+// -----
+
+// COM: A loaded dividend has contiguity and divisibility 1, so the deduction
+// COM: could not have concluded anything. This is the `test_bin_op` shape: a
+// COM: frontend-style unconditional check would abort here for no benefit.
+module {
+tt.func public @loaded_dividend(%arg0: tensor<128x!tt.ptr<i32>>) -> (tensor<128xi32>, tensor<128xi32>) {
+  %cst = arith.constant dense<4> : tensor<128xi32>
+  %x = tt.load %arg0 : tensor<128x!tt.ptr<i32>>
+  %rem = arith.remsi %x, %cst : tensor<128xi32>
+  %div = arith.divsi %x, %cst : tensor<128xi32>
+  tt.return %rem, %div : tensor<128xi32>, tensor<128xi32>
+}
+// CHECK-LABEL: @loaded_dividend
+// CHECK-NOT:     tt.assert
+// CHECK:         arith.remsi
+// CHECK:         arith.divsi
+}
+
+// -----
+
+// COM: A runtime scalar divisor is constant along the dimension but has no
+// COM: constant value, so it cannot be checked for positivity. Deliberately
+// COM: left signed: correct, just not optimized.
+module {
+tt.func public @runtime_divisor(%arg0: i32) -> tensor<128xi32> {
+  %range = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+  %d = tt.splat %arg0 : i32 -> tensor<128xi32>
+  %rem = arith.remsi %range, %d : tensor<128xi32>
+  tt.return %rem : tensor<128xi32>
+}
+// CHECK-LABEL: @runtime_divisor
+// CHECK-NOT:     tt.assert
+// CHECK:         arith.remsi
+}
+
+// -----
+
+// COM: A negative constant divisor satisfies the deduction's match conditions,
+// COM: but divui/remui would reinterpret it as a large positive value. Asserting
+// COM: the divisor instead would emit a check that fails on every launch.
+module {
+tt.func public @negative_divisor() -> tensor<128xi32> {
+  %cst = arith.constant dense<-4> : tensor<128xi32>
+  %range = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+  %div = arith.divsi %range, %cst : tensor<128xi32>
+  tt.return %div : tensor<128xi32>
+}
+// CHECK-LABEL: @negative_divisor
+// CHECK-NOT:     tt.assert
+// CHECK:         arith.divsi
+}
+
+// -----
+
+// COM: Offsetting a range by a runtime scalar drops its divisibility to 1, so
+// COM: the deduction's gcd is 1 and there is nothing to recover. Pins the
+// COM: `gcd > 1` term: this shape is common in real kernels.
+module {
+tt.func public @gcd_is_one(%arg0: i32) -> tensor<128xi32> {
+  %cst = arith.constant dense<5> : tensor<128xi32>
+  %range = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+  %off = tt.splat %arg0 : i32 -> tensor<128xi32>
+  %idx = arith.addi %range, %off : tensor<128xi32>
+  %rem = arith.remsi %idx, %cst : tensor<128xi32>
+  tt.return %rem : tensor<128xi32>
+}
+// CHECK-LABEL: @gcd_is_one
+// CHECK-NOT:     tt.assert
+// CHECK:         arith.remsi
+}
+
+// -----
+
+// COM: The match conditions hold, but every element of the dividend is negative,
+// COM: so the assertion would fail on every launch and the unsigned result would
+// COM: differ from the signed one. A kernel that computes correctly today must
+// COM: not start aborting, so leave it signed. The range is [-256, -129], which
+// COM: only the integer range analysis can establish: the guard is a range
+// COM: query, not a constant check.
+module {
+tt.func public @provably_negative_computed_dividend() -> tensor<128xi32> {
+  %cst = arith.constant dense<-256> : tensor<128xi32>
+  %cst16 = arith.constant dense<16> : tensor<128xi32>
+  %range = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+  %neg = arith.addi %range, %cst : tensor<128xi32>
+  %div = arith.divsi %neg, %cst16 : tensor<128xi32>
+  tt.return %div : tensor<128xi32>
+}
+// CHECK-LABEL: @provably_negative_computed_dividend
+// CHECK-NOT:     tt.assert
+// CHECK:         arith.divsi
+}
+
+// -----
+
+// COM: Two independent runtime offsets, so the dividend is non-negative only if
+// COM: both kernel arguments are. A conjunction cannot be partially satisfied, so
+// COM: a dividend needing more than one fact is left signed rather than guarded
+// COM: by a pile of checks.
+module {
+tt.func public @dividend_needs_two_facts(%arg0: i32, %arg1: i32) -> tensor<128xi32> {
+  %cst = arith.constant dense<128> : tensor<128xi32>
+  %c64_i32 = arith.constant 64 : i32
+  %s0 = arith.muli %arg0, %c64_i32 : i32
+  %s1 = arith.muli %arg1, %c64_i32 : i32
+  %o0 = tt.splat %s0 : i32 -> tensor<128xi32>
+  %o1 = tt.splat %s1 : i32 -> tensor<128xi32>
+  %range = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+  %t = arith.addi %range, %o0 : tensor<128xi32>
+  %idx = arith.addi %t, %o1 : tensor<128xi32>
+  %rem = arith.remsi %idx, %cst : tensor<128xi32>
+  tt.return %rem : tensor<128xi32>
+}
+// CHECK-LABEL: @dividend_needs_two_facts
+// CHECK-NOT:     tt.assert
+// CHECK:         arith.remsi
+}
+
+// -----
+
+// COM: Both remaining sites bail when the result is not a ranked tensor, so a
+// COM: scalar operation never matches.
+module {
+tt.func public @scalar_operands(%arg0: i32) -> i32 {
+  %c128 = arith.constant 128 : i32
+  %rem = arith.remsi %arg0, %c128 : i32
+  tt.return %rem : i32
+}
+// CHECK-LABEL: @scalar_operands
+// CHECK-NOT:     tt.assert
+// CHECK:         arith.remsi
+}

--- a/third_party/intel/include/Dialect/Triton/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/Triton/Transforms/Passes.td
@@ -167,6 +167,34 @@ def TritonIntelSimplifySignedArithmetic
   ];
 }
 
+def TritonIntelSpeculateSignedDivRem
+    : Pass<"triton-intel-speculate-signed-div-rem", "mlir::ModuleOp"> {
+  let summary = "Convert signed div/rem to unsigned under a runtime assertion";
+
+  let description = [{
+    Converts arith.divsi/arith.remsi to arith.divui/arith.remui under a
+    tt.assert that the dividend is non-negative. This recovers the AxisInfo
+    constancy and contiguity deductions, which are disabled for the signed
+    operations because their floor-division argument only holds for a
+    non-negative dividend. A negative dividend then aborts with a diagnostic
+    instead of silently producing a wrong answer.
+
+    An operation is converted only when the deduction would have fired on it and
+    the check it needs is worth its cost; anything else is left signed, keeping
+    the sound but weaker lattice. SpeculateSignedDivRem.cpp documents each of
+    those conditions at the site that applies it.
+
+    Runs after TritonIntelSimplifySignedArithmetic, whose simpler prover has
+    already converted the operations that need no runtime check to be sound.
+  }];
+
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::scf::SCFDialect",
+    "mlir::triton::TritonDialect"
+  ];
+}
+
 def TritonIntelGPUFoldTrueCmpI
     : Pass<"triton-intel-fold-true-cmpi", "mlir::ModuleOp"> {
   let summary = "Fold provably true/false arith.cmpi to constants";

--- a/third_party/intel/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_triton_library(TritonIntelTransforms
   RemoveMasks.cpp
   RewriteTensorDescriptorToPointer.cpp
   SimplifySignedArithmetic.cpp
+  SpeculateSignedDivRem.cpp
   StrideVersioning.cpp
 
   DEPENDS

--- a/third_party/intel/lib/Dialect/Triton/Transforms/SpeculateSignedDivRem.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/SpeculateSignedDivRem.cpp
@@ -1,0 +1,336 @@
+#include "intel/include/Analysis/AxisInfoExt.h"
+#include "intel/include/Analysis/Range.h"
+#include "intel/include/Analysis/SignedDivRemDeduction.h"
+#include "intel/include/Analysis/SignednessProver.h"
+#include "intel/include/Dialect/Triton/Transforms/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "triton-intel-speculate-signed-div-rem"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace tt = mlir::triton;
+
+namespace mlir::triton::intel {
+#define GEN_PASS_DEF_TRITONINTELSPECULATESIGNEDDIVREM
+#include "intel/include/Dialect/Triton/Transforms/Passes.h.inc"
+} // namespace mlir::triton::intel
+
+namespace {
+
+using tt::intel::Goal;
+using tt::intel::Proof;
+using tt::intel::RequiredCondition;
+
+/// Returns true if a signed division of `value` is one worth speculating on: a
+/// signless integer wider than `i1`. A 1-bit dividend holds 0 and -1, which no
+/// deduction this pass recovers applies to.
+bool isAssertableIntegerType(Value value) {
+  Type elemTy = getElementTypeOrSelf(value.getType());
+  return elemTy.isSignlessInteger() && elemTy.getIntOrFloatBitWidth() > 1;
+}
+
+/// Returns true if the check guarding `op` can be asserted outside every
+/// enclosing loop.
+bool isCheckHoistableOutOfLoops(Operation *op) {
+  // emitAssert() folds the check into a loop-carried flag for each enclosing
+  // `scf.for` and stops at any other region-holding parent, so the assertion
+  // ends up in the region of the first such parent.
+  Operation *parent = op->getParentOp();
+  while (isa_and_nonnull<scf::ForOp>(parent))
+    parent = parent->getParentOp();
+
+  return parent && !isa<LoopLikeOpInterface>(parent) &&
+         !parent->getParentOfType<LoopLikeOpInterface>();
+}
+
+/// Folds `cond` into a loop-carried flag on `forOp` and returns the loop result
+/// holding its conjunction over every executed iteration. `cond` must be
+/// defined inside `forOp`'s body. Returns a null value if `forOp` cannot carry
+/// an additional iteration argument.
+Value accumulateIntoLoop(RewriterBase &rewriter, scf::ForOp forOp, Value cond) {
+  Location loc = cond.getLoc();
+
+  // The flag starts out true and is only ever cleared, so a loop that does not
+  // execute yields "no violation" - which is what a division that never runs
+  // means.
+  rewriter.setInsertionPoint(forOp);
+  Value init = arith::ConstantOp::create(rewriter, loc,
+                                         rewriter.getOneAttr(cond.getType()));
+
+  // Add the flag as a pass-through iteration argument first and redirect its
+  // yielded value afterwards. Computing the conjunction in the
+  // `NewYieldValuesFn` callback instead would have it reference `cond`, which
+  // lives in the body being moved to the new loop while the callback runs.
+  FailureOr<LoopLikeOpInterface> newLoop =
+      cast<LoopLikeOpInterface>(forOp.getOperation())
+          .replaceWithAdditionalIterOperands(
+              rewriter, init, /*replaceInitOperandUsesInLoop=*/false);
+  if (failed(newLoop)) {
+    rewriter.eraseOp(init.getDefiningOp());
+    return {};
+  }
+
+  auto newForOp = cast<scf::ForOp>(newLoop->getOperation());
+  BlockArgument flag = newForOp.getRegionIterArgs().back();
+  Operation *yieldOp = newForOp.getBody()->getTerminator();
+  rewriter.setInsertionPoint(yieldOp);
+  Value conjunction = arith::AndIOp::create(rewriter, loc, flag, cond);
+  rewriter.modifyOpInPlace(yieldOp, [&]() {
+    yieldOp->setOperand(yieldOp->getNumOperands() - 1, conjunction);
+  });
+
+  return newForOp.getResults().back();
+}
+
+class SignedDivRemSpeculator {
+public:
+  void run(ModuleOp moduleOp) {
+    tt::intel::ModuleAxisInfoAnalysis axisInfo(moduleOp);
+
+    SmallVector<Operation *> candidates;
+    moduleOp.walk([&](Operation *op) {
+      if (isCandidate(op, axisInfo))
+        candidates.push_back(op);
+    });
+    if (candidates.empty())
+      return;
+
+    // Deciding which dividends are worth speculating on needs the range
+    // analysis. It is built lazily, because it costs far more than the AxisInfo
+    // query above and most modules have no candidate at all.
+    DominanceInfo domInfo(moduleOp);
+    std::unique_ptr<DataFlowSolver> solver = createDataFlowSolver();
+    solver->load<tt::intel::IntegerRangeAnalysis>(moduleOp, domInfo);
+    if (failed(solver->initializeAndRun(moduleOp))) {
+      LDBG("range analysis failed, leaving all candidates signed");
+      return;
+    }
+
+    // Split the candidates by what the prover says about the dividend: those it
+    // proves outright convert for free, those it reduces to exactly one missing
+    // fact convert under a runtime check, and the rest are left signed.
+    SmallVector<Operation *> proven;
+    SmallVector<std::pair<Operation *, RequiredCondition>> speculative;
+    for (Operation *op : candidates) {
+      tt::intel::Proof proof =
+          tt::intel::proveSign(op->getOperand(0), Goal::NonNegative, *solver);
+
+      // The dividend is negative on every launch, or depends on a value that
+      // is. Converting changes the result *and* asserts something that fails
+      // unconditionally, so a kernel that computes correctly today would start
+      // aborting.
+      if (proof.verdict == Proof::Refuted) {
+        LDBG("skipped, dividend cannot be non-negative: " << *op);
+        continue;
+      }
+
+      if (proof.verdict == Proof::Satisfied) {
+        proven.push_back(op);
+        continue;
+      }
+
+      // A conjunction cannot be partially satisfied, so every member would have
+      // to be checked for the conversion to be sound. One check is the expected
+      // shape; more than that means the recursion wandered.
+      if (proof.requiredConditions.size() != 1) {
+        LDBG("skipped, dividend needs " << proof.requiredConditions.size()
+                                        << " facts: " << *op);
+        continue;
+      }
+
+      // An assertion in a loop body costs several times the kernel runtime -
+      // far more than the deduction it recovers is worth - so an operation
+      // whose check cannot be kept out of every loop is left signed instead.
+      // This gates only the checked conversions; the proven ones emit no check,
+      // so where a check would have landed does not concern them. See
+      // emitAssert().
+      if (!isCheckHoistableOutOfLoops(op)) {
+        LDBG("skipped, assertion would land inside a loop: " << *op);
+        continue;
+      }
+
+      speculative.push_back({op, proof.requiredConditions.front()});
+    }
+
+    for (Operation *op : proven) {
+      LDBG("converted unchecked, dividend is provably non-negative: " << *op);
+      convertToUnsigned(op);
+    }
+
+    // Convert every remaining candidate and materialize its check before
+    // asserting any of them: emitting an assertion can rebuild an enclosing
+    // loop, which invalidates every handle to that loop's iteration arguments -
+    // and a dividend is often one of them.
+    for (auto [cond, goal] : convertWithChecks(speculative))
+      emitAssert(cond, goal);
+  }
+
+private:
+  bool isCandidate(Operation *op,
+                   tt::intel::ModuleAxisInfoAnalysis &axisInfo) const {
+    if (!isa<arith::DivSIOp, arith::RemSIOp>(op))
+      return false;
+
+    Value lhs = op->getOperand(0), rhs = op->getOperand(1);
+    if (!isAssertableIntegerType(lhs))
+      return false;
+
+    tt::AxisInfo *lhsInfo = axisInfo.getAxisInfo(lhs);
+    tt::AxisInfo *rhsInfo = axisInfo.getAxisInfo(rhs);
+    if (!lhsInfo || !rhsInfo)
+      return false;
+
+    // The divisor must be a positive constant. `divui`/`remui` reinterpret a
+    // negative divisor as a large positive one, so the result would be wrong
+    // even for a non-negative dividend, and asserting the divisor is positive
+    // would emit a check that fails on every launch for e.g. `x // -4`.
+    std::optional<int64_t> divisor = rhsInfo->getConstantValue();
+    if (!divisor.has_value() || *divisor <= 0)
+      return false;
+
+    if (!tt::intel::signedDivRemDeductionApplies(op, *lhsInfo, *rhsInfo))
+      return false;
+
+    LDBG("candidate: " << *op);
+    return true;
+  }
+
+  /// Replaces `op` with its unsigned counterpart, erasing it, and returns the
+  /// replacement. Sound only where the dividend is non-negative, which the
+  /// caller must have established or arranged to check.
+  Value convertToUnsigned(Operation *op) {
+    Value lhs = op->getOperand(0), rhs = op->getOperand(1);
+    OpBuilder builder(op);
+    Location loc = op->getLoc();
+
+    Value replacement =
+        isa<arith::DivSIOp>(op)
+            ? arith::DivUIOp::create(builder, loc, lhs, rhs).getResult()
+            : arith::RemUIOp::create(builder, loc, lhs, rhs).getResult();
+    op->getResult(0).replaceAllUsesWith(replacement);
+    op->erase();
+
+    return replacement;
+  }
+
+  /// Rewrites every candidate to its unsigned counterpart and materializes the
+  /// check of the one fact its dividend's non-negativity was reduced to,
+  /// returning each check alongside the goal it establishes.
+  ///
+  /// The fact is checked rather than the dividend because it is what the
+  /// deduction actually rests on, and it is usually the cheaper of the two: a
+  /// scalar kernel argument in place of a tensor of indices. The check is
+  /// stronger than `dividend >= 0` where the proof rules are sufficient but not
+  /// necessary - `a + b >= 0` does not need both terms to be non-negative - so
+  /// a kernel can in principle be aborted for a dividend that would have been
+  /// fine. That needs the offset to cancel the negative term exactly, which the
+  /// divisibility the deduction requires of the dividend makes hard to arrange.
+  ///
+  /// One check is emitted per distinct (fact, goal, block) triple. Keying on
+  /// the block keeps a check dominating the divisions it guards without a
+  /// dominance query, and collapses the common case of one dividend feeding
+  /// both a division and a remainder. The check is placed at the division
+  /// rather than at the fact's definition, so that a division under a
+  /// conditional is only asserted on the paths that reach it.
+  SmallVector<std::pair<Value, Goal>> convertWithChecks(
+      ArrayRef<std::pair<Operation *, RequiredCondition>> candidates) {
+    SmallVector<std::pair<Value, Goal>> conditions;
+    DenseSet<std::tuple<Value, unsigned, Block *>> checked;
+
+    for (auto [op, obligation] : candidates) {
+      auto [fact, goal] = obligation;
+      Location loc = op->getLoc();
+      Block *block = op->getBlock();
+
+      Value replacement = convertToUnsigned(op);
+
+      if (!checked.insert({fact, static_cast<unsigned>(goal), block}).second)
+        continue;
+
+      OpBuilder builder(replacement.getDefiningOp());
+      Value zero = arith::ConstantOp::create(
+          builder, loc, builder.getZeroAttr(fact.getType()));
+      // The comparison is built in the fact's own type, which is exact at every
+      // width: the rules that reach a narrower fact preserve its sign. A fact
+      // reached through an `arith.extsi` can even be an `i1`, where `sge 0`
+      // holds exactly when the bit is clear - the one value that sign-extends
+      // to something non-negative.
+      //
+      // A fact is usually `>= 0`, but the rule for a division inside the
+      // dividend demands a strictly positive divisor.
+      arith::CmpIPredicate predicate = goal == Goal::NonNegative
+                                           ? arith::CmpIPredicate::sge
+                                           : arith::CmpIPredicate::sgt;
+      Value cond = arith::CmpIOp::create(builder, loc, predicate, fact, zero);
+      conditions.push_back({cond, goal});
+      LDBG("checked fact: " << fact);
+    }
+
+    return conditions;
+  }
+
+  /// Emits the single `tt.assert` backing a check built by convertWithChecks().
+  ///
+  /// A check inside a loop body is not asserted there: it is folded into a
+  /// loop-carried flag and asserted once after the outermost enclosing
+  /// `scf.for` instead. A `tt.assert` lowers to an opaque call that keeps IGC
+  /// from optimizing any loop containing it, which costs several times the
+  /// kernel runtime, whereas the same assertion outside the loop is free. The
+  /// conjunction flags exactly the same launches, it just no longer points at
+  /// the iteration that caused the violation. Note also that an out-of-range
+  /// unsigned quotient may fault on a subsequent access before the assertion is
+  /// reached; the diagnostic is a best effort either way.
+  void emitAssert(Value cond, Goal goal) {
+    IRRewriter rewriter(cond.getContext());
+    Operation *defOp = cond.getDefiningOp();
+
+    // isCheckHoistableOutOfLoops() kept only candidates whose loop ancestors
+    // are all `scf.for`s, so this walk reaches a point outside every loop.
+    // Stopping early is not expected for an `scf.for`, which supports
+    // iter_args unconditionally.
+    while (auto forOp = dyn_cast<scf::ForOp>(defOp->getParentOp())) {
+      Value accumulated = accumulateIntoLoop(rewriter, forOp, cond);
+      if (!accumulated)
+        break;
+      cond = accumulated;
+      defOp = cond.getDefiningOp();
+    }
+
+    StringRef assumption =
+        goal == Goal::NonNegative ? "non-negative" : "positive";
+    rewriter.setInsertionPointAfter(defOp);
+    tt::AssertOp::create(
+        rewriter, cond.getLoc(), cond,
+        ("signed division or remainder with a negative dividend: the compiler "
+         "assumed this value was " +
+         assumption +
+         " to prove the dividend non-negative, in order to optimize the memory "
+         "access pattern. Restructure the kernel so the dividend is "
+         "non-negative.")
+            .str());
+  }
+};
+
+struct TritonIntelSpeculateSignedDivRem
+    : tt::intel::impl::TritonIntelSpeculateSignedDivRemBase<
+          TritonIntelSpeculateSignedDivRem> {
+public:
+  void runOnOperation() final {
+    ModuleOp moduleOp = getOperation();
+    SignedDivRemSpeculator speculator;
+    speculator.run(moduleOp);
+    assert(succeeded(verify(moduleOp)) && "Module verification failed");
+  }
+};
+
+} // namespace

--- a/third_party/intel/lib/Dialect/Triton/Transforms/SpeculateSignedDivRem.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/SpeculateSignedDivRem.cpp
@@ -194,8 +194,8 @@ private:
     // negative divisor as a large positive one, so the result would be wrong
     // even for a non-negative dividend, and asserting the divisor is positive
     // would emit a check that fails on every launch for e.g. `x // -4`.
-    std::optional<int64_t> divisor = rhsInfo->getConstantValue();
-    if (!divisor.has_value() || *divisor <= 0)
+    const std::optional<APInt> &divisor = rhsInfo->getConstantValue();
+    if (!divisor.has_value() || !divisor->isStrictlyPositive())
       return false;
 
     if (!tt::intel::signedDivRemDeductionApplies(op, *lhsInfo, *rhsInfo))

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -70,6 +70,8 @@ void init_triton_intel_passes_ttir(py::module_ &&m) {
   ADD_PASS_WRAPPER_0("add_fuse_reshape", intel::createTritonIntelFuseReshape);
   ADD_PASS_WRAPPER_0("add_simplify_signed_arithmetic",
                      intel::createTritonIntelSimplifySignedArithmetic);
+  ADD_PASS_WRAPPER_0("add_speculate_signed_div_rem",
+                     intel::createTritonIntelSpeculateSignedDivRem);
   ADD_PASS_WRAPPER_0("add_fold_true_cmpi",
                      intel::createTritonIntelGPUFoldTrueCmpI);
   ADD_FUNC_PASS_WRAPPER_0("add_prepare_if_combining",


### PR DESCRIPTION
Add a new TTIR pass that converts signed division and remainder operations (arith.divsi, arith.remsi) to their unsigned counterparts (arith.divui, arith.remui) under a runtime assertion that the dividend is non-negative.