### PR TITLE
[XPU] Skip backward remat of DPAS layouts onto non-float chains

### DIFF
--- a/test/TritonIntelGPU/RemoveLayoutConversions/backward-remat-dpas-guard.mlir
+++ b/test/TritonIntelGPU/RemoveLayoutConversions/backward-remat-dpas-guard.mlir
@@ -1,0 +1,101 @@
+// RUN: triton-opt %s -split-input-file -tritonintelgpu-remove-layout-conversions 2>&1 | FileCheck %s --enable-var-scope
+
+
+// COM: Backward rematerialization must not bake DPAS-family encodings into
+// COM: chains of values that have no DPAS conversion path: offset (i32/i64),
+// COM: mask (i1), and pointer values. The elementwise lowering only
+// COM: reproduces the DPAS fan-out for this backend's dot data types (float
+// COM: and 8-bit integers), so rematerializing address/mask arithmetic in a
+// COM: dot_op<dpas> or (slice of) dpas layout mislowers it. The veto is per
+// COM: value in the remat slice: a float chain (e.g. a descriptor load feeding
+// COM: dot_op<dpas>) and the i8 chain below are still rematerialized, so the
+// COM: convert_layout ops on the guarded chains must be preserved.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 1], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+#dpas8 = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 4, threadsPerWarp = 16, warpsPerCTA = [4, 1], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot8 = #ttg.dot_op<{opIdx = 0, parent = #dpas8, kWidth = 2}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 16 : i32} {
+  // CHECK-LABEL: @no_backward_remat_dot_op_dpas_i64_chain
+  tt.func @no_backward_remat_dot_op_dpas_i64_chain() -> tensor<64x32xi64, #dot0> {
+    // COM: i64 offset chain feeding a convert to dot_op<dpas>: the slice
+    // COM: assigns the dot_op encoding to the whole i64/i32 chain, and the
+    // COM: element types are not DPAS dot data types, so the remat is skipped
+    // COM: and the chain keeps its blocked encoding.
+    // CHECK: tt.make_range {{.*}} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    // CHECK: arith.extsi {{.*}} : tensor<64x32xi32, #blocked> to tensor<64x32xi64, #blocked>
+    // CHECK: ttg.convert_layout {{.*}} : tensor<64x32xi64, #blocked> -> tensor<64x32xi64, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    // CHECK: tt.return
+    %r = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %e = tt.expand_dims %r {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+    %b = tt.broadcast %e : tensor<64x1xi32, #blocked> -> tensor<64x32xi32, #blocked>
+    %x = arith.extsi %b : tensor<64x32xi32, #blocked> to tensor<64x32xi64, #blocked>
+    %c = ttg.convert_layout %x : tensor<64x32xi64, #blocked> -> tensor<64x32xi64, #dot0>
+    tt.return %c : tensor<64x32xi64, #dot0>
+  }
+
+  // CHECK-LABEL: @no_backward_remat_dpas_slice_i64_chain
+  tt.func @no_backward_remat_dpas_slice_i64_chain() -> tensor<64xi64, #ttg.slice<{dim = 1, parent = #dpas}>> {
+    // COM: i64 chain targeting slice<dpas>: the slice unwraps to a DPAS
+    // COM: encoding and i64 is not a DPAS dot data type, so the remat is
+    // COM: skipped and the convert stays.
+    // CHECK: tt.make_range {{.*}} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    // CHECK: arith.extsi {{.*}} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>> to tensor<64xi64, #ttg.slice<{dim = 1, parent = #blocked}>>
+    // CHECK: ttg.convert_layout {{.*}} : tensor<64xi64, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64xi64, #ttg.slice<{dim = 1, parent = #mma}>>
+    // CHECK: tt.return
+    %r = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %x = arith.extsi %r : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>> to tensor<64xi64, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %c = ttg.convert_layout %x : tensor<64xi64, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64xi64, #ttg.slice<{dim = 1, parent = #dpas}>>
+    tt.return %c : tensor<64xi64, #ttg.slice<{dim = 1, parent = #dpas}>>
+  }
+
+  // CHECK-LABEL: @no_backward_remat_dpas_slice_i1_mask_chain
+  tt.func @no_backward_remat_dpas_slice_i1_mask_chain(%arg0: i32) -> tensor<64xi1, #ttg.slice<{dim = 1, parent = #dpas}>> {
+    // COM: i1 mask chain (cmpi against a splat argument so it cannot be
+    // COM: constant-folded) targeting slice<dpas>: i1 is not a DPAS dot data
+    // COM: type, convert stays.
+    // CHECK: tt.make_range {{.*}} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    // CHECK: arith.cmpi {{.*}} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    // CHECK: ttg.convert_layout {{.*}} : tensor<64xi1, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64xi1, #ttg.slice<{dim = 1, parent = #mma}>>
+    // CHECK: tt.return
+    %r = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %s = tt.splat %arg0 : i32 -> tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %m = arith.cmpi slt, %r, %s : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %c = ttg.convert_layout %m : tensor<64xi1, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64xi1, #ttg.slice<{dim = 1, parent = #dpas}>>
+    tt.return %c : tensor<64xi1, #ttg.slice<{dim = 1, parent = #dpas}>>
+  }
+
+  // CHECK-LABEL: @backward_remat_dpas_slice_f32_chain_allowed
+  tt.func public @backward_remat_dpas_slice_f32_chain_allowed(%arg0: f32) -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #dpas}>> {
+    // COM: Positive control: an all-dot-data-type chain (splat/mulf of f32)
+    // COM: has no value outside the DPAS dot data types in the remat slice, so
+    // COM: rematerializing it in a slice<DPAS> layout is sound and the convert
+    // COM: is still removed. (The i32 make_range feeding a sitofp is NOT a dot
+    // COM: data type, so that variant is governed by the vetoed cases above.)
+    // CHECK: tt.splat {{.*}} : f32 -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    // CHECK: arith.mulf {{.*}} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    // CHECK-NOT: ttg.convert_layout
+    // CHECK: tt.return
+    %f = tt.splat %arg0 : f32 -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %x = arith.mulf %f, %f : tensor<64xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %c = ttg.convert_layout %x : tensor<64xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #dpas}>>
+    tt.return %c : tensor<64xf32, #ttg.slice<{dim = 1, parent = #dpas}>>
+  }
+
+  // CHECK-LABEL: @backward_remat_dot_op_dpas_i8_chain_allowed
+  tt.func public @backward_remat_dot_op_dpas_i8_chain_allowed(%arg0: i8) -> tensor<64x32xi8, #dot8> {
+    // COM: Positive control: an i8-only chain (splat/addi) feeding a convert
+    // COM: to dot_op<dpas>. i8 is a first-class DPAS dot data type (packed
+    // COM: four per channel, opsPerChan = 4), so the remat is not vetoed and
+    // COM: the convert is removed.
+    // CHECK: tt.splat {{.*}} : i8 -> tensor<64x32xi8, #ttg.dot_op<{opIdx = 0, parent = #mma1, kWidth = 2}>>
+    // CHECK: arith.addi {{.*}} : tensor<64x32xi8, #ttg.dot_op<{opIdx = 0, parent = #mma1, kWidth = 2}>>
+    // CHECK-NOT: ttg.convert_layout
+    // CHECK: tt.return
+    %s = tt.splat %arg0 : i8 -> tensor<64x32xi8, #blocked>
+    %x = arith.addi %s, %s : tensor<64x32xi8, #blocked>
+    %c = ttg.convert_layout %x : tensor<64x32xi8, #blocked> -> tensor<64x32xi8, #dot8>
+    tt.return %c : tensor<64x32xi8, #dot8>
+  }
+}

--- a/test/TritonIntelGPU/backward_combine_dpas_dot_layout.mlir
+++ b/test/TritonIntelGPU/backward_combine_dpas_dot_layout.mlir
@@ -3,7 +3,10 @@
 // COM: Case 1:
 // COM: Checks that the loads for the operands of a tt.dot operation are placed
 // COM: into registers (have dot layout) rather than shared local memory (via a
-// COM: ttg.convert_layout operation).
+// COM: ttg.convert_layout operation). The backward-remat veto is per slice
+// COM: value and only rejects element types that are not DPAS dot data
+// COM: types, so the f16 descriptor loads below still rematerialize
+// COM: directly into dot_op<dpas>.
 
 // CHECK: #[[DPAS:.+]] = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 16], warpsPerCTA = [2, 2], order = [1, 0]}>
@@ -128,8 +131,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %desc_a = tt.make_tensor_descriptor %arg0, [%arg3, %arg5], [%arg6, %c1_i64] : <f16>, <64x32xf16>
     %desc_b = tt.make_tensor_descriptor %arg1, [%arg5, %arg4], [%arg7, %c1_i64] : <f16>, <32x256xf16>
     %23 = scf.for %arg9 = %c0_i32 to %arg5 step %c32_i32 iter_args(%arg10 = %cst) -> (tensor<64x256xf32, #dpas>) : i32 {
-      // COM: Layout conversions in the loop should be removed.
+      // COM: Layout conversions in the loop are removed: the f16 descriptor
+      // COM: loads rematerialize in dot_op<dpas> directly.
       // CHECK: scf.for
+      // CHECK: tt.descriptor_load {{.*}} -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #[[DPAS]], kWidth = 1}>>
+      // CHECK: tt.descriptor_load {{.*}} -> tensor<32x256xf16, #ttg.dot_op<{opIdx = 1, parent = #[[DPAS]], kWidth = 2}>>
       // CHECK-NOT: ttg.convert_layout
       // CHECK: scf.yield
       %28 = tt.descriptor_load %desc_a[%c0_i32, %arg9] {ttig.block_io = "row_major"} : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #blocked>
@@ -184,7 +190,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %desc_a = tt.make_tensor_descriptor %arg0, [%arg5, %arg5], [%c0_i64, %c1_i64] : <f16>, <64x32xf16>
     %desc_b = tt.make_tensor_descriptor %arg1, [%arg5, %arg5], [%c0_i64, %c1_i64] : <f16>, <32x256xf16>
     %23 = scf.for %arg9 = %c0_i32 to %arg5 step %c32_i32 iter_args(%arg10 = %cst) -> (tensor<64x256xf32, #blocked1>) : i32 {
+      // COM: Layout conversions in the loop are removed: the f16 descriptor
+      // COM: loads rematerialize in dot_op<dpas> directly.
       // CHECK: scf.for
+      // CHECK: tt.descriptor_load {{.*}} -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #[[DPAS]], kWidth = 1}>>
+      // CHECK: tt.descriptor_load {{.*}} -> tensor<32x256xf16, #ttg.dot_op<{opIdx = 1, parent = #[[DPAS]], kWidth = 2}>>
       // CHECK-NOT: ttg.convert_layout
       // CHECK: scf.yield
       %28 = tt.descriptor_load %desc_a[%c0_i32, %arg9] {ttig.block_io = "row_major"} : !tt.tensordesc<64x32xf16> -> tensor<64x32xf16, #blocked>

--- a/test/TritonIntelGPU/combine.mlir
+++ b/test/TritonIntelGPU/combine.mlir
@@ -2441,10 +2441,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x64x!tt.ptr<f16>, #blocked2>
     %3 = tt.splat %arg1 : !tt.ptr<i8> -> tensor<128x64x!tt.ptr<i8>, #blocked>
     %4 = tt.splat %arg1 : !tt.ptr<i8> -> tensor<128x64x!tt.ptr<i8>, #blocked>
-    // CHECK: %[[F:.+]]:3 = scf.for {{.*}} -> (tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>)
+    // COM: The backward-remat veto fires per value in the slice: the dot
+    // COM: operand converts (%7, %8) and the i1 compare convert to the DPAS
+    // COM: layout (%13, i1 is not a DPAS dot data type) cannot be
+    // COM: rematerialized away because their slices cover pointer/i1 chains,
+    // COM: and the loop drops the now-dead DPAS loop-carried chain, so it
+    // COM: carries two values instead of three.
+    // CHECK: %[[F:.+]]:2 = scf.for {{.*}} -> (tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>)
     // CHECK-COUNT-4: convert_layout
     // CHECK-NOT: convert_layout
-    // CHECK:   scf.yield {{.*}} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    // CHECK:   scf.yield {{.*}} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
     // CHECK: }
     // CHECK: tt.return %[[F]]#0, %[[F]]#1 : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
      %5:3 = scf.for %arg2 = %c0_i32 to %c2048_i32 step %c64_i32 iter_args(%arg3 = %cst_2, %arg4 = %cst, %arg5 = %cst_0) -> (tensor<128x64xf32, #dpas>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>)  : i32 {
@@ -2985,8 +2991,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 32 : i32, "ttg.th
       scf.yield %74, %75, %76 : tensor<256x256xf32, #blocked>, tensor<256x32x!tt.ptr<f16>, #blocked2>, tensor<32x256x!tt.ptr<f16>, #blocked1>
     }
     // CHECK: [[SCF:%.*]]:3 = scf.for {{.*}} -> (tensor<256x256xf32, #[[$DPAS]]>, {{.*}})  : i32 {
-    // CHECK: tt.expand_dims {{.*}} -> tensor<256x1xi32, #[[$DPAS]]>
-    // CHECK-NOT: ttg.convert_layout
+    // COM: The slice-level guard keeps the i32/i1 address and mask chains in
+    // COM: their blocked layout (pointer/i1 values are not DPAS dot data
+    // COM: types); the store operands are materialized in the DPAS layout
+    // COM: through explicit convert_layout ops instead.
+    // CHECK: tt.expand_dims {{.*}} -> tensor<256x1xi32, #blocked1>
+    // CHECK: ttg.convert_layout {{.*}} : tensor<256x256x!tt.ptr<f16>, #blocked1> -> tensor<256x256x!tt.ptr<f16>, #[[$DPAS]]>
     // CHECK: [[RES:%.*]] = arith.truncf [[SCF]]#0 : tensor<256x256xf32, #[[$DPAS]]> to tensor<256x256xf16, #[[$DPAS]]>
     // CHECK: tt.store {{.*}}, [[RES]], {{.*}} : tensor<256x256x!tt.ptr<f16>, #[[$DPAS]]>
     %42 = tt.expand_dims %3 {axis = 1 : i32} : tensor<256xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> -> tensor<256x1xi32, #blocked1>

--- a/test/TritonIntelGPU/hoist-convert-dot-operand.mlir
+++ b/test/TritonIntelGPU/hoist-convert-dot-operand.mlir
@@ -162,16 +162,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
-// COM: Chained FP8 matmul with fp_to_fp downcast between the two dots. Three
-// COM: distinct backward-propagation targets are exercised:
-// COM:   A operand (%x) — load → convert: the blocked layout collapses and the
-// COM:     splat/load land directly in dot_op<opIdx=0, kWidth=2>.
-// COM:   B operand (%y) — splat/expand_dims/broadcast/addptr chain + load: the
-// COM:     entire chain is rewritten to dot_op<opIdx=1, kWidth=4>.
-// COM:   B operand (%w) — pointer arithmetic chain starts in a different
-// COM:     blocked layout (different splat shape), so the hoist cannot collapse
-// COM:     the chain all the way; it leaves a single convert_layout next to the
-// COM:     splat/broadcast and rewrites the downstream addptr/load in dot_op.
+// COM: Chained FP8 matmul with fp_to_fp downcast between the two dots.
+// COM:
+// COM: Backward rematerialization is vetoed per slice value: DPAS-family
+// COM: encodings only cover the dot data types (float, 8-bit integer) and have
+// COM: no conversion path for pointer/offset values, so baking them into the
+// COM: splat/expand_dims/broadcast/addptr pointer and offset chains mislowers
+// COM: them. All three operand chains (X, Y, W) therefore keep their blocked
+// COM: layouts and each load is followed by an explicit convert_layout to the
+// COM: dot_op encoding.
 // COM:
 // COM: Between the two dots, tt.fp_to_fp downcasts the f32 mma result to
 // COM: f8E4M3FN. The convert_layout from #mma to dot_op<opIdx=0> must NOT hoist
@@ -191,21 +190,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %Z: !tt.ptr<f32>      {tt.divisibility = 16 : i32}) {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
 
-    // A operand: convert-next-to-load is fully absorbed. Splat/load produce
-    // dot_op<opIdx=0, kWidth=2> directly.
+    // A operand: the convert is no longer absorbed into the splat/load; the
+    // chain keeps its blocked layout and the convert_layout remains.
     //
-    // CHECK: tt.splat %arg0 : !tt.ptr<f8E4M3FN> -> tensor<128x64x!tt.ptr<f8E4M3FN>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
-    // CHECK: %[[X:.*]] = tt.load {{.*}} {ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f8E4M3FN>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+    // CHECK: tt.splat %arg0 : !tt.ptr<f8E4M3FN> -> tensor<128x64x!tt.ptr<f8E4M3FN>, #blocked>
+    // CHECK: %[[X:.*]] = tt.load {{.*}} {ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f8E4M3FN>, #blocked>
     %Xp = tt.splat %X : !tt.ptr<f8E4M3FN> -> tensor<128x64x!tt.ptr<f8E4M3FN>, #blocked4>
     %x = tt.load %Xp {ttig.block_io = "row_major"} : tensor<128x64x!tt.ptr<f8E4M3FN>, #blocked4>
 
-    // B operand (Y): full splat/expand_dims/broadcast/addptr chain rewritten to
-    // dot_op<opIdx=1, kWidth=4>. No intermediate convert_layout remains.
+    // B operand (Y): the splat/expand_dims/broadcast/addptr chain keeps its
+    // blocked layout; the convert_layout to dot_op<opIdx=1, kWidth=4> remains.
     //
-    // CHECK: tt.splat %arg1 : !tt.ptr<f8E4M3FN> -> tensor<64x1x!tt.ptr<f8E4M3FN>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
-    // CHECK: tt.expand_dims {{.*}} : tensor<128xi32, {{.*}}> -> tensor<1x128xi32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
-    // CHECK: tt.addptr {{.*}} : tensor<64x128x!tt.ptr<f8E4M3FN>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
-    // CHECK: %[[Y:.*]] = tt.load {{.*}} {ttig.block_io = "row_major"} : tensor<64x128x!tt.ptr<f8E4M3FN>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    // CHECK: tt.splat %arg1 : !tt.ptr<f8E4M3FN> -> tensor<64x1x!tt.ptr<f8E4M3FN>, #blocked1>
+    // CHECK: tt.expand_dims {{.*}} : tensor<128xi32, {{.*}}> -> tensor<1x128xi32, #blocked1>
+    // CHECK: tt.addptr {{.*}} : tensor<64x128x!tt.ptr<f8E4M3FN>, #blocked1>
+    // CHECK: %[[Y:.*]] = tt.load {{.*}} {ttig.block_io = "row_major"} : tensor<64x128x!tt.ptr<f8E4M3FN>, #blocked1>
     %Ys_19 = tt.splat %Y : !tt.ptr<f8E4M3FN> -> tensor<64x1x!tt.ptr<f8E4M3FN>, #blocked3>
     %Ys_21 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked3}>>
     %Ys_23 = tt.expand_dims %Ys_21 {axis = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked3}>> -> tensor<1x128xi32, #blocked3>
@@ -214,15 +213,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %Ys_27 = tt.addptr %Ys_25, %Ys_26 : tensor<64x128x!tt.ptr<f8E4M3FN>, #blocked3>, tensor<64x128xi32, #blocked3>
     %y = tt.load %Ys_27 {ttig.block_io = "row_major"} : tensor<64x128x!tt.ptr<f8E4M3FN>, #blocked3>
 
-    // B operand (W): splat starts in a different blocked layout so the hoist
-    // cannot collapse the chain entirely. One convert_layout remains — between
-    // the broadcast and the addptr — with all downstream ops in dot_op.
+    // B operand (W): the splat lands directly in the chain's blocked layout,
+    // so the chain needs no convert_layout at all; only the load result is
+    // converted to dot_op.
     //
-    // CHECK: %[[SPW:.*]] = tt.splat %arg2 : !tt.ptr<f8E4M3FN> -> tensor<128x1x!tt.ptr<f8E4M3FN>, #blocked>
-    // CHECK: %[[BW:.*]] = tt.broadcast %[[SPW]] : tensor<128x1x!tt.ptr<f8E4M3FN>, #blocked> -> tensor<128x128x!tt.ptr<f8E4M3FN>, #blocked>
-    // CHECK: ttg.convert_layout %[[BW]] : tensor<128x128x!tt.ptr<f8E4M3FN>, #blocked> -> tensor<128x128x!tt.ptr<f8E4M3FN>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
-    // CHECK: tt.addptr {{.*}} : tensor<128x128x!tt.ptr<f8E4M3FN>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
-    // CHECK: %[[W:.*]] = tt.load {{.*}} {ttig.block_io = "row_major"} : tensor<128x128x!tt.ptr<f8E4M3FN>, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    // CHECK: %[[SPW:.*]] = tt.splat %arg2 : !tt.ptr<f8E4M3FN> -> tensor<128x1x!tt.ptr<f8E4M3FN>, #blocked1>
+    // CHECK: %[[BW:.*]] = tt.broadcast %[[SPW]] : tensor<128x1x!tt.ptr<f8E4M3FN>, #blocked1> -> tensor<128x128x!tt.ptr<f8E4M3FN>, #blocked1>
+    // CHECK: tt.addptr {{.*}} : tensor<128x128x!tt.ptr<f8E4M3FN>, #blocked1>
+    // CHECK: %[[W:.*]] = tt.load {{.*}} {ttig.block_io = "row_major"} : tensor<128x128x!tt.ptr<f8E4M3FN>, #blocked1>
     %Ws_29 = tt.splat %W : !tt.ptr<f8E4M3FN> -> tensor<128x1x!tt.ptr<f8E4M3FN>, #blocked2>
     %Ws_31 = tt.broadcast %Ws_29 : tensor<128x1x!tt.ptr<f8E4M3FN>, #blocked2> -> tensor<128x128x!tt.ptr<f8E4M3FN>, #blocked2>
     %Ws_32 = ttg.convert_layout %Ws_31 : tensor<128x128x!tt.ptr<f8E4M3FN>, #blocked2> -> tensor<128x128x!tt.ptr<f8E4M3FN>, #blocked3>
@@ -230,9 +228,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %Ws_35 = tt.addptr %Ws_32, %Ws_33 : tensor<128x128x!tt.ptr<f8E4M3FN>, #blocked3>, tensor<128x128xi32, #blocked3>
     %w = tt.load %Ws_35 {ttig.block_io = "row_major"} : tensor<128x128x!tt.ptr<f8E4M3FN>, #blocked3>
 
-    // First dot: operands consumed directly, no extra convert_layout.
+    // First dot: each load is followed by its convert_layout to dot_op.
     //
-    // CHECK: %[[Z:.*]] = tt.dot %[[X]], %[[Y]]{{.*}}-> tensor<128x128xf32, #mma>
+    // CHECK: %[[XDOT:.*]] = ttg.convert_layout %[[X]] : tensor<128x64xf8E4M3FN, #blocked> -> tensor<128x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+    // CHECK: %[[YDOT:.*]] = ttg.convert_layout %[[Y]] : tensor<64x128xf8E4M3FN, #blocked1> -> tensor<64x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    // CHECK: %[[Z:.*]] = tt.dot %[[XDOT]], %[[YDOT]]{{.*}}-> tensor<128x128xf32, #mma>
     %x_41 = ttg.convert_layout %x : tensor<128x64xf8E4M3FN, #blocked4> -> tensor<128x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
     %y_42 = ttg.convert_layout %y : tensor<64x128xf8E4M3FN, #blocked3> -> tensor<64x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
     %cst2 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #mma>
@@ -243,7 +243,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     //
     // CHECK: %[[Z8:.*]] = tt.fp_to_fp %[[Z]], rounding = rtne : tensor<128x128xf32, #mma> -> tensor<128x128xf8E4M3FN, #mma>
     // CHECK: %[[Z8DOT:.*]] = ttg.convert_layout %[[Z8]] : tensor<128x128xf8E4M3FN, #mma> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
-    // CHECK: tt.dot %[[Z8DOT]], %[[W]], {{.*}} -> tensor<128x128xf32, #mma>
+    // CHECK: %[[WDOT:.*]] = ttg.convert_layout %[[W]] : tensor<128x128xf8E4M3FN, #blocked1> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    // CHECK: tt.dot %[[Z8DOT]], %[[WDOT]], {{.*}} -> tensor<128x128xf32, #mma>
     // CHECK: tt.store
     %z_44 = tt.fp_to_fp %z, rounding = rtne : tensor<128x128xf32, #mma> -> tensor<128x128xf8E4M3FN, #mma>
     %z_47 = ttg.convert_layout %z_44 : tensor<128x128xf8E4M3FN, #mma> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>

--- a/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/RemoveLayoutConversions.cpp
@@ -1899,6 +1899,53 @@ static bool rematDegradesLoad(const SetVector<Value> &slice,
   return false;
 }
 
+/// Backward remat bakes the convert's target encoding into the whole
+/// producer chain in the slice. ptr/mask/offset chains have no equivalent
+/// DPAS conversion path — the block-IO specializations only handle dot
+/// data types — so relabeling them with a DPAS-family encoding mislowers
+/// them. The check therefore inspects every value in the slice rather
+/// than the convert's result type alone (the slice of a sitofp carries
+/// i32 offsets, that of a dot-operand load its mask).
+static bool
+rematBakesDpasOntoNonDotDataType(const SetVector<Value> &slice,
+                                 const DenseMap<Value, Attribute> &layout) {
+  for (Value v : slice) {
+    auto it = layout.find(v);
+    if (it == layout.end())
+      continue; // Not relabeled.
+
+    // Unwrap to the layout that determines the per-element distribution.
+    Attribute enc = it->second;
+    if (auto sliceEnc = dyn_cast<ttg::SliceEncodingAttr>(enc))
+      enc = sliceEnc.getParent();
+    bool isDpasFamily = isa<ttgi::DpasEncodingAttr>(enc);
+    if (!isDpasFamily) {
+      if (auto dotEnc = dyn_cast<ttg::DotOperandEncodingAttr>(enc))
+        isDpasFamily = isa<ttgi::DpasEncodingAttr>(dotEnc.getParent());
+    }
+    if (!isDpasFamily)
+      continue;
+
+    auto tensorTy = dyn_cast<RankedTensorType>(v.getType());
+    if (!tensorTy)
+      continue;
+    // DPAS dot data types of this backend: float and 8-bit integers (i8/u8,
+    // packed four per channel). Only these are reproduced by the elementwise
+    // lowering; i1/i16/i32/i64/pointer values are vetoed below.
+    auto elemTy = tensorTy.getElementType();
+    auto intTy = dyn_cast<IntegerType>(elemTy);
+    if (isa<FloatType>(elemTy) || (intTy && intTy.getWidth() == 8))
+      continue;
+    // Values that already use the target encoding are not rewritten by
+    // rewriteSlice, so they are not made worse by this remat.
+    if (tensorTy.getEncoding() == it->second)
+      continue;
+    return true;
+  }
+
+  return false;
+}
+
 void LayoutRematerialization::backwardRematerialization(
     ttg::ConvertLayoutOp convertOp) {
   RankedTensorType targetType = convertOp.getType();
@@ -1961,13 +2008,22 @@ void LayoutRematerialization::backwardRematerialization(
     return;
   }
 
-  // 2. Veto if rematerialization would degrade a load encoding.
+  // 2. Veto if rematerialization would bake a DPAS-family encoding onto a
+  // value whose element type is not a DPAS dot data type (see
+  // rematBakesDpasOntoNonDotDataType).
+  if (rematBakesDpasOntoNonDotDataType(slice, layout)) {
+    LDBG("  skip remat: would bake a DPAS encoding onto a non-dot-data-type "
+         "value");
+    return;
+  }
+
+  // 3. Veto if rematerialization would degrade a load encoding.
   if (rematDegradesLoad(slice, layout)) {
     LDBG("  skip remat: would degrade a load encoding");
     return;
   }
 
-  // 3. Determine whether rematerialisation is beneficial.
+  // 4. Determine whether rematerialisation is beneficial.
   if (!isRematBeneficial(convertOp, slice, /*newCvtCost=*/0,
                          convertCostCache)) {
     LDBG("  skipped rematerialization");
@@ -1983,7 +2039,7 @@ void LayoutRematerialization::backwardRematerialization(
   // Compute external-use analysis before rewriteSlice mutates slice.
   auto nonSliceOnlyValues = getNonSliceOnlyValues(slice, convertOp);
 
-  // 4. Rewrite the slice.
+  // 5. Rewrite the slice.
   rewriteSlice(slice, layout, convertOp);
 
   // Build forward propagation candidates using pre-rewrite analysis.


### PR DESCRIPTION
## Problem

Backward rematerialization in RemoveLayoutConversions pushes the convert's
target encoding onto the whole producer chain below it. When that target
is a DPAS-family layout (`#ttig.dpas`, `slice<dpas>`, or
`dot_op<dpas>`), values in the chain whose element type is not one of the
backend's DPAS dot data types (floating-point or 8-bit integer) — i1
masks, i16/i32/i64 offset chains, pointer tensors — get relabeled with a
layout whose cross-lane distribution the element-wise lowering does not
reproduce for them. For pointer tensors the failure is fatal downstream:
`BlockIOConversionBase::isBlockIOCandidate` (LoadStoreOpToLLVM) selects
the 2D-block-store path from the pointed-to tensor's encoding alone, so
a dpas-encoded pointer tensor reaches it with coordinates computed from
an undefined distribution, and module creation fails with DEVICE_LOST.

## Solution

Veto the remat per value in the slice computed by
`getRematerializableSlice`: if any value that would be relabeled gets a
DPAS-family encoding while its element type is not float, skip the
remat. Checking the slice instead of the convert's own element type
matters because the offending value often sits below the convert — e.g.
an f32 value produced by a `sitofp` carries its i32 index chain in the
same slice, and a dot operand load carries its mask.

Float chains are unaffected: descriptor loads still rematerialize
directly into `dot_op<dpas>` (the packed 2D block load path). Only
plain pointer-based load chains — which could never lower correctly
with a DPAS encoding anyway — keep their blocked layout with an
explicit convert.

## Tests

- `test/TritonIntelGPU/RemoveLayoutConversions/backward-remat-dpas-guard.mlir`:
  i64 and i1 chains targeting both `dot_op<DPAS>` and `slice<DPAS>`
  keep their converts (veto fires), while an all-float chain and an i8
  chain are still rematerialized.
- `test/TritonIntelGPU/RemoveLayoutConversions/backward_combine_dpas_dot_layout.mlir`:
  descriptor loads fold into `dot_op<dpas>` again (restored behavior).
- `test/TritonIntelGPU/combine.mlir`, `test/TritonIntelGPU/hoist-convert-dot-operand.mlir`:
  non-float expectations unchanged, comments describe the slice-level
  veto. The new guard tests fail on the unpatched pass (the converts
  they pin are eliminated there).
- `lit test/TritonIntelGPU`: 83/83 passed.

Known residual (out of scope here): forward propagation can still place
a DPAS encoding on a pointer tensor via an explicit `convert_layout`
(unchanged from before this PR), and `isBlockIOCandidate`'s
encoding-only check is the root cause for that path — a follow-up could
make it require the pointee element type to match the encoding's
assumptions.

## End-to-end evidence

Observed end-to-end on an attention-sink kernel compiled for XPU: the
backward kernel fails module creation with DEVICE_LOST; with
`ttig.block_io` stripped the kernel runs. The downstream test suite
that triggered this (15 tests, including the empty-row attention-sink
case) passes 15/15 with this fix.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- [x] I have added tests.
  - `/test` for `lit` tests

- [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
  including the "tests should be minimal" section.
