### PR TITLE
[XPU] Bail to scalar loads on misaligned 2D block-load boundaries

### DIFF
--- a/python/test/unit/intel/test_block_load_nan.py
+++ b/python/test/unit/intel/test_block_load_nan.py
@@ -9,7 +9,7 @@ from triton._internal_testing import is_xpu
 
 @pytest.mark.parametrize("M, N",
                          [[256, 64], [256, 32], [128, 32], [128, 16], [128, 8], [64, 64], [64, 32], [32, 32], [16, 64]])
-@pytest.mark.parametrize("dtype_str", ["float32"])
+@pytest.mark.parametrize("dtype_str", ["float32", "float16"])
 @pytest.mark.skipif(not is_xpu(), reason="Block load tests are specific to the XPU backend")
 @pytest.mark.xfail(not triton.runtime.driver.active.get_current_target().arch['has_2d_block_io'],
                    reason="Block loads not supported on this architecture", run=False)
@@ -29,40 +29,6 @@ def test_block_load_dpas_layout(M, N, dtype_str, device, tmp_path: pathlib.Path)
     block_io = "\"row_major\""
 
     ty = {"float32": "f32", "float16": "f16", "int8": "i8"}[dtype_str]
-
-    ref_ir = layouts + f"""
-    module attributes {{ttig.min_sg_size = 16 : i32, ttig.support_bfloat16_conversion, ttig.support_subgroup_matrix_multiply_accumulate, ttig.support_2d_block_io, ttig.target_arch = "spir64", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = {num_warps} : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32}} {{
-        tt.func public @block_load_dpas_layout(%arg0: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}, %arg2: !tt.ptr<{ty}> {{tt.divisibility = 16: i32}}, %arg3: !tt.ptr<{ty}> {{tt.divisibility = 16: i32}}) attributes {{noinline = false}} {{
-            %0 = tt.get_program_id x : i32
-
-            %Mload_i32 = arith.constant {M-1} : i32
-            %Nload_i32 = arith.constant {N-1} : i32
-            %Mload_i64 = arith.constant {M-1} : i64
-            %Nload_i64 = arith.constant {N-1} : i64
-
-            %M_i32 = arith.constant {M} : i32
-            %N_i32 = arith.constant {N} : i32
-            %M_i64 = arith.constant {M} : i64
-            %N_i64 = arith.constant {N} : i64
-            %c1_i64 = arith.constant 1 : i64
-            %c0_i32 = arith.constant 0 : i32
-
-            // A matrix
-            %1 = tt.make_tensor_descriptor %arg0, [%Mload_i32, %Nload_i32], [%Nload_i64, %c1_i64]  : <{ty}>, !tt.tensordesc<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
-            %2 = tt.descriptor_load %1[%0, %c0_i32] {{ttig.block_io = "row_major"}} : !tt.tensordesc<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>> -> tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
-            %3 = tt.make_tensor_descriptor %arg1, [%M_i32, %N_i32], [%N_i64, %c1_i64] : <{ty}>, !tt.tensordesc<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
-            tt.descriptor_store %3[%0, %c0_i32], %2 : !tt.tensordesc<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}> >, tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
-
-            // B matrix
-            %4 = tt.make_tensor_descriptor %arg2, [%Nload_i32, %Mload_i32], [%Mload_i64, %c1_i64]  : <{ty}>, !tt.tensordesc<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
-            %5 = tt.descriptor_load %4[%c0_i32, %0] {{ttig.block_io = {block_io} }} : !tt.tensordesc<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>> -> tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
-            %6 = tt.make_tensor_descriptor %arg3, [%N_i32, %M_i32], [%M_i64, %c1_i64] : <{ty}>, !tt.tensordesc<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
-            tt.descriptor_store %6[%c0_i32, %0], %5 : !tt.tensordesc<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}> >, tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
-
-            tt.return
-        }}
-    }}
-    """
 
     ir = layouts + f"""
     module attributes {{ttig.min_sg_size = 16 : i32, ttig.support_bfloat16_conversion, ttig.support_subgroup_matrix_multiply_accumulate, ttig.support_2d_block_io, ttig.target_arch = "spir64", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = {num_warps} : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32}} {{
@@ -100,20 +66,6 @@ def test_block_load_dpas_layout(M, N, dtype_str, device, tmp_path: pathlib.Path)
 
     torch_dtype = getattr(torch, dtype_str)
 
-    a_ref = torch.ones((M, N), dtype=torch_dtype, device=device)
-    b_ref = torch.ones((N, M), dtype=torch_dtype, device=device)
-    x_ref = torch.empty_like(a_ref)
-    y_ref = torch.empty_like(b_ref)
-
-    temp_file = tmp_path / "test_block_load_dpas_layout_ref.ttgir"
-    temp_file.write_text(ref_ir)
-    kernel = triton.compile(str(temp_file))
-
-    kernel[(1, 1, 1)](a_ref, x_ref, b_ref, y_ref)
-
-    x_ref[x_ref == 0] = float('nan')
-    y_ref[y_ref == 0] = float('nan')
-
     a = torch.ones((M, N), dtype=torch_dtype, device=device)
     b = torch.ones((N, M), dtype=torch_dtype, device=device)
     x = torch.empty_like(a)
@@ -127,4 +79,17 @@ def test_block_load_dpas_layout(M, N, dtype_str, device, tmp_path: pathlib.Path)
 
     torch.set_printoptions(profile="full", precision=2, sci_mode=0, linewidth=200)
 
-    assert torch.allclose(x_ref, x, equal_nan=True) and torch.allclose(y_ref, y, equal_nan=True)
+    # Build expected output explicitly: 1.0 for in-bounds elements, NaN for OOB.
+    # The descriptor has shape (M-1, N-1) for A and (N-1, M-1) for B, loaded into
+    # full (M, N) and (N, M) tiles respectively.
+    # This avoids depending on a zero-padding reference path, which is unreliable
+    # for packed fp16 (kWidth=2) operands where hardware boundary behaviour varies.
+    x_expected = torch.ones((M, N), dtype=torch_dtype, device=device)
+    x_expected[M - 1:, :] = float('nan')  # OOB row
+    x_expected[:, N - 1:] = float('nan')  # OOB col
+
+    y_expected = torch.ones((N, M), dtype=torch_dtype, device=device)
+    y_expected[N - 1:, :] = float('nan')  # OOB row
+    y_expected[:, M - 1:] = float('nan')  # OOB col
+
+    assert torch.allclose(x_expected, x, equal_nan=True) and torch.allclose(y_expected, y, equal_nan=True)

--- a/python/test/unit/intel/test_block_load_nan.py
+++ b/python/test/unit/intel/test_block_load_nan.py
@@ -80,11 +80,6 @@ def test_block_load_dpas_layout(M, N, dtype_str, padding_id, expected_oob, devic
 
     torch.set_printoptions(profile="full", precision=2, sci_mode=0, linewidth=200)
 
-    # Build expected output explicitly: 1.0 for in-bounds elements, NaN for OOB
-    # (PAD_NAN) or 0.0 (PAD_ZERO). The descriptor has shape (M-1, N-1) for A and
-    # (N-1, M-1) for B, loaded into full (M, N) and (N, M) tiles respectively.
-    # This avoids depending on a zero-padding reference path, which is unreliable
-    # for packed fp16 (kWidth=2) operands where hardware boundary behaviour varies.
     x_expected = torch.ones((M, N), dtype=torch_dtype, device=device)
     x_expected[M - 1:, :] = expected_oob  # OOB row
     x_expected[:, N - 1:] = expected_oob  # OOB col

--- a/python/test/unit/intel/test_block_load_nan.py
+++ b/python/test/unit/intel/test_block_load_nan.py
@@ -10,10 +10,11 @@ from triton._internal_testing import is_xpu
 @pytest.mark.parametrize("M, N",
                          [[256, 64], [256, 32], [128, 32], [128, 16], [128, 8], [64, 64], [64, 32], [32, 32], [16, 64]])
 @pytest.mark.parametrize("dtype_str", ["float32", "float16"])
+@pytest.mark.parametrize("padding_id, expected_oob", [(2, float('nan')), (1, 0.0)], ids=["pad_nan", "pad_zero"])
 @pytest.mark.skipif(not is_xpu(), reason="Block load tests are specific to the XPU backend")
 @pytest.mark.xfail(not triton.runtime.driver.active.get_current_target().arch['has_2d_block_io'],
                    reason="Block loads not supported on this architecture", run=False)
-def test_block_load_dpas_layout(M, N, dtype_str, device, tmp_path: pathlib.Path):
+def test_block_load_dpas_layout(M, N, dtype_str, padding_id, expected_oob, device, tmp_path: pathlib.Path):
     # modify the layouts to ensure the correct OCL/SPIRV intrinsic is called for each datatype
     if dtype_str == "float32":
         A_width = 1
@@ -48,14 +49,14 @@ def test_block_load_dpas_layout(M, N, dtype_str, device, tmp_path: pathlib.Path)
             %c0_i32 = arith.constant 0 : i32
 
             // A matrix
-            %1 = tt.make_tensor_descriptor %arg0, [%Mload_i32, %Nload_i32], [%Nload_i64, %c1_i64] {{padding = 2 : i32}} : <{ty}>, !tt.tensordesc<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
-            %2 = tt.descriptor_load %1[%0, %c0_i32] {{ttig.block_io = "row_major", ttig.desc_padding = 2 : i32}} : !tt.tensordesc<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>> -> tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
+            %1 = tt.make_tensor_descriptor %arg0, [%Mload_i32, %Nload_i32], [%Nload_i64, %c1_i64] {{padding = {padding_id} : i32}} : <{ty}>, !tt.tensordesc<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
+            %2 = tt.descriptor_load %1[%0, %c0_i32] {{ttig.block_io = "row_major", ttig.desc_padding = {padding_id} : i32}} : !tt.tensordesc<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>> -> tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
             %3 = tt.make_tensor_descriptor %arg1, [%M_i32, %N_i32], [%N_i64, %c1_i64] : <{ty}>, !tt.tensordesc<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
             tt.descriptor_store %3[%0, %c0_i32], %2 : !tt.tensordesc<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}> >, tensor<{M}x{N}x{ty}, #ttg.dot_op<{{opIdx = 0, parent = #mma, kWidth = {A_width}}}>>
 
             // B matrix
-            %4 = tt.make_tensor_descriptor %arg2, [%Nload_i32, %Mload_i32], [%Mload_i64, %c1_i64] {{padding = 2 : i32}} : <{ty}>, !tt.tensordesc<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
-            %5 = tt.descriptor_load %4[%c0_i32, %0] {{ttig.block_io = {block_io}, ttig.desc_padding = 2 : i32}} : !tt.tensordesc<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>> -> tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
+            %4 = tt.make_tensor_descriptor %arg2, [%Nload_i32, %Mload_i32], [%Mload_i64, %c1_i64] {{padding = {padding_id} : i32}} : <{ty}>, !tt.tensordesc<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
+            %5 = tt.descriptor_load %4[%c0_i32, %0] {{ttig.block_io = {block_io}, ttig.desc_padding = {padding_id} : i32}} : !tt.tensordesc<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>> -> tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
             %6 = tt.make_tensor_descriptor %arg3, [%N_i32, %M_i32], [%M_i64, %c1_i64] : <{ty}>, !tt.tensordesc<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
             tt.descriptor_store %6[%c0_i32, %0], %5 : !tt.tensordesc<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}> >, tensor<{N}x{M}x{ty}, #ttg.dot_op<{{opIdx = 1, parent = #mma, kWidth = {B_width}}}>>
 
@@ -79,17 +80,17 @@ def test_block_load_dpas_layout(M, N, dtype_str, device, tmp_path: pathlib.Path)
 
     torch.set_printoptions(profile="full", precision=2, sci_mode=0, linewidth=200)
 
-    # Build expected output explicitly: 1.0 for in-bounds elements, NaN for OOB.
-    # The descriptor has shape (M-1, N-1) for A and (N-1, M-1) for B, loaded into
-    # full (M, N) and (N, M) tiles respectively.
+    # Build expected output explicitly: 1.0 for in-bounds elements, NaN for OOB
+    # (PAD_NAN) or 0.0 (PAD_ZERO). The descriptor has shape (M-1, N-1) for A and
+    # (N-1, M-1) for B, loaded into full (M, N) and (N, M) tiles respectively.
     # This avoids depending on a zero-padding reference path, which is unreliable
     # for packed fp16 (kWidth=2) operands where hardware boundary behaviour varies.
     x_expected = torch.ones((M, N), dtype=torch_dtype, device=device)
-    x_expected[M - 1:, :] = float('nan')  # OOB row
-    x_expected[:, N - 1:] = float('nan')  # OOB col
+    x_expected[M - 1:, :] = expected_oob  # OOB row
+    x_expected[:, N - 1:] = expected_oob  # OOB col
 
     y_expected = torch.ones((N, M), dtype=torch_dtype, device=device)
-    y_expected[N - 1:, :] = float('nan')  # OOB row
-    y_expected[:, M - 1:] = float('nan')  # OOB col
+    y_expected[N - 1:, :] = expected_oob  # OOB row
+    y_expected[:, M - 1:] = expected_oob  # OOB col
 
     assert torch.allclose(x_expected, x, equal_nan=True) and torch.allclose(y_expected, y, equal_nan=True)

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -315,19 +315,17 @@ private:
     bool padNan = padding == tt::PaddingOption::PAD_NAN;
     UnitAttr padNanAttr = padNan ? builder.getUnitAttr() : UnitAttr();
 
-    // PVC Max 1100 applies OOB boundary checks at i32 (4-byte) granularity for
-    // 2D block loads, even for fp16 (elem_size_in_bits=16). When base_width is
+    // OOB boundary checks are applied at i32 (4-byte) granularity for
+    // 2D block loads, even for elem_size_in_bits < 32. When base_width is
     // not a multiple of 4 bytes, the last partial i32 word is considered OOB
     // and hardware zeroes it -- including any in-bounds element it contains.
-    // For VNNI (B-operand) loads, the hardware additionally packs
+    // For VNNI loads, the hardware additionally packs
     // kAlignBytes/elemSizeInBytes K-rows into each i32 word; an odd row count
     // causes the same coarse-granularity corruption in the row direction.
     //
     // This is a conservative, compile-time-only fix: whenever either check
     // could be violated for a compile-time-constant descriptor shape, bail to
     // the existing scalar-load fallback instead of emitting a 2D block load.
-    // Widening base_width (when pitch headroom permits) instead of bailing is
-    // left to a follow-up patch (#6002).
     const bool isPadded = padding == tt::PaddingOption::PAD_NAN ||
                           padding == tt::PaddingOption::PAD_ZERO;
     if (isPadded) {

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -315,6 +315,70 @@ private:
     bool padNan = padding == tt::PaddingOption::PAD_NAN;
     UnitAttr padNanAttr = padNan ? builder.getUnitAttr() : UnitAttr();
 
+    // PVC Max 1100 applies OOB boundary checks at i32 (4-byte) granularity for
+    // 2D block loads, even for fp16 (elem_size_in_bits=16). When base_width is
+    // not a multiple of 4 bytes, the last partial i32 word is considered OOB
+    // and hardware zeroes it -- including any in-bounds element it contains.
+    // For VNNI (B-operand) loads, the hardware additionally packs
+    // kAlignBytes/elemSizeInBytes K-rows into each i32 word; an odd row count
+    // causes the same coarse-granularity corruption in the row direction.
+    //
+    // This is a conservative, compile-time-only fix: whenever either check
+    // could be violated for a compile-time-constant descriptor shape, bail to
+    // the existing scalar-load fallback instead of emitting a 2D block load.
+    // Widening base_width (when pitch headroom permits) instead of bailing is
+    // left to a follow-up patch (#6002).
+    const bool isPadded = padding == tt::PaddingOption::PAD_NAN ||
+                          padding == tt::PaddingOption::PAD_ZERO;
+    if (isPadded) {
+      const unsigned elemSizeInBytes = elemSizeInBits / 8;
+      constexpr unsigned kAlignBytes = 4; // i32 word = hardware OOB granularity
+
+      // Column direction: base_width (last dim) must be a multiple of
+      // kAlignBytes, or the last partial i32 word's OOB check corrupts the
+      // in-bounds element(s) sharing that word.
+      for (auto d : allDescs) {
+        const auto descColCount =
+            tt::intel::getFoldedConstantValue(d->getOperand(descRank));
+        if (!descColCount) {
+          // Non-constant shape: cannot determine alignment statically.
+          // TODO: runtime column counts still hit the underlying hardware bug
+          // when misaligned; a runtime check + fallback would close this gap.
+          continue;
+        }
+        int64_t colBytes = *descColCount * elemSizeInBytes;
+        if (colBytes % kAlignBytes != 0) {
+          LDBG("Padded load: base_width="
+               << colBytes
+               << " not 4-aligned — 2D block load skipped for: " << *op);
+          return;
+        }
+      }
+
+      // Row direction: i32 granularity OOB check applies only to VNNI (B
+      // operand) loads where multiple K-rows are packed into each i32 word.
+      auto dotOpEnc = dyn_cast<ttg::DotOperandEncodingAttr>(encoding);
+      const bool isVNNILoad = dotOpEnc && dotOpEnc.getOpIdx() == 1;
+      if (isVNNILoad) {
+        const unsigned vnniGranularity = kAlignBytes / elemSizeInBytes;
+        // TODO: non-constant row count returns true (conservatively passes),
+        // but a runtime odd row count still causes the i32-pairing problem at
+        // runtime. A proper fix requires either a runtime check or
+        // restricting this path to constant-only row counts.
+        bool rowsAligned = llvm::all_of(allDescs, [&](tt::MakeTensorDescOp d) {
+          const auto descRowCount = tt::intel::getFoldedConstantValue(
+              d->getOperand(1 + (descRank - 2)));
+          return !descRowCount || (*descRowCount % vnniGranularity == 0);
+        });
+        if (!rowsAligned) {
+          LDBG("Padded load: odd VNNI K-row count — 2D block load skipped "
+               "for: "
+               << *op);
+          return;
+        }
+      }
+    }
+
     auto blockLoadOp = ttgi::Subgroup2DBlockLoadOp::create(
         builder, loc, op.getType(), basePtr, baseWidth, baseHeight, basePitch,
         offsetX, offsetY, batchStrides, padNanAttr,

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -353,8 +353,8 @@ private:
         }
       }
 
-      // Row direction: i32 granularity OOB check applies only to VNNI (B
-      // operand) loads where multiple K-rows are packed into each i32 word.
+      // Row direction: i32 granularity OOB check to VNNI loads
+      // where multiple K-rows are packed into each i32 word.
       auto dotOpEnc = dyn_cast<ttg::DotOperandEncodingAttr>(encoding);
       const bool isVNNILoad = dotOpEnc && dotOpEnc.getOpIdx() == 1;
       if (isVNNILoad) {


### PR DESCRIPTION
    PVC Max 1100's 2D block-load hardware applies out-of-bounds checks at
    i32 (4-byte) granularity. When a NaN- or zero-padded descriptor's
    column byte-width isn't a multiple of 4, or (for VNNI B-operand loads)
    its K-row count isn't a multiple of the row-packing granularity, the
    coarse-grained OOB check corrupts the last valid element together with
    the padding it's supposed to fill.
    
    Add a conservative, compile-time-only bail: whenever either check
    could be violated for a foldable descriptor shape, fall back to the
    existing scalar-load path instead of emitting a 2D block load.
    base_width rounding (recovering the fast path via pitch headroom) is
    left to a follow-up patch.
    
    Verified on PVC Max 1100: reverting this change reproduces the exact
    corruption (last valid column reads 0 instead of 1) on every affected
    case; restoring it fixes all of them.