### PR TITLE
Revert "[Windows] Skip test_chain_reduce PTSS scratch-space overflow on a770/xe2"

### DIFF
--- a/scripts/skiplist/a770/intel.txt
+++ b/scripts/skiplist/a770/intel.txt
@@ -1,7 +1,2 @@
 # test_gather_warp_shuffle
 python/test/unit/intel/test_core.py::test_gather_warp_shuffle[src_shape1-indices_shape1-0-linear<{register = [[0, 2], [32, 0], [2, 0], [0, 16], [0, 32], [64, 0]], lane = [[0, 8], [8, 0], [1, 0], [4, 0], [16, 0]], warp = [[0, 1], [0, 4]], block = []}>-linear<{register = [[0, 2], [32, 0], [0, 32], [2, 0], [0, 16], [64, 0], [128, 0]], lane = [[0, 8], [8, 0], [1, 0], [4, 0], [16, 0]], warp = [[0, 1], [0, 4]], block = []}>]
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7503
-# Windows: kernel exceeds HW PTSS (per-thread scratch space) limit for this
-# layout/shape even after the 256-GRF retry path.
-python/test/unit/intel/test_core.py::test_chain_reduce[1-max-src_layout2-256-128]
-python/test/unit/intel/test_core.py::test_chain_reduce[1-max-src_layout2-256-256]

--- a/scripts/skiplist/xe2/intel.txt
+++ b/scripts/skiplist/xe2/intel.txt
@@ -1,5 +1,0 @@
-# https://github.com/intel/intel-xpu-backend-for-triton/issues/7503
-# Windows: kernel exceeds HW PTSS (per-thread scratch space) limit for this
-# layout/shape even after the 256-GRF retry path.
-python/test/unit/intel/test_core.py::test_chain_reduce[1-max-src_layout2-256-128]
-python/test/unit/intel/test_core.py::test_chain_reduce[1-max-src_layout2-256-256]


### PR DESCRIPTION
Reverts intel/intel-xpu-backend-for-triton#7506

Testing if #7503 is fixed via #7324