### PR TITLE
[TritonGEN] Lower the 2D block prefetch shapes the SPV library lacks to GenISA

### DIFF
--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -211,6 +211,11 @@ static bool isSPVBuiltinAvailableImpl(TritonGEN::Matrix2DBlockPrefetchOp op) {
       op.getVBlocks() == 1)
     return false;
 
+  // intel_sub_group_2d_block_prefetch_64b_{1,2,4}r8x1c
+  if (op.getElemSizeInBits() == 64 && op.getTileWidth() == 8 &&
+      op.getVBlocks() == 1 && op.getTileHeight() < 8)
+    return false;
+
   return true;
 }
 


### PR DESCRIPTION
`64b_{1,2,4}r8x1c` reaches `ocloc` as an unresolved `__internal_intel_sub_group_2d_block_prefetch_*` reference, which silently costs inductor its prologue fusion. Route those shapes to GenISA like the two gaps already handled here.