### PR TITLE
[TritonIntelGPU] #7854 w/a: Explicitly pack dp4a registers

### DIFF
--- a/python/test/unit/intel/test_int8_fma_dot.py
+++ b/python/test/unit/intel/test_int8_fma_dot.py
@@ -1,0 +1,54 @@
+"""End-to-end coverage for INT8 dots that do not use DPAS (issue #7854).
+
+`DPASAnalysis::canUseDPAS` is function-wide: one dot that DPAS cannot handle --
+an `input_precision="ieee"` f32 dot, for instance -- demotes *every* dot in the
+same function to the FMA path, including an INT8 dot of a perfectly DPAS-able
+shape. That INT8 dot used to be silently wrong: the FMA lowering emitted a
+`mul`/`add` chain, and IGC folded it back into a `dp4a` whose two operands it
+had reordered independently, computing sum_j a[permA(j)] * b[permB(j)].
+
+There was no INT8 coverage of the FMA path before this test; the only
+end-to-end FMA dot test is f16 (`test_stage_large_fma_dots_via_slm.py`).
+"""
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton._internal_testing import is_xpu
+
+
+@triton.jit
+def _int8_dot_with_ieee_dot(a_ptr, b_ptr, c_ptr, ieee_ptr, BLOCK: tl.constexpr):
+    """The INT8 dot is DPAS-able on its own; the IEEE dot below is what pushes
+    the whole function onto FMA."""
+    offs = tl.arange(0, BLOCK)
+    a = tl.load(a_ptr + offs[:, None] * BLOCK + offs[None, :])
+    b = tl.load(b_ptr + offs[:, None] * BLOCK + offs[None, :])
+    c_ptrs = c_ptr + offs[:, None] * BLOCK + offs[None, :]
+    tl.store(c_ptrs, tl.dot(a, b, acc=tl.load(c_ptrs), out_dtype=tl.int32))
+
+    x = (offs[:, None] + offs[None, :]).to(tl.float32)
+    tl.store(ieee_ptr + offs[:, None] * BLOCK + offs[None, :], tl.dot(x, x, input_precision="ieee"))
+
+
+@pytest.mark.skipif(not is_xpu(), reason="XPU-only test")
+# K < 32 is rejected outright for INT8 by the `min_dot_size` guard in
+# `third_party/intel/backend/compiler.py`, so 32 is the smallest usable block.
+@pytest.mark.parametrize("BLOCK", [32, 64])
+def test_int8_dot_demoted_to_fma(BLOCK, device):
+    generator = torch.Generator(device="cpu").manual_seed(17)
+    a = torch.randint(-4, 5, (BLOCK, BLOCK), dtype=torch.int8, generator=generator)
+    b = torch.randint(-4, 5, (BLOCK, BLOCK), dtype=torch.int8, generator=generator)
+    c = torch.randint(-16, 17, (BLOCK, BLOCK), dtype=torch.int32, generator=generator)
+    expected = a.to(torch.int32) @ b.to(torch.int32) + c
+
+    acc = c.to(device)
+    ieee_out = torch.empty((BLOCK, BLOCK), dtype=torch.float32, device=device)
+    kernel = _int8_dot_with_ieee_dot[(1, )](a.to(device), b.to(device), acc, ieee_out, BLOCK=BLOCK, num_warps=4)
+
+    # The point of the test is the FMA path, so fail loudly if a pipeline change
+    # makes this shape use DPAS instead and the coverage silently disappears.
+    assert "#ttig.dpas" not in kernel.asm["ttgir"], "kernel no longer exercises the FMA path"
+    torch.testing.assert_close(acc.cpu(), expected)

--- a/test/Conversion/intel/dot_fma_dp4a.mlir
+++ b/test/Conversion/intel/dot_fma_dp4a.mlir
@@ -1,0 +1,69 @@
+// RUN: triton-opt %s -split-input-file --intel-allocate-shared-memory --convert-triton-intel-gpu-to-llvm | FileCheck %s
+
+// COM: An INT8 dot on the FMA path must be lowered to dp4a instructions rather
+// COM: than to a mul/add chain: IGC folds such a chain back into a dp4a and
+// COM: mis-pairs its two operands (issue #7854).
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#dot_operand_a = #ttg.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #ttg.dot_op<{opIdx=1, parent=#blocked}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK: llvm.func spir_funccc @llvm.genx.GenISA.dp4a.ss.i32(i32, i32, i32, i1) -> i32
+  // CHECK-LABEL: matmul_int8_fmadot
+  tt.func @matmul_int8_fmadot(%ptr: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                              %a: !ttg.memdesc<32x16xi8, #shared, #smem>,
+                              %b: !ttg.memdesc<16x32xi8, #shared, #smem>) {
+    %cst = arith.constant dense<0> : tensor<32x32xi32, #blocked>
+    %a_mat = ttg.local_load %a : !ttg.memdesc<32x16xi8, #shared, #smem> -> tensor<32x16xi8, #dot_operand_a>
+    %b_mat = ttg.local_load %b : !ttg.memdesc<16x32xi8, #shared, #smem> -> tensor<16x32xi8, #dot_operand_b>
+    %a_i32 = arith.extsi %a_mat : tensor<32x16xi8, #dot_operand_a> to tensor<32x16xi32, #dot_operand_a>
+    %b_i32 = arith.extsi %b_mat : tensor<16x32xi8, #dot_operand_b> to tensor<16x32xi32, #dot_operand_b>
+    // COM: Both operands are packed from four i8 values in the same order, so
+    // COM: component i of one side pairs with component i of the other.
+    // CHECK:           llvm.mlir.undef : vector<4xi8>
+    // CHECK-COUNT-4:   llvm.insertelement %{{.*}}, %{{.*}}[%{{.*}} : i32] : vector<4xi8>
+    // CHECK:           llvm.bitcast %{{.*}} : vector<4xi8> to i32
+    // CHECK:           llvm.mlir.undef : vector<4xi8>
+    // CHECK-COUNT-4:   llvm.insertelement %{{.*}}, %{{.*}}[%{{.*}} : i32] : vector<4xi8>
+    // CHECK:           llvm.bitcast %{{.*}} : vector<4xi8> to i32
+    // CHECK:           llvm.call spir_funccc @llvm.genx.GenISA.dp4a.ss.i32(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}} : (i32, i32, i32, i1) -> i32
+    %d = tt.dot %a_i32, %b_i32, %cst : tensor<32x16xi32, #dot_operand_a> * tensor<16x32xi32, #dot_operand_b> -> tensor<32x32xi32, #blocked>
+    %30 = tt.splat %ptr : !tt.ptr<i32> -> tensor<32x1x!tt.ptr<i32>, #blocked>
+    %36 = tt.broadcast %30 : tensor<32x1x!tt.ptr<i32>, #blocked> -> tensor<32x32x!tt.ptr<i32>, #blocked>
+    tt.store %36, %d : tensor<32x32x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: dp4a only takes 8-bit components, so a wider integer dot keeps the
+// COM: generic mul/add chain. A chain of fewer than four products is not
+// COM: foldable into a dp4a, so it is not exposed to #7854.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#dot_operand_a = #ttg.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #ttg.dot_op<{opIdx=1, parent=#blocked}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: matmul_int16_fmadot
+  // CHECK-NOT: dp4a
+  tt.func @matmul_int16_fmadot(%ptr: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                               %a: !ttg.memdesc<32x16xi16, #shared, #smem>,
+                               %b: !ttg.memdesc<16x32xi16, #shared, #smem>) {
+    %cst = arith.constant dense<0> : tensor<32x32xi32, #blocked>
+    %a_mat = ttg.local_load %a : !ttg.memdesc<32x16xi16, #shared, #smem> -> tensor<32x16xi16, #dot_operand_a>
+    %b_mat = ttg.local_load %b : !ttg.memdesc<16x32xi16, #shared, #smem> -> tensor<16x32xi16, #dot_operand_b>
+    %a_i32 = arith.extsi %a_mat : tensor<32x16xi16, #dot_operand_a> to tensor<32x16xi32, #dot_operand_a>
+    %b_i32 = arith.extsi %b_mat : tensor<16x32xi16, #dot_operand_b> to tensor<16x32xi32, #dot_operand_b>
+    // CHECK: llvm.mul
+    %d = tt.dot %a_i32, %b_i32, %cst : tensor<32x16xi32, #dot_operand_a> * tensor<16x32xi32, #dot_operand_b> -> tensor<32x32xi32, #blocked>
+    %30 = tt.splat %ptr : !tt.ptr<i32> -> tensor<32x1x!tt.ptr<i32>, #blocked>
+    %36 = tt.broadcast %30 : tensor<32x1x!tt.ptr<i32>, #blocked> -> tensor<32x32x!tt.ptr<i32>, #blocked>
+    tt.store %36, %d : tensor<32x32x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/CMakeLists.txt
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/CMakeLists.txt
@@ -14,6 +14,7 @@ add_triton_library(TritonIntelGPUToLLVM
     ControlFlowOpToLLVM.cpp
     ConvertLayoutOpToLLVM.cpp
     DotOpToLLVM/DPAS.cpp
+    DotOpToLLVM/FMA.cpp
     DotOpToLLVM.cpp
     ElementwiseOpToLLVM.cpp
     Fp4ToFpOpToLLVM.cpp

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM.cpp
@@ -11,6 +11,10 @@ template <typename OpTy>
 LogicalResult convertDPAS(OpTy op, typename OpTy::Adaptor adaptor,
                           TritonIntelGPUToLLVMTypeConverter *typeConverter,
                           ConversionPatternRewriter &rewriter);
+LogicalResult convertIntegerFMADot(triton::DotOp op,
+                                   triton::DotOp::Adaptor adaptor,
+                                   const LLVMTypeConverter *typeConverter,
+                                   ConversionPatternRewriter &rewriter);
 } // namespace fma_details
 
 namespace {
@@ -38,9 +42,16 @@ struct DotOpConversion : public ConvertTritonGPUOpToLLVMPattern<triton::DotOp> {
                                       rewriter);
     }
 
-    if (isa<BlockedEncodingAttr>(
-            cast<RankedTensorType>(D.getType()).getEncoding()))
+    auto DTensorTy = cast<RankedTensorType>(D.getType());
+    if (isa<BlockedEncodingAttr>(DTensorTy.getEncoding())) {
+      // Lower integer dots to dp4a rather than to a mul/add chain: IGC folds
+      // such a chain back into a dp4a and mis-pairs its two operands
+      // (intel/intel-xpu-backend-for-triton#7854).
+      if (isa<IntegerType>(DTensorTy.getElementType()))
+        return fma_details::convertIntegerFMADot(op, adaptor,
+                                                 getTypeConverter(), rewriter);
       return convertFMADot(op, adaptor, getTypeConverter(), rewriter);
+    }
 
     llvm::report_fatal_error(
         "Unsupported DotOp found when converting TritonGPU to LLVM.");

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -1,0 +1,153 @@
+//===- FMA.cpp - FMA dot lowering for Intel GPUs --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Utils/LLVMIntr.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "triton/Conversion/TritonGPUToLLVM/FMADotUtility.h"
+#include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::gpu;
+
+namespace {
+
+/// Number of 8-bit components consumed by one dp4a instruction.
+constexpr unsigned NumDp4aComponents = 4;
+
+/// Multiplier emitting `dp4a` for dot products over extended 8-bit integers.
+///
+/// Upstream's generic multiplier emits a `mul`/`add` chain, which IGC folds
+/// back into a `dp4a` in `CustomSafeOptPass::matchDp4a()`. That pattern match
+/// reorders the two operands of the folded instruction independently, so it can
+/// pair `a[i]` with `b[j]`, `i != j`, and compute a different dot product from
+/// the one that was written (issue #7854). Emitting the instruction directly is
+/// correct by construction, and is better code than the chain regardless: one
+/// instruction per four elements of K instead of four multiplies and four
+/// additions.
+///
+/// The operands reach this point extended to the accumulator type (by
+/// `decomposeMixedModeDotOp`, or by the kernel itself); \p aIsSigned and
+/// \p bIsSigned record how, which is what makes truncating them back to i8 for
+/// dp4a value-preserving.
+class Dp4aFMAVectorMultiplier : public FMAVectorMultiplier {
+  ConversionPatternRewriter &rewriter;
+  Location loc;
+  bool aIsSigned;
+  bool bIsSigned;
+
+  /// \returns the four \p vals, truncated to their original 8 bits and packed
+  /// into a single i32, which is how dp4a takes its operands.
+  Value packComponents(ArrayRef<Value> vals) {
+    assert(vals.size() == NumDp4aComponents && "Unexpected operand count");
+    TritonLLVMOpBuilder builder(loc, rewriter);
+    Type i8Ty = rewriter.getI8Type();
+    auto vecTy = VectorType::get(NumDp4aComponents, i8Ty);
+    Value vec = builder.undef(vecTy);
+    for (auto [idx, val] : llvm::enumerate(vals))
+      vec = builder.insert_element(vecTy, vec, builder.trunc(i8Ty, val),
+                                   builder.i32_val(idx));
+    return builder.bitcast(vec, rewriter.getI32Type());
+  }
+
+  /// Emits `acc + a·b` as a single dp4a instruction.
+  Value createDp4a(ArrayRef<Value> a, ArrayRef<Value> b, Value acc) {
+    TritonLLVMOpBuilder builder(loc, rewriter);
+    Type i32Ty = rewriter.getI32Type();
+    Type i1Ty = rewriter.getI1Type();
+    // The name encodes the signedness of the two operands, in that order.
+    std::string funcName = "llvm.genx.GenISA.dp4a.";
+    funcName += aIsSigned ? "s" : "u";
+    funcName += bIsSigned ? "s" : "u";
+    funcName += ".i32";
+
+    SmallVector<Type> argTypes{i32Ty, i32Ty, i32Ty, i1Ty};
+    SmallVector<Value> args{acc, packComponents(a), packComponents(b),
+                            builder.i1_val(false) /*saturate*/};
+    return intel::createDeviceFunctionCall(rewriter, funcName, i32Ty, argTypes,
+                                           args, /*paramAttrs=*/{},
+                                           intel::noUnwindWillReturnAttrs)
+        .getResult();
+  }
+
+public:
+  Dp4aFMAVectorMultiplier(ConversionPatternRewriter &rewriter, Location loc,
+                          bool aIsSigned, bool bIsSigned)
+      : rewriter(rewriter), loc(loc), aIsSigned(aIsSigned),
+        bIsSigned(bIsSigned) {}
+
+  Value multiplyVectors(ArrayRef<Value> a, ArrayRef<Value> b,
+                        Value c) override {
+    unsigned K = a.size();
+    assert(b.size() == K && "Operands must have the same size");
+    TritonLLVMOpBuilder builder(loc, rewriter);
+
+    Value accum = c;
+    unsigned k = 0;
+    for (; k + NumDp4aComponents <= K; k += NumDp4aComponents)
+      accum = createDp4a(a.slice(k, NumDp4aComponents),
+                         b.slice(k, NumDp4aComponents), accum);
+
+    // Trailing elements when K is not a multiple of four. Fewer than four
+    // products cannot be folded into a dp4a, so this tail is not exposed to the
+    // mis-pairing described above.
+    for (; k < K; ++k)
+      accum = builder.add(builder.mul(a[k], b[k]), accum);
+    return accum;
+  }
+};
+
+/// \returns whether \p operand is an 8-bit integer tensor extended to a wider
+/// type, and whether that extension is signed. Layout conversions are looked
+/// through: they do not change the value.
+std::optional<bool> getInt8ExtensionKind(Value operand) {
+  while (auto cvt = operand.getDefiningOp<ConvertLayoutOp>())
+    operand = cvt.getSrc();
+
+  Operation *def = operand.getDefiningOp();
+  bool isSigned;
+  if (isa_and_nonnull<arith::ExtSIOp>(def))
+    isSigned = true;
+  else if (isa_and_nonnull<arith::ExtUIOp>(def))
+    isSigned = false;
+  else
+    return std::nullopt;
+
+  auto srcTy = dyn_cast<RankedTensorType>(def->getOperand(0).getType());
+  if (!srcTy || !srcTy.getElementType().isInteger(8))
+    return std::nullopt;
+  return isSigned;
+}
+
+} // namespace
+
+namespace fma_details {
+
+LogicalResult convertIntegerFMADot(DotOp op, DotOp::Adaptor adaptor,
+                                   const LLVMTypeConverter *typeConverter,
+                                   ConversionPatternRewriter &rewriter) {
+  // dp4a accumulates into i32 and multiplies extended 8-bit values; any other
+  // integer dot keeps the generic mul/add chain, which IGC cannot fold into a
+  // dp4a and therefore cannot mis-pair.
+  if (!cast<RankedTensorType>(op.getType()).getElementType().isInteger(32))
+    return convertFMADot(op, adaptor, typeConverter, rewriter);
+
+  std::optional<bool> aIsSigned = getInt8ExtensionKind(op.getA());
+  std::optional<bool> bIsSigned = getInt8ExtensionKind(op.getB());
+  if (!aIsSigned || !bIsSigned)
+    return convertFMADot(op, adaptor, typeConverter, rewriter);
+
+  Dp4aFMAVectorMultiplier multiplier(rewriter, op.getLoc(), *aIsSigned,
+                                     *bIsSigned);
+  return parametricConvertFMADot(op, adaptor, typeConverter, rewriter,
+                                 multiplier);
+}
+
+} // namespace fma_details


### PR DESCRIPTION
Workaround for an IGC issue where registers are packed incorrectly when emitting dp4a ops.
https://github.com/intel/intel-xpu-backend-for-triton/issues/7854
