### PR TITLE
[TEST] Add float16 coverage to test_block_load_nan.py (#6002)

### DIFF
--- a/python/test/unit/intel/test_block_load_nan.py
+++ b/python/test/unit/intel/test_block_load_nan.py
@@ -9,7 +9,7 @@ from triton._internal_testing import is_xpu
 
 @pytest.mark.parametrize("M, N",
                          [[256, 64], [256, 32], [128, 32], [128, 16], [128, 8], [64, 64], [64, 32], [32, 32], [16, 64]])
-@pytest.mark.parametrize("dtype_str", ["float32"])
+@pytest.mark.parametrize("dtype_str", ["float32", "float16"])
 @pytest.mark.skipif(not is_xpu(), reason="Block load tests are specific to the XPU backend")
 @pytest.mark.xfail(not triton.runtime.driver.active.get_current_target().arch['has_2d_block_io'],
                    reason="Block loads not supported on this architecture", run=False)
@@ -29,40 +29,6 @@ def test_block_load_dpas_layout(M, N, dtype_str, device, tmp_path: pathlib.Path)
     block_io = "\"row_major\""
 
     ty = {"float32": "f32", "float16": "f16", "int8": "i8"}[dtype_str]
-
-    ref_ir = layouts + f"""
-    module attributes {{ttig.min_sg_size = 16 : i32, ttig.support_bfloat16_conversion, ttig.support_subgroup_matrix_multiply_accumulate, ttig.support_2d_block_io, ttig.target_arch = "spir64", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = {num_warps} : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32}} {{
-        tt.func public @block_load_dpas_layout(%arg0: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}, %arg2: !tt.ptr<{ty}> {{tt.divisibility = 16: i32}}, %arg3: !tt.ptr<{ty}> {{tt.divisibility = 16: i32}}) attributes {{noinline = false}} {{
-            %0 = tt.get_program_id x : i32
-
-            %Mload_i32 = arith.constant {M-1} : i32
-            %Nload_i32 = arith.constant {N-1} : i32
-            %Mload_i64 = arith.constant {M-1} : i64
-            %Nload_i64 = arith.constant {N-1} : i64
-
-            %M_i32 = arith.constant {M} : i32
-            %N_i32 = arith.constant {N} : i32
-            %M_i64 = arith.constant {M} : i64
-            %N_i64 = arith.constant {N} : i64
-            %c1_i64 = arith.constant 1 : i64
-            %c0_i32 = arith.constant 0 : i32
-
-            // A matrix
-            %1 = tt.make_tensor_descriptor %arg0, [%Mload_i32, %Nload_i32], [%Nload_i64, %c1_i64]  : <{ty}>, !tt.tensordesc<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
-            %2 = tt.descriptor_load %1[%0, %c0_i32] {{ttig.block_io = "row_major"}} : !tt.tensordesc<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>> -> tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
-            %3 = tt.make_tensor_descriptor %arg1, [%M_i32, %N_i32], [%N_i64, %c1_i64] : <{ty}>, !tt.tensordesc<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
-            tt.descriptor_store %3[%0, %c0_i32], %2 : !tt.tensordesc<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}> >, tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
-
-            // B matrix
-            %4 = tt.make_tensor_descriptor %arg2, [%Nload_i32, %Mload_i32], [%Mload_i64, %c1_i64]  : <{ty}>, !tt.tensordesc<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
-            %5 = tt.descriptor_load %4[%c0_i32, %0] {{ttig.block_io = {block_io} }} : !tt.tensordesc<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>> -> tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
-            %6 = tt.make_tensor_descriptor %arg3, [%N_i32, %M_i32], [%M_i64, %c1_i64] : <{ty}>, !tt.tensordesc<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
-            tt.descriptor_store %6[%c0_i32, %0], %5 : !tt.tensordesc<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}> >, tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
-
-            tt.return
-        }}
-    }}
-    """
 
     ir = layouts + f"""
     module attributes {{ttig.min_sg_size = 16 : i32, ttig.support_bfloat16_conversion, ttig.support_subgroup_matrix_multiply_accumulate, ttig.support_2d_block_io, ttig.target_arch = "spir64", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = {num_warps} : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32}} {{
@@ -100,20 +66,6 @@ def test_block_load_dpas_layout(M, N, dtype_str, device, tmp_path: pathlib.Path)
 
     torch_dtype = getattr(torch, dtype_str)
 
-    a_ref = torch.ones((M, N), dtype=torch_dtype, device=device)
-    b_ref = torch.ones((N, M), dtype=torch_dtype, device=device)
-    x_ref = torch.empty_like(a_ref)
-    y_ref = torch.empty_like(b_ref)
-
-    temp_file = tmp_path / "test_block_load_dpas_layout_ref.ttgir"
-    temp_file.write_text(ref_ir)
-    kernel = triton.compile(str(temp_file))
-
-    kernel[(1, 1, 1)](a_ref, x_ref, b_ref, y_ref)
-
-    x_ref[x_ref == 0] = float('nan')
-    y_ref[y_ref == 0] = float('nan')
-
     a = torch.ones((M, N), dtype=torch_dtype, device=device)
     b = torch.ones((N, M), dtype=torch_dtype, device=device)
     x = torch.empty_like(a)
@@ -127,4 +79,17 @@ def test_block_load_dpas_layout(M, N, dtype_str, device, tmp_path: pathlib.Path)
 
     torch.set_printoptions(profile="full", precision=2, sci_mode=0, linewidth=200)
 
-    assert torch.allclose(x_ref, x, equal_nan=True) and torch.allclose(y_ref, y, equal_nan=True)
+    # Build expected output explicitly: 1.0 for in-bounds elements, NaN for OOB.
+    # The descriptor has shape (M-1, N-1) for A and (N-1, M-1) for B, loaded into
+    # full (M, N) and (N, M) tiles respectively.
+    # This avoids depending on the zero-padding reference path, which is unreliable
+    # for packed fp16 (kWidth=2) operands where hardware boundary behaviour varies.
+    x_expected = torch.ones((M, N), dtype=torch_dtype, device=device)
+    x_expected[M - 1:, :] = float('nan')  # OOB row
+    x_expected[:, N - 1:] = float('nan')  # OOB col
+
+    y_expected = torch.ones((N, M), dtype=torch_dtype, device=device)
+    y_expected[N - 1:, :] = float('nan')  # OOB row
+    y_expected[:, M - 1:] = float('nan')  # OOB col
+
+    assert torch.allclose(x_expected, x, equal_nan=True) and torch.allclose(y_expected, y, equal_nan=True)


### PR DESCRIPTION
Extends test_block_load_dpas_layout to cover float16 (opsPerChan=2, kWidth=2) in addition to float32. The float16 path exercises the VNNI B-operand packed boundary: the B descriptor has odd K dimension (N-1), so the last in-bounds K row is packed with the first OOB row in a single i32 word. With NaN padding, that in-bounds row must remain 1.0 and the OOB row must become NaN.

Also replaces the zero-padding reference approach with explicit expected tensors (1.0 in-bounds, NaN at the border row/col). The zero-padding reference is unreliable for packed fp16 operands: hardware OOB checks at i32 granularity can cause the reference to read OOB elements as 1.0 instead of 0.0, making the zero->NaN conversion silently incorrect. The explicit expected tensors directly express the correct NaN-padding semantics and are independent of hardware zero-padding behaviour.

Tested on BMG (Arc Pro B65): 18/18 passed (9 float32 + 9 float16).

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
