### PR TITLE
[SGLANG] Enable the dense attention unittests on XPU

### DIFF
--- a/scripts/sglang/README.md
+++ b/scripts/sglang/README.md
@@ -21,7 +21,7 @@ One flag per kernel family, each with its own `TRITON_TEST_SUITE` and skip list
 
 | Flag | Test files, relative to `sglang/test/` |
 |---|---|
-| `--sglang-attention` | `registered/attention/test_create_kvindices.py`, `registered/attention/test_triton_attention_kernels.py` |
+| `--sglang-attention` | `registered/attention/test_create_kvindices.py`, `registered/attention/test_triton_attention_kernels.py`, `registered/attention/unittests/dense/test_triton.py` |
 | `--sglang-quant` | `registered/quant/test_fp8_kernel.py`, `test_triton_scaled_mm.py`, `test_awq_dequant.py` |
 | `--sglang-moe` | `registered/lora/test_fused_moe_lora_kernel.py` |
 | `--sglang-mamba` | `registered/layers/mamba/test_causal_conv1d.py`, `test_mamba_ssm.py`, `test_mamba_ssm_ssd.py` |
@@ -49,7 +49,22 @@ kernels to `kernels/ops/` (RFC #29630), so recheck them after a pin bump.
 | `decode_attention_fwd`, `_normal`, `_grouped` | `kernels/ops/attention/decode_attention.py` |
 | `extend_attention_fwd`, `_unified`, `build_unified_kv_indices` | `kernels/ops/attention/extend_attention.py` |
 | `context_attention_fwd` | `kernels/ops/attention/prefill_attention.py` |
-| `create_flashinfer_kv_indices_triton` | `kernels/ops/attention/utils.py` |
+| `create_flashinfer_kv_indices_triton` | `kernels/ops/kvcache/kv_indices.py`, re-exported from `kernels/ops/attention/utils.py` |
+| `get_num_kv_splits_triton` | `kernels/ops/attention/metadata.py` |
+
+`unittests/dense/test_triton.py` is the second source of coverage for those
+kernels and the only one that reaches `get_num_kv_splits_triton`. Instead of
+calling the kernels directly it drives `RadixAttention` through the real
+`TritonAttnBackend` and compares against HF-style torch reference modules, so it
+also covers the metadata builders, page sizes 1/16/32, CUDA-graph decode,
+split-op extend and spec-verify. Measured launches for one run: `_fwd_kernel` 55,
+`_fwd_kernel_stage2` 41, `_fwd_kernel_stage1` 34, `create_flashinfer_kv_indices_triton` 70,
+`get_num_kv_splits_triton` 22, `_fwd_grouped_kernel_stage1` 7.
+
+Upstream gates it on `torch.cuda.is_available()` and registers it for CUDA and
+ROCm only; `sglang-test-fix.patch` makes the gate, the RNG seeding and the
+capture stream device-agnostic via `get_device_module()` and adds
+`register_xpu_ci`. Those hunks are written to be upstreamable as-is.
 
 `--sglang-quant`:
 
@@ -117,7 +132,7 @@ Local run at the current pin, one suite at a time. The skip lists come from it.
 
 | Suite | Result | Time |
 |---|---|---|
-| `--sglang-attention` | 8 passed, 2 skipped (1 upstream, 1 skip-listed) | 26s |
+| `--sglang-attention` | 18 passed, 2 skipped (1 upstream, 1 skip-listed) | 116s |
 | `--sglang-quant` | 5 passed | 43s |
 | `--sglang-moe` | 108 skipped, all skip-listed | 4s |
 | `--sglang-mamba` | 932 passed, 16 skipped upstream | 15s |
@@ -143,6 +158,22 @@ Nothing failed because of Triton codegen.
 - **CUDA-only tests.** `test_fused_moe_lora_kernel.py` is parametrized with
   `device="cuda:0"` and `test_dspark_kernel_parity.py` calls `torch.cuda`; both
   are skip-listed. Two of three `test_kda_kernels.py` classes skip themselves.
+- **Two kernels still uncovered.** `compute_position_kernel`
+  (`kernels/ops/attention/position.py`) and `write_req_to_token_pool_triton`
+  (`kernels/ops/memory/common.py`) run on every XPU extend forward and no SGLang
+  test touches them. `unittests/dense/` does not help: it builds `ForwardBatch`
+  directly and passes `positions=` in by hand, bypassing `ForwardBatch.init_new`
+  where `compute_position` is called. Both need a new test, upstream.
+- **Other `unittests/` families are still CUDA-gated.** Only `dense/test_triton.py`
+  is enabled here. 29 more files under `registered/attention/unittests/` carry the
+  same `torch.cuda.is_available()` gate, including the other Triton-backend rows
+  `mla/test_triton.py`, `swa/test_triton.py`, `lightning/test_triton.py`,
+  `kda/test_triton.py` and `gdn/test_triton.py`. Eight kits besides
+  `speculative_draft_runner.py` also repeat the `torch.cuda` RNG pattern
+  (`mla_attention.py`, `gdn_attention.py`, `kda_attention.py`, `mamba2_attention.py`,
+  `lightning_attention.py`, `dsa_attention.py`, `dsv4_attention.py`,
+  `dual_chunk_attention.py`). Enable one family at a time; `gdn/` and `kda/` stay
+  blocked on `tl.make_block_ptr` regardless (see below).
 - **Sliding window OOM.** `test_extend_attention_sliding_window` runs the kernel
   fine, but its torch reference needs more than 48 GB. Unskip when it is chunked.
 - **BMG.** `scripts/skiplist/xe2/` is a copy of `default/`; nothing measured on

--- a/scripts/sglang/sglang-test-fix.patch
+++ b/scripts/sglang/sglang-test-fix.patch
@@ -119,3 +119,106 @@ index ff90b20a70..4a49fb66a5 100644
  
          unified_kv_indptr, unified_kv_indices, prefix_lens = build_unified_kv_indices(
              kv_indptr,
+diff --git a/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py b/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
+index b352cd7c29..382b758886 100644
+--- a/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
++++ b/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
+@@ -22,6 +22,7 @@ from sglang.srt.model_executor.graph_shared_output import GraphSharedOutput
+ from sglang.srt.model_executor.model_runner import ModelRunner
+ from sglang.srt.runtime_context import get_context, get_parallel
+ from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
++from sglang.srt.utils import get_device, get_device_module
+ 
+ # Unit tests run without distributed initialization. Backends that size buffers by
+ # attention tensor-parallel degree should see the single-rank default.
+@@ -32,7 +33,7 @@ DEFAULT_HEAD_DIM = 16
+ DEFAULT_HIDDEN_SIZE = 64
+ DEFAULT_MAX_CONTEXT_LEN = 64
+ DEFAULT_DTYPE = torch.float16
+-DEFAULT_DEVICE = "cuda"
++DEFAULT_DEVICE = get_device()
+ DENSE_ATOL = 3e-2
+ DENSE_RTOL = 3e-2
+ 
+@@ -979,7 +980,7 @@ def build_dense_attention_fixture(
+ ) -> DenseAttentionFixture:
+     seed = 2026 + len(case.name) + case.num_kv_heads
+     torch.manual_seed(seed)
+-    torch.cuda.manual_seed_all(seed)
++    get_device_module().manual_seed_all(seed)
+ 
+     model_config = TinyModelConfig(
+         num_heads=case.num_heads,
+diff --git a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
+index cbebd85c09..9aa2a04860 100644
+--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
++++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
+@@ -32,6 +32,7 @@ from sglang.srt.speculative.frozen_kv_mtp_info import (
+ )
+ from sglang.srt.speculative.frozen_kv_mtp_worker_v2 import FrozenKVMTPDraftWorker
+ from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
++from sglang.srt.utils import get_device_module
+ 
+ from ..attention_methods.dense_attention import (
+     DEFAULT_DEVICE,
+@@ -266,22 +267,25 @@ def _seeded_rng(seed: int, *, device: str | torch.device):
+     input builders below need deterministic randomness per case but must not
+     leak that seed into the rest of the test process (build_*_fixture relies
+     on its own seeding for parameter init)."""
++    device_module = get_device_module()
+     cpu_state = torch.random.get_rng_state()
+-    cuda_state = torch.cuda.get_rng_state(device=device)
++    device_state = device_module.get_rng_state(device=device)
+     try:
+         torch.manual_seed(seed)
+-        torch.cuda.manual_seed_all(seed)
++        device_module.manual_seed_all(seed)
+         yield
+     finally:
+         torch.random.set_rng_state(cpu_state)
+-        torch.cuda.set_rng_state(cuda_state, device=device)
++        device_module.set_rng_state(device_state, device=device)
+ 
+ 
+ @contextmanager
+ def _single_rank_graph_capture(stream=None):
+     # Mirrors `graph_capture(stream=None)`: capture runs on the caller's stream
+     # when it leases one, so the shim stays valid for both call shapes.
+-    yield SimpleNamespace(stream=stream if stream is not None else torch.cuda.Stream())
++    yield SimpleNamespace(
++        stream=stream if stream is not None else get_device_module().Stream()
++    )
+ 
+ 
+ def _reset_cuda_graph_test_buffers() -> None:
+diff --git a/test/registered/attention/unittests/dense/test_triton.py b/test/registered/attention/unittests/dense/test_triton.py
+index 5cb86c296e..7933988446 100644
+--- a/test/registered/attention/unittests/dense/test_triton.py
++++ b/test/registered/attention/unittests/dense/test_triton.py
+@@ -3,8 +3,12 @@ import unittest
+ import torch
+ 
+ from sglang.srt.model_executor.forward_batch_info import ForwardMode
+-from sglang.srt.utils import is_hip
+-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
++from sglang.srt.utils import get_device_module, is_hip
++from sglang.test.ci.ci_register import (
++    register_amd_ci,
++    register_cuda_ci,
++    register_xpu_ci,
++)
+ from sglang.test.kits.attention_unittest.attention_methods.dense_attention import (
+     DenseAttentionCase,
+     make_dense_cases,
+@@ -33,9 +37,10 @@ from sglang.test.test_utils import CustomTestCase
+ register_cuda_ci(est_time=25, stage="base-b", runner_config="4-gpu-b200")
+ register_cuda_ci(est_time=25, stage="base-b", runner_config="1-gpu-large")
+ register_amd_ci(est_time=25, suite="stage-b-test-1-gpu-large-amd")
++register_xpu_ci(est_time=25, suite="stage-b-test-1-gpu-xpu")
+ 
+ 
+-@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
++@unittest.skipIf(not get_device_module().is_available(), "an accelerator is required")
+ class TestTritonDenseAttentionBackendCorrectness(CustomTestCase):
+     CASES = make_dense_cases("triton")
+     CUDA_GRAPH_CASES = (

--- a/scripts/test-triton.sh
+++ b/scripts/test-triton.sh
@@ -978,11 +978,15 @@ run_sglang_attention_tests() {
 
   enter_sglang_test_env
   # KV index build, decode/extend/prefill attention.
+  # unittests/dense/test_triton.py drives the same kernels through RadixAttention
+  # against HF-style torch references, and is the only thing here that covers
+  # get_num_kv_splits_triton. sglang-test-fix.patch makes it device-agnostic.
   # test_fp4_indexer.py is left out: it imports sgl_kernel, which is not installed.
   TRITON_TEST_SUITE=sglang_attention \
     run_pytest_command -vvv \
       test/registered/attention/test_create_kvindices.py \
-      test/registered/attention/test_triton_attention_kernels.py
+      test/registered/attention/test_triton_attention_kernels.py \
+      test/registered/attention/unittests/dense/test_triton.py
 }
 
 run_sglang_quant_tests() {


### PR DESCRIPTION
Enables the upstream dense attention unittests in --sglang-attention. They were skipped on XPU because test_triton.py gates on torch.cuda.is_available() and the kit hardcodes DEFAULT_DEVICE = "cuda". The patch routes the gate, the RNG seeding and the capture stream through get_device_module() and adds register_xpu_ci.  Takes the suite from 8 to 18 passed, no new skips. It is also the only test there that touches **get_num_kv_splits_triton**.

Closes #8010 