### PR TITLE
[XPU] Drop GenISA 2D block prefetch fallback on non-LTS drivers

### DIFF
--- a/.claude/rules/intel-gpu-lowering.md
+++ b/.claude/rules/intel-gpu-lowering.md
@@ -80,7 +80,7 @@ For SPIR-V stores, the value is first stored to a local alloca, then a pointer t
 
 **GenISA path**: `llvm.genx.GenISA.LSC2DBlockPrefetch.isVoid`
 
-Prefetch always uses SPIR-V (never falls back to GenISA) — `isSPVBuiltinAvailableImpl` returns `true` unconditionally for prefetch.
+Prefetch prefers the SPIR-V builtin; `isSPVBuiltinAvailableImpl` returns `false` for three configurations with no SPIR-V runtime builtin — d16 with tile_width=32 / v_blocks=1, 8b with tile_width=16 / v_blocks=1, and 64b with tile_width=8 / v_blocks=1 / tile_height<8. On LTS drivers these fall back to GenISA; on non-LTS drivers the GenISA fallback is erased, which is safe since the prefetch is only a performance hint.
 
 ### 64-Byte Alignment Compensation
 Hardware requires 64-byte aligned base addresses. The lowering compensates non-aligned addresses:

--- a/test/TritonGEN/tritongen-2Dblockprefetch-to-llvm.mlir
+++ b/test/TritonGEN/tritongen-2Dblockprefetch-to-llvm.mlir
@@ -345,6 +345,10 @@ llvm.func @triton_gen.2Dblockprefetch(%ptr : !llvm.ptr<1>, %base_width : i32, %b
 
 // -----
 
+// COM: 8b with tile_width=16, vBlocks=1 has no SPV runtime builtin, so it
+// COM: falls back to GenISA. The GenISA fallback is only emitted on LTS
+// COM: drivers; model one here (ttig.is_lts) so the fallback stays exercised.
+module attributes {ttig.is_lts} {
 llvm.func @triton_gen.2Dblockprefetch(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
   // CHECK-COUNT-2: llvm.mlir.constant(1 : i32) : i32
   // CHECK:         [[ElemSize:%.*]] = llvm.mlir.constant(8 : i32) : i32
@@ -354,6 +358,7 @@ llvm.func @triton_gen.2Dblockprefetch(%ptr : !llvm.ptr<1>, %base_width : i32, %b
   // CHECK:    llvm.call spir_funccc @llvm.genx.GenISA.LSC2DBlockPrefetch.isVoid({{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %arg5, [[ElemSize]], [[TileWidth]], [[TileHeight]], [[VBlocks]], {{.*}}) {{.*}} : (i64, i32, i32, i32, i32, i32, i32, i32, i32, i32, i1, i1, i32) -> ()
   triton_gen.2Dblockprefetch %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=8, tile_width=16, tile_height=32, v_blocks=1, cache_control=Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32)
   llvm.return
+}
 }
 
 // -----
@@ -445,12 +450,15 @@ llvm.func @triton_gen.2Dblockprefetch(%ptr : !llvm.ptr<1>, %base_width : i32, %b
 // -----
 
 // COM: d16 with tile_width=32, vBlocks=1 has no SPV runtime builtin (16b_?r32x1c
-// COM: is missing). Verify it falls back to GenISA LSC2DBlockPrefetch intrinsic.
+// COM: is missing). Verify it falls back to GenISA LSC2DBlockPrefetch intrinsic
+// COM: on LTS drivers (ttig.is_lts).
+module attributes {ttig.is_lts} {
 llvm.func @triton_gen.2Dblockprefetch_d16_genisa_fallback(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
   // CHECK-NOT: @_Z36__spirv_Subgroup2DBlockPrefetchINTEL
   // CHECK:     llvm.call spir_funccc @llvm.genx.GenISA.LSC2DBlockPrefetch.isVoid({{.*}}) {{.*}} : (i64, i32, i32, i32, i32, i32, i32, i32, i32, i32, i1, i1, i32) -> ()
   triton_gen.2Dblockprefetch %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=16, tile_width=32, tile_height=8, v_blocks=1, cache_control=Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32)
   llvm.return
+}
 }
 
 // -----
@@ -477,4 +485,31 @@ llvm.func @triton_gen.2Dblockprefetch(%ptr : !llvm.ptr<1>, %base_width : i32, %b
   triton_gen.2Dblockprefetch %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=8, tile_width=32, tile_height=8, v_blocks=1, cache_control=L1UC_L3UC} : (!llvm.ptr<1>, i32, i32, i32, i32, i32)
   llvm.return
 }
+}
+
+// -----
+
+// COM: d16 with tile_width=32, vBlocks=1 has no SPV runtime builtin (16b_?r32x1c
+// COM: is missing). On non-LTS drivers (no ttig.is_lts) the GenISA fallback is
+// COM: not supported either, so the prefetch hint is dropped entirely.
+llvm.func @triton_gen.2Dblockprefetch_dropped_non_lts(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // CHECK:     llvm.func @triton_gen.2Dblockprefetch_dropped_non_lts
+  // CHECK-NOT: 2DBlockPrefetch
+  // CHECK:     llvm.return
+  triton_gen.2Dblockprefetch %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=16, tile_width=32, tile_height=8, v_blocks=1, cache_control=Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32)
+  llvm.return
+}
+
+// -----
+
+// COM: 8b with tile_width=16, vBlocks=1 has no SPV runtime builtin
+// COM: (intel_sub_group_2d_block_prefetch_8b_?r16x1c is missing). On non-LTS
+// COM: drivers (no ttig.is_lts) the GenISA fallback is not supported either,
+// COM: so the prefetch hint is dropped entirely.
+llvm.func @triton_gen.2Dblockprefetch_dropped_non_lts_8b(%ptr : !llvm.ptr<1>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // CHECK:     llvm.func @triton_gen.2Dblockprefetch_dropped_non_lts_8b
+  // CHECK-NOT: 2DBlockPrefetch
+  // CHECK:     llvm.return
+  triton_gen.2Dblockprefetch %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=8, tile_width=16, tile_height=8, v_blocks=1, cache_control=Default} : (!llvm.ptr<1>, i32, i32, i32, i32, i32)
+  llvm.return
 }

--- a/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
+++ b/third_party/intel/lib/TritonGENToLLVM/TritonGENToLLVMPass.cpp
@@ -1173,6 +1173,19 @@ struct TritonMatrix2DBlockPrefetchLowering
   LogicalResult
   matchAndRewrite(TritonGEN::Matrix2DBlockPrefetchOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    // The GenISA fallback is only supported by LTS drivers. On regular
+    // drivers the SPIR-V translator passes llvm.genx.GenISA intrinsics
+    // through as unresolved external functions, which crashes IGC during
+    // module translation. The prefetch is only a performance hint, so drop
+    // it when no SPIR-V builtin form exists. Erase before the assert
+    // branches are created, so no asserts are left for the dropped op.
+    if (!op->getParentOfType<mlir::ModuleOp>()->hasAttr(
+            intel::TritonIntelGPUDialect::getIsLTSAttrName()) &&
+        !isSPVBuiltinAvailable(op)) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+
     create2DBlockAsserts(op, rewriter, emitter);
 
     if (!isSPVBuiltinAvailable(op)) {


### PR DESCRIPTION
## Problem

On non-LTS drivers, `TritonMatrix2DBlockPrefetchLowering` can emit
`llvm.genx.GenISA.LSC2DBlockPrefetch.isVoid` calls that crash the system IGC
during SPIR-V module translation (host SIGSEGV in `zeModuleCreate`).

The lowering falls back to the GenISA interface whenever
`isSPVBuiltinAvailable(op)` is false. That helper returns false in two cases:
the module carries `ttig.is_lts` (LTS driver, the intended consumer of the
GenISA form), or the prefetch configuration has no SPIR-V runtime builtin
(currently 16b with `tile_width=32, v_blocks=1`, 8b with `tile_width=16,
v_blocks=1`, and 64b with `tile_height<8`). In the second case on a regular
(non-LTS) driver the GenISA call has no consumer at all: the pinned Khronos
SPIR-V LLVM translator does not recognize `llvm.genx.GenISA.*` intrinsics and
passes them through as unresolved external functions (Triton explicitly allows
unknown intrinsics with the `llvm.genx.GenISA.` prefix), so the system IGC
aborts the whole module during translation.

## Solution

In `matchAndRewrite`, erase the prefetch op when the parent module is
not an LTS one and `isSPVBuiltinAvailable(op)` is false. The check runs
before any replacement code (including the 2D-block asserts) is
created, so a dropped prefetch leaves nothing behind. A prefetch is a
pure performance hint, so dropping it is safe and preserves semantics.
The LTS path is unchanged — modules with `ttig.is_lts` still get the
GenISA intrinsic.

Only the prefetch fallback is changed. The `Matrix2DBlockLoadOp`/`StoreOp`
GenISA fallbacks are likewise reachable on non-LTS drivers for configurations
without an SPV builtin, but loads and stores cannot be dropped; that is a
pre-existing, separate issue not triggered here (none of the kernels that
surfaced this bug exercises a load/store configuration without an SPV
builtin).

## Tests

`test/TritonGEN/tritongen-2Dblockprefetch-to-llvm.mlir`:

- The two existing GenISA-fallback cases (the `8b/tile_width=16/v_blocks=1`
  case and the `2Dblockprefetch_d16_genisa_fallback` case whose COM comment
  explicitly verifies the GenISA fallback) had no `ttig.is_lts` on their
  module, so with this fix they no longer produce a GenISA call. They are now
  wrapped in `module attributes {ttig.is_lts}` to keep testing the intended
  LTS fallback behavior. Verified: green on an unfixed build, red on a fixed
  build without the attribute (FileCheck finds no
  `GenISA.LSC2DBlockPrefetch` call in either function body), green again with
  the attribute.
- New case `2Dblockprefetch_dropped_non_lts`: a
  `16b/tile_width=32/v_blocks=1` prefetch in a module without `ttig.is_lts` is
  erased — `CHECK-NOT: 2DBlockPrefetch` between the function label and
  `llvm.return` rejects both the GenISA intrinsic and the SPV builtin forms.
  Must-red verified: on an unfixed build the case fails because the GenISA
  call is emitted; on a fixed build it passes.
- New case `2Dblockprefetch_dropped_non_lts_8b`: an
  `8b/tile_width=16/v_blocks=1` prefetch in a module without `ttig.is_lts`
  is likewise erased, covering the 8-bit side of the no-builtin
  configuration set.
- On the fixed build: `lit test/TritonGEN` 8/8 passed,
  `lit test/TritonIntelGPU` 82/82 passed (no regressions).

## End-to-end evidence

Reproducer: an attention kernel compiled on XPU with a non-LTS driver
deterministically SIGSEGVs in `zeModuleCreate` (IGC module translation)
because the kernel emits 10 `llvm.genx.GenISA.LSC2DBlockPrefetch.isVoid`
calls with the `elem_size=16/tile_width=32/v_blocks=1` configuration.
Stripping the GenISA calls from the LLIR makes the module load successfully,
confirming causality. With this fix (plus the unrelated layout fixes in the
same branch series), the triggering downstream test suite passes 15/15.
