### PR TITLE
[NFC][XPU] Reduce upstream divergence in histogram and print lowering

### DIFF
--- a/third_party/intel/lib/TritonIntelGPUToLLVM/HistogramOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/HistogramOpToLLVM.cpp
@@ -80,12 +80,13 @@ public:
     auto *ctx = op.getContext();
     Value input = adaptor.getSrc();
     auto typeConverter = getTypeConverter();
-    SmallVector<Value> srcValues = unpackLLElements(loc, input, rewriter);
+    SmallVector<Value> srcValues =
+        unpackUniqueTensorElements(loc, input, rewriter);
 
     Value llMask = adaptor.getMask();
     SmallVector<Value> maskValues;
     if (llMask)
-      maskValues = unpackLLElements(loc, llMask, rewriter);
+      maskValues = unpackUniqueTensorElements(loc, llMask, rewriter);
 
     int numBins = op.getType().getDimSize(0);
     auto mod = op->getParentOfType<ModuleOp>();
@@ -135,8 +136,8 @@ public:
           b.sdiv(histogramValue[i], b.i32_val(replicationFactor));
     }
 
-    Value results = packLLElements(loc, typeConverter, histogramValue, rewriter,
-                                   op.getType());
+    Value results = packUniqueTensorElements(loc, typeConverter, histogramValue,
+                                             rewriter, op.getType());
     rewriter.replaceOp(op, results);
     return success();
   }

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/PrintOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/PrintOpToLLVM.cpp
@@ -98,8 +98,6 @@ struct PrintOpConversion
     assert(elems.size() == indices.size());
     assert(dimWidths.size() == indices.front().size());
 
-    size_t rank = dimWidths.size();
-
     // Format is:
     //   pid (<x>, <y>, <z>) idx (<i1>, <i2>, ...)<prefix> (operand <n>) <elem>
     // where we leave off "(operand <n>)" if there's only one operand.


### PR DESCRIPTION
Closes #7913

NFC alignment of two Intel lowering files with upstream. No behaviour change.

- **`HistogramOpToLLVM.cpp`**: use `unpack/packUniqueTensorElements` instead of `unpack/packLLElements`, matching upstream triton-lang/triton#10722. Those are currently pass-through wrappers around each other in `lib/Conversion/TritonGPUToLLVM/Utility.cpp`, so emitted LLVM is unchanged; the point is to be on the API upstream is evolving. Left alone deliberately: the `removeZeroBasesAlongDim` workaround, the raw `b.store`/`b.load` in `computeHistogram` (Intel's `storeShared` would add a `cf.cond_br` diamond for a constant-true predicate), and the `numThreadsPerWarp == 16` assert case.
- **`PrintOpToLLVM.cpp`**: drop a dead `size_t rank` local, as upstream did.

Testing (CPU only): `triton-opt` output for `histogram_to_llvm.mlir` and `tritongpu_to_gen.mlir` is byte-identical before/after; `lit test/TritonIntelGPU/` 82/82; `lit test/Conversion/intel/` 23/24 with the one failure (`atomic_poll.mlir`) confirmed pre-existing on the base commit; `pre-commit --all-files` passes.