### PR TITLE
[vLLM] Add unified attention test config to nondeterministic b580 failure list

### DIFF
--- a/scripts/skiplist/xe2/vllm_tdesc.txt
+++ b/scripts/skiplist/xe2/vllm_tdesc.txt
@@ -885,6 +885,7 @@ tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_at
 
 # Nondeterministic tensor-likes are not close on B580: https://github.com/intel/intel-xpu-backend-for-triton/issues/7395
 tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_attn_fp16_input_fp8_output[8-32768-50.0-None-16-128-num_heads1-seq_lens3]
+tests/kernels/attention/test_triton_unified_attention.py::test_triton_unified_attn_fp16_input_fp8_output[0-2048-50.0-128-16-128-num_heads1-seq_lens3]
 
 # Reference moe_sum kernel interface mismatch: https://github.com/intel/intel-xpu-backend-for-triton/issues/7811
 tests/kernels/moe/test_moe.py::test_moe_sum[contig-dtype0-128-2-1]


### PR DESCRIPTION
Adds a skip to https://github.com/intel/intel-xpu-backend-for-triton/issues/7395.

Nondeterminism:
* Attempt 1: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/33677746463/attempts/1 (FAIL)
* Attempt 2: https://github.com/intel/intel-xpu-backend-for-triton/actions/runs/33677746463/attempts/2 (PASS)
