### PR TITLE
[CI] Use rss-ubuntu-2404 runner for CodeQL workflow

### DIFF
--- a/.github/actions/setup-pyenv-python/action.yml
+++ b/.github/actions/setup-pyenv-python/action.yml
@@ -51,6 +51,8 @@ runs:
       shell: bash
       run: |
         set -x
+        mkdir -p ~/.local/bin
+        echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
         ls -l ~/.local/bin/
         ln -sf $(which pip${{ inputs.python-version }}) ~/.local/bin/pip
         ln -sf $(which python${{ inputs.python-version }}) ~/.local/bin/python

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: code-scanning
+    runs-on: rss-ubuntu-2404
     permissions:
       # required for all workflows
       security-events: write
@@ -74,7 +74,7 @@ jobs:
   report:
     name: Generate SDL Security Report
     needs: analyze
-    runs-on: code-scanning
+    runs-on: rss-ubuntu-2404
     permissions:
       security-events: read
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v7
 
+    # rss-ubuntu-2404 has no C compiler preinstalled; pyenv needs one to build Python from source.
+    - name: Install build toolchain
+      if: matrix.build-mode == 'manual'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends build-essential
+
     # Initialize FIRST so the build tracer is installed before the C/C++ compile.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,6 +47,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends build-essential libffi-dev
         fi
+        echo "MAX_JOBS=${MAX_JOBS:-8}" >> "$GITHUB_ENV"
 
     # Initialize FIRST so the build tracer is installed before the C/C++ compile.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,12 +36,17 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v7
 
-    # rss-ubuntu-2404 has no C compiler preinstalled; pyenv needs one to build Python from source.
+    # rss-ubuntu-2404 has no C compiler preinstalled; pyenv needs one (plus libffi
+    # for the _ctypes module) to build Python from source.
     - name: Install build toolchain
       if: matrix.build-mode == 'manual'
       run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends build-essential
+        if command -v gcc >/dev/null 2>&1; then
+          echo "gcc already present: $(gcc --version | head -n1)"
+        else
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends build-essential libffi-dev
+        fi
 
     # Initialize FIRST so the build tracer is installed before the C/C++ compile.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends build-essential libffi-dev
         fi
-        echo "MAX_JOBS=${MAX_JOBS:-4}" >> "$GITHUB_ENV"
+        echo "MAX_JOBS=${MAX_JOBS:-2}" >> "$GITHUB_ENV"
 
     # Initialize FIRST so the build tracer is installed before the C/C++ compile.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends build-essential libffi-dev
         fi
-        echo "MAX_JOBS=${MAX_JOBS:-8}" >> "$GITHUB_ENV"
+        echo "MAX_JOBS=${MAX_JOBS:-4}" >> "$GITHUB_ENV"
 
     # Initialize FIRST so the build tracer is installed before the C/C++ compile.
     - name: Initialize CodeQL


### PR DESCRIPTION
## Summary
- Switch the `analyze` and `report` jobs in codeql.yml from the `code-scanning` runner label to `rss-ubuntu-2404`.

## Test plan
- [x] Trigger a manual `workflow_dispatch` run on this branch and confirm both jobs pick up the `rss-ubuntu-2404` runner and complete successfully: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/33441414953