### PR TITLE
[BACKEND] Report `n_spills` in spilled registers per work-item

### DIFF
--- a/third_party/intel/backend/driver.c
+++ b/third_party/intel/backend/driver.c
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <algorithm>
 #include <cstddef>
 #include <cstring>
 #include <iostream>
@@ -383,7 +384,23 @@ compileLevelZeroObjects(uint8_t *binary_ptr, const size_t binary_size,
     return std::make_tuple(nullptr, nullptr, -1);
   }
 
-  const int32_t n_spills = props.spillMemSize;
+  // `spillMemSize` is in bytes per *hardware thread*, i.e. per sub-group. The
+  // `n_spills` returned by `load_binary` is a backend-agnostic quantity that
+  // consumers (e.g. inductor's `spill_threshold`) compare against fixed
+  // thresholds, and its established unit is spilled 32-bit registers per
+  // work-item: the CUDA backend divides `CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES`
+  // (bytes per thread, and a CUDA thread is one lane) by 4. Convert to that
+  // unit here: divide by the sub-group size to go from per-hardware-thread to
+  // per-work-item, and by 4 to go from bytes to 32-bit registers. Reporting
+  // raw bytes inflates the number by a factor of `4 * sub_group_size` (128x at
+  // SIMD 32), making such thresholds fire on kernels that barely spill. Round
+  // up so a non-zero spill never reports as zero.
+  const uint32_t subGroupSize = props.requiredSubgroupSize
+                                    ? props.requiredSubgroupSize
+                                    : std::max(props.maxSubgroupSize, 1u);
+  const uint32_t bytesPerSpilledReg = 4 * subGroupSize;
+  const int32_t n_spills =
+      (props.spillMemSize + bytesPerSpilledReg - 1) / bytesPerSpilledReg;
 
   return std::make_tuple(l0_module, l0_kernel, n_spills);
 }
@@ -593,7 +610,8 @@ extern "C" EXPORT_FUNC PyObject *load_binary(PyObject *args) {
 
         if (debugEnabled)
           std::cout << "(I): Retry with large GRF succeeded, kernel has "
-                    << n_spills << " spills" << std::endl;
+                    << n_spills << " spilled registers per work-item"
+                    << std::endl;
       }
     } catch (const std::exception &e) {
       if (firstBuildFailed) {
@@ -611,8 +629,9 @@ extern "C" EXPORT_FUNC PyObject *load_binary(PyObject *args) {
   }
 
   if (debugEnabled && n_spills) {
-    std::cout << "(I): Detected " << n_spills << " spills for  \""
-              << kernel_name << "\"" << std::endl;
+    std::cout << "(I): Detected " << n_spills
+              << " spilled registers per work-item for  \"" << kernel_name
+              << "\"" << std::endl;
   }
 
   auto n_regs = build_flags.n_regs();


### PR DESCRIPTION
Closes #7782

## Problem

`load_binary` returned Level Zero's `ze_kernel_properties_t::spillMemSize` verbatim:

```c
const int32_t n_spills = props.spillMemSize;
```

That field is **bytes per hardware thread**, i.e. per sub-group. But `n_spills` is a backend-agnostic quantity that consumers compare against fixed, backend-independent thresholds, and its established unit is **spilled 32-bit registers per work-item**. The CUDA backend establishes it explicitly ([`third_party/nvidia/backend/driver.c`](https://github.com/intel/intel-xpu-backend-for-triton/blob/main/third_party/nvidia/backend/driver.c)):

```c
cuFuncGetAttribute(&n_spills, CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES, fun);
n_spills /= 4;
```

`LOCAL_SIZE_BYTES` is bytes per CUDA thread, and a CUDA thread *is* one lane, so `/4` converts bytes to 32-bit registers per lane. On Intel a hardware thread is a whole sub-group, so reporting the raw byte count inflates the value by `4 * sub_group_size` — **128x at SIMD 32**.

## Impact

Anything comparing `n_spills` to a fixed threshold sees barely-spilling kernels as heavy spillers.

The reported case (#7782, `pyhpc_equation_of_state`, fp64 pointwise, Arc Pro B60): inductor's `pointwise()` heuristic prunes any launch config whose `launcher.n_spills` exceeds `inductor_meta["spill_threshold"]` (16 by default). The winning config spills 512 B/hardware-thread = **4 registers per work-item**, but was reported as `512`. All three candidate configs were pruned, all scored `inf`, and the tie was broken by list order — selecting the slowest config (`XBLOCK=1024, num_warps=4`, which really does spill 781 registers/work-item).

With the unit corrected, the same kernel selects `XBLOCK=32, num_warps=1`:

| `n_spills` source | value for the good config | selected config | time |
|---|---|---|---|
| raw bytes (before) | 512 | `XBLOCK=1024, nw=4` | 3.106 ms / 11.15 GB/s |
| registers/work-item (after) | 4 | `XBLOCK=32, nw=1` | **0.852 ms / 40.63 GB/s** |

**3.6x**, with no codegen change — 0.852 ms is level with the hand-written equivalent of the same kernel (0.814–0.841 ms). The bad configs are still correctly pruned after conversion (781 and 119 registers/work-item, both > 16).

## The fix

Divide by `4 * sub_group_size`, preferring `requiredSubgroupSize` and falling back to `maxSubgroupSize` when the kernel has no required size. Round **up** so a non-zero spill never reports as zero.

Rounding up is what keeps the auto-GRF retry semantics bit-for-bit identical: that check is `n_spills > max_reg_spill` with `max_reg_spill == 0`, so it only asks "did it spill at all", and with ceiling division a non-zero byte count still yields a non-zero register count.

## Verification

Direct check on B60 (SIMD 32, GRF = 64 B), instrumenting `compileLevelZeroObjects`:

```
spillMemSize=9344 reqSG=32 maxSG=32 -> n_spills=73    # default GRF
spillMemSize=512  reqSG=32 maxSG=32 -> n_spills=4     # after the 256-GRF retry
```

9344 B = 146 × 64 B, matching IGC's own "spilled around 146 registers" diagnostic for that build — independent corroboration that the raw field is per-hardware-thread. `CompiledKernel.n_spills` then reads `4` with `n_regs=256`, and the GRF retry still triggers exactly as before.

## Scope notes

- `extract_spill_size_from_zebin` in `compiler.py` is untouched and still works in bytes; it parses IGC's ZEBIN metadata directly and is not part of this contract.
- No in-tree test asserts an `n_spills` value, so nothing else changes.
- **Behavior change worth flagging** (per the repo's change-discipline rule): the two `TRITON_DEBUG` messages that print the spill count now say "spilled registers per work-item" and report the converted number rather than raw bytes.
- This fix is necessary but **not sufficient** for #7782 end-to-end: `torch._inductor.config.use_static_cuda_launcher` is on by default and aliased for XPU, and that path gets `n_spills` from torch's own C++ loader (`static_triton_launcher.py: load_kernel()` -> `_load_kernel`) rather than from Triton, so the matching unit fix is also needed on the PyTorch side. Measurements above were taken with the static launcher disabled to exercise Triton's value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
