### PR TITLE
Remove unused constant-splat helpers from `TritonLLVMOpBuilder`

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -269,32 +269,6 @@ struct TritonLLVMOpBuilder {
   Value i32_val(int64_t val) { return int_val(32, val); }
   Value i64_val(int64_t val) { return int_val(64, val); }
 
-  Value const_val(Type ty, Attribute attr) {
-    return LLVM::ConstantOp::create(*builder, loc, ty, attr);
-  }
-
-  Value vec_splat_i1_cons(unsigned numElements, int32_t val) {
-    auto type = builder->getIntegerType(1);
-    SmallVector<int32_t> consElems(numElements, val);
-    SmallVector<Attribute> attrElems;
-    for (auto c : consElems)
-      attrElems.push_back(builder->getIntegerAttr(type, c));
-    auto attr =
-        DenseElementsAttr::get(VectorType::get(numElements, type), attrElems);
-    return const_val(VectorType::get(numElements, type), attr);
-  }
-
-  Value vec_splat_i32_cons(unsigned numElements, int32_t val) {
-    auto type = builder->getIntegerType(32);
-    SmallVector<int32_t> consElems(numElements, val);
-    SmallVector<Attribute> attrElems;
-    for (auto c : consElems)
-      attrElems.push_back(builder->getIntegerAttr(type, c));
-    auto attr =
-        DenseElementsAttr::get(VectorType::get(numElements, type), attrElems);
-    return const_val(VectorType::get(numElements, type), attr);
-  }
-
   Location loc;
   OpBuilder *builder;
 };

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1195,8 +1195,8 @@ struct BlockIOConversionBase : public LoadStoreConversionBase {
                              APFloat::getNaN(floatType.getFloatSemantics())));
         }
 
-        Value other = b.const_val(
-            unpackedType,
+        Value other = LLVM::ConstantOp::create(
+            rewriter, loc, unpackedType,
             DenseElementsAttr::get(
                 VectorType::get(numElemsPerUnpackedType, unpackedElemType),
                 constOtherElems));


### PR DESCRIPTION
`vec_splat_i1_cons` and `vec_splat_i32_cons` have no callers anywhere in the repository. `const_val` has a single one, in the Intel block-IO lowering, which this change rewrites to the `LLVM::ConstantOp::create` form the surrounding code already uses -- the exact call `const_val` performed.

This makes `include/triton/Conversion/TritonGPUToLLVM/Utility.h` identical to upstream.
