### PR TITLE
[TritonIntelGPU] Carry batch strides on `ttig.2d_block_load` (#7882)

### DIFF
--- a/python/test/unit/intel/test_block_io.py
+++ b/python/test/unit/intel/test_block_io.py
@@ -207,3 +207,89 @@ def test_block_io(M, N, dtype_str, layout, transpose, device, tmp_path: pathlib.
         assert 'spirv_Subgroup2DBlockStoreINTEL' in llir or 'GenISA.LSC2DBlockWrite' in llir
         load_count = llir.count('spirv_Subgroup2DBlockLoad') + llir.count('GenISA.LSC2DBlockRead')
         assert load_count > 0 or transpose
+
+
+# The 2D block I/O tile only covers the inner two dimensions, so every leading
+# (batch) dimension needs its own stride from the tensor descriptor. Re-deriving
+# it from the 2D surface parameters steps an outer batch dimension by the wrong
+# amount whenever its stride differs from `shapes[-2] * strides[-2]`, and reads
+# the wrong slice with no diagnostic (issue #7882). Of the shapes below only the
+# rank-4 one has such a dimension; the rank-3 shapes are dense and happen to
+# agree with the re-derived value, so they serve as controls that the common
+# path is unaffected.
+#
+# Row-major only, deliberately. A `ttig.block_io = "column_major"` descriptor
+# load must declare the descriptor's inner two dimensions *swapped* relative to
+# the result tensor -- see `descriptor_load_store_to_llvm.mlir`, which documents
+# "the column_major flag swaps the inner two dims before the load" and encodes
+# it as `!tt.tensordesc<16x8xf32> -> tensor<8x16xf32>`. Giving the descriptor
+# and the result the same type, as a column-major variant of this test would,
+# is not valid input for that path, so it tests nothing about the batch stride:
+# measured on BMG, all nine such combinations fail identically with and without
+# the #7882 fix. Build the descriptor with swapped inner dims if column-major
+# rank > 2 coverage is wanted; do not just re-add a `transpose` parameter here.
+@pytest.mark.parametrize("shape", [[64, 64, 32], [128, 128, 16], [4, 64, 64, 32]])
+@pytest.mark.parametrize("dtype_str", ["float32", "float16", "int8"])
+@pytest.mark.skipif(not is_xpu(), reason="Block store tests are specific to the XPU backend")
+def test_block_io_nd(shape, dtype_str, device, tmp_path: pathlib.Path):
+    rank = len(shape)
+
+    if rank == 3:
+        layout = BlockedLayout([1, 1, 1], [1, 2, 16], [8, 4, 1], [2, 1, 0])
+    else:
+        layout = BlockedLayout([1, 1, 1, 1], [1, 1, 2, 16], [4, 2, 4, 1], [3, 2, 1, 0])
+
+    # Generate IR constants for shape and strides.
+    shapes_ir = "\n".join([f"%dim{i}_i32 = arith.constant {s} : i32" for i, s in enumerate(shape)])
+    strides_row_major = [shape[-2] * shape[-1], shape[-1], 1]
+    for s in reversed(shape[1:-2]):
+        strides_row_major.insert(0, strides_row_major[0] * s)
+    strides_row_major_ir = "\n".join(
+        [f"%stride_row_major_{i}_i64 = arith.constant {s} : i64" for i, s in enumerate(strides_row_major)])
+    strides_row_major_list = [f"%stride_row_major_{i}_i64" for i in range(rank)]
+
+    ty = {"float32": "f32", "float16": "f16", "bfloat16": "i16", "int8": "i8"}[dtype_str]
+    support_block_io = triton.runtime.driver.active.get_current_target().arch['has_2d_block_io']
+
+    tensor_type = "x".join(str(s) for s in shape) + f"x{ty}"
+    offsets = ", ".join(["%c0_i32"] * rank)
+
+    ir = f"""
+    #layout = {layout}
+    module attributes {{{"ttig.support_2d_block_io," if support_block_io else ""} "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = {int(np.prod(warps_per_cta(layout)))} : i32, ttg.target = "xpu", "ttg.threads-per-warp" = {int(np.prod(layout.threads_per_warp))} : i32}} {{
+        tt.func public @block_store(%src: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}, %dst: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}) {{
+            {shapes_ir}
+            {strides_row_major_ir}
+            %c1_i64 = arith.constant 1 : i64
+            %c0_i32 = arith.constant 0 : i32
+
+            %src_ptr = tt.make_tensor_descriptor %src, [{", ".join([f"%dim{i}_i32" for i in range(rank)])}], {"[" + ", ".join(strides_row_major_list) + "]"} : !tt.ptr<{ty}>, !tt.tensordesc<{tensor_type}>
+            %store_val = tt.descriptor_load %src_ptr[{offsets}] {{ttig.block_io = "row_major", padding = 1 : i32}} : !tt.tensordesc<{tensor_type}> -> tensor<{tensor_type}, #layout>
+
+            %dst_ptr = tt.make_tensor_descriptor %dst, [{", ".join([f"%dim{i}_i32" for i in range(rank)])}], {"[" + ", ".join(strides_row_major_list) + "]"} : !tt.ptr<{ty}>, !tt.tensordesc<{tensor_type}>
+            tt.descriptor_store %dst_ptr [{offsets}], %store_val {{ttig.block_io = "row_major"}} : !tt.tensordesc<{tensor_type}>, tensor<{tensor_type}, #layout>
+
+            tt.return
+        }}
+    }}
+    """
+
+    torch_dtype = getattr(torch, dtype_str)
+    if torch_dtype.is_floating_point:
+        a = torch.randn(shape, dtype=torch_dtype, device=device)
+    else:
+        a = torch.randint(low=-127, high=128, size=shape, dtype=torch_dtype, device=device)
+
+    x = torch.empty_like(a)
+
+    temp_file = tmp_path / "test_block_io_nd.ttgir"
+    temp_file.write_text(ir)
+    kernel = triton.compile(str(temp_file))
+
+    kernel[(1, 1, 1)](a, x)
+    assert torch.equal(a, x)
+
+    if support_block_io:
+        llir = kernel.asm["llir"]
+        load_count = llir.count('spirv_Subgroup2DBlockLoad') + llir.count('GenISA.LSC2DBlockRead')
+        assert load_count > 0

--- a/python/test/unit/intel/test_block_io.py
+++ b/python/test/unit/intel/test_block_io.py
@@ -209,85 +209,89 @@ def test_block_io(M, N, dtype_str, layout, transpose, device, tmp_path: pathlib.
         assert load_count > 0 or transpose
 
 
-# The 2D block I/O tile only covers the inner two dimensions, so every leading
-# (batch) dimension needs its own stride from the tensor descriptor. Re-deriving
-# it from the 2D surface parameters steps an outer batch dimension by the wrong
-# amount whenever its stride differs from `shapes[-2] * strides[-2]`, and reads
-# the wrong slice with no diagnostic (issue #7882). Of the shapes below only the
-# rank-4 one has such a dimension; the rank-3 shapes are dense and happen to
-# agree with the re-derived value, so they serve as controls that the common
-# path is unaffected.
-#
-# Row-major only, deliberately. A `ttig.block_io = "column_major"` descriptor
-# load must declare the descriptor's inner two dimensions *swapped* relative to
-# the result tensor -- see `descriptor_load_store_to_llvm.mlir`, which documents
-# "the column_major flag swaps the inner two dims before the load" and encodes
-# it as `!tt.tensordesc<16x8xf32> -> tensor<8x16xf32>`. Giving the descriptor
-# and the result the same type, as a column-major variant of this test would,
-# is not valid input for that path, so it tests nothing about the batch stride:
-# measured on BMG, all nine such combinations fail identically with and without
-# the #7882 fix. Build the descriptor with swapped inner dims if column-major
-# rank > 2 coverage is wanted; do not just re-add a `transpose` parameter here.
+# The 2D block I/O tile covers only the inner two dimensions, so every leading
+# dimension needs its own stride from the tensor descriptor. Re-deriving it from the
+# 2D surface parameters steps a leading dimension by the wrong amount whenever its
+# stride differs from `shapes[-2] * strides[-2]`, reading the wrong slice with no
+# diagnostic (issue #7882). Only the rank-4 shape below has such a dimension; the
+# dense rank-3 shapes agree with the re-derived value and act as controls.
 @pytest.mark.parametrize("shape", [[64, 64, 32], [128, 128, 16], [4, 64, 64, 32]])
 @pytest.mark.parametrize("dtype_str", ["float32", "float16", "int8"])
+@pytest.mark.parametrize("block_io", ["row_major", "column_major"])
 @pytest.mark.skipif(not is_xpu(), reason="Block store tests are specific to the XPU backend")
-def test_block_io_nd(shape, dtype_str, device, tmp_path: pathlib.Path):
+def test_block_io_nd(shape, dtype_str, block_io, device, tmp_path: pathlib.Path):
     rank = len(shape)
-
-    if rank == 3:
-        layout = BlockedLayout([1, 1, 1], [1, 2, 16], [8, 4, 1], [2, 1, 0])
-    else:
-        layout = BlockedLayout([1, 1, 1, 1], [1, 1, 2, 16], [4, 2, 4, 1], [3, 2, 1, 0])
-
-    # Generate IR constants for shape and strides.
-    shapes_ir = "\n".join([f"%dim{i}_i32 = arith.constant {s} : i32" for i, s in enumerate(shape)])
-    strides_row_major = [shape[-2] * shape[-1], shape[-1], 1]
-    for s in reversed(shape[1:-2]):
-        strides_row_major.insert(0, strides_row_major[0] * s)
-    strides_row_major_ir = "\n".join(
-        [f"%stride_row_major_{i}_i64 = arith.constant {s} : i64" for i, s in enumerate(strides_row_major)])
-    strides_row_major_list = [f"%stride_row_major_{i}_i64" for i in range(rank)]
-
     ty = {"float32": "f32", "float16": "f16", "bfloat16": "i16", "int8": "i8"}[dtype_str]
+    torch_dtype = getattr(torch, dtype_str)
     support_block_io = triton.runtime.driver.active.get_current_target().arch['has_2d_block_io']
 
-    tensor_type = "x".join(str(s) for s in shape) + f"x{ty}"
-    offsets = ", ".join(["%c0_i32"] * rank)
+    # A column_major load reads along the tile's second-to-last dimension, so that
+    # dimension has to vary fastest and, below 32 bits, pack to d32 per lane, or the
+    # tile is rejected and never becomes a block load at all.
+    transpose = block_io == "column_major"
+    size_per_thread, order = [1] * rank, list(reversed(range(rank)))
+    if transpose:
+        size_per_thread[rank - 2] = 4 // torch_dtype.itemsize
+        order[0], order[1] = order[1], order[0]
+    layout = BlockedLayout(size_per_thread, [1, 2, 16] if rank == 3 else [1, 1, 2, 16],
+                           [8, 4, 1] if rank == 3 else [4, 2, 4, 1], order)
+
+    # A column_major load declares the descriptor's inner two dimensions swapped
+    # relative to the loaded tile, so the two types differ and must not be merged. The
+    # source is twice as deep and read at index `batch`, so that leading stride is both
+    # folded into the base pointer and walked by the result layout.
+    desc_shape = shape[:-2] + [shape[-1], shape[-2]] if transpose else list(shape)
+    batch = desc_shape[0]
+    src_shape = [2 * batch] + desc_shape[1:]
+
+    def consts(name, values, mlir_ty):
+        return "\n            ".join(f"%{name}{i} = arith.constant {v} : {mlir_ty}" for i, v in enumerate(values))
+
+    def refs(name):
+        return ", ".join(f"%{name}{i}" for i in range(rank))
+
+    def dense_strides(s):
+        return list(np.cumprod([1] + s[:0:-1]))[::-1]
+
+    src_type = "x".join(str(s) for s in desc_shape) + f"x{ty}"
+    dst_type = "x".join(str(s) for s in shape) + f"x{ty}"
 
     ir = f"""
     #layout = {layout}
     module attributes {{{"ttig.support_2d_block_io," if support_block_io else ""} "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = {int(np.prod(warps_per_cta(layout)))} : i32, ttg.target = "xpu", "ttg.threads-per-warp" = {int(np.prod(layout.threads_per_warp))} : i32}} {{
         tt.func public @block_store(%src: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}, %dst: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}) {{
-            {shapes_ir}
-            {strides_row_major_ir}
-            %c1_i64 = arith.constant 1 : i64
-            %c0_i32 = arith.constant 0 : i32
+            {consts("src_dim", src_shape, "i32")}
+            {consts("src_str", dense_strides(src_shape), "i64")}
+            {consts("src_off", [batch] + [0] * (rank - 1), "i32")}
+            {consts("dst_dim", shape, "i32")}
+            {consts("dst_str", dense_strides(shape), "i64")}
+            {consts("dst_off", [0] * rank, "i32")}
 
-            %src_ptr = tt.make_tensor_descriptor %src, [{", ".join([f"%dim{i}_i32" for i in range(rank)])}], {"[" + ", ".join(strides_row_major_list) + "]"} : !tt.ptr<{ty}>, !tt.tensordesc<{tensor_type}>
-            %store_val = tt.descriptor_load %src_ptr[{offsets}] {{ttig.block_io = "row_major", padding = 1 : i32}} : !tt.tensordesc<{tensor_type}> -> tensor<{tensor_type}, #layout>
+            %src_desc = tt.make_tensor_descriptor %src, [{refs("src_dim")}], [{refs("src_str")}] : !tt.ptr<{ty}>, !tt.tensordesc<{src_type}>
+            %val = tt.descriptor_load %src_desc[{refs("src_off")}] {{ttig.block_io = "{block_io}", padding = 1 : i32}} : !tt.tensordesc<{src_type}> -> tensor<{dst_type}, #layout>
 
-            %dst_ptr = tt.make_tensor_descriptor %dst, [{", ".join([f"%dim{i}_i32" for i in range(rank)])}], {"[" + ", ".join(strides_row_major_list) + "]"} : !tt.ptr<{ty}>, !tt.tensordesc<{tensor_type}>
-            tt.descriptor_store %dst_ptr [{offsets}], %store_val {{ttig.block_io = "row_major"}} : !tt.tensordesc<{tensor_type}>, tensor<{tensor_type}, #layout>
+            %dst_desc = tt.make_tensor_descriptor %dst, [{refs("dst_dim")}], [{refs("dst_str")}] : !tt.ptr<{ty}>, !tt.tensordesc<{dst_type}>
+            tt.descriptor_store %dst_desc[{refs("dst_off")}], %val {{ttig.block_io = "row_major"}} : !tt.tensordesc<{dst_type}>, tensor<{dst_type}, #layout>
 
             tt.return
         }}
     }}
     """
 
-    torch_dtype = getattr(torch, dtype_str)
     if torch_dtype.is_floating_point:
-        a = torch.randn(shape, dtype=torch_dtype, device=device)
+        a = torch.randn(src_shape, dtype=torch_dtype, device=device)
     else:
-        a = torch.randint(low=-127, high=128, size=shape, dtype=torch_dtype, device=device)
+        a = torch.randint(low=-127, high=128, size=src_shape, dtype=torch_dtype, device=device)
 
-    x = torch.empty_like(a)
+    x = torch.empty(shape, dtype=torch_dtype, device=device)
 
     temp_file = tmp_path / "test_block_io_nd.ttgir"
     temp_file.write_text(ir)
     kernel = triton.compile(str(temp_file))
 
     kernel[(1, 1, 1)](a, x)
-    assert torch.equal(a, x)
+    tile = a[batch:2 * batch]
+    assert torch.equal(tile.transpose(-2, -1) if transpose else tile, x)
 
     if support_block_io:
         llir = kernel.asm["llir"]

--- a/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
+++ b/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
@@ -235,6 +235,24 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
 
 // -----
 
+// COM: Test a rank-3 column-major (transposed) block load. The batch stride is
+// COM: independent of the inner-two-dim memory layout.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4, 2], repCluster = [1, 1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth=2}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: @block_load_batch_rank3_column_major
+  tt.func public @block_load_batch_rank3_column_major(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i64) {
+    // CHECK: %[[BOFF:.*]] = llvm.mul %{{.*}}, %arg6 : i64
+    // CHECK: %[[BPTR:.*]] = llvm.getelementptr %{{.*}}{{\[}}%[[BOFF]]{{\]}} : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f16
+    // CHECK: triton_gen.2Dblockload %[[BPTR]]
+    // CHECK-SAME: transpose = true
+    %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] batch_strides[%arg6] {column_major} : !tt.ptr<f16> -> tensor<2x32x64xf16, #dot1>
+    tt.return
+  }
+}
+
+// -----
+
 // COM: Test subgroup-size=32 DotOp-B block load lowers with VNNI transform.
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 32, warpsPerCTA = [2, 2], repCluster = [1, 1], A = [16, 16], B = [16, 16], C = [16, 16]}>
 #dot = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>

--- a/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
+++ b/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
@@ -196,6 +196,45 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
 
 // -----
 
+// COM: Test a rank-3 (batched) block load. The 2D surface params describe one
+// COM: tile plane, so the step between batch slices must come from the
+// COM: batch_strides operand. Re-deriving it as base_height * (base_pitch /
+// COM: elem_bytes) reads the wrong slice for any non-densely-packed
+// COM: descriptor (issue #7882).
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4, 2], repCluster = [1, 1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth=1}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: @block_load_batch_rank3
+  tt.func public @block_load_batch_rank3(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i64) {
+    // CHECK: %[[BOFF:.*]] = llvm.mul %{{.*}}, %arg6 : i64
+    // CHECK: %[[BPTR:.*]] = llvm.getelementptr %{{.*}}{{\[}}%[[BOFF]]{{\]}} : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f16
+    // CHECK: triton_gen.2Dblockload %[[BPTR]]
+    %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] batch_strides[%arg6] {row_major} : !tt.ptr<f16> -> tensor<2x64x32xf16, #dot0>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Test a rank-4 block load: each leading dim gets its own stride, applied
+// COM: outermost-first as a chain of GEPs. A single shared stride (the #7882
+// COM: behaviour) would make the outer batch dim off by the inner dim's extent.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1, 8, 1], threadsPerWarp = [1, 1, 1, 16], warpsPerCTA = [2, 2, 2, 1], order = [3, 2, 1, 0]}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: @block_load_batch_rank4
+  tt.func public @block_load_batch_rank4(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i64, %arg7: i64) {
+    // CHECK: %[[B0:.*]] = llvm.mul %{{.*}}, %arg6 : i64
+    // CHECK: %[[P0:.*]] = llvm.getelementptr %{{.*}}{{\[}}%[[B0]]{{\]}} : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f16
+    // CHECK: %[[B1:.*]] = llvm.mul %{{.*}}, %arg7 : i64
+    // CHECK: %[[P1:.*]] = llvm.getelementptr %[[P0]]{{\[}}%[[B1]]{{\]}} : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f16
+    // CHECK: triton_gen.2Dblockload %[[P1]]
+    %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] batch_strides[%arg6, %arg7] {row_major} : !tt.ptr<f16> -> tensor<2x2x16x16xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
 // COM: Test subgroup-size=32 DotOp-B block load lowers with VNNI transform.
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 32, warpsPerCTA = [2, 2], repCluster = [1, 1], A = [16, 16], B = [16, 16], C = [16, 16]}>
 #dot = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>

--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
@@ -100,6 +100,32 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 
 // -----
 
+// COM: 3D column-major descriptor load. A column_major load declares the descriptor's
+// COM: inner two dims swapped relative to the result (<2x64x32> -> <2x32x64>), so the
+// COM: batch dim is still leading and still needs its own stride.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4, 2], repCluster = [1, 1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @descriptor_load_batch_column_major
+  tt.func @descriptor_load_batch_column_major(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i64, %arg5: i64, %batch_idx: i32) -> tensor<2x32x64xf16, #dot1> {
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2, %arg3], [%arg4, %arg5, %c1_i64] : <f16>, <2x64x32xf16>
+    // CHECK: ttig.extract_desc
+    // CHECK: %[[STRIDE0:.*]] = ttig.extract_desc %{{.*}}[3] : <2x64x32xf16> -> i64
+    // CHECK: %[[BATCH_EXT:.*]] = arith.extsi %arg6 : i32 to i64
+    // CHECK: %[[BATCH_OFF:.*]] = arith.muli %[[BATCH_EXT]], %[[STRIDE0]]
+    // CHECK: %[[ADJ_PTR:.*]] = tt.addptr %{{.*}}, %[[BATCH_OFF]]
+    // CHECK: ttig.2d_block_load %[[ADJ_PTR]]
+    // CHECK-SAME: batch_strides{{\[}}%[[STRIDE0]]{{\]}}
+    // CHECK-SAME: {column_major}
+    %0 = tt.descriptor_load %desc[%batch_idx, %c0_i32, %c0_i32] {ttig.block_io = "column_major"} : !tt.tensordesc<2x64x32xf16> -> tensor<2x32x64xf16, #dot1>
+    tt.return %0 : tensor<2x32x64xf16, #dot1>
+  }
+}
+
+// -----
+
 // COM: Rank-reducing descriptor load. The descriptor has rank 3 (with a leading
 // COM: size-1 batch dim) but the result tensor has rank 2. The batch index is
 // COM: folded into the base pointer via tt.addptr.

--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
@@ -75,6 +75,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 // COM: 3D descriptor load with batch dimension. The leading batch index should
 // COM: be folded into the base pointer via tt.addptr, and the inner-2 dims
 // COM: produce the 2D block load surface params.
+// COM: The result layout also spans the batch dim, so the op must additionally
+// COM: carry that dim's real stride in `batch_strides` — the surface params
+// COM: describe a single tile plane and cannot express it (issue #7882).
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4, 2], repCluster = [1, 1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
@@ -84,11 +87,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %c0_i32 = arith.constant 0 : i32
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2, %arg3], [%arg4, %arg5, %c1_i64] : <f16>, <2x64x32xf16>
     // CHECK: ttig.extract_desc
-    // CHECK: ttig.extract_desc
+    // CHECK: %[[STRIDE0:.*]] = ttig.extract_desc %{{.*}}[3] : <2x64x32xf16> -> i64
     // CHECK: %[[BATCH_EXT:.*]] = arith.extsi %arg6 : i32 to i64
-    // CHECK: %[[BATCH_OFF:.*]] = arith.muli %[[BATCH_EXT]], %{{.*}}
+    // CHECK: %[[BATCH_OFF:.*]] = arith.muli %[[BATCH_EXT]], %[[STRIDE0]]
     // CHECK: %[[ADJ_PTR:.*]] = tt.addptr %{{.*}}, %[[BATCH_OFF]]
     // CHECK: ttig.2d_block_load %[[ADJ_PTR]]
+    // CHECK-SAME: batch_strides{{\[}}%[[STRIDE0]]{{\]}}
     %0 = tt.descriptor_load %desc[%batch_idx, %c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<2x64x32xf16> -> tensor<2x64x32xf16, #dot0>
     tt.return %0 : tensor<2x64x32xf16, #dot0>
   }

--- a/test/TritonIntelGPU/tritonintelgpu-invalid.mlir
+++ b/test/TritonIntelGPU/tritonintelgpu-invalid.mlir
@@ -111,6 +111,20 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 
 // -----
 
+// COM: Every leading (batch) dim needs its own stride: the 2D surface params
+// COM: describe a single tile plane and cannot express the batch step (#7882).
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4, 2], repCluster = [1, 1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  tt.func @ttig.2d_block_load.missing_batch_stride(%base_ptr: !tt.ptr<f16>, %width: i32, %height: i32, %pitch: i32, %x: i32, %y: i32) -> tensor<2x64x32xf16, #dot0> {
+    // expected-error @below {{'ttig.2d_block_load' op expected 1 batch stride(s) for a rank-3 result, got 0}}
+    %0 = ttig.2d_block_load %base_ptr, %width, %height, %pitch[%x, %y] {row_major} : !tt.ptr<f16> -> tensor<2x64x32xf16, #dot0>
+    tt.return %0 : tensor<2x64x32xf16, #dot0>
+  }
+}
+
+// -----
+
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -225,6 +225,15 @@ def TTIG_Subgroup2DBlockLoadOp : TTIG_Op<"2d_block_load"> {
     descriptor indices) that are combined with per-sub-tile linear layout
     offsets during LLVM lowering.
 
+    `batch_strides` carries the element stride of each leading (batch)
+    dimension of the result tensor, i.e. one value per dimension in
+    `[0, rank - 2)`, outermost first. The 2D block I/O tile only ever covers
+    the inner two dimensions, so the LLVM lowering walks the batch dimensions
+    of the result layout and folds `offset * batch_strides[dim]` into the base
+    pointer. These strides cannot be derived from `base_width` / `base_height`
+    / `base_pitch` (those describe a single 2D surface only), so they must be
+    supplied by the producer of this op.
+
     When `pad_nan` is set, the LLVM lowering builds boundary masks from
     the surface dimensions and fills out-of-bounds elements with NaN.
     Otherwise, the hardware zero-fills out-of-bounds elements.
@@ -238,6 +247,7 @@ def TTIG_Subgroup2DBlockLoadOp : TTIG_Op<"2d_block_load"> {
     I32:$base_pitch,
     I32:$offset_x,
     I32:$offset_y,
+    Variadic<I64>:$batch_strides,
     OptionalAttr<UnitAttr>:$pad_nan,
     TTIG_BlockIOMode:$memory_layout
   );
@@ -246,6 +256,7 @@ def TTIG_Subgroup2DBlockLoadOp : TTIG_Op<"2d_block_load"> {
   let assemblyFormat = [{
     $base_ptr `,` $base_width `,` $base_height `,` $base_pitch
     `[` $offset_x `,` $offset_y `]`
+    (`batch_strides` `[` $batch_strides^ `]`)?
     `{` $memory_layout (`,` `pad_nan` $pad_nan^)? `}`
     attr-dict `:` type($base_ptr) `->` type($result)
   }];

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
@@ -126,9 +126,17 @@ LogicalResult Subgroup2DBlockLoadOp::verify() {
   if (!resultType)
     return emitOpError("result must be a ranked tensor type");
 
-  if (resultType.getRank() < 2)
-    return emitOpError("result tensor must have rank >= 2, got ")
-           << resultType.getRank();
+  unsigned rank = resultType.getRank();
+  if (rank < 2)
+    return emitOpError("result tensor must have rank >= 2, got ") << rank;
+
+  // The 2D block I/O tile covers the inner 2 dimensions only; every leading
+  // (batch) dimension needs an explicit stride because it cannot be derived
+  // from the 2D surface parameters.
+  if (getBatchStrides().size() != rank - 2)
+    return emitOpError("expected ")
+           << (rank - 2) << " batch stride(s) for a rank-" << rank
+           << " result, got " << getBatchStrides().size();
 
   return success();
 }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -4041,6 +4041,7 @@ struct Subgroup2DBlockLoadOpConversion
     Value pitch = adaptor.getBasePitch();
     Value baseOffsetX = adaptor.getOffsetX();
     Value baseOffsetY = adaptor.getOffsetY();
+    ValueRange batchStrides = adaptor.getBatchStrides();
 
     Value elemBytes = b.i32_val(elemSizeInBits / 8);
 
@@ -4100,6 +4101,19 @@ struct Subgroup2DBlockLoadOpConversion
     unsigned blockRowIdx = cfg.isTransposeRequired ? cfg.colDim : cfg.rowDim;
     unsigned blockColIdx = cfg.isTransposeRequired ? cfg.rowDim : cfg.colDim;
 
+    // `computeAddress` indexes `batch_strides` by dimension number, so the 2D
+    // tile must cover exactly the inner two dimensions and each remaining
+    // dimension must have a stride. `LowerTo2DBlockLoad` enforces the tile
+    // shape when it creates the op, but that shape comes from the layout, so
+    // the op verifier can only count the strides. Bail rather than read out of
+    // bounds: `ttig` is illegal in this conversion and this is the op's only
+    // pattern, so this is a legalization failure, not a fallback to a slower
+    // path. No in-tree producer can reach it.
+    if (batchStrides.size() != rank - 2 ||
+        std::min(blockRowIdx, blockColIdx) != rank - 2 ||
+        std::max(blockRowIdx, blockColIdx) != rank - 1)
+      return failure();
+
     // Per-sub-tile: combine base offsets with linear layout offsets.
     auto computeAddress =
         [&](unsigned /*registerIdx*/,
@@ -4121,11 +4135,12 @@ struct Subgroup2DBlockLoadOpConversion
         else if (dim == blockColIdx)
           offsetX = adjustedOffset;
         else {
-          // Batch dimensions: fold into base pointer via GEP.
-          Value strideInElems =
-              b.zext(int_ty(64), b.mul(baseHeight, b.udiv(pitch, elemBytes)));
+          // Batch dimensions: fold into base pointer via GEP. The stride is
+          // carried by the op (`batch_strides`) — it cannot be recovered from
+          // the 2D surface parameters, which describe a single tile plane.
+          assert(dim < batchStrides.size() && "missing batch stride");
           Value offset64 = b.zext(int_ty(64), adjustedOffset);
-          Value batchOffset = b.mul(offset64, strideInElems);
+          Value batchOffset = b.mul(offset64, batchStrides[dim]);
           addrElem = b.gep(ptr_ty(ctx, 1), eltTy, addrElem, batchOffset);
         }
       }

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -303,13 +303,21 @@ private:
     Value offsetX = indices[descRank - 1];
     Value offsetY = indices[descRank - 2];
 
+    // The batch *indices* were folded into base_ptr above, but the result
+    // layout also walks the batch dimensions during LLVM lowering and needs
+    // their real strides, which are not derivable from the 2D surface params.
+    // Result dim d is descriptor dim d + (descRank - rank).
+    SmallVector<Value> batchStrides;
+    for (unsigned d = 0; d + 2 < rank; ++d)
+      batchStrides.push_back(strides[d + (descRank - rank)]);
+
     // Determine padding mode from the descriptor.
     bool padNan = padding == tt::PaddingOption::PAD_NAN;
     UnitAttr padNanAttr = padNan ? builder.getUnitAttr() : UnitAttr();
 
     auto blockLoadOp = ttgi::Subgroup2DBlockLoadOp::create(
         builder, loc, op.getType(), basePtr, baseWidth, baseHeight, basePitch,
-        offsetX, offsetY, padNanAttr,
+        offsetX, offsetY, batchStrides, padNanAttr,
         ttgi::BlockIOModeAttr::get(builder.getContext(), memLayout));
 
     // Propagate one_matrix_per_load attribute if present.


### PR DESCRIPTION
## The bug

`ttig.2d_block_load` describes a single 2D tile plane — base pointer, width, height, pitch
and one `(x, y)` offset — but its result can be rank > 2, and the result layout walks the
leading (batch) dimensions during LLVM lowering. No operand carried a stride for those, so
`Subgroup2DBlockLoadOpConversion::computeAddress` re-derived one:

```cpp
Value strideInElems =
    b.zext(int_ty(64), b.mul(baseHeight, b.udiv(pitch, elemBytes)));
```

That value **does not depend on `dim`** — it is built from tile-plane parameters, so every
batch dimension gets the same multiplier, `shapes[-2] * strides[-2]`. Dimension `d` is
therefore stepped correctly only when `strides[d] == shapes[-2] * strides[-2]`. The
innermost batch dimension of a dense descriptor satisfies that by coincidence, which is why
rank-3 usually worked; any outer batch dimension is stepped by the wrong amount and the load
silently reads the wrong slice, with no diagnostic.

Dense packing does not save it — the rank-4 shape below is fully dense and dim 0 is 64× off:

| descriptor | multiplier before | correct |
|---|---|---|
| rank-3 `[64,64,32]`, strides `[2048,32,1]` (dense) | `2048` | `2048` — accidentally right |
| rank-3 padded, strides `[4096,32,1]` | `2048` | `4096` |
| rank-4 `[4,64,64,32]`, strides `[131072,2048,32,1]` | `2048`, `2048` | `131072`, `2048` |

One refinement on the issue title: the descriptor *indices* were never dropped — those are
folded using the true strides and are correct. Only the stride the **result layout** uses to
span the batch extents was re-derived, so a correct and an incorrect multiplier can appear in
the same function.

## The fix

Carry the strides on the op: `Variadic<I64>:$batch_strides`, one per dimension in
`[0, rank - 2)`, outermost first. The verifier requires `rank >= 2` and exactly `rank - 2`
strides; `LowerTo2DBlockLoad` (the only producer) fills them with
`strides[d + (descRank - rank)]`; the lowering multiplies by them.

**Why an operand**, since this changes an existing op's operand list: deriving the stride at
lowering time is not possible, because `LowerTo2DBlockLoad` has already consumed the
descriptor and the op carries only the flattened surface parameters. An attribute cannot hold
it either — the strides are runtime SSA values (`ttig.extract_desc` results; the pitch check
nearby has to *attempt* a constant fold and handles that fold failing). An operand also lets
the verifier enforce arity.

**One guard added.** Indexing `batch_strides` by dimension number is valid only while the
tile covers exactly the inner two dimensions. `LowerTo2DBlockLoad` rejects layouts that
violate that, but the tile shape comes from the encoding, so the verifier can only *count*
strides. The lowering therefore bails rather than indexing past the operand list. `ttig` is
illegal in this conversion and this is the op's only pattern, so that `failure()` is a clean
legalization error, not a silent fallback. No in-tree producer can reach it.

**Compatibility.** The verifier now requires exactly `rank - 2` strides, so a hand-written
rank > 2 `ttig.2d_block_load` without them no longer verifies. `ttig` is internal with a single
in-tree producer, so nothing in-tree is affected.

## Tests

Neither existing test could have caught this: `2d-block-load-to-llvm.mlir` had no rank > 2
case, and the rank-3 case in `LowerTo2DBlockLoad/descriptor-load.mlir` matched the batch
multiplier as `%{{.*}}` — a wildcard on the value the bug corrupts. Added rank-3 and rank-4
lowering cases that bind the GEP multiplier to a specific stride operand, the same binding in
the pass test, a verifier negative test, and `test_block_io_nd` from the issue.

Of the issue's three shapes only `[4,64,64,32]` fails; the other two are dense and agree with
the re-derived value, so they serve as controls. The smallest failing case is a *padded
rank-3* descriptor, which is added as a lit test.

`test_block_io_nd` covers both `block_io` modes and reads at a non-zero leading index in every
case. The column-major cases give the descriptor the inner two dims swapped relative to the
result (`<..x64x32>` -> `<..x32x64>`); same-type column-major input, as first written in the
issue, is not valid for this path. Below 32 bits the transposed dim must also pack to d32 per
lane or the tile is rejected and the op degrades to `tt.descriptor_load`, which would make the
case assert nothing — hence the dtype-derived layout.

## Verification

Reverting *only* the `computeAddress` hunk while keeping the plumbing makes the rank-3 and
rank-4 lowering CHECKs fail and leaves the pass and verifier tests passing, so the tests
cover distinct layers.

On an Arc Pro B50, with `libtriton.so` the only variable and only the `computeAddress` hunk
reverted (plumbing kept in both arms), `test_block_io_nd` goes **6 failed / 12 passed → 18
passed** — the six are exactly `[4,64,64,32]` at each dtype, in both `block_io` modes. Whole
file: 378 passed. So this is live silent corruption, not a latent IR-level concern.


