### PR TITLE
[CI] Cap MAX_JOBS at 8 and raise the setup timeout to 4h on BMG

### DIFF
--- a/.github/actions/setup-pytorch/action.yml
+++ b/.github/actions/setup-pytorch/action.yml
@@ -19,6 +19,9 @@ inputs:
   mode:
     description: Source or wheels
     default: source
+  max_jobs:
+    description: MAX_JOBS for the PyTorch build, keep empty for one job per core
+    default: ""
   cache:
     description: Cache enabled or disabled
     default: enabled
@@ -119,6 +122,10 @@ runs:
 
         # Limit AOT
         export TORCH_XPU_ARCH_LIST="pvc,bmg,dg2,arl-h,mtl-h"
+
+        if [[ -n "${{ inputs.max_jobs }}" ]]; then
+          export MAX_JOBS="${{ inputs.max_jobs }}"
+        fi
 
         cd pytorch
         # FIXME: Compatibility with versions of CMake older than 3.5 has been removed, this brakes compilation of third_party/protobuf:

--- a/.github/workflows/sglang-tests-bmg.yml
+++ b/.github/workflows/sglang-tests-bmg.yml
@@ -24,5 +24,7 @@ jobs:
     uses: ./.github/workflows/sglang-tests-reusable.yml
     with:
       runner_label: b60
+      max_jobs: 8
+      setup_timeout_minutes: 240
       skip_list: xe2
     secrets: inherit

--- a/.github/workflows/sglang-tests-reusable.yml
+++ b/.github/workflows/sglang-tests-reusable.yml
@@ -15,6 +15,14 @@ on:
         description: Skip list directory override
         type: string
         default: ""
+      max_jobs:
+        description: MAX_JOBS for the PyTorch build, keep empty for one job per core
+        type: string
+        default: ""
+      setup_timeout_minutes:
+        description: Timeout for the setup job
+        type: number
+        default: 180
       python_version:
         description: Python version
         type: string
@@ -41,7 +49,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ${{ fromJSON((inputs.runner_label == '' || startsWith(inputs.runner_label, 'max')) && format('["linux", "rolling", "{0}"]', inputs.runner_label || 'max1100') || format('["linux", "{0}"]', inputs.runner_label)) }}
-    timeout-minutes: 180
+    timeout-minutes: ${{ inputs.setup_timeout_minutes }}
     defaults:
       run:
         shell: bash -noprofile --norc -eo pipefail -c "source /opt/intel/oneapi/setvars.sh > /dev/null; source {0}"
@@ -82,6 +90,8 @@ jobs:
 
       - name: Setup PyTorch
         uses: ./.github/actions/setup-pytorch
+        with:
+          max_jobs: ${{ inputs.max_jobs }}
 
       - name: Build Triton wheel
         run: |
@@ -177,6 +187,8 @@ jobs:
       - name: Setup PyTorch
         id: setup-pytorch
         uses: ./.github/actions/setup-pytorch
+        with:
+          max_jobs: ${{ inputs.max_jobs }}
 
       # sglang imports torchvision.io at module level and install-sglang.sh strips
       # torch* from its pyproject, so it has to be installed here, from the PyTorch pin.


### PR DESCRIPTION
A single SYCL device compile peaks at 2-5 GB and ninja defaults to one job per core, so on the 30 GB BMG runners the PyTorch build swaps instead of progressing and then needs more than 3h once capped.