### PR TITLE
[Windows] Add eol rules in `.gitattributes` for `3122.patch` to not broke a build if git option `core.autocrlf` is enabled

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+third_party/intel/cmake/3122.patch text eol=lf


### PR DESCRIPTION
Checked locally - it helps.

The problem was found in https://github.com/pytorch/pytorch/pull/195006 (in pytorch CI `core.autocrlf true`).