### PR TITLE
Switch pre-commit checks runner to rss-ubuntu-2404

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -63,7 +63,7 @@ permissions: read-all
 jobs:
   pre-commit:
     name: Pre-commit checks
-    runs-on: Linux
+    runs-on: rss-ubuntu-2404
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
- Switch the `pre-commit` job's `runs-on` in `build-test.yml` from `Linux` to `rss-ubuntu-2404`, matching the runner label already used in `codeql.yml` and `wheels-triton-shim.yml`.

## Test plan
- [ ] CI runs the `pre-commit` job successfully on the `rss-ubuntu-2404` runner