### PR TITLE
[Benchmarks] Update `flex-attention-custom-masks` PagedNoop config

### DIFF
--- a/benchmarks/triton_kernels_benchmark/flex_attention_benchmark_custom_masks.py
+++ b/benchmarks/triton_kernels_benchmark/flex_attention_benchmark_custom_masks.py
@@ -111,7 +111,8 @@ def run_bench_paged(q, k, v, score_mod, _, __):
     phys_block_mask = paged_attn.convert_logical_block_mask(logical_block_mask, batch_idx=batch_idx)
     phys_score_mod = paged_attn.get_score_mod(score_mod)
 
-    kernel_options = {'num_stages': 2, 'num_warps': 16 if D == 128 else 8, 'BLOCKS_ARE_CONTIGUOUS': False}
+    num_stages = 2 if D == 64 else 1
+    kernel_options = {'num_stages': num_stages, 'num_warps': 16 if D == 128 else 8, 'BLOCKS_ARE_CONTIGUOUS': False}
 
     return flex_attention(q, k_cache, v_cache, score_mod=phys_score_mod, block_mask=phys_block_mask,
                           kernel_options=kernel_options)


### PR DESCRIPTION
The paged kernel spills heavily with 2 pipeline stages: the page-table indirection keeps extra values live across the loop, and D=96 pads its accumulator to V_HEAD_DIM_ROUNDED=128 on top of that. One stage drops the spill from ~15KB to ~128B. D=64 needs no padding, stays off the spill cliff, and is the only head dim that still profits from 2-stage pipelining.