### PR TITLE
[LoadStoreOpToLLVM] Default tt.descriptor_load to predicated loads

### DIFF
--- a/python/test/unit/intel/test_block_tdesc.py
+++ b/python/test/unit/intel/test_block_tdesc.py
@@ -6,14 +6,6 @@ import triton
 from triton._internal_testing import is_xpu
 
 
-@pytest.fixture(autouse=True, params=[False, True], ids=["branch-io", "predicated-io"])
-def predicated_io(request, monkeypatch):
-    if request.param:
-        monkeypatch.setenv("TRITON_INTEL_PREDICATED_LOAD", "1")
-        monkeypatch.setenv("TRITON_INTEL_PREDICATED_STORE", "1")
-    yield
-
-
 @pytest.mark.parametrize("M, N",
                          [[256, 64], [256, 32], [128, 32], [128, 16], [64, 64], [64, 32], [32, 32], [16, 64], [16, 16]])
 @pytest.mark.parametrize("dtype_str", ["float32", "float16", "int8"])

--- a/test/Conversion/intel/tritongpu_to_gen.mlir
+++ b/test/Conversion/intel/tritongpu_to_gen.mlir
@@ -350,7 +350,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttig.su
     %10 = arith.cmpi "slt", %4, %9 : tensor<64xi32, #blocked>
     // load op has a vector width = 1 due to the %mask's alignment
     // PREDICATED: llvm.call spir_funccc @_Z27__spirv_PredicatedLoadINTELPU3AS1vbi({{.*}}) {{.*}} : (!llvm.ptr<1>, i1, i32) -> i32
-    // NO_PREDICATED: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<1> -> i32
+    // NO-PREDICATED: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<1> -> i32
     %11 = tt.load %6, %10 : tensor<64x!tt.ptr<f32>, #blocked>
     %12 = tt.load %8, %10 : tensor<64x!tt.ptr<f32>, #blocked>
     %13 = arith.addf %11, %12 : tensor<64xf32, #blocked>

--- a/test/TritonIntelGPU/descriptor_load_predicated_default.mlir
+++ b/test/TritonIntelGPU/descriptor_load_predicated_default.mlir
@@ -1,0 +1,171 @@
+// RUN: triton-opt %s -split-input-file --tritonintelgpu-lower-to-2d-block-load --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s --check-prefixes=CHECK,PREDICATED
+// RUN: env TRITON_INTEL_PREDICATED_LOAD=0 triton-opt %s -split-input-file --tritonintelgpu-lower-to-2d-block-load --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s --check-prefixes=CHECK,NO-PREDICATED
+// RUN: env TRITON_INTEL_PREDICATED_LOAD=yes triton-opt %s -split-input-file --tritonintelgpu-lower-to-2d-block-load --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s --check-prefixes=CHECK,PREDICATED
+
+// Pin the *default* lowering of tt.descriptor_load on the non-2D-block path.
+//
+// RUN 1 deliberately leaves TRITON_INTEL_PREDICATED_LOAD unset: it is the only
+// line here that pins the default, and the only one whose expected output
+// changes if the default is flipped back. RUN 2 pins the explicit `=0`
+// override. RUN 3 passes an unparseable value, which isEnvValueBool rejects to
+// nullopt and therefore must fall back to the default path.
+//
+// The pass order mirrors production (compiler.py: lower_to_2d_block_load ->
+// allocate_shared_memory -> to_llvmir). No chunk here puts a descriptor load
+// inside an scf.for, so --convert-scf-to-cf is not needed: createPredicatedBlock
+// splits the enclosing block, which an unlowered scf.for region rejects.
+//
+// TRITON_INTEL_PREDICATED_STORE is deliberately never set: descriptor stores are
+// already predicated by default, and pinning the var here would hide that.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_predicated_io"} {
+  // shape=[5,5] is not divisible by block_shape=[4,4], so the fallback emits
+  // PER-ELEMENT boundary masks.
+  // CHECK-LABEL: llvm.func spir_kernelcc @desc_load_default_per_element(
+  tt.func public @desc_load_default_per_element(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32) -> (tensor<4x4xf32, #blocked>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c5_i32 = arith.constant 5 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c5_i32, %c5_i32], [%c1_i64, %c4_i64] {order = array<i32: 0>} : <f32>, <4x4xf32>
+
+    // The mask IR is bit-for-bit identical in both arms, so the predicate
+    // operand is intentionally left as a wildcard; the load form is what
+    // discriminates them.
+    // CHECK:              %[[PTR0:.*]] = llvm.bitcast %{{.*}} : !llvm.ptr<1> to !llvm.ptr<1>
+    // CHECK:              %[[OTHER0:.*]] = llvm.bitcast %{{.*}} : vector<1xf32> to i32
+    // PREDICATED-NEXT:    %[[V0:.*]] = triton_gen.predicated_load %[[PTR0]], %{{.*}}, %[[OTHER0]] {cache_control = Default} : (!llvm.ptr<1>, i1, i32) -> i32
+    // NO-PREDICATED-NEXT: llvm.cond_br %{{.*}}, ^[[BB_LOAD:bb[0-9]+]], ^[[BB_MERGE:bb[0-9]+]](%[[OTHER0]] : i32)
+    // NO-PREDICATED-NEXT: ^[[BB_LOAD]]:
+    // NO-PREDICATED-NEXT: %[[LOADED0:.*]] = llvm.load %[[PTR0]] {alignment = 4 : i64} : !llvm.ptr<1> -> i32
+    // NO-PREDICATED-NEXT: llvm.br ^[[BB_MERGE]](%[[LOADED0]] : i32)
+    // NO-PREDICATED-NEXT: ^[[BB_MERGE]](%[[V0:.*]]: i32):
+    // CHECK-NEXT:         llvm.bitcast %[[V0]] : i32 to f32
+    %3 = tt.descriptor_load %0[%arg1, %arg2] : !tt.tensordesc<4x4xf32> -> tensor<4x4xf32, #blocked>
+    tt.return %3 : tensor<4x4xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_predicated_io"} {
+  // shape=[8,8] and offset=4 are both divisible by block_shape=[4,4], so the
+  // fallback emits BLOCK-LEVEL masks whose predicate is uniformly true. This is
+  // the regime the old "IGC folds control flow better" rationale was about: it
+  // still emits a mask, and after the flip it still becomes a predicated load.
+  // CHECK-LABEL: llvm.func spir_kernelcc @desc_load_default_block_level(
+  tt.func public @desc_load_default_block_level(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) -> (tensor<4x4xf32, #blocked>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c8_i32 = arith.constant 8 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c8_i32, %c8_i32], [%c1_i64, %c4_i64] {order = array<i32: 0>} : <f32>, <4x4xf32>
+
+    // CHECK:              %[[PTR0:.*]] = llvm.bitcast %{{.*}} : !llvm.ptr<1> to !llvm.ptr<1>
+    // CHECK:              %[[OTHER0:.*]] = llvm.bitcast %{{.*}} : vector<1xf32> to i32
+    // PREDICATED-NEXT:    %[[V0:.*]] = triton_gen.predicated_load %[[PTR0]], %{{.*}}, %[[OTHER0]] {cache_control = Default} : (!llvm.ptr<1>, i1, i32) -> i32
+    // NO-PREDICATED-NEXT: llvm.cond_br %{{.*}}, ^[[BB_LOAD:bb[0-9]+]], ^[[BB_MERGE:bb[0-9]+]](%[[OTHER0]] : i32)
+    // NO-PREDICATED-NEXT: ^[[BB_LOAD]]:
+    // NO-PREDICATED-NEXT: %[[LOADED0:.*]] = llvm.load %[[PTR0]] {alignment = 4 : i64} : !llvm.ptr<1> -> i32
+    // NO-PREDICATED-NEXT: llvm.br ^[[BB_MERGE]](%[[LOADED0]] : i32)
+    // NO-PREDICATED-NEXT: ^[[BB_MERGE]](%[[V0:.*]]: i32):
+    // CHECK-NEXT:         llvm.bitcast %[[V0]] : i32 to f32
+    %3 = tt.descriptor_load %0[%c4_i32, %c4_i32] : !tt.tensordesc<4x4xf32> -> tensor<4x4xf32, #blocked>
+    tt.return %3 : tensor<4x4xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 4], order = [1, 0]}>
+
+// Same shape as @desc_load_default_per_element, but the module does NOT carry
+// ttig.support_predicated_io. The capability gate short-circuits first, so every
+// arm - including the ones that request predication - must take the branch path.
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @desc_load_no_capability(
+  tt.func public @desc_load_no_capability(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32) -> (tensor<4x4xf32, #blocked>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c5_i32 = arith.constant 5 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c5_i32, %c5_i32], [%c1_i64, %c4_i64] {order = array<i32: 0>} : <f32>, <4x4xf32>
+
+    // CHECK-NOT:  triton_gen.predicated_load
+    // CHECK:      %[[PTR:.*]] = llvm.bitcast %{{.*}} : !llvm.ptr<1> to !llvm.ptr<1>
+    // CHECK:      %[[OTHER:.*]] = llvm.bitcast %{{.*}} : vector<1xf32> to i32
+    // CHECK-NEXT: llvm.cond_br %{{.*}}, ^[[BB_LOAD:bb[0-9]+]], ^[[BB_MERGE:bb[0-9]+]](%[[OTHER]] : i32)
+    // CHECK-NEXT: ^[[BB_LOAD]]:
+    // CHECK-NEXT: %[[LOADED:.*]] = llvm.load %[[PTR]] {alignment = 4 : i64} : !llvm.ptr<1> -> i32
+    // CHECK-NEXT: llvm.br ^[[BB_MERGE]](%[[LOADED]] : i32)
+    // CHECK-NOT:  triton_gen.predicated_load
+    %3 = tt.descriptor_load %0[%arg1, %arg2] : !tt.tensordesc<4x4xf32> -> tensor<4x4xf32, #blocked>
+    tt.return %3 : tensor<4x4xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_predicated_io"} {
+  // The DescriptorStoreOp default is unconditional in every arm: it is already
+  // on, and TRITON_INTEL_PREDICATED_LOAD must not perturb it.
+  // CHECK-LABEL: llvm.func spir_kernelcc @desc_store_default(
+  tt.func public @desc_store_default(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32, %arg3: tensor<4x4xf32, #blocked>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c5_i32 = arith.constant 5 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c5_i32, %c5_i32], [%c1_i64, %c4_i64] {order = array<i32: 0>} : <f32>, <4x4xf32>
+
+    // CHECK: triton_gen.predicated_store %{{.*}}, %{{.*}}, %{{.*}} {cache_control = Default} : (!llvm.ptr<1>, i32, i1) -> ()
+    tt.descriptor_store %0[%arg1, %arg2], %arg3 : !tt.tensordesc<4x4xf32>, tensor<4x4xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked1 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+// Only the predicated arm forwards the eviction-policy hint to an LSC
+// cache-control decoration; the branch arm drops it silently. Defaulting
+// descriptor loads to predication therefore starts emitting L1IAR_L3C where
+// nothing was emitted before - a second, independent behavioural change that
+// must not regress unnoticed.
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttig.support_predicated_io} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @desc_load_default_evict_first(
+  tt.func @desc_load_default_evict_first(%desc: !tt.tensordesc<128xf32>) {
+    %c0_i32 = arith.constant 0 : i32
+    // PREDICATED:        triton_gen.predicated_load %{{.*}}, %{{.*}}, %{{.*}} {cache_control = L1IAR_L3C} : (!llvm.ptr<1>, i1, i32) -> i32
+    // NO-PREDICATED-NOT: L1IAR_L3C
+    // NO-PREDICATED:     llvm.cond_br
+    // NO-PREDICATED-NOT: L1IAR_L3C
+    %val = tt.descriptor_load %desc[%c0_i32] evictionPolicy = evict_first : !tt.tensordesc<128xf32> -> tensor<128xf32, #blocked1>
+    tt.return
+  }
+}
+
+// -----
+
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth=1}>
+
+// A descriptor load that IS 2D-block-eligible never reaches the predication
+// gate, even with ttig.support_predicated_io present. If 2D lowering ever
+// declined this tile, it would fall through to the masked path and the
+// CHECK-NOT lines would fire.
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io", "ttig.support_predicated_io"} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @desc_load_2d_block_immune(
+  tt.func public @desc_load_2d_block_immune(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i32, %arg5: i32) {
+    %c1_i64 = arith.constant 1 : i64
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2], [%arg3, %c1_i64] : <f16>, <64x32xf16>
+    // CHECK-NOT:     triton_gen.predicated_load
+    // CHECK-COUNT-2: triton_gen.2Dblockload {{.*}} {elem_size_in_bits = 16, tile_width = 16, tile_height = 8, v_blocks = 2, transpose = false, vnni_transform = false, cache_control = Default}
+    // CHECK-NOT:     triton_gen.predicated_load
+    %load = tt.descriptor_load %desc[%arg4, %arg5] {ttig.block_io = "row_major"} : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #dot0>
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/descriptor_load_predicated_default.mlir
+++ b/test/TritonIntelGPU/descriptor_load_predicated_default.mlir
@@ -1,14 +1,13 @@
 // RUN: triton-opt %s -split-input-file --tritonintelgpu-lower-to-2d-block-load --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s --check-prefixes=CHECK,PREDICATED
 // RUN: env TRITON_INTEL_PREDICATED_LOAD=0 triton-opt %s -split-input-file --tritonintelgpu-lower-to-2d-block-load --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s --check-prefixes=CHECK,NO-PREDICATED
-// RUN: env TRITON_INTEL_PREDICATED_LOAD=yes triton-opt %s -split-input-file --tritonintelgpu-lower-to-2d-block-load --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s --check-prefixes=CHECK,PREDICATED
+// RUN: env TRITON_INTEL_PREDICATED_LOAD=1 triton-opt %s -split-input-file --tritonintelgpu-lower-to-2d-block-load --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s --check-prefixes=CHECK,PREDICATED
 
 // Pin the *default* lowering of tt.descriptor_load on the non-2D-block path.
 //
 // RUN 1 deliberately leaves TRITON_INTEL_PREDICATED_LOAD unset: it is the only
 // line here that pins the default, and the only one whose expected output
-// changes if the default is flipped back. RUN 2 pins the explicit `=0`
-// override. RUN 3 passes an unparseable value, which isEnvValueBool rejects to
-// nullopt and therefore must fall back to the default path.
+// changes if the default is flipped back. RUN 2 and RUN 3 pin the explicit
+// `=0` and `=1` overrides.
 //
 // The pass order mirrors production (compiler.py: lower_to_2d_block_load ->
 // allocate_shared_memory -> to_llvmir). No chunk here puts a descriptor load

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -452,13 +452,17 @@ struct LoadStoreConversionBase {
             op, TritonIntelGPUDialect::getSupportPredicatedIOAttrName()))
       return false;
 
-    // Predicated load is enabled by default for LoadOp but disabled by default
-    // for DescriptorLoadOp. DescriptorLoadOp always generates boundary-check
-    // predicates (even when all elements are in-bounds), and the predicated
-    // load intrinsic prevents IGC from optimizing these uniformly-true
-    // predicates as effectively as the control-flow-based approach. Both can be
-    // overridden by env vars. Predicated store is enabled by default for both
-    // op types.
+    // Note that the DescriptorLoadOp fallback *always* emits a boundary-check
+    // mask, even for provably in-bounds tiles: every dimension is classified as
+    // either block-level or per-element, so the unconditional-load path is
+    // unreachable for that op and the choice made here applies to all of its
+    // masked loads.
+    //
+    // Predicated load and store are both enabled by default for all four op
+    // types; either env var still overrides in both directions. Defaulting
+    // DescriptorLoadOp on gives up IGC's folding of uniformly-true predicates
+    // in the control-flow form; that trade measured favorable on Xe2, see
+    // issue #7090.
     static const std::optional<bool> usePredicatedLoad =
         tools::isEnvValueBool(tools::getStrEnv("TRITON_INTEL_PREDICATED_LOAD"));
     static const std::optional<bool> usePredicatedStore = tools::isEnvValueBool(
@@ -471,7 +475,7 @@ struct LoadStoreConversionBase {
     } else if constexpr (std::is_same_v<OpType, StoreOp>) {
       return !usePredicatedStore.has_value() || usePredicatedStore.value();
     } else if constexpr (std::is_same_v<OpType, DescriptorLoadOp>) {
-      return usePredicatedLoad.has_value() && usePredicatedLoad.value();
+      return !usePredicatedLoad.has_value() || usePredicatedLoad.value();
     } else if constexpr (std::is_same_v<OpType, DescriptorStoreOp>) {
       return !usePredicatedStore.has_value() || usePredicatedStore.value();
     }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -452,16 +452,16 @@ struct LoadStoreConversionBase {
             op, TritonIntelGPUDialect::getSupportPredicatedIOAttrName()))
       return false;
 
-    // Note that the DescriptorLoadOp fallback *always* emits a boundary-check
-    // mask, even for provably in-bounds tiles: every dimension is classified as
-    // either block-level or per-element, so the unconditional-load path is
-    // unreachable for that op and the choice made here applies to all of its
-    // masked loads.
+    // Predicated load and store are enabled by default for all four op types
+    // (LoadOp, StoreOp, DescriptorLoadOp, DescriptorStoreOp). Either env var
+    // (TRITON_INTEL_PREDICATED_LOAD, TRITON_INTEL_PREDICATED_STORE) overrides
+    // in both directions.
     //
-    // Predicated load and store are both enabled by default for all four op
-    // types; either env var still overrides in both directions. Defaulting
-    // DescriptorLoadOp on gives up IGC's folding of uniformly-true predicates
-    // in the control-flow form; that trade measured favorable on Xe2, see
+    // Note that DescriptorLoadOp always emits a boundary-check mask, even for
+    // provably in-bounds tiles, so this choice applies to all of its masked
+    // fallback loads (2D block loads bypass this path entirely). Predicating
+    // them costs IGC's folding of the uniformly-true predicates that the
+    // control-flow form exposes; that trade measured favorable on Xe2, see
     // issue #7090.
     static const std::optional<bool> usePredicatedLoad =
         tools::isEnvValueBool(tools::getStrEnv("TRITON_INTEL_PREDICATED_LOAD"));


### PR DESCRIPTION
DescriptorLoadOp was the only one of the four canUsePredicatedInstructions
specialisations that required TRITON_INTEL_PREDICATED_LOAD to be set
explicitly; LoadOp, StoreOp and DescriptorStoreOp already default to on. Make
it match, so an unset env var selects the predicated lowering. Either env var
still overrides in both directions.

Effect on a tt.descriptor_load that cannot become a 2D block read:

- The mask becomes an operand of triton_gen.predicated_load, lowering to
  __spirv_PredicatedLoadINTEL, rather than a branch condition around a plain
  load. createPredicatedBlock no longer splits the enclosing block, so the
  region keeps straight-line control flow.

- The eviction policy now reaches the LSC cache-control decoration: only the
  predicated arm forwards it through tritonToIntelCacheModifier, the branch arm
  drops it. This is visible only for descriptor loads that carry a non-NORMAL
  policy and also miss the 2D block path.

- Every masked fallback descriptor load is affected, not only those that need a
  mask. Each dimension is classified as block-level or per-element, so the
  unconditional-load arm is unreachable for this op, and provably in-bounds
  tiles with a uniformly-true predicate now take the predicated form too.

2D block reads never reach this gate and are unchanged.

Closes #7090, which has the measurements and rationale.
