### PR TITLE
[TritonIntelGPU] Gate ReduceVariableLiveness sinking on measured register pressure, not tile size

### DIFF
--- a/test/TritonIntelGPU/reduce-variable-liveness-grf-mode.mlir
+++ b/test/TritonIntelGPU/reduce-variable-liveness-grf-mode.mlir
@@ -2,7 +2,6 @@
 // RUN: triton-opt %s -tritonintelgpu-reduce-variable-liveness=grf-mode=128 -cse | FileCheck %s --check-prefixes=CHECK,SINK
 // RUN: triton-opt %s -tritonintelgpu-reduce-variable-liveness=grf-mode=256 -cse | FileCheck %s --check-prefixes=CHECK,SINK
 // RUN: triton-opt %s -tritonintelgpu-reduce-variable-liveness=grf-mode=512 -cse | FileCheck %s --check-prefixes=CHECK,KEEP
-// RUN: triton-opt %s -tritonintelgpu-reduce-variable-liveness=grf-mode=bogus -verify-diagnostics -o /dev/null
 // RUN: triton-opt %s -tritonintelgpu-reduce-variable-liveness=grf-mode=bogus -cse | FileCheck %s --check-prefixes=CHECK,SINK
 
 // COM: This module's `scf.for` body measures ~1536 B/lane live-in pressure at
@@ -14,12 +13,11 @@
 // COM: the 256-GRF-mode per-lane budget's 200% floor (1024 B) and the
 // COM: 512-GRF-mode one (2048 B), so default/128/256 sink the A operand's
 // COM: load into the loop while 512 keeps it outside. A bogus grf-mode falls
-// COM: back to the 'default' budget (with a warning), so it also sinks.
+// COM: back to the 'default' budget, so it also sinks.
 // CHECK: #[[$DPAS:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 8], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 8], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth=1}>
 #dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth=2}>
-// expected-warning@+1 {{unrecognized grf-mode 'bogus' for tritonintelgpu-reduce-variable-liveness; falling back to the 'default' GRF budget}}
 module attributes {ttig.support_2d_block_io, "ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
   tt.func @grf_mode_gate(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
     // CHECK-LABEL: tt.func @grf_mode_gate

--- a/test/TritonIntelGPU/reduce-variable-liveness-grf-mode.mlir
+++ b/test/TritonIntelGPU/reduce-variable-liveness-grf-mode.mlir
@@ -1,0 +1,52 @@
+// RUN: triton-opt %s -tritonintelgpu-reduce-variable-liveness -cse | FileCheck %s --check-prefixes=CHECK,SINK
+// RUN: triton-opt %s -tritonintelgpu-reduce-variable-liveness=grf-mode=128 -cse | FileCheck %s --check-prefixes=CHECK,SINK
+// RUN: triton-opt %s -tritonintelgpu-reduce-variable-liveness=grf-mode=256 -cse | FileCheck %s --check-prefixes=CHECK,SINK
+// RUN: triton-opt %s -tritonintelgpu-reduce-variable-liveness=grf-mode=512 -cse | FileCheck %s --check-prefixes=CHECK,KEEP
+// RUN: triton-opt %s -tritonintelgpu-reduce-variable-liveness=grf-mode=bogus -verify-diagnostics -o /dev/null
+// RUN: triton-opt %s -tritonintelgpu-reduce-variable-liveness=grf-mode=bogus -cse | FileCheck %s --check-prefixes=CHECK,SINK
+
+// COM: This module's `scf.for` body measures ~1536 B/lane live-in pressure at
+// COM: pass-run time (the 256x128 A operand contributes 1024 B/lane, a second
+// COM: live-in 128x128 tensor contributes another 512 B/lane -- confirmed via
+// COM: `-test-register-pressure`; that second tensor is dead code and gets
+// COM: cleaned up by the `-cse` in the RUN lines above, after the pass has
+// COM: already made its sink/keep decision). That value sits strictly between
+// COM: the 256-GRF-mode per-lane budget's 200% floor (1024 B) and the
+// COM: 512-GRF-mode one (2048 B), so default/128/256 sink the A operand's
+// COM: load into the loop while 512 keeps it outside. A bogus grf-mode falls
+// COM: back to the 'default' budget (with a warning), so it also sinks.
+// CHECK: #[[$DPAS:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 8], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 8], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth=1}>
+#dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth=2}>
+// expected-warning@+1 {{unrecognized grf-mode 'bogus' for tritonintelgpu-reduce-variable-liveness; falling back to the 'default' GRF budget}}
+module attributes {ttig.support_2d_block_io, "ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  tt.func @grf_mode_gate(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    // CHECK-LABEL: tt.func @grf_mode_gate
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x256xf32, #dpas>
+    %c128_i32 = arith.constant 128 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
+    %0 = tt.make_tensor_descriptor %arg0, [%c0_i32, %c0_i32], [%c0_i64, %c0_i64] : <f16>, <256x128xf16>
+    %1 = tt.make_tensor_descriptor %arg1, [%c0_i32, %c0_i32], [%c0_i64, %c0_i64] : <f16>, <128x256xf16>
+    %5 = tt.make_tensor_descriptor %arg2, [%c0_i32, %c0_i32], [%c0_i64, %c0_i64] : <f16>, <128x128xf16>
+    // SINK:      ttig.descriptor_prefetch %{{.*}}[%c0_i32, %c0_i32] {{.*}} : !tt.tensordesc<256x128xf16>
+    // KEEP:      tt.descriptor_load %{{.*}}[%c0_i32, %c0_i32] {{.*}} : !tt.tensordesc<256x128xf16> -> tensor<256x128xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DPAS]], kWidth = 1}>>
+    // KEEP-NOT:  ttig.descriptor_prefetch %{{.*}}[%c0_i32, %c0_i32] {{.*}} : !tt.tensordesc<256x128xf16>
+    %2 = tt.descriptor_load %0[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<256x128xf16> -> tensor<256x128xf16, #dot0>
+    %bias = tt.descriptor_load %5[%c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<128x128xf16> -> tensor<128x128xf16, #dot0>
+    ttig.descriptor_prefetch %1[%c0_i32, %c0_i32] : !tt.tensordesc<128x256xf16>
+    %4:2 = scf.for %arg3 = %c0_i32 to %c128_i32 step %c128_i32 iter_args(%arg4 = %cst, %arg5 = %c0_i32) -> (tensor<256x256xf32, #dpas>, i32)  : i32 {
+      // CHECK:      scf.for
+      // SINK:       tt.descriptor_load {{.*}} : !tt.tensordesc<256x128xf16> -> tensor<256x128xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DPAS]], kWidth = 1}>>
+      // KEEP-NOT:   tt.descriptor_load {{.*}} : !tt.tensordesc<256x128xf16> -> tensor<256x128xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DPAS]], kWidth = 1}>>
+      %7 = arith.addi %arg5, %c128_i32 : i32
+      ttig.descriptor_prefetch %1[%7, %c0_i32] : !tt.tensordesc<128x256xf16>
+      %8 = tt.descriptor_load %1[%arg5, %c0_i32] {ttig.block_io = "column_major"} : !tt.tensordesc<128x256xf16> -> tensor<128x256xf16, #dot1>
+      %biasuse = arith.addf %bias, %bias : tensor<128x128xf16, #dot0>
+      %9 = tt.dot %2, %8, %arg4, inputPrecision = tf32 : tensor<256x128xf16, #dot0> * tensor<128x256xf16, #dot1> -> tensor<256x256xf32, #dpas>
+      scf.yield %9, %7 : tensor<256x256xf32, #dpas>, i32
+    }
+    tt.return
+  }
+}

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -428,7 +428,7 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
         intel.passes.ttgpuir.add_pipeline(pm, opt.num_stages, opt.use_barrier)
 
         if (opt.reduce_variable_liveness):
-            intel.passes.ttgpuir.add_reduce_variable_liveness(pm)
+            intel.passes.ttgpuir.add_reduce_variable_liveness(pm, opt.grf_mode)
 
         # Off by default: code sinking is perf-neutral on measured kernels (it
         # reliably reduces register spills, but the relieved traffic is not on

--- a/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/Transforms/Passes.td
@@ -347,11 +347,20 @@ def TritonIntelGPUReduceVariableLiveness
   let description = [{
     This pass attempts to reduce the variable liveness
     by reducing the distance between loads and usage.
+
+    A load is only sunk when the loop it would otherwise stay live across is
+    measured (via RegisterPressureAnalysis) to be under at least 200% of the
+    per-lane GRF budget for the given GRF mode.
   }];
 
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
                            "mlir::scf::SCFDialect",
                            "mlir::arith::ArithDialect"];
+
+  let options = [
+    Option<"grfMode", "grf-mode", "std::string", /*default*/"\"default\"",
+           "GRF mode ('default', 'auto', '128', '256' or '512')">,
+  ];
 }
 
 def TritonIntelGPUCodeSinking

--- a/third_party/intel/lib/TritonIntelGPUTransforms/ReduceVariableLiveness.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/ReduceVariableLiveness.cpp
@@ -1,7 +1,6 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 
 #include "Dialect/TritonIntelGPU/IR/Attributes.h"
@@ -17,7 +16,6 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 #include <algorithm>
-#include <array>
 #include <optional>
 
 namespace mlir::triton::gpu::intel {
@@ -43,40 +41,9 @@ namespace {
 // liveInPressure` reports bytes **per lane** (see RegisterPressure.h), so the
 // floor below must be expressed in the same per-lane unit rather than the
 // per-*hardware-thread* unit `getGRFBytesPerThread` returns on its own --
-// see `getPerLaneGRFBudgetInBytes`, which does that conversion using the
-// module's actual threads-per-warp rather than an assumed constant.
+// see `RegisterPressureAnalysis::getPerLaneGRFBudgetInBytes`, which does that
+// conversion using the module's actual threads-per-warp.
 constexpr uint32_t LIVE_IN_PRESSURE_GRF_BUDGET_MULTIPLIER = 2; // 200%
-
-/// The set of `grf-mode` values `getGRFBytesPerThread` assigns a real,
-/// mode-specific budget to. Anything else silently collapses to its
-/// "default" fallback (4096 bytes/thread) inside that function, so an
-/// unrecognized value is caught and warned about here instead.
-constexpr std::array<StringRef, 5> VALID_GRF_MODES = {"default", "auto", "128",
-                                                      "256", "512"};
-
-/// Convert the per-hardware-thread GRF budget for \p grfMode into a per-lane
-/// figure, dividing by the module's actual threads-per-warp so the result is
-/// in the same unit `RegisterPressureAnalysis::liveInPressure` reports.
-/// Falls back to the unscaled per-thread budget (with a diagnostic) if
-/// threads-per-warp is missing or non-positive, rather than dividing by zero.
-unsigned getPerLaneGRFBudgetInBytes(StringRef grfMode, ModuleOp mod) {
-  if (!llvm::is_contained(VALID_GRF_MODES, grfMode))
-    mod.emitWarning("unrecognized grf-mode '" + grfMode +
-                    "' for tritonintelgpu-reduce-variable-liveness; "
-                    "falling back to the 'default' GRF budget");
-  unsigned grfBudget =
-      ttg::intel::RegisterPressureAnalysis::getGRFBytesPerThread(grfMode);
-  int threadsPerWarp = ttg::TritonGPUDialect::getThreadsPerWarp(mod);
-  if (threadsPerWarp <= 0) {
-    mod.emitWarning(
-        "ttg.threads-per-warp is missing or non-positive; cannot convert "
-        "the per-hardware-thread GRF budget to a per-lane figure, falling "
-        "back to the unscaled per-thread budget for tritonintelgpu-"
-        "reduce-variable-liveness");
-    return grfBudget;
-  }
-  return grfBudget / static_cast<unsigned>(threadsPerWarp);
-}
 
 /// Return true if the lifespan of the \p v value is considered long.
 bool isLongLifeSpanVariable(
@@ -298,7 +265,9 @@ public:
 
     Operation *rootOperation = getOperation();
     ModuleOp mod = getOperation();
-    unsigned perLaneGRFBudget = getPerLaneGRFBudgetInBytes(grfMode, mod);
+    unsigned perLaneGRFBudget =
+        ttg::intel::RegisterPressureAnalysis::getPerLaneGRFBudgetInBytes(
+            grfMode, mod);
     ttg::intel::RegisterPressureAnalysis analysis(rootOperation);
     // TODO: extend the pass to handle `while` loops.
     rootOperation->walk([&](scf::ForOp forOp) {

--- a/third_party/intel/lib/TritonIntelGPUTransforms/ReduceVariableLiveness.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/ReduceVariableLiveness.cpp
@@ -1,6 +1,7 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 
 #include "Dialect/TritonIntelGPU/IR/Attributes.h"
@@ -16,6 +17,7 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 #include <algorithm>
+#include <array>
 #include <optional>
 
 namespace mlir::triton::gpu::intel {
@@ -34,65 +36,68 @@ using TensorValue = TypedValue<RankedTensorType>;
 
 namespace {
 
-// Live-in register-pressure floor (in bytes, summed across all lanes of the
-// workgroup) below which shortening a load's live range is not worthwhile: the
-// loop body is not under enough pressure to benefit.
-//
-// `RegisterPressureAnalysis` reports *per-thread* bytes, so the gate scales the
-// reported value back up by the workgroup's thread count before comparing. That
-// keeps this threshold in the same unit it has always had, and therefore keeps
-// the gate firing on exactly the same loops at every warp count. Expressing the
-// floor per-thread instead is not equivalent: a fixed per-thread number is a
-// different full-tensor bound at every thread count, and the attention kernels
-// that this transform exists to help sit right at the boundary.
-constexpr uint32_t TOTAL_BLOCK_SIZE_THRESHOLD_IN_BYTES = 32768;
-constexpr uint32_t LARGE_TENSOR_MINOR_SHAPE_THRESHOLD = 128;
-constexpr uint32_t LARGE_TENSOR_MAJOR_SHAPE_THRESHOLD = 128;
-constexpr uint32_t LARGE_TENSOR_SIZE_THRESHOLD_IN_BYTES =
-    LARGE_TENSOR_MAJOR_SHAPE_THRESHOLD * LARGE_TENSOR_MINOR_SHAPE_THRESHOLD * 2;
+// A load is worth sinking (moving closer to its use, with a cheap prefetch
+// left behind) when the loop it would otherwise stay live across is under
+// enough register pressure to make trading a redundant-but-cheap 2D block
+// load for freed registers a real win. `RegisterPressureAnalysis::
+// liveInPressure` reports bytes **per lane** (see RegisterPressure.h), so the
+// floor below must be expressed in the same per-lane unit rather than the
+// per-*hardware-thread* unit `getGRFBytesPerThread` returns on its own --
+// see `getPerLaneGRFBudgetInBytes`, which does that conversion using the
+// module's actual threads-per-warp rather than an assumed constant.
+constexpr uint32_t LIVE_IN_PRESSURE_GRF_BUDGET_MULTIPLIER = 2; // 200%
 
-/// Return the total size of the tensor type /p tensorType in bytes.
-/// If the tensor element type is not a int or a float, this function return 0.
-unsigned getSizeInBytes(RankedTensorType &tensorType) {
-  Type elType = tensorType.getElementType();
-  if (!elType.isIntOrFloat())
-    return 0;
-  unsigned elTypeBitWidth = elType.getIntOrFloatBitWidth();
-  unsigned totalNumElement = 1;
-  for (int64_t dim : tensorType.getShape()) {
-    totalNumElement *= dim;
+/// The set of `grf-mode` values `getGRFBytesPerThread` assigns a real,
+/// mode-specific budget to. Anything else silently collapses to its
+/// "default" fallback (4096 bytes/thread) inside that function, so an
+/// unrecognized value is caught and warned about here instead.
+constexpr std::array<StringRef, 5> VALID_GRF_MODES = {"default", "auto", "128",
+                                                      "256", "512"};
+
+/// Convert the per-hardware-thread GRF budget for \p grfMode into a per-lane
+/// figure, dividing by the module's actual threads-per-warp so the result is
+/// in the same unit `RegisterPressureAnalysis::liveInPressure` reports.
+/// Falls back to the unscaled per-thread budget (with a diagnostic) if
+/// threads-per-warp is missing or non-positive, rather than dividing by zero.
+unsigned getPerLaneGRFBudgetInBytes(StringRef grfMode, ModuleOp mod) {
+  if (!llvm::is_contained(VALID_GRF_MODES, grfMode))
+    mod.emitWarning("unrecognized grf-mode '" + grfMode +
+                    "' for tritonintelgpu-reduce-variable-liveness; "
+                    "falling back to the 'default' GRF budget");
+  unsigned grfBudget =
+      ttg::intel::RegisterPressureAnalysis::getGRFBytesPerThread(grfMode);
+  int threadsPerWarp = ttg::TritonGPUDialect::getThreadsPerWarp(mod);
+  if (threadsPerWarp <= 0) {
+    mod.emitWarning(
+        "ttg.threads-per-warp is missing or non-positive; cannot convert "
+        "the per-hardware-thread GRF budget to a per-lane figure, falling "
+        "back to the unscaled per-thread budget for tritonintelgpu-"
+        "reduce-variable-liveness");
+    return grfBudget;
   }
-  return totalNumElement * (elTypeBitWidth / 8);
+  return grfBudget / static_cast<unsigned>(threadsPerWarp);
 }
 
 /// Return true if the lifespan of the \p v value is considered long.
 bool isLongLifeSpanVariable(
     Value v, const ttg::intel::RegisterPressureAnalysis &analysis,
-    Block *dotBlock) {
-  // The variable is considered as a long life span elected for being moved if:
-  // the live-in variables of the forOp consist in a large amount of bytes and
-  // the variable defined by `v` is a large tensor (with large amount of element
-  // in the minor dimenssion) and the variable liveness of `v` expends before
-  // the dot block. i.e. used in a block - loaded in another block
+    Block *dotBlock, unsigned perLaneGRFBudget) {
+  // The variable is considered as a long life span elected for being moved if
+  // it is a 2D tensor, it is genuinely live-in to the block (defined outside,
+  // used inside -- i.e. it would otherwise stay resident across the whole
+  // loop), and the loop is under enough measured register pressure that
+  // shortening this value's live range is worth the redundant reload.
   TensorValue tensorV = dyn_cast<TensorValue>(v);
   if (!tensorV)
     return false;
 
   auto tensorType = cast<RankedTensorType>(tensorV.getType());
   auto tensorOrder = ttg::getOrder(tensorType);
-  // Scale the per-thread pressure reported by the analysis back to bytes summed
-  // across the workgroup, the unit TOTAL_BLOCK_SIZE_THRESHOLD_IN_BYTES is in.
-  auto mod = dotBlock->getParentOp()->getParentOfType<ModuleOp>();
-  unsigned numThreads = ttg::lookupNumWarps(dotBlock->getParentOp()) *
-                        ttg::TritonGPUDialect::getThreadsPerWarp(mod);
-  unsigned liveInSizeInBytes = analysis.liveInPressure(dotBlock) * numThreads;
-  return (
-      (tensorOrder.size() == 2) &&
-      (getSizeInBytes(tensorType) >= LARGE_TENSOR_SIZE_THRESHOLD_IN_BYTES) &&
-      (tensorType.getShape()[tensorOrder[1]] >=
-       LARGE_TENSOR_MINOR_SHAPE_THRESHOLD) &&
-      (liveInSizeInBytes > TOTAL_BLOCK_SIZE_THRESHOLD_IN_BYTES) &&
-      analysis.isLiveIn(dotBlock, v));
+  unsigned liveInSizeInBytes = analysis.liveInPressure(dotBlock);
+  return ((tensorOrder.size() == 2) &&
+          (liveInSizeInBytes >=
+           perLaneGRFBudget * LIVE_IN_PRESSURE_GRF_BUDGET_MULTIPLIER) &&
+          analysis.isLiveIn(dotBlock, v));
 }
 
 /// Return true if the \p loadOp is suitable to be moved.
@@ -148,7 +153,8 @@ void createPrefetchOp(tt::DescriptorLoadOp loadOp) {
 /// operands.
 /// Returns `true` if at least one operand has been moved.
 bool optimizeDotOperands(scf::ForOp forOp, SmallVector<Value> &prefetchedValue,
-                         ttg::intel::RegisterPressureAnalysis &analysis) {
+                         ttg::intel::RegisterPressureAnalysis &analysis,
+                         unsigned perLaneGRFBudget) {
   Block *loop = forOp.getBody();
   bool opMoved = false;
 
@@ -243,7 +249,8 @@ bool optimizeDotOperands(scf::ForOp forOp, SmallVector<Value> &prefetchedValue,
     // dot operand may be a ConvertLayoutOp result (possibly inside the loop)
     // while the load result is the truly long-lived value defined outside.
     Value loadResult = loadOp->getResult(0);
-    if (!isLongLifeSpanVariable(loadResult, analysis, dotBlock))
+    if (!isLongLifeSpanVariable(loadResult, analysis, dotBlock,
+                                perLaneGRFBudget))
       return;
     auto tensorType = cast<RankedTensorType>(operand.getType());
     Type elTy = tensorType.getElementType();
@@ -290,10 +297,13 @@ public:
     }
 
     Operation *rootOperation = getOperation();
+    ModuleOp mod = getOperation();
+    unsigned perLaneGRFBudget = getPerLaneGRFBudgetInBytes(grfMode, mod);
     ttg::intel::RegisterPressureAnalysis analysis(rootOperation);
     // TODO: extend the pass to handle `while` loops.
     rootOperation->walk([&](scf::ForOp forOp) {
-      if (optimizeDotOperands(forOp, prefetchedValue, analysis)) {
+      if (optimizeDotOperands(forOp, prefetchedValue, analysis,
+                              perLaneGRFBudget)) {
         // The register pressure analysis must be re-performed before the
         // processing of each "for loop" given that the liveness of variables
         // may have changed as a result of the code, and specifically `LoadOps`,

--- a/third_party/intel/triton_xpu.cc
+++ b/third_party/intel/triton_xpu.cc
@@ -167,8 +167,9 @@ void init_triton_intel_passes_ttgpuir(py::module_ &&m) {
                      gpu::intel::createTritonIntelGPUOptimizeReductionLocality);
   ADD_PASS_WRAPPER_0("add_lower_to_2d_block_load",
                      gpu::intel::createTritonIntelGPULowerTo2DBlockLoad);
-  ADD_PASS_WRAPPER_0("add_reduce_variable_liveness",
-                     gpu::intel::createTritonIntelGPUReduceVariableLiveness);
+  ADD_PASS_OPTION_WRAPPER_1(
+      "add_reduce_variable_liveness",
+      gpu::intel::createTritonIntelGPUReduceVariableLiveness, std::string);
   ADD_PASS_WRAPPER_0("add_loop_distribute",
                      gpu::intel::createTritonIntelGPULoopDistribute);
   ADD_PASS_WRAPPER_0("add_code_sinking",


### PR DESCRIPTION
Fixes #7934 (sub-issue of #7777).

## Problem

The `ReduceVariableLiveness` pass never fires for this kernel's backward pass: its per-tensor shape gate (`>= 32768` bytes, `>= 128` minor-dim) excludes every tensor this kernel produces, since `head_dim=64` caps every tile at 16,384 bytes. Confirmed via `triton-opt` before/after IR diff (zero `descriptor_prefetch` ops inserted). This leaves register spilling unaddressed, accounting for a real fraction of the remaining slowdown after the ~3.78x already recovered on `main`.

## Fix

Discussed with @etiotto (the pass's original author): large tiles are always worth sinking, but small tiles should only sink if the loop is genuinely under measured high register pressure, via `RegisterPressureAnalysis` (#7320) rather than a size proxy. Unified the large/small-tile split into a single rule: sink a candidate load iff it's live-in to the loop and the loop's measured live-in register pressure is >= 200% of a per-lane GRF budget. Also fixes a per-lane vs per-hardware-thread unit mismatch in how pressure was compared against the GRF budget, and adds a `grf-mode` pass option so the threshold scales correctly with GRF mode.

Based on top of #7933 (still open), which fixes the same class of unit mismatch in `HoistLayoutConversions` and introduces `RegisterPressureAnalysis::getPerLaneGRFBudgetInBytes` as a shared method. This branch calls that shared method instead of keeping its own local copy, so the diff here is properly stacked on that one. Once #7933 merges to `main`, this PR's base should be retargeted there.

## Validation

456/459 lit tests pass (1 pre-existing, unrelated failure), new grf-mode-specific lit coverage. 457/460 pass on the full suite on top of #7933 (the one failure, `atomic_poll.mlir`, is the same pre-existing unrelated failure this branch has had throughout).

A hardware re-confirmation on this rebased state (including the #7933 fix) is pending. Numbers below are from the last full validation pass, taken before this rebase:

```
customer reported:       10.029 ms
main (as-is):              2.6 ms   (3.78x recovered)
main + this fix:          ~1.84 ms  (additional ~1.4x)
CUDA L20 (unchanged):     0.526 ms  (~3.5x gap remains, latency-bound, separate larger scope)
```

## Note for reviewers

`main` has separately merged a global LLVM-pin revert (`a127683631`) since the numbers above were measured. Any future absolute-number drift vs. that table should be checked against that before being attributed to this change, the pass-on/pass-off delta within a single measurement run is the reliable signal, not the absolute numbers across different `main` snapshots.