### PR TITLE
[Intel] Map store cache modifiers `ca` and `cv` (#7899)

### DIFF
--- a/test/Conversion/intel/load_store_to_llvm.mlir
+++ b/test/Conversion/intel/load_store_to_llvm.mlir
@@ -65,12 +65,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
     tt.store %6, %cst cacheModifier = cs : tensor<256x!tt.ptr<f32>, #blocked0>
     tt.store %6, %cst cacheModifier = wt : tensor<256x!tt.ptr<f32>, #blocked0>
     tt.store %6, %cst cacheModifier = cv : tensor<256x!tt.ptr<f32>, #blocked0>
+    // COM: no cache modifier
     // CHECK-COUNT-2: llvm.store {{.*}} {alignment = 16 : i64} : vector<4xi32>, !llvm.ptr<1>
+    // COM: `ca` -> L1WB_L3WB, write-back being the store-side sense of
+    // COM: "cached", so no annotation.
     // CHECK-COUNT-2: llvm.store {{.*}} {alignment = 16 : i64} : vector<4xi32>, !llvm.ptr<1>
-    // CHECK-COUNT-2: llvm.store {{.*}} {alignment = 16 : i64, nontemporal} : vector<4xi32>, !llvm.ptr<1>
+    // COM: `cg` -> L1UC_L3WB, which asks for L3 write-back. `nontemporal` is a
+    // COM: single bit that IGC turns into LSC `.uc.uc`, bypassing L3 too, so it
+    // COM: cannot express `cg`; a plain store carries no annotation for it.
+    // COM: See getNonTemporalFlag().
     // CHECK-COUNT-2: llvm.store {{.*}} {alignment = 16 : i64} : vector<4xi32>, !llvm.ptr<1>
-    // CHECK-COUNT-2: llvm.store {{.*}} {alignment = 16 : i64, nontemporal} : vector<4xi32>, !llvm.ptr<1>
+    // COM: `wb` -> L1WB_L3WB; no annotation.
     // CHECK-COUNT-2: llvm.store {{.*}} {alignment = 16 : i64} : vector<4xi32>, !llvm.ptr<1>
+    // COM: `cs` -> L1S_L3S, which keeps the line in L3, so `nontemporal` does
+    // COM: not express it either. Unannotated, a documented approximation.
+    // CHECK-COUNT-2: llvm.store {{.*}} {alignment = 16 : i64} : vector<4xi32>, !llvm.ptr<1>
+    // COM: `wt` -> L1WT_L3WT; no annotation.
+    // CHECK-COUNT-2: llvm.store {{.*}} {alignment = 16 : i64} : vector<4xi32>, !llvm.ptr<1>
+    // COM: `cv` -> L1UC_L3UC, which `nontemporal` does express exactly, and is
+    // COM: the sole store modifier that sets it.
     // CHECK-COUNT-2: llvm.store {{.*}} {alignment = 16 : i64, nontemporal} : vector<4xi32>, !llvm.ptr<1>
     tt.return
   }

--- a/test/Conversion/intel/load_store_to_llvm.mlir
+++ b/test/Conversion/intel/load_store_to_llvm.mlir
@@ -107,6 +107,63 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttig.sup
 
 // -----
 
+// COM: `ca` on a masked store is mapped to L1WB_L3WB -- the same control as
+// COM: `wb`, write-back being the store-side sense of "cached". It used to be
+// COM: missing from the store side of tritonToIntelCacheModifier(), so this
+// COM: kernel aborted the compiler on `invalid cache modifier for StoreOp`.
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttig.support_predicated_io} {
+  // CHECK-LABEL: store_ca_predicated
+  tt.func @store_ca_predicated(%ptr: tensor<1024x!tt.ptr<f32>, #blocked>, %val: tensor<1024xf32, #blocked>, %mask: tensor<1024xi1, #blocked>) {
+    // CHECK: triton_gen.predicated_store {{.*}} {cache_control = L1WB_L3WB} : (!llvm.ptr<1>, i32, i1) -> ()
+    tt.store %ptr, %val, %mask cacheModifier = ca : tensor<1024x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: `cv` on a masked store has a cache control of its own (L1 uncached,
+// COM: L3 uncached). It used to be missing from the store side of
+// COM: tritonToIntelCacheModifier(), so this kernel aborted the compiler on
+// COM: `invalid cache modifier for StoreOp`.
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttig.support_predicated_io} {
+  // CHECK-LABEL: store_cv_predicated
+  tt.func @store_cv_predicated(%ptr: tensor<1024x!tt.ptr<f32>, #blocked>, %val: tensor<1024xf32, #blocked>, %mask: tensor<1024xi1, #blocked>) {
+    // CHECK: triton_gen.predicated_store {{.*}} {cache_control = L1UC_L3UC} : (!llvm.ptr<1>, i32, i1) -> ()
+    tt.store %ptr, %val, %mask cacheModifier = cv : tensor<1024x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Masked `ca` and `cv` stores on a target WITHOUT predicated-I/O support
+// COM: fall back to control-flow-guarded plain llvm.store. `ca` (L1WB_L3WB)
+// COM: emits an unannotated store. `cv` (L1UC_L3UC) sets the `nontemporal`
+// COM: flag, which encodes it exactly. This fallback path is NOT changed by
+// COM: the fix that added `ca` and `cv` support to the predicated path. This
+// COM: test confirms the fallback behavior stayed intact.
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: store_ca_cv_scalar_fallback
+  tt.func @store_ca_cv_scalar_fallback(%ptr: tensor<1024x!tt.ptr<f32>, #blocked>, %val: tensor<1024xf32, #blocked>, %mask: tensor<1024xi1, #blocked>) {
+    tt.store %ptr, %val, %mask cacheModifier = ca : tensor<1024x!tt.ptr<f32>, #blocked>
+    tt.store %ptr, %val, %mask cacheModifier = cv : tensor<1024x!tt.ptr<f32>, #blocked>
+    // CHECK: llvm.store {{.*}} {alignment = 4 : i64} : i32, !llvm.ptr<1>
+    // CHECK-NOT: triton_gen.predicated_store
+    // CHECK: llvm.store {{.*}} {alignment = 4 : i64, nontemporal} : i32, !llvm.ptr<1>
+    // CHECK-NOT: triton_gen.predicated_store
+    tt.return
+  }
+}
+
+// -----
+
 // COM: evict_first without an explicit cache modifier routes to L1IAR_L3C on
 // COM: the predicated load path.
 

--- a/test/Conversion/intel/store_nontemporal_cg_cs.mlir
+++ b/test/Conversion/intel/store_nontemporal_cg_cs.mlir
@@ -1,0 +1,61 @@
+// RUN: env TRITON_INTEL_PREDICATED_STORE=1 triton-opt %s -split-input-file \
+// RUN:   --convert-triton-intel-gpu-to-llvm | FileCheck %s --implicit-check-not=nontemporal
+
+// COM: A masked `cg`/`cs` store on a target with predicated-I/O support lowers
+// COM: to a two-armed block: a wide store on the fast arm (every lane of the
+// COM: vector group in bounds) and per-element `triton_gen.predicated_store` ops
+// COM: on the slow arm. Only the fast arm goes through getNonTemporalFlag(),
+// COM: while the slow arm carries an explicit cache control, so this is the
+// COM: configuration in which the two arms used to disagree: `nontemporal` (IGC
+// COM: lowers it to LSC `.uc.uc`, i.e. L1UC_L3UC, which is `cv`'s policy) on the
+// COM: fast arm against the requested control on the slow one.
+// COM:
+// COM: `--implicit-check-not=nontemporal` on the RUN line is the negative
+// COM: regression this file carries: no store here may set the flag.
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttig.support_predicated_io} {
+  // CHECK-LABEL: store_cg_masked_predicated
+  tt.func @store_cg_masked_predicated(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %n: i32) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128xf32, #blocked>
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked>
+    %2 = tt.addptr %1, %0 : tensor<128x!tt.ptr<f32>, #blocked>, tensor<128xi32, #blocked>
+    %3 = tt.splat %n : i32 -> tensor<128xi32, #blocked>
+    %4 = arith.cmpi slt, %0, %3 : tensor<128xi32, #blocked>
+    tt.store %2, %cst, %4 cacheModifier = cg : tensor<128x!tt.ptr<f32>, #blocked>
+    // CHECK: llvm.cond_br
+    // COM: Fast arm: one wide unannotated store.
+    // CHECK: llvm.store {{.*}} {alignment = 16 : i64} : vector<4xi32>, !llvm.ptr<1>
+    // COM: Slow arm: one predicated store per element of the group, carrying the
+    // COM: control `cg` actually asks for.
+    // CHECK-COUNT-4: triton_gen.predicated_store {{.*}} {cache_control = L1UC_L3WB} : (!llvm.ptr<1>, f32, i1) -> ()
+    // CHECK: llvm.return
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttig.support_predicated_io} {
+  // CHECK-LABEL: store_cs_masked_predicated
+  tt.func @store_cs_masked_predicated(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %n: i32) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128xf32, #blocked>
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked>
+    %2 = tt.addptr %1, %0 : tensor<128x!tt.ptr<f32>, #blocked>, tensor<128xi32, #blocked>
+    %3 = tt.splat %n : i32 -> tensor<128xi32, #blocked>
+    %4 = arith.cmpi slt, %0, %3 : tensor<128xi32, #blocked>
+    tt.store %2, %cst, %4 cacheModifier = cs : tensor<128x!tt.ptr<f32>, #blocked>
+    // CHECK: llvm.cond_br
+    // COM: Fast arm: one wide unannotated store. Dropping the flag here is an
+    // COM: approximation, not an exact lowering -- a plain `llvm.store` has no
+    // COM: way to express L1S_L3S. See the NOTE in getNonTemporalFlag().
+    // CHECK: llvm.store {{.*}} {alignment = 16 : i64} : vector<4xi32>, !llvm.ptr<1>
+    // COM: Slow arm: L1S_L3S is emitted exactly.
+    // CHECK-COUNT-4: triton_gen.predicated_store {{.*}} {cache_control = L1S_L3S} : (!llvm.ptr<1>, f32, i1) -> ()
+    // CHECK: llvm.return
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -552,6 +552,8 @@ struct LoadStoreConversionBase {
      * "cg" -> L1UC_L3WB (Cache at global level, not L1)
      * "cs" -> L1S_L3S (Cache streaming at all levels)
      * "wt" -> L1WT_L3WT (Cache write-through at all levels)
+     * "ca" -> L1WB_L3WB (Cache at all levels)
+     * "cv" -> L1UC_L3UC (Bypass cache at all levels)
      **/
     switch (cacheModifier) {
     case CacheModifier::NONE:
@@ -564,9 +566,14 @@ struct LoadStoreConversionBase {
       return TritonGEN::StoreCacheControl::L1S_L3S;
     case CacheModifier::WT:
       return TritonGEN::StoreCacheControl::L1WT_L3WT;
-    default:
-      llvm_unreachable("invalid cache modifier for StoreOp");
+    case CacheModifier::CA:
+      return TritonGEN::StoreCacheControl::L1WB_L3WB;
+    case CacheModifier::CV:
+      // Reconciles with the plain-store arm which maps cv to !nontemporal
+      // (IGC lowers to LSC .uc.uc = L1UC_L3UC).
+      return TritonGEN::StoreCacheControl::L1UC_L3UC;
     }
+    llvm_unreachable("invalid cache modifier for StoreOp");
   }
 
   template <typename OpType,

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -602,21 +602,32 @@ struct LoadStoreConversionBase {
       // `MD_nontemporal` kind. The predicated path is immune because its
       // carrier is a call, which InstCombine never retypes.
       //
-      // So a plain load leaves both modifiers unannotated and runs at the
-      // hardware default (`.ca.ca`). Cache modifiers are performance hints, so
-      // caching more than asked is always safe, and it measures fastest of the
-      // available options on the workload above. Revisit if LLVM starts
-      // preserving unknown metadata across load retyping.
+      // So a plain load or store leaves both modifiers unannotated. A plain
+      // load then runs at the hardware default (`.ca.ca`); a plain store runs
+      // at the platform store default, which is not `.ca.ca` and whose policy
+      // is not established here. Cache modifiers are performance hints, so
+      // caching more than asked is always safe, and for loads it measures
+      // fastest of the available options on the workload above. Revisit if LLVM
+      // starts preserving unknown metadata across load retyping.
       //
-      // This covers every load arm of both `tt.load` and `tt.descriptor_load`:
-      // the unmasked plain load, the masked fallback that guards a plain load
-      // with control flow, and (correctly, via the decoration) the predicated
-      // load. Which of the two masked arms is taken depends on
-      // TRITON_INTEL_PREDICATED_LOAD, so neither may rely on the flag.
+      // This covers every arm of `tt.load`, `tt.descriptor_load` and `tt.store`
+      // that emits a plain `llvm.load`/`llvm.store`: the unmasked access, the
+      // masked fallback that guards a plain access with control flow, the
+      // masked store whose mask is statically uniform across the vector group,
+      // and the fast arm of the two-armed predicated store block. Explicit
+      // per-level cache controls are emitted only on the paths that pass a
+      // Load/StoreCacheControl to TritonGEN::Predicated{Load,Store}Op. Which of
+      // the masked arms is taken depends on
+      // TRITON_INTEL_PREDICATED_{LOAD,STORE}, so no arm may rely on the flag.
       //
-      // FIXME: the store path still collapses `cg`/`cs` onto this flag and
-      // needs the same treatment.
-      return std::is_same_v<OpType, StoreOp>;
+      // NOTE: for `cs` this is a deliberate approximation. `L1S_L3S` cannot be
+      // expressed on a plain store, so the only choice is between bypassing L3
+      // (which `cs` did not ask for) and the platform default (which may retain
+      // in L1). We take the default: it is what the predicated arm ends up with
+      // anyway, since IGC was measured to drop the explicit `L1S_L3S`, and
+      // caching more than asked cannot affect correctness -- these modifiers
+      // are performance hints.
+      return false;
     case triton::CacheModifier::CV:
       return true;
     case triton::CacheModifier::CA:


### PR DESCRIPTION
The `StoreOp` overload of `tritonToIntelCacheModifier()` handled 5 of the
7 `CacheModifier` values; `ca` and `cv` hit `default: llvm_unreachable`,
so a masked `tt.store` carrying either aborted the compiler. Map them to
`L1WB_L3WB` and `L1UC_L3UC`, both already handled downstream by
`storeCacheControlToDecoration()`.

Also drop the `default:` arm and move `llvm_unreachable` after the switch,
so a future enum value fails the build via `-Wswitch` instead of aborting
at runtime.

Store-side counterpart to #7901. `getNonTemporalFlag()` and the load-side
switch are untouched.

Closes #7899
