### PR TITLE
[benchmarks] Run third-party benchmarks on b580 instead of max1550

### DIFF
--- a/.github/workflows/third-party-benchmarks.yml
+++ b/.github/workflows/third-party-benchmarks.yml
@@ -56,7 +56,7 @@ jobs:
     name: Third party benchmarks
     runs-on:
       - linux
-      - ${{ inputs.runner_label || 'max1550' }}
+      - ${{ inputs.runner_label || 'b580' }}
     timeout-minutes: 720
     defaults:
       run:


### PR DESCRIPTION
Change the default runner label for the third party benchmarks workflow from max1550 (PVC) to b580 (BMG).

This will impact scheduled, PR-triggered, and default manually dispatched runs.

I will create issues for any failures.