### PR TITLE
[MaterializeBlockPointer] Lift the H != 1 guard on 1D strided stores

### DIFF
--- a/python/test/unit/intel/test_1d_reshape_store_correctness.py
+++ b/python/test/unit/intel/test_1d_reshape_store_correctness.py
@@ -50,41 +50,50 @@ def strided_store_kernel(
     tl.store(out_ptr + out_offset, val, mask=mask)
 
 
+def _has_block_store(llir):
+    """True if the kernel emitted a 2D block store message."""
+    return 'spirv_Subgroup2DBlockStoreINTEL' in llir or 'GenISA.LSC2DBlockWrite' in llir
+
+
 @pytest.mark.skipif(not is_xpu(), reason="XPU-specific test")
 @pytest.mark.parametrize(
-    "W, S, XBLOCK, num_warps, dtype_str",
+    "W, S, XBLOCK, num_warps, expect_block_store, dtype_str",
     [
-        # H = XBLOCK / W = 1: this IS the case that exercises
-        # `reshape1DStridedStore` (it requires H == 1 per the TODO in
-        # MaterializeBlockPointer.cpp).  num_warps must be 1 so that
-        # H / num_warps >= 1.
-        (32, 96, 32, 1, "float16"),
-        (32, 128, 32, 1, "float16"),
-        (32, 192, 32, 1, "float16"),
-        # H > 1: baseline functional correctness only — the store reshape
-        # optimization is currently disabled for H != 1, so these cases do
-        # not exercise the optimized path but verify the fallback gather
-        # store remains correct.
-        (32, 96, 1024, 4, "float16"),
-        (32, 128, 1024, 4, "float16"),
-        (32, 192, 1024, 4, "float16"),
+        # H = XBLOCK / W = 1: a single contiguous row.  num_warps must be 1 so
+        # that H / num_warps >= 1.
+        (32, 96, 32, 1, True, "float16"),
+        (32, 128, 32, 1, True, "float16"),
+        (32, 192, 32, 1, True, "float16"),
+        # H > 1: the multi-row case.  Per-warp height is H/num_warps = 8, the
+        # store hardware maximum, so one 2D block store replaces 32 rows of
+        # scatter.  This is the case the `H != 1` guard used to block.
+        (32, 96, 1024, 4, True, "float16"),
+        (32, 128, 1024, 4, True, "float16"),
+        (32, 192, 1024, 4, True, "float16"),
+        # W < threadsPerWarp (16 < 32): must fall back.  A [1, tpw] encoding on
+        # a dimension of size W < tpw is replicated and cannot be legalized
+        # (same reason as the load-side bail-out for issue #6738).
+        (16, 96, 512, 4, False, "float16"),
     ],
     ids=[
         "H1_W32_S96_f16",
         "H1_W32_S128_f16",
         "H1_W32_S192_f16",
-        "H32_W32_S96_f16_fallback",
-        "H32_W32_S128_f16_fallback",
-        "H32_W32_S192_f16_fallback",
+        "H32_W32_S96_f16",
+        "H32_W32_S128_f16",
+        "H32_W32_S192_f16",
+        "H32_W16_S96_f16_narrow_fallback",
     ],
 )
-def test_1d_reshape_strided_store(W, S, XBLOCK, num_warps, dtype_str, device):
+def test_1d_reshape_strided_store(W, S, XBLOCK, num_warps, expect_block_store, dtype_str, device):
     """Test 1D-to-2D block store reshape and fallback produce correct results.
 
-    With H = XBLOCK / W == 1, the Inductor-style strided store is lowered
-    via `reshape1DStridedStore` to a 2D block store.  With H > 1, the
-    current implementation rejects the reshape (TODO: hardware transpose
-    unsupported) and this case exercises the gather-store fallback.
+    The Inductor-style strided store is lowered via `reshape1DStridedStore` to a
+    2D block store, for H == 1 and for H > 1 alike: the value is reshaped to the
+    natural 2D encoding and then converted into the hardware delivery encoding
+    (lane k owns column k, registers stack rows).  `expect_block_store` pins
+    whether the optimization fired — without it a silently-skipped reshape would
+    still pass the numeric checks below.
     """
     num_rows = 1024
     xnumel = W * num_rows  # total elements
@@ -106,7 +115,7 @@ def test_1d_reshape_strided_store(W, S, XBLOCK, num_warps, dtype_str, device):
 
     # Launch kernel
     grid = (xnumel + XBLOCK - 1) // XBLOCK
-    strided_store_kernel[(grid, )](
+    kernel = strided_store_kernel[(grid, )](
         x_tri,
         out_tri,
         xnumel,
@@ -115,6 +124,14 @@ def test_1d_reshape_strided_store(W, S, XBLOCK, num_warps, dtype_str, device):
         XBLOCK=XBLOCK,
         num_warps=num_warps,
     )
+
+    # Pin whether the 1D->2D reshape actually fired.  The numeric assertions
+    # below pass either way, so without this a regression that silently skips
+    # the optimization would go unnoticed.
+    llir = kernel.asm["llir"]
+    assert _has_block_store(llir) == expect_block_store, (
+        f"expected block store: {expect_block_store}, got {not expect_block_store} "
+        f"for W={W}, S={S}, XBLOCK={XBLOCK}, num_warps={num_warps}")
 
     # Compare: reshape output to [num_rows, S] and check the first W columns
     # of each row (the rest should remain zero)
@@ -282,15 +299,26 @@ def _wgt_load_kernel(
 @pytest.mark.parametrize(
     "W, S, H, dtype_str",
     [
-        # i8 / W=64 > tpw=32 / H=1 (store is gated at H=1 anyway).
+        # i8 / W=64 > tpw=32 / H=1.
         # BLOCK=W*H=64. Single instance, pure arange — matchStridedPattern fires.
         # Before the fix: tile_width=64, elem_size=8 → lane l stores to
         #   dst[l] and dst[l+32] but holds cols 2l and 2l+1 → wrong columns.
         # After the fix:  tile_width=32, elem_size=16 → packed correctly.
         (64, 128, 1, "int8"),
         (64, 192, 1, "int8"),
+        # Same, with H = 8 = maxPerWarpHeight for stores.  This combines the
+        # W > tpw packing with the multi-row geometry unblocked by lifting the
+        # `H != 1` guard: sizePerThread = [8, 2], so each lane holds 2 adjacent
+        # columns of all 8 rows and the packed tile is 32 wide by 8 high.
+        (64, 128, 8, "int8"),
+        (64, 192, 8, "int8"),
     ],
-    ids=["H1_W64_S128_i8_wgt_tpw", "H1_W64_S192_i8_wgt_tpw"],
+    ids=[
+        "H1_W64_S128_i8_wgt_tpw",
+        "H1_W64_S192_i8_wgt_tpw",
+        "H8_W64_S128_i8_wgt_tpw",
+        "H8_W64_S192_i8_wgt_tpw",
+    ],
 )
 def test_1d_reshape_strided_store_w_gt_tpw(W, S, H, dtype_str, device):
     """Regression test: 1D strided store with W > threadsPerWarp must produce correct data."""
@@ -306,7 +334,10 @@ def test_1d_reshape_strided_store_w_gt_tpw(W, S, H, dtype_str, device):
     x_tri = to_triton(x_np, device=device)
     out_tri = torch.zeros(out_size, dtype=x_tri.dtype, device=device)
 
-    _wgt_store_kernel[(1, )](x_tri, out_tri, W=W, S=S, BLOCK=BLOCK, num_warps=1)
+    kernel = _wgt_store_kernel[(1, )](x_tri, out_tri, W=W, S=S, BLOCK=BLOCK, num_warps=1)
+
+    assert _has_block_store(kernel.asm["llir"]), \
+        f"1D->2D store reshape did not fire for W={W} S={S} H={H}"
 
     np.testing.assert_array_equal(
         to_numpy(out_tri),

--- a/python/test/unit/intel/test_1d_reshape_store_correctness.py
+++ b/python/test/unit/intel/test_1d_reshape_store_correctness.py
@@ -95,6 +95,11 @@ def test_1d_reshape_strided_store(W, S, XBLOCK, num_warps, expect_block_store, d
     whether the optimization fired — without it a silently-skipped reshape would
     still pass the numeric checks below.
     """
+    # On devices without 2D block IO the optimization is not emitted; override
+    # the parametrized expectation so the numeric checks still run.
+    if not triton.runtime.driver.active.get_current_target().arch.get('has_2d_block_io', False):
+        expect_block_store = False
+
     num_rows = 1024
     xnumel = W * num_rows  # total elements
 

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-anchor.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-anchor.mlir
@@ -42,8 +42,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
   // CHECK-LABEL: tt.func @test_store_convert_layout_survives
-  // CHECK: tt.reshape %{{.*}} allow_reorder efficient_layout
-  // CHECK: tt.reshape %{{.*}} efficient_layout
+  // CHECK: tt.reshape %{{.*}}
+  // CHECK: tt.reshape %{{.*}}
   // CHECK: ttg.convert_layout
   // CHECK: tt.store %{{.*}} {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64}
   tt.func @test_store_convert_layout_survives(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<1024xf16, #blocked1d>) {

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-anchor.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-anchor.mlir
@@ -42,10 +42,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
   // CHECK-LABEL: tt.func @test_store_convert_layout_survives
+  // COM: Two reshapes, then the value-side ConvertLayout (anchored by ttig.block_io_stride)
+  // COM: must survive RemoveLayoutConversions. Binding [[CVT]] and verifying it is used as
+  // COM: the store's value operand ensures the correct (storeEnc) value reaches the store.
   // CHECK: tt.reshape %{{.*}}
   // CHECK: tt.reshape %{{.*}}
-  // CHECK: ttg.convert_layout
-  // CHECK: tt.store %{{.*}} {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64}
+  // CHECK: [[CVT:%[0-9]+]] = ttg.convert_layout
+  // CHECK: tt.store %{{.*}}, [[CVT]] {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64}
   tt.func @test_store_convert_layout_survives(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<1024xf16, #blocked1d>) {
     %idx = tt.make_range {start = 0 : i32, end = 1024 : i32} : tensor<1024xi32, #blocked1d>
     %c32 = arith.constant dense<32> : tensor<1024xi32, #blocked1d>

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-anchor.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-anchor.mlir
@@ -28,3 +28,35 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return %result : tensor<1024xf16, #blocked1d>
   }
 }
+
+// -----
+
+// COM: Same regression test for the store side (H > 1).  reshape1DStridedStore
+// COM: converts the value from the natural 2D encoding into the HW delivery
+// COM: encoding; if RemoveLayoutConversions folds that ConvertLayoutOp away, the
+// COM: store receives the natural encoding again and writes to the wrong
+// COM: positions — exactly the silent corruption of #6531/#6634.  The anchor in
+// COM: isExpensiveLoadOrStore keys on ttig.block_io_stride, not on op kind, so
+// COM: this holds for stores as well as loads.
+
+#blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @test_store_convert_layout_survives
+  // CHECK: tt.reshape %{{.*}} allow_reorder efficient_layout
+  // CHECK: tt.reshape %{{.*}} efficient_layout
+  // CHECK: ttg.convert_layout
+  // CHECK: tt.store %{{.*}} {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64}
+  tt.func @test_store_convert_layout_survives(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<1024xf16, #blocked1d>) {
+    %idx = tt.make_range {start = 0 : i32, end = 1024 : i32} : tensor<1024xi32, #blocked1d>
+    %c32 = arith.constant dense<32> : tensor<1024xi32, #blocked1d>
+    %c96 = arith.constant dense<96> : tensor<1024xi32, #blocked1d>
+    %rem = arith.remui %idx, %c32 : tensor<1024xi32, #blocked1d>
+    %div = arith.divui %idx, %c32 : tensor<1024xi32, #blocked1d>
+    %mul = arith.muli %div, %c96 : tensor<1024xi32, #blocked1d>
+    %off = arith.addi %rem, %mul : tensor<1024xi32, #blocked1d>
+    %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked1d>
+    %ptrs = tt.addptr %base, %off : tensor<1024x!tt.ptr<f16>, #blocked1d>, tensor<1024xi32, #blocked1d>
+    tt.store %ptrs, %arg1 : tensor<1024x!tt.ptr<f16>, #blocked1d>
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-disabled.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-disabled.mlir
@@ -67,3 +67,36 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return %result : tensor<1024xf16, #blocked1d_large>
   }
 }
+
+// -----
+
+// COM: Test 3: 1D strided STORE with H > 1 — the case unblocked by lifting the
+// COM: H != 1 guard.  When enabled it reshapes [1024] -> [32, 32], converts the
+// COM: value into the HW delivery encoding and annotates the store.  When
+// COM: disabled the original tt.store must survive unchanged, because the
+// COM: gather store cannot handle the [H,W] registers-stride-rows encoding.
+
+#blocked1d_large = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @test_1d_strided_store_multi_row
+  tt.func @test_1d_strided_store_multi_row(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<1024xf16, #blocked1d_large>) {
+    %idx = tt.make_range {start = 0 : i32, end = 1024 : i32} : tensor<1024xi32, #blocked1d_large>
+    %c32 = arith.constant dense<32> : tensor<1024xi32, #blocked1d_large>
+    %c96 = arith.constant dense<96> : tensor<1024xi32, #blocked1d_large>
+    %rem = arith.remui %idx, %c32 : tensor<1024xi32, #blocked1d_large>
+    %div = arith.divui %idx, %c32 : tensor<1024xi32, #blocked1d_large>
+    %mul = arith.muli %div, %c96 : tensor<1024xi32, #blocked1d_large>
+    %off = arith.addi %rem, %mul : tensor<1024xi32, #blocked1d_large>
+    %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked1d_large>
+    %ptrs = tt.addptr %base, %off : tensor<1024x!tt.ptr<f16>, #blocked1d_large>, tensor<1024xi32, #blocked1d_large>
+    // DISABLED-NOT: tt.reshape
+    // DISABLED: tt.store %{{.*}}, %{{.*}} : tensor<1024x!tt.ptr<f16>
+    // DISABLED-NOT: ttig.block_io
+    // ENABLED: tt.reshape %{{.*}} allow_reorder efficient_layout
+    // ENABLED: tt.reshape %{{.*}} efficient_layout
+    // ENABLED: ttg.convert_layout
+    // ENABLED: tt.store %{{.*}}, %{{.*}} {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64} : tensor<32x32x!tt.ptr<f16>
+    tt.store %ptrs, %arg1 : tensor<1024x!tt.ptr<f16>, #blocked1d_large>
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-disabled.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-disabled.mlir
@@ -70,11 +70,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
-// COM: Test 3: 1D strided STORE with H > 1 — the case unblocked by lifting the
-// COM: H != 1 guard.  When enabled it reshapes [1024] -> [32, 32], converts the
-// COM: value into the HW delivery encoding and annotates the store.  When
-// COM: disabled the original tt.store must survive unchanged, because the
-// COM: gather store cannot handle the [H,W] registers-stride-rows encoding.
+// COM: Test 3: 1D strided STORE with H > 1 When enabled it reshapes
+// COM: [1024] -> [32, 32], converts the value into the HW delivery encoding
+// COM: and annotates the store. When disabled the original tt.store must survive unchanged.
 
 #blocked1d_large = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-disabled.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-disabled.mlir
@@ -90,8 +90,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // DISABLED-NOT: tt.reshape
     // DISABLED: tt.store %{{.*}}, %{{.*}} : tensor<1024x!tt.ptr<f16>
     // DISABLED-NOT: ttig.block_io
-    // ENABLED: tt.reshape %{{.*}} allow_reorder efficient_layout
-    // ENABLED: tt.reshape %{{.*}} efficient_layout
+    // ENABLED: tt.reshape %{{.*}} : tensor<1024x!tt.ptr<f16>,
+    // ENABLED: tt.reshape %{{.*}} : tensor<1024xf16,
+    // ENABLED: ttg.convert_layout
     // ENABLED: ttg.convert_layout
     // ENABLED: tt.store %{{.*}}, %{{.*}} {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64} : tensor<32x32x!tt.ptr<f16>
     tt.store %ptrs, %arg1 : tensor<1024x!tt.ptr<f16>, #blocked1d_large>

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-llvm.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-llvm.mlir
@@ -30,15 +30,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
 // -----
 
-// COM: Test 2: Multi-row tile (H > 1) — no 2D block store emitted.
+// COM: Test 2: Multi-row tile (H > 1) — one 2D block store per warp.
 // COM: numElements=1024, W=32, S=96, fp16, numWarps=4, H = 1024/32 = 32.
-// COM: FIXME: The 2D block store lowering does not correctly handle H > 1
-// COM: because offsetY is hardcoded to 0. Once the lowering is fixed, this
-// COM: test should expect triton_gen.2Dblockstore.
+// COM: Per-warp height is 32/4 = 8, so the message carries a vector<8xi16>:
+// COM: lane k holds column k of all 8 rows, which is exactly what the hardware
+// COM: consumes.  Geometry comes from the shared getBlockIOStoreTileSize helper
+// COM: (elem_size_in_bits = 16, tile_width = 32) — no hand-built tile.
 
 #blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
   // CHECK-LABEL: llvm.func spir_kernelcc @test_1d_reshape_multi_row
+  // CHECK: triton_gen.2Dblockstore {{.*}} {elem_size_in_bits = 16, tile_width = 32, tile_height = 8, v_blocks = 1, cache_control = Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32, vector<8xi16>)
   // CHECK-NOT: triton_gen.2Dblockstore
   tt.func @test_1d_reshape_multi_row(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<1024xf16, #blocked1d>) {
     %idx = tt.make_range {start = 0 : i32, end = 1024 : i32} : tensor<1024xi32, #blocked1d>

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape.mlir
@@ -266,3 +266,59 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return
   }
 }
+
+// -----
+
+// COM: Test 10: 1D strided store with H < numWarps (perWarpH = 0).
+// COM: i8, BLOCK=64, W=64, S=128, numWarps=2, tpw=32.
+// COM: H = 64/64 = 1. perWarpH = 1/2 = 0 → HW delivery encoding cannot be
+// COM: constructed; reshape must bail out and leave a scatter store.
+
+#blocked_h_lt_nw_store = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [2], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @test_1d_strided_store_h_lt_numwarps
+  // CHECK-NOT: tt.reshape
+  // CHECK-NOT: ttig.block_io
+  // CHECK: tt.store %{{.*}}, %{{.*}} : tensor<64x!tt.ptr<i8>
+  tt.func @test_1d_strided_store_h_lt_numwarps(%arg0: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg1: tensor<64xi8, #blocked_h_lt_nw_store>) {
+    %idx  = tt.make_range {start = 0 : i32, end = 64 : i32} : tensor<64xi32, #blocked_h_lt_nw_store>
+    %cW   = arith.constant dense<64>  : tensor<64xi32, #blocked_h_lt_nw_store>
+    %cS   = arith.constant dense<128> : tensor<64xi32, #blocked_h_lt_nw_store>
+    %rem  = arith.remui %idx, %cW : tensor<64xi32, #blocked_h_lt_nw_store>
+    %div  = arith.divui %idx, %cW : tensor<64xi32, #blocked_h_lt_nw_store>
+    %mul  = arith.muli  %div, %cS : tensor<64xi32, #blocked_h_lt_nw_store>
+    %off  = arith.addi  %rem, %mul : tensor<64xi32, #blocked_h_lt_nw_store>
+    %base = tt.splat %arg0 : !tt.ptr<i8> -> tensor<64x!tt.ptr<i8>, #blocked_h_lt_nw_store>
+    %ptrs = tt.addptr %base, %off : tensor<64x!tt.ptr<i8>, #blocked_h_lt_nw_store>, tensor<64xi32, #blocked_h_lt_nw_store>
+    tt.store %ptrs, %arg1 : tensor<64x!tt.ptr<i8>, #blocked_h_lt_nw_store>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Test 11: 1D strided load with H < numWarps (perWarpH = 0).
+// COM: i8, BLOCK=64, W=64, S=128, numWarps=2, tpw=32.
+// COM: H = 64/64 = 1. perWarpH = 1/2 = 0 → HW delivery encoding cannot be
+// COM: constructed; reshape must bail out and leave a gather load.
+
+#blocked_h_lt_nw_load = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [2], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @test_1d_strided_load_h_lt_numwarps
+  // CHECK-NOT: tt.reshape
+  // CHECK-NOT: ttig.block_io
+  // CHECK: tt.load %{{.*}} : tensor<64x!tt.ptr<i8>
+  tt.func @test_1d_strided_load_h_lt_numwarps(%arg0: !tt.ptr<i8> {tt.divisibility = 16 : i32}) -> tensor<64xi8, #blocked_h_lt_nw_load> {
+    %idx  = tt.make_range {start = 0 : i32, end = 64 : i32} : tensor<64xi32, #blocked_h_lt_nw_load>
+    %cW   = arith.constant dense<64>  : tensor<64xi32, #blocked_h_lt_nw_load>
+    %cS   = arith.constant dense<128> : tensor<64xi32, #blocked_h_lt_nw_load>
+    %rem  = arith.remui %idx, %cW : tensor<64xi32, #blocked_h_lt_nw_load>
+    %div  = arith.divui %idx, %cW : tensor<64xi32, #blocked_h_lt_nw_load>
+    %mul  = arith.muli  %div, %cS : tensor<64xi32, #blocked_h_lt_nw_load>
+    %off  = arith.addi  %rem, %mul : tensor<64xi32, #blocked_h_lt_nw_load>
+    %base = tt.splat %arg0 : !tt.ptr<i8> -> tensor<64x!tt.ptr<i8>, #blocked_h_lt_nw_load>
+    %ptrs = tt.addptr %base, %off : tensor<64x!tt.ptr<i8>, #blocked_h_lt_nw_load>, tensor<64xi32, #blocked_h_lt_nw_load>
+    %res  = tt.load %ptrs : tensor<64x!tt.ptr<i8>, #blocked_h_lt_nw_load>
+    tt.return %res : tensor<64xi8, #blocked_h_lt_nw_load>
+  }
+}

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape.mlir
@@ -30,13 +30,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
 // COM: Test 2: Multi-row tile (H > 1).
 // COM: numElements=1024, W=32, S=96, fp16, numWarps=4, H = 1024/32 = 32.
-// COM: FIXME: The 2D block store lowering does not correctly handle H > 1
-// COM: because offsetY is hardcoded to 0. Once the lowering is fixed, this
-// COM: test should expect tt.reshape and ttig.block_io attributes.
+// COM: The store encoding is built explicitly to match hardware delivery
+// COM: (sizePerThread=[H/numWarps, W/tpw]=[8,1], threadsPerWarp=[1,32]: lane k
+// COM: owns column k, registers stack rows) and the value is converted into it
+// COM: from the natural 2D reshape of the 1D encoding ([1,8]/[8,4]).  Handing
+// COM: the inferred encoding straight to the store instead is what silently
+// COM: corrupted data in #6531/#6634.
+
+// CHECK-DAG: [[STOREENC:#[a-z0-9_]+]] = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+// CHECK-DAG: [[CONSENC:#[a-z0-9_]+]] = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 
 #blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
-  // CHECK-LABEL: tt.func @test_multi_row_h32
+  // COM: Plain CHECK (not CHECK-LABEL) so the [[STOREENC]]/[[CONSENC]] captures
+  // COM: above stay in scope — FileCheck matches CHECK-LABEL blocks independently.
+  // CHECK: tt.func @test_multi_row_h32
   tt.func @test_multi_row_h32(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<1024xf16, #blocked1d>) {
     %idx = tt.make_range {start = 0 : i32, end = 1024 : i32} : tensor<1024xi32, #blocked1d>
     %cst32 = arith.constant dense<32> : tensor<1024xi32, #blocked1d>
@@ -47,8 +55,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %off = arith.addi %rem, %mul : tensor<1024xi32, #blocked1d>
     %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked1d>
     %ptrs = tt.addptr %base, %off : tensor<1024x!tt.ptr<f16>, #blocked1d>, tensor<1024xi32, #blocked1d>
-    // CHECK-NOT: tt.reshape
-    // CHECK: tt.store %{{.*}}, %{{.*}} : tensor<1024x!tt.ptr<f16>
+    // CHECK: [[PTR2D:%[0-9]+]] = tt.reshape %{{.*}} allow_reorder efficient_layout : tensor<1024x!tt.ptr<f16>, {{.*}}> -> tensor<32x32x!tt.ptr<f16>, [[STOREENC]]>
+    // CHECK: [[VAL2D:%[0-9]+]] = tt.reshape %{{.*}} efficient_layout : tensor<1024xf16, {{.*}}> -> tensor<32x32xf16, [[CONSENC]]>
+    // CHECK: [[CVT:%[0-9]+]] = ttg.convert_layout [[VAL2D]] : tensor<32x32xf16, [[CONSENC]]> -> tensor<32x32xf16, [[STOREENC]]>
+    // CHECK: tt.store [[PTR2D]], [[CVT]] {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64} : tensor<32x32x!tt.ptr<f16>, [[STOREENC]]>
     tt.store %ptrs, %arg1 : tensor<1024x!tt.ptr<f16>, #blocked1d>
     tt.return
   }
@@ -226,5 +236,33 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %mask = arith.constant dense<true> : tensor<128xi1, #blocked1d>
     %result = tt.load %ptrs, %mask : tensor<128x!tt.ptr<f16>, #blocked1d>
     tt.return %result : tensor<128xf16, #blocked1d>
+  }
+}
+
+// -----
+
+// COM: Test 9: 1D strided store with W < threadsPerWarp (W=16, tpw=32), H=32.
+// COM: The store path carries the same bail-out as the load (issue #6738): a
+// COM: [1,tpw] encoding on a dimension of size W < tpw is replicated and the
+// COM: reshape cannot be legalized.  Must fall back to the scatter store.
+
+#blocked1d = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @test_1d_strided_store_narrow_width
+  // CHECK-NOT: tt.reshape
+  // CHECK-NOT: ttig.block_io
+  // CHECK: tt.store %{{.*}}, %{{.*}} : tensor<128x!tt.ptr<f16>
+  tt.func @test_1d_strided_store_narrow_width(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<128xf16, #blocked1d>) {
+    %idx = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32, #blocked1d>
+    %c16 = arith.constant dense<16> : tensor<128xi32, #blocked1d>
+    %c96 = arith.constant dense<96> : tensor<128xi32, #blocked1d>
+    %rem = arith.remui %idx, %c16 : tensor<128xi32, #blocked1d>
+    %div = arith.divui %idx, %c16 : tensor<128xi32, #blocked1d>
+    %mul = arith.muli %div, %c96 : tensor<128xi32, #blocked1d>
+    %off = arith.addi %rem, %mul : tensor<128xi32, #blocked1d>
+    %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x!tt.ptr<f16>, #blocked1d>
+    %ptrs = tt.addptr %base, %off : tensor<128x!tt.ptr<f16>, #blocked1d>, tensor<128xi32, #blocked1d>
+    tt.store %ptrs, %arg1 : tensor<128x!tt.ptr<f16>, #blocked1d>
+    tt.return
   }
 }

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape.mlir
@@ -30,12 +30,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
 // COM: Test 2: Multi-row tile (H > 1).
 // COM: numElements=1024, W=32, S=96, fp16, numWarps=4, H = 1024/32 = 32.
-// COM: The store encoding is built explicitly to match hardware delivery
-// COM: (sizePerThread=[H/numWarps, W/tpw]=[8,1], threadsPerWarp=[1,32]: lane k
-// COM: owns column k, registers stack rows) and the value is converted into it
-// COM: from the natural 2D reshape of the 1D encoding ([1,8]/[8,4]).  Handing
-// COM: the inferred encoding straight to the store instead is what silently
-// COM: corrupted data in #6531/#6634.
+// COM: Both ptr and val are reshaped then ConvertLayoutOps convert both into the HW delivery encoding
+// COM: (sizePerThread=[8,1], threadsPerWarp=[1,32]: lane k owns column k, registers
+// COM: stack rows). RemoveLayoutConversions back-propagates the store encoding into
+// COM: the pointer arithmetic and eliminates the ptr ConvertLayout.
 
 // CHECK-DAG: [[STOREENC:#[a-z0-9_]+]] = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 // CHECK-DAG: [[CONSENC:#[a-z0-9_]+]] = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
@@ -55,10 +53,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %off = arith.addi %rem, %mul : tensor<1024xi32, #blocked1d>
     %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked1d>
     %ptrs = tt.addptr %base, %off : tensor<1024x!tt.ptr<f16>, #blocked1d>, tensor<1024xi32, #blocked1d>
-    // CHECK: [[PTR2D:%[0-9]+]] = tt.reshape %{{.*}} allow_reorder efficient_layout : tensor<1024x!tt.ptr<f16>, {{.*}}> -> tensor<32x32x!tt.ptr<f16>, [[STOREENC]]>
-    // CHECK: [[VAL2D:%[0-9]+]] = tt.reshape %{{.*}} efficient_layout : tensor<1024xf16, {{.*}}> -> tensor<32x32xf16, [[CONSENC]]>
+    // CHECK: [[PTR2D:%[0-9]+]] = tt.reshape %{{.*}} : tensor<1024x!tt.ptr<f16>, {{.*}}> -> tensor<32x32x!tt.ptr<f16>, [[CONSENC]]>
+    // CHECK: [[VAL2D:%[0-9]+]] = tt.reshape %{{.*}} : tensor<1024xf16, {{.*}}> -> tensor<32x32xf16, [[CONSENC]]>
+    // CHECK: ttg.convert_layout [[PTR2D]] : tensor<32x32x!tt.ptr<f16>, [[CONSENC]]> -> tensor<32x32x!tt.ptr<f16>, [[STOREENC]]>
     // CHECK: [[CVT:%[0-9]+]] = ttg.convert_layout [[VAL2D]] : tensor<32x32xf16, [[CONSENC]]> -> tensor<32x32xf16, [[STOREENC]]>
-    // CHECK: tt.store [[PTR2D]], [[CVT]] {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64} : tensor<32x32x!tt.ptr<f16>, [[STOREENC]]>
+    // CHECK: tt.store %{{.*}}, [[CVT]] {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64} : tensor<32x32x!tt.ptr<f16>, [[STOREENC]]>
     tt.store %ptrs, %arg1 : tensor<1024x!tt.ptr<f16>, #blocked1d>
     tt.return
   }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -775,49 +775,28 @@ private:
       return;
     }
 
-    // Construct "store encoding" matching HW delivery:
-    // lanes map to contiguous column blocks, and each lane stores consecutive
-    // rows for its block in its local fragment
+    // Reshape pointer and value to [H, W] with their natural 2D encodings
+    auto ptrReshape = tt::ReshapeOp::create(builder, loc, newShape, info->ptr,
+                                            /*allowReorder=*/false);
+    auto valReshape =
+        tt::ReshapeOp::create(builder, loc, newShape, op.getValue(),
+                              /*allowReorder=*/false);
+
+    // Build HW delivery encoding and convert both ptr and val into it.
     auto storeEnc =
         buildHWDelivery2DEncoding(ctx, perWarpH, W, threadsPerWarp, numWarps);
-
-    // Construct "consumer encoding" — the natural 2D reshape of the value's
-    // original 1D encoding.
-    auto valTensorTy = cast<RankedTensorType>(op.getValue().getType());
-    std::optional<Attribute> consumerEnc =
-        derive2DConsumerEncoding(ctx, valTensorTy, info->W);
-    if (!consumerEnc)
-      return;
-
-    // Reshape pointer to [H, W] with store encoding.
-    // Mark efficient_layout so RemoveLayoutConversions does not
-    // rematerialize these reshapes with a different encoding.
     auto storePtrTy =
         RankedTensorType::get(newShape, ptrTensorTy.getElementType(), storeEnc);
-    auto ptrReshape = tt::ReshapeOp::create(builder, loc, storePtrTy, info->ptr,
-                                            /*allowReorder=*/true,
-                                            /*efficientLayout=*/true);
-
-    // Reshape the value to [H, W] in the consumer encoding, then convert it
-    // into the hardware delivery layout.
-    Type valElemTy = valTensorTy.getElementType();
-    auto consumerValTy =
-        RankedTensorType::get(newShape, valElemTy, *consumerEnc);
-    auto valReshape =
-        tt::ReshapeOp::create(builder, loc, consumerValTy, op.getValue(),
-                              /*allowReorder=*/false,
-                              /*efficientLayout=*/true);
-
-    // ConvertLayoutOp: consumer encoding -> store encoding.
-    Value storeVal = valReshape.getResult();
-    if (*consumerEnc != storeEnc) {
-      auto storeValTy = RankedTensorType::get(newShape, valElemTy, storeEnc);
-      storeVal =
-          ttg::ConvertLayoutOp::create(builder, loc, storeValTy, valReshape);
-    }
+    Value storePtr =
+        ttg::ConvertLayoutOp::create(builder, loc, storePtrTy, ptrReshape);
+    auto valTy = cast<RankedTensorType>(op.getValue().getType());
+    auto storeValTy =
+        RankedTensorType::get(newShape, valTy.getElementType(), storeEnc);
+    Value storeVal =
+        ttg::ConvertLayoutOp::create(builder, loc, storeValTy, valReshape);
 
     // Create the new 2D store.
-    auto newStore = tt::StoreOp::create(builder, loc, ptrReshape, storeVal,
+    auto newStore = tt::StoreOp::create(builder, loc, storePtr, storeVal,
                                         op.getCache(), op.getEvict());
 
     setBlockIOAttrs(newStore, ctx, info->S);

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -675,29 +675,21 @@ private:
       LDBG("Expected 1D blocked encoding with order=[0], skip 1D reshape");
       return std::nullopt;
     }
-    unsigned spt = origEnc.getSizePerThread()[0];
-    unsigned tpw = origEnc.getThreadsPerWarp()[0];
-    unsigned wpc = origEnc.getWarpsPerCTA()[0];
-    unsigned spt1 = std::min(spt, static_cast<unsigned>(W));
-    if (spt1 == 0 || spt % spt1 != 0) {
-      LDBG("Original sizePerThread ("
-           << spt << ") not divisible by spt1=" << spt1 << ", skip 1D reshape");
+    int64_t blockSize = oneDTy.getShape()[0];
+    SmallVector<int64_t> srcShape = {blockSize};
+    SmallVector<int64_t> dstShape = {blockSize / W, W};
+    auto *interface =
+        cast<tt::DialectInferLayoutInterface>(&origEnc.getDialect());
+    Attribute dstEnc;
+    if (failed(interface->inferReshapeOpEncoding(srcShape, origEnc, dstShape,
+                                                 dstEnc, /*allowReorder=*/false,
+                                                 /*loc=*/std::nullopt)))
       return std::nullopt;
-    }
-    unsigned spt0 = spt / spt1;
-    unsigned tpw1 = std::min(tpw, static_cast<unsigned>(W) / spt1);
-    if (tpw1 == 0 || tpw % tpw1 != 0) {
-      LDBG("Original threadsPerWarp ("
-           << tpw << ") not divisible by tpw1=" << tpw1 << ", skip 1D reshape");
-      return std::nullopt;
-    }
-    unsigned tpw0 = tpw / tpw1;
-    return ttg::BlockedEncodingAttr::get(
-        ctx, {spt0, spt1}, {tpw0, tpw1}, {wpc, 1}, {1, 0},
-        ttg::CGAEncodingAttr::fromSplitParams(
-            ctx, /*CTAsPerCGA=*/SmallVector<unsigned>(2, 1),
-            /*CTASplitNum=*/SmallVector<unsigned>(2, 1),
-            /*CTAOrder=*/{0, 1}));
+    auto enc = dyn_cast<ttg::BlockedEncodingAttr>(dstEnc);
+    if (!enc)
+      LDBG("inferReshapeOpEncoding returned non-blocked encoding, "
+           "skip 1D reshape");
+    return enc ? std::optional(enc) : std::nullopt;
   }
 
   /// Detect 1D tensor-of-pointers StoreOp with strided access pattern

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -733,6 +733,14 @@ private:
   /// [12] to [3, 4], and annotates it so that StoreOpToBlockIOConversion
   /// emits a single LSC2DBlockWrite(base, width=4, height=3, pitch=6).
   ///
+  /// Mirror image of reshape1DStridedLoad. The 2D block store consumes data in
+  /// a fixed layout (lane k = column k, registers stack rows), so we construct
+  /// an explicit "store encoding" matching that hardware delivery and insert a
+  /// ConvertLayoutOp from the natural "consumer encoding" into it. Handing
+  /// tt.reshape's *inferred* encoding to the store instead is what silently
+  /// corrupted data for H > 1 in #6531/#6634: the inferred encoding places each
+  /// lane's values in adjacent columns of one row, while the hardware places
+  /// them one per row at intervals of threadsPerWarp.
   void reshape1DStridedStore(tt::StoreOp op, RankedTensorType ptrTensorTy,
                              MLIRContext *ctx) const {
     LDBG("Attempting 1D strided store reshape for: " << *op);
@@ -757,36 +765,80 @@ private:
     if (!info)
       return;
 
-    // With H > 1, tt.reshape infers a blocked encoding that does not match the
-    // 2D block store's hardware delivery pattern: the hardware places each
-    // lane's values at intervals of threadsPerWarp in the packed-flat tile, but
-    // the inferred encoding places them in adjacent positions.
-    if (info->H != 1) {
-      LDBG("H=" << info->H
-                << " > 1 not yet supported for store, skip 1D reshape");
-      return;
-    }
-
     // Create reshaped tensors: [N] -> [H, W].
     Location loc = op.getLoc();
     OpBuilder builder(op);
     SmallVector<int64_t> newShape = {info->H, info->W};
 
-    // Use the ReshapeOp builder that infers the 2D encoding automatically.
-    auto ptrReshape = tt::ReshapeOp::create(builder, loc, newShape, info->ptr,
-                                            /*allowReorder=*/false);
-    Value val = op.getValue();
-    auto valReshape = tt::ReshapeOp::create(builder, loc, newShape, val,
-                                            /*allowReorder=*/false);
+    unsigned threadsPerWarp = ttg::TritonGPUDialect::getThreadsPerWarp(
+        op->getParentOfType<ModuleOp>());
+    unsigned numWarps = info->numWarps;
+    unsigned perWarpH = static_cast<unsigned>(info->H / numWarps);
+    unsigned W = static_cast<unsigned>(info->W);
+
+    // Same restriction as the load path (issue #6738): a BlockedEncoding with
+    // threadsPerWarp=[1,tpw] on a dimension of size W < tpw is replicated, and
+    // the reshape lowering rejects it as an "expensive view" (make_llir
+    // failure).  W not a multiple of tpw would make the encoding cover fewer
+    // than W columns per register, which is not the hardware delivery order.
+    if (W < threadsPerWarp || W % threadsPerWarp != 0) {
+      LDBG("W=" << W << " is not a positive multiple of threadsPerWarp="
+                << threadsPerWarp << ", skip 1D store reshape");
+      return;
+    }
+
+    // Construct "store encoding" matching HW delivery:
+    // lane k = column k, registers stack rows.
+    auto storeEnc =
+        buildHWDelivery2DEncoding(ctx, perWarpH, W, threadsPerWarp, numWarps);
+
+    // Construct "consumer encoding" — the natural 2D reshape of the value's
+    // original 1D encoding.  Derived from the value, not the pointer: the
+    // ConvertLayoutOp we insert operates on the value.
+    auto valTensorTy = cast<RankedTensorType>(op.getValue().getType());
+    std::optional<ttg::BlockedEncodingAttr> consumerEnc =
+        derive2DConsumerEncoding(ctx, valTensorTy, info->W);
+    if (!consumerEnc)
+      return;
+
+    // Reshape pointer to [H, W] with store encoding.
+    // Mark efficient_layout so RemoveLayoutConversions does not
+    // rematerialize these reshapes with a different encoding.
+    auto storePtrTy =
+        RankedTensorType::get(newShape, ptrTensorTy.getElementType(), storeEnc);
+    auto ptrReshape = tt::ReshapeOp::create(builder, loc, storePtrTy, info->ptr,
+                                            /*allowReorder=*/true,
+                                            /*efficientLayout=*/true);
+
+    // Reshape the value to [H, W] in the consumer encoding, then convert it
+    // into the hardware delivery layout.  This is the exact inverse of the
+    // load's ConvertLayoutOp + reshape-back pair.
+    Type valElemTy = valTensorTy.getElementType();
+    auto consumerValTy =
+        RankedTensorType::get(newShape, valElemTy, *consumerEnc);
+    auto valReshape =
+        tt::ReshapeOp::create(builder, loc, consumerValTy, op.getValue(),
+                              /*allowReorder=*/false,
+                              /*efficientLayout=*/true);
+
+    // ConvertLayoutOp: consumer encoding -> store encoding.  The two coincide
+    // whenever each lane already owns one column per row (e.g. H == 1), in
+    // which case there is nothing to convert.
+    Value storeVal = valReshape.getResult();
+    if (*consumerEnc != storeEnc) {
+      auto storeValTy = RankedTensorType::get(newShape, valElemTy, storeEnc);
+      storeVal =
+          ttg::ConvertLayoutOp::create(builder, loc, storeValTy, valReshape);
+    }
 
     // Create the new 2D store.
-    auto newStore = tt::StoreOp::create(builder, loc, ptrReshape, valReshape,
+    auto newStore = tt::StoreOp::create(builder, loc, ptrReshape, storeVal,
                                         op.getCache(), op.getEvict());
 
     setBlockIOAttrs(newStore, ctx, info->S);
     copyNonBlockIOAttrs(op, newStore);
 
-    LDBG("Created 2D block store: " << *newStore);
+    LDBG("Created 2D block store with layout conversion: " << *newStore);
 
     op.erase();
   }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -740,15 +740,6 @@ private:
   /// recovers W, H, and S from the arithmetic, reshapes the store from
   /// [12] to [3, 4], and annotates it so that StoreOpToBlockIOConversion
   /// emits a single LSC2DBlockWrite(base, width=4, height=3, pitch=6).
-  ///
-  /// Mirror image of reshape1DStridedLoad. The 2D block store consumes data in
-  /// a fixed layout (lane k = column k, registers stack rows), so we construct
-  /// an explicit "store encoding" matching that hardware delivery and insert a
-  /// ConvertLayoutOp from the natural "consumer encoding" into it. Handing
-  /// tt.reshape's *inferred* encoding to the store instead is what silently
-  /// corrupted data for H > 1 in #6531/#6634: the inferred encoding places each
-  /// lane's values in adjacent columns of one row, while the hardware places
-  /// them one per row at intervals of threadsPerWarp.
   void reshape1DStridedStore(tt::StoreOp op, RankedTensorType ptrTensorTy,
                              MLIRContext *ctx) const {
     LDBG("Attempting 1D strided store reshape for: " << *op);
@@ -784,11 +775,11 @@ private:
     unsigned perWarpH = static_cast<unsigned>(info->H / numWarps);
     unsigned W = static_cast<unsigned>(info->W);
 
-    // Same restriction as the load path (issue #6738): a BlockedEncoding with
     // threadsPerWarp=[1,tpw] on a dimension of size W < tpw is replicated, and
     // the reshape lowering rejects it as an "expensive view" (make_llir
     // failure).  W not a multiple of tpw would make the encoding cover fewer
-    // than W columns per register, which is not the hardware delivery order.
+    // than W columns in the lane mapping, which is not the hardware delivery
+    // order.
     if (W < threadsPerWarp || W % threadsPerWarp != 0) {
       LDBG("W=" << W << " is not a positive multiple of threadsPerWarp="
                 << threadsPerWarp << ", skip 1D store reshape");
@@ -796,13 +787,13 @@ private:
     }
 
     // Construct "store encoding" matching HW delivery:
-    // lane k = column k, registers stack rows.
+    // lanes map to contiguous column blocks, and each lane stores consecutive
+    // rows for its block in its local fragment
     auto storeEnc =
         buildHWDelivery2DEncoding(ctx, perWarpH, W, threadsPerWarp, numWarps);
 
     // Construct "consumer encoding" — the natural 2D reshape of the value's
-    // original 1D encoding.  Derived from the value, not the pointer: the
-    // ConvertLayoutOp we insert operates on the value.
+    // original 1D encoding.
     auto valTensorTy = cast<RankedTensorType>(op.getValue().getType());
     std::optional<ttg::BlockedEncodingAttr> consumerEnc =
         derive2DConsumerEncoding(ctx, valTensorTy, info->W);
@@ -819,8 +810,7 @@ private:
                                             /*efficientLayout=*/true);
 
     // Reshape the value to [H, W] in the consumer encoding, then convert it
-    // into the hardware delivery layout.  This is the exact inverse of the
-    // load's ConvertLayoutOp + reshape-back pair.
+    // into the hardware delivery layout.
     Type valElemTy = valTensorTy.getElementType();
     auto consumerValTy =
         RankedTensorType::get(newShape, valElemTy, *consumerEnc);
@@ -829,9 +819,7 @@ private:
                               /*allowReorder=*/false,
                               /*efficientLayout=*/true);
 
-    // ConvertLayoutOp: consumer encoding -> store encoding.  The two coincide
-    // whenever each lane already owns one column per row (e.g. H == 1), in
-    // which case there is nothing to convert.
+    // ConvertLayoutOp: consumer encoding -> store encoding.
     Value storeVal = valReshape.getResult();
     if (*consumerEnc != storeEnc) {
       auto storeValTy = RankedTensorType::get(newShape, valElemTy, storeEnc);
@@ -895,8 +883,8 @@ private:
     // would create a replicated layout that the reshape lowering rejects
     // as an "expensive view" (make_llir failure).  Likewise, when W is not
     // a multiple of tpw the HW delivery encoding covers fewer than W columns
-    // per register, which would mismatch the consumer encoding derived from
-    // the 1D layout.  Bail out in both cases.
+    // in the lane mapping, which would mismatch the consumer encoding derived
+    // from the 1D layout.  Bail out in both cases.
     if (W < threadsPerWarp || W % threadsPerWarp != 0) {
       LDBG("W=" << W << " is not a positive multiple of threadsPerWarp="
                 << threadsPerWarp << ", not supported for 1D load reshape");

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -665,8 +665,8 @@ private:
   /// *to* it, the store converts *from* it *to* HW delivery.
   ///
   /// Returns std::nullopt if \p oneDTy does not carry a 1D blocked encoding
-  /// with order=[0], or if the 1D factors do not split evenly across [H, W].
-  static std::optional<ttg::BlockedEncodingAttr>
+  /// with order=[0], or if encoding inference fails for the [H, W] shape.
+  static std::optional<Attribute>
   derive2DConsumerEncoding(MLIRContext *ctx, RankedTensorType oneDTy,
                            int64_t W) {
     auto origEnc = dyn_cast<ttg::BlockedEncodingAttr>(oneDTy.getEncoding());
@@ -685,11 +685,7 @@ private:
                                                  dstEnc, /*allowReorder=*/false,
                                                  /*loc=*/std::nullopt)))
       return std::nullopt;
-    auto enc = dyn_cast<ttg::BlockedEncodingAttr>(dstEnc);
-    if (!enc)
-      LDBG("inferReshapeOpEncoding returned non-blocked encoding, "
-           "skip 1D reshape");
-    return enc ? std::optional(enc) : std::nullopt;
+    return dstEnc;
   }
 
   /// Detect 1D tensor-of-pointers StoreOp with strided access pattern
@@ -788,7 +784,7 @@ private:
     // Construct "consumer encoding" — the natural 2D reshape of the value's
     // original 1D encoding.
     auto valTensorTy = cast<RankedTensorType>(op.getValue().getType());
-    std::optional<ttg::BlockedEncodingAttr> consumerEnc =
+    std::optional<Attribute> consumerEnc =
         derive2DConsumerEncoding(ctx, valTensorTy, info->W);
     if (!consumerEnc)
       return;
@@ -900,7 +896,7 @@ private:
 
     // Construct "consumer encoding" — the natural 2D reshape of the original
     // 1D encoding, i.e. what the rest of the pipeline expects.
-    std::optional<ttg::BlockedEncodingAttr> consumerEnc =
+    std::optional<Attribute> consumerEnc =
         derive2DConsumerEncoding(ctx, ptrTensorTy, info->W);
     if (!consumerEnc)
       return;

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -691,14 +691,6 @@ private:
            << tpw << ") not divisible by tpw1=" << tpw1 << ", skip 1D reshape");
       return std::nullopt;
     }
-    // Guard against integer-truncation under-coverage: spt1 * tpw1 must equal W
-    // exactly, otherwise the 2D encoding would cover fewer columns than W.
-    if (spt1 * tpw1 != static_cast<unsigned>(W)) {
-      LDBG("spt1=" << spt1 << " * tpw1=" << tpw1 << " = " << spt1 * tpw1
-                   << " != W=" << W
-                   << ", would under-cover the W dimension, skip 1D reshape");
-      return std::nullopt;
-    }
     unsigned tpw0 = tpw / tpw1;
     return ttg::BlockedEncodingAttr::get(
         ctx, {spt0, spt1}, {tpw0, tpw1}, {wpc, 1}, {1, 0},
@@ -783,6 +775,15 @@ private:
     if (W < threadsPerWarp || W % threadsPerWarp != 0) {
       LDBG("W=" << W << " is not a positive multiple of threadsPerWarp="
                 << threadsPerWarp << ", skip 1D store reshape");
+      return;
+    }
+
+    // Each warp must own at least one row; with fewer rows than warps the HW
+    // delivery encoding cannot be constructed (sizePerThread[0] would be 0).
+    if (perWarpH == 0) {
+      LDBG("H=" << info->H << " < numWarps=" << numWarps
+                << " (perWarpH=0), cannot construct HW delivery encoding, "
+                << "skip 1D store reshape");
       return;
     }
 
@@ -888,6 +889,15 @@ private:
     if (W < threadsPerWarp || W % threadsPerWarp != 0) {
       LDBG("W=" << W << " is not a positive multiple of threadsPerWarp="
                 << threadsPerWarp << ", not supported for 1D load reshape");
+      return;
+    }
+
+    // Each warp must own at least one row; with fewer rows than warps the HW
+    // delivery encoding cannot be constructed (sizePerThread[0] would be 0).
+    if (perWarpH == 0) {
+      LDBG("H=" << info->H << " < numWarps=" << numWarps
+                << " (perWarpH=0), cannot construct HW delivery encoding, "
+                << "skip 1D load reshape");
       return;
     }
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -691,6 +691,14 @@ private:
            << tpw << ") not divisible by tpw1=" << tpw1 << ", skip 1D reshape");
       return std::nullopt;
     }
+    // Guard against integer-truncation under-coverage: spt1 * tpw1 must equal W
+    // exactly, otherwise the 2D encoding would cover fewer columns than W.
+    if (spt1 * tpw1 != static_cast<unsigned>(W)) {
+      LDBG("spt1=" << spt1 << " * tpw1=" << tpw1 << " = " << spt1 * tpw1
+                   << " != W=" << W
+                   << ", would under-cover the W dimension, skip 1D reshape");
+      return std::nullopt;
+    }
     unsigned tpw0 = tpw / tpw1;
     return ttg::BlockedEncodingAttr::get(
         ctx, {spt0, spt1}, {tpw0, tpw1}, {wpc, 1}, {1, 0},
@@ -885,11 +893,13 @@ private:
     // remaining lanes' delivery pattern does not match a plain row/col
     // layout, and constructing a BlockedEncoding with threadsPerWarp=[1,tpw]
     // would create a replicated layout that the reshape lowering rejects
-    // as an "expensive view" (make_llir failure).  Bail out for now; this
-    // case can be re-enabled once the lowering handles sub-subgroup tiles.
-    if (W < threadsPerWarp) {
-      LDBG("W=" << W << " < threadsPerWarp=" << threadsPerWarp
-                << " not supported for 1D load reshape");
+    // as an "expensive view" (make_llir failure).  Likewise, when W is not
+    // a multiple of tpw the HW delivery encoding covers fewer than W columns
+    // per register, which would mismatch the consumer encoding derived from
+    // the 1D layout.  Bail out in both cases.
+    if (W < threadsPerWarp || W % threadsPerWarp != 0) {
+      LDBG("W=" << W << " is not a positive multiple of threadsPerWarp="
+                << threadsPerWarp << ", not supported for 1D load reshape");
       return;
     }
 

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -637,6 +637,69 @@ private:
                 IntegerAttr::get(IntegerType::get(ctx, 64), stride));
   }
 
+  /// Build the 2D blocked encoding that matches 2D block I/O hardware
+  /// delivery: lane k owns column k, registers stack rows.  When W > tpw each
+  /// thread owns W/tpw consecutive columns.  Shared by the load and store 1D
+  /// reshape paths — both need the tensor laid out exactly the way the hardware
+  /// message reads/writes it.
+  static ttg::BlockedEncodingAttr
+  buildHWDelivery2DEncoding(MLIRContext *ctx, unsigned perWarpH, unsigned W,
+                            unsigned threadsPerWarp, unsigned numWarps) {
+    return ttg::BlockedEncodingAttr::get(
+        ctx,
+        /*sizePerThread=*/{perWarpH, W / threadsPerWarp},
+        /*threadsPerWarp=*/{1, threadsPerWarp},
+        /*warpsPerCTA=*/{numWarps, 1},
+        /*order=*/{1, 0},
+        ttg::CGAEncodingAttr::fromSplitParams(
+            ctx, /*CTAsPerCGA=*/SmallVector<unsigned>(2, 1),
+            /*CTASplitNum=*/SmallVector<unsigned>(2, 1),
+            /*CTAOrder=*/{0, 1}));
+  }
+
+  /// Build the "consumer encoding" — the natural 2D reshape of a 1D blocked
+  /// encoding. For sizePerThread=[spt], threadsPerWarp=[tpw],
+  /// warpsPerCTA=[wpc], order=[0], the natural reshape to [H, W] with
+  /// order=[1,0] distributes elements column-first.  This is the layout on the
+  /// pipeline side of the ConvertLayoutOp: the load converts *from* HW delivery
+  /// *to* it, the store converts *from* it *to* HW delivery.
+  ///
+  /// Returns std::nullopt if \p oneDTy does not carry a 1D blocked encoding
+  /// with order=[0], or if the 1D factors do not split evenly across [H, W].
+  static std::optional<ttg::BlockedEncodingAttr>
+  derive2DConsumerEncoding(MLIRContext *ctx, RankedTensorType oneDTy,
+                           int64_t W) {
+    auto origEnc = dyn_cast<ttg::BlockedEncodingAttr>(oneDTy.getEncoding());
+    if (!origEnc || origEnc.getSizePerThread().size() != 1 ||
+        origEnc.getOrder().size() != 1 || origEnc.getOrder()[0] != 0) {
+      LDBG("Expected 1D blocked encoding with order=[0], skip 1D reshape");
+      return std::nullopt;
+    }
+    unsigned spt = origEnc.getSizePerThread()[0];
+    unsigned tpw = origEnc.getThreadsPerWarp()[0];
+    unsigned wpc = origEnc.getWarpsPerCTA()[0];
+    unsigned spt1 = std::min(spt, static_cast<unsigned>(W));
+    if (spt1 == 0 || spt % spt1 != 0) {
+      LDBG("Original sizePerThread ("
+           << spt << ") not divisible by spt1=" << spt1 << ", skip 1D reshape");
+      return std::nullopt;
+    }
+    unsigned spt0 = spt / spt1;
+    unsigned tpw1 = std::min(tpw, static_cast<unsigned>(W) / spt1);
+    if (tpw1 == 0 || tpw % tpw1 != 0) {
+      LDBG("Original threadsPerWarp ("
+           << tpw << ") not divisible by tpw1=" << tpw1 << ", skip 1D reshape");
+      return std::nullopt;
+    }
+    unsigned tpw0 = tpw / tpw1;
+    return ttg::BlockedEncodingAttr::get(
+        ctx, {spt0, spt1}, {tpw0, tpw1}, {wpc, 1}, {1, 0},
+        ttg::CGAEncodingAttr::fromSplitParams(
+            ctx, /*CTAsPerCGA=*/SmallVector<unsigned>(2, 1),
+            /*CTASplitNum=*/SmallVector<unsigned>(2, 1),
+            /*CTAOrder=*/{0, 1}));
+  }
+
   /// Detect 1D tensor-of-pointers StoreOp with strided access pattern
   /// and reshape to 2D store with block IO attributes.
   ///
@@ -669,6 +732,7 @@ private:
   /// recovers W, H, and S from the arithmetic, reshapes the store from
   /// [12] to [3, 4], and annotates it so that StoreOpToBlockIOConversion
   /// emits a single LSC2DBlockWrite(base, width=4, height=3, pitch=6).
+  ///
   void reshape1DStridedStore(tt::StoreOp op, RankedTensorType ptrTensorTy,
                              MLIRContext *ctx) const {
     LDBG("Attempting 1D strided store reshape for: " << *op);
@@ -779,53 +843,15 @@ private:
 
     // Construct "load encoding" matching HW delivery:
     // lane k = column k, registers stack rows.
-    // When W > tpw, each thread owns W/tpw consecutive columns.
-    unsigned loadSpt1 = W / threadsPerWarp;
-    auto loadEnc = ttg::BlockedEncodingAttr::get(
-        ctx,
-        /*sizePerThread=*/{perWarpH, loadSpt1},
-        /*threadsPerWarp=*/{1, threadsPerWarp},
-        /*warpsPerCTA=*/{numWarps, 1},
-        /*order=*/{1, 0},
-        ttg::CGAEncodingAttr::fromSplitParams(
-            ctx, /*CTAsPerCGA=*/SmallVector<unsigned>(2, 1),
-            /*CTASplitNum=*/SmallVector<unsigned>(2, 1),
-            /*CTAOrder=*/{0, 1}));
+    auto loadEnc =
+        buildHWDelivery2DEncoding(ctx, perWarpH, W, threadsPerWarp, numWarps);
 
     // Construct "consumer encoding" — the natural 2D reshape of the original
-    // 1D encoding. For a 1D blocked encoding with sizePerThread=[spt],
-    // threadsPerWarp=[tpw], warpsPerCTA=[wpc], order=[0], the natural reshape
-    // to [H, W] with order=[1,0] distributes elements column-first.
-    auto origEnc =
-        dyn_cast<ttg::BlockedEncodingAttr>(ptrTensorTy.getEncoding());
-    if (!origEnc || origEnc.getSizePerThread().size() != 1 ||
-        origEnc.getOrder().size() != 1 || origEnc.getOrder()[0] != 0) {
-      LDBG("Expected 1D blocked encoding with order=[0], skip 1D reshape");
+    // 1D encoding, i.e. what the rest of the pipeline expects.
+    std::optional<ttg::BlockedEncodingAttr> consumerEnc =
+        derive2DConsumerEncoding(ctx, ptrTensorTy, info->W);
+    if (!consumerEnc)
       return;
-    }
-    unsigned spt = origEnc.getSizePerThread()[0];
-    unsigned tpw = origEnc.getThreadsPerWarp()[0];
-    unsigned wpc = origEnc.getWarpsPerCTA()[0];
-    unsigned spt1 = std::min(spt, static_cast<unsigned>(info->W));
-    if (spt1 == 0 || spt % spt1 != 0) {
-      LDBG("Original sizePerThread ("
-           << spt << ") not divisible by spt1=" << spt1 << ", skip 1D reshape");
-      return;
-    }
-    unsigned spt0 = spt / spt1;
-    unsigned tpw1 = std::min(tpw, static_cast<unsigned>(info->W) / spt1);
-    if (tpw1 == 0 || tpw % tpw1 != 0) {
-      LDBG("Original threadsPerWarp ("
-           << tpw << ") not divisible by tpw1=" << tpw1 << ", skip 1D reshape");
-      return;
-    }
-    unsigned tpw0 = tpw / tpw1;
-    auto consumerEnc = ttg::BlockedEncodingAttr::get(
-        ctx, {spt0, spt1}, {tpw0, tpw1}, {wpc, 1}, {1, 0},
-        ttg::CGAEncodingAttr::fromSplitParams(
-            ctx, /*CTAsPerCGA=*/SmallVector<unsigned>(2, 1),
-            /*CTASplitNum=*/SmallVector<unsigned>(2, 1),
-            /*CTAOrder=*/{0, 1}));
 
     // Reshape pointer to [H, W] with load encoding.
     // Mark efficient_layout so RemoveLayoutConversions does not
@@ -861,7 +887,7 @@ private:
 
     // ConvertLayoutOp: load encoding -> consumer encoding.
     auto consumerResultTy =
-        RankedTensorType::get(newShape, pointeeTy, consumerEnc);
+        RankedTensorType::get(newShape, pointeeTy, *consumerEnc);
     auto converted =
         ttg::ConvertLayoutOp::create(builder, loc, consumerResultTy, newLoad);
 


### PR DESCRIPTION
reshape1DStridedStore bailed out for H > 1, which made the transform nearly
dead: matchStridedPattern requires H % numWarps == 0, so H == 1 forces
numWarps == 1 and the reshape only ever converted a single contiguous row of at
most 64 bytes into a one-row 2D block store, which has the same memory traffic as
the coalesced vector store it replaced. All the value is in H > 1, which the guard
blocked.

The guard was a mitigation for #6531/#6634, not a design. #6531 handed
tt.reshape's inferred 2D encoding straight to the store lowering. That encoding
gives each thread sizePerThread adjacent columns of one row, while the 2D block
message hands lane l one column per row with registers stepping down rows. The
result was silent wrong data in densenet121, phlippe_densenet, and ghostnet_100.

Fix it the way the load path already does (#6693/#6747): build an explicit
storeEnc that is the hardware delivery order:

  sizePerThread = [H/numWarps, W/tpw]
  threadsPerWarp = [1, tpw]
  warpsPerCTA = [numWarps, 1]
  order = [1, 0]

Then reshape the value to the natural 2D encoding and insert
ttg.convert_layout into storeEnc. Convert the layout instead of mis-declaring it.

For f16/W=32/H=32/4 warps, this emits one
triton_gen.2Dblockstore(tile_width=32, tile_height=8, vector<8xi16>) per warp in
place of 32 rows of scatter.

Also carry over the load's W < threadsPerWarp bail-out (#6738): a [1, tpw]
encoding on a dimension of size W < tpw is replicated and the reshape cannot be
legalized ("expensive view" in make_llir). The check additionally rejects W not
being a multiple of tpw, which would cover fewer than W columns per register.

storeEnc is a layout that getBlockIOStoreTileSize accepts, which matters now that
the hand-built BlockIOTileSizeInfo is gone: no contiguous-dim register bases
beyond the packing limit, tileHeight = H/numWarps <= 8 =
MAX_TILE_HEIGHT_STORE matching matchStridedPattern's maxPerWarpHeight, no
transpose, and no vnni.

For W > tpw, the helper's packRegister folds the adjacent per-lane columns into a
wider element, so i8/W=64 becomes elem_size_in_bits=16/tile_width=32.

The ConvertLayoutOp is skipped when storeEnc equals the consumer encoding, which
is the case whenever each lane already owns one column per row (H == 1).

Anchoring needs no change: isExpensiveLoadOrStore keys on
ttig.block_io_stride rather than op kind, so RemoveLayoutConversions leaves the
store-side anchor intact.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
