### PR TITLE
[TritonGENToLLVM] Declare predicated load as reading only argument memory

### DIFF
--- a/test/TritonGEN/tritongen-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-to-llvm.mlir
@@ -162,7 +162,7 @@ llvm.func @triton_gen.sub_group_block_write(%ptr: !llvm.ptr<1>, %val : i32) {
 
 // -----
 
-// CHECK: llvm.func spir_funccc @_Z27__spirv_PredicatedLoadINTELPU3AS1vbi(!llvm.ptr<1>, i1, i32) -> i32 attributes {no_unwind, will_return}
+// CHECK: llvm.func spir_funccc @_Z27__spirv_PredicatedLoadINTELPU3AS1vbi(!llvm.ptr<1>, i1, i32) -> i32 attributes {memory_effects = #llvm.memory_effects<other = none, argMem = read, inaccessibleMem = none, errnoMem = none, targetMem0 = none, targetMem1 = none>, no_unwind, will_return}
 llvm.func @triton_gen.predicated_load(%ptr : !llvm.ptr<1>, %predicate : i1, %default_value : i32) {
   // CHECK:     llvm.func @triton_gen.predicated_load(%arg0: !llvm.ptr<1>, %arg1: i1, %arg2: i32) {
   // CHECK:       %0 = llvm.call spir_funccc @_Z27__spirv_PredicatedLoadINTELPU3AS1vbi(%arg0, %arg1, %arg2) {{.*}} : (!llvm.ptr<1>, i1, i32) -> i32

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -1348,9 +1348,22 @@ struct TritonPredicatedLoadOpLowering
     SmallVector<Value> args{op.getPtr(), op.getPredicate(),
                             op.getDefaultValue()};
 
+    // A predicated load only reads memory reachable through its pointer
+    // argument. Declare that explicitly: defaulting to `memory(readwrite)`
+    // prevents LLVM and IGC from redundancy-eliminating, hoisting and
+    // reordering these calls the way they do for plain loads.
+    auto memAttr = rewriter.getAttr<LLVM::MemoryEffectsAttr>(
+        /*other=*/LLVM::ModRefInfo::NoModRef,
+        /*argMem=*/LLVM::ModRefInfo::Ref,
+        /*inaccessibleMem=*/LLVM::ModRefInfo::NoModRef,
+        /*errnoMem=*/LLVM::ModRefInfo::NoModRef,
+        /*targetMem0=*/LLVM::ModRefInfo::NoModRef,
+        /*targetMem1=*/LLVM::ModRefInfo::NoModRef);
+    auto funcAttrs = intel::noUnwindWillReturnAttrs;
+    funcAttrs.memEffectsAttr = memAttr;
+
     LLVM::CallOp callOp = intel::createDeviceFunctionCall(
-        rewriter, fnName, resType, argTypes, args, {},
-        intel::noUnwindWillReturnAttrs);
+        rewriter, fnName, resType, argTypes, args, {}, funcAttrs);
 
     if (std::optional<TritonGEN::DecorationCacheControlAttr> optCacheControls =
             loadCacheControlToCacheControls(rewriter, op.getCacheControl(),


### PR DESCRIPTION
`TritonPredicatedLoadOpLowering` passed the bare `noUnwindWillReturnAttrs` attribute set, which leaves the memory effects unspecified. As a result `__spirv_PredicatedLoadINTEL` was declared without a `memory(...)` clause, i.e. implicitly `memory(readwrite)`, so LLVM and IGC had to assume a masked load can write all of memory and could not redundancy-eliminate, hoist or reorder it. The sibling pure loads in this file (`SubGroupBlockReadOp` and the 2D block loads) already declare `argMem = Ref`.

A predicated load only reads memory reachable through its pointer argument, so declare that. The emitted declaration becomes `memory(argmem: read)` and LLVM additionally infers `nofree`.

Part of #7755