### PR TITLE
Drop the duplicate `handleArgPtrDatatype` in `FuncOpToLLVM`

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
@@ -65,23 +65,6 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     return success();
   }
 
-  static void handleArgPtrDatatype(triton::FuncOp funcOp,
-                                   LLVM::LLVMFuncOp &llvmFuncOp) {
-
-    // The convertion from triton::PointerType to LLVM::LLVMPointerType losts
-    // the pointee datatype. This function add the pointee datatype to arg
-    // attribute.
-    FunctionType fty = funcOp.getFunctionType();
-    for (unsigned i = 0; i < fty.getNumInputs(); ++i) {
-      auto argType = fty.getInput(i);
-      if (auto argPtrType = dyn_cast<triton::PointerType>(argType)) {
-        auto argDType = argPtrType.getPointeeType();
-        llvmFuncOp.setArgAttr(i, "tt.pointee_type",
-                              mlir::TypeAttr::get(argDType));
-      }
-    }
-  }
-
   static void attachKernelAttributes(LLVM::LLVMFuncOp newFuncOp,
                                      triton::FuncOp funcOp,
                                      ConversionPatternRewriter &rewriter) {


### PR DESCRIPTION
`FuncOpConversion` carries a static `handleArgPtrDatatype` whose body is identical to the free function core already provides in `TritonGPUToLLVM/Utility.cpp`, declared in `Utility.h` and called by `third_party/amd/lib/TritonAMDGPUToLLVM/FuncOpToLLVM.cpp` as well as by `third_party/intel/lib/TritonIntelGPUToLLVM/PipelineManager.h`.

The static member shadowed it, so the call in this file resolved to the copy instead of the shared function. Removing the copy makes the call resolve to `mlir::triton::handleArgPtrDatatype` and makes this file identical to upstream.
