### PR TITLE
[XPU] Gate the auto-large-GRF retry on the reported n_spills

### DIFF
--- a/.claude/rules/intel-gpu-hardware.md
+++ b/.claude/rules/intel-gpu-hardware.md
@@ -17,11 +17,18 @@ Each hardware thread has a private register file. **Do not guess** GRF register 
 
 ### Auto-GRF Mode Selection (`grf_mode='default'`)
 1. Compile with default (small) GRF
-2. Extract spill size from ZEBIN `.ze_info` section
-3. If `spill_size > 0` bytes → recompile with 256-GRF mode
-4. The threshold is `0` — *any* spill retries — aligned between `MAX_REG_SPILL` in `compiler.py` and `max_reg_spill` in `driver.c`
+2. Extract spill size from ZEBIN `.ze_info` section (AOT) or query Level Zero
+   `spillMemSize` (JIT) — both are **bytes per hardware thread**
+3. Normalize to **dword-equivalents per lane** (`bytes / (4 × sub-group size)`),
+   the unit CUDA/HIP report `n_spills` in and that external consumers threshold on
+4. If that exceeds `16` → recompile with 256-GRF mode
 
-The retry is gated on the raw **byte** count, which Level Zero allocates per hardware thread.
+The threshold is `16` dword-equivalents/lane, aligned between
+`MAX_REG_SPILL_SLOTS_PER_LANE` in `compiler.py` and `kMaxSpillSlotsPerLane` in
+`driver.c`. It is PyTorch inductor's default `spill_threshold` for non-HIP, so a
+spill at or below it cannot change inductor's autotuning verdict and a rebuild
+would only cost compile time. Compare in the normalized unit, not in bytes —
+inductor tests the truncated per-lane count, so a byte threshold over-triggers.
 
 ### Constraints
 - **256-GRF requires `num_warps ≤ 32`** (because halved thread occupancy limits available hardware threads)

--- a/python/test/unit/intel/test_auto_grf_num_warps_guard.py
+++ b/python/test/unit/intel/test_auto_grf_num_warps_guard.py
@@ -13,7 +13,7 @@ launch with the raw `ZE_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION`.
 The fix drops the large-GRF entries from `make_zebin`'s retry list when
 `num_warps > 32`, so both automatic upgrade triggers are covered:
 
-  * the spill-based upgrade (`spill_size > MAX_REG_SPILL`), and
+  * the spill-based upgrade (`spill_slots_per_lane(...) > MAX_REG_SPILL_SLOTS_PER_LANE`), and
   * the build-failure retry (e.g. the LTS2 degenerate-zebin case),
 
 keeping the working — if slower, spilling — default-GRF binary in both cases.

--- a/python/test/unit/intel/test_native_code_generation.py
+++ b/python/test/unit/intel/test_native_code_generation.py
@@ -3,7 +3,8 @@ import triton
 import triton.language as tl
 
 from triton._internal_testing import numpy_random, to_triton, is_xpu_cri
-from triton.backends.intel.compiler import MAX_REG_SPILL, extract_spill_size_from_zebin
+from triton.backends.intel.compiler import (MAX_REG_SPILL_SLOTS_PER_LANE, extract_spill_size_from_zebin,
+                                            spill_slots_per_lane)
 
 
 def test_empty_kernel(device):
@@ -28,12 +29,15 @@ def test_auto_large_grf(device, tmp_path):
         tl.store(X + x, y)
 
     x = to_triton(numpy_random(SIZE, dtype_str="float32"), device=device, dst_type="float32")
-    # Triton XPU will choose large GRF mode when spill_size > MAX_REG_SPILL.
+    # Triton XPU chooses large GRF mode when the spill frame, normalized to
+    # dword-equivalents per lane, exceeds the reported-`n_spills` budget.
     k = kernel[(1, )](x, SIZE=SIZE, num_warps=1, generate_native_code=True, grf_mode='default')
     zebin = tmp_path / "kernel.zebin"
     zebin.write_bytes(k.kernel)
     spill_size = extract_spill_size_from_zebin(str(zebin))
-    if spill_size <= MAX_REG_SPILL:
-        pytest.skip(f"Kernel did not spill above MAX_REG_SPILL ({spill_size} <= {MAX_REG_SPILL}); "
+    spill_slots = spill_slots_per_lane(spill_size, k.metadata.threads_per_warp)
+    if spill_slots <= MAX_REG_SPILL_SLOTS_PER_LANE:
+        pytest.skip(f"Kernel did not spill above the threshold ({spill_slots} <= "
+                    f"{MAX_REG_SPILL_SLOTS_PER_LANE} dword-equivalents/lane, from {spill_size} B/thread); "
                     "auto-large-GRF path was not exercised. Consider increasing SIZE.")
     assert "-cl-intel-256-GRF-per-thread" in k.metadata.build_flags

--- a/third_party/intel/backend/compiler.py
+++ b/third_party/intel/backend/compiler.py
@@ -79,8 +79,12 @@ class XPUOptions:
         return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
 
-# Aligned with max_reg_spill in third_party/intel/backend/driver.c
-MAX_REG_SPILL = 0
+# Largest spill the auto-large-GRF upgrade tolerates before rebuilding, in the
+# unit external consumers compare `n_spills` in: dword-equivalents per lane. 16
+# is PyTorch inductor's default `spill_threshold` for non-HIP, so a spill at or
+# below this cannot change inductor's verdict and a rebuild would only cost
+# compile time. Kept in sync with `kMaxSpillSlotsPerLane` in driver.c.
+MAX_REG_SPILL_SLOTS_PER_LANE = 16
 
 SPILL_SIZE_RE = re.compile(r'spill_size\s*[:=]\s*(\d+)')
 PTSS_OVERFLOW_RE = re.compile(
@@ -117,6 +121,19 @@ def extract_spill_size_from_zebin(file):
         if match is not None:
             return int(match.group(1))
     return 0
+
+
+def spill_slots_per_lane(spill_size, threads_per_warp):
+    """Convert a zebin `spill_size` to the unit `n_spills` is reported in.
+
+    `spill_size` is bytes allocated per hardware thread; CUDA and HIP report
+    `n_spills` as dword-equivalents per lane, and that is the unit external
+    consumers threshold on. Mirrors `Spills::slotsPerLane` in driver.c, down to
+    the truncating division and the raw-byte fallback for an unknown width.
+    """
+    if spill_size <= 0 or threads_per_warp <= 0:
+        return spill_size
+    return spill_size // (4 * threads_per_warp)
 
 
 def min_dot_size(device_props: Union[Dict, GPUTarget]):
@@ -669,7 +686,8 @@ class XPUBackend(BaseBackend, metaclass=XPUBackendMeta):
                     subprocess.check_output(ocloc_cmd, stderr=subprocess.STDOUT, text=True)
                     if options.grf_mode == "default":
                         spill_size = extract_spill_size_from_zebin(fbin)
-                        if spill_size <= MAX_REG_SPILL:
+                        spill_slots = spill_slots_per_lane(spill_size, metadata["threads_per_warp"])
+                        if spill_slots <= MAX_REG_SPILL_SLOTS_PER_LANE:
                             break
                 except (subprocess.CalledProcessError, IntelGPUError) as e:
                     # If GRF mode was not last yet, retry with different GRF mode

--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -581,12 +581,22 @@ extern "C" EXPORT_FUNC PyObject *load_binary(PyObject *args) {
   }
 
   const bool debugEnabled = getBoolEnv("TRITON_DEBUG");
-  constexpr int32_t max_reg_spill = 0;
+  // Only rebuild at large GRF once the kernel spills past what torch inductor's
+  // autotuner tolerates, so the rebuild can only rescue a config inductor would
+  // have discarded and never perturbs one it would have kept. 16 is inductor's
+  // default `spill_threshold` for non-HIP (`triton_heuristics.py`); a caller
+  // that overrides it is not tracked here.
+  //
+  // Compared against `slotsPerLane()` -- the very value handed to Python as
+  // `n_spills` -- rather than converting the budget into bytes: inductor tests
+  // the truncated per-lane count, so a byte threshold would also fire on the
+  // band that truncates back down to an accepted value. An unknown SIMD width
+  // makes `slotsPerLane()` fall back to raw bytes, which retries on all but the
+  // smallest spills (issue #7821).
+  constexpr int64_t kMaxSpillSlotsPerLane = 16;
 
-  // Gated on raw bytes, not on the normalized per-lane count, so GRF-mode
-  // selection -- and therefore codegen -- is unchanged by #7896.
   if (canRetryWithLargeGRF &&
-      (firstBuildFailed || n_spills.getBytes() > max_reg_spill)) {
+      (firstBuildFailed || n_spills.slotsPerLane() > kMaxSpillSlotsPerLane)) {
     PyObject *orig_type = nullptr, *orig_value = nullptr, *orig_tb = nullptr;
     // Save the original error before clearing it for the retry attempt.
     if (firstBuildFailed)


### PR DESCRIPTION
The auto-large-GRF rebuild recompiles a kernel at 256 GRF whenever the
128-GRF build spills more than a threshold. That threshold was a flat 0
bytes (#7615), so any spill at all triggered a recompile.

Raise it to 16, compared against the same value XPU reports to Python as
`n_spills` — dword-equivalents per lane (#7896, #7950), the unit CUDA
and HIP report and that external consumers threshold on. 16 is PyTorch
inductor's default `spill_threshold` for non-HIP, so the retry now fires
exactly on the configs inductor would discard: recompiles below the
threshold cannot change inductor's accept/reject decision (the retry
runs first and returns the post-retry count), they only add compile time
during autotuning, while recompiles above it still rescue configs
inductor would otherwise reject.

The comparison is done in the normalized unit rather than by converting
the budget back into bytes. Level Zero and zebin both report spill bytes
per hardware thread, so a byte threshold has to scale by the compiled
SIMD width — and even then it over-triggers, because inductor tests the
*truncated* per-lane count and therefore still accepts the byte range
that truncates back down to the threshold.

Effective retry point, versus the old flat 0:

| | before | now |
|---|---|---|
| unit compared | raw bytes per hardware thread | dword-equivalents per lane (`n_spills`) |
| threshold | `> 0` | `> 16` |
| retries at, SIMD16 | any spill | 1024 B/thread |
| retries at, SIMD32 | any spill | 2048 B/thread |

Changes:

- `driver.c`: replace the byte comparison with
  `n_spills.slotsPerLane() > kMaxSpillSlotsPerLane`, reusing the
  conversion already used for the value handed to Python. An unknown
  SIMD width still falls back to raw bytes, retrying on all but the
  smallest spills; the `-1` query-failure sentinel still does not retry.
- `compiler.py`: `MAX_REG_SPILL` (0) -> `MAX_REG_SPILL_SLOTS_PER_LANE`
  (16), with `spill_slots_per_lane()` mirroring `Spills::slotsPerLane`
  so the AOT `make_zebin` path and the JIT path agree.
- Update the two unit tests and the checked-in GRF rule doc, which still
  documented the 0-byte threshold.

See #7821.
