### PR TITLE
[DOC] Correct the stale auto-GRF spill threshold (1000 -> 0)

### DIFF
--- a/.claude/rules/intel-gpu-hardware.md
+++ b/.claude/rules/intel-gpu-hardware.md
@@ -18,8 +18,10 @@ Each hardware thread has a private register file. **Do not guess** GRF register 
 ### Auto-GRF Mode Selection (`grf_mode='default'`)
 1. Compile with default (small) GRF
 2. Extract spill size from ZEBIN `.ze_info` section
-3. If `spill_size > 1000` bytes → recompile with 256-GRF mode
-4. Threshold of 1000 is empirical, aligned between `compiler.py` and `driver.c`
+3. If `spill_size > 0` bytes → recompile with 256-GRF mode
+4. The threshold is `0` — *any* spill retries — aligned between `MAX_REG_SPILL` in `compiler.py` and `max_reg_spill` in `driver.c`
+
+The retry is gated on the raw **byte** count, which Level Zero allocates per hardware thread.
 
 ### Constraints
 - **256-GRF requires `num_warps ≤ 32`** (because halved thread occupancy limits available hardware threads)

--- a/python/test/unit/intel/test_auto_grf_num_warps_guard.py
+++ b/python/test/unit/intel/test_auto_grf_num_warps_guard.py
@@ -108,8 +108,8 @@ def _launch(num_warps, n=4096, kernel=None):
 
 @triton.jit
 def _heavy_spill(a_ptr, b_ptr, c_ptr, d_ptr, out_ptr, n, BLOCK: tl.constexpr):
-    """A kernel with enough live values to spill hard (n_spills > 1000) at a
-    large BLOCK, so the runtime spill-based recompile (driver.c) fires."""
+    """A kernel with enough live values to spill at a large BLOCK, so the
+    runtime spill-based recompile (driver.c, any nonzero spill bytes) fires."""
     offs = tl.arange(0, BLOCK)
     m = offs < n
     a = tl.load(a_ptr + offs, mask=m, other=0.0)


### PR DESCRIPTION
# [DOC] Correct the stale auto-GRF spill threshold (1000 → 0)

Two places state the auto-GRF-256 retry threshold as `1000` bytes. It is `0` — *any* spill
triggers the retry:

- `MAX_REG_SPILL = 0` — `third_party/intel/backend/compiler.py:83`, used as
  `spill_size <= MAX_REG_SPILL` at `:672`
- `constexpr int32_t max_reg_spill = 0` — `third_party/intel/backend/driver.c:514`, used as
  `n_spills > max_reg_spill` at `:516`

The stale `1000` is actively misleading: it reads as though a mild spill is tolerated, when in
fact any nonzero spill forces a second compile. It also makes the auto-GRF path look far less
aggressive than it is when reasoning about spill-related performance.

Documentation only — no code, no test logic.
