### PR TITLE
[AsyncCompile] Release failed async compiles instead of caching them (#7385)

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -4,6 +4,7 @@ import itertools
 import multiprocessing
 import os
 import re
+import time
 import gc
 import pathlib
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
@@ -1024,6 +1025,787 @@ def test_async_compile_error(fresh_triton_cache):
     # After the AsyncCompileMode context manager exits, the active mode should
     # be set to None again, even if there was an error.
     assert triton.runtime._async_compile.active_mode.get() is None
+    # Failed async placeholders must not stay cached; otherwise their Future
+    # objects keep exception tracebacks alive.
+    assert len(fn.device_caches[0][0]) == 0
+
+
+def test_async_compile_multiple_errors(fresh_triton_cache):
+
+    @triton.jit
+    def bad_a(x: tl.constexpr):
+        tl.static_assert(x == 111)
+
+    @triton.jit
+    def bad_b(x: tl.constexpr):
+        tl.static_assert(x == 222)
+
+    with pytest.raises(triton.compiler.errors.CompileTimeAssertionFailure):
+        with (
+                ThreadPoolExecutor(2) as pool,
+                triton.AsyncCompileMode(pool),
+        ):
+            bad_a.warmup(1, grid=(1, ))
+            bad_b.warmup(1, grid=(1, ))
+
+            assert len(bad_a.device_caches[0][0]) == 1
+            assert len(bad_b.device_caches[0][0]) == 1
+
+    # The drain has to reach every pending compile, not stop at the first one
+    # that raises: a leftover FutureKernel keeps its exception traceback, and
+    # through it the whole compilation context, alive until interpreter exit.
+    assert len(bad_a.device_caches[0][0]) == 0
+    assert len(bad_b.device_caches[0][0]) == 0
+    assert triton.runtime._async_compile.active_mode.get() is None
+
+
+def _make_failed_future_kernel():
+    future = Future()
+    future.set_running_or_notify_cancel()
+    try:
+        raise ValueError("boom")
+    except ValueError as exc:
+        # Set from inside the handler so the future carries a real traceback.
+        future.set_exception(exc)
+    future_kernel = triton.FutureKernel(future)
+    future_kernel.add_callbacks(lambda kernel: None, lambda fk: None)
+    return future_kernel
+
+
+def test_async_compile_failed_future_repeated_result():
+    resolved_twice = _make_failed_future_kernel()
+    with pytest.raises(ValueError, match="boom"):
+        resolved_twice.result()
+    with pytest.raises(RuntimeError, match="previously failed"):
+        resolved_twice.result()
+
+    ignored_twice = _make_failed_future_kernel()
+    assert ignored_twice.result(ignore_errors=True) is None
+    assert ignored_twice.result(ignore_errors=True) is None
+
+    attribute_probe = _make_failed_future_kernel()
+    assert attribute_probe.result(ignore_errors=True) is None
+    with pytest.raises(RuntimeError, match="previously failed"):
+        _ = attribute_probe.does_not_exist
+
+    late_waiter = _make_failed_future_kernel()
+    assert late_waiter.result(ignore_errors=True) is None
+    drained = []
+    late_waiter.add_callbacks(lambda kernel: drained.append("finalize"), lambda fk: drained.append("cleanup"))
+    assert late_waiter.result(ignore_errors=True) is None
+    assert drained == ["cleanup"]
+
+    for future_kernel in (resolved_twice, ignored_twice, attribute_probe, late_waiter):
+        assert not any(isinstance(value, BaseException) for value in vars(future_kernel).values())
+
+
+def test_async_compile_base_exception_evicts_cache():
+    cache = {}
+    future = Future()
+    future.set_running_or_notify_cancel()
+    try:
+        raise KeyboardInterrupt("worker interrupted")
+    except KeyboardInterrupt as exc:
+        future.set_exception(exc)
+
+    def store(kernel):
+        cache["K"] = kernel
+
+    def evict(_future_kernel):
+        cache.pop("K", None)
+
+    future_kernel = triton.FutureKernel(future)
+    future_kernel.add_callbacks(store, evict)
+    cache["K"] = future_kernel
+
+    # A worker can fail with a BaseException, and the bookkeeping still has to
+    # run: a retained Future keeps the exception traceback and every compiler
+    # frame behind it. ignore_errors covers compile errors only, so an
+    # interpreter-level exception must still propagate.
+    with pytest.raises(KeyboardInterrupt):
+        future_kernel.result(ignore_errors=True)
+
+    assert "K" not in cache
+    assert future_kernel.future is None
+    assert future_kernel._state == "failed"
+    assert not any(isinstance(value, BaseException) for value in vars(future_kernel).values())
+
+    with pytest.raises(RuntimeError, match="previously failed"):
+        future_kernel.result()
+
+    # ignore_errors only ever covers compilation errors, so the terminal state
+    # of an interrupted compile has to keep raising rather than quietly
+    # returning None on every later resolution.
+    with pytest.raises(RuntimeError, match="previously failed"):
+        future_kernel.result(ignore_errors=True)
+
+    # Contrast: a compile that failed with a plain Exception stays ignorable.
+    exception_future = Future()
+    exception_future.set_running_or_notify_cancel()
+    try:
+        raise ValueError("compile blew up")
+    except ValueError as exc:
+        exception_future.set_exception(exc)
+
+    ignorable = triton.FutureKernel(exception_future)
+    ignorable.add_callbacks(store, evict)
+    assert ignorable.result(ignore_errors=True) is None
+    assert ignorable.result(ignore_errors=True) is None
+
+
+def test_async_compile_base_exception_mid_drain_evicts_pending():
+    INTERRUPT_DELAY = 0.05
+    SLOW_COMPILE_DELAY = 1.5
+    cache = {}
+
+    def finalize(slot):
+
+        def store(kernel):
+            cache[slot] = kernel
+
+        return store
+
+    def cleanup(slot):
+
+        def evict(_future_kernel):
+            cache.pop(slot, None)
+
+        return evict
+
+    def interrupted_compile():
+        time.sleep(INTERRUPT_DELAY)
+        raise KeyboardInterrupt("simulated ctrl-c in worker")
+
+    def slow_compile():
+        time.sleep(SLOW_COMPILE_DELAY)
+        return "kernel-b"
+
+    # The pool is driven by hand rather than with `with`: its shutdown waits for
+    # the slow compile, which would hide the very promptness being measured.
+    pool = ThreadPoolExecutor(2)
+    try:
+        started = time.perf_counter()
+        with pytest.raises(KeyboardInterrupt):
+            with triton.AsyncCompileMode(pool) as mode:
+                cache["a"] = mode.submit("KA", interrupted_compile, finalize("a"), cleanup("a"))
+                abandoned = mode.submit("KB", slow_compile, finalize("b"), cleanup("b"))
+                cache["b"] = abandoned
+        elapsed = time.perf_counter() - started
+    finally:
+        pool.shutdown(wait=True)
+
+    assert not isinstance(cache.get("a"), triton.FutureKernel)
+    assert not isinstance(cache.get("b"), triton.FutureKernel)
+    assert abandoned.future is None
+    assert abandoned._state == "failed"
+    assert not any(isinstance(value, BaseException) for value in vars(abandoned).values())
+    # Aborting must not wait on compiles still in flight; without this the fix
+    # could regress into draining everything before re-raising.
+    assert elapsed < 1.0
+
+
+def test_async_compile_interrupt_while_waiting_evicts_pending(monkeypatch):
+    SENTINEL = object()
+    cache = {}
+
+    def interrupted_as_completed(_futures):
+        raise KeyboardInterrupt("simulated ctrl-c while waiting for compiles")
+
+    monkeypatch.setattr(triton.runtime._async_compile, "as_completed", interrupted_as_completed)
+
+    def finalize(slot):
+
+        def store(kernel):
+            cache[slot] = kernel
+
+        return store
+
+    def cleanup(slot):
+
+        def evict(_future_kernel):
+            cache.pop(slot, None)
+
+        return evict
+
+    # A real Ctrl-C most likely lands while the thread is parked inside
+    # as_completed(), which raises from the for statement rather than from
+    # result(), so the abandon sweep has to cover the whole drain and not just
+    # the resolution of one future.
+    with MockThreadPool() as pool:
+        with pytest.raises(KeyboardInterrupt):
+            with triton.AsyncCompileMode(pool) as mode:
+                cache["a"] = mode.submit("KA", lambda: SENTINEL, finalize("a"), cleanup("a"))
+                cache["b"] = mode.submit("KB", lambda: SENTINEL, finalize("b"), cleanup("b"))
+
+    assert not isinstance(cache.get("a"), triton.FutureKernel)
+    assert not isinstance(cache.get("b"), triton.FutureKernel)
+
+
+def test_async_compile_interrupt_cleanup_submit_evicts_everything(monkeypatch):
+    SENTINEL = object()
+    cache = {}
+    queued = []
+
+    def interrupted_as_completed(_futures):
+        raise KeyboardInterrupt("simulated ctrl-c while waiting for compiles")
+
+    monkeypatch.setattr(triton.runtime._async_compile, "as_completed", interrupted_as_completed)
+
+    def finalize(slot):
+
+        def store(kernel):
+            cache[slot] = kernel
+
+        return store
+
+    def cleanup(slot):
+
+        def evict(_future_kernel):
+            cache.pop(slot, None)
+
+        return evict
+
+    with MockThreadPool() as pool:
+        with pytest.raises(KeyboardInterrupt):
+            with triton.AsyncCompileMode(pool) as mode:
+
+                def evict_and_submit_new_key(_future_kernel):
+                    cache.pop("a", None)
+                    # Inserts a brand-new key while the abandon sweep is running
+                    # its own cleanup callbacks, so a sweep that walked a
+                    # snapshot taken up front could never visit it.
+                    second = mode.submit("KB", lambda: SENTINEL, finalize("b"), cleanup("b"))
+                    cache["b"] = second
+                    queued.append(second)
+
+                cache["a"] = mode.submit("KA", lambda: SENTINEL, finalize("a"), evict_and_submit_new_key)
+
+    assert not isinstance(cache.get("a"), triton.FutureKernel)
+    assert not isinstance(cache.get("b"), triton.FutureKernel)
+    assert len(queued) == 1
+    assert queued[0]._state == "failed"
+    assert queued[0].future is None
+
+
+def test_async_compile_body_interrupt_does_not_wait():
+    cache = {}
+
+    def slow_compile():
+        time.sleep(1.5)
+        return object()
+
+    def store(kernel):
+        cache["slow"] = kernel
+
+    def evict(_future_kernel):
+        cache.pop("slow", None)
+
+    pool = ThreadPoolExecutor(2)
+    try:
+        started = time.perf_counter()
+        with pytest.raises(KeyboardInterrupt):
+            with triton.AsyncCompileMode(pool) as mode:
+                cache["slow"] = mode.submit("slow", slow_compile, store, evict)
+                raise KeyboardInterrupt("simulated ctrl-c in the with body")
+        elapsed = time.perf_counter() - started
+    finally:
+        # Executor.__exit__ waits for the slow compile, which would fold that
+        # wait into the measurement, so shut the pool down outside it.
+        pool.shutdown(wait=True)
+
+    assert not isinstance(cache.get("slow"), triton.FutureKernel)
+    # An interrupt raised in the body must abort just as promptly as one coming
+    # out of a worker, instead of draining every compile still in flight.
+    assert elapsed < 1.0
+
+
+def test_async_compile_future_kernel_dunder_probe_does_not_compile():
+    never_completed = Future()
+    future_kernel = triton.FutureKernel(never_completed)
+    future_kernel.add_callbacks(lambda kernel: None, lambda fk: None)
+
+    assert hasattr(future_kernel, "__deepcopy__") is False
+    assert hasattr(future_kernel, "__copy__") is False
+    assert hasattr(future_kernel, "__setstate__") is False
+    # Probing must not have blocked on (or resolved) the pending compile.
+    assert future_kernel.future is never_completed
+    assert not never_completed.done()
+
+
+def test_async_compile_future_kernel_forwards_private_kernel_api():
+
+    class FakeKernel:
+
+        def __init__(self):
+            self.calls = []
+            self._run = "launcher"
+
+        def _init_handles(self):
+            self.calls.append("_init_handles")
+
+    fake = FakeKernel()
+    future = Future()
+    future.set_result(fake)
+    future_kernel = triton.FutureKernel(future)
+    future_kernel.add_callbacks(lambda kernel: None, lambda fk: None)
+
+    # CompiledKernel exposes _init_handles/_run and callers reach for them
+    # through whatever the JIT cache handed back, so the proxy has to forward
+    # single-underscore names instead of treating them as its own privates.
+    future_kernel._init_handles()
+    assert fake.calls == ["_init_handles"]
+    assert future_kernel._run == "launcher"
+    assert future_kernel.kernel is fake
+
+
+def test_async_compile_future_kernel_new_without_init():
+    uninitialized = triton.FutureKernel.__new__(triton.FutureKernel)
+
+    # Allocated without __init__, so there is no state to resolve. __getattr__
+    # must refuse instead of recursing through result() to read the very
+    # attribute it was asked for, which would hang or blow the stack.
+    with pytest.raises(AttributeError):
+        getattr(uninitialized, "anything")
+    with pytest.raises(AttributeError):
+        getattr(uninitialized, "_state")
+    assert hasattr(uninitialized, "__deepcopy__") is False
+
+
+def test_async_compile_future_kernel_forwards_getitem():
+    launched = []
+
+    class FakeKernel:
+
+        def __getitem__(self, grid):
+            launched.append(grid)
+            return f"runner{grid}"
+
+    future = Future()
+    future.set_result(FakeKernel())
+    future_kernel = triton.FutureKernel(future)
+    future_kernel.add_callbacks(lambda kernel: None, lambda fk: None)
+
+    # kernel[grid](...) is the launch idiom, and implicit dunder lookup goes to
+    # the type rather than through __getattr__, so the proxy needs a real
+    # __getitem__ for a warmed-up kernel to be launchable at all.
+    assert future_kernel[(1, 2, 3)] == "runner(1, 2, 3)"
+    assert future_kernel.__getitem__((4, 5, 6)) == "runner(4, 5, 6)"
+    assert launched == [(1, 2, 3), (4, 5, 6)]
+    assert hasattr(future_kernel, "__deepcopy__") is False
+
+
+def test_async_compile_cleanup_base_exception_still_evicts():
+    calls = []
+    cache = {"a": "placeholder", "b": "placeholder", "c": "placeholder"}
+    future = Future()
+    future.set_running_or_notify_cancel()
+    try:
+        raise ValueError("compile blew up")
+    except ValueError as exc:
+        future.set_exception(exc)
+
+    def cleanup(slot, interrupt=False):
+
+        def evict(_future_kernel):
+            calls.append(slot)
+            cache.pop(slot, None)
+            if interrupt:
+                raise KeyboardInterrupt("simulated ctrl-c in a cleanup callback")
+
+        return evict
+
+    future_kernel = triton.FutureKernel(future)
+    future_kernel.add_callbacks(lambda kernel: None, cleanup("a", interrupt=True))
+    future_kernel.add_callbacks(lambda kernel: None, cleanup("b"))
+    future_kernel.add_callbacks(lambda kernel: None, cleanup("c"))
+
+    # A second Ctrl-C is plausible exactly while cleanup is running, and it must
+    # not cost the remaining waiters their eviction: all of them run, and the
+    # interrupt surfaces afterwards.
+    with pytest.raises(KeyboardInterrupt):
+        future_kernel.result()
+
+    assert calls == ["a", "b", "c"]
+    assert cache == {}
+    assert future_kernel._state == "failed"
+    assert future_kernel.future is None
+
+
+def test_async_compile_callback_error_does_not_block_others():
+    compiled = object()
+    calls = []
+
+    def record(name, raises=False):
+
+        def callback(_):
+            calls.append(name)
+            if raises:
+                raise RuntimeError(name)
+
+        return callback
+
+    with MockThreadPool() as pool:
+        succeeding = triton.FutureKernel(pool.submit(lambda: compiled))
+        succeeding.add_callbacks(record("f1", raises=True), record("c1"))
+        succeeding.add_callbacks(record("f2"), record("c2"))
+        succeeding.add_callbacks(record("f3"), record("c3"))
+        pool.run_one()
+
+        with pytest.raises(Exception) as finalize_failure:
+            succeeding.result()
+        assert calls == ["f1", "f2", "f3"]
+        assert str(finalize_failure.value) == "f1"
+
+        calls.clear()
+
+        def failing_compile():
+            raise ValueError("compile blew up")
+
+        failing = triton.FutureKernel(pool.submit(failing_compile))
+        failing.add_callbacks(record("f1"), record("c1", raises=True))
+        failing.add_callbacks(record("f2"), record("c2"))
+        failing.add_callbacks(record("f3"), record("c3"))
+        pool.run_one()
+
+        with pytest.raises(Exception) as compile_failure:
+            failing.result()
+        assert calls == ["c1", "c2", "c3"]
+        assert isinstance(compile_failure.value, ValueError)
+        assert str(compile_failure.value) == "compile blew up"
+
+
+def test_async_compile_shared_key_late_waiter():
+    SENTINEL = object()
+    cache = {}
+
+    def finalize(slot):
+
+        def store(kernel):
+            cache[slot] = kernel
+
+        return store
+
+    def cleanup(slot):
+
+        def evict(_future_kernel):
+            cache.pop(slot, None)
+
+        return evict
+
+    with MockThreadPool() as pool, triton.AsyncCompileMode(pool) as mode:
+        # Mirrors jit.py: the cache slot is overwritten with the FutureKernel
+        # right after submit() returns, so a late waiter that joins a resolved
+        # compile has to be finalized by result().
+        first = mode.submit("K", lambda: SENTINEL, finalize("a"), cleanup("a"))
+        cache["a"] = first
+        pool.run_one()
+        assert first.result() is SENTINEL
+        assert cache["a"] is SENTINEL
+
+        late = mode.submit("K", lambda: SENTINEL, finalize("b"), cleanup("b"))
+        cache["b"] = late
+        assert late is first
+
+    assert cache["b"] is SENTINEL
+    assert not isinstance(cache["b"], triton.FutureKernel)
+
+
+def test_async_compile_exit_drains_reentrant_submits():
+    SENTINEL = object()
+    cache = {}
+
+    def finalize(slot):
+
+        def store(kernel):
+            cache[slot] = kernel
+
+        return store
+
+    def cleanup(slot):
+
+        def evict(_future_kernel):
+            cache.pop(slot, None)
+
+        return evict
+
+    with ThreadPoolExecutor(2) as pool, triton.AsyncCompileMode(pool) as mode:
+
+        def finalize_and_submit_more(kernel):
+            cache["a"] = kernel
+            # Queued from inside a finalize callback, i.e. after the drain has
+            # already started: __exit__ must notice the new work instead of
+            # walking a one-shot snapshot of the future list.
+            cache["b"] = mode.submit("KB", lambda: SENTINEL, finalize("b"), cleanup("b"))
+
+        cache["a"] = mode.submit("KA", lambda: SENTINEL, finalize_and_submit_more, cleanup("a"))
+
+    assert cache["a"] is SENTINEL
+    assert cache["b"] is SENTINEL
+    assert not isinstance(cache["b"], triton.FutureKernel)
+    assert mode.raw_futures == []
+    assert mode.future_kernels == {}
+
+
+def test_async_compile_exit_drains_same_key_reentrant_submits():
+    SENTINEL = object()
+    cache = {}
+
+    def finalize(slot):
+
+        def store(kernel):
+            cache[slot] = kernel
+
+        return store
+
+    def cleanup(slot):
+
+        def evict(_future_kernel):
+            cache.pop(slot, None)
+
+        return evict
+
+    with ThreadPoolExecutor(2) as pool, triton.AsyncCompileMode(pool) as mode:
+
+        def finalize_and_resubmit_same_key(kernel):
+            cache["a"] = kernel
+            # Same key, so submit() takes the dedup path: this appends another
+            # finalize callback but queues no new future, which leaves the
+            # callback runner as the only thing that can ever drain it.
+            cache["b"] = mode.submit("K", lambda: SENTINEL, finalize("b"), cleanup("b"))
+
+        cache["a"] = mode.submit("K", lambda: SENTINEL, finalize_and_resubmit_same_key, cleanup("a"))
+
+    assert cache["a"] is SENTINEL
+    assert cache["b"] is SENTINEL
+    assert not isinstance(cache["a"], triton.FutureKernel)
+    assert not isinstance(cache["b"], triton.FutureKernel)
+    assert mode.raw_futures == []
+    assert mode.future_kernels == {}
+
+
+def test_async_compile_reentrant_result_from_finalize_callback():
+    SENTINEL = object()
+    calls = []
+    future = Future()
+    future.set_result(SENTINEL)
+    future_kernel = triton.FutureKernel(future)
+
+    def finalize_reentrant(kernel):
+        calls.append("reentrant")
+        assert future_kernel.result() is kernel
+
+    def finalize_plain(_kernel):
+        calls.append("plain")
+
+    def cleanup(_future_kernel):
+        calls.append("cleanup")
+
+    future_kernel.add_callbacks(finalize_reentrant, cleanup)
+    future_kernel.add_callbacks(finalize_plain, cleanup)
+
+    # Resolving from inside a finalize callback must not re-run any callback nor
+    # leave the lifecycle half-applied, even though the outer resolution has not
+    # reached its terminal assignments yet.
+    assert future_kernel.result() is SENTINEL
+    assert calls == ["reentrant", "plain"]
+    assert future_kernel._state == "succeeded"
+    assert future_kernel.future is None
+    assert future_kernel.kernel is SENTINEL
+
+    assert future_kernel.result() is SENTINEL
+    assert calls == ["reentrant", "plain"]
+
+
+def test_async_compile_same_key_submit_from_cleanup_callback():
+    cache = {}
+
+    def compile_fails():
+        raise ValueError("compile blew up")
+
+    def cleanup(slot):
+
+        def evict(_future_kernel):
+            cache.pop(slot, None)
+
+        return evict
+
+    with pytest.raises(ValueError, match="compile blew up"):
+        with MockThreadPool() as pool, triton.AsyncCompileMode(pool) as mode:
+
+            def resubmit_same_key(_future_kernel):
+                cache.pop("a", None)
+                # Same key from inside a cleanup callback: submit() dedups onto
+                # this very FutureKernel, so only the cleanup runner can ever
+                # reach the callback it appends.
+                cache["b"] = mode.submit("K", compile_fails, lambda kernel: None, cleanup("b"))
+
+            cache["a"] = mode.submit("K", compile_fails, lambda kernel: None, resubmit_same_key)
+            pool.run_all()
+
+    assert "a" not in cache
+    assert "b" not in cache
+
+
+def test_async_compile_mode_rejects_nesting():
+    with MockThreadPool() as pool, triton.AsyncCompileMode(pool) as outer:
+        assert triton.runtime._async_compile.active_mode.get() is outer
+
+        with pytest.raises(RuntimeError, match="already active"):
+            with triton.AsyncCompileMode(pool):
+                pass
+
+        # __enter__ raised before installing itself, so __exit__ never ran and
+        # the outer mode must still be the active one.
+        assert triton.runtime._async_compile.active_mode.get() is outer
+
+    assert triton.runtime._async_compile.active_mode.get() is None
+
+
+def test_async_compile_ignore_errors_mode_swallows_compile_failures():
+    cache = {}
+
+    def compile_fails():
+        raise ValueError("compile blew up")
+
+    def store(kernel):
+        cache["K"] = kernel
+
+    def evict(_future_kernel):
+        cache.pop("K", None)
+
+    with MockThreadPool() as pool, triton.AsyncCompileMode(pool, ignore_errors=True) as mode:
+        cache["K"] = mode.submit("K", compile_fails, store, evict)
+        pool.run_all()
+
+    assert "K" not in cache
+    assert triton.runtime._async_compile.active_mode.get() is None
+
+
+def test_async_compile_submit_deduplicates_by_key():
+    SENTINEL = object()
+    cache = {}
+    compiles = []
+
+    def compile_once():
+        compiles.append("compile")
+        return SENTINEL
+
+    def finalize(slot):
+
+        def store(kernel):
+            cache[slot] = kernel
+
+        return store
+
+    def cleanup(slot):
+
+        def evict(_future_kernel):
+            cache.pop(slot, None)
+
+        return evict
+
+    with MockThreadPool() as pool, triton.AsyncCompileMode(pool) as mode:
+        first = mode.submit("K", compile_once, finalize("a"), cleanup("a"))
+        cache["a"] = first
+        second = mode.submit("K", compile_once, finalize("b"), cleanup("b"))
+        cache["b"] = second
+
+        assert second is first
+        assert len(pool.work_queue) == 1
+        assert len(mode.raw_futures) == 1
+        pool.run_all()
+
+    assert compiles == ["compile"]
+    assert cache["a"] is SENTINEL
+    assert cache["b"] is SENTINEL
+
+
+def test_async_compile_body_exception_with_compile_failure():
+    cache = {}
+
+    def compile_fails():
+        raise ValueError("compile blew up")
+
+    def store(kernel):
+        cache["K"] = kernel
+
+    def evict(_future_kernel):
+        cache.pop("K", None)
+
+    with pytest.raises(ValueError, match="compile blew up") as compile_failure:
+        with MockThreadPool() as pool, triton.AsyncCompileMode(pool) as mode:
+            cache["K"] = mode.submit("K", compile_fails, store, evict)
+            pool.run_all()
+            raise RuntimeError("body blew up")
+
+    # The drain's first error is what propagates, and the body exception has to
+    # survive as its context so neither failure is lost.
+    assert isinstance(compile_failure.value.__context__, RuntimeError)
+    assert str(compile_failure.value.__context__) == "body blew up"
+    assert "K" not in cache
+
+
+def test_async_compile_finalize_error_leaves_terminal_state():
+    SENTINEL = object()
+    calls = []
+    future = Future()
+    future.set_result(SENTINEL)
+
+    def finalize_raises(_kernel):
+        calls.append("finalize")
+        raise RuntimeError("finalize blew up")
+
+    def cleanup(_future_kernel):
+        calls.append("cleanup")
+
+    future_kernel = triton.FutureKernel(future)
+    future_kernel.add_callbacks(finalize_raises, cleanup)
+
+    with pytest.raises(RuntimeError, match="finalize blew up"):
+        future_kernel.result()
+
+    assert future_kernel.kernel is SENTINEL
+    assert future_kernel.future is None
+    assert future_kernel._state == "succeeded"
+    assert calls == ["finalize"]
+
+    # A callback error must not leave the compile unresolved: resolving again
+    # hands back the kernel and must not re-run the callback that raised.
+    assert future_kernel.result() is SENTINEL
+    assert calls == ["finalize"]
+
+
+def test_async_compile_finalize_base_exception_leaves_terminal_state():
+    SENTINEL = object()
+    calls = []
+    future = Future()
+    future.set_result(SENTINEL)
+
+    def finalize_interrupts(_kernel):
+        calls.append("interrupt")
+        raise KeyboardInterrupt("simulated ctrl-c in a finalize callback")
+
+    def finalize_plain(_kernel):
+        calls.append("plain")
+
+    def cleanup(_future_kernel):
+        calls.append("cleanup")
+
+    future_kernel = triton.FutureKernel(future)
+    future_kernel.add_callbacks(finalize_interrupts, cleanup)
+    future_kernel.add_callbacks(finalize_plain, cleanup)
+
+    # The compile itself succeeded, so an interrupt out of a callback must not
+    # cost the remaining waiters their finalize nor abandon the terminal
+    # transition: dropping it would lose the kernel and keep the future.
+    with pytest.raises(KeyboardInterrupt):
+        future_kernel.result()
+
+    assert calls == ["interrupt", "plain"]
+    assert future_kernel._state == "succeeded"
+    assert future_kernel.future is None
+    assert future_kernel.kernel is SENTINEL
+    assert not any(isinstance(value, BaseException) for value in vars(future_kernel).values())
 
 
 def test_higher_order_kernel(device, fresh_triton_cache, capsys):

--- a/python/triton/runtime/_async_compile.py
+++ b/python/triton/runtime/_async_compile.py
@@ -8,27 +8,153 @@ active_mode: ContextVar[Optional[AsyncCompileMode]] = ContextVar("async_compile_
 
 class FutureKernel:
 
-    def __init__(self, finalize_compile: Callable, future: Future):
-        self.finalize_compile = finalize_compile
+    def __init__(self, future: Future):
+        # Assigned first: __getattr__ reads private state, so every private
+        # attribute must exist before anything else can trigger a lookup.
+        self._state = "pending"
+        # Several warmups can share one pending compile by cache key. Keep
+        # per-waiter callbacks so every JIT cache entry is finalized or cleaned.
+        self._finalize_callbacks: list[Callable] = []
+        self._cleanup_callbacks: list[Callable] = []
+        self._error_type_name = ""
+        self._error_message = ""
+        self._error_is_exception = False
         self.kernel = None
         self.future = future
 
+    def add_callbacks(self, finalize_compile: Callable, cleanup_compile: Callable):
+        self._finalize_callbacks.append(finalize_compile)
+        self._cleanup_callbacks.append(cleanup_compile)
+
+    def _run_finalize_callbacks(self, kernel):
+        # Detach before invoking: a callback may register further waiters, and
+        # every waiter must run even when an earlier one raises. The first
+        # error is reported, the rest are dropped.
+        first_error = None
+        # Looping rather than draining one batch: a same-key submit() appends
+        # here without queueing a new future, so no other code path would ever
+        # reach the callbacks it adds. A callback that unconditionally
+        # re-submits its own key is an infinite loop in the caller's own logic;
+        # looping is more honest than silently leaking its cache entry.
+        while self._finalize_callbacks:
+            callbacks, self._finalize_callbacks = self._finalize_callbacks, []
+            for finalize_compile in callbacks:
+                try:
+                    finalize_compile(kernel)
+                except BaseException as exc:
+                    if first_error is None:
+                        first_error = exc
+        return first_error
+
+    def _run_cleanup_callbacks(self):
+        # Looped for the same reason as _run_finalize_callbacks: a callback can
+        # append another cleanup that nothing else would ever run.
+        #
+        # Asymmetric with _run_finalize_callbacks on purpose. A plain Exception
+        # here is swallowed so a cleanup failure can never mask the compilation
+        # error the caller is about to receive, but an interpreter-level unwind
+        # is returned instead, for the caller to re-raise once the terminal
+        # transition is complete.
+        first_error = None
+        while self._cleanup_callbacks:
+            callbacks, self._cleanup_callbacks = self._cleanup_callbacks, []
+            for cleanup_compile in callbacks:
+                try:
+                    cleanup_compile(self)
+                except Exception:
+                    pass
+                except BaseException as exc:
+                    if first_error is None:
+                        first_error = exc
+        return first_error
+
+    def _fail(self, error_type_name: str, error_message: str, error_is_exception: bool):
+        # The single terminal-failure transition, and the only one that never
+        # waits on the future. Dropping the future and evicting the JIT cache
+        # entry is what releases a compile: with nothing left referencing this
+        # object, the worker's eventual result -- or its exception traceback,
+        # and every compiler frame behind it -- becomes garbage. Only plain
+        # strings and a bool are kept, never the exception itself.
+        if self._state != "pending":
+            return None
+        self._error_type_name = error_type_name
+        self._error_message = error_message
+        self._error_is_exception = error_is_exception
+        self._state = "failed"
+        self.future = None
+        cleanup_error = self._run_cleanup_callbacks()
+        self._finalize_callbacks = []
+        return cleanup_error
+
     def result(self, ignore_errors: bool = False):
-        if self.kernel is not None:
+        if self._state == "failed":
+            # Waiters that joined after the failure still need their cache
+            # entry cleaned; their finalize callbacks are moot and dropped.
+            cleanup_error = self._run_cleanup_callbacks()
+            self._finalize_callbacks = []
+            if cleanup_error is not None:
+                raise cleanup_error
+            # Only a compilation error stays ignorable: an interrupted compile
+            # must keep raising on every later resolution too, not just the
+            # first one.
+            if ignore_errors and self._error_is_exception:
+                return None
+            raise RuntimeError("Async compilation for this kernel previously failed with "
+                               f"{self._error_type_name}: {self._error_message}")
+        if self._state == "succeeded":
+            # Waiters that joined after the compile resolved never saw a
+            # finalize callback run, so drain theirs before handing back.
+            callback_error = self._run_finalize_callbacks(self.kernel)
+            self._cleanup_callbacks = []
+            if callback_error is not None:
+                raise callback_error
             return self.kernel
 
         try:
             kernel = self.future.result()
-        except Exception:
-            if ignore_errors:
-                return
-            else:
-                raise
-        self.finalize_compile(kernel)
+        except BaseException as exc:
+            # BaseException is caught too: a worker cancelled or interrupted
+            # mid-compile would otherwise leave the future -- and its traceback
+            # -- cached.
+            cleanup_error = self._fail(type(exc).__name__, str(exc), isinstance(exc, Exception))
+            if cleanup_error is not None:
+                raise cleanup_error
+            # ignore_errors is an affordance for compilation errors; something
+            # that is not an Exception is unwinding the interpreter and must
+            # never be swallowed.
+            if ignore_errors and isinstance(exc, Exception):
+                return None
+            raise
+        callback_error = self._run_finalize_callbacks(kernel)
+        self._cleanup_callbacks = []
+        self._state = "succeeded"
+        self.future = None
         self.kernel = kernel
+        if callback_error is not None:
+            raise callback_error
         return kernel
 
+    def __getitem__(self, item):
+        # Implicit dunder lookups go to the type, never through __getattr__, so
+        # the kernel[grid](...) launch idiom needs a real method here for a
+        # warmed-up kernel to be usable at all.
+        return self.result()[item]
+
     def __getattr__(self, name):
+        if name.startswith("__") and name.endswith("__"):
+            # copy/pickle/repr probe for dunders like __deepcopy__ and expect
+            # AttributeError; resolving a compile here would raise the wrong
+            # error, and on a pending compile would block instead. Only dunders
+            # are refused: CompiledKernel's own _init_handles/_run have to keep
+            # forwarding through the proxy. __del__ is deliberately not proxied
+            # either -- forwarding a destructor would tie the compiled kernel's
+            # finalizer to the proxy's lifetime, which is not the same object.
+            raise AttributeError(name)
+        if "_state" not in self.__dict__:
+            # Allocated without __init__ (copy/pickle via __new__): there is
+            # nothing to resolve, and forwarding would recurse through
+            # result() reading the very attribute that is missing.
+            raise AttributeError(name)
         # Defer to the compiled kernel so users can interact with this object
         # like a normal CompiledKernel without needing to call result() first.
         return getattr(self.result(), name)
@@ -42,15 +168,17 @@ class AsyncCompileMode:
         self.raw_futures = []
         self.future_kernels = {}
 
-    def submit(self, key, compile_fn, finalize_fn):
+    def submit(self, key, compile_fn, finalize_fn, cleanup_fn):
         future = self.future_kernels.get(key)
         if future is not None:
+            future.add_callbacks(finalize_fn, cleanup_fn)
             return future
 
         future = self.executor.submit(compile_fn)
         future._key = key
         self.raw_futures.append(future)
-        future_kernel = FutureKernel(finalize_fn, future)
+        future_kernel = FutureKernel(future)
+        future_kernel.add_callbacks(finalize_fn, cleanup_fn)
         self.future_kernels[key] = future_kernel
         return future_kernel
 
@@ -60,8 +188,62 @@ class AsyncCompileMode:
         active_mode.set(self)
         return self
 
+    def _abandon_pending(self, exc: BaseException):
+        # Give up on every compile still in flight without waiting for it:
+        # evicting the cache entries is what releases them. A cleanup callback
+        # that unwinds in here is ignored on purpose, because the exception
+        # already propagating takes precedence and the sweep has to stay
+        # exhaustive.
+        #
+        # One pass is not enough. _fail() runs the cleanup callbacks, and a
+        # cleanup callback can submit(), inserting a key that a snapshot taken
+        # up front would never visit -- leaving it cached and still pending.
+        # Re-scan until a scan finds nothing pending. A callback that
+        # unconditionally submits a new key loops here rather than silently
+        # leaking, the same trade the callback runners make.
+        while True:
+            pending = [
+                future_kernel for future_kernel in self.future_kernels.values() if future_kernel._state == "pending"
+            ]
+            if not pending:
+                return
+            for future_kernel in pending:
+                future_kernel._fail(type(exc).__name__, str(exc), isinstance(exc, Exception))
+
     def __exit__(self, exc_type, exc_value, traceback):
         active_mode.set(None)
         # Finalize any outstanding compiles
-        for future in as_completed(self.raw_futures):
-            self.future_kernels[future._key].result(self.ignore_errors)
+        first_error = None
+        try:
+            if exc_type is not None and not issubclass(exc_type, Exception):
+                # The body is unwinding the interpreter, so abandon the compiles
+                # in flight instead of making a Ctrl-C wait for all of them.
+                self._abandon_pending(exc_value)
+            else:
+                # A callback can submit further compiles, and as_completed() only
+                # walks the futures it was handed, so keep draining until the
+                # queue stays empty.
+                while self.raw_futures:
+                    draining, self.raw_futures = self.raw_futures, []
+                    for future in as_completed(draining):
+                        try:
+                            self.future_kernels[future._key].result(self.ignore_errors)
+                        except Exception as e:
+                            # Keep draining: stopping here would leave the
+                            # remaining compiles unresolved and cached, and only
+                            # the first error is worth reporting to the caller.
+                            if first_error is None:
+                                first_error = e
+        except BaseException as e:
+            # Attached to the whole drain rather than to a single result(): an
+            # interrupt most often arrives while the thread is parked inside
+            # as_completed(), which raises from the for statement.
+            self._abandon_pending(e)
+            raise
+        finally:
+            # Completed futures can still point back to compile frames so need
+            # to drop them to avoid resource leakage.
+            self.raw_futures = []
+            self.future_kernels = {}
+        if first_error is not None:
+            raise first_error

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -893,7 +893,13 @@ class JITFunction(JITCallable, KernelInterface[T]):
                 self._call_hook(knobs.runtime.jit_post_compile_hook, key, signature, target, device, constexprs,
                                 options, [attrs], warmup)
 
-            kernel = async_mode.submit(cache_key, async_compile, finalize_compile)
+            def cleanup_compile(future_kernel):
+                # On failure, remove the unresolved async placeholder from cache to avoid the failed
+                # Future's exception traceback holding and leaking compiler locals.
+                if kernel_cache.get(key) is future_kernel:
+                    del kernel_cache[key]
+
+            kernel = async_mode.submit(cache_key, async_compile, finalize_compile, cleanup_compile)
             kernel_cache[key] = kernel
         else:
             kernel = self.compile(src, target=target, options=options.__dict__)


### PR DESCRIPTION
`SpirvUtils`-style lifetime bug, other direction: an object that is never released rather than one released too early. A failed async compile left its `FutureKernel` parked in `JITFunction.device_caches[<device>][0]`. The future holds the exception, whose `__traceback__` holds the compile frames, which hold the `ir.context` — so nanobind reported a leaked `triton._C.libtriton.ir.context` at interpreter shutdown of the `runtime/` suite. `runtime/test_cache.py::test_async_compile_error` on its own reproduces the entire report. The accompanying `leaked N types / M functions` lines are a cascade, not separate bugs — nanobind gates them on at least one leaked *instance*, so one retained `ir.context` dumps every registered type and method.

This applies [triton-lang/triton#10921](https://github.com/triton-lang/triton/pull/10921) (@antiagainst), which evicts the placeholder on failure, and extends it — **#10921 alone is not sufficient.** It only covers a single failing compile, the one case the suite exercised: `AsyncCompileMode.__exit__` iterates `as_completed()` and the first raising `result()` aborts the loop, after which the `finally` discards `raw_futures`/`future_kernels` without resolving the rest, so **two** failing compiles in one block leave the second placeholder cached and the identical report returns. On top of that eviction this makes the exit drain exhaustive, gives a failed `FutureKernel` a traceback-free terminal error, finalizes late and reentrant waiters, runs every callback even when one raises, releases the compile on `BaseException` and interrupt, and narrows the `__getattr__` guard to dunders only. On `python/test/unit/runtime/`: `231 passed` + `1 instance / 5 types / 210 functions` → **`255 passed` + no report**, 24 new tests, `-k async_compile` from 3 to 27.

Closes #7385.

<details>
<summary><b>Why the type/function counts grew without a second bug</b></summary>

nanobind's `internals_cleanup()` gates type and function reporting on at least one leaked instance:

```c
// Only report function/type leaks if actual nanobind instances were leaked
if (!leak)
    print_leak_warnings = false;
```

So one retained `ir.context` dumps every registered type and method. That is why the report grew from `1 instance / 1 type / 5 functions` in July to `1 / 2 / 196` in August with nothing new behind it — worth knowing, because it looks alarming in the issue history.

</details>

<details>
<summary><b>Relationship to upstream</b></summary>

#10921 has been an unreviewed draft since 2026-07-17 (0 reviews, 0 comments), so there was nothing to wait for. `test_async_compile_multiple_errors` covers the two-failure case it misses.

The three touched files are pure upstream code — `_async_compile.py` and `jit.py` were byte-identical between the two trees before this change — so the same patch should go upstream to keep the next merge a no-op. Filed here first because the leak is reported here and #10921 is stalled.

</details>

<details>
<summary><b>What this changes, beyond #10921's eviction</b></summary>

- **Exhaustive drain on exit.** `__exit__` drains every pending compile and re-raises the first error, and keeps draining work a callback queued *during* teardown, which `as_completed()` cannot see because it only walks the futures it was handed.
- **Traceback-free terminal error.** Re-resolving a failed `FutureKernel` reports the compile failure instead of `AttributeError: 'NoneType' object has no attribute 'result'`. Not cosmetic: the exhaustive drain resolves each `FutureKernel` a second time, so without this the `AttributeError` surfaces *from inside `__exit__`* and replaces the caller's real compile error. Only `type(exc).__name__` and `str(exc)` are kept — storing the exception would re-pin the traceback and reintroduce the leak, and `CompilationError.__init__(src, node, error_message)` makes reconstructing the original class impossible anyway.
- **Late and reentrant waiters are finalized.** A waiter joining an already-resolved shared compile previously had its callbacks silently discarded, leaving a `FutureKernel` in the caller's cache forever. Same-key and new-key reentrancy are distinct paths: a same-key `submit()` takes the dedup branch and appends no new raw future, so the fix has to drain callbacks, not just futures.
- **Every callback runs even when one raises**, including a `BaseException`, with the first error reported. Otherwise an interrupt during teardown strands every waiter behind it. Plain `Exception`s from cleanup callbacks are swallowed deliberately so they cannot mask the compilation error; a non-`Exception` unwind is re-raised after the terminal transition completes.
- **`BaseException` failures release the compile too**, and an interrupted drain abandons the compiles still in flight — however the interrupt arrives: from a worker, from `as_completed()` while it is waiting, or from the `with` body. Catching only `Exception` left the `FutureKernel` pending with its future — and traceback — retained and the placeholder cached, i.e. this exact leak. Evicting the cache entry is enough to release them, so `KeyboardInterrupt` aborts promptly on every path rather than waiting for in-flight compiles; that promptness is asserted (`< 1.0 s` against a 1.5 s compile) so it cannot silently regress. `ignore_errors` covers compilation errors and never an interpreter-level unwind — on the first resolution *and* every later one.
- **`__getattr__` refuses only dunders.** Resolving a compile to answer a `copy`/`pickle`/`repr` probe raised the wrong error, or blocked forever on a pending compile. The guard must stay narrow — `CompiledKernel._init_handles`/`_run` have to keep forwarding through the proxy, and `python/tutorials/02-fused-softmax.py:164` calls `kernel._init_handles()` on whatever `warmup()` returned.

`FutureKernel`'s lifecycle is now an explicit `pending`/`succeeded`/`failed` state rather than inferred from `None` sentinels, and the per-waiter callback lists are private.

</details>

<details>
<summary><b>API note — source-incompatible change to two exported symbols</b></summary>

`AsyncCompileMode.submit()` gains a required `cleanup_fn` (from #10921) and `FutureKernel.__init__` drops its finalize parameter in favour of `add_callbacks()`. Both symbols are exported from `triton` but undocumented. No in-tree consumer and no surveyed public consumer was found — searched GitHub-wide plus `pytorch/pytorch`, `vllm-project/vllm`, `linkedin/Liger-Kernel` (`torch._inductor`'s `AsyncCompile` is an unrelated abstraction with a coincidental name). That is a survey, not a proof: this remains a source-incompatible change to exported symbols. In-tree there is exactly one `submit()` call site, `jit.py:902`.

`cleanup_fn` is deliberately **required** rather than optional: making it optional would let a caller silently reintroduce this leak class.

</details>

<details>
<summary><b>Tests — 24 new</b></summary>

In `python/test/unit/runtime/test_cache.py`; `-k async_compile` goes from 3 to 27. Coverage: two failures in one mode, repeated resolution of a failed compile, shared-key waiters registered late and from inside a callback (same-key and new-key are distinct paths), waiters resubmitted from a cleanup callback, reentrant `result()` from a finalize callback, raising callbacks including `BaseException`, `BaseException` compile failures, interrupts from a worker / from `as_completed()` / from the `with` body, `ignore_errors` eviction and its non-ignorability for interpreter unwinds, dunder probes, `__getitem__` forwarding, `__new__`-without-`__init__`, mode nesting, and `submit()` dedup.

Four previously-accidental contracts are now pinned deliberately: `ignore_errors` still evicts, a body exception combined with a compile failure (the compile error propagates, the body exception preserved as its `__context__`), the terminal state after a finalize callback raises, and prompt abort on interrupt.

Only the real-kernel tests need a GPU; the rest drive `MockThreadPool` or a bare `concurrent.futures.Future`. One encodes the core constraint as an executable invariant:

```python
assert not any(isinstance(v, BaseException) for v in vars(fk).values())
```

</details>

<details>
<summary><b>Validation</b></summary>

Intel Data Center GPU Max 1100, CPython 3.12.13, nanobind 2.10.2, `python/test/unit/runtime/`:

| | before | after |
|---|---|---|
| tests | `231 passed, 1 deselected, 27 xfailed` | `255 passed, 1 deselected, 27 xfailed` |
| nanobind report | `1 instance / 5 types / 210 functions` | none |
| wall time | 26.93 s | 16.13 s |

Repeated across runs — the report fires at `Py_FinalizeEx` and is timing-sensitive, so a single green run is weak evidence for a leak fix. The changed code only executes inside a `with AsyncCompileMode(...)` block, so every non-async compile path is untouched.

</details>

<details>
<summary><b>Sequencing note</b></summary>

`a6ebf2c200` on `codex/ft-blockers-audit` ("Lock AsyncCompileMode submit and finalize_compile") touches this same region for a different race and keeps the old 3-arg `submit()`. Whichever lands second will conflict. Thread safety was deliberately left out here to stay out of its way.

</details>
