### PR TITLE
Fix wildcard glob in pip install for PyTorch nightly wheel

### DIFF
--- a/scripts/install-pytorch.sh
+++ b/scripts/install-pytorch.sh
@@ -188,7 +188,7 @@ if [ "$BUILD_PYTORCH" = false ]; then
     --dir $TEMP_DIR
   cd $TEMP_DIR/$WHEEL_PATTERN
   echo "**** Install PyTorch and pinned dependencies from nightly builds. ****"
-  pip install torch*
+  pip install torch*.whl
   rm -rf $TEMP_DIR
   exit 0
 fi


### PR DESCRIPTION
## Summary
`pip install torch*` in `scripts/install-pytorch.sh` uses an unrestricted glob that can match other files beginning with `torch` in the temp download directory, which breaks the script, if there are other files stored alongside
```
ERROR: Invalid requirement: 'torch-2.15.0a0+git98bf8ee-cp310-cp310-linux_x86_64.whl.sigstore.json': Expected semicolon (after name with no version specifier) or end
    torch-2.15.0a0+git98bf8ee-cp310-cp310-linux_x86_64.whl.sigstore.json
```
Restricting the glob to `.whl` files: `pip install torch*.whl`.

## Test plan
- [x] Run `scripts/install-pytorch.sh` in the non-`BUILD_PYTORCH` path and confirm only the intended wheel is installed.

Discovered by @whitneywhtsang 