### PR TITLE
[RemoveLayoutConversions] Stop backward slice at while/warp-specialize results

### DIFF
--- a/test/TritonIntelGPU/combine.mlir
+++ b/test/TritonIntelGPU/combine.mlir
@@ -1882,6 +1882,53 @@ tt.func @whileop(%ptr: tensor<1024x!tt.ptr<f32>, #blocked>, %cond: i1) {
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// CHECK-LABEL: whileop_backward_negative
+// CHECK: scf.while
+// CHECK:  scf.yield
+// CHECK: ttg.convert_layout
+tt.func @whileop_backward_negative(%ptr: tensor<1024x!tt.ptr<i32>, #blocked>, %cond: i1) {
+  %1 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked1>
+  %2 = scf.while (%arg0 = %1, %arg1 = %cond) : (tensor<1024xi32, #blocked1>, i1) -> (tensor<1024xi32, #blocked1>) {
+      scf.condition(%arg1) %arg0 : tensor<1024xi32, #blocked1>
+    } do {
+    ^bb0(%arg0: tensor<1024xi32, #blocked1>):
+      %4 = ttg.convert_layout %arg0 : tensor<1024xi32, #blocked1> -> tensor<1024xi32, #blocked>
+      %5 = arith.addi %4, %4 : tensor<1024xi32, #blocked>
+      %6 = ttg.convert_layout %5 : tensor<1024xi32, #blocked> -> tensor<1024xi32, #blocked1>
+      scf.yield %6, %cond : tensor<1024xi32, #blocked1>, i1
+    }
+  %3 = ttg.convert_layout %2 : tensor<1024xi32, #blocked1> -> tensor<1024xi32, #blocked>
+  tt.store %ptr, %3 : tensor<1024x!tt.ptr<i32>, #blocked>
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// CHECK-LABEL: warp_specialize_backward_negative
+// CHECK: ttg.warp_specialize
+// CHECK: ttg.warp_yield {{.*}} : tensor<1024xi32, #blocked>
+// CHECK: () -> tensor<1024xi32, #blocked>
+// CHECK: ttg.convert_layout {{.*}} : tensor<1024xi32, #blocked> -> tensor<1024xi32, #blocked1>
+tt.func @warp_specialize_backward_negative(%arg0: tensor<1024xi32, #blocked>) -> tensor<1024xi32, #blocked1> {
+  %0 = ttg.warp_specialize()
+  default {
+    %1 = arith.addi %arg0, %arg0 : tensor<1024xi32, #blocked>
+    ttg.warp_yield %1 : tensor<1024xi32, #blocked>
+  } : () -> tensor<1024xi32, #blocked>
+  %2 = ttg.convert_layout %0 : tensor<1024xi32, #blocked> -> tensor<1024xi32, #blocked1>
+  tt.return %2 : tensor<1024xi32, #blocked1>
+}
+}
+
+// -----
+
 // Suppose we have a loop which yields a value from outside the loop:
 //   %x = ...
 //   %y = ...

--- a/test/TritonIntelGPU/combine.mlir
+++ b/test/TritonIntelGPU/combine.mlir
@@ -1929,6 +1929,34 @@ tt.func @warp_specialize_backward_negative(%arg0: tensor<1024xi32, #blocked>) ->
 
 // -----
 
+// scf.index_switch is not special-cased by rewriteSlice, so retyping its result
+// would leave the scf.yield in each region at the old encoding (the same defect
+// as ttg.warp_yield above). It is blocked because it implements
+// RegionBranchOpInterface, so the convert below must survive.
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// CHECK-LABEL: index_switch_backward_negative
+// CHECK: %[[SW:[0-9]+]] = scf.index_switch
+// CHECK: ttg.convert_layout %[[SW]] : tensor<1024xi32, #blocked1> -> tensor<1024xi32, #blocked>
+tt.func @index_switch_backward_negative(%ptr: tensor<1024x!tt.ptr<i32>, #blocked>, %idx: index) {
+  %1 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked1>
+  %2 = scf.index_switch %idx -> tensor<1024xi32, #blocked1>
+  case 0 {
+    scf.yield %1 : tensor<1024xi32, #blocked1>
+  }
+  default {
+    %3 = arith.addi %1, %1 : tensor<1024xi32, #blocked1>
+    scf.yield %3 : tensor<1024xi32, #blocked1>
+  }
+  %4 = ttg.convert_layout %2 : tensor<1024xi32, #blocked1> -> tensor<1024xi32, #blocked>
+  tt.store %ptr, %4 : tensor<1024x!tt.ptr<i32>, #blocked>
+  tt.return
+}
+}
+
+// -----
+
 // Suppose we have a loop which yields a value from outside the loop:
 //   %x = ...
 //   %y = ...

--- a/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
@@ -277,6 +277,12 @@ LogicalResult getConvertBackwardSlice(
     auto currentValueType = cast<RankedTensorType>(currentValue.getType());
     if (currentValueType.getEncoding() == encoding)
       continue;
+    // Backward propagation through while / warp-specialize regions is
+    // unsupported: rewriteSlice has no case for them and would retype the
+    // results without updating the regions (see WarpYieldOp::verify).
+    if (isa_and_nonnull<scf::WhileOp, ttg::WarpSpecializeOp>(
+            currentValue.getDefiningOp()))
+      return failure();
     slice.insert(currentValue);
 
     Value existing;

--- a/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/Utility.cpp
@@ -8,6 +8,7 @@
 
 #include "triton/Analysis/Utility.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 #include "intel/include/Dialect/TritonIntelGPU/IR/Attributes.h"
@@ -277,12 +278,20 @@ LogicalResult getConvertBackwardSlice(
     auto currentValueType = cast<RankedTensorType>(currentValue.getType());
     if (currentValueType.getEncoding() == encoding)
       continue;
-    // Backward propagation through while / warp-specialize regions is
-    // unsupported: rewriteSlice has no case for them and would retype the
-    // results without updating the regions (see WarpYieldOp::verify).
-    if (isa_and_nonnull<scf::WhileOp, ttg::WarpSpecializeOp>(
-            currentValue.getDefiningOp()))
-      return failure();
+    // Backward propagation is only supported for region ops whose results
+    // survive rewriteSlice's generic clone+setType path. ForOp and IfOp have
+    // explicit handling below; everything else implementing
+    // RegionBranchOpInterface is rejected, because retyping a result tied to a
+    // region terminator's operands leaves the terminator at the old encoding
+    // (see WarpYieldOp::verify). Note this is a conservative proxy for
+    // structured control flow, not an exact test: region ops that do not
+    // implement the interface (tt.reduce, tt.scan, tt.map_elementwise) pass
+    // through here and rely on their regions being scalar-level, so retyping
+    // the tensor result keeps them valid.
+    if (Operation *defOp = currentValue.getDefiningOp())
+      if (isa<RegionBranchOpInterface>(defOp) &&
+          !isa<scf::ForOp, scf::IfOp>(defOp))
+        return failure();
     slice.insert(currentValue);
 
     Value existing;


### PR DESCRIPTION
A ttg.warp_specialize result in the backward slice yields invalid IR:
rewriteSlice retypes only the cloned results, so ttg.warp_yield keeps the old
encoding and fails its verifier. scf::WhileOp guarded too (today masked by
canBeRemat). Adds a negative lit test for each.

Fixes #7891

### Second commit — whitelist instead of blacklist (review feedback)

Per review, the two-op blacklist is replaced by a check for
`RegionBranchOpInterface`, whitelisting `scf::ForOp` and `scf::IfOp` — the two
ops the walk handles explicitly — so a future region op is rejected by default
rather than silently taking the unsafe path. A plain `getNumRegions() > 0` gate
was not usable: it also rejects `tt.reduce`/`tt.scan`, which propagate fine today
via `inferSrcEncoding`.

This turned out to fix a **live miscompile** the blacklist missed, not only
future ops: `scf.index_switch` already reaches `rewriteSlice`'s generic
clone+`setType` path, so its result is retyped while both region `scf.yield`s
stay at the old encoding, tripping `IndexSwitchOp::verify`. The added
`index_switch_backward_negative` fails on the first commit for exactly that
reason and passes on the second.

The interface is a **conservative proxy** for "results tied to a region
terminator's operands", not an exact test. Region ops that do not implement it
(`tt.reduce`, `tt.scan`, `tt.map_elementwise`) still pass through, relying on
their regions being scalar-level so retyping the tensor result keeps them valid.
`ttg.mask` is a known gap — in the failure class but not covered; it is
unreachable here because no Intel pass creates it (only the upstream software
pipeliner's `wrapInMaskOp`, which Intel never runs) and upstream `resolveMaskOp`
erases it in-pass. Discussed on the review thread.

**Upstream divergence (deliberate).** Upstream carries the same blacklist at
`lib/Dialect/TritonGPU/Transforms/Utility.cpp:935-937`
(`isa_and_nonnull<scf::ForOp, scf::WhileOp, ttg::WarpSpecializeOp>`), so this
makes the Intel copy of `getConvertBackwardSlice` diverge on that line. Recorded
here so a future divergence sweep reads it as intentional rather than drift. The
Intel copy already diverges via `TRITON_INTEL_REMOVELAYOUTCONVERSION_SUPPORT_FOR_LOOP`.

**Verification.** `test/TritonIntelGPU/` 81/81, `test/Conversion/intel/` 24/24.
Over-blocking checked by running the unmodified `combine.mlir` against the new
binary: clean, so no existing case regresses.
