### PR TITLE
[SGLANG] Enable `test_fused_moe.py` in the MoE suite

### DIFF
--- a/scripts/sglang/sglang-test-fix.patch
+++ b/scripts/sglang/sglang-test-fix.patch
@@ -119,3 +119,168 @@ index ff90b20a70..4a49fb66a5 100644
  
          unified_kv_indptr, unified_kv_indices, prefix_lens = build_unified_kv_indices(
              kv_indptr,
+diff --git a/python/sglang/srt/layers/activation.py b/python/sglang/srt/layers/activation.py
+index 8e5d6d048c..79df66b8e0 100644
+--- a/python/sglang/srt/layers/activation.py
++++ b/python/sglang/srt/layers/activation.py
+@@ -105,7 +105,23 @@ if _is_cuda:
+         return _act_and_mul(_jit_gelu_tanh_and_mul, _sgl_gelu_tanh_and_mul, input, out)
+ 
+ elif _is_xpu:
+-    from sgl_kernel import gelu_and_mul, gelu_tanh_and_mul, silu_and_mul
++    try:
++        from sgl_kernel import gelu_and_mul, gelu_tanh_and_mul, silu_and_mul
++    except ImportError:
++        # sgl-kernel-xpu is optional. Fall back to the same math forward_native
++        # uses, keeping the (input, out) signature the forward_xpu methods expect.
++        def silu_and_mul(input: torch.Tensor, out: torch.Tensor) -> None:
++            d = input.shape[-1] // 2
++            out.copy_(F.silu(input[..., :d]) * input[..., d:])
++
++        def gelu_and_mul(input: torch.Tensor, out: torch.Tensor) -> None:
++            d = input.shape[-1] // 2
++            out.copy_(F.gelu(input[..., :d], approximate="none") * input[..., d:])
++
++        def gelu_tanh_and_mul(input: torch.Tensor, out: torch.Tensor) -> None:
++            d = input.shape[-1] // 2
++            out.copy_(F.gelu(input[..., :d], approximate="tanh") * input[..., d:])
++
+ elif _is_hip:
+     from sgl_kernel import gelu_and_mul, gelu_quick, gelu_tanh_and_mul, silu_and_mul
+ elif _is_musa:
+diff --git a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+index 758c2eacf6..8bb83ed3c5 100644
+--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
++++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+@@ -73,7 +73,12 @@ elif _is_hip:
+     # Note: vllm_ops is not needed for HIP when _use_aiter=False
+     # because the code uses moe_sum_reduce_triton as fallback (line 619)
+ elif _is_xpu:
+-    from sgl_kernel import moe_sum_reduce, silu_and_mul
++    try:
++        from sgl_kernel import moe_sum_reduce, silu_and_mul
++    except ImportError:
++        # sgl-kernel-xpu is optional, so fall through to the native torch
++        # silu_and_mul and the Triton moe_sum_reduce_triton below.
++        _is_xpu = False
+ elif _is_musa:
+     from sgl_kernel import moe_sum_reduce
+ 
+diff --git a/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py b/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
+index 9c611a4682..f2dbdb928f 100644
+--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
++++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
+@@ -18,6 +18,61 @@ _is_musa = is_musa()
+ if _is_cuda or _is_hip or _is_xpu or _is_musa:
+     from sglang.kernels.ops.moe import moe_align_block_size as sgl_moe_align_block_size
+ 
++if _is_xpu:
++    try:
++        import sgl_kernel  # noqa: F401
++    except ImportError:
++        # sgl-kernel-xpu is optional, but sgl_moe_align_block_size resolves to a
++        # kernel with no XPU implementation, so without it the Triton MoE kernels
++        # have no way to group tokens by expert. Group them with torch instead:
++        # same layout, sentinel padding and per-block expert ids.
++        def sgl_moe_align_block_size(
++            topk_ids: torch.Tensor,
++            num_experts: int,
++            block_size: int,
++            sorted_ids: torch.Tensor,
++            expert_ids: torch.Tensor,
++            num_tokens_post_pad: torch.Tensor,
++            cumsum_buffer: torch.Tensor,
++            pad_sorted_token_ids: bool = False,
++            ignore_invalid_expert: bool = False,
++        ) -> None:
++            numel = topk_ids.numel()
++            flat = topk_ids.flatten().to(torch.int64)
++            if bool((flat < 0).any()):
++                raise NotImplementedError(
++                    "the torch moe_align_block_size fallback does not handle the "
++                    "expert-parallel -1 sentinel; install sgl-kernel-xpu for EP"
++                )
++            order = torch.argsort(flat, stable=True).cpu()
++            counts = torch.bincount(flat, minlength=num_experts).cpu().tolist()
++
++            # Tokens past num_tokens_post_pad are never read, but the padding
++            # sentinel numel is >= num_valid_tokens so the kernels mask it out.
++            sorted_ids.fill_(numel)
++            expert_ids.zero_()
++
++            blocks, block_experts, pos = [], [], 0
++            for expert, count in enumerate(counts):
++                if count == 0:
++                    continue
++                num_blocks = triton.cdiv(count, block_size)
++                block = torch.full((num_blocks * block_size,), numel, dtype=torch.int32)
++                block[:count] = order[pos : pos + count].to(torch.int32)
++                pos += count
++                blocks.append(block)
++                block_experts += [expert] * num_blocks
++
++            if not blocks:
++                num_tokens_post_pad.zero_()
++                return
++            tokens = torch.cat(blocks)
++            sorted_ids[: tokens.numel()].copy_(tokens)
++            expert_ids[: len(block_experts)].copy_(
++                torch.tensor(block_experts, dtype=torch.int32)
++            )
++            num_tokens_post_pad.fill_(tokens.numel())
++
+ if _is_cuda:
+     from sglang.kernels.ops.moe.moe_align_small_numel import (
+         SMALL_NUMEL_LIMIT,
+diff --git a/python/sglang/srt/layers/moe/topk.py b/python/sglang/srt/layers/moe/topk.py
+index e7431a2f2e..44f4e48042 100644
+--- a/python/sglang/srt/layers/moe/topk.py
++++ b/python/sglang/srt/layers/moe/topk.py
+@@ -194,7 +194,28 @@ if _is_cuda or _is_hip or _is_xpu:
+         # XPU has no tvm_ffi, so the CUDA JIT topk_sigmoid isn't reachable;
+         # use the AOT symbols from sgl_kernel directly. topk_sigmoid was aligned
+         # with the post-#28715 CUDA signature in sgl-kernel-xpu#285.
+-        from sgl_kernel import topk_sigmoid, topk_softmax
++        try:
++            from sgl_kernel import topk_sigmoid, topk_softmax
++        except ImportError:
++            # sgl-kernel-xpu is optional. Route softmax scoring through torch and
++            # leave topk_sigmoid undefined, exactly as the branch below does when
++            # its JIT kernel is missing.
++            def topk_softmax(
++                topk_weights: torch.Tensor,
++                topk_ids: torch.Tensor,
++                gating_output: torch.Tensor,
++                renormalize: bool = False,
++            ) -> None:
++                weights, ids = torch.topk(
++                    torch.softmax(gating_output.float(), dim=-1),
++                    topk_ids.shape[1],
++                    dim=-1,
++                )
++                if renormalize:
++                    weights = weights / weights.sum(dim=-1, keepdim=True)
++                topk_weights.copy_(weights)
++                topk_ids.copy_(ids)
++
+     else:
+         from sglang.kernels.ops.moe import topk_softmax
+ 
+diff --git a/test/registered/moe/test_fused_moe.py b/test/registered/moe/test_fused_moe.py
+index d7f22c2c65..1f636cd2c5 100644
+--- a/test/registered/moe/test_fused_moe.py
++++ b/test/registered/moe/test_fused_moe.py
+@@ -117,7 +117,12 @@ class TestFusedMOE(CustomTestCase):
+         if use_fp8_w8a8:
+             # AssertionError: fp8e4nv data type is not supported on CUDA arch < 89
+             capability = get_device_capability()
+-            if not _is_hip and not (capability[0] >= 9 or capability == (8, 9)):
++            # get_device_capability() reports (None, None) on XPU, so treat an
++            # unknown capability as unsupported rather than raising a TypeError.
++            if not _is_hip and (
++                capability[0] is None
++                or not (capability[0] >= 9 or capability == (8, 9))
++            ):
+                 return
+ 
+             a = self.create_random_gpu_tensor((m, k), dtype)

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -1007,11 +1007,13 @@ run_sglang_moe_tests() {
   echo "********************************************************"
 
   enter_sglang_test_env
-  # Fused MoE + LoRA.
-  # test_fused_moe.py and test/manual/test_triton_moe_wna16.py are left out: same
-  # sgl_kernel import as the INT8 tests.
+  # Fused MoE + LoRA. sglang-test-fix.patch guards the optional sgl_kernel
+  # imports on the Triton MoE path and adds native fallbacks, which is what
+  # lets test_fused_moe.py import and run here.
+  # test/manual/test_triton_moe_wna16.py is still left out.
   TRITON_TEST_SUITE=sglang_moe \
     run_pytest_command -vvv \
+      test/registered/moe/test_fused_moe.py \
       test/registered/lora/test_fused_moe_lora_kernel.py
 }
 


### PR DESCRIPTION
Enables the upstream `test_fused_moe.py` in `--sglang-moe`, which until now could not even import on XPU because `srt/layers/activation.py` imports `sgl_kernel` at module level. The patch adds a native fallback for that import and makes the fp8 capability check skip rather than raise on XPU, where `get_device_capability()` returns `(None, None)`.

Closes #8011 