### PR TITLE
[CI] Grant id-token to benchmark wheel-build jobs for Sigstore signing

### DIFF
--- a/.github/workflows/build-benchmarks-wheel.yml
+++ b/.github/workflows/build-benchmarks-wheel.yml
@@ -37,7 +37,9 @@ concurrency:
   group: ${{ github.workflow }}-wheel-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'keep-going') && github.run_id || github.event.pull_request.number) || github.ref }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions:
+  contents: read
+  id-token: write   # required for keyless Sigstore/OIDC signing
 
 jobs:
   build:
@@ -52,9 +54,6 @@ jobs:
       fail-fast: false
       max-parallel: 2
     timeout-minutes: 120
-    permissions:
-      id-token: write   # required for keyless Sigstore/OIDC signing
-      contents: read
     defaults:
       run:
         shell: bash -noprofile --norc -eo pipefail -c "source /opt/intel/oneapi/setvars.sh > /dev/null; source {0}"

--- a/.github/workflows/on-label.yml
+++ b/.github/workflows/on-label.yml
@@ -80,6 +80,9 @@ jobs:
   # ---- Build wheel ----
 
   build-wheel:
+    permissions:
+      contents: read
+      id-token: write   # for Sigstore signing in the reusable wheel-build workflow
     if: >-
       contains(github.event.pull_request.labels.*.name, 'run-benchmarks') ||
       contains(github.event.pull_request.labels.*.name, 'run-vllm-benchmarks') ||

--- a/.github/workflows/sglang-benchmarks-bmg.yml
+++ b/.github/workflows/sglang-benchmarks-bmg.yml
@@ -22,6 +22,9 @@ concurrency:
 
 jobs:
   build-wheel:
+    permissions:
+      contents: read
+      id-token: write   # for Sigstore signing in the reusable wheel-build workflow
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"

--- a/.github/workflows/sglang-benchmarks-pvc.yml
+++ b/.github/workflows/sglang-benchmarks-pvc.yml
@@ -22,6 +22,9 @@ concurrency:
 
 jobs:
   build-wheel:
+    permissions:
+      contents: read
+      id-token: write   # for Sigstore signing in the reusable wheel-build workflow
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"

--- a/.github/workflows/triton-benchmarks-bmg.yml
+++ b/.github/workflows/triton-benchmarks-bmg.yml
@@ -17,6 +17,9 @@ on:
 
 jobs:
   build-wheel:
+    permissions:
+      contents: read
+      id-token: write   # for Sigstore signing in the reusable wheel-build workflow
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"

--- a/.github/workflows/triton-benchmarks-pvc.yml
+++ b/.github/workflows/triton-benchmarks-pvc.yml
@@ -17,6 +17,9 @@ on:
 
 jobs:
   build-wheel:
+    permissions:
+      contents: read
+      id-token: write   # for Sigstore signing in the reusable wheel-build workflow
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"

--- a/.github/workflows/vllm-benchmarks-bmg.yml
+++ b/.github/workflows/vllm-benchmarks-bmg.yml
@@ -23,6 +23,9 @@ concurrency:
 
 jobs:
   build-wheel:
+    permissions:
+      contents: read
+      id-token: write   # for Sigstore signing in the reusable wheel-build workflow
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"

--- a/.github/workflows/vllm-benchmarks-pvc.yml
+++ b/.github/workflows/vllm-benchmarks-pvc.yml
@@ -23,6 +23,9 @@ concurrency:
 
 jobs:
   build-wheel:
+    permissions:
+      contents: read
+      id-token: write   # for Sigstore signing in the reusable wheel-build workflow
     uses: ./.github/workflows/build-benchmarks-wheel.yml
     with:
       python-version: "3.12"


### PR DESCRIPTION
PR #7840 added a keyless Sigstore signing step to the reusable build-benchmarks-wheel.yml, which requires `id-token: write`. The workflows that call it only granted `permissions: read-all`, which excludes id-token. A reusable workflow cannot request more token permissions than its caller, so every triggered benchmark workflow failed at startup validation ("workflow file issue", startup_failure) with zero jobs.

Add a job-level `permissions` block granting `contents: read` and `id-token: write` on each build-wheel job that calls the reusable signing workflow, leaving `read-all` intact for all other jobs.