### PR TITLE
[SGLANG] Add `--sglang-norm` suite from the device-agnostic kernel tests

### DIFF
--- a/.github/workflows/sglang-tests-reusable.yml
+++ b/.github/workflows/sglang-tests-reusable.yml
@@ -230,7 +230,7 @@ jobs:
         run: |
           ${{ env.TRITON_TEST_CMD }} --sglang-mamba
 
-      # sglang-rest groups short suites: gdn, kda, spec
+      # sglang-rest groups short suites: gdn, kda, spec, norm
       - name: Run gdn tests
         if: ${{ matrix.suite == 'sglang-rest' && steps.install.outcome == 'success' && !cancelled() }}
         run: |
@@ -245,6 +245,11 @@ jobs:
         if: ${{ matrix.suite == 'sglang-rest' && steps.install.outcome == 'success' && !cancelled() }}
         run: |
           ${{ env.TRITON_TEST_CMD }} --sglang-spec
+
+      - name: Run norm tests
+        if: ${{ matrix.suite == 'sglang-rest' && steps.install.outcome == 'success' && !cancelled() }}
+        run: |
+          ${{ env.TRITON_TEST_CMD }} --sglang-norm
 
       - name: Save pip cache
         if: ${{ steps.pip-cache.outputs.status == 'miss' }}

--- a/scripts/sglang/README.md
+++ b/scripts/sglang/README.md
@@ -10,6 +10,12 @@ Install SGLang and run its Triton kernel tests on Intel XPU.
   Triton survive, installs SGLang editable into `$TRITON_PROJ/sglang`.
 - `sglang-pin.txt` - upstream commit.
 - `sglang-test-fix.patch` - XPU fixes on top of the pin.
+- `xpu_device_rewrite.py` - rewrites hardcoded `device="cuda"`, `.cuda()` and
+  `torch.cuda.*` to their XPU equivalents under `test/registered/kernels`,
+  recursively. Run by `install-sglang.sh` after patching. It is a rewrite rather
+  than patch hunks because there are ~150 such references at this pin and ~1600
+  once SGLang's `kernels/ops/` test reorganisation lands, all of which would
+  conflict on every pin bump. Idempotent; `--check` reports without writing.
 
 `import sglang` needs torchvision, which `install-sglang.sh` does not install.
 CI builds it from `pytorch/.github/ci_commit_pins/vision.txt`.
@@ -28,6 +34,7 @@ One flag per kernel family, each with its own `TRITON_TEST_SUITE` and skip list
 | `--sglang-gdn` | `registered/attention/test_chunk_gated_delta_rule.py` |
 | `--sglang-kda` | `registered/attention/test_kda_kernels.py` |
 | `--sglang-spec` | `registered/spec/dspark/test_dspark_kernel_parity.py` |
+| `--sglang-norm` | `registered/kernels/test_fused_op.py`, `test_fused_op_gpu_parity.py`, `test_kernels_namespace.py` |
 
 Two things to know before editing this:
 
@@ -111,6 +118,13 @@ fork silently picks the NVIDIA kernels instead of failing.
 | `expand_prefill_causally`, `build_page_table_positions`, `build_causal_swa_page_indices` | `kernels/ops/attention/dsv4_attn_metadata_kernels.py` |
 | `dspark_accept`, `dspark_attn_metadata`, `dspark_draft_model`, `dspark_schedule`, `dspark_verify_window` | `srt/speculative/dspark_components/kernels/` |
 
+`--sglang-norm`:
+
+| Kernels | Source |
+|---|---|
+| `fused_add_rmsnorm`, `rmsnorm`, `gemma_rmsnorm`, `gemma_fused_add_rmsnorm` | `kernels/ops/layernorm/fused_op.py` |
+| kernel registry / capability dispatch (`K.capabilities_satisfied`) | `kernels/registry.py` |
+
 ## Results on Max 1100
 
 Local run at the current pin, one suite at a time. The skip lists come from it.
@@ -124,8 +138,52 @@ Local run at the current pin, one suite at a time. The skip lists come from it.
 | `--sglang-gdn` | 29 skipped, all skip-listed | 4s |
 | `--sglang-kda` | 1 passed, 12 skipped upstream | 6s |
 | `--sglang-spec` | 1 skipped, skip-listed | 6s |
+| `--sglang-norm` | 94 passed | 13s |
 
 Nothing failed because of Triton codegen.
+
+## Why the rest of the kernel test tree is not in a suite
+
+Measured on SGLang `771e613d`, i.e. after the `kernels/ops/<family>/` test
+reorganisation that follows this pin - so this is the map for the next pin bump.
+All 45 test files of the `gemm`, `layernorm`, `elementwise`, `activation`,
+`embeddings`, `kvcache` and `quantization` families were run on Max 1100 after
+the device rewrite. Only the three `--sglang-norm` files are green. The others
+fail or skip for reasons that have nothing to do with Triton codegen - not one
+file produced a Triton compile error:
+
+| Blocker | Files | Detail |
+|---|---|---|
+| nvcc | 13 | the test compares Triton against an sgl-kernel CUDA reference that it JIT-builds with `nvcc` |
+| `sgl_kernel` | 7 | import-time failure, same gap as the #7655 files |
+| `flashinfer`, `deep_gemm`, `cutedsl`, `tilelang`, `imageio` | 6 | CUDA-only reference implementation or optional dep |
+| upstream skip | 6 | gated on `is_cuda()`, so they self-skip (`gemm` is entirely in this state: 482 skipped) |
+| SGLang XPU dispatch gap | 5 | the XPU branch never reaches the Triton kernel, e.g. `VocabParallelEmbedding._use_triton_embedding` returns False, `test_kvcacheio_asymmetric` raises `NameError` on undefined XPU transfer kernels |
+| CUDA graphs | 1 | `gemm/test_chunked_sgmv_cuda_graph.py` needs graph capture plus `JITFunction._clear_cache` |
+
+Files with a passing subset but a blocked remainder, worth revisiting when the
+blockers clear (the failures are parametrizations, not whole test functions, so
+skip-listing them is not worth the noise today):
+`layernorm/test_rmsnorm.py` 17/45, `layernorm/test_rmsnorm_hf.py` 15/43,
+`layernorm/test_gemma4_fused_routing.py` 17/47, `layernorm/test_mhc_kernels.py`
+4/24, `kvcache/test_set_mla_kv_buffer.py` 6/25,
+`elementwise/test_bias_gelu.py` 1/8.
+
+## SGLang's own XPU tests
+
+`test/registered/xpu/` (24 files, `register_xpu_ci`) is not a source of Triton
+coverage and is deliberately not wired in: 13 files launch a server, 6 are
+nightly multi-GPU model tests, and the 5 kernel-level ones test dispatch or
+SYCL/oneDNN paths, not Triton - `test_topk.py` takes `topk_sigmoid`/
+`topk_softmax` from `sgl_kernel` when `is_xpu()`, and `test_xpu_int4_dense.py`
+uses `aten._convert_weight_to_int4pack`. All 24 fail at import without
+`sgl_kernel`, which for XPU is a separate SYCL repo (`sgl-kernel-xpu`, built by
+upstream's `release-whl-kernel-xpu.yml`).
+
+SGLang's only XPU-specific Triton code is
+`srt/hardware_backend/xpu/kernels/fla/{chunk_delta_h,chunk_fwd}.py`, which uses
+`tl.make_block_ptr` 25 times and so cannot run here at all - see the block
+pointer gap below.
 
 ## Known gaps
 
@@ -169,7 +227,7 @@ Matrix entries, one report artifact each, aggregated by the `reports` job:
 | `sglang-quant` | `--sglang-quant` |
 | `sglang-moe` | `--sglang-moe` |
 | `sglang-mamba` | `--sglang-mamba` |
-| `sglang-rest` | `--sglang-gdn`, `--sglang-kda`, `--sglang-spec` |
+| `sglang-rest` | `--sglang-gdn`, `--sglang-kda`, `--sglang-spec`, `--sglang-norm` |
 
 The short suites share `sglang-rest`, like `vllm-rest`. Each entry installs
 SGLang itself, because `run_sglang_tests` calls `install-sglang.sh` - there is no
@@ -189,6 +247,7 @@ bash scripts/test-triton.sh --sglang-mamba --skip-pip-install --skip-pytorch-ins
 bash scripts/test-triton.sh --sglang-gdn --skip-pip-install --skip-pytorch-install
 bash scripts/test-triton.sh --sglang-kda --skip-pip-install --skip-pytorch-install
 bash scripts/test-triton.sh --sglang-spec --skip-pip-install --skip-pytorch-install
+bash scripts/test-triton.sh --sglang-norm --skip-pip-install --skip-pytorch-install
 ```
 
 ## Reference

--- a/scripts/sglang/install-sglang.sh
+++ b/scripts/sglang/install-sglang.sh
@@ -90,6 +90,12 @@ clone_sglang() {
 patch_sglang() {
   git -C "$SGLANG_DIR" apply "$SGLANG_PATCH"
 
+  # Rewritten instead of patched: hundreds of hardcoded cuda references that
+  # would conflict on every pin bump. Recursive, and scoped to the test tree so
+  # no kernel dispatch behaviour is masked.
+  python3 "$SGLANG_SCRIPTS_DIR/xpu_device_rewrite.py" --quiet \
+    "$SGLANG_DIR/test/registered/kernels"
+
   # That's how sglang assumes we'll pick out platform for now.
   # NOTE: python/pyproject.toml is tracked upstream, so the reset in prepare_source
   # reverts this overwrite - it has to be redone on every preparation.
@@ -176,6 +182,11 @@ installed_at_pin() {
 
   # The patch has to be applied already, i.e. reverse-applying it must be possible.
   git -C "$SGLANG_DIR" apply --reverse --check "$SGLANG_PATCH" 2>/dev/null || return 1
+
+  # The device rewrite has to be applied already, otherwise a checkout prepared
+  # before it was introduced would be reused as-is.
+  python3 "$SGLANG_SCRIPTS_DIR/xpu_device_rewrite.py" --check --quiet \
+    "$SGLANG_DIR/test/registered/kernels" 2>/dev/null | grep -q 'no changes' || return 1
 }
 
 # Dependencies SGLang needs at runtime but that pyproject_xpu.toml deliberately

--- a/scripts/sglang/xpu_device_rewrite.py
+++ b/scripts/sglang/xpu_device_rewrite.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Rewrite hardcoded CUDA device references to XPU in SGLang's kernel test tree.
+
+Only device *selection* is rewritten; occurrences of "cuda" in kernel names,
+comments and skip reasons are left alone so that failures stay readable. The
+rewrite is idempotent.
+
+Usage:
+  xpu_device_rewrite.py [--check] [--quiet] PATH [PATH ...]
+
+Arguments:
+  PATH: files or directories to rewrite (directories are walked for ``*.py``).
+
+Options:
+  --check: report what would change, do not write.
+  --quiet: only print the totals.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# (name, pattern, replacement). `device-const` matches identifiers *ending* in
+# device/dev, so `device_type="cuda"` is left alone: tests construct CUDA
+# platform descriptors to assert that a capability matcher rejects them.
+_RULES: list[tuple[str, re.Pattern[str], str]] = [
+    ("device-kwarg", re.compile(r"""(\bdevice\s*=\s*)(['"])cuda(:\d+)?\2"""), r'\1"xpu\3"'),
+    ("device-const", re.compile(r"""(\b[A-Za-z_]*(?:DEVICE|device|DEV|dev)\s*=\s*)(['"])cuda(:\d+)?\2"""),
+     r'\1"xpu\3"'),
+    ("torch-device", re.compile(r"""(torch\.device\(\s*)(['"])cuda(:\d+)?\2"""), r'\1"xpu\3"'),
+    ("torch-device-fstr", re.compile(r"""(torch\.device\(\s*f)(['"])cuda:"""), r"\1\g<2>xpu:"),
+    ("to-str", re.compile(r"""(\.to\(\s*)(['"])cuda(:\d+)?\2"""), r'\1"xpu\3"'),
+    ("dot-cuda", re.compile(r"""\.cuda\(\s*\)"""), '.to("xpu")'),
+    ("torch-cuda-api", re.compile(r"""\btorch\.cuda\.(?=[A-Za-z_])"""), "torch.xpu."),
+]
+
+
+def rewrite_text(text: str) -> tuple[str, dict[str, int]]:
+    """Apply every rule, returning the new text and a per-rule substitution count."""
+    counts: dict[str, int] = {}
+    for name, pattern, repl in _RULES:
+        text, n = pattern.subn(repl, text)
+        if n:
+            counts[name] = counts.get(name, 0) + n
+    return text, counts
+
+
+def iter_files(paths: list[str]) -> list[Path]:
+    files: list[Path] = []
+    for raw in paths:
+        p = Path(raw)
+        if p.is_dir():
+            files.extend(sorted(p.rglob("*.py")))
+        elif p.is_file():
+            files.append(p)
+        else:
+            print(f"WARNING: no such path, skipping: {p}", file=sys.stderr)
+    return files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("paths", nargs="+", metavar="PATH")
+    parser.add_argument("--check", action="store_true", help="report only, do not write")
+    parser.add_argument("--quiet", action="store_true", help="only print the totals")
+    args = parser.parse_args()
+
+    totals: dict[str, int] = {}
+    changed = 0
+    files = iter_files(args.paths)
+    for path in files:
+        original = path.read_text(encoding="utf-8", errors="surrogateescape")
+        rewritten, counts = rewrite_text(original)
+        if not counts:
+            continue
+        changed += 1
+        for name, n in counts.items():
+            totals[name] = totals.get(name, 0) + n
+        if not args.quiet:
+            detail = ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+            verb = "would rewrite" if args.check else "rewrote"
+            print(f"{verb} {path}: {detail}")
+        if not args.check:
+            path.write_text(rewritten, encoding="utf-8", errors="surrogateescape")
+
+    summary = ", ".join(f"{k}={v}" for k, v in sorted(totals.items())) or "no changes"
+    print(f"**** xpu-device-rewrite: {changed}/{len(files)} files, {summary} ****")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -54,6 +54,7 @@ TEST:
     --sglang-gdn
     --sglang-kda
     --sglang-spec
+    --sglang-norm
     --install-sglang
     --liger
     --install-liger
@@ -117,6 +118,7 @@ TEST_SGLANG_MAMBA=false
 TEST_SGLANG_GDN=false
 TEST_SGLANG_KDA=false
 TEST_SGLANG_SPEC=false
+TEST_SGLANG_NORM=false
 INSTALL_SGLANG=false
 TEST_LIGER=false
 INSTALL_LIGER=false
@@ -321,6 +323,11 @@ while (( $# != 0 )); do
       ;;
     --sglang-spec)
       TEST_SGLANG_SPEC=true
+      TEST_DEFAULT=false
+      shift
+      ;;
+    --sglang-norm)
+      TEST_SGLANG_NORM=true
       TEST_DEFAULT=false
       shift
       ;;
@@ -969,6 +976,7 @@ run_sglang_tests() {
   run_sglang_gdn_tests
   run_sglang_kda_tests
   run_sglang_spec_tests
+  run_sglang_norm_tests
 }
 
 run_sglang_attention_tests() {
@@ -1063,6 +1071,22 @@ run_sglang_spec_tests() {
   TRITON_TEST_SUITE=sglang_spec \
     run_pytest_command -vvv \
       test/registered/spec/dspark/test_dspark_kernel_parity.py
+}
+
+run_sglang_norm_tests() {
+  echo "********************************************************"
+  echo "******  Running SGLang norm/fused-op tests       *******"
+  echo "********************************************************"
+
+  enter_sglang_test_env
+  # Fused RMSNorm/layernorm ops and kernel registry dispatch. The rest of the
+  # kernel test tree needs nvcc, sgl_kernel or flashinfer for its reference;
+  # see scripts/sglang/README.md.
+  TRITON_TEST_SUITE=sglang_norm \
+    run_pytest_command -vvv \
+      test/registered/kernels/ops/layernorm/test_fused_op.py \
+      test/registered/kernels/ops/layernorm/test_fused_op_gpu_parity.py \
+      test/registered/kernels/ops/layernorm/test_kernels_namespace.py
 }
 
 run_liger_install() {
@@ -1517,6 +1541,9 @@ test_triton() {
   fi
   if [ "$TEST_SGLANG_SPEC" == true ]; then
     run_sglang_spec_tests
+  fi
+  if [ "$TEST_SGLANG_NORM" == true ]; then
+    run_sglang_norm_tests
   fi
   if [ "$INSTALL_LIGER" == true ]; then
     run_liger_install


### PR DESCRIPTION
Add `xpu_device_rewrite.py`, run from `install-sglang.sh`, to rewrite the hardcoded cuda device references in SGLang's kernel test tree, and a `--sglang-norm` suite on top of it covering the fused RMSNorm/layernorm ops and the kernel registry dispatch: 94 passed in 13s on Max 1100. It joins the existing `sglang-rest` CI matrix entry, so no new runner slot.
