### PR TITLE
[CI] Raise the SGLang job timeouts to 4h

### DIFF
--- a/.github/workflows/sglang-tests-reusable.yml
+++ b/.github/workflows/sglang-tests-reusable.yml
@@ -41,7 +41,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ${{ fromJSON((inputs.runner_label == '' || startsWith(inputs.runner_label, 'max')) && format('["linux", "rolling", "{0}"]', inputs.runner_label || 'max1100') || format('["linux", "{0}"]', inputs.runner_label)) }}
-    timeout-minutes: 180
+    timeout-minutes: 240
     defaults:
       run:
         shell: bash -noprofile --norc -eo pipefail -c "source /opt/intel/oneapi/setvars.sh > /dev/null; source {0}"
@@ -132,7 +132,7 @@ jobs:
           - sglang-mamba
           - sglang-rest
     runs-on: ${{ fromJSON((inputs.runner_label == '' || startsWith(inputs.runner_label, 'max')) && format('["linux", "rolling", "{0}"]', inputs.runner_label || 'max1100') || format('["linux", "{0}"]', inputs.runner_label)) }}
-    timeout-minutes: 180
+    timeout-minutes: 240
     defaults:
       run:
         shell: bash -noprofile --norc -eo pipefail -c "source /opt/intel/oneapi/setvars.sh > /dev/null; source {0}"


### PR DESCRIPTION
From a cold PyTorch cache the setup job does not fit into 3h, and the tests job matches what vLLM already uses.