### PR TITLE
[vLLM] Use wheels from partially-failed nightly runs

### DIFF
--- a/scripts/vllm/install-vllm.sh
+++ b/scripts/vllm/install-vllm.sh
@@ -324,6 +324,21 @@ try_install_wheel_from_run() {
   return 0
 }
 
+# Try a run id.
+# Exits the script on install (0) or commit-mismatch (1).
+# Returns to caller when the run_id is null or the run has no wheel.
+try_run() {
+  [[ "$1" == "null" ]] && return 0
+
+  local status
+  rm -rf "$temp_dir"/*
+  try_install_wheel_from_run "$1" "$wheel_pattern" "$temp_dir" && exit 0 || status=$?
+
+  [[ $status -eq 1 ]] && exit 1
+
+  return 0
+}
+
 if [[ "$build_vllm" == false ]]; then
   if ! command -v gh &>/dev/null; then
     echo "ERROR: gh is not installed." >&2
@@ -342,28 +357,12 @@ if [[ "$build_vllm" == false ]]; then
 
   # Try latest completed run first (any conclusion)
   latest_run="$(gh run list --workflow nightly-wheels.yml --branch "$triton_repo_branch" -R "$triton_repo" --status completed --json databaseId --limit 1 | jq -r '.[0].databaseId')"
-  try_install_wheel_from_run "$latest_run" "$wheel_pattern" "$temp_dir" && status=0 || status=$?
-
-  if [[ $status -eq 0 ]]; then
-    exit 0
-  elif [[ $status -eq 1 ]]; then
-    exit 1
-  fi
+  try_run "$latest_run"
 
   # Latest run didn't have a wheel for this Python version, try latest successful run
   echo "*** Latest run has no wheel for this Python version, trying latest successful run... ***"
   latest_success_run="$(gh run list --workflow nightly-wheels.yml --branch "$triton_repo_branch" -R "$triton_repo" --json databaseId,conclusion --limit 20 | jq -r '[.[] | select(.conclusion=="success")][0].databaseId')"
-
-  if [[ "$latest_success_run" != "null" && "$latest_success_run" != "$latest_run" ]]; then
-    rm -rf "$temp_dir"/*
-    try_install_wheel_from_run "$latest_success_run" "$wheel_pattern" "$temp_dir" && status=0 || status=$?
-
-    if [[ $status -eq 0 ]]; then
-      exit 0
-    elif [[ $status -eq 1 ]]; then
-      exit 1
-    fi
-  fi
+  [[ "$latest_success_run" != "$latest_run" ]] && try_run "$latest_success_run"
 
   echo "ERROR: No nightly build vllm-xpu-kernels wheel found. Use --source to build from source." >&2
   exit 1

--- a/scripts/vllm/install-vllm.sh
+++ b/scripts/vllm/install-vllm.sh
@@ -287,6 +287,43 @@ if [[ "$clean" == true ]]; then
   python "$SCRIPTS_DIR/vllm/vllm_xpu_patch.py" "$VLLM_PROJ"
 fi
 
+# Try downloading and installing vLLM XPU kernels wheel from a specific run.
+# Returns: 0 = installed successfully, 1 = wrong commit, 2 = no wheel found
+try_install_wheel_from_run() {
+  local run_id="$1"
+  local wheel_pattern="$2"
+  local temp_dir="$3"
+
+  echo "*** Trying run $run_id... ***"
+  if ! gh run download "$run_id" \
+      --repo "$triton_repo" \
+      --pattern "$wheel_pattern" \
+      --dir "$temp_dir" 2>/dev/null; then
+    return 2
+  fi
+
+  local downloaded_wheel="$(find "$temp_dir" -name 'vllm_xpu_kernels-*.whl' -print -quit)"
+  if [[ -z "$downloaded_wheel" ]]; then
+    return 2
+  fi
+
+  local wheel_commit="$(basename "$downloaded_wheel")"
+  wheel_commit="${wheel_commit#*+g}"
+  wheel_commit="${wheel_commit%%.*}"
+
+  if [[ "$vllm_xpu_kernels_pinned_commit" != "$wheel_commit"* ]]; then
+    echo "ERROR: vLLM XPU kernels nightly wheel commit ($wheel_commit) does not match pinned commit ($vllm_xpu_kernels_pinned_commit). Use --source to build from source." >&2
+    return 1
+  fi
+
+  echo "*** Installing vLLM XPU kernels from nightly builds. ***"
+  pip install "$downloaded_wheel"
+  echo "*** Installing vLLM from source. ***"
+  install_vllm
+  show_installs
+  return 0
+}
+
 if [[ "$build_vllm" == false ]]; then
   if ! command -v gh &>/dev/null; then
     echo "ERROR: gh is not installed." >&2
@@ -299,36 +336,37 @@ if [[ "$build_vllm" == false ]]; then
   fi
 
   echo "*** Downloading nightly builds. ***"
-  run_id="$(gh run list --workflow nightly-wheels.yml --branch "$triton_repo_branch" -R "$triton_repo" --json databaseId,conclusion | jq -r '[.[] | select(.conclusion=="success")][0].databaseId')"
+  wheel_pattern="wheels-vllm-py$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-*"
   temp_dir="$(mktemp -d)"
   trap 'rm -rf "$temp_dir"' EXIT
-  wheel_pattern="wheels-vllm-py$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")-*"
-  gh run download "$run_id" \
-    --repo "$triton_repo" \
-    --pattern "$wheel_pattern" \
-    --dir "$temp_dir"
 
-  downloaded_wheel="$(find "$temp_dir" -name 'vllm_xpu_kernels-*.whl' -print -quit)"
-  if [[ -n "$downloaded_wheel" ]]; then
-    wheel_commit="$(basename "$downloaded_wheel")"
-    wheel_commit="${wheel_commit#*+g}"
-    wheel_commit="${wheel_commit%%.*}"
+  # Try latest run first (any conclusion)
+  latest_run="$(gh run list --workflow nightly-wheels.yml --branch "$triton_repo_branch" -R "$triton_repo" --json databaseId --limit 1 | jq -r '.[0].databaseId')"
+  try_install_wheel_from_run "$latest_run" "$wheel_pattern" "$temp_dir"
+  status=$?
 
-    if [[ "$vllm_xpu_kernels_pinned_commit" == "$wheel_commit"* ]]; then
-      echo "*** Installing vLLM XPU kernels from nightly builds. ***"
-      pip install "$downloaded_wheel"
-      echo "*** Installing vLLM from source. ***"
-      install_vllm
-      show_installs
-
-      exit 0
-    fi
-
-    echo "ERROR: vLLM XPU kernels nightly wheel commit ($wheel_commit) does not match pinned commit ($vllm_xpu_kernels_pinned_commit). Use --source to build from source." >&2
-  else
-    echo "ERROR: No nightly build vllm-xpu-kernels wheel found. Use --source to build from source." >&2
+  if [[ $status -eq 0 ]]; then
+    exit 0
+  elif [[ $status -eq 1 ]]; then
+    exit 1
   fi
 
+  # Latest run didn't have a wheel for this Python version, try latest successful run
+  echo "*** Latest run has no wheel for this Python version, trying latest successful run... ***"
+  latest_success_run="$(gh run list --workflow nightly-wheels.yml --branch "$triton_repo_branch" -R "$triton_repo" --json databaseId,conclusion --limit 20 | jq -r '[.[] | select(.conclusion=="success")][0].databaseId')"
+
+  if [[ "$latest_success_run" != "$latest_run" ]]; then
+    try_install_wheel_from_run "$latest_success_run" "$wheel_pattern" "$temp_dir"
+    status=$?
+
+    if [[ $status -eq 0 ]]; then
+      exit 0
+    elif [[ $status -eq 1 ]]; then
+      exit 1
+    fi
+  fi
+
+  echo "ERROR: No nightly build vllm-xpu-kernels wheel found. Use --source to build from source." >&2
   exit 1
 fi
 

--- a/scripts/vllm/install-vllm.sh
+++ b/scripts/vllm/install-vllm.sh
@@ -298,7 +298,7 @@ try_install_wheel_from_run() {
   if ! gh run download "$run_id" \
       --repo "$triton_repo" \
       --pattern "$wheel_pattern" \
-      --dir "$temp_dir" 2>/dev/null; then
+      --dir "$temp_dir"; then
     return 2
   fi
 
@@ -340,10 +340,9 @@ if [[ "$build_vllm" == false ]]; then
   temp_dir="$(mktemp -d)"
   trap 'rm -rf "$temp_dir"' EXIT
 
-  # Try latest run first (any conclusion)
-  latest_run="$(gh run list --workflow nightly-wheels.yml --branch "$triton_repo_branch" -R "$triton_repo" --json databaseId --limit 1 | jq -r '.[0].databaseId')"
-  try_install_wheel_from_run "$latest_run" "$wheel_pattern" "$temp_dir"
-  status=$?
+  # Try latest completed run first (any conclusion)
+  latest_run="$(gh run list --workflow nightly-wheels.yml --branch "$triton_repo_branch" -R "$triton_repo" --status completed --json databaseId --limit 1 | jq -r '.[0].databaseId')"
+  try_install_wheel_from_run "$latest_run" "$wheel_pattern" "$temp_dir" && status=0 || status=$?
 
   if [[ $status -eq 0 ]]; then
     exit 0
@@ -355,9 +354,9 @@ if [[ "$build_vllm" == false ]]; then
   echo "*** Latest run has no wheel for this Python version, trying latest successful run... ***"
   latest_success_run="$(gh run list --workflow nightly-wheels.yml --branch "$triton_repo_branch" -R "$triton_repo" --json databaseId,conclusion --limit 20 | jq -r '[.[] | select(.conclusion=="success")][0].databaseId')"
 
-  if [[ "$latest_success_run" != "$latest_run" ]]; then
-    try_install_wheel_from_run "$latest_success_run" "$wheel_pattern" "$temp_dir"
-    status=$?
+  if [[ "$latest_success_run" != "null" && "$latest_success_run" != "$latest_run" ]]; then
+    rm -rf "$temp_dir"/*
+    try_install_wheel_from_run "$latest_success_run" "$wheel_pattern" "$temp_dir" && status=0 || status=$?
 
     if [[ $status -eq 0 ]]; then
       exit 0


### PR DESCRIPTION
The install-vllm.sh script was filtering nightly runs by `conclusion=="success"`, which excluded runs where Python 3.15 failed but Python 3.10-3.12 vLLM wheels were successfully built and uploaded.

This caused the script to fall back to the last fully successful run, resulting in a commit mismatch error when the pin was updated.

Change the logic to try two runs in order:
1. Latest run (any conclusion) - handles partial failures
2. Latest successful run - fallback for genuine failures

This allows using wheels from runs where only some Python versions fail (e.g., Python 3.15 beta instability) while keeping a safe fallback.