### PR TITLE
[MaterializeBlockPointer] Decline block IO when the mask degenerates the 2D block tile

### DIFF
--- a/test/TritonIntelGPU/materialize-block-pointer.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer.mlir
@@ -133,6 +133,57 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 32 : i32, "ttg.th
 
 // -----
 
+// COM: Negative case - the row bound of the mask is an opaque runtime scalar, so
+// COM: the mask has constancy 1 along the row dimension. A 2D block message carries
+// COM: a single predicate for the whole tile, so the tile would be clamped to one
+// COM: row; decline block IO instead and let the load keep its coalesced layout.
+#blocked7 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 4], warpsPerCTA = [32, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func public @masked_opaque_row_bound_no_block_io
+  tt.func public @masked_opaque_row_bound_no_block_io(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}) {
+    %m_size = tt.load %arg1 : !tt.ptr<i32>
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked7}>>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked7}>> -> tensor<1x32xi32, #blocked7>
+    %2 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<1x32x!tt.ptr<bf16>, #blocked7>
+    %3 = tt.addptr %2, %1 : tensor<1x32x!tt.ptr<bf16>, #blocked7>, tensor<1x32xi32, #blocked7>
+    %4 = tt.broadcast %3 : tensor<1x32x!tt.ptr<bf16>, #blocked7> -> tensor<256x32x!tt.ptr<bf16>, #blocked7>
+    %5 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 1, parent = #blocked7}>>
+    %6 = tt.expand_dims %5 {axis = 1 : i32} : tensor<256xi32, #ttg.slice<{dim = 1, parent = #blocked7}>> -> tensor<256x1xi32, #blocked7>
+    %7 = tt.splat %m_size : i32 -> tensor<256x1xi32, #blocked7>
+    %8 = arith.cmpi slt, %6, %7 : tensor<256x1xi32, #blocked7>
+    %mask = tt.broadcast %8 : tensor<256x1xi1, #blocked7> -> tensor<256x32xi1, #blocked7>
+    // CHECK-NOT: ttig.block_io
+    tt.load %4, %mask : tensor<256x32x!tt.ptr<bf16>, #blocked7>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: The same mask shape as above, but the row bound is known to be a multiple
+// COM: of 16, so the mask is uniform over a 16-row tile and block IO is kept.
+#blocked8 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 4], warpsPerCTA = [32, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func public @masked_divisible_row_bound_load
+  tt.func public @masked_divisible_row_bound_load(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %m_size: i32 {tt.divisibility = 16 : i32}) {
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked8}>>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked8}>> -> tensor<1x32xi32, #blocked8>
+    %2 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<1x32x!tt.ptr<bf16>, #blocked8>
+    %3 = tt.addptr %2, %1 : tensor<1x32x!tt.ptr<bf16>, #blocked8>, tensor<1x32xi32, #blocked8>
+    %4 = tt.broadcast %3 : tensor<1x32x!tt.ptr<bf16>, #blocked8> -> tensor<256x32x!tt.ptr<bf16>, #blocked8>
+    %5 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 1, parent = #blocked8}>>
+    %6 = tt.expand_dims %5 {axis = 1 : i32} : tensor<256xi32, #ttg.slice<{dim = 1, parent = #blocked8}>> -> tensor<256x1xi32, #blocked8>
+    %7 = tt.splat %m_size : i32 -> tensor<256x1xi32, #blocked8>
+    %8 = arith.cmpi slt, %6, %7 : tensor<256x1xi32, #blocked8>
+    %mask = tt.broadcast %8 : tensor<256x1xi1, #blocked8> -> tensor<256x32xi1, #blocked8>
+    // CHECK: tt.load {{.*}} {ttig.block_io = "row_major"}
+    tt.load %4, %mask : tensor<256x32x!tt.ptr<bf16>, #blocked8>
+    tt.return
+  }
+}
+
+// -----
+
 // COM: 3D regular pointer.
 #blocked = #ttg.blocked<{sizePerThread = [1, 4, 4], threadsPerWarp = [1, 4, 8], warpsPerCTA = [2, 2, 1], order = [2, 1, 0]}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -248,6 +248,9 @@ private:
       return;
     }
 
+    if (!maskPermitsBlockTile(op, axisInfoAnalysis, rank))
+      return;
+
     // Determine if LoadOp is row-major or column-major.
     tt::intel::StrideInfo *strideInfo = strideAnalysis.getStrideInfo(ptr);
     auto isMajor = [rank, &strideInfo](RankedTensorType tensorTy,
@@ -309,6 +312,52 @@ private:
                   StringAttr::get(op.getContext(),
                                   ttgi::stringifyBlockIOMode(
                                       ttgi::BlockIOMode::ColumnMajor)));
+  }
+
+  /// A 2D block message carries a single predicate for the whole tile, so
+  /// `getBlockIOTileSize` clamps the tile to the mask's constancy along each
+  /// tensor dimension. Return false when the mask of \p op cannot support a
+  /// tile spanning more than one element in one of the two innermost dims: the
+  /// clamp then degenerates the tile to a single row (or rejects it outright in
+  /// the lowering), and the load is served better by the predicated-load path
+  /// in its coalesced layout.
+  ///
+  /// Marking such an op block-I/O capable is not merely useless but harmful:
+  /// RemoveLayoutConversions de-anchors the load into a dot-operand layout on
+  /// the promise of a wide block tile that the clamp then withholds, so the
+  /// operand is reassembled from one hardware message per row plus a shuffle
+  /// per element.
+  ///
+  /// A mask whose bound is an opaque runtime scalar — e.g. the per-group token
+  /// count in a grouped GEMM, `offs_am < tl.load(offsets_ptr + g)` — has
+  /// constancy 1 along the M dim, because the compare visitor can only derive
+  /// constancy from the divisibility of both sides.
+  template <typename OpType>
+  bool maskPermitsBlockTile(OpType op,
+                            tt::intel::ModuleAxisInfoAnalysis &axisInfoAnalysis,
+                            unsigned rank) const {
+    Value mask = op.getMask();
+    if (!mask || matchPattern(mask, m_One()))
+      return true;
+
+    const tt::AxisInfo *maskAxisInfo = axisInfoAnalysis.getAxisInfo(mask);
+    if (!maskAxisInfo) {
+      LDBG("No axis info for mask, skip block IO attribute");
+      return false;
+    }
+
+    // Mirrors getBlockIOTileSize, which rejects a non-power-of-2 constancy
+    // outright and clamps each tile dimension to the constancy along it.
+    for (unsigned dim : {rank - 2, rank - 1}) {
+      int64_t constancy = maskAxisInfo->getConstancy(dim);
+      if (constancy < 2 || !llvm::isPowerOf2_64(constancy)) {
+        LDBG("Mask constancy along dim " << dim << " is " << constancy
+                                         << ", which degenerates the 2D block "
+                                            "tile; skip block IO attribute");
+        return false;
+      }
+    }
+    return true;
   }
 
   /// Look through cast wrappers (index_cast, extui, extsi, trunci, etc.)


### PR DESCRIPTION
3d59136d7 ("Allow block_io on masked loads", #7205) degrades gemm-grouped performance (5.56->1.27 TFlops) and improves gemm-grouped-batched performance (9.71->24.8 TFlops). This PR aims to keep the improvement and fix the regression. 

A 2D block load carries a single predicate for the whole tile, so getBlockIOTileSize clamps each tile dimension to the mask's constancy along it. When the mask's row bound is an opaque runtime scalar its constancy along that dimension is 1, and the clamp leaves the tile at its un-grown lane seed: a single row, one subgroup wide.

Setting ttig.block_io on such a load is worse than not setting it. RemoveLayoutConversions de-anchors the load into a dot-operand layout on the promise of a wide block tile that the clamp then withholds, so the operand is reassembled from one hardware message per row plus a shuffle per element. Rejecting later, in getBlockIOTileSize or in the lowering, is too late: the load has already been de-anchored, and rematDegradesLoad cannot veto because both encodings collapse to the same gather cost estimate. The decision has to be made where the attribute is set.

Add a maskPermitsBlockTile guard that declines the attribute when the mask's constancy along either of the two innermost dimensions is < 2 or not a power of two — exactly the conditions under which the tile dimension would be clamped to 1.

Rather than merely restoring the original performance it improves on it (5.56->1.27->9.56 TFlops), because the guard is per-operand: operand A falls back to predicated loads, while operand B keeps its column_major block IO (mask constancy [64, 128]), a configuration neither arm produced before:

<img width="1223" height="382" alt="image" src="https://github.com/user-attachments/assets/e90b7783-bebf-4494-91c7-4731a9e67c2d" />
