### PR TITLE
[vLLM] Cap BMG build parallelism to avoid `cc1plus` OOM

### DIFF
--- a/.github/workflows/on-label.yml
+++ b/.github/workflows/on-label.yml
@@ -45,6 +45,8 @@ jobs:
     with:
       runner_label: b580
       skip_list: xe2
+      # Default -j(2*cores) OOM-kills cc1plus building the wheel on b580.
+      max_jobs: "8"
     secrets: inherit
 
   vllm-tests-pvc:

--- a/.github/workflows/vllm-tests-bmg.yml
+++ b/.github/workflows/vllm-tests-bmg.yml
@@ -26,4 +26,6 @@ jobs:
     with:
       runner_label: b580
       skip_list: xe2
+      # Default -j(2*cores) OOM-kills cc1plus building the wheel on b580.
+      max_jobs: "8"
     secrets: inherit

--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -19,6 +19,10 @@ on:
         description: Skip list directory override
         type: string
         default: ""
+      max_jobs:
+        description: Build parallelism, keep empty for 2 * number of cores
+        type: string
+        default: ""
       python_version:
         description: Python version
         type: string
@@ -93,6 +97,13 @@ jobs:
 
       - name: Build Triton wheel
         run: |
+          max_jobs="${{ inputs.max_jobs }}"
+          if [[ -z "$max_jobs" && "${{ inputs.runner_label }}" == "b580" ]]; then
+            max_jobs=8
+          fi
+          if [[ -n "$max_jobs" ]]; then
+            export MAX_JOBS="$max_jobs"
+          fi
           python -m build --wheel --no-isolation
           ls -lh dist/*.whl
 

--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -97,12 +97,8 @@ jobs:
 
       - name: Build Triton wheel
         run: |
-          max_jobs="${{ inputs.max_jobs }}"
-          if [[ -z "$max_jobs" && "${{ inputs.runner_label }}" == "b580" ]]; then
-            max_jobs=8
-          fi
-          if [[ -n "$max_jobs" ]]; then
-            export MAX_JOBS="$max_jobs"
+          if [[ -n "${{ inputs.max_jobs }}" ]]; then
+            export MAX_JOBS="${{ inputs.max_jobs }}"
           fi
           python -m build --wheel --no-isolation
           ls -lh dist/*.whl

--- a/.github/workflows/vllm-tests.yml
+++ b/.github/workflows/vllm-tests.yml
@@ -44,6 +44,8 @@ jobs:
     uses: ./.github/workflows/vllm-tests-reusable.yml
     with:
       runner_label: ${{ inputs.runner_label }}
+      # Default -j(2*cores) OOM-kills cc1plus building the wheel on b580.
+      max_jobs: ${{ inputs.runner_label == 'b580' && '8' || '' }}
       vllm_pin: ${{ inputs.vllm_pin }}
       vllm_xpu_kernels_pin: ${{ inputs.vllm_xpu_kernels_pin }}
       skip_list: ${{ inputs.skip_list }}


### PR DESCRIPTION
The vLLM BMG test build compiles the Triton wheel on the `b580` runner pool. On the `bmg-499320` host (20 cores) the default `-j(2*cores)`=`-j40` OOM-kills `cc1plus`, intermittently failing the setup job. Add a `max_jobs` input and default `MAX_JOBS=8` on `b580`, mirroring the sglang-tests workflow `max_jobs` fix implemented in https://github.com/intel/intel-xpu-backend-for-triton/pull/7725.

Example failing build on `bmg-499320`: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/32521072574/job/96893157767