### PR TITLE
[MaterializeBlockPointer] Reshape `other` in the 1D strided load rewrite

### DIFF
--- a/python/test/unit/intel/test_1d_reshape_store_correctness.py
+++ b/python/test/unit/intel/test_1d_reshape_store_correctness.py
@@ -60,6 +60,17 @@ def _has_block_load(llir):
     return 'spirv_Subgroup2DBlockLoadINTEL' in llir or 'GenISA.LSC2DBlockRead' in llir
 
 
+def _reshaped_to_block_io(ttgir):
+    """True if MaterializeBlockPointer reshaped the access to a tagged 2D one.
+
+    Weaker than `_has_block_load`, and the right marker for masked loads: the
+    pass reshapes and tags them, but a non-constant mask makes the later
+    2D-block-load lowering fall back to a predicated gather, so no block-load
+    message reaches LLIR.
+    """
+    return 'ttig.block_io_stride' in ttgir
+
+
 @pytest.mark.skipif(not is_xpu(), reason="XPU-specific test")
 @pytest.mark.parametrize(
     "W, S, XBLOCK, num_warps, expect_block_store, dtype_str",
@@ -482,4 +493,294 @@ def test_1d_reshape_strided_load_multi_warp_base(W, S, XBLOCK, num_warps, dtype_
         rtol=1e-3,
         atol=1e-3,
         err_msg=f"Strided load mismatch for W={W}, S={S}, XBLOCK={XBLOCK}, num_warps={num_warps}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #7928 — `other` parameter handling in
+# `reshape1DStridedLoad`.
+#
+# Before the fix, MaterializeBlockPointer reshaped `ptr` and `mask` to 2D but
+# forwarded `other` verbatim as 1D, causing a verifier error:
+#   'tt.load' op failed to verify that other matches ptr type
+#
+# These tests guard against the verifier regression and verify correct
+# numerics with both constant and non-constant `other` values.
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def strided_load_with_other_kernel(
+    in_ptr,
+    out_ptr,
+    xnumel,
+    W: tl.constexpr,
+    S: tl.constexpr,
+    XBLOCK: tl.constexpr,
+):
+    """Inductor-style strided load with `other=0.0` — issue #7928 repro."""
+    xoffset = tl.program_id(0) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)
+    xmask = xindex < xnumel
+
+    # Strided load address computation (Inductor pattern)
+    col = xindex % W
+    row = xindex // W
+    in_offset = col + row * S
+
+    # Load with `other=0.0` — triggers the bug when mask is not provably true
+    val = tl.load(in_ptr + in_offset, xmask, other=0.0)
+
+    # Contiguous store
+    tl.store(out_ptr + xindex, val, mask=xmask)
+
+
+@pytest.mark.skipif(not is_xpu(), reason="XPU-specific test")
+def test_1d_reshape_strided_load_with_other_issue7928(device):
+    """Issue #7928 repro: strided load with `other=0.0` and xnumel == XBLOCK.
+
+    This is the exact kernel from the issue report. Before the fix, it failed
+    with a verifier error. After the fix, it compiles and produces correct
+    results.
+    """
+    W, S, XBLOCK = 32, 96, 4096
+    num_warps = 4
+    rows = XBLOCK // W
+    xnumel = XBLOCK  # Mask is provably true for this case
+
+    rs = RandomState(17)
+    # Create padded 2D input surface [rows, S]
+    in_full = numpy_random((rows, S), dtype_str="float16", rs=rs)
+    # Reference: read first W columns of each row
+    in_values = in_full[:, :W].flatten()
+    out_ref = in_values.copy()
+
+    # Device tensors
+    in_tri = to_triton(in_full.flatten(), device=device)
+    out_tri = torch.zeros(XBLOCK, dtype=torch.float16, device=device)
+
+    grid = (XBLOCK + XBLOCK - 1) // XBLOCK
+    kernel = strided_load_with_other_kernel[(grid, )](
+        in_tri,
+        out_tri,
+        xnumel,
+        W=W,
+        S=S,
+        XBLOCK=XBLOCK,
+        num_warps=num_warps,
+    )
+
+    # Pin that the 1D->2D reshape actually fired: this is the path `other` has
+    # to survive, and without the assertion the test would keep passing if the
+    # optimization stopped firing.  A masked load is reshaped and tagged but
+    # lowers to a predicated gather, so assert on the TTGIR tag, not on an
+    # emitted block-load message.
+    if triton.runtime.driver.active.get_current_target().arch.get('has_2d_block_io', False):
+        assert _reshaped_to_block_io(kernel.asm["ttgir"]), \
+            "1D->2D load reshape did not fire"
+
+    np.testing.assert_allclose(
+        to_numpy(out_tri),
+        out_ref,
+        rtol=1e-3,
+        atol=1e-3,
+        err_msg="Issue #7928 repro: strided load with other=0.0 failed",
+    )
+
+
+@triton.jit
+def strided_load_partial_mask_kernel(
+    in_ptr,
+    out_ptr,
+    xnumel,
+    W: tl.constexpr,
+    S: tl.constexpr,
+    XBLOCK: tl.constexpr,
+):
+    """Strided load with partial mask and sentinel `other=-1.0`."""
+    xoffset = tl.program_id(0) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)
+    xmask = xindex < xnumel
+
+    # Strided load address computation (Inductor pattern)
+    col = xindex % W
+    row = xindex // W
+    in_offset = col + row * S
+
+    # Load with sentinel `other=-1.0` — masked-off positions should be -1.0
+    val = tl.load(in_ptr + in_offset, xmask, other=-1.0)
+
+    # Contiguous store (including masked-off positions)
+    tl.store(out_ptr + xindex, val)
+
+
+@pytest.mark.skipif(not is_xpu(), reason="XPU-specific test")
+@pytest.mark.parametrize(
+    "xnumel",
+    [
+        900,  # Boundary inside tile: 900 / 32 = 28.125 rows
+        1000,  # Boundary inside tile: 1000 / 32 = 31.25 rows
+        950,  # Boundary inside tile: 950 / 32 = 29.6875 rows
+        864,  # Boundary inside tile: 864 / 32 = 27 rows (aligned to row but not tile)
+    ],
+    ids=["xnumel_900", "xnumel_1000", "xnumel_950", "xnumel_864"],
+)
+def test_1d_reshape_strided_load_partial_mask_with_other(xnumel, device):
+    """Partial mask + sentinel `other=-1.0` — correctness test for issue #7928.
+
+    This test verifies that `other` is correctly applied to masked-off positions
+    when the mask boundary falls *inside* a candidate tile (not just at a
+    tile-aligned tail). This is the only case that proves correctness rather
+    than verifier-cleanliness.
+    """
+    W, S, XBLOCK = 32, 96, 1024
+    num_warps = 4
+    rows = (xnumel + W - 1) // W
+
+    rs = RandomState(17)
+    # Create padded 2D input surface [rows, S]
+    in_full = numpy_random((rows, S), dtype_str="float16", rs=rs)
+
+    # Reference: read first W columns of each row, then apply mask
+    out_ref = np.full(XBLOCK, -1.0, dtype=np.float16)
+    for i in range(xnumel):
+        row_i = i // W
+        col_i = i % W
+        if row_i < rows:
+            out_ref[i] = in_full[row_i, col_i]
+
+    # Device tensors
+    in_tri = to_triton(in_full.flatten(), device=device)
+    out_tri = torch.zeros(XBLOCK, dtype=torch.float16, device=device)
+
+    grid = (XBLOCK + XBLOCK - 1) // XBLOCK
+    kernel = strided_load_partial_mask_kernel[(grid, )](
+        in_tri,
+        out_tri,
+        xnumel,
+        W=W,
+        S=S,
+        XBLOCK=XBLOCK,
+        num_warps=num_warps,
+    )
+
+    # Pin that the 1D->2D reshape actually fired: this is the path `other` has
+    # to survive, and without the assertion the test would keep passing if the
+    # optimization stopped firing.  A masked load is reshaped and tagged but
+    # lowers to a predicated gather, so assert on the TTGIR tag, not on an
+    # emitted block-load message.
+    if triton.runtime.driver.active.get_current_target().arch.get('has_2d_block_io', False):
+        assert _reshaped_to_block_io(kernel.asm["ttgir"]), \
+            "1D->2D load reshape did not fire"
+
+    # Verify loaded values (positions < xnumel)
+    np.testing.assert_allclose(
+        to_numpy(out_tri)[:xnumel],
+        out_ref[:xnumel],
+        rtol=1e-3,
+        atol=1e-3,
+        err_msg=f"Loaded values mismatch for xnumel={xnumel}",
+    )
+
+    # Verify masked-off values (positions >= xnumel) are sentinel -1.0
+    np.testing.assert_allclose(
+        to_numpy(out_tri)[xnumel:],
+        out_ref[xnumel:],
+        rtol=0,
+        atol=0,
+        err_msg=f"Masked-off values not -1.0 for xnumel={xnumel}",
+    )
+
+
+@triton.jit
+def strided_load_nonsplat_other_kernel(
+    in_ptr,
+    other_ptr,
+    out_ptr,
+    xnumel,
+    W: tl.constexpr,
+    S: tl.constexpr,
+    XBLOCK: tl.constexpr,
+):
+    """Strided load with non-splat `other` from a loaded tensor."""
+    xoffset = tl.program_id(0) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)
+    xmask = xindex < xnumel
+
+    # Load the `other` tensor (distinct per-element values)
+    other_vals = tl.load(other_ptr + xindex)
+
+    # Strided load address computation (Inductor pattern)
+    col = xindex % W
+    row = xindex // W
+    in_offset = col + row * S
+
+    # Load with non-splat `other` — verifies `other` is reshaped, not broadcast
+    val = tl.load(in_ptr + in_offset, xmask, other=other_vals)
+
+    # Contiguous store
+    tl.store(out_ptr + xindex, val)
+
+
+@pytest.mark.skipif(not is_xpu(), reason="XPU-specific test")
+def test_1d_reshape_strided_load_nonsplat_other(device):
+    """Non-splat `other` — verifies `other` is reshaped, not narrowed.
+
+    This test uses a loaded tensor with distinct per-element values as `other`.
+    If the lowering incorrectly broadcasts a single register value or
+    mis-indexes `otherElems`, the test will fail on elementwise comparison.
+    """
+    W, S, XBLOCK = 32, 96, 1024
+    num_warps = 4
+    xnumel = 900  # Partial mask
+    rows = (xnumel + W - 1) // W
+
+    rs = RandomState(17)
+    # Create padded 2D input surface [rows, S]
+    in_full = numpy_random((rows, S), dtype_str="float16", rs=rs)
+
+    # Create non-splat `other` tensor (distinct values)
+    other_np = np.arange(XBLOCK, dtype=np.float16) * 0.01
+
+    # Reference: apply mask, using `other` for masked-off positions
+    out_ref = other_np.copy()
+    for i in range(xnumel):
+        row_i = i // W
+        col_i = i % W
+        if row_i < rows:
+            out_ref[i] = in_full[row_i, col_i]
+
+    # Device tensors
+    in_tri = to_triton(in_full.flatten(), device=device)
+    other_tri = to_triton(other_np, device=device)
+    out_tri = torch.zeros(XBLOCK, dtype=torch.float16, device=device)
+
+    grid = (XBLOCK + XBLOCK - 1) // XBLOCK
+    kernel = strided_load_nonsplat_other_kernel[(grid, )](
+        in_tri,
+        other_tri,
+        out_tri,
+        xnumel,
+        W=W,
+        S=S,
+        XBLOCK=XBLOCK,
+        num_warps=num_warps,
+    )
+
+    # Pin that the 1D->2D reshape actually fired: this is the path `other` has
+    # to survive, and without the assertion the test would keep passing if the
+    # optimization stopped firing.  A masked load is reshaped and tagged but
+    # lowers to a predicated gather, so assert on the TTGIR tag, not on an
+    # emitted block-load message.
+    if triton.runtime.driver.active.get_current_target().arch.get('has_2d_block_io', False):
+        assert _reshaped_to_block_io(kernel.asm["ttgir"]), \
+            "1D->2D load reshape did not fire"
+
+    # Elementwise comparison
+    np.testing.assert_allclose(
+        to_numpy(out_tri),
+        out_ref,
+        rtol=1e-3,
+        atol=1e-3,
+        err_msg="Non-splat other mismatch",
     )

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-llvm.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape-llvm.mlir
@@ -162,3 +162,51 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return %result : tensor<128xf16, #blocked1d>
   }
 }
+
+// -----
+
+// COM: Test 7: 1D strided load with partial mask and `other` — issue #7928.
+// COM: This tests both the verifier regression (does `other` get reshaped?) and
+// COM: the end-to-end correctness. The mask is genuinely partial: xindex < xnumel
+// COM: where xnumel=900 falls inside the 1024-element tile boundary. This prevents
+// COM: canonicalization from dropping `other` as dead (a provably-true mask makes
+// COM: `other` unused and can be folded away).
+// COM:
+// COM: MaterializeBlockPointer *does* reshape this load to 2D and tag it with
+// COM: ttig.block_io / ttig.block_io_stride — the point of the fix is that the
+// COM: reshaped load stays well-typed, since forwarding `other` as 1D makes the
+// COM: verifier reject the whole kernel.  The subsequent 2D-block-load lowering
+// COM: then declines: a non-constant mask forces the per-element predicated
+// COM: gather.  Measured on PVC 1100: with `xindex < xnumel` no
+// COM: Subgroup2DBlockLoadINTEL / LSC2DBlockRead reaches LLIR, and that is true
+// COM: with *and without* `other`, so it is a property of the masked path rather
+// COM: than of this fix.  Hence CHECK-NOT below, placed between the label and
+// COM: the llvm.return anchor so it scans the whole function body.
+
+#blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: llvm.func spir_kernelcc @test_1d_strided_load_partial_mask_with_other
+  // CHECK-NOT: triton_gen.2Dblockload
+  // CHECK: llvm.return
+  tt.func @test_1d_strided_load_partial_mask_with_other(
+      %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %xnumel: i32) -> tensor<1024xf16, #blocked1d> {
+    %idx = tt.make_range {start = 0 : i32, end = 1024 : i32} : tensor<1024xi32, #blocked1d>
+    %c32 = arith.constant dense<32> : tensor<1024xi32, #blocked1d>
+    %c96 = arith.constant dense<96> : tensor<1024xi32, #blocked1d>
+    %rem = arith.remui %idx, %c32 : tensor<1024xi32, #blocked1d>
+    %div = arith.divui %idx, %c32 : tensor<1024xi32, #blocked1d>
+    %mul = arith.muli %div, %c96 : tensor<1024xi32, #blocked1d>
+    %off = arith.addi %rem, %mul : tensor<1024xi32, #blocked1d>
+    %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked1d>
+    %ptrs = tt.addptr %base, %off : tensor<1024x!tt.ptr<f16>, #blocked1d>, tensor<1024xi32, #blocked1d>
+
+    // Partial mask: xindex < xnumel, not a provably-true constant
+    %xnumel_splat = tt.splat %xnumel : i32 -> tensor<1024xi32, #blocked1d>
+    %mask = arith.cmpi slt, %idx, %xnumel_splat : tensor<1024xi32, #blocked1d>
+    %other = arith.constant dense<-1.0> : tensor<1024xf16, #blocked1d>
+
+    %result = tt.load %ptrs, %mask, %other : tensor<1024x!tt.ptr<f16>, #blocked1d>
+    tt.return %result : tensor<1024xf16, #blocked1d>
+  }
+}

--- a/test/TritonIntelGPU/materialize-block-pointer-1d-reshape.mlir
+++ b/test/TritonIntelGPU/materialize-block-pointer-1d-reshape.mlir
@@ -328,3 +328,89 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.thr
     tt.return %res : tensor<64xi8, #blocked_h_lt_nw_load>
   }
 }
+
+// -----
+
+// COM: Test 12: 1D strided load with `other` operand — issue #7928 repro.
+// COM: W=32, S=96, f16, 1024 elements, H=32, numWarps=4.
+// COM: The load has both a mask and an `other` operand (dense<0.0>).
+// COM: Before the fix: MaterializeBlockPointer reshapes ptr and mask to 2D but
+// COM: forwards `other` verbatim as 1D → verifier error.
+// COM: After the fix: `other` is reshaped to match the 2D load's result type.
+// COM: Check the SSA flow: both ptr2d and other2d flow into the new tt.load,
+// COM: and the load produces a 2D result with the HW delivery encoding.
+
+// CHECK-DAG: [[LOAD2DENC:#[a-z0-9_]+]] = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+// CHECK-DAG: [[CONS2DENC:#[a-z0-9_]+]] = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+// CHECK-DAG: [[ENC1D:#[a-z0-9_]+]] = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+#blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  // CHECK: tt.func @test_1d_strided_load_with_other
+  tt.func @test_1d_strided_load_with_other(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) -> tensor<1024xf16, #blocked1d> {
+    %idx = tt.make_range {start = 0 : i32, end = 1024 : i32} : tensor<1024xi32, #blocked1d>
+    %c32 = arith.constant dense<32> : tensor<1024xi32, #blocked1d>
+    %c96 = arith.constant dense<96> : tensor<1024xi32, #blocked1d>
+    %rem = arith.remui %idx, %c32 : tensor<1024xi32, #blocked1d>
+    %div = arith.divui %idx, %c32 : tensor<1024xi32, #blocked1d>
+    %mul = arith.muli %div, %c96 : tensor<1024xi32, #blocked1d>
+    %off = arith.addi %rem, %mul : tensor<1024xi32, #blocked1d>
+    %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked1d>
+    %ptrs = tt.addptr %base, %off : tensor<1024x!tt.ptr<f16>, #blocked1d>, tensor<1024xi32, #blocked1d>
+    %mask = arith.constant dense<true> : tensor<1024xi1, #blocked1d>
+    %other = arith.constant dense<0.0> : tensor<1024xf16, #blocked1d>
+    // COM: ptr, mask and `other` must all end up in the SAME encoding — the HW
+    // COM: delivery encoding the new load is typed with. tt.load's verifier
+    // COM: requires mask/other to match ptr's type, and the block-IO lowering
+    // COM: indexes otherElems[registerIdx] alongside maskElems.
+    // COM: Each one is a data-moving reshape (no allow_reorder) into its natural
+    // COM: 2D encoding followed by a ttg.convert_layout into HW delivery order.
+    // COM: A relabel (allow_reorder efficient_layout) would be wrong here: it
+    // COM: lowers to a no-op, so the registers would still hold the 1D order
+    // COM: while the type claimed HW delivery order (see #7918).
+    // CHECK: [[PTRR:%[0-9]+]] = tt.reshape %{{.*}} : tensor<1024x!tt.ptr<f16>, [[ENC1D]]> -> tensor<32x32x!tt.ptr<f16>, [[CONS2DENC]]>
+    // CHECK: [[PTR2D:%[0-9]+]] = ttg.convert_layout [[PTRR]] : tensor<32x32x!tt.ptr<f16>, [[CONS2DENC]]> -> tensor<32x32x!tt.ptr<f16>, [[LOAD2DENC]]>
+    // CHECK: [[MASKR:%[0-9]+]] = tt.reshape %{{.*}} : tensor<1024xi1, [[ENC1D]]> -> tensor<32x32xi1, [[CONS2DENC]]>
+    // CHECK: [[MASK2D:%[0-9]+]] = ttg.convert_layout [[MASKR]] : tensor<32x32xi1, [[CONS2DENC]]> -> tensor<32x32xi1, [[LOAD2DENC]]>
+    // CHECK: [[OTHERR:%[0-9]+]] = tt.reshape %{{.*}} : tensor<1024xf16, [[ENC1D]]> -> tensor<32x32xf16, [[CONS2DENC]]>
+    // CHECK: [[OTHER2D:%[0-9]+]] = ttg.convert_layout [[OTHERR]] : tensor<32x32xf16, [[CONS2DENC]]> -> tensor<32x32xf16, [[LOAD2DENC]]>
+    // CHECK: [[LOAD2D:%[0-9]+]] = tt.load [[PTR2D]], [[MASK2D]], [[OTHER2D]] {ttig.block_io = "row_major", ttig.block_io_stride = 96 : i64} : tensor<32x32x!tt.ptr<f16>, [[LOAD2DENC]]>
+    // CHECK: [[CVT:%[0-9]+]] = ttg.convert_layout [[LOAD2D]] : tensor<32x32xf16, [[LOAD2DENC]]> -> tensor<32x32xf16, [[CONS2DENC]]>
+    // CHECK: tt.reshape [[CVT]] efficient_layout : tensor<32x32xf16, [[CONS2DENC]]> -> tensor<1024xf16, [[ENC1D]]>
+    %result = tt.load %ptrs, %mask, %other : tensor<1024x!tt.ptr<f16>, #blocked1d>
+    tt.return %result : tensor<1024xf16, #blocked1d>
+  }
+}
+
+// -----
+
+// COM: Test 13: 1D strided load with non-splat `other` — block argument.
+// COM: This pins that `other` is actually reshaped and not narrowed to a
+// COM: scalar or single register value. The block argument is a block-scoped
+// COM: SSA value with distinct per-element contents.
+
+#blocked1d = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @test_1d_strided_load_with_nonsplat_other
+  tt.func @test_1d_strided_load_with_nonsplat_other(
+      %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %arg_other: tensor<1024xf16, #blocked1d>) -> tensor<1024xf16, #blocked1d> {
+    %idx = tt.make_range {start = 0 : i32, end = 1024 : i32} : tensor<1024xi32, #blocked1d>
+    %c32 = arith.constant dense<32> : tensor<1024xi32, #blocked1d>
+    %c96 = arith.constant dense<96> : tensor<1024xi32, #blocked1d>
+    %rem = arith.remui %idx, %c32 : tensor<1024xi32, #blocked1d>
+    %div = arith.divui %idx, %c32 : tensor<1024xi32, #blocked1d>
+    %mul = arith.muli %div, %c96 : tensor<1024xi32, #blocked1d>
+    %off = arith.addi %rem, %mul : tensor<1024xi32, #blocked1d>
+    %base = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked1d>
+    %ptrs = tt.addptr %base, %off : tensor<1024x!tt.ptr<f16>, #blocked1d>, tensor<1024xi32, #blocked1d>
+    %mask = arith.constant dense<true> : tensor<1024xi1, #blocked1d>
+    // COM: Pin the 2D result shape: a lowering that narrowed `other` to a single
+    // COM: register value or broadcast one element would not produce 32x32.
+    // CHECK: [[OTHERR:%[0-9]+]] = tt.reshape %arg1 : tensor<1024xf16, {{.*}}> -> tensor<32x32xf16, {{.*}}>
+    // CHECK: [[OTHER2D:%[0-9]+]] = ttg.convert_layout [[OTHERR]] : tensor<32x32xf16, {{.*}}> -> tensor<32x32xf16, {{.*}}>
+    // CHECK: tt.load {{.*}}, {{.*}}, [[OTHER2D]]
+    %result = tt.load %ptrs, %mask, %arg_other : tensor<1024x!tt.ptr<f16>, #blocked1d>
+    tt.return %result : tensor<1024xf16, #blocked1d>
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/MaterializeBlockPointer.cpp
@@ -908,9 +908,23 @@ private:
     Type pointeeTy =
         cast<tt::PointerType>(ptrTensorTy.getElementType()).getPointeeType();
     auto loadResultTy = RankedTensorType::get(newShape, pointeeTy, loadEnc);
-    auto newLoad = tt::LoadOp::create(builder, loc, loadResultTy, loadPtr,
-                                      mask2d, op.getOther(), op.getCache(),
-                                      op.getEvict(), op.getIsVolatile());
+
+    // Reshape `other` if present, same treatment as the pointer and the mask.
+    // Its type is verifier-locked to getPointeeType(ptr), so its 2D form is
+    // exactly the new load result type.  The block-IO lowering indexes
+    // otherElems[registerIdx] alongside maskElems[registerIdx], so it must
+    // carry the load encoding rather than the 1D source encoding.
+    Value other2d;
+    if (Value other = op.getOther()) {
+      auto otherReshape = tt::ReshapeOp::create(builder, loc, newShape, other,
+                                                /*allowReorder=*/false);
+      other2d = ttg::ConvertLayoutOp::create(builder, loc, loadResultTy,
+                                             otherReshape);
+    }
+
+    auto newLoad =
+        tt::LoadOp::create(builder, loc, loadResultTy, loadPtr, mask2d, other2d,
+                           op.getCache(), op.getEvict(), op.getIsVolatile());
 
     // Set block IO attributes.
     setBlockIOAttrs(newLoad, ctx, info->S);


### PR DESCRIPTION
reshape1DStridedLoad rewrites a 1D strided `tt.load` into a 2D load carrying
the HW delivery encoding, reshaping the pointer and the mask into that
encoding. `other` was forwarded unchanged from the 1D op, so on any masked
load with an `other` operand the rewritten load was ill-typed: the verifier
requires `other` to match getPointeeType(ptr) in both shape and encoding,
and a 1D `other` matches neither. The kernel failed to compile with

```
'tt.load' op failed to verify that other matches ptr type
```

Give `other` the same treatment as the pointer and the mask: reshape to
[H, W] with allowReorder=false, then convert_layout into the load encoding.
A plain relabel would be wrong here for the same reason it is wrong for the
pointer (#7918) - that reshape lowers to a no-op, so the registers would
still hold the 1D layout while the type claims HW delivery order, and the
block-IO lowering indexes otherElems[registerIdx] alongside
maskElems[registerIdx]. `other` is optional, so a null operand is
propagated as null and the rewritten load keeps the original operand shape.

Fixes #7928

🤖 Generated with [Claude Code](https://claude.com/claude-code)
