### PR TITLE
[scripts] Use `uv pip` when pip is not available

### DIFF
--- a/scripts/compile-triton.sh
+++ b/scripts/compile-triton.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 export PIP_DISABLE_PIP_VERSION_CHECK=1
 
+# Provides the `pip` wrapper (pip or `uv pip`).
+source "$(dirname "$0")/pip-utils.sh"
+
 # Select what to build.
 BUILD_LLVM=false
 BUILD_TRITON=false

--- a/scripts/docs-triton.sh
+++ b/scripts/docs-triton.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Provides the `pip` wrapper (pip or `uv pip`).
+source "$(dirname "$0")/pip-utils.sh"
+
 # Select which tests to run.
 VENV=false
 ARGS=
@@ -36,7 +39,7 @@ export TRITON_PROJ=$BASE/intel-xpu-backend-for-triton
 export TRITON_PROJ_BUILD=$TRITON_PROJ/python/build
 export SCRIPTS_DIR=$(cd $(dirname "$0") && pwd)
 
-python3 -m pip install lit pytest pytest-xdist pytest-rerunfailures 'pytest-skip>=0.2.0'
+pip install lit pytest pytest-xdist pytest-rerunfailures 'pytest-skip>=0.2.0'
 
 source $SCRIPTS_DIR/pytest-utils.sh
 $SCRIPTS_DIR/install-pytorch.sh $([ $VENV = true ] && echo "--venv")
@@ -52,7 +55,7 @@ run_build_docs() {
   echo "***************************************************"
   echo "************   Building Triton Docs    ************"
   echo "***************************************************"
-  python3 -m pip install matplotlib 'pandas<3.0' tabulate sphinx sphinx_rtd_theme sphinx_gallery sphinx_multiversion myst_parser -q
+  pip install matplotlib 'pandas<3.0' tabulate sphinx sphinx_rtd_theme sphinx_gallery sphinx_multiversion myst_parser -q
   cd $TRITON_PROJ/docs
   python3 -m sphinx . _build/html/mai
 }

--- a/scripts/install-pti.sh
+++ b/scripts/install-pti.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Provides the `pip` wrapper (pip or `uv pip`).
+source "$(dirname "$0")/pip-utils.sh"
+
 # Select what to build.
 BUILD_LEVEL_ZERO=false
 for arg in "$@"; do

--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Provides the `pip` wrapper (pip or `uv pip`).
+source "$(dirname "$0")/pip-utils.sh"
+
 # Select what to install.
 BUILD_PYTORCH=false
 BUILD_LATEST=false

--- a/scripts/pip-utils.sh
+++ b/scripts/pip-utils.sh
@@ -1,0 +1,57 @@
+# Common helper providing a `pip` wrapper that works both in traditional Python
+# environments and in uv-managed ones. Environments created by `uv venv` do not
+# contain pip, so packages have to be installed with `uv pip` there.
+#
+# Usage: source this file and call `pip` as usual, for example:
+#
+#   source "$(dirname "$0")/pip-utils.sh"
+#   pip install ninja
+#
+# `pip` is resolved in the following order:
+#   1. `python -m pip`, if pip is available in the active interpreter (this
+#      keeps the behavior of traditional environments unchanged);
+#   2. `uv pip`, if `uv` is in PATH (uv-managed environments without pip);
+# if neither is available, the wrapper fails with an explanatory message.
+
+# Resolved pip front-end, e.g. (python -m pip) or (uv pip). Empty until the
+# first `pip` call.
+PIP_CMD=()
+# Virtual environment `PIP_CMD` was resolved for, to re-resolve the front-end if
+# a virtual environment is activated (or deactivated) after this file is sourced.
+# The initial value is not a valid path, so the first `pip` call always resolves.
+PIP_CMD_VIRTUAL_ENV="<unresolved>"
+
+pip_python_cmd() {
+  if command -v python &>/dev/null; then
+    echo python
+  else
+    echo python3
+  fi
+}
+
+pip_resolve_cmd() {
+  local python_cmd
+  python_cmd="$(pip_python_cmd)"
+
+  if "$python_cmd" -m pip --version &>/dev/null; then
+    PIP_CMD=("$python_cmd" -m pip)
+  elif command -v uv &>/dev/null; then
+    PIP_CMD=(uv pip)
+  else
+    echo "**** ERROR: neither pip nor uv is available, cannot install Python packages. ****" >&2
+    echo "**** INFO: install pip ($python_cmd -m ensurepip) or uv (https://docs.astral.sh/uv/). ****" >&2
+    return 1
+  fi
+
+  PIP_CMD_VIRTUAL_ENV="${VIRTUAL_ENV:-}"
+  # Print to stderr, so that the message does not end up in the output of
+  # commands like `$(pip show <package>)`.
+  echo "**** Using '${PIP_CMD[*]}' to install Python packages ****" >&2
+}
+
+pip() {
+  if [ "$PIP_CMD_VIRTUAL_ENV" != "${VIRTUAL_ENV:-}" ]; then
+    pip_resolve_cmd || return 1
+  fi
+  "${PIP_CMD[@]}" "$@"
+}

--- a/scripts/pip-utils.sh
+++ b/scripts/pip-utils.sh
@@ -21,8 +21,12 @@ PIP_CMD=()
 # The initial value is not a valid path, so the first `pip` call always resolves.
 PIP_CMD_VIRTUAL_ENV="<unresolved>"
 
+# `python` is preferred over `python3`, because the scripts run `python`
+# themselves, so packages have to be installed for that interpreter, and because
+# `python3` does not necessarily exist on Windows. `python3` is used when
+# `python` is missing or is Python 2.
 pip_python_cmd() {
-  if command -v python &>/dev/null; then
+  if [ "$(python -c 'import sys; print(sys.version_info[0])' 2>/dev/null)" = 3 ]; then
     echo python
   else
     echo python3

--- a/scripts/sglang/install-sglang.sh
+++ b/scripts/sglang/install-sglang.sh
@@ -60,6 +60,9 @@ done
 SGLANG_SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SGLANG_SCRIPTS_DIR/../.." && pwd)"
 
+# Provides the `pip` wrapper (pip or `uv pip`).
+source "$ROOT/scripts/pip-utils.sh"
+
 # Clone/install into the project root (matches scripts/vllm/install-vllm.sh and
 # test-triton.sh's run_sglang_tests, which expect ./sglang there).
 cd "$ROOT"

--- a/scripts/test-pytorch.sh
+++ b/scripts/test-pytorch.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Provides the `pip` wrapper (pip or `uv pip`).
+source "$(dirname "$0")/pip-utils.sh"
+
 cd pytorch
 pip install -r .ci/docker/requirements-ci.txt
 

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -432,6 +432,8 @@ fi
 TRITON_PROJ="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && cd .. && pwd )"
 SCRIPTS_DIR="$TRITON_PROJ/scripts"
 source "$SCRIPTS_DIR/pytest-utils.sh"
+# Provides the `pip` wrapper (pip or `uv pip`).
+source "$SCRIPTS_DIR/pip-utils.sh"
 
 if [ "$TRITON_TEST_REPORTS" == true ]; then
     capture_runtime_env
@@ -442,10 +444,10 @@ install_deps() {
     echo "**** Skipping installation of pip dependencies ****"
   else
     echo "**** Installing pip dependencies ****"
-    python -m pip install -r "$SCRIPTS_DIR/requirements-test.txt"
+    pip install -r "$SCRIPTS_DIR/requirements-test.txt"
 
     if [ "$TRITON_TEST_WARNING_REPORTS" == true ]; then
-      python -m pip install git+https://github.com/kwasd/pytest-capturewarnings-ng@v1.2.0
+      pip install git+https://github.com/kwasd/pytest-capturewarnings-ng@v1.2.0
     fi
   fi
 
@@ -661,7 +663,7 @@ run_tutorial_tests() {
   echo "***************************************************"
   echo "**** Running Triton Tutorial tests           ******"
   echo "***************************************************"
-  python -m pip install matplotlib 'pandas<3.0' tabulate -q
+  pip install matplotlib 'pandas<3.0' tabulate -q
 
   cd $TRITON_PROJ/python/test/tutorials
 
@@ -802,7 +804,7 @@ run_test_deps_install() {
 
 run_vllm_test_deps_install() {
   run_test_deps_install
-  python -m pip install \
+  pip install \
     accelerate \
     blake3 \
     cachetools \

--- a/scripts/vllm/install-vllm.sh
+++ b/scripts/vllm/install-vllm.sh
@@ -8,6 +8,9 @@ readonly SCRIPTS_DIR="$ROOT/scripts"
 readonly VLLM_PROJ="$ROOT/vllm"
 readonly VLLM_XPU_KERNELS_PROJ="$ROOT/vllm-xpu-kernels"
 
+# Provides the `pip` wrapper (pip or `uv pip`).
+source "$SCRIPTS_DIR/pip-utils.sh"
+
 # Check if the specified package is installed and matches the pinned commit.
 # Returns 0 if the installed package is correct, 1 if it needs to be installed/reinstalled.
 check_installed_package() {
@@ -16,18 +19,18 @@ check_installed_package() {
   local force="$3"
   local latest="$4"
 
-  if ! python -m pip show "$package" &>/dev/null; then
+  if ! pip show "$package" &>/dev/null; then
     return 1
   fi
 
   if [[ "$latest" == true ]]; then
     echo "*** --latest specified: ignoring installed $package. ***"
-    python -m pip uninstall -y "$package"
+    pip uninstall -y "$package"
 
     return 1
   fi
 
-  local current_commit="$(python -m pip show "$package" | awk '/^Version:/ {print $2}')"
+  local current_commit="$(pip show "$package" | awk '/^Version:/ {print $2}')"
   current_commit="${current_commit#*+g}"
   current_commit="${current_commit%%.*}"
   echo "*** $package is installed at commit: $current_commit. ***"
@@ -48,15 +51,15 @@ check_installed_package() {
     exit 1
   fi
 
-  python -m pip uninstall -y "$package"
+  pip uninstall -y "$package"
 
   return 1
 }
 
 show_installs() {
   echo "*** Installed versions: ***"
-  echo "vllm: $(python -m pip show vllm | awk '/^Version:/ {print $2}')."
-  echo "vllm-xpu-kernels: $(python -m pip show vllm-xpu-kernels | awk '/^Version:/ {print $2}')."
+  echo "vllm: $(pip show vllm | awk '/^Version:/ {print $2}')."
+  echo "vllm-xpu-kernels: $(pip show vllm-xpu-kernels | awk '/^Version:/ {print $2}')."
 }
 
 update_submodules_and_clean() {
@@ -132,9 +135,9 @@ install_vllm() {
     -e '/^xgrammar/d' \
     -e '/^--extra-index-url.*https:\/\/download\.pytorch\.org\/whl/d' \
     "$VLLM_PROJ/requirements/xpu.txt"
-  python -m pip install -r "$VLLM_PROJ/requirements/xpu.txt"
+  pip install -r "$VLLM_PROJ/requirements/xpu.txt"
 
-  VLLM_TARGET_DEVICE=xpu python -m pip install --no-deps --no-build-isolation -e "$VLLM_PROJ"
+  VLLM_TARGET_DEVICE=xpu pip install --no-deps --no-build-isolation -e "$VLLM_PROJ"
 }
 
 cd "$ROOT"
@@ -313,7 +316,7 @@ if [[ "$build_vllm" == false ]]; then
 
     if [[ "$vllm_xpu_kernels_pinned_commit" == "$wheel_commit"* ]]; then
       echo "*** Installing vLLM XPU kernels from nightly builds. ***"
-      python -m pip install "$downloaded_wheel"
+      pip install "$downloaded_wheel"
       echo "*** Installing vLLM from source. ***"
       install_vllm
       show_installs
@@ -373,11 +376,11 @@ if [[ "$check_wheel" == false ]] || [[ "$vllm_xpu_kernels_wheel_exists" == false
     -e '/^triton/d' \
     -e '/^--extra-index-url.*https:\/\/download\.pytorch\.org\/whl/d' \
     "$VLLM_XPU_KERNELS_PROJ/requirements.txt"
-  python -m pip install -r "$VLLM_XPU_KERNELS_PROJ/requirements.txt"
+  pip install -r "$VLLM_XPU_KERNELS_PROJ/requirements.txt"
   VLLM_TARGET_DEVICE=xpu python -m build --wheel --no-isolation "$VLLM_XPU_KERNELS_PROJ"
 fi
 
 install_vllm
-python -m pip install "$VLLM_XPU_KERNELS_PROJ"/dist/*.whl
+pip install "$VLLM_XPU_KERNELS_PROJ"/dist/*.whl
 
 show_installs


### PR DESCRIPTION
## Problem

Environments created by `uv venv` do not contain `pip`, so every script in
`scripts/` that installs Python packages fails there. Replacing `pip` with
`uv pip` unconditionally is not an option either: it breaks everyone who keeps
using traditional Python tooling and does not have `uv` installed.

## Fix

Add `scripts/pip-utils.sh`, a sourced helper (like `scripts/pytest-utils.sh`)
that defines a `pip` wrapper resolving to:

1. `python -m pip`, if pip is available in the active interpreter — traditional
   environments and CI keep the exact behavior they have today;
2. `uv pip`, if `uv` is in PATH — uv-managed environments without pip;

and failing with an explanatory message if neither is available.

Notes on the implementation:

* The front-end is resolved on the first `pip` call and re-resolved whenever
  `VIRTUAL_ENV` changes, so the `--venv` options that activate an environment
  *after* the helper is sourced (`compile-triton.sh`, `docs-triton.sh`,
  `test-triton.sh`, `install-pytorch.sh`) pick the right front-end.
* The "Using '<cmd>'" notice is printed to stderr, so command substitutions
  such as `$(pip show vllm | awk ...)` in `scripts/vllm/install-vllm.sh` stay
  clean.
* `pip` is preferred over `uv pip` when both are usable, so that merely having
  `uv` installed does not change any existing flow. This also matters because
  `scripts/install-pti.sh` runs `pip install uv`, which would otherwise flip
  the remaining scripts to `uv pip` in the middle of a run, and because
  `uv pip install` refuses to run outside a virtual environment without
  `--system`.

All `pip` / `python -m pip` invocations in `scripts/` now go through the
wrapper:

* `scripts/compile-triton.sh`
* `scripts/docs-triton.sh`
* `scripts/install-pti.sh`
* `scripts/install-pytorch.sh`
* `scripts/sglang/install-sglang.sh`
* `scripts/test-pytorch.sh`
* `scripts/test-triton.sh`
* `scripts/vllm/install-vllm.sh`

## Testing

* `bash -n` on all touched scripts, `--help` smoke runs of each script.
* Environment with pip resolves to `python -m pip`; a pip-less `uv venv`
  resolves to `uv pip`; activating a venv after sourcing re-resolves correctly;
  with neither pip nor uv available the wrapper fails with the error message.
* Replayed the `install-pytorch.sh` check sequence (`pip show torch`,
  `pip list --format=freeze`, `pip install`, `pip uninstall -y`) against a
  pip-less `uv venv`: all commands work (`uv` accepts `-y` as a no-op).
* `scripts/install-pytorch.sh` in a regular environment still short-circuits
  correctly on the pinned commit.
