### PR TITLE
[MaterializeBlockPointer] Fix wrong per-warp base in 1D strided load reshape

### DIFF
--- a/python/test/unit/intel/test_1d_reshape_store_correctness.py
+++ b/python/test/unit/intel/test_1d_reshape_store_correctness.py
@@ -55,6 +55,11 @@ def _has_block_store(llir):
     return 'spirv_Subgroup2DBlockStoreINTEL' in llir or 'GenISA.LSC2DBlockWrite' in llir
 
 
+def _has_block_load(llir):
+    """True if the kernel emitted a 2D block load message."""
+    return 'spirv_Subgroup2DBlockLoadINTEL' in llir or 'GenISA.LSC2DBlockRead' in llir
+
+
 @pytest.mark.skipif(not is_xpu(), reason="XPU-specific test")
 @pytest.mark.parametrize(
     "W, S, XBLOCK, num_warps, expect_block_store, dtype_str",
@@ -381,4 +386,100 @@ def test_1d_reshape_strided_load_w_gt_tpw(W, S, H, dtype_str, device):
         to_numpy(out_tri),
         out_ref,
         err_msg=f"Load mismatch W={W} S={S} H={H} (W > threadsPerWarp bug)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the wrong per-warp row base in reshape1DStridedLoad.
+#
+# See: https://github.com/intel/intel-xpu-backend-for-triton/issues/7918
+#
+# The pointer and mask used to be reshaped with `allow_reorder
+# efficient_layout`, which only retypes the tensor and moves no data, so the
+# registers still held pointers in 1D order while the type claimed the 2D
+# block load's delivery encoding.  The lowering reads each warp's base address
+# out of that tensor, so warp w started at the row the *1D* layout put there
+# rather than at row perWarpH*w.
+#
+# The bug is invisible unless the 1D source layout needs more than one
+# register repetition per lane, i.e.
+#
+#     reps1D = XBLOCK / (sizePerThread1D * threadsPerWarp * num_warps) > 1
+#
+# because at reps1D == 1 the two layouts happen to agree on the warp base.
+# That is why the tests above miss it: `test_1d_reshape_strided_load` uses
+# XBLOCK=1024 with num_warps=4, giving 1024/(8*32*4) = 1, and the
+# `_w_gt_tpw` tests use num_warps=1, where no per-warp base exists at all.
+# Every config below has reps1D >= 2 and num_warps >= 2.
+# ---------------------------------------------------------------------------
+@pytest.mark.skipif(not is_xpu(), reason="XPU-specific test")
+@pytest.mark.parametrize(
+    "W, S, XBLOCK, num_warps, dtype_str",
+    [
+        # The shape reported in #7918: reps1D = 4096/(8*32*4) = 4, per-warp
+        # height 32 (the load hardware maximum).  Warp w read row 8*w instead
+        # of 32*w, so 3072 of every 4096 elements came back wrong.
+        (32, 96, 4096, 4, "float16"),
+        (32, 128, 4096, 4, "float16"),
+        (32, 192, 4096, 4, "float16"),
+        # Fewer warps, same reps1D = 2048/(8*32*2) = 4: per-warp height is
+        # still 32 but there are only two warps to get wrong.
+        (32, 96, 2048, 2, "float16"),
+        # More warps, reps1D = 4096/(8*32*8) = 2 and per-warp height 16.
+        # Exercises a per-warp height below the hardware maximum.
+        (32, 96, 4096, 8, "float16"),
+    ],
+    ids=[
+        "W32_S96_X4096_w4_f16",
+        "W32_S128_X4096_w4_f16",
+        "W32_S192_X4096_w4_f16",
+        "W32_S96_X2048_w2_f16",
+        "W32_S96_X4096_w8_f16",
+    ],
+)
+def test_1d_reshape_strided_load_multi_warp_base(W, S, XBLOCK, num_warps, dtype_str, device):
+    """Every warp must read from its own row base after the 1D->2D load reshape.
+
+    Uses the same Inductor-style gather as `test_1d_reshape_strided_load` but
+    with reps1D >= 2, the regime in which a wrong per-warp base is observable.
+    Four program instances are launched so the per-program offset is exercised
+    alongside the per-warp base.
+    """
+    # Enough rows for four program instances.
+    rows_per_block = XBLOCK // W
+    num_rows = 4 * rows_per_block
+    xnumel = W * num_rows
+
+    rs = RandomState(17)
+    # Padded 2D input surface [num_rows, S]; the kernel reads its first W columns.
+    in_full = numpy_random((num_rows, S), dtype_str=dtype_str, rs=rs)
+    out_ref = in_full[:, :W].flatten() * np.dtype(dtype_str).type(2.0)
+
+    in_tri = to_triton(in_full.flatten(), device=device)
+    out_tri = torch.zeros(xnumel, dtype=getattr(torch, dtype_str), device=device)
+
+    grid = (xnumel + XBLOCK - 1) // XBLOCK
+    kernel = strided_load_kernel[(grid, )](
+        in_tri,
+        out_tri,
+        xnumel,
+        W=W,
+        S=S,
+        XBLOCK=XBLOCK,
+        num_warps=num_warps,
+    )
+
+    # Pin that the 1D->2D reshape actually fired.  Without this the test would
+    # keep passing if the optimization were disabled, and would no longer guard
+    # anything.  Skip the check on devices that have no 2D block I/O.
+    if triton.runtime.driver.active.get_current_target().arch.get('has_2d_block_io', False):
+        assert _has_block_load(kernel.asm["llir"]), \
+            f"1D->2D load reshape did not fire for W={W} S={S} XBLOCK={XBLOCK} num_warps={num_warps}"
+
+    np.testing.assert_allclose(
+        to_numpy(out_tri),
+        out_ref,
+        rtol=1e-3,
+        atol=1e-3,
+        err_msg=f"Strided load mismatch for W={W}, S={S}, XBLOCK={XBLOCK}, num_warps={num_warps}",
     )

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-anchor.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-anchor.mlir
@@ -1,15 +1,22 @@
 // RUN: triton-opt %s -split-input-file -tritonintelgpu-materialize-block-pointer -tritonintelgpu-remove-layout-conversions | FileCheck %s
 
-// COM: Regression test: verify that RemoveLayoutConversions does NOT remove
-// COM: the ConvertLayoutOp inserted by reshape1DStridedLoad.  The load encoding
-// COM: matches HW delivery order and must be anchored; without the anchor fix
-// COM: in isExpensiveLoadOrStore the ConvertLayoutOp is eliminated and the load
+// COM: Regression test for how RemoveLayoutConversions treats the two
+// COM: ConvertLayoutOps that reshape1DStridedLoad inserts.
+// COM:
+// COM: The one on the *result* must survive.  The load encoding matches HW
+// COM: delivery order and must be anchored; without the anchor fix in
+// COM: isExpensiveLoadOrStore that ConvertLayoutOp is eliminated and the load
 // COM: encoding is changed, producing incorrect results at runtime.
+// COM:
+// COM: The one on the *pointer* is expected to fold away.  RLC back-propagates
+// COM: the load encoding through the elementwise addptr chain, so the reshape
+// COM: feeds the load directly and no data movement remains.
 
 #blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
   // CHECK-LABEL: tt.func @test_convert_layout_survives
-  // CHECK: tt.reshape %{{.*}} allow_reorder efficient_layout
+  // CHECK: tt.reshape %{{.*}} : tensor<1024x!tt.ptr<f16>, {{.*}}> -> tensor<32x32x!tt.ptr<f16>, {{.*}}>
+  // CHECK-NOT: ttg.convert_layout
   // CHECK: tt.load %{{.*}} {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64}
   // CHECK: tt.reshape %{{.*}} efficient_layout
   // CHECK: ttg.convert_layout

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-anchor.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-anchor.mlir
@@ -1,16 +1,18 @@
 // RUN: triton-opt %s -split-input-file -tritonintelgpu-materialize-block-pointer -tritonintelgpu-remove-layout-conversions | FileCheck %s
 
-// COM: Regression test for how RemoveLayoutConversions treats the two
-// COM: ConvertLayoutOps that reshape1DStridedLoad inserts.
+// COM: Regression test for how RemoveLayoutConversions treats the ConvertLayoutOps
+// COM: that reshape1DStridedLoad inserts: one per reshaped operand (pointer, and
+// COM: mask when the load is masked) plus one on the result.
 // COM:
 // COM: The one on the *result* must survive.  The load encoding matches HW
 // COM: delivery order and must be anchored; without the anchor fix in
 // COM: isExpensiveLoadOrStore that ConvertLayoutOp is eliminated and the load
 // COM: encoding is changed, producing incorrect results at runtime.
 // COM:
-// COM: The one on the *pointer* is expected to fold away.  RLC back-propagates
-// COM: the load encoding through the elementwise addptr chain, so the reshape
-// COM: feeds the load directly and no data movement remains.
+// COM: The ones on the *pointer* and *mask* are expected to fold away.  RLC
+// COM: back-propagates the load encoding through the elementwise addptr chain and
+// COM: into the mask constant, so the reshapes feed the load directly and no data
+// COM: movement remains — which the CHECK-NOT below pins.
 
 #blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-disabled.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-disabled.mlir
@@ -59,7 +59,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // DISABLED-NOT: tt.reshape
     // DISABLED: tt.load %{{.*}} : tensor<1024x!tt.ptr<f16>
     // DISABLED-NOT: ttig.block_io
-    // ENABLED: tt.reshape %{{.*}} allow_reorder efficient_layout
+    // ENABLED: tt.reshape %{{.*}} : tensor<1024x!tt.ptr<f16>, {{.*}}> -> tensor<32x32x!tt.ptr<f16>, {{.*}}>
+    // ENABLED: ttg.convert_layout
     // ENABLED: tt.load %{{.*}} {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64}
     // ENABLED: ttg.convert_layout
     // ENABLED: tt.reshape %{{.*}} efficient_layout

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape.mlir
@@ -158,11 +158,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
 #blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  // COM: The pointer and mask must be reshaped without reordering and then
+  // COM: physically converted into the load encoding. A relabelling reshape
+  // COM: (allow_reorder efficient_layout) moves no data, so the operands would
+  // COM: claim the load encoding while still holding 1D-ordered values.
   // CHECK-LABEL: tt.func @test_1d_strided_load
-  // CHECK: tt.reshape %{{.*}} allow_reorder efficient_layout
-  // CHECK: tt.load %{{.*}} {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64}
-  // CHECK: ttg.convert_layout
-  // CHECK: tt.reshape %{{.*}} efficient_layout
+  // CHECK: [[PTR2D:%[0-9]+]] = tt.reshape %{{.*}} : tensor<1024x!tt.ptr<f16>, {{.*}}> -> tensor<32x32x!tt.ptr<f16>, [[CONSENC:#[a-z0-9_]+]]>
+  // CHECK: [[PTRCVT:%[0-9]+]] = ttg.convert_layout [[PTR2D]] : tensor<32x32x!tt.ptr<f16>, [[CONSENC]]> -> tensor<32x32x!tt.ptr<f16>, [[LOADENC:#[a-z0-9_]+]]>
+  // CHECK: [[MASK2D:%[0-9]+]] = tt.reshape %{{.*}} : tensor<1024xi1, {{.*}}> -> tensor<32x32xi1, [[CONSENC]]>
+  // CHECK: [[MASKCVT:%[0-9]+]] = ttg.convert_layout [[MASK2D]] : tensor<32x32xi1, [[CONSENC]]> -> tensor<32x32xi1, [[LOADENC]]>
+  // CHECK: [[LOADED:%[0-9]+]] = tt.load [[PTRCVT]], [[MASKCVT]] {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64} : tensor<32x32x!tt.ptr<f16>, [[LOADENC]]>
+  // CHECK: [[CVT:%[0-9]+]] = ttg.convert_layout [[LOADED]] : tensor<32x32xf16, [[LOADENC]]> -> tensor<32x32xf16, [[CONSENC]]>
+  // CHECK: tt.reshape [[CVT]] efficient_layout : tensor<32x32xf16, [[CONSENC]]> -> tensor<1024xf16, {{.*}}>
   tt.func @test_1d_strided_load(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) -> tensor<1024xf16, #blocked1d> {
     %idx = tt.make_range {start = 0 : i32, end = 1024 : i32} : tensor<1024xi32, #blocked1d>
     %c32 = arith.constant dense<32> : tensor<1024xi32, #blocked1d>

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -880,31 +880,35 @@ private:
     if (!consumerEnc)
       return;
 
-    // Reshape pointer to [H, W] with load encoding.
-    // Mark efficient_layout so RemoveLayoutConversions does not
-    // rematerialize these reshapes with a different encoding.
+    // Reshape pointer to [H, W] with its natural 2D encoding, then convert it
+    // into the load encoding, mirroring reshape1DStridedStore.  A plain relabel
+    // (allow_reorder + efficient_layout) would be incorrect: that reshape
+    // lowers to a no-op, so the registers would still hold the pointers laid
+    // out per the 1D source encoding while the type claims HW delivery order.
+    auto ptrReshape = tt::ReshapeOp::create(builder, loc, newShape, info->ptr,
+                                            /*allowReorder=*/false);
     auto loadPtrTy =
         RankedTensorType::get(newShape, ptrTensorTy.getElementType(), loadEnc);
-    auto ptrReshape = tt::ReshapeOp::create(builder, loc, loadPtrTy, info->ptr,
-                                            /*allowReorder=*/true,
-                                            /*efficientLayout=*/true);
+    Value loadPtr =
+        ttg::ConvertLayoutOp::create(builder, loc, loadPtrTy, ptrReshape);
 
-    // Reshape mask if present.
+    // Reshape mask if present, same treatment as the pointer.
     Value mask2d;
     if (Value mask = op.getMask()) {
       auto maskTy = cast<RankedTensorType>(mask.getType());
+      auto maskReshape = tt::ReshapeOp::create(builder, loc, newShape, mask,
+                                               /*allowReorder=*/false);
       auto loadMaskTy =
           RankedTensorType::get(newShape, maskTy.getElementType(), loadEnc);
-      mask2d = tt::ReshapeOp::create(builder, loc, loadMaskTy, mask,
-                                     /*allowReorder=*/true,
-                                     /*efficientLayout=*/true);
+      mask2d =
+          ttg::ConvertLayoutOp::create(builder, loc, loadMaskTy, maskReshape);
     }
 
     // Create 2D load with load encoding.
     Type pointeeTy =
         cast<tt::PointerType>(ptrTensorTy.getElementType()).getPointeeType();
     auto loadResultTy = RankedTensorType::get(newShape, pointeeTy, loadEnc);
-    auto newLoad = tt::LoadOp::create(builder, loc, loadResultTy, ptrReshape,
+    auto newLoad = tt::LoadOp::create(builder, loc, loadResultTy, loadPtr,
                                       mask2d, op.getOther(), op.getCache(),
                                       op.getEvict(), op.getIsVolatile());
 


### PR DESCRIPTION
The 1D->2D load rewrite reshaped the pointer and mask with
`allow_reorder efficient_layout`. That reshape only changes the type, it
does not move data, so the pointer tensor claimed the layout the 2D block
load expects while the registers still held pointers in the original 1D
order.

The lowering reads each warp's base address out of that tensor, so every
warp but the first started at the wrong row. With BLOCK=4096, W=32, S=96
and num_warps=4, warp w read row 8*w instead of 32*w and 3072 of 4096
elements came back wrong.

Reshape the pointer and mask without reordering, then convert them to the
load layout with ttg::ConvertLayoutOp. The store path already does this,
which is why stores were never affected. The lowering is unchanged.

The convert costs nothing: RemoveLayoutConversions pushes the layout back
into the addptr chain and folds it away. The generated LLVM IR keeps the
same 8192 B of shared memory, one barrier and one LSC2DBlockRead as before.

Update the three lit tests that matched the old pointer reshape.

Fixes #7918