### PR TITLE
[XPU] Keep store operands on a single encoding in RemoveLayoutConversions

### DIFF
--- a/test/TritonIntelGPU/RemoveLayoutConversions/store-constant-operand.mlir
+++ b/test/TritonIntelGPU/RemoveLayoutConversions/store-constant-operand.mlir
@@ -1,0 +1,91 @@
+// RUN: triton-opt %s -split-input-file -tritonintelgpu-remove-layout-conversions -verify-each 2>&1 | FileCheck %s --enable-var-scope
+
+// COM: Test that RemoveLayoutConversions does not propagate an mma-derived
+// COM: encoding onto the operands of a store when one of them is an
+// COM: arith.constant.
+// COM:
+// COM: A store operand that is shared with another store carries the
+// COM: mma-derived candidate into that store. When the second store's value
+// COM: is a constant, the candidate is pushed onto the constant as well.
+// COM: resolveConflicts() prefers mma-derived encodings for non-load/store
+// COM: ops, so the constant is resolved to the mma-derived encoding, and
+// COM: rewriteOp() re-types the constant in place. A constant's value
+// COM: attribute must keep the result type, so the rewritten op fails the
+// COM: arith.constant verifier. Skip propagating onto such stores: a
+// COM: constant operand cannot be re-encoded, and propagating onto the
+// COM: remaining operands only would leave the store with mixed operand
+// COM: encodings.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 1], repCluster = [2, 1], A = [16, 16], B = [16, 16], C = [16, 16]}>
+#dotop0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+#dotop1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32, ttig.min_sg_size = 16 : i32, ttig.support_subgroup_matrix_multiply_accumulate, ttig.target_arch = "spir64"} {
+  // CHECK-LABEL: @store_constant_operand
+  tt.func public @store_constant_operand(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    // COM: The zero constant must survive on its original blocked encoding; it
+    // COM: cannot be re-typed to the mma-derived encoding.
+    // CHECK: %[[CST:.*]] = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #[[BLOCKED:.+]]>
+    %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #blocked>
+    %cstAcc = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #blocked>
+    %acc = ttg.convert_layout %cstAcc : tensor<16x16xf32, #blocked> -> tensor<16x16xf32, #dpas>
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %cond = arith.cmpi slt, %c0, %c1 : i32
+    %m = tt.splat %cond : i1 -> tensor<16x16xi1, #blocked>
+    %off = arith.constant dense<0> : tensor<16x16xi32, #blocked>
+    %pb = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>, #blocked>
+    %p0 = tt.addptr %pb, %off : tensor<16x16x!tt.ptr<f32>, #blocked>, tensor<16x16xi32, #blocked>
+    %pa = tt.splat %arg1 : !tt.ptr<f16> -> tensor<16x16x!tt.ptr<f16>, #blocked>
+    %a = tt.load %pa, %m : tensor<16x16x!tt.ptr<f16>, #blocked>
+    %a0 = ttg.convert_layout %a : tensor<16x16xf16, #blocked> -> tensor<16x16xf16, #dotop0>
+    %a1 = ttg.convert_layout %a : tensor<16x16xf16, #blocked> -> tensor<16x16xf16, #dotop1>
+    %d = tt.dot %a0, %a1, %acc : tensor<16x16xf16, #dotop0> * tensor<16x16xf16, #dotop1> -> tensor<16x16xf32, #dpas>
+    %d2 = ttg.convert_layout %d : tensor<16x16xf32, #dpas> -> tensor<16x16xf32, #blocked>
+    // COM: The first store is folded onto the dot encoding as usual.
+    // CHECK: tt.store {{.+}}, {{.+}}, {{.+}} : tensor<16x16x!tt.ptr<f32>, #[[DPAS:.+]]>
+    tt.store %p0, %d2, %m : tensor<16x16x!tt.ptr<f32>, #blocked>
+    // COM: The store of the constant keeps a single encoding shared by all of
+    // COM: its operands: the blocked zero constant is stored as the value.
+    // CHECK: tt.store {{.+}}, %[[CST]], {{.+}} : tensor<16x16x!tt.ptr<f32>, #[[BLOCKED]]>
+    tt.store %p0, %cst, %m : tensor<16x16x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Same guard when the constant is the store mask rather than the value:
+// COM: the mma-derived candidate would be pushed onto the constant mask,
+// COM: which then fails the arith.constant verifier for the same reason.
+
+#blocked_m = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+#dpas_m = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 1], repCluster = [2, 1], A = [16, 16], B = [16, 16], C = [16, 16]}>
+#dotop0_m = #ttg.dot_op<{opIdx = 0, parent = #dpas_m, kWidth = 1}>
+#dotop1_m = #ttg.dot_op<{opIdx = 1, parent = #dpas_m, kWidth = 2}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "xpu", "ttg.threads-per-warp" = 16 : i32, ttig.min_sg_size = 16 : i32, ttig.support_subgroup_matrix_multiply_accumulate, ttig.target_arch = "spir64"} {
+  // CHECK-LABEL: @store_constant_mask
+  tt.func public @store_constant_mask(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    // COM: The mask constant must survive on its original blocked encoding.
+    // CHECK: %[[MASK:.*]] = arith.constant dense<true> : tensor<16x16xi1, #[[BLOCKED:.+]]>
+    %cstMask = arith.constant dense<true> : tensor<16x16xi1, #blocked_m>
+    %cstAcc = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #blocked_m>
+    %acc = ttg.convert_layout %cstAcc : tensor<16x16xf32, #blocked_m> -> tensor<16x16xf32, #dpas_m>
+    %off = arith.constant dense<0> : tensor<16x16xi32, #blocked_m>
+    %pb = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>, #blocked_m>
+    %p0 = tt.addptr %pb, %off : tensor<16x16x!tt.ptr<f32>, #blocked_m>, tensor<16x16xi32, #blocked_m>
+    %pa = tt.splat %arg1 : !tt.ptr<f16> -> tensor<16x16x!tt.ptr<f16>, #blocked_m>
+    %a = tt.load %pa : tensor<16x16x!tt.ptr<f16>, #blocked_m>
+    %a0 = ttg.convert_layout %a : tensor<16x16xf16, #blocked_m> -> tensor<16x16xf16, #dotop0_m>
+    %a1 = ttg.convert_layout %a : tensor<16x16xf16, #blocked_m> -> tensor<16x16xf16, #dotop1_m>
+    %d = tt.dot %a0, %a1, %acc : tensor<16x16xf16, #dotop0_m> * tensor<16x16xf16, #dotop1_m> -> tensor<16x16xf32, #dpas_m>
+    %d2 = ttg.convert_layout %d : tensor<16x16xf32, #dpas_m> -> tensor<16x16xf32, #blocked_m>
+    // COM: The store of the constant mask keeps a single encoding shared by
+    // COM: all operands.
+    // CHECK: tt.store {{.+}}, {{.+}}, %[[MASK]] : tensor<16x16x!tt.ptr<f32>, #[[BLOCKED]]>
+    tt.store %p0, %d2, %cstMask : tensor<16x16x!tt.ptr<f32>, #blocked_m>
+    tt.return
+  }
+}

--- a/test/TritonIntelGPU/RemoveLayoutConversions/store-encoding-conflict.mlir
+++ b/test/TritonIntelGPU/RemoveLayoutConversions/store-encoding-conflict.mlir
@@ -1,0 +1,90 @@
+// RUN: triton-opt %s -split-input-file -tritonintelgpu-remove-layout-conversions -verify-each 2>&1 | FileCheck %s --enable-var-scope
+
+// COM: Test that RemoveLayoutConversions never rewrites a tt.store so that its
+// COM: ptr/value/mask operands end up with different encodings.
+// COM:
+// COM: In LayoutPropagation, the candidate encodings of each store operand are
+// COM: accumulated independently by different upstream chains (here: two
+// COM: distinct dpas encodings feeding the value and the mask through
+// COM: convert_layouts, plus the pointer argument anchored in a blocked
+// COM: layout). resolveConflicts() picks one encoding per value independently,
+// COM: so the operands can resolve to *different* layouts. rewriteStoreOp()
+// COM: previously only checked that every operand changed encoding, and then
+// COM: assigned each operand its own resolved encoding, producing a store that
+// COM: violates the tt.store verifier ("value type matches ptr type").
+// COM:
+// COM: With the fix, the incompatible encodings are not propagated onto the
+// COM: store operands in the first place, and the inconsistent rewrite is
+// COM: rejected as a backstop. The store keeps a single encoding for all
+// COM: operands and the converts feeding it are preserved.
+
+#blocked_a = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#dpas_a = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 1], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dpas_b = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 16 : i32, ttg.target = "xpu", ttig.min_sg_size = 16 : i32, ttig.support_subgroup_matrix_multiply_accumulate, ttig.target_arch = "spir64"} {
+  // CHECK-LABEL: @store_operand_encoding_conflict
+  // COM: The pointer is anchored in the blocked layout, the value and mask in
+  // COM: two different dpas layouts.
+  tt.func @store_operand_encoding_conflict(
+      %ptr: tensor<16x16x!tt.ptr<f32>, #blocked_a>,
+      %val: tensor<16x16xf32, #dpas_b>,
+      %mask: tensor<16x16xi1, #dpas_a>) {
+    // COM: The value and mask reach the store through converts from two
+    // COM: different dpas encodings. Forward propagation pushes each dpas
+    // COM: encoding onto all three store operands; the operands then resolve
+    // COM: their conflicts independently and may pick different layouts.
+    // COM: The converts must survive with their original dpas sources, i.e.
+    // COM: the dpas encodings must not be folded into the store operands.
+    // CHECK: %[[V:.*]] = ttg.convert_layout %arg1 : tensor<16x16xf32, #[[DPAS_B:.+]]> -> tensor<16x16xf32, #[[BLOCKED:.+]]>
+    // CHECK: %[[M:.*]] = ttg.convert_layout %arg2 : tensor<16x16xi1, #[[DPAS_A:.+]]> -> tensor<16x16xi1, #[[BLOCKED]]>
+    %v = ttg.convert_layout %val : tensor<16x16xf32, #dpas_b> -> tensor<16x16xf32, #blocked_a>
+    %m = ttg.convert_layout %mask : tensor<16x16xi1, #dpas_a> -> tensor<16x16xi1, #blocked_a>
+    // COM: The store must survive with all operands on a single, consistent
+    // COM: encoding.
+    // CHECK: tt.store %arg0, %[[V]], %[[M]] : tensor<16x16x!tt.ptr<f32>, #[[BLOCKED]]>
+    tt.store %ptr, %v, %m : tensor<16x16x!tt.ptr<f32>, #blocked_a>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: The propagation gate above only covers encodings that reach the store
+// COM: through forward propagation onto the store operands. A store operand
+// COM: can also accumulate a private candidate encoding from its own def
+// COM: chain: here every operand reaches the store through a convert_layout
+// COM: whose source carries a distinct dpas encoding, so the gate never
+// COM: fires and resolveConflicts() may resolve the operands to *different*
+// COM: encodings. rewriteStoreOp() must reject such a rewrite: without the
+// COM: consistency check it would assign each operand its own encoding and
+// COM: produce a store that violates the tt.store verifier.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#dpas_p = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 1], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dpas_v = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dpas_m = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [2, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 16 : i32, ttg.target = "xpu", ttig.min_sg_size = 16 : i32, ttig.support_subgroup_matrix_multiply_accumulate, ttig.target_arch = "spir64"} {
+  // CHECK-LABEL: @store_operand_backstop
+  tt.func @store_operand_backstop(
+      %off: tensor<16x16xi32, #dpas_p>,
+      %msk: tensor<16x16xi1, #dpas_m>,
+      %val: tensor<16x16xf32, #dpas_v>,
+      %base: tensor<16x16x!tt.ptr<f32>, #blocked>) {
+    %offc = ttg.convert_layout %off : tensor<16x16xi32, #dpas_p> -> tensor<16x16xi32, #blocked>
+    %p = tt.addptr %base, %offc : tensor<16x16x!tt.ptr<f32>, #blocked>, tensor<16x16xi32, #blocked>
+    %v = ttg.convert_layout %val : tensor<16x16xf32, #dpas_v> -> tensor<16x16xf32, #blocked>
+    %m = ttg.convert_layout %msk : tensor<16x16xi1, #dpas_m> -> tensor<16x16xi1, #blocked>
+    // COM: The operands resolve to three different dpas encodings; the
+    // COM: rewrite is rejected and every operand is converted back to the
+    // COM: single blocked encoding the store keeps.
+    // CHECK: tt.addptr
+    // CHECK: %[[P:.*]] = ttg.convert_layout {{.*}} : tensor<16x16x!tt.ptr<f32>, #{{.+}}> -> tensor<16x16x!tt.ptr<f32>, #[[ENC:.+]]>
+    // CHECK: %[[V:.*]] = ttg.convert_layout {{.*}} : tensor<16x16xf32, #{{.+}}> -> tensor<16x16xf32, #[[ENC]]>
+    // CHECK: %[[M:.*]] = ttg.convert_layout {{.*}} : tensor<16x16xi1, #{{.+}}> -> tensor<16x16xi1, #[[ENC]]>
+    // CHECK: tt.store %[[P]], %[[V]], %[[M]] : tensor<16x16x!tt.ptr<f32>, #[[ENC]]>
+    tt.store %p, %v, %m : tensor<16x16x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -523,6 +523,14 @@ void LayoutPropagation::setEncoding(ValueRange values, LayoutInfo &info,
   }
 }
 
+// A constant's value attribute must keep the result type, so it cannot be
+// re-encoded in place.
+static bool hasConstantOperand(ValueRange values) {
+  return llvm::any_of(values, [](Value v) {
+    return isa_and_nonnull<arith::ConstantOp>(v.getDefiningOp());
+  });
+}
+
 SmallVector<Value> LayoutPropagation::propagateToUsers(Value value,
                                                        LayoutInfo &info) {
   SmallVector<Value> changed;
@@ -602,7 +610,26 @@ SmallVector<Value> LayoutPropagation::propagateToUsers(Value value,
         SmallVector<Value> valuesToChange{storeOp.getPtr(), storeOp.getValue()};
         if (storeOp.getMask())
           valuesToChange.emplace_back(storeOp.getMask());
-        setEncoding(valuesToChange, info, changed, user);
+        // All operands of a store must share a single encoding. Only
+        // propagate the layout if every encoding already assigned to an
+        // operand is part of the incoming set, so that the first chain to
+        // reach the store determines its candidates and a later chain with
+        // a different encoding is not propagated onto the operands. This
+        // is conservative: a store reached by multiple incompatible chains
+        // is left unfolded, and rewriteStoreOp() below still rejects the
+        // rewrite if the operands resolve to different encodings. Skip
+        // stores with constant operands as well: a constant cannot be
+        // re-encoded in place, and propagating onto the remaining operands
+        // only would also leave the store with mixed operand encodings.
+        bool isCompatible = llvm::all_of(valuesToChange, [&](Value v) {
+          auto it = layouts.find(v);
+          return it == layouts.end() ||
+                 llvm::all_of(it->second.encodings, [&](Attribute e) {
+                   return info.encodings.contains(e);
+                 });
+        });
+        if (isCompatible && !hasConstantOperand(valuesToChange))
+          setEncoding(valuesToChange, info, changed, user);
       }
       continue;
     }
@@ -610,7 +637,9 @@ SmallVector<Value> LayoutPropagation::propagateToUsers(Value value,
       if (llvm::all_of(info.encodings, checkMMAorMMADerived)) {
         SmallVector<Value> valuesToChange{descStoreOp.getDesc(),
                                           descStoreOp.getSrc()};
-        setEncoding(valuesToChange, info, changed, user);
+        // See tt::StoreOp above: constants cannot be re-encoded in place.
+        if (!hasConstantOperand(valuesToChange))
+          setEncoding(valuesToChange, info, changed, user);
       }
       continue;
     }
@@ -929,16 +958,25 @@ bool LayoutPropagation::rewriteStoreOp(tt::StoreOp storeOp) {
   Operation *op = storeOp.getOperation();
   llvm::MutableArrayRef<OpOperand> operands = op->getOpOperands();
   // Check if all store op operands should use new encoding.
-  bool usesNewEncoding = llvm::all_of(operands, [&](OpOperand &operand) {
+  SmallVector<Attribute, 3> newEncodings;
+  bool usesNewEncoding = true;
+  for (OpOperand &operand : operands) {
     auto it = layouts.find(operand.get());
-    if (it == layouts.end())
-      return false;
+    if (it == layouts.end()) {
+      usesNewEncoding = false;
+      break;
+    }
     LayoutInfo &info = it->second;
     assert(info.encodings.size() == 1 &&
            "we should have resolved to a single encoding");
-    auto encoding = getEncodingBeforeRewrite(operand.get());
-    return encoding != *info.encodings.begin();
-  });
+    newEncodings.push_back(*info.encodings.begin());
+    usesNewEncoding &=
+        getEncodingBeforeRewrite(operand.get()) != *info.encodings.begin();
+  }
+  // The verifier requires all operands of a store to have the same encoding.
+  // If the analysis resolved them to different encodings, leave the store
+  // untouched rather than remapping each operand to a different layout.
+  usesNewEncoding &= llvm::all_equal(newEncodings);
   if (usesNewEncoding) {
     for (OpOperand &operand : op->getOpOperands()) {
       auto it = layouts.find(operand.get());


### PR DESCRIPTION
## Problem

`LayoutPropagation::propagateToUsers` pushes mma-derived encodings onto a
`tt.store`'s ptr, value, and mask (and onto `tt.descriptor_store`'s
operands). Two independent failure modes result:

1. **Mixed-encoding stores.** Each operand accumulates its candidate
   encodings independently from its own upstream chains, and
   `resolveConflicts()` resolves each operand to a single encoding
   independently of the others. Nothing guarantees the operands resolve
   to the *same* layout, and `rewriteStoreOp()` only checked that every
   operand *changed* encoding before remapping each operand to its own
   resolved encoding. The result can be a store whose operands disagree:

   ```
   error: 'tt.store' op failed to verify that value type matches ptr type
   ```

2. **Re-typed constants.** When a store operand is shared with another
   store whose value or mask is an `arith.constant`, the candidate
   encoding is pushed onto the constant as well. `resolveConflicts()`
   prefers mma-derived encodings for values that are not defined by
   load/store ops, so the constant resolves to the mma-derived encoding,
   and `rewriteOp()` re-types the constant in place via
   `setEncodingInPlace()`. A constant's `value` attribute must have the
   same type as its result:

   ```
   error: 'arith.constant' op failed to verify that all of {value, result} have same type
   ```

Both were observed end-to-end while compiling chunk-based linear-attention
kernels (backward passes whose stores are fed by converts from multiple
dpas chains, and a backward pass storing a shared mask together with a
zero-initialized constant accumulator).

## Solution

- In the `StoreOp` case of `propagateToUsers`, only propagate the
  encoding when every encoding already assigned to a store operand is
  contained in the incoming set, so that the first chain to reach the
  store determines its candidate encodings and a later chain carrying a
  different encoding is not propagated onto the operands. This is a
  propagation-time guard: it keeps incompatible candidates off the
  store operands in the first place, at the cost of not folding stores
  reached by multiple incompatible chains.
- Skip stores with constant operands (both `tt.store` and
  `tt.descriptor_store`): a constant cannot be given a new encoding in
  place, and propagating onto the remaining operands only would leave
  the store with mixed operand encodings.
- As a backstop, make `rewriteStoreOp()` reject the rewrite unless all
  operands resolved to the same encoding (`llvm::all_equal`). This
  covers operands that accumulated private candidates from their own def
  chains without ever flowing through the propagation gate. The rewrite
  is rejected (the store keeps its original single encoding) rather than
  forcing one operand's encoding onto the others, because an
  operand-rewriting remap that picks one resolved encoding could still
  disagree with encodings anchored elsewhere (e.g. a blocked pointer
  chain feeding other users). `newEncodings` is only consulted when
  every operand changed encoding, so it holds one entry per operand.

## Tests

- `test/TritonIntelGPU/RemoveLayoutConversions/store-encoding-conflict.mlir`:
  - `@store_operand_encoding_conflict`: operands are fed by converts from
    two *different* dpas encodings plus a pointer anchored in a blocked
    layout. The CHECK lines pin the converts to be preserved and the
    store to keep a single consistent encoding; the RUN line passes
    `-verify-each` so any store whose operands disagree fails the test
    through the verifier.
  - `@store_operand_backstop`: every operand reaches the store through a
    convert from its own distinct dpas encoding, so the propagation gate
    never fires and the operands resolve to different encodings. The
    `all_equal` backstop rejects the rewrite.
- `test/TritonIntelGPU/RemoveLayoutConversions/store-constant-operand.mlir`:
  - `@store_constant_operand`: a dot result converted back to a blocked
    layout is stored alongside a second store sharing the same pointer
    and mask whose value is a zero constant. Without the fix the pass
    fails with the `arith.constant` verifier error above; the CHECK lines
    pin the constant to its blocked encoding and the store to a single
    consistent encoding.
  - `@store_constant_mask`: the same guard with the constant in the mask
    position.
- `lit test/TritonIntelGPU`: 84/84 passed.
- End-to-end: the operator test cases that crashed the compiler with both
  verifier errors now compile and pass.

Supersedes #7971, which fixed the constant failure mode alone and
conflicted textually with this change; both fixes are folded in here.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- [x] I have added tests.
  - `/test` for `lit` tests

- [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
  including the "tests should be minimal" section.
