### PR TITLE
[SimplifySignedArithmetic] Recognize PyTorch floordiv patterns

### DIFF
--- a/test/Triton/Intel/SimplifySignedArithmetic/floordiv-pattern.mlir
+++ b/test/Triton/Intel/SimplifySignedArithmetic/floordiv-pattern.mlir
@@ -1,0 +1,137 @@
+// RUN: triton-opt %s -split-input-file -triton-intel-simplify-signed-arithmetic | FileCheck %s
+
+// Test the PyTorch Inductor floordiv lowering pattern.
+// The floordiv implementation uses bitwise complement (~) to handle negative dividends,
+// and abs() for the divisor. SimplifySignedArithmetic should recognize these patterns
+// and convert the final divsi to divui.
+
+// CHECK-LABEL: tt.func @floordiv_pattern
+tt.func @floordiv_pattern(%a: i32, %b: i32) -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %c_minus1 = arith.constant -1 : i32
+
+  // Step 1: Guard against division by zero
+  %b_zero = arith.cmpi eq, %b, %c0 : i32
+  %b_safe = arith.select %b_zero, %c1, %b : i32
+
+  // Step 2: Make b positive by taking absolute value
+  %b_neg = arith.cmpi slt, %b_safe, %c0 : i32
+  %neg_a = arith.subi %c0, %a : i32
+  %a1 = arith.select %b_neg, %neg_a, %a : i32
+  %neg_b = arith.subi %c0, %b_safe : i32
+  %b_pos = arith.select %b_neg, %neg_b, %b_safe : i32
+
+  // Step 3: Make a non-negative using bitwise complement
+  %a_neg = arith.cmpi slt, %a1, %c0 : i32
+  %not_a = arith.xori %a1, %c_minus1 : i32
+  %a_nonneg = arith.select %a_neg, %not_a, %a1 : i32
+
+  // Step 4: Divide - should be optimized to divui
+  // CHECK: arith.divui
+  // CHECK-NOT: arith.divsi
+  %quot = arith.divsi %a_nonneg, %b_pos : i32
+
+  // Step 5: Transform result back
+  %quot_fixed = arith.xori %quot, %c_minus1 : i32
+  %result1 = arith.select %a_neg, %quot_fixed, %quot : i32
+  %result = arith.select %b_zero, %c0, %result1 : i32
+
+  tt.return %result : i32
+}
+
+// -----
+
+// CHECK-LABEL: @floordiv_pattern_tensor
+// Test with tensor types (vectorized floordiv)
+tt.func @floordiv_pattern_tensor(%a: tensor<1024xi32>, %b: tensor<1024xi32>) -> tensor<1024xi32> {
+  %c0 = arith.constant dense<0> : tensor<1024xi32>
+  %c1 = arith.constant dense<1> : tensor<1024xi32>
+  %c_minus1 = arith.constant dense<-1> : tensor<1024xi32>
+
+  // Step 1: Guard against division by zero
+  %b_zero = arith.cmpi eq, %b, %c0 : tensor<1024xi32>
+  %b_safe = arith.select %b_zero, %c1, %b : tensor<1024xi1>, tensor<1024xi32>
+
+  // Step 2: Make b positive by taking absolute value
+  %b_neg = arith.cmpi slt, %b_safe, %c0 : tensor<1024xi32>
+  %neg_a = arith.subi %c0, %a : tensor<1024xi32>
+  %a1 = arith.select %b_neg, %neg_a, %a : tensor<1024xi1>, tensor<1024xi32>
+  %neg_b = arith.subi %c0, %b_safe : tensor<1024xi32>
+  %b_pos = arith.select %b_neg, %neg_b, %b_safe : tensor<1024xi1>, tensor<1024xi32>
+
+  // Step 3: Make a non-negative using bitwise complement
+  %a_neg = arith.cmpi slt, %a1, %c0 : tensor<1024xi32>
+  %not_a = arith.xori %a1, %c_minus1 : tensor<1024xi32>
+  %a_nonneg = arith.select %a_neg, %not_a, %a1 : tensor<1024xi1>, tensor<1024xi32>
+
+  // Step 4: Divide - should be optimized to divui
+  // CHECK: arith.divui
+  // CHECK-NOT: arith.divsi
+  %quot = arith.divsi %a_nonneg, %b_pos : tensor<1024xi32>
+
+  // Step 5: Transform result back
+  %quot_fixed = arith.xori %quot, %c_minus1 : tensor<1024xi32>
+  %result1 = arith.select %a_neg, %quot_fixed, %quot : tensor<1024xi1>, tensor<1024xi32>
+  %result = arith.select %b_zero, %c0, %result1 : tensor<1024xi1>, tensor<1024xi32>
+
+  tt.return %result : tensor<1024xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @floordiv_simplified
+// Test a simplified version without all the transformations
+// This should NOT be optimized because we can't prove the properties
+tt.func @floordiv_simplified(%a: i32, %b: i32) -> i32 {
+  // Without the pattern, divsi should remain
+  // CHECK: arith.divsi
+  // CHECK-NOT: arith.divui
+  %quot = arith.divsi %a, %b : i32
+  tt.return %quot : i32
+}
+
+// -----
+
+// CHECK-LABEL: @abs_pattern_positive
+// Test that abs pattern is recognized when input is guaranteed non-zero
+tt.func @abs_pattern_positive(%x: i32) -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+
+  // Make x non-zero: select(x == 0, 1, x)
+  %x_zero = arith.cmpi eq, %x, %c0 : i32
+  %x_nonzero = arith.select %x_zero, %c1, %x : i32
+
+  // Take absolute value: select(x < 0, -x, x)
+  %x_neg = arith.cmpi slt, %x_nonzero, %c0 : i32
+  %neg_x = arith.subi %c0, %x_nonzero : i32
+  %abs_x = arith.select %x_neg, %neg_x, %x_nonzero : i32
+
+  // Use as divisor - should be recognized as strictly positive
+  // CHECK: arith.divui
+  // CHECK-NOT: arith.divsi
+  %result = arith.divsi %c1, %abs_x : i32
+  tt.return %result : i32
+}
+
+// -----
+
+// CHECK-LABEL: @bitwise_not_nonnegative
+// Test that select(x < 0, ~x, x) is recognized as non-negative
+tt.func @bitwise_not_nonnegative(%x: i32) -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %c_minus1 = arith.constant -1 : i32
+
+  // Pattern: select(x < 0, ~x, x)
+  %x_neg = arith.cmpi slt, %x, %c0 : i32
+  %not_x = arith.xori %x, %c_minus1 : i32
+  %x_nonneg = arith.select %x_neg, %not_x, %x : i32
+
+  // Use as dividend with positive divisor
+  // CHECK: arith.divui
+  // CHECK-NOT: arith.divsi
+  %result = arith.divsi %x_nonneg, %c1 : i32
+  tt.return %result : i32
+}

--- a/third_party/intel/lib/Dialect/Triton/Transforms/SimplifySignedArithmetic.cpp
+++ b/third_party/intel/lib/Dialect/Triton/Transforms/SimplifySignedArithmetic.cpp
@@ -1,5 +1,6 @@
 #include "intel/include/Analysis/Range.h"
 #include "intel/include/Dialect/Triton/Transforms/Passes.h"
+#include "intel/include/Utils/Utility.h"
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Dominance.h"
@@ -107,6 +108,68 @@ private:
     return isNonNegative(op.getLhs()) && isStrictlyPositive(op.getRhs());
   }
 
+  /// Helper: Check if select matches pattern: select(x < 0, xor(x, -1), x)
+  /// This is the bitwise NOT pattern used by PyTorch floordiv.
+  static bool matchesBitwiseNotPattern(arith::SelectOp selOp) {
+    auto cmpOp = selOp.getCondition().getDefiningOp<arith::CmpIOp>();
+    if (!cmpOp || cmpOp.getPredicate() != arith::CmpIPredicate::slt)
+      return false;
+
+    Value cmpLhs = cmpOp.getLhs();
+    if (!tt::intel::isConstant(cmpOp.getRhs(), 0))
+      return false;
+
+    auto xorOp = selOp.getTrueValue().getDefiningOp<arith::XOrIOp>();
+    if (!xorOp || selOp.getFalseValue() != cmpLhs)
+      return false;
+
+    // Check xor(x, -1) in either operand order
+    return (xorOp.getLhs() == cmpLhs &&
+            tt::intel::isConstant(xorOp.getRhs(), -1)) ||
+           (xorOp.getRhs() == cmpLhs &&
+            tt::intel::isConstant(xorOp.getLhs(), -1));
+  }
+
+  /// Helper: Check if value is guaranteed non-zero via pattern: select(x == 0,
+  /// positive_const, x)
+  bool isGuaranteedNonZero(Value value) const {
+    auto selOp = value.getDefiningOp<arith::SelectOp>();
+    if (!selOp)
+      return false;
+
+    auto cmpOp = selOp.getCondition().getDefiningOp<arith::CmpIOp>();
+    if (!cmpOp || cmpOp.getPredicate() != arith::CmpIPredicate::eq)
+      return false;
+
+    // Pattern: select(x == 0, positive_const, x)
+    // Check: comparison is against zero, true branch is positive, false branch
+    // is x
+    return tt::intel::isConstant(cmpOp.getRhs(), 0) &&
+           isPositiveConstant(selOp.getTrueValue()) &&
+           selOp.getFalseValue() == cmpOp.getLhs();
+  }
+
+  /// Helper: Check if select matches pattern: select(x < 0, sub(0, x), x) =
+  /// abs(x)
+  static bool matchesAbsPattern(arith::SelectOp selOp, Value &absOperand) {
+    auto cmpOp = selOp.getCondition().getDefiningOp<arith::CmpIOp>();
+    if (!cmpOp || cmpOp.getPredicate() != arith::CmpIPredicate::slt)
+      return false;
+
+    Value cmpLhs = cmpOp.getLhs();
+    if (!tt::intel::isConstant(cmpOp.getRhs(), 0) ||
+        selOp.getFalseValue() != cmpLhs)
+      return false;
+
+    auto subOp = selOp.getTrueValue().getDefiningOp<arith::SubIOp>();
+    if (!subOp || !tt::intel::isConstant(subOp.getLhs(), 0) ||
+        subOp.getRhs() != cmpLhs)
+      return false;
+
+    absOperand = cmpLhs;
+    return true;
+  }
+
   /// Returns true if value is provably non-negative (>= 0).
   bool isNonNegative(Value value) const {
     // Check range analysis first
@@ -188,11 +251,23 @@ private:
     if (auto minOp = dyn_cast<arith::MinSIOp>(defOp))
       return isNonNegative(minOp.getLhs()) && isNonNegative(minOp.getRhs());
 
-    // arith.select yields one of its two value operands; non-negative iff both
-    // candidate values are non-negative.
-    if (auto selOp = dyn_cast<arith::SelectOp>(defOp))
+    // arith.select: check for special patterns first, then general case
+    if (auto selOp = dyn_cast<arith::SelectOp>(defOp)) {
+      // Special pattern: select(x < 0, xor(x, -1), x)
+      // This is the floordiv pattern for ensuring non-negative dividend.
+      // When x < 0: ~x = -(x+1) >= 0 (since x <= -1)
+      // When x >= 0: x >= 0
+      if (matchesBitwiseNotPattern(selOp)) {
+        LLVM_DEBUG(
+            llvm::dbgs()
+            << "Recognized pattern: select(x < 0, ~x, x) is non-negative\n");
+        return true;
+      }
+
+      // General case: non-negative iff both branches are non-negative
       return isNonNegative(selOp.getTrueValue()) &&
              isNonNegative(selOp.getFalseValue());
+    }
 
     // arith.andi is non-negative if EITHER operand is non-negative, since
     // MSB(a & b) = MSB(a) & MSB(b). Subsumes the constant-mask case.
@@ -265,6 +340,19 @@ private:
     if (auto maxOp = dyn_cast<arith::MaxSIOp>(defOp))
       return isStrictlyPositive(maxOp.getLhs()) ||
              isStrictlyPositive(maxOp.getRhs());
+
+    // Pattern: abs(x) where x is guaranteed non-zero
+    // select(x < 0, sub(0, x), x) = abs(x) is strictly positive if x != 0
+    if (auto selOp = dyn_cast<arith::SelectOp>(defOp)) {
+      Value absOperand;
+      if (matchesAbsPattern(selOp, absOperand) &&
+          isGuaranteedNonZero(absOperand)) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "Recognized pattern: abs(select(x==0, 1, x)) "
+                      "is strictly positive\n");
+        return true;
+      }
+    }
 
     // tt.splat preserves strict positivity (tensor divisors).
     if (auto splatOp = dyn_cast<tt::SplatOp>(defOp))


### PR DESCRIPTION
This change enables SimplifySignedArithmetic to optimize PyTorch Inductor's floordiv lowering by recognizing two specific patterns:

1. Bitwise NOT for non-negative values: `select(x < 0, xor(x, -1), x)`
   - When x < 0: ~x = -(x+1) >= 0 (since x <= -1)
   - When x >= 0: x >= 0
   - Result is always non-negative

2. Absolute value with non-zero guard: `abs(select(y == 0, 1, y))`
   - Combines zero-guard with absolute value
   - Result is always strictly positive

PyTorch Inductor lowers floordiv using these patterns to safely convert signed division to unsigned division. Previously, SimplifySignedArithmetic couldn't recognize this pattern, missing optimization opportunities.

With these additions, divsi operations in the floordiv pattern are now correctly converted to divui, improving performance on hardware where unsigned division is more efficient.