### PR TITLE
[BUILD] Fix TritonIntelGPUIR missing dependency on generated headers

### DIFF
--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/CMakeLists.txt
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/CMakeLists.txt
@@ -8,4 +8,6 @@ add_triton_library(TritonIntelGPUIR
 
   LINK_LIBS PUBLIC
   MLIRSideEffectInterfaces
+  TritonGENIR
+  TritonGPUIR
 )


### PR DESCRIPTION
`TritonIntelGPUIR` compiles `Dialect.cpp` and `Ops.cpp`, which include:

- `intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h` → `TritonGENOpsAttrDefs.h.inc` (produced by `TritonGENAttrDefsIncGen`)
- `triton/Dialect/Triton/IR/Dialect.h` → `Dialect.h.inc` (produced by `TritonTableGen`)

The target declared neither a `DEPENDS` entry nor a link dependency that guarantees those TableGen outputs exist before its objects are compiled. Its only order-only dependencies were `TritonIntelGPUTableGen` and `TritonIntelGPUAttrDefsIncGen`.

Under a parallel build this is a race: whether `Dialect.cpp.o` starts before the corresponding TableGen steps finish depends purely on build scheduling. When it loses the race, the build fails with:

```
third_party/intel/include/Dialect/TritonGEN/IR/TritonGENDialect.h:25:10: fatal error:
intel/include/Dialect/TritonGEN/IR/TritonGENOpsAttrDefs.h.inc: No such file or directory
```

This has been latent since #6272, which moved the `TritonGENDialect.h` include out of `TritonIntelGPU/IR/Dialect.h` into the `.cpp` files, making `TritonIntelGPUIR` a first-party consumer of that generated header. Because the failure is scheduling-dependent, it shows up as an intermittent CI build failure on unrelated PRs and disappears on re-run.ode)