### PR TITLE
[vLLM] Increase test-suite timeout to 4 hours

### DIFF
--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -144,7 +144,7 @@ jobs:
           - vllm-tdesc
           - vllm-rest
     runs-on: ${{ fromJSON((inputs.runner_label == '' || startsWith(inputs.runner_label, 'max')) && format('["linux", "rolling", "{0}"]', inputs.runner_label || 'max1100') || format('["linux", "{0}"]', inputs.runner_label)) }}
-    timeout-minutes: 180
+    timeout-minutes: 240
     defaults:
       run:
         shell: bash -noprofile --norc -eo pipefail -c "source /opt/intel/oneapi/setvars.sh > /dev/null; source {0}"


### PR DESCRIPTION
Some recent vLLM test runs have nearly finished but been cancelled by the 3 hour test-suite timeout.

I'm increasing the timeout by 1 hour for a bigger buffer.

Example run that barely hit the timeout: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/33010397128/job/98527118176