### PR TITLE
[XPU] Fuse reshape for descriptors with a unit middle dimension

### DIFF
--- a/test/Triton/Intel/FuseReshape/fuse-reshape.mlir
+++ b/test/Triton/Intel/FuseReshape/fuse-reshape.mlir
@@ -104,3 +104,37 @@ tt.func public @noFuseNonDivisibleBlockExtent(%arg0: tensor<16x16xf32>, %arg1: !
 // CHECK-LABEL: noFuseNonDivisibleBlockExtent
 // CHECK: tt.descriptor_load
 // CHECK: tt.reshape
+
+// -----
+
+// COM: Collapse a unit-extent middle dimension into the innermost one. The
+// COM: merged extent is bounded exactly: (32-1)*128 + 128 == 4096.
+tt.func public @fuseLoadWithReshapeMiddleDim(%arg0: tensor<128x256xbf16>, %arg1: !tt.ptr<bf16>) {
+  %c0_i32 = arith.constant 0 : i32
+  %c2_i32 = arith.constant 2 : i32
+  %c3_i32 = arith.constant 3 : i32
+  %c32_i32 = arith.constant 32 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c1024_i32 = arith.constant 1024 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %c128_i64 = arith.constant 128 : i64
+  %c4096_i64 = arith.constant 4096 : i64
+  %cst = arith.constant dense<0.000000e+00> : tensor<64x256xf32>
+  %0 = tt.make_tensor_descriptor %arg1, [%c1024_i32, %c32_i32, %c128_i32], [%c4096_i64, %c128_i64, %c1_i64] : <bf16>, <64x1x128xbf16>
+  %1 = tt.descriptor_load %0[%c2_i32, %c3_i32, %c0_i32] : !tt.tensordesc<64x1x128xbf16> -> tensor<64x1x128xbf16>
+  %2 = tt.reshape %1 : tensor<64x1x128xbf16> -> tensor<64x128xbf16>
+  %3 = tt.dot %2, %arg0, %cst, inputPrecision = tf32 : tensor<64x128xbf16> * tensor<128x256xbf16> -> tensor<64x256xf32>
+  tt.return
+}
+// CHECK-LABEL: fuseLoadWithReshapeMiddleDim
+// CHECK-NOT: tt.reshape
+// CHECK: [[DIV:%.*]] = arith.divui %c128_i64, %c1_i64 : i64
+// CHECK: [[TRUNC:%.*]] = arith.trunci [[DIV]] : i64 to i32
+// CHECK: [[SUB:%.*]] = arith.subi %c32_i32, %{{.*}} : i32
+// CHECK: [[MUL1:%.*]] = arith.muli [[SUB]], [[TRUNC]] : i32
+// CHECK: [[ADD1:%.*]] = arith.addi [[MUL1]], %c128_i32 : i32
+// CHECK: [[DESC:%.*]] = tt.make_tensor_descriptor %arg1, [%c1024_i32, [[ADD1]]], [%c4096_i64, %c1_i64] : <bf16>, <64x128xbf16>
+// CHECK: [[MUL2:%.*]] = arith.muli %c3_i32, [[TRUNC]] : i32
+// CHECK: [[ADD2:%.*]] = arith.addi [[MUL2]], %c0_i32 : i32
+// CHECK: [[LOAD:%.*]] = tt.descriptor_load [[DESC]][%c2_i32, [[ADD2]]] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
+// CHECK: tt.dot [[LOAD]], {{.*}}, {{.*}}, inputPrecision = tf32 : tensor<64x128xbf16> * tensor<128x256xbf16> -> tensor<64x256xf32>

--- a/test/Triton/Intel/FuseReshape/fuse-reshape.mlir
+++ b/test/Triton/Intel/FuseReshape/fuse-reshape.mlir
@@ -1,5 +1,6 @@
 // RUN: triton-opt %s -split-input-file -triton-intel-fuse-reshape | FileCheck %s
 
+// COM: Unit outermost dimension: merged extent is (1-1)*(1024/4) + 64 == 64.
 tt.func public @fuseLoadWithReshape1(%arg0: tensor<256x32xbf16>, %arg1: !tt.ptr<bf16>) {
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
@@ -20,7 +21,9 @@ tt.func public @fuseLoadWithReshape1(%arg0: tensor<256x32xbf16>, %arg1: !tt.ptr<
 // CHECK-NOT: tt.reshape
 // CHECK: [[DIV:%.*]] = arith.divui %c1024_i64, %c4_i64 : i64
 // CHECK: [[TRUNC:%.*]] = arith.trunci [[DIV]] : i64 to i32
-// CHECK: [[MUL1:%.*]] = arith.muli %c1_i32, [[TRUNC]] : i32
+// CHECK-DAG: [[ONE:%.*]] = arith.constant 1 : i32
+// CHECK: [[SUB:%.*]] = arith.subi %c1_i32, [[ONE]] : i32
+// CHECK: [[MUL1:%.*]] = arith.muli [[SUB]], [[TRUNC]] : i32
 // CHECK: [[ADD1:%.*]] = arith.addi [[MUL1]], %c64_i32 : i32
 // CHECK: [[DESC:%.*]] = tt.make_tensor_descriptor %arg1, [[[ADD1]], %c1024_i32], [%c4_i64, %c1_i64] : <bf16>, <32x256xbf16>
 // CHECK: [[MUL2:%.*]] = arith.muli %c2_i32, [[TRUNC]] : i32
@@ -30,6 +33,7 @@ tt.func public @fuseLoadWithReshape1(%arg0: tensor<256x32xbf16>, %arg1: !tt.ptr<
 
 // -----
 
+// COM: Same, in a loop: (512-1)*(1024/1) + 1024 == 512*1024.
 tt.func public @fuseLoadWithReshape2(%arg0: tensor<32x256xbf16>, %arg1: !tt.ptr<bf16>) {
   %c0_i32 = arith.constant 0 : i32
   %c1_i64 = arith.constant 1 : i64
@@ -53,7 +57,9 @@ tt.func public @fuseLoadWithReshape2(%arg0: tensor<32x256xbf16>, %arg1: !tt.ptr<
 // CHECK-NOT: tt.reshape
 // CHECK: [[DIV:%.*]] = arith.divui %c1024_i64, %c1_i64 : i64
 // CHECK: [[TRUNC:%.*]] = arith.trunci [[DIV]] : i64 to i32
-// CHECK: [[MUL1:%.*]] = arith.muli %c512_i32, [[TRUNC]] : i32
+// CHECK-DAG: [[ONE:%.*]] = arith.constant 1 : i32
+// CHECK: [[SUB:%.*]] = arith.subi %c512_i32, [[ONE]] : i32
+// CHECK: [[MUL1:%.*]] = arith.muli [[SUB]], [[TRUNC]] : i32
 // CHECK: [[ADD1:%.*]] = arith.addi [[MUL1]], %c1024_i32 : i32
 // CHECK: [[DESC:%.*]] = tt.make_tensor_descriptor %arg1, [[[ADD1]], %c32_i32], [%c1_i64, %c512_i64] : <bf16>, <256x32xbf16>
 // CHECK: scf.for
@@ -107,8 +113,7 @@ tt.func public @noFuseNonDivisibleBlockExtent(%arg0: tensor<16x16xf32>, %arg1: !
 
 // -----
 
-// COM: Collapse a unit-extent middle dimension into the innermost one. The
-// COM: merged extent is bounded exactly: (32-1)*128 + 128 == 4096.
+// COM: Unit middle dimension: merged extent is (32-1)*128 + 128 == 4096.
 tt.func public @fuseLoadWithReshapeMiddleDim(%arg0: tensor<128x256xbf16>, %arg1: !tt.ptr<bf16>) {
   %c0_i32 = arith.constant 0 : i32
   %c2_i32 = arith.constant 2 : i32
@@ -130,7 +135,8 @@ tt.func public @fuseLoadWithReshapeMiddleDim(%arg0: tensor<128x256xbf16>, %arg1:
 // CHECK-NOT: tt.reshape
 // CHECK: [[DIV:%.*]] = arith.divui %c128_i64, %c1_i64 : i64
 // CHECK: [[TRUNC:%.*]] = arith.trunci [[DIV]] : i64 to i32
-// CHECK: [[SUB:%.*]] = arith.subi %c32_i32, %{{.*}} : i32
+// CHECK-DAG: [[ONE:%.*]] = arith.constant 1 : i32
+// CHECK: [[SUB:%.*]] = arith.subi %c32_i32, [[ONE]] : i32
 // CHECK: [[MUL1:%.*]] = arith.muli [[SUB]], [[TRUNC]] : i32
 // CHECK: [[ADD1:%.*]] = arith.addi [[MUL1]], %c128_i32 : i32
 // CHECK: [[DESC:%.*]] = tt.make_tensor_descriptor %arg1, [%c1024_i32, [[ADD1]]], [%c4096_i64, %c1_i64] : <bf16>, <64x128xbf16>
@@ -138,3 +144,76 @@ tt.func public @fuseLoadWithReshapeMiddleDim(%arg0: tensor<128x256xbf16>, %arg1:
 // CHECK: [[ADD2:%.*]] = arith.addi [[MUL2]], %c0_i32 : i32
 // CHECK: [[LOAD:%.*]] = tt.descriptor_load [[DESC]][%c2_i32, [[ADD2]]] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16>
 // CHECK: tt.dot [[LOAD]], {{.*}}, {{.*}}, inputPrecision = tf32 : tensor<64x128xbf16> * tensor<128x256xbf16> -> tensor<64x256xf32>
+
+// -----
+
+// COM: Do not fuse a unit middle dimension when the innermost extent is not
+// COM: provably a multiple of its block extent.
+tt.func public @noFuseMiddleDimNonDivisibleBlockExtent(%arg0: tensor<128x256xbf16>, %arg1: !tt.ptr<bf16>) {
+  %c0_i32 = arith.constant 0 : i32
+  %c3_i32 = arith.constant 3 : i32
+  %c32_i32 = arith.constant 32 : i32
+  %c130_i32 = arith.constant 130 : i32
+  %c1024_i32 = arith.constant 1024 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %c130_i64 = arith.constant 130 : i64
+  %c4160_i64 = arith.constant 4160 : i64
+  %cst = arith.constant dense<0.000000e+00> : tensor<64x256xf32>
+  %0 = tt.make_tensor_descriptor %arg1, [%c1024_i32, %c32_i32, %c130_i32], [%c4160_i64, %c130_i64, %c1_i64] : <bf16>, <64x1x128xbf16>
+  %1 = tt.descriptor_load %0[%c0_i32, %c3_i32, %c0_i32] : !tt.tensordesc<64x1x128xbf16> -> tensor<64x1x128xbf16>
+  %2 = tt.reshape %1 : tensor<64x1x128xbf16> -> tensor<64x128xbf16>
+  %3 = tt.dot %2, %arg0, %cst, inputPrecision = tf32 : tensor<64x128xbf16> * tensor<128x256xbf16> -> tensor<64x256xf32>
+  tt.return
+}
+// CHECK-LABEL: noFuseMiddleDimNonDivisibleBlockExtent
+// CHECK: tt.descriptor_load
+// CHECK: tt.reshape
+
+// -----
+
+// COM: Do not fuse (nor crash) a rank-reducing load: the block shape does not
+// COM: match the loaded shape.
+tt.func public @noFuseRankReducingDescriptor(%arg0: tensor<128x256xbf16>, %arg1: !tt.ptr<bf16>) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c32_i32 = arith.constant 32 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c1024_i32 = arith.constant 1024 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %c128_i64 = arith.constant 128 : i64
+  %c4096_i64 = arith.constant 4096 : i64
+  %c4194304_i64 = arith.constant 4194304 : i64
+  %cst = arith.constant dense<0.000000e+00> : tensor<64x256xf32>
+  %0 = tt.make_tensor_descriptor %arg1, [%c1_i32, %c1024_i32, %c32_i32, %c128_i32], [%c4194304_i64, %c4096_i64, %c128_i64, %c1_i64] : <bf16>, <1x64x1x128xbf16>
+  %1 = tt.descriptor_load %0[%c0_i32, %c0_i32, %c1_i32, %c0_i32] : !tt.tensordesc<1x64x1x128xbf16> -> tensor<64x1x128xbf16>
+  %2 = tt.reshape %1 : tensor<64x1x128xbf16> -> tensor<64x128xbf16>
+  %3 = tt.dot %2, %arg0, %cst, inputPrecision = tf32 : tensor<64x128xbf16> * tensor<128x256xbf16> -> tensor<64x256xf32>
+  tt.return
+}
+// CHECK-LABEL: noFuseRankReducingDescriptor
+// CHECK: tt.descriptor_load
+// CHECK: tt.reshape
+
+// -----
+
+// COM: Do not fuse when the block shape puts the unit extent in a different
+// COM: dimension than the loaded shape: the reshape drops 1, the descriptor 0.
+tt.func public @noFuseBlockShapeMismatch(%arg0: tensor<128x256xbf16>, %arg1: !tt.ptr<bf16>) {
+  %c0_i32 = arith.constant 0 : i32
+  %c3_i32 = arith.constant 3 : i32
+  %c64_i32 = arith.constant 64 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c1024_i32 = arith.constant 1024 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %c128_i64 = arith.constant 128 : i64
+  %c8192_i64 = arith.constant 8192 : i64
+  %cst = arith.constant dense<0.000000e+00> : tensor<64x256xf32>
+  %0 = tt.make_tensor_descriptor %arg1, [%c1024_i32, %c64_i32, %c128_i32], [%c8192_i64, %c128_i64, %c1_i64] : <bf16>, <1x64x128xbf16>
+  %1 = tt.descriptor_load %0[%c0_i32, %c3_i32, %c0_i32] : !tt.tensordesc<1x64x128xbf16> -> tensor<64x1x128xbf16>
+  %2 = tt.reshape %1 : tensor<64x1x128xbf16> -> tensor<64x128xbf16>
+  %3 = tt.dot %2, %arg0, %cst, inputPrecision = tf32 : tensor<64x128xbf16> * tensor<128x256xbf16> -> tensor<64x256xf32>
+  tt.return
+}
+// CHECK-LABEL: noFuseBlockShapeMismatch
+// CHECK: tt.descriptor_load
+// CHECK: tt.reshape

--- a/third_party/intel/lib/Dialect/Triton/Transforms/FuseReshape.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/FuseReshape.cpp
@@ -42,6 +42,12 @@ namespace {
 //                       : !tt.tensordesc<512x64xf16>
 //   %A = tt.descriptor_load %desc[%x*%d+%y,%z] -> tensor<512x64xf16>
 //   dot %A, ... : tensor<512x64xf16> x tensor<64x32xf16> -> tensor<512x32xf16>
+// The unit-extent dimension may also be the middle one (e.g. a one-head tile of
+// a contiguous (TOKENS, HEADS, HEAD_DIM) tensor), collapsed the same way with
+// %d = %b / %c:
+//   %desc = tt.make_tensor_descriptor %base, [%s0,(%s1-1)*%d+%s2], [%a,%c]
+//                       : !tt.tensordesc<64x128xf16>
+//   %A = tt.descriptor_load %desc[%x,%y*%d+%z] -> tensor<64x128xf16>
 class FuseReshapeWithLoad : public tt::intel::Fuser {
 public:
   void run(ModuleOp moduleOp) {
@@ -98,6 +104,25 @@ public:
   }
 
 private:
+  /// The unit-extent dimension collapsed away by the fusion, always merged into
+  /// the dimension immediately following it: 1xNxM or Nx1xM -> NxM.
+  enum class CollapseKind { Outermost, Middle };
+
+  /// `Outermost` takes precedence, so a `1x1xM` shape keeps its prior behavior.
+  static std::optional<CollapseKind> getCollapseKind(ArrayRef<int64_t> shape) {
+    if (shape.size() != 3)
+      return std::nullopt;
+    if (shape[0] == 1)
+      return CollapseKind::Outermost;
+    if (shape[1] == 1)
+      return CollapseKind::Middle;
+    return std::nullopt;
+  }
+
+  static unsigned getCollapsedDim(CollapseKind kind) {
+    return kind == CollapseKind::Outermost ? 0 : 1;
+  }
+
   void fuse(const DefUseChain &chain) final {
     assert(isa<tt::ReshapeOp>(chain.getEnd()) &&
            "Expecting 'chain' to be terminated by a 'tt.reshape' operation");
@@ -128,10 +153,12 @@ private:
 
     // Create a MakeTensorDescOp yielding a 2-dim tensor descriptor.
     auto descType = cast<tt::TensorDescType>(makeTensorDescOp.getType());
-    [[maybe_unused]] ArrayRef<int64_t> resShape =
+    ArrayRef<int64_t> resShape =
         cast<RankedTensorType>(descType.getBlockType()).getShape();
-    assert(resShape[0] == 1 && "Result shape should have extent equal to 1 in "
-                               "the outermost dimension");
+    std::optional<CollapseKind> kind = getCollapseKind(resShape);
+    assert(kind && "Result shape should have extent equal to 1 in either the "
+                   "outermost or the middle dimension");
+    const unsigned collapsedDim = getCollapsedDim(*kind);
 
     auto tensorType = cast<RankedTensorType>(reshapeOp.getType());
     auto newDescType = tt::TensorDescType::get(
@@ -142,47 +169,55 @@ private:
     OperandRange shapes = makeTensorDescOp.getShape();
     OperandRange strides = makeTensorDescOp.getStrides();
 
-    // Collapse the 3-dim tensor into a 2-dim tensor.
-    // Given a make_tensor_descriptor with:
-    //   shape  [s0, s1, s2]
-    //   stride [a, b, c]
-    // Create a make_tensor_descriptor with:
-    //   shape  [s0 * a / b + s1, s2]
-    //   stride [b, c]
-    SmallVector<Value> newShape(makeTensorDescOp.getShape().drop_front());
-    SmallVector<Value> newStrides(makeTensorDescOp.getStrides().drop_front());
+    // Merge `collapsedDim` into the next dimension. Erasing it from a 3-element
+    // list leaves the merged entry at index `collapsedDim`. Given shape
+    // [s0,s1,s2] / stride [a,b,c], produce for Outermost:
+    //   shape [s0 * a/b + s1, s2]        stride [b, c]
+    // and for Middle:
+    //   shape [s0, (s1-1) * b/c + s2]    stride [a, c]
+    SmallVector<Value> newShape(shapes);
+    SmallVector<Value> newStrides(strides);
+    newShape.erase(newShape.begin() + collapsedDim);
+    newStrides.erase(newStrides.begin() + collapsedDim);
 
-    const unsigned innermostDimIdx = shapes.size() - 1;
-    const unsigned newInnermostDimIdx = (innermostDimIdx - 1);
-    const unsigned newOutermostDimIdx = !newInnermostDimIdx;
-    auto div = arith::DivUIOp::create(builder, loc, strides[0],
-                                      newStrides[newOutermostDimIdx]);
-    auto trunc =
-        builder.createOrFold<arith::TruncIOp>(loc, shapes[0].getType(), div);
+    auto div = arith::DivUIOp::create(builder, loc, strides[collapsedDim],
+                                      strides[collapsedDim + 1]);
+    auto trunc = builder.createOrFold<arith::TruncIOp>(
+        loc, shapes[collapsedDim].getType(), div);
 
-    newShape[newOutermostDimIdx] = arith::AddIOp::create(
-        builder, loc, arith::MulIOp::create(builder, loc, shapes[0], trunc),
-        newShape[newOutermostDimIdx]);
+    // For Middle the merged dimension becomes the 2D block surface width, which
+    // must not exceed the pitch, so bound it exactly. Outermost merges into the
+    // surface height instead, which the pitch does not constrain.
+    Value scaled;
+    if (*kind == CollapseKind::Middle) {
+      Value one = arith::ConstantOp::create(
+          builder, loc,
+          builder.getIntegerAttr(shapes[collapsedDim].getType(), 1));
+      Value extentMinusOne =
+          arith::SubIOp::create(builder, loc, shapes[collapsedDim], one);
+      scaled = arith::MulIOp::create(builder, loc, extentMinusOne, trunc);
+    } else {
+      scaled = arith::MulIOp::create(builder, loc, shapes[collapsedDim], trunc);
+    }
+
+    newShape[collapsedDim] =
+        arith::AddIOp::create(builder, loc, scaled, newShape[collapsedDim]);
 
     Value newDesc = tt::MakeTensorDescOp::create(
         builder, loc, newDescType, makeTensorDescOp.getBase(), newShape,
         newStrides, makeTensorDescOp.getPadding());
     LLVM_DEBUG(llvm::dbgs() << "new MakeTensorDescOp:\n  " << newDesc << "\n");
 
-    // Adjust the descriptor load operation indices.
-    // Given a make_tensor_descriptor with shape/strides:
-    //   shape  [s0, s1, s2]
-    //   stride [a, b, c]
-    // And a descriptor_load with offsets:
-    //   offset [x, y, z]
-    // Create a new descriptor_load operation with indices:
-    //   offset [x * a / b + y, z]
+    // Adjust the load indices the same way: offsets [x,y,z] become
+    // [x * a/b + y, z] for Outermost and [x, y * b/c + z] for Middle.
     builder.setInsertionPoint(descLoadOp);
     OperandRange offsets = descLoadOp.getIndices();
-    SmallVector<Value> newOffsets(offsets.drop_front());
-    newOffsets[newOutermostDimIdx] = arith::AddIOp::create(
-        builder, loc, arith::MulIOp::create(builder, loc, offsets[0], trunc),
-        newOffsets[newOutermostDimIdx]);
+    SmallVector<Value> newOffsets(offsets);
+    newOffsets.erase(newOffsets.begin() + collapsedDim);
+    newOffsets[collapsedDim] = arith::AddIOp::create(
+        builder, loc,
+        arith::MulIOp::create(builder, loc, offsets[collapsedDim], trunc),
+        newOffsets[collapsedDim]);
 
     auto resType = cast<tt::TensorDescType>(newDesc.getType()).getBlockType();
     auto newDescLoadOp = tt::DescriptorLoadOp::create(
@@ -205,13 +240,13 @@ private:
   //   - tt.dot(tt.reshape(tt.load(..., )))
   //   - tt.dot(tt.reshape(tt.descriptor_load(..., )))
   // Where:
-  //  - the reshape operation drops the outermost dimension of the operand,
-  //    which is a 3-dim tensor with outermost dimension extent equal to one
+  //  - the reshape operation drops the outermost or the middle dimension of the
+  //    operand, which is a 3-dim tensor whose dropped dimension has extent one
   //  - the reshape result is used by a dot operation
   //  - the reshape operation uses the result of a 3-dim load operation on a
   //    tensor descriptor (transitively) defined by a `make_tensor_descriptor`
   //  - the tensor descriptor refers to a tensor that has extent
-  //    equal to 1 on the outermost dimension
+  //    equal to 1 on the dropped dimension
   //  - the load operation doesn't have boundary checks on either of the
   //    dimensions collapsed
   bool isCandidate(tt::ReshapeOp reshapeOp) const {
@@ -219,18 +254,19 @@ private:
 
     ArrayRef<int64_t> reshapeOperandShape =
         reshapeOp.getSrc().getType().getShape();
-    if (reshapeOperandShape.size() != 3 || reshapeOperandShape.front() != 1)
+    std::optional<CollapseKind> kind = getCollapseKind(reshapeOperandShape);
+    if (!kind)
       return false;
 
     ArrayRef<int64_t> reshapeResultShape = reshapeOp.getType().getShape();
     if (reshapeResultShape.size() != reshapeOperandShape.size() - 1)
       return false;
 
-    for (auto pair :
-         llvm::zip(reshapeOperandShape.drop_front(), reshapeResultShape)) {
-      if (std::get<0>(pair) != std::get<1>(pair))
-        return false;
-    }
+    // The reshape must drop exactly the unit-extent dimension.
+    SmallVector<int64_t> expectedShape(reshapeOperandShape);
+    expectedShape.erase(expectedShape.begin() + getCollapsedDim(*kind));
+    if (!llvm::equal(expectedShape, reshapeResultShape))
+      return false;
 
     // Check whether \p reshapeOp is used by a `dotOp`.
     auto usedByDotOp = [](tt::ReshapeOp reshapeOp) {
@@ -272,27 +308,24 @@ private:
 
     tt::TensorDescType descTy = makeTensorDescOp->getResult().getType();
     auto tensorTy = cast<RankedTensorType>(descTy.getBlockType());
-    assert((tensorTy.getRank() == 3 && tensorTy.getDimSize(0) == 1) &&
-           "Unexpected tensor type");
+    std::optional<CollapseKind> kind = getCollapseKind(tensorTy.getShape());
+    assert(kind && "Unexpected tensor type");
+    const unsigned collapsedDim = getCollapsedDim(*kind);
+    const unsigned mergedDim = collapsedDim + 1;
 
-    // The fusion collapses dimensions using strides[0] / strides[1]. This is
-    // only valid when strides[0] is an exact multiple of strides[1]. Reject
-    // cases where divisibility cannot be proven (e.g., padded strides).
+    // The fusion divides strides[collapsedDim] by strides[mergedDim], so it is
+    // only valid when that division is exact (e.g. not for padded strides).
     OperandRange strides = makeTensorDescOp->getStrides();
-    if (!isProvablyDivisible(strides[0], strides[1]))
+    if (!isProvablyDivisible(strides[collapsedDim], strides[mergedDim]))
       return false;
 
-    // After fusion the per-dimension bounds check on the collapsed (middle)
-    // dimension is replaced by a single bounds check on the merged
-    // dimension. That is only sound if a block load can never straddle the
-    // boundary between two "rows" of the outermost dimension, i.e. the real
-    // extent of the collapsed dimension must be an exact multiple of its
-    // block extent. Reject cases where this cannot be proven (e.g. the
-    // block extent is larger than the real extent, as with a ragged/padded
-    // last block).
+    // Fusion replaces the per-dimension bounds check on the collapsed dimension
+    // with a single check on the merged one, which is only sound if a block
+    // load can never straddle a boundary between two "rows" of the collapsed
+    // dimension.
     OperandRange shapes = makeTensorDescOp->getShape();
-    int64_t blockExtent = tensorTy.getDimSize(1);
-    if (!mlir::triton::gpu::intel::isDivisible(shapes[1], blockExtent))
+    int64_t blockExtent = tensorTy.getDimSize(mergedDim);
+    if (!mlir::triton::gpu::intel::isDivisible(shapes[mergedDim], blockExtent))
       return false;
 
     return true;

--- a/third_party/intel/lib/Dialect/Triton/Transforms/FuseReshape.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/FuseReshape.cpp
@@ -38,15 +38,13 @@ namespace {
 //   dot %A, ... : tensor<512x64xf16> x tensor<64x32xf16> -> tensor<512x32xf16>
 // into:
 //   %d = %a / %b
-//   %desc = tt.make_tensor_descriptor %base, [%s0*%d+%s1,%s2], [%b,%c]
+//   %desc = tt.make_tensor_descriptor %base, [(%s0-1)*%d+%s1,%s2], [%b,%c]
 //                       : !tt.tensordesc<512x64xf16>
 //   %A = tt.descriptor_load %desc[%x*%d+%y,%z] -> tensor<512x64xf16>
 //   dot %A, ... : tensor<512x64xf16> x tensor<64x32xf16> -> tensor<512x32xf16>
-// The unit-extent dimension may also be the middle one (e.g. a one-head tile of
-// a contiguous (TOKENS, HEADS, HEAD_DIM) tensor), collapsed the same way with
-// %d = %b / %c:
+// A unit-extent middle dimension (e.g. a one-head tile of a contiguous
+// (TOKENS, HEADS, HEAD_DIM) tensor) is collapsed the same way, with %d = %b/%c:
 //   %desc = tt.make_tensor_descriptor %base, [%s0,(%s1-1)*%d+%s2], [%a,%c]
-//                       : !tt.tensordesc<64x128xf16>
 //   %A = tt.descriptor_load %desc[%x,%y*%d+%z] -> tensor<64x128xf16>
 class FuseReshapeWithLoad : public tt::intel::Fuser {
 public:
@@ -104,23 +102,24 @@ public:
   }
 
 private:
-  /// The unit-extent dimension collapsed away by the fusion, always merged into
-  /// the dimension immediately following it: 1xNxM or Nx1xM -> NxM.
-  enum class CollapseKind { Outermost, Middle };
-
-  /// `Outermost` takes precedence, so a `1x1xM` shape keeps its prior behavior.
-  static std::optional<CollapseKind> getCollapseKind(ArrayRef<int64_t> shape) {
+  /// Return the unit-extent dimension collapsed into the one following it:
+  /// 1xNxM or Nx1xM -> NxM. Dimension 0 wins, so `1x1xM` keeps its behavior.
+  static std::optional<unsigned> getCollapsedDim(ArrayRef<int64_t> shape) {
     if (shape.size() != 3)
       return std::nullopt;
     if (shape[0] == 1)
-      return CollapseKind::Outermost;
+      return 0;
     if (shape[1] == 1)
-      return CollapseKind::Middle;
+      return 1;
     return std::nullopt;
   }
 
-  static unsigned getCollapsedDim(CollapseKind kind) {
-    return kind == CollapseKind::Outermost ? 0 : 1;
+  /// Return \p values without the element at index \p dim.
+  template <typename RangeT>
+  static auto dropDim(RangeT &&values, unsigned dim) {
+    auto res = llvm::to_vector(values);
+    res.erase(res.begin() + dim);
+    return res;
   }
 
   void fuse(const DefUseChain &chain) final {
@@ -152,13 +151,12 @@ private:
                             << descLoadOp << "\n");
 
     // Create a MakeTensorDescOp yielding a 2-dim tensor descriptor.
-    auto descType = cast<tt::TensorDescType>(makeTensorDescOp.getType());
-    ArrayRef<int64_t> resShape =
-        cast<RankedTensorType>(descType.getBlockType()).getShape();
-    std::optional<CollapseKind> kind = getCollapseKind(resShape);
-    assert(kind && "Result shape should have extent equal to 1 in either the "
-                   "outermost or the middle dimension");
-    const unsigned collapsedDim = getCollapsedDim(*kind);
+    std::optional<unsigned> dim =
+        getCollapsedDim(makeTensorDescOp.getType().getBlockType().getShape());
+    assert(dim && "Result shape should have extent equal to 1 in either the "
+                  "outermost or the middle dimension");
+    const unsigned collapsedDim = *dim;
+    const unsigned mergedDim = collapsedDim + 1;
 
     auto tensorType = cast<RankedTensorType>(reshapeOp.getType());
     auto newDescType = tt::TensorDescType::get(
@@ -169,55 +167,43 @@ private:
     OperandRange shapes = makeTensorDescOp.getShape();
     OperandRange strides = makeTensorDescOp.getStrides();
 
-    // Merge `collapsedDim` into the next dimension. Erasing it from a 3-element
-    // list leaves the merged entry at index `collapsedDim`. Given shape
-    // [s0,s1,s2] / stride [a,b,c], produce for Outermost:
-    //   shape [s0 * a/b + s1, s2]        stride [b, c]
-    // and for Middle:
-    //   shape [s0, (s1-1) * b/c + s2]    stride [a, c]
-    SmallVector<Value> newShape(shapes);
-    SmallVector<Value> newStrides(strides);
-    newShape.erase(newShape.begin() + collapsedDim);
-    newStrides.erase(newStrides.begin() + collapsedDim);
-
+    // An index pair (i,j) in `collapsedDim`/`mergedDim` addresses the same
+    // element as the single index i * d + j, with d = the stride ratio. Erasing
+    // `collapsedDim` leaves the merged entry at index `collapsedDim`, so shape
+    // [s0,s1,s2] / stride [a,b,c] yields [(s0-1)*a/b+s1, s2] / [b,c] or
+    // [s0, (s1-1)*b/c+s2] / [a,c].
     auto div = arith::DivUIOp::create(builder, loc, strides[collapsedDim],
-                                      strides[collapsedDim + 1]);
-    auto trunc = builder.createOrFold<arith::TruncIOp>(
+                                      strides[mergedDim]);
+    Value ratio = builder.createOrFold<arith::TruncIOp>(
         loc, shapes[collapsedDim].getType(), div);
+    auto merge = [&](Value hi, Value lo) -> Value {
+      return arith::AddIOp::create(
+          builder, loc, arith::MulIOp::create(builder, loc, hi, ratio), lo);
+    };
 
-    // For Middle the merged dimension becomes the 2D block surface width, which
-    // must not exceed the pitch, so bound it exactly. Outermost merges into the
-    // surface height instead, which the pitch does not constrain.
-    Value scaled;
-    if (*kind == CollapseKind::Middle) {
-      Value one = arith::ConstantOp::create(
-          builder, loc,
-          builder.getIntegerAttr(shapes[collapsedDim].getType(), 1));
-      Value extentMinusOne =
-          arith::SubIOp::create(builder, loc, shapes[collapsedDim], one);
-      scaled = arith::MulIOp::create(builder, loc, extentMinusOne, trunc);
-    } else {
-      scaled = arith::MulIOp::create(builder, loc, shapes[collapsedDim], trunc);
-    }
-
+    // The extent merges the largest *index* of the collapsed dimension, hence
+    // s-1: over-declaring it would loosen the descriptor's bounds check and,
+    // for an innermost `mergedDim`, push the block surface width past the
+    // pitch.
+    SmallVector<Value> newShape = dropDim(shapes, collapsedDim);
+    SmallVector<Value> newStrides = dropDim(strides, collapsedDim);
+    Value one = arith::ConstantIntOp::create(builder, loc,
+                                             shapes[collapsedDim].getType(), 1);
     newShape[collapsedDim] =
-        arith::AddIOp::create(builder, loc, scaled, newShape[collapsedDim]);
+        merge(arith::SubIOp::create(builder, loc, shapes[collapsedDim], one),
+              newShape[collapsedDim]);
 
     Value newDesc = tt::MakeTensorDescOp::create(
         builder, loc, newDescType, makeTensorDescOp.getBase(), newShape,
         newStrides, makeTensorDescOp.getPadding());
     LLVM_DEBUG(llvm::dbgs() << "new MakeTensorDescOp:\n  " << newDesc << "\n");
 
-    // Adjust the load indices the same way: offsets [x,y,z] become
-    // [x * a/b + y, z] for Outermost and [x, y * b/c + z] for Middle.
+    // Merge the load indices the same way, without the s-1: they are indices.
     builder.setInsertionPoint(descLoadOp);
     OperandRange offsets = descLoadOp.getIndices();
-    SmallVector<Value> newOffsets(offsets);
-    newOffsets.erase(newOffsets.begin() + collapsedDim);
-    newOffsets[collapsedDim] = arith::AddIOp::create(
-        builder, loc,
-        arith::MulIOp::create(builder, loc, offsets[collapsedDim], trunc),
-        newOffsets[collapsedDim]);
+    SmallVector<Value> newOffsets = dropDim(offsets, collapsedDim);
+    newOffsets[collapsedDim] =
+        merge(offsets[collapsedDim], newOffsets[collapsedDim]);
 
     auto resType = cast<tt::TensorDescType>(newDesc.getType()).getBlockType();
     auto newDescLoadOp = tt::DescriptorLoadOp::create(
@@ -245,8 +231,8 @@ private:
   //  - the reshape result is used by a dot operation
   //  - the reshape operation uses the result of a 3-dim load operation on a
   //    tensor descriptor (transitively) defined by a `make_tensor_descriptor`
-  //  - the tensor descriptor refers to a tensor that has extent
-  //    equal to 1 on the dropped dimension
+  //  - the descriptor's block shape equals the loaded shape (the *tensor*
+  //    extent on the dropped dimension is arbitrary)
   //  - the load operation doesn't have boundary checks on either of the
   //    dimensions collapsed
   bool isCandidate(tt::ReshapeOp reshapeOp) const {
@@ -254,18 +240,13 @@ private:
 
     ArrayRef<int64_t> reshapeOperandShape =
         reshapeOp.getSrc().getType().getShape();
-    std::optional<CollapseKind> kind = getCollapseKind(reshapeOperandShape);
-    if (!kind)
-      return false;
-
-    ArrayRef<int64_t> reshapeResultShape = reshapeOp.getType().getShape();
-    if (reshapeResultShape.size() != reshapeOperandShape.size() - 1)
+    std::optional<unsigned> collapsedDim = getCollapsedDim(reshapeOperandShape);
+    if (!collapsedDim)
       return false;
 
     // The reshape must drop exactly the unit-extent dimension.
-    SmallVector<int64_t> expectedShape(reshapeOperandShape);
-    expectedShape.erase(expectedShape.begin() + getCollapsedDim(*kind));
-    if (!llvm::equal(expectedShape, reshapeResultShape))
+    if (!llvm::equal(dropDim(reshapeOperandShape, *collapsedDim),
+                     reshapeOp.getType().getShape()))
       return false;
 
     // Check whether \p reshapeOp is used by a `dotOp`.
@@ -308,9 +289,17 @@ private:
 
     tt::TensorDescType descTy = makeTensorDescOp->getResult().getType();
     auto tensorTy = cast<RankedTensorType>(descTy.getBlockType());
-    std::optional<CollapseKind> kind = getCollapseKind(tensorTy.getShape());
-    assert(kind && "Unexpected tensor type");
-    const unsigned collapsedDim = getCollapsedDim(*kind);
+    // `tt.descriptor_load` only requires a matching element type and count, so
+    // the block shape may differ from the loaded shape (e.g. a rank-reducing
+    // load). The collapsed dimension is found in the loaded shape while the
+    // fusion indexes the descriptor's shape/strides, so the two must agree.
+    if (!llvm::equal(tensorTy.getShape(), descLoadOp.getType().getShape()))
+      return false;
+
+    std::optional<unsigned> dim = getCollapsedDim(tensorTy.getShape());
+    if (!dim)
+      return false;
+    const unsigned collapsedDim = *dim;
     const unsigned mergedDim = collapsedDim + 1;
 
     // The fusion divides strides[collapsedDim] by strides[mergedDim], so it is
@@ -319,10 +308,10 @@ private:
     if (!isProvablyDivisible(strides[collapsedDim], strides[mergedDim]))
       return false;
 
-    // Fusion replaces the per-dimension bounds check on the collapsed dimension
-    // with a single check on the merged one, which is only sound if a block
-    // load can never straddle a boundary between two "rows" of the collapsed
-    // dimension.
+    // Fusion replaces the per-dimension bounds check with a single check on the
+    // merged dimension, which is only sound if a block load can never straddle
+    // a boundary between two "rows" of the collapsed dimension, e.g. a
+    // ragged/padded last block (issues/7464).
     OperandRange shapes = makeTensorDescOp->getShape();
     int64_t blockExtent = tensorTy.getDimSize(mergedDim);
     if (!mlir::triton::gpu::intel::isDivisible(shapes[mergedDim], blockExtent))


### PR DESCRIPTION
FuseReshape only collapsed rank-3 descriptor loads of the form 1xNxM. A descriptor for a one-head tile of a contiguous (TOKENS, HEADS, HEAD_DIM) tensor has the shape Nx1xM, so it was skipped. LowerTo2DBlockLoad then rejected it because the tile is not in the innermost two dimensions. No 2D block load was emitted and the kernel was up to 10x slower than pointer loads.

Collapse a unit middle dimension too, merging it into the innermost one. The merged extent is bounded exactly, because it becomes the 2D block surface width and must not exceed the pitch.

Closes #7679 
