### PR TITLE
Disable pyenv-built Python by default in CI workflows

### DIFF
--- a/.github/workflows/build-test-gpu.yml
+++ b/.github/workflows/build-test-gpu.yml
@@ -42,7 +42,7 @@ on:
       use_pyenv_python:
         description: Use Python built with pyenv
         type: boolean
-        default: true
+        default: false
 
 permissions: read-all
 
@@ -64,4 +64,4 @@ jobs:
       skip_list: ${{ inputs.skip_list }}
       run_name: ${{ inputs.run_name || format('Build and test {0}', inputs.runner_label) }}
       enable_unskip: ${{ inputs.enable_unskip }}
-      use_pyenv_python: ${{ inputs.use_pyenv_python || true }}
+      use_pyenv_python: ${{ inputs.use_pyenv_python || false }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -82,7 +82,7 @@ jobs:
         uses: ./.github/actions/setup-python
         with:
           python_version: "3.10"
-          use_pyenv: true
+          use_pyenv: false
 
       - name: Run pre-commit checks
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,7 +64,7 @@ jobs:
       uses: ./.github/actions/setup-python
       with:
         python_version: "3.10"
-        use_pyenv: true
+        use_pyenv: false
 
     - name: Build Triton (traced)
       if: matrix.build-mode == 'manual'

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -28,7 +28,7 @@ jobs:
         uses: ./.github/actions/setup-python
         with:
           python_version: "3.10"
-          use_pyenv: true
+          use_pyenv: false
 
       - name: Load coverity from cache
         id: coverity-cache

--- a/.github/workflows/e2e-accuracy.yml
+++ b/.github/workflows/e2e-accuracy.yml
@@ -158,7 +158,7 @@ jobs:
         uses: ./.github/actions/setup-python
         with:
           python_version: "3.10"
-          use_pyenv: true
+          use_pyenv: false
 
       - name: Download all artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/reports-manual.yml
+++ b/.github/workflows/reports-manual.yml
@@ -57,7 +57,7 @@ jobs:
         uses: ./.github/actions/setup-python
         with:
           python_version: "3.10"
-          use_pyenv: true
+          use_pyenv: false
 
       - name: Install triton_utils
         run: |

--- a/.github/workflows/sglang-tests-reusable.yml
+++ b/.github/workflows/sglang-tests-reusable.yml
@@ -26,7 +26,7 @@ on:
       use_pyenv_python:
         description: Use Python built with pyenv
         type: boolean
-        default: true
+        default: false
 
 permissions: read-all
 

--- a/.github/workflows/sglang-tests.yml
+++ b/.github/workflows/sglang-tests.yml
@@ -27,7 +27,7 @@ on:
       use_pyenv_python:
         description: Use Python built with pyenv
         type: boolean
-        default: true
+        default: false
 
 permissions: read-all
 

--- a/.github/workflows/vllm-tests-reusable.yml
+++ b/.github/workflows/vllm-tests-reusable.yml
@@ -30,7 +30,7 @@ on:
       use_pyenv_python:
         description: Use Python built with pyenv
         type: boolean
-        default: true
+        default: false
       use_branch_wheel:
         description: Use prebuilt vLLM XPU kernels wheel from the current branch (must have a successful nightly build)
         type: boolean

--- a/.github/workflows/vllm-tests.yml
+++ b/.github/workflows/vllm-tests.yml
@@ -31,7 +31,7 @@ on:
       use_pyenv_python:
         description: Use Python built with pyenv
         type: boolean
-        default: true
+        default: false
       use_branch_wheel:
         description: Use prebuilt vLLM XPU kernels wheel from the current branch (must have a successful nightly build)
         type: boolean


### PR DESCRIPTION
## Summary
- Switches all `use_pyenv` inputs and `use_pyenv_python` workflow-call input defaults from `true` to `false` across CI workflows to reduce CI time
- Reusable workflows that take `use_pyenv_python` purely as a caller-supplied input (build-test-reusable.yml, reports-reusable.yml) are unaffected since they don't hardcode a default of `true`.

## Test plan
- [x] CI runs green on this branch for the affected workflows (failures are unrelated)