### PR TITLE
[RemoveLayoutConversions] Fix race condition with same pointer, different encodings

### DIFF
--- a/test/TritonIntelGPU/remove-layout-conversions-race-condition.mlir
+++ b/test/TritonIntelGPU/remove-layout-conversions-race-condition.mlir
@@ -1,0 +1,78 @@
+// RUN: triton-opt %s -split-input-file --tritonintelgpu-remove-layout-conversions | FileCheck %s
+
+// COM: NEGATIVE case — reject rematerialization when pointer is loaded and stored with different encodings.
+// COM: This prevents a race condition where the same pointer is accessed with different thread-to-address mappings.
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @reject_remat_different_encoding
+  tt.func @reject_remat_different_encoding(%in_out_ptr: !tt.ptr<f32>, %out_ptr: !tt.ptr<f32>) {
+    %c0 = arith.constant 0 : i32
+    %c128 = arith.constant 128 : i32
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked>
+
+    // Load from in_out_ptr with #blocked encoding
+    %ptr_splat = tt.splat %in_out_ptr : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked>
+    %ptrs = tt.addptr %ptr_splat, %range : tensor<128x!tt.ptr<f32>, #blocked>, tensor<128xi32, #blocked>
+    %load = tt.load %ptrs : tensor<128x!tt.ptr<f32>, #blocked>
+
+    // Compute something with the loaded data
+    %cst = arith.constant dense<2.0> : tensor<128xf32, #blocked>
+    %result = arith.mulf %load, %cst : tensor<128xf32, #blocked>
+
+    // Store back to in_out_ptr with #blocked encoding (establishes the encoding for this pointer)
+    tt.store %ptrs, %result : tensor<128x!tt.ptr<f32>, #blocked>
+
+    // Convert to #blocked1 for out_ptr store
+    // CHECK: ttg.convert_layout
+    %converted = ttg.convert_layout %result : tensor<128xf32, #blocked> -> tensor<128xf32, #blocked1>
+
+    // Store to out_ptr with #blocked1 encoding
+    %out_ptr_splat = tt.splat %out_ptr : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked1>
+    %range1 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked1>
+    %out_ptrs = tt.addptr %out_ptr_splat, %range1 : tensor<128x!tt.ptr<f32>, #blocked1>, tensor<128xi32, #blocked1>
+    tt.store %out_ptrs, %converted : tensor<128x!tt.ptr<f32>, #blocked1>
+
+    // COM: The convert_layout should NOT be removed because rematerializing
+    // COM: the load in #blocked1 would create a race (different encoding = different thread mapping).
+
+    tt.return
+  }
+}
+
+// -----
+
+// COM: POSITIVE case — allow rematerialization when pointer is loaded and stored with same encoding.
+// COM: This is safe because the same encoding means the same thread-to-address mapping.
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @allow_remat_same_encoding
+  tt.func @allow_remat_same_encoding(%in_out_ptr: !tt.ptr<f32>, %out_ptr: !tt.ptr<f32>) {
+    %c0 = arith.constant 0 : i32
+    %c128 = arith.constant 128 : i32
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked>
+
+    // Load from in_out_ptr with #blocked encoding
+    %ptr_splat = tt.splat %in_out_ptr : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked>
+    %ptrs = tt.addptr %ptr_splat, %range : tensor<128x!tt.ptr<f32>, #blocked>, tensor<128xi32, #blocked>
+    %load = tt.load %ptrs : tensor<128x!tt.ptr<f32>, #blocked>
+
+    // Compute something with the loaded data
+    %cst = arith.constant dense<2.0> : tensor<128xf32, #blocked>
+    %result = arith.mulf %load, %cst : tensor<128xf32, #blocked>
+
+    // Store back to in_out_ptr with #blocked encoding
+    tt.store %ptrs, %result : tensor<128x!tt.ptr<f32>, #blocked>
+
+    // Use result again for out_ptr (same encoding)
+    %out_ptr_splat = tt.splat %out_ptr : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked>
+    %out_ptrs = tt.addptr %out_ptr_splat, %range : tensor<128x!tt.ptr<f32>, #blocked>, tensor<128xi32, #blocked>
+    tt.store %out_ptrs, %result : tensor<128x!tt.ptr<f32>, #blocked>
+
+    // CHECK-NOT: ttg.convert_layout
+    // COM: No convert_layout should appear because both stores use the same encoding,
+    // COM: so rematerialization is safe (no race condition).
+
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -1097,6 +1097,53 @@ static bool isRematerializableInSlice(Operation *op) {
   return canBeRemat(op) || isExpensiveLoadRematCandidate(op);
 }
 
+// FIXME(#7890): Helper function to get the base pointer by tracing through
+// AddPtrOp and SplatOp operations.
+static Value getBasePointer(Value ptr) {
+  Value base = ptr;
+  // Trace through AddPtrOp chains
+  while (auto addPtrOp = base.getDefiningOp<tt::AddPtrOp>())
+    base = addPtrOp.getPtr();
+  // Trace through SplatOp to get the scalar pointer
+  if (auto splatOp = base.getDefiningOp<tt::SplatOp>())
+    base = splatOp.getSrc();
+  return base;
+}
+
+// FIXME(#7890): Check if a pointer is stored to anywhere in the function with
+// a DIFFERENT encoding than the target encoding. Used to reject
+// rematerializations that could create race conditions when the same pointer is
+// accessed with different encodings. If the store uses the SAME encoding, it's
+// safe.
+static bool isPointerStoredWithDifferentEncoding(Value basePtr,
+                                                 tt::FuncOp funcOp,
+                                                 Attribute targetEncoding) {
+  // Lambda to check if a store conflicts with the target encoding
+  auto checkStoreEncoding = [&](Value storePtr, Value storeValue) -> bool {
+    if (getBasePointer(storePtr) == basePtr) {
+      auto valueTy = dyn_cast<RankedTensorType>(storeValue.getType());
+      if (valueTy) {
+        Attribute storeEncoding = valueTy.getEncoding();
+        if (storeEncoding != targetEncoding)
+          return true; // Different encoding - conflict!
+      }
+    }
+    return false;
+  };
+
+  auto result = funcOp.walk([&](Operation *op) {
+    if (auto storeOp = dyn_cast<tt::StoreOp>(op)) {
+      if (checkStoreEncoding(storeOp.getPtr(), storeOp.getValue()))
+        return WalkResult::interrupt();
+    } else if (auto descStoreOp = dyn_cast<tt::DescriptorStoreOp>(op)) {
+      if (checkStoreEncoding(descStoreOp.getDesc(), descStoreOp.getSrc()))
+        return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return result.wasInterrupted();
+}
+
 void LayoutRematerialization::updateRematMapping(
     SmallVector<std::tuple<Value, Value>> &values) {
   for (auto [old, newV] : values) {
@@ -1600,6 +1647,49 @@ LogicalResult LayoutRematerialization::getRematerializableSlice(
         return failure();
     }
   }
+
+  // FIXME(#7890): Check to prevent rematerializing loads from pointers that are
+  // stored to elsewhere with a DIFFERENT encoding.
+  //
+  // When rematerializing memory operations with different encodings, we must
+  // ensure that operations on the same pointer use consistent thread-to-address
+  // mappings. Otherwise, different work-items will access different addresses
+  // for the same logical element, creating a race condition.
+  //
+  // Example: If in_out_ptr0 is loaded in this slice (to be rematerialized with
+  // #blocked1), and there's a store to in_out_ptr0 elsewhere with #blocked,
+  // we would create:
+  //   - Path 1 (store): Lane 0 writes to address X (encoding #blocked)
+  //   - Path 2 (load):  Lane 0 reads from address Y (encoding #blocked1,
+  //   transposed)
+  // This creates a race where lanes read/write each other's data.
+  //
+  // However, if the store uses the SAME encoding (rootEncoding), both the load
+  // and store would use the same thread-to-address mapping, which is safe.
+  for (Value v : slice) {
+    Operation *op = v.getDefiningOp();
+    if (!op)
+      continue;
+
+    // Check loads - if the pointer is stored to with a different encoding,
+    // reject
+    Value ptr;
+    if (auto loadOp = dyn_cast<tt::LoadOp>(op))
+      ptr = loadOp.getPtr();
+    else if (auto descLoadOp = dyn_cast<tt::DescriptorLoadOp>(op))
+      ptr = descLoadOp.getDesc();
+    else
+      continue;
+
+    Value basePtr = getBasePointer(ptr);
+    if (isPointerStoredWithDifferentEncoding(basePtr, funcOp, rootEncoding)) {
+      LDBG("Rejecting slice: pointer "
+           << basePtr << " is loaded (in slice) with encoding " << rootEncoding
+           << " but stored elsewhere with different encoding");
+      return failure();
+    }
+  }
+
   sliceArg = std::move(slice);
   layoutArg = std::move(layout);
   return success();

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -1097,8 +1097,8 @@ static bool isRematerializableInSlice(Operation *op) {
   return canBeRemat(op) || isExpensiveLoadRematCandidate(op);
 }
 
-// FIXME(#7890): Helper function to get the base pointer by tracing through
-// AddPtrOp and SplatOp operations.
+// Helper function to get the base pointer by tracing through AddPtrOp and
+// SplatOp operations.
 static Value getBasePointer(Value ptr) {
   Value base = ptr;
   // Trace through AddPtrOp chains
@@ -1110,11 +1110,10 @@ static Value getBasePointer(Value ptr) {
   return base;
 }
 
-// FIXME(#7890): Check if a pointer is stored to anywhere in the function with
-// a DIFFERENT encoding than the target encoding. Used to reject
-// rematerializations that could create race conditions when the same pointer is
-// accessed with different encodings. If the store uses the SAME encoding, it's
-// safe.
+// Check if a pointer is stored to anywhere in the function with a DIFFERENT
+// encoding than the target encoding. Used to reject rematerializations that
+// could create race conditions when the same pointer is accessed with different
+// encodings. If the store uses the SAME encoding, it's safe.
 static bool isPointerStoredWithDifferentEncoding(Value basePtr,
                                                  tt::FuncOp funcOp,
                                                  Attribute targetEncoding) {
@@ -1648,8 +1647,8 @@ LogicalResult LayoutRematerialization::getRematerializableSlice(
     }
   }
 
-  // FIXME(#7890): Check to prevent rematerializing loads from pointers that are
-  // stored to elsewhere with a DIFFERENT encoding.
+  // Check to prevent rematerializing loads from pointers that are stored to
+  // elsewhere with a DIFFERENT encoding.
   //
   // When rematerializing memory operations with different encodings, we must
   // ensure that operations on the same pointer use consistent thread-to-address


### PR DESCRIPTION
Prevents rematerialization when a load's pointer is also stored with a different encoding. Different encodings create different thread-to-address mappings, causing a race condition where threads access wrong memory locations.

The fix adds `isPointerStoredWithDifferentEncoding()` to check if a pointer in the rematerialization slice is stored elsewhere in the function with a different encoding than the target. If so, rematerialization is rejected.

Fixes #7890