### PR TITLE
Move CodeQL build toolchain install into a reusable action

### DIFF
--- a/.github/actions/install-build-toolchain/action.yml
+++ b/.github/actions/install-build-toolchain/action.yml
@@ -1,0 +1,14 @@
+name: install-build-toolchain
+description: Install a C compiler and libffi (needed by pyenv to build Python from source)
+runs:
+  using: "composite"
+  steps:
+    - name: Install build toolchain
+      shell: bash
+      run: |
+        if command -v gcc >/dev/null 2>&1; then
+          echo "gcc already present: $(gcc --version | head -n1)"
+        else
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends build-essential libffi-dev
+        fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,14 +40,11 @@ jobs:
     # for the _ctypes module) to build Python from source.
     - name: Install build toolchain
       if: matrix.build-mode == 'manual'
-      run: |
-        if command -v gcc >/dev/null 2>&1; then
-          echo "gcc already present: $(gcc --version | head -n1)"
-        else
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends build-essential libffi-dev
-        fi
-        echo "MAX_JOBS=${MAX_JOBS:-2}" >> "$GITHUB_ENV"
+      uses: ./.github/actions/install-build-toolchain
+
+    - name: Set MAX_JOBS
+      if: matrix.build-mode == 'manual'
+      run: echo "MAX_JOBS=${MAX_JOBS:-2}" >> "$GITHUB_ENV"
 
     # Initialize FIRST so the build tracer is installed before the C/C++ compile.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,10 +42,6 @@ jobs:
       if: matrix.build-mode == 'manual'
       uses: ./.github/actions/install-build-toolchain
 
-    - name: Set MAX_JOBS
-      if: matrix.build-mode == 'manual'
-      run: echo "MAX_JOBS=${MAX_JOBS:-2}" >> "$GITHUB_ENV"
-
     # Initialize FIRST so the build tracer is installed before the C/C++ compile.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
@@ -62,6 +58,10 @@ jobs:
       with:
         python_version: "3.10"
         use_pyenv: true
+
+    - name: Set MAX_JOBS
+      if: matrix.build-mode == 'manual'
+      run: echo "MAX_JOBS=${MAX_JOBS:-2}" >> "$GITHUB_ENV"
 
     - name: Build Triton (traced)
       if: matrix.build-mode == 'manual'


### PR DESCRIPTION
## Summary
- Extracts the gcc/libffi install step from `codeql.yml` into a new composite action, `.github/actions/install-build-toolchain`, so it can be reused by other workflows that need a C compiler (e.g. for building Python from source via pyenv).
- `MAX_JOBS` default-setting is kept as a separate inline step in `codeql.yml` since it's specific to that workflow's use of the toolchain.

## Test plan
- [ ] CI run of `codeql.yml` on this PR succeeds for the `c-cpp` (manual build-mode) matrix leg