### PR TITLE
[XPU] Use shared attachAllocationSizeAndOffsetAttr in AllocateSharedMemory

### DIFF
--- a/test/Conversion/intel/intel-allocate-shared-memory.mlir
+++ b/test/Conversion/intel/intel-allocate-shared-memory.mlir
@@ -45,6 +45,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 // CHECK-SAME: ttg.shared = 544 : i32
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32} {
   tt.func @test_f16(%arg0: tensor<16x16xf16, #blocked>) -> tensor<16x16xf16, #blocked1> {
+    // Scratch buffers carry both the offset and the allocated size.
+    // CHECK: ttg.convert_layout {{.*}}allocation.offset = 0 : i32, allocation.size = 544 : i32
     %0 = ttg.convert_layout %arg0 : tensor<16x16xf16, #blocked> -> tensor<16x16xf16, #blocked1>
     tt.return %0 : tensor<16x16xf16, #blocked1>
   }
@@ -95,5 +97,33 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
   tt.func @test_contiguous(%arg0: tensor<32x128xf32, #blocked>) -> tensor<32x128xf32, #blocked1> {
     %0 = ttg.convert_layout %arg0 : tensor<32x128xf32, #blocked> -> tensor<32x128xf32, #blocked1>
     tt.return %0 : tensor<32x128xf32, #blocked1>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [1, 16], warpsPerCTA = [1, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [16, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
+
+// Check a call site gets the virtual buffer reserving the callee's scratch memory.
+//
+// Deliberately do not check `allocation.size` on the `tt.call`: whether virtual
+// buffers carry it depends on the upstream revision. Upstream 18a3c9740 (#11268)
+// replaced the `!isVirtualBuffer(bufferId)` guard in
+// `attachAllocationSizeAndOffsetAttr` with `!isa<FunctionOpInterface>(op)`, which
+// starts emitting it on call sites. Only the offset is stable across both.
+
+// CHECK-LABEL: module attributes
+// CHECK-SAME: ttg.shared = 544 : i32
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func private @test_callee(%arg0: tensor<16x16xf16, #blocked>) {
+    // CHECK: ttg.convert_layout {{.*}}allocation.offset = 0 : i32, allocation.size = 544 : i32
+    %0 = ttg.convert_layout %arg0 : tensor<16x16xf16, #blocked> -> tensor<16x16xf16, #blocked1>
+    tt.return
+  }
+  tt.func public @test_caller(%arg0: tensor<16x16xf16, #blocked>) {
+    // CHECK: tt.call @test_callee{{.*}}allocation.offset = 0 : i32
+    tt.call @test_callee(%arg0) : (tensor<16x16xf16, #blocked>) -> ()
+    tt.return
   }
 }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/AllocateSharedMemory.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/AllocateSharedMemory.cpp
@@ -1,6 +1,7 @@
 #include "intel/include/Analysis/Allocation.h"
 #include "intel/include/TritonIntelGPUToLLVM/Passes.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "triton/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.h"
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -16,51 +17,9 @@ struct AllocateSharedMemory
           AllocateSharedMemory> {
   void runOnOperation() override {
     ModuleOp mod = getOperation();
-    MLIRContext *ctx = &getContext();
-    auto i32Ty = IntegerType::get(ctx, 32);
     ModuleAllocation allocation(
         mod, ::mlir::triton::intel::allocationAnalysisScratchSizeFn);
-
-    mod.walk<mlir::WalkOrder::PreOrder>([&](FunctionOpInterface funcOp) {
-      auto *funcAllocation = allocation.getFuncData(funcOp);
-      funcOp.walk([&](Operation *op) {
-        // Handle scratch buffers (from operations like convert_layout)
-        auto oBufferId = funcAllocation->getBufferId(op);
-        if (oBufferId != Allocation::InvalidBufferId) {
-          int offset = funcAllocation->getOffset(oBufferId);
-          op->setAttr("allocation.offset", IntegerAttr::get(i32Ty, offset));
-          return;
-        }
-
-        // Handle explicit buffers (from values like local_alloc results)
-        if (op->getNumResults() != 1)
-          return;
-
-        Value value = op->getResult(0);
-        auto bufferIds = funcAllocation->getBufferIds(value);
-        if (bufferIds.empty())
-          return;
-
-        // For partitioned tensors, set an array of offsets (one per partition)
-        if (bufferIds.size() > 1) {
-          SmallVector<Attribute> offsetAttrs;
-          for (auto bufferId : bufferIds) {
-            int partitionOffset = funcAllocation->getOffset(bufferId);
-            offsetAttrs.push_back(IntegerAttr::get(i32Ty, partitionOffset));
-          }
-          op->setAttr("allocation.offset", ArrayAttr::get(ctx, offsetAttrs));
-          return;
-        }
-
-        // Standard single offset for non-partitioned tensors
-        int offset = funcAllocation->getOffset(bufferIds[0]);
-        op->setAttr("allocation.offset", IntegerAttr::get(i32Ty, offset));
-      });
-      return WalkResult::skip();
-    });
-    mod->setAttr("ttg.shared",
-                 mlir::IntegerAttr::get(mlir::IntegerType::get(ctx, 32),
-                                        allocation.getSharedMemorySize()));
+    mlir::triton::gpu::attachAllocationSizeAndOffsetAttr(mod, allocation);
   }
 };
 } // namespace


### PR DESCRIPTION
Intel's IntelAllocateSharedMemory pass carried a hand-copied duplicate of
the walk that attaches `allocation.offset` to scratch and explicit buffers
and sets the `ttg.shared` module attribute. Upstream factored that logic
into `mlir::triton::gpu::attachAllocationSizeAndOffsetAttr`, which upstream,
NVIDIA and AMD all call. Call it from Intel too and delete the copy.

The copy had already drifted: it was missing the block that also sets
`allocation.size` on non-virtual scratch buffers. Adopting the helper
therefore starts emitting that attribute. Its only reader tree-wide is
NVIDIA's ProxyFenceInsertion, which is not part of any Intel pipeline, so
the attribute is inert for Intel -- but this is an IR change, not a no-op.

No CMakeLists change is needed: TritonIntelGPUToLLVM already calls
out-of-line functions defined in TritonGPUToLLVM (for example
LLVM::getSharedMemoryBase) without listing it in LINK_LIBS, because
add_triton_library builds OBJECT libraries whose objects are all linked
into triton-opt and libtriton.

Also add lit coverage for the attributes themselves, which no test checked
before: `allocation.size` on a scratch buffer, and a `tt.call` sub-test
covering the virtual-buffer path.

Closes #7872
