### PR TITLE
Add platform selection logic to on-label workflow

### DIFF
--- a/.github/workflows/on-label.yml
+++ b/.github/workflows/on-label.yml
@@ -13,10 +13,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ---- Platform selection for benchmarks ----
+  # FIXME: Temporarily lost max1550 machines, so PVC benchmarks are disabled by default.
+  # Use 'pvc-only' label to explicitly enable them.
+
+  select-benchmark-platforms:
+    runs-on: ubuntu-latest
+    outputs:
+      run-pvc-benchmarks: ${{ steps.determine.outputs.run-pvc-benchmarks }}
+    steps:
+      - name: Determine if PVC benchmarks should run
+        id: determine
+        run: |
+          LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+          PVC_ONLY=$(echo "$LABELS" | jq 'contains(["pvc-only"])')
+
+          # PVC benchmarks (max1550) only run if pvc-only label is present
+          if [ "$PVC_ONLY" = "true" ]; then
+            echo "run-pvc-benchmarks=true" >> $GITHUB_OUTPUT
+          else
+            echo "run-pvc-benchmarks=false" >> $GITHUB_OUTPUT
+          fi
+
   # ---- vLLM tests ----
 
   vllm-tests-bmg:
-    if: contains(github.event.pull_request.labels.*.name, 'run-vllm-tests')
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'run-vllm-tests') &&
+      !contains(github.event.pull_request.labels.*.name, 'pvc-only')
     uses: ./.github/workflows/vllm-tests-reusable.yml
     with:
       runner_label: b580
@@ -24,7 +48,9 @@ jobs:
     secrets: inherit
 
   vllm-tests-pvc:
-    if: contains(github.event.pull_request.labels.*.name, 'run-vllm-tests')
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'run-vllm-tests') &&
+      !contains(github.event.pull_request.labels.*.name, 'bmg-only')
     uses: ./.github/workflows/vllm-tests-reusable.yml
     with:
       runner_label: max1100
@@ -45,15 +71,19 @@ jobs:
 
   vllm-benchmarks-bmg:
     needs: build-wheel
-    if: contains(github.event.pull_request.labels.*.name, 'run-vllm-benchmarks')
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'run-vllm-benchmarks') &&
+      !contains(github.event.pull_request.labels.*.name, 'pvc-only')
     uses: ./.github/workflows/vllm-benchmarks.yml
     with:
       runner_label: b580
     secrets: inherit
 
   vllm-benchmarks-pvc:
-    needs: build-wheel
-    if: contains(github.event.pull_request.labels.*.name, 'run-vllm-benchmarks')
+    needs: [select-benchmark-platforms, build-wheel]
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'run-vllm-benchmarks') &&
+      needs.select-benchmark-platforms.outputs.run-pvc-benchmarks == 'true'
     uses: ./.github/workflows/vllm-benchmarks.yml
     with:
       runner_label: max1550
@@ -63,15 +93,19 @@ jobs:
 
   triton-benchmarks-bmg:
     needs: build-wheel
-    if: contains(github.event.pull_request.labels.*.name, 'run-benchmarks')
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'run-benchmarks') &&
+      !contains(github.event.pull_request.labels.*.name, 'pvc-only')
     uses: ./.github/workflows/triton-benchmarks.yml
     with:
       runner_label: b580
       skip_benchmarks: '["flex-attention-causal-batch16"]'
 
   triton-benchmarks-pvc:
-    needs: build-wheel
-    if: contains(github.event.pull_request.labels.*.name, 'run-benchmarks')
+    needs: [select-benchmark-platforms, build-wheel]
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'run-benchmarks') &&
+      needs.select-benchmark-platforms.outputs.run-pvc-benchmarks == 'true'
     uses: ./.github/workflows/triton-benchmarks.yml
     with:
       runner_label: max1550
@@ -81,15 +115,19 @@ jobs:
 
   sglang-benchmarks-bmg:
     needs: build-wheel
-    if: contains(github.event.pull_request.labels.*.name, 'run-sglang-benchmarks')
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'run-sglang-benchmarks') &&
+      !contains(github.event.pull_request.labels.*.name, 'pvc-only')
     uses: ./.github/workflows/sglang-benchmarks.yml
     with:
       runner_label: b580
     secrets: inherit
 
   sglang-benchmarks-pvc:
-    needs: build-wheel
-    if: contains(github.event.pull_request.labels.*.name, 'run-sglang-benchmarks')
+    needs: [select-benchmark-platforms, build-wheel]
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'run-sglang-benchmarks') &&
+      needs.select-benchmark-platforms.outputs.run-pvc-benchmarks == 'true'
     uses: ./.github/workflows/sglang-benchmarks.yml
     with:
       runner_label: max1550


### PR DESCRIPTION
Adds intelligent platform selection to the on-label workflow to handle platform-specific test and benchmark runs:

- Introduces `bmg-only` and `pvc-only` labels for explicit platform control
- Adds `select-benchmark-platforms` job to centralize benchmark platform logic
- Temporarily disables PVC benchmarks (max1550) by default due to machine unavailability