### PR TITLE
[TEST] Fix lit config for LLVM 23+ compatibility

### DIFF
--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -14,7 +14,7 @@ from lit.llvm.subst import ToolSubst
 # name: The name of this test suite
 config.name = 'TRITON'
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = ['.mlir', '.ll']


### PR DESCRIPTION
Fixes CI failures caused by lit-23.1.0 upgrade that enforces the deprecation of `execute_external=True` parameter.

Between August 25, 2026 07:14 UTC and 19:42 UTC, the `lit` package was upgraded in PyPI from 18.1.8 to 23.1.0. The new version causes a hard failure when `execute_external=True` is used:

```
ValueError: execute_external=True is deprected as of LLVM-23 and the option will be removed in LLVM-24. 
Please move to using the internal shell (execute_external=False).
```