### PR TITLE
[XPU] Report `n_spills` in dword-equivalents per lane

### DIFF
--- a/python/test/unit/intel/test_driver.py
+++ b/python/test/unit/intel/test_driver.py
@@ -35,7 +35,75 @@ def test_auto_grf(device, monkeypatch, capfd):
     # The output should contain the recompiling information for large GRF mode.
     assert "retrying with large GRF mode" in outs[0]
     # The spill size of returned kernel should be same kernel as the one compiled with large GRF mode.
-    assert re.findall(r"\d+\.?\d*", outs[1])[0] == re.findall(r"\d+\.?\d*", outs[2])[0]
+    # Compare the *byte* counts specifically: the auto-GRF retry is gated on raw
+    # bytes (driver.c `max_reg_spill`), not on the per-lane count that #7896
+    # normalizes for Python, so this is what pins the retry behaviour.
+    retried = re.search(r"kernel has (\d+) spill bytes per hardware thread", outs[1])
+    selected = re.search(r"Detected (\d+) spill bytes per hardware thread", outs[2])
+    assert retried is not None, f"unexpected retry log line: {outs[1]!r}"
+    assert selected is not None, f"unexpected selection log line: {outs[2]!r}"
+    assert retried.group(1) == selected.group(1)
+
+
+@pytest.mark.xfail(is_xpu_cri(), reason="unable to get spill_size")
+@pytest.mark.parametrize("warp_size", [16, 32])
+def test_n_spills_reported_per_lane(device, monkeypatch, capfd, warp_size):
+    """`n_spills` is dword-equivalents per lane, as on CUDA/HIP (issue #7896).
+
+    Level Zero reports `spillMemSize` in bytes per hardware thread, so the value
+    handed to Python is `bytes // (4 * SIMD)`. Both operands come from the
+    post-retry log line rather than from the request, because the compiled width
+    can differ from the requested `warp_size` under the auto-GRF retry; that
+    agreement is asserted separately so a divergence fails loudly instead of
+    being absorbed into the arithmetic.
+    """
+    monkeypatch.setenv("TRITON_DEBUG", "1")
+    BLOCK = 1024 * 8
+    z_tri = torch.empty(BLOCK, dtype=torch.int32, device=device)
+
+    # Known-spilling fixture, shared with test_auto_grf.
+    @triton.jit
+    def _kernel(z, BLOCK: tl.constexpr):
+        # make it hard to re-schedule.
+        off = tl.arange(0, BLOCK)
+        a = tl.load(z + off)
+        result = tl.sum(a, axis=0, keep_dims=True)
+        tl.store(z + off, a + result)
+
+    kernel = _kernel[(1, )](z_tri, BLOCK=BLOCK, num_warps=2, warp_size=warp_size)
+
+    out = capfd.readouterr().out
+    pattern = re.compile(r"Detected (\d+) spill bytes per hardware thread; "
+                         r"n_spills (\d+) dword-equivalents/lane \(SIMD(\d+)\)")
+    # Keep the last match: it describes the finally selected binary.
+    matches = pattern.findall(out)
+    if not matches:
+        pytest.skip(f"fixture no longer spills on this IGC version; log was:\n{out}")
+    spill_bytes, logged_slots, logged_simd = (int(group) for group in matches[-1])
+
+    # Pin the divisor against the request, so a compiled-width divergence is a
+    # failure rather than something the arithmetic below hides.
+    assert logged_simd == warp_size, f"compiled SIMD {logged_simd} != requested warp_size {warp_size}"
+    assert kernel.metadata.threads_per_warp == warp_size
+
+    assert spill_bytes > 0
+    assert logged_slots == spill_bytes // (4 * warp_size)
+    assert kernel.n_spills == logged_slots
+    # The unit really changed: raw bytes must not reach Python any more.
+    assert kernel.n_spills < spill_bytes
+
+
+def test_n_spills_zero_without_spills(device):
+    """A kernel that allocates no scratch reports 0, not the -1 error sentinel."""
+
+    @triton.jit
+    def _tiny(x_ptr, y_ptr):
+        tl.store(y_ptr, tl.load(x_ptr))
+
+    x = torch.ones(1, dtype=torch.float32, device=device)
+    y = torch.empty(1, dtype=torch.float32, device=device)
+    kernel = _tiny[(1, )](x, y)
+    assert kernel.n_spills == 0
 
 
 def test_get_properties_error(device):

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -7,8 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -325,7 +327,58 @@ void freeKernelBundle(PyObject *p) {
       PyCapsule_GetPointer(p, "kernel_bundle"));
 }
 
-using Spills = int32_t;
+// Scratch/spill accounting for one compiled kernel.
+//
+// Level Zero reports `spillMemSize` in bytes, allocated per hardware thread:
+// compute-runtime forwards zebin `execution_env.spill_size` unchanged, and the
+// same per-thread quantity is multiplied by the hardware thread count to size
+// the scratch surface. CUDA and HIP instead report `n_spills` as
+// `LOCAL_SIZE_BYTES / 4` -- dword-equivalents per lane. External consumers
+// (torch inductor) compare `n_spills` against thresholds calibrated on that
+// unit, so XPU normalizes to it before handing the value to Python.
+class Spills {
+public:
+  // Unknown: the Level Zero query failed, so there is no byte count and no
+  // SIMD width. -1 is the sentinel `load_binary` hands to Python, and it must
+  // survive `spillsToPyInt` intact rather than being clamped to 0.
+  Spills() = default;
+
+  Spills(int64_t bytes, uint32_t subgroupSize)
+      : bytes(bytes), subgroupSize(subgroupSize) {}
+
+  // Names the default-constructed unknown state, which a bare `Spills()` at a
+  // call site does not.
+  static Spills unknown() { return Spills(); }
+
+  int64_t getBytes() const { return bytes; }
+  uint32_t getSubgroupSize() const { return subgroupSize; }
+
+  // Approximate dword-equivalents per lane. Truncating division deliberately
+  // matches the CUDA/HIP `n_spills /= 4`, so a scratch allocation smaller than
+  // one dword per lane reports 0 exactly as a small CUDA stack frame does.
+  // Returns `bytes` unchanged when the SIMD width is unknown: L0 reports
+  // scratch per hardware thread, so that over-reports rather than hiding an
+  // allocation.
+  int64_t slotsPerLane() const {
+    if (bytes <= 0 || subgroupSize == 0)
+      return bytes; // error sentinel, no allocation, or unknown width
+    return bytes / (int64_t{4} * subgroupSize);
+  }
+
+private:
+  int64_t bytes = -1;        // L0 spillMemSize (uint32_t) widened; -1 == error.
+  uint32_t subgroupSize = 0; // Compiled SIMD width; 0 == unknown.
+};
+
+// Converts a spill count to the `Py_BuildValue("i")` domain, saturating rather
+// than wrapping. Only the unknown-width byte passthrough can approach the
+// bound. Positive values only -- the -1 error sentinel must survive intact, so
+// this must not be a clamp against a 0 lower bound.
+static int spillsToPyInt(int64_t slots) {
+  constexpr int64_t maxPyInt = std::numeric_limits<int>::max();
+  return slots > maxPyInt ? std::numeric_limits<int>::max()
+                          : static_cast<int>(slots);
+}
 
 template <typename L0_DEVICE, typename L0_CONTEXT>
 std::tuple<ze_module_handle_t, ze_kernel_handle_t, Spills>
@@ -352,7 +405,7 @@ compileLevelZeroObjects(uint8_t *binary_ptr, const size_t binary_size,
                                      __FILE__, __LINE__);
   if (PyErr_Occurred()) {
     cleanupPartialObjects();
-    return std::make_tuple(nullptr, nullptr, -1);
+    return std::make_tuple(nullptr, nullptr, Spills::unknown());
   }
 
   // Retrieve the kernel properties (e.g. register spills).
@@ -360,10 +413,10 @@ compileLevelZeroObjects(uint8_t *binary_ptr, const size_t binary_size,
                                      __FILE__, __LINE__);
   if (PyErr_Occurred()) {
     cleanupPartialObjects();
-    return std::make_tuple(nullptr, nullptr, -1);
+    return std::make_tuple(nullptr, nullptr, Spills::unknown());
   }
 
-  ze_kernel_properties_t props;
+  ze_kernel_properties_t props{};
   props.stype = ZE_STRUCTURE_TYPE_KERNEL_PROPERTIES;
   props.pNext = nullptr;
 
@@ -372,12 +425,21 @@ compileLevelZeroObjects(uint8_t *binary_ptr, const size_t binary_size,
       __LINE__);
   if (PyErr_Occurred()) {
     cleanupPartialObjects();
-    return std::make_tuple(nullptr, nullptr, -1);
+    return std::make_tuple(nullptr, nullptr, Spills::unknown());
   }
 
-  const int32_t n_spills = props.spillMemSize;
+  // `requiredSubgroupSize` is the kernel contract, populated from the
+  // `intel_reqd_sub_group_size` attribute that Triton always emits, and is 0
+  // when that attribute is absent. `maxSubgroupSize` is not a device capability
+  // bound: compute-runtime maps it to the kernel's own compiled SIMD width
+  // (zebin `execution_env.simd_size`, a required field), which makes it a sound
+  // fallback and leaves the unknown-width path effectively unreachable.
+  const uint32_t subgroupSize = props.requiredSubgroupSize != 0
+                                    ? props.requiredSubgroupSize
+                                    : props.maxSubgroupSize;
 
-  return std::make_tuple(l0_module, l0_kernel, n_spills);
+  return std::make_tuple(l0_module, l0_kernel,
+                         Spills(props.spillMemSize, subgroupSize));
 }
 
 struct BuildFlags {
@@ -513,7 +575,10 @@ extern "C" EXPORT_FUNC PyObject *load_binary(PyObject *args) {
   const bool debugEnabled = getBoolEnv("TRITON_DEBUG");
   constexpr int32_t max_reg_spill = 0;
 
-  if (canRetryWithLargeGRF && (firstBuildFailed || n_spills > max_reg_spill)) {
+  // Gated on raw bytes, not on the normalized per-lane count, so GRF-mode
+  // selection -- and therefore codegen -- is unchanged by #7896.
+  if (canRetryWithLargeGRF &&
+      (firstBuildFailed || n_spills.getBytes() > max_reg_spill)) {
     PyObject *orig_type = nullptr, *orig_value = nullptr, *orig_tb = nullptr;
     // Save the original error before clearing it for the retry attempt.
     if (firstBuildFailed)
@@ -585,7 +650,11 @@ extern "C" EXPORT_FUNC PyObject *load_binary(PyObject *args) {
 
         if (debugEnabled)
           std::cout << "(I): Retry with large GRF succeeded, kernel has "
-                    << n_spills << " spills" << std::endl;
+                    << n_spills.getBytes()
+                    << " spill bytes per hardware thread; "
+                    << "n_spills " << n_spills.slotsPerLane()
+                    << " dword-equivalents/lane (SIMD"
+                    << n_spills.getSubgroupSize() << ")" << std::endl;
       }
     } catch (const std::exception &e) {
       if (firstBuildFailed) {
@@ -602,9 +671,15 @@ extern "C" EXPORT_FUNC PyObject *load_binary(PyObject *args) {
     }
   }
 
-  if (debugEnabled && n_spills) {
-    std::cout << "(I): Detected " << n_spills << " spills for  \""
-              << kernel_name << "\"" << std::endl;
+  // Both numbers are logged: the byte count is what the retry gate above acts
+  // on, the per-lane count is what Python receives. test_auto_grf matches the
+  // byte count specifically to pin the retry, so keep that wording stable.
+  if (debugEnabled && n_spills.getBytes()) {
+    std::cout << "(I): Detected " << n_spills.getBytes()
+              << " spill bytes per hardware thread; n_spills "
+              << n_spills.slotsPerLane() << " dword-equivalents/lane (SIMD"
+              << n_spills.getSubgroupSize() << ") for \"" << kernel_name << "\""
+              << std::endl;
   }
 
   auto n_regs = build_flags.n_regs();
@@ -623,8 +698,8 @@ extern "C" EXPORT_FUNC PyObject *load_binary(PyObject *args) {
   auto kernel_bundle_py = PyCapsule_New(reinterpret_cast<void *>(mod),
                                         "kernel_bundle", freeKernelBundle);
   last_build_flag = build_flags;
-  return Py_BuildValue("(OOiii)", kernel_bundle_py, kernel_py, n_regs, n_spills,
-                       n_max_threads);
+  return Py_BuildValue("(OOiii)", kernel_bundle_py, kernel_py, n_regs,
+                       spillsToPyInt(n_spills.slotsPerLane()), n_max_threads);
 }
 
 extern "C" EXPORT_FUNC PyObject *init_devices(PyObject *cap) {


### PR DESCRIPTION
`CompiledKernel.n_spills` is public and compared against thresholds
calibrated on CUDA/HIP, which report it as `LOCAL_SIZE_BYTES / 4` --
dword-equivalents per lane. XPU returned the raw Level Zero
`spillMemSize`: a byte count per hardware thread, 128x larger at SIMD32.
`driver.c` now pairs it with the compiled SIMD width and divides by
`4 * subgroupSize` before `Py_BuildValue`.

The auto-GRF retry stays gated on raw bytes, so codegen is unchanged. The
division truncates, matching CUDA/HIP, so a kernel allocating under one
dword per lane now reports 0.

Closes #7896

