### PR TITLE
[BlockIO] Bounds-check batch dimensions of rank>2 descriptor block loads

### DIFF
--- a/python/test/unit/intel/test_block_io.py
+++ b/python/test/unit/intel/test_block_io.py
@@ -297,3 +297,111 @@ def test_block_io_nd(shape, dtype_str, block_io, device, tmp_path: pathlib.Path)
         llir = kernel.asm["llir"]
         load_count = llir.count('spirv_Subgroup2DBlockLoad') + llir.count('GenISA.LSC2DBlockRead')
         assert load_count > 0
+
+
+# An out-of-bounds descriptor read must return the padding value in ANY dimension, batch
+# dimensions included. The batch offset is folded into the base pointer, which escapes the
+# hardware surface clamp entirely, so it needs its own boundary check (issue #7922).
+#
+# The source is allocated DEEPER than the shape DECLARED on the descriptor and the extra
+# planes hold a sentinel, so a sentinel coming back is direct proof the check was skipped.
+OOB_SENTINEL = 7.0
+OOB_TILE_SHAPE = [64, 64, 32]
+# The declared batch extent differs from the tile extent (64), so an implementation that
+# bounds the batch dimension by the tile extent instead of the declared extent is caught.
+OOB_DECLARED_SHAPE = [32, 64, 32]
+OOB_ALLOC_SHAPE = [128, 64, 32]
+# Offset 31 against declared extent 32 leaves exactly ONE plane in bounds and 33 out, so
+# per-sub-tile predication is required and an all-or-nothing check fails. That one valid
+# plane also keeps the test from passing vacuously on an all-padding result.
+OOB_OFFSETS = [31, 0, 0]
+
+
+def expected_oob_tile(src, pad_value):
+    """Result element `r` reads descriptor coordinate `OOB_OFFSETS[d] + r_d`, and is the
+    padding value unless EVERY coordinate lies inside the declared shape."""
+    grids = torch.meshgrid(*[torch.arange(s, device=src.device) for s in OOB_TILE_SHAPE], indexing="ij")
+
+    coords, valid = [], torch.ones(OOB_TILE_SHAPE, dtype=torch.bool, device=src.device)
+    for d, grid in enumerate(grids):
+        c = grid.long() + OOB_OFFSETS[d]
+        valid &= (c >= 0) & (c < OOB_DECLARED_SHAPE[d])
+        # Clamp so the gather itself stays inside the allocation; masked out below.
+        coords.append(c.clamp(0, src.shape[d] - 1))
+
+    pad = torch.tensor(pad_value, dtype=src.dtype, device=src.device)
+    return torch.where(valid, src[tuple(coords)], pad)
+
+
+@pytest.mark.parametrize("padding", ["zero", "nan"])
+@pytest.mark.skipif(not is_xpu(), reason="Block load tests are specific to the XPU backend")
+def test_block_io_nd_out_of_bounds(padding, device, tmp_path: pathlib.Path):
+    if not triton.runtime.driver.active.get_current_target().arch['has_2d_block_io']:
+        pytest.skip("Target has no 2D block IO support, so the block load path is never taken")
+
+    ty, torch_dtype = "f16", torch.float16
+    rank = len(OOB_TILE_SHAPE)
+    layout = BlockedLayout([1, 1, 1], [1, 2, 16], [8, 4, 1], [2, 1, 0])
+
+    def consts(name, values, mlir_ty):
+        return "\n            ".join(f"%{name}{i} = arith.constant {v} : {mlir_ty}" for i, v in enumerate(values))
+
+    def refs(name):
+        return ", ".join(f"%{name}{i}" for i in range(rank))
+
+    def dense_strides(s):
+        return list(np.cumprod([1] + s[:0:-1]))[::-1]
+
+    # PAD_ZERO = 1, PAD_NAN = 2. The option is declared on the descriptor; the block IO
+    # rewrite propagates it onto the load as `ttig.desc_padding`.
+    pad_nan = padding == "nan"
+    desc_pad = " {padding = 2 : i32}" if pad_nan else ""
+    load_pad = ", ttig.desc_padding = 2 : i32" if pad_nan else ""
+
+    tile_type = "x".join(str(s) for s in OOB_TILE_SHAPE) + f"x{ty}"
+
+    # Dims come from the declared shape but strides are dense over the whole allocation,
+    # so an out-of-range batch index lands on sentinel memory, not an unmapped page.
+    ir = f"""
+    #layout = {layout}
+    module attributes {{ttig.support_2d_block_io, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = {int(np.prod(warps_per_cta(layout)))} : i32, ttg.target = "xpu", "ttg.threads-per-warp" = {int(np.prod(layout.threads_per_warp))} : i32}} {{
+        tt.func public @block_load_oob(%src: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}, %dst: !tt.ptr<{ty}> {{tt.divisibility = 16 : i32}}) {{
+            {consts("src_dim", OOB_DECLARED_SHAPE, "i32")}
+            {consts("src_str", dense_strides(OOB_ALLOC_SHAPE), "i64")}
+            {consts("src_off", OOB_OFFSETS, "i32")}
+            {consts("dst_dim", OOB_TILE_SHAPE, "i32")}
+            {consts("dst_str", dense_strides(OOB_TILE_SHAPE), "i64")}
+            {consts("dst_off", [0] * rank, "i32")}
+
+            %src_desc = tt.make_tensor_descriptor %src, [{refs("src_dim")}], [{refs("src_str")}]{desc_pad} : !tt.ptr<{ty}>, !tt.tensordesc<{tile_type}>
+            %val = tt.descriptor_load %src_desc[{refs("src_off")}] {{ttig.block_io = "row_major"{load_pad}}} : !tt.tensordesc<{tile_type}> -> tensor<{tile_type}, #layout>
+
+            %dst_desc = tt.make_tensor_descriptor %dst, [{refs("dst_dim")}], [{refs("dst_str")}] : !tt.ptr<{ty}>, !tt.tensordesc<{tile_type}>
+            tt.descriptor_store %dst_desc[{refs("dst_off")}], %val {{ttig.block_io = "row_major"}} : !tt.tensordesc<{tile_type}>, tensor<{tile_type}, #layout>
+
+            tt.return
+        }}
+    }}
+    """
+
+    src = torch.full(OOB_ALLOC_SHAPE, OOB_SENTINEL, dtype=torch_dtype, device=device)
+    # The per-plane ramp keeps a correct read distinguishable from a constant fill.
+    plane_ramp = torch.arange(OOB_DECLARED_SHAPE[0], dtype=torch_dtype, device=device) * 0.01
+    src[:32, :64, :32] = 3.0 + plane_ramp.reshape(-1, 1, 1)
+    x = torch.full(OOB_TILE_SHAPE, -1.0, dtype=torch_dtype, device=device)
+
+    temp_file = tmp_path / "test_block_io_nd_out_of_bounds.ttgir"
+    temp_file.write_text(ir)
+    kernel = triton.compile(str(temp_file))
+
+    kernel[(1, 1, 1)](src, x)
+    expect = expected_oob_tile(src, float("nan") if pad_nan else 0.0)
+    torch.testing.assert_close(
+        x, expect, rtol=0, atol=0, equal_nan=True,
+        msg=lambda default: f"{default}\nsentinel leaked into {int((x == OOB_SENTINEL).sum())} element(s)")
+
+    # Without this the tile could have been lowered to a gather, which predicates every
+    # element anyway and would pass while leaving the block load path untested.
+    llir = kernel.asm["llir"]
+    load_count = llir.count('spirv_Subgroup2DBlockLoad') + llir.count('GenISA.LSC2DBlockRead')
+    assert load_count > 0

--- a/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
+++ b/test/TritonIntelGPU/2d-block-load-to-llvm.mlir
@@ -205,11 +205,23 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth=1}>
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
   // CHECK-LABEL: @block_load_batch_rank3
-  tt.func public @block_load_batch_rank3(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i64) {
+  tt.func public @block_load_batch_rank3(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i64, %arg7: i32, %arg8: i32) {
     // CHECK: %[[BOFF:.*]] = llvm.mul %{{.*}}, %arg6 : i64
     // CHECK: %[[BPTR:.*]] = llvm.getelementptr %{{.*}}{{\[}}%[[BOFF]]{{\]}} : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f16
+    // COM: The batch offset is folded into the base pointer, which re-bases the
+    // COM: 2D surface and so escapes the hardware's base_width x base_height
+    // COM: clamp. It must be bounds-checked against the descriptor's declared
+    // COM: extent instead (issue #7922). Signed compares, because a negative
+    // COM: descriptor index is out of bounds and must not wrap.
+    // CHECK: %[[IDX:.*]] = llvm.add %arg7, %{{.*}} : i32
+    // CHECK-DAG: %[[GE0:.*]] = llvm.icmp "sge" %[[IDX]], %{{.*}} : i32
+    // CHECK-DAG: %[[LT:.*]] = llvm.icmp "slt" %[[IDX]], %arg8 : i32
+    // CHECK: %[[PRED:.*]] = llvm.and %[[GE0]], %[[LT]]
+    // COM: A failing check pushes the Y coordinate past base_height, so the
+    // COM: hardware returns the zero padding instead of reading the surface.
+    // CHECK: llvm.select %[[PRED]]
     // CHECK: triton_gen.2Dblockload %[[BPTR]]
-    %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] batch_strides[%arg6] {row_major} : !tt.ptr<f16> -> tensor<2x64x32xf16, #dot0>
+    %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] batch_strides[%arg6] batch_offsets[%arg7] batch_shapes[%arg8] {row_major} : !tt.ptr<f16> -> tensor<2x64x32xf16, #dot0>
     tt.return
   }
 }
@@ -222,13 +234,24 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
 #blocked = #ttg.blocked<{sizePerThread = [1, 1, 8, 1], threadsPerWarp = [1, 1, 1, 16], warpsPerCTA = [2, 2, 2, 1], order = [3, 2, 1, 0]}>
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
   // CHECK-LABEL: @block_load_batch_rank4
-  tt.func public @block_load_batch_rank4(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i64, %arg7: i64) {
+  tt.func public @block_load_batch_rank4(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i64, %arg7: i64, %arg8: i32, %arg9: i32, %arg10: i32, %arg11: i32) {
     // CHECK: %[[B0:.*]] = llvm.mul %{{.*}}, %arg6 : i64
     // CHECK: %[[P0:.*]] = llvm.getelementptr %{{.*}}{{\[}}%[[B0]]{{\]}} : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f16
+    // COM: Each batch dim is bounds-checked against ITS OWN declared extent,
+    // COM: interleaved with the GEP chain: dim 0 against %arg10, dim 1 against
+    // COM: %arg11. Checking both against one extent would be an indexing bug
+    // COM: (issue #7922).
+    // CHECK: %[[LT0:.*]] = llvm.icmp "slt" %{{.*}}, %arg10 : i32
+    // CHECK: %[[PRED0:.*]] = llvm.and %{{.*}}, %[[LT0]] : i1
     // CHECK: %[[B1:.*]] = llvm.mul %{{.*}}, %arg7 : i64
     // CHECK: %[[P1:.*]] = llvm.getelementptr %[[P0]]{{\[}}%[[B1]]{{\]}} : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f16
+    // CHECK: %[[LT1:.*]] = llvm.icmp "slt" %{{.*}}, %arg11 : i32
+    // CHECK: %[[PRED1:.*]] = llvm.and %{{.*}}, %[[LT1]] : i1
+    // COM: Both dimensions must gate the load, so their predicates are ANDed.
+    // CHECK: %[[PRED:.*]] = llvm.and %[[PRED0]], %[[PRED1]] : i1
+    // CHECK: llvm.select %[[PRED]]
     // CHECK: triton_gen.2Dblockload %[[P1]]
-    %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] batch_strides[%arg6, %arg7] {row_major} : !tt.ptr<f16> -> tensor<2x2x16x16xf16, #blocked>
+    %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] batch_strides[%arg6, %arg7] batch_offsets[%arg8, %arg9] batch_shapes[%arg10, %arg11] {row_major} : !tt.ptr<f16> -> tensor<2x2x16x16xf16, #blocked>
     tt.return
   }
 }
@@ -241,12 +264,41 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32,
 #dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth=2}>
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
   // CHECK-LABEL: @block_load_batch_rank3_column_major
-  tt.func public @block_load_batch_rank3_column_major(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i64) {
+  tt.func public @block_load_batch_rank3_column_major(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i64, %arg7: i32, %arg8: i32) {
     // CHECK: %[[BOFF:.*]] = llvm.mul %{{.*}}, %arg6 : i64
     // CHECK: %[[BPTR:.*]] = llvm.getelementptr %{{.*}}{{\[}}%[[BOFF]]{{\]}} : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f16
     // CHECK: triton_gen.2Dblockload %[[BPTR]]
     // CHECK-SAME: transpose = true
-    %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] batch_strides[%arg6] {column_major} : !tt.ptr<f16> -> tensor<2x32x64xf16, #dot1>
+    %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] batch_strides[%arg6] batch_offsets[%arg7] batch_shapes[%arg8] {column_major} : !tt.ptr<f16> -> tensor<2x32x64xf16, #dot1>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Test a MIXED rank-reducing block load: the descriptor is rank 4 but the
+// COM: result is rank 3, so descriptor batch dim 0 is dropped while dim 1 is still
+// COM: spanned by the result layout. Both indices are folded into the base pointer
+// COM: and so escape the hardware surface clamp (issue #7922), but they need
+// COM: different checks: the dropped dim is uniform across sub-tiles, the retained
+// COM: one is not. This is the only case where `batch_offsets`/`batch_shapes` are
+// COM: indexed at a non-zero `rankDelta`, so it is what pins that mapping.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4, 2], repCluster = [1, 1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth=1}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: @block_load_batch_mixed_rank_reducing
+  tt.func public @block_load_batch_mixed_rank_reducing(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i64, %arg7: i32, %arg8: i32, %arg9: i32, %arg10: i32) {
+    // COM: Dropped dim 0: no sub-tile offset is added, so its index is compared
+    // COM: directly against its own extent.
+    // CHECK: llvm.icmp "slt" %arg7, %arg9 : i32
+    // COM: Retained dim 1 is offset by the sub-tile and checked against ITS extent.
+    // COM: Reading either operand list at the wrong `rankDelta` would compare
+    // COM: against %arg7/%arg9 here and silently bound the wrong dimension.
+    // CHECK: %[[IDX:.*]] = llvm.add %arg8, %{{.*}} : i32
+    // CHECK: llvm.icmp "slt" %[[IDX]], %arg10 : i32
+    // CHECK: llvm.select
+    // CHECK: triton_gen.2Dblockload
+    %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] batch_strides[%arg6] batch_offsets[%arg7, %arg8] batch_shapes[%arg9, %arg10] {row_major} : !tt.ptr<f16> -> tensor<2x64x32xf16, #dot0>
     tt.return
   }
 }
@@ -292,6 +344,47 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32,
   tt.func public @block_load_dot_b_subgroup32_transpose(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
     // CHECK: triton_gen.2Dblockload {{.*}} transpose = true
     %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] {column_major} : !tt.ptr<f16> -> tensor<32x32xf16, #dot>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Test pad_nan on a rank-3 (batched) block load. The NaN mask must bound the
+// COM: batch dim by the descriptor's declared extent at the descriptor's index,
+// COM: not by the tile extent at index 0 (issue #7922). All NaN-mask IR is emitted
+// COM: before any address IR, so a compare against the declared extent %arg8 that
+// COM: precedes the batch-stride multiply can only come from the mask.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4, 2], repCluster = [1, 1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth=1}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: @block_load_batch_rank3_pad_nan
+  tt.func public @block_load_batch_rank3_pad_nan(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i64, %arg7: i32, %arg8: i32) {
+    // COM: Bounding by the tile extent instead would never reference %arg8 here.
+    // CHECK: %[[EXT:.*]] = llvm.trunc %arg8
+    // CHECK: llvm.icmp "slt" %{{.*}}, %[[EXT]] : i32
+    // CHECK: triton_gen.2Dblockload
+    %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] batch_strides[%arg6] batch_offsets[%arg7] batch_shapes[%arg8] {row_major, pad_nan} : !tt.ptr<f16> -> tensor<2x64x32xf16, #dot0>
+    tt.return
+  }
+}
+
+// -----
+
+// COM: Test pad_nan on a rank-reducing block load. The dropped batch dim has no
+// COM: result dimension for the NaN mask to iterate, so its bounds check must be
+// COM: ANDed into every mask element instead (issue #7922). Without this, an
+// COM: out-of-range batch index yields zeros rather than NaN.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth=1}>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, "ttig.support_2d_block_io"} {
+  // CHECK-LABEL: @block_load_batch_rank_reducing_pad_nan
+  tt.func public @block_load_batch_rank_reducing_pad_nan(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32) {
+    // CHECK: %[[LT:.*]] = llvm.icmp "slt" %arg6, %arg7 : i32
+    // CHECK: %[[DROP:.*]] = llvm.and %{{.*}}, %[[LT]] : i1
+    // CHECK: llvm.and %[[DROP]], %{{.*}} : i1
+    // CHECK: triton_gen.2Dblockload
+    %0 = ttig.2d_block_load %arg0, %arg1, %arg2, %arg3[%arg4, %arg5] batch_offsets[%arg6] batch_shapes[%arg7] {row_major, pad_nan} : !tt.ptr<f16> -> tensor<64x32xf16, #dot0>
     tt.return
   }
 }

--- a/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
+++ b/test/TritonIntelGPU/LowerTo2DBlockLoad/descriptor-load.mlir
@@ -78,6 +78,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 // COM: The result layout also spans the batch dim, so the op must additionally
 // COM: carry that dim's real stride in `batch_strides` — the surface params
 // COM: describe a single tile plane and cannot express it (issue #7882).
+// COM: Because the descriptor rank is > 2 the op also carries one `batch_offsets`
+// COM: and one `batch_shapes` entry per descriptor batch dim, to bound-check the
+// COM: batch axis (issue #7922).
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4, 2], repCluster = [1, 1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
@@ -86,13 +89,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %c1_i64 = arith.constant 1 : i64
     %c0_i32 = arith.constant 0 : i32
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2, %arg3], [%arg4, %arg5, %c1_i64] : <f16>, <2x64x32xf16>
-    // CHECK: ttig.extract_desc
+    // CHECK: %[[SHAPE0:.*]] = ttig.extract_desc %{{.*}}[0] : <2x64x32xf16> -> i64
     // CHECK: %[[STRIDE0:.*]] = ttig.extract_desc %{{.*}}[3] : <2x64x32xf16> -> i64
     // CHECK: %[[BATCH_EXT:.*]] = arith.extsi %arg6 : i32 to i64
     // CHECK: %[[BATCH_OFF:.*]] = arith.muli %[[BATCH_EXT]], %[[STRIDE0]]
     // CHECK: %[[ADJ_PTR:.*]] = tt.addptr %{{.*}}, %[[BATCH_OFF]]
+    // CHECK: %[[SHAPE0_I32:.*]] = arith.trunci %[[SHAPE0]] : i64 to i32
     // CHECK: ttig.2d_block_load %[[ADJ_PTR]]
     // CHECK-SAME: batch_strides{{\[}}%[[STRIDE0]]{{\]}}
+    // CHECK-SAME: batch_offsets{{\[}}%arg6{{\]}}
+    // CHECK-SAME: batch_shapes{{\[}}%[[SHAPE0_I32]]{{\]}}
+    // CHECK-SAME: {row_major}
     %0 = tt.descriptor_load %desc[%batch_idx, %c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<2x64x32xf16> -> tensor<2x64x32xf16, #dot0>
     tt.return %0 : tensor<2x64x32xf16, #dot0>
   }
@@ -102,7 +109,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 
 // COM: 3D column-major descriptor load. A column_major load declares the descriptor's
 // COM: inner two dims swapped relative to the result (<2x64x32> -> <2x32x64>), so the
-// COM: batch dim is still leading and still needs its own stride.
+// COM: batch dim is still leading and still needs its own stride, plus its own
+// COM: `batch_offsets`/`batch_shapes` entry (issue #7922).
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4, 2], repCluster = [1, 1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot1 = #ttg.dot_op<{opIdx = 1, parent = #dpas, kWidth = 2}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
@@ -111,13 +119,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %c1_i64 = arith.constant 1 : i64
     %c0_i32 = arith.constant 0 : i32
     %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2, %arg3], [%arg4, %arg5, %c1_i64] : <f16>, <2x64x32xf16>
-    // CHECK: ttig.extract_desc
+    // CHECK: %[[SHAPE0:.*]] = ttig.extract_desc %{{.*}}[0] : <2x64x32xf16> -> i64
     // CHECK: %[[STRIDE0:.*]] = ttig.extract_desc %{{.*}}[3] : <2x64x32xf16> -> i64
     // CHECK: %[[BATCH_EXT:.*]] = arith.extsi %arg6 : i32 to i64
     // CHECK: %[[BATCH_OFF:.*]] = arith.muli %[[BATCH_EXT]], %[[STRIDE0]]
     // CHECK: %[[ADJ_PTR:.*]] = tt.addptr %{{.*}}, %[[BATCH_OFF]]
+    // CHECK: %[[SHAPE0_I32:.*]] = arith.trunci %[[SHAPE0]] : i64 to i32
     // CHECK: ttig.2d_block_load %[[ADJ_PTR]]
     // CHECK-SAME: batch_strides{{\[}}%[[STRIDE0]]{{\]}}
+    // CHECK-SAME: batch_offsets{{\[}}%arg6{{\]}}
+    // CHECK-SAME: batch_shapes{{\[}}%[[SHAPE0_I32]]{{\]}}
     // CHECK-SAME: {column_major}
     %0 = tt.descriptor_load %desc[%batch_idx, %c0_i32, %c0_i32] {ttig.block_io = "column_major"} : !tt.tensordesc<2x64x32xf16> -> tensor<2x32x64xf16, #dot1>
     tt.return %0 : tensor<2x32x64xf16, #dot1>
@@ -129,6 +140,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
 // COM: Rank-reducing descriptor load. The descriptor has rank 3 (with a leading
 // COM: size-1 batch dim) but the result tensor has rank 2. The batch index is
 // COM: folded into the base pointer via tt.addptr.
+// COM: Because the result rank is 2 the batch dim is NOT spanned by the result
+// COM: layout, so `batch_strides` stays EMPTY while `batch_offsets`/`batch_shapes`
+// COM: are still emitted for the bounds check (issue #7922).
 #dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
 #dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
@@ -138,12 +152,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %c1_i64 = arith.constant 1 : i64
     %c0_i32 = arith.constant 0 : i32
     %desc = tt.make_tensor_descriptor %arg0, [%c1_i32, %arg1, %arg2], [%arg3, %c1_i64, %c1_i64] : <f16>, <1x64x32xf16>
-    // CHECK: ttig.extract_desc
+    // CHECK: %[[SHAPE0:.*]] = ttig.extract_desc %{{.*}}[0] : <1x64x32xf16> -> i64
     // CHECK: ttig.extract_desc
     // CHECK: %[[BATCH_EXT:.*]] = arith.extsi %arg4 : i32 to i64
     // CHECK: %[[BATCH_OFF:.*]] = arith.muli %[[BATCH_EXT]], %{{.*}}
     // CHECK: %[[ADJ_PTR:.*]] = tt.addptr %{{.*}}, %[[BATCH_OFF]]
+    // CHECK: %[[SHAPE0_I32:.*]] = arith.trunci %[[SHAPE0]] : i64 to i32
     // CHECK: ttig.2d_block_load %[[ADJ_PTR]]
+    // CHECK-SAME: batch_offsets{{\[}}%arg4{{\]}}
+    // CHECK-SAME: batch_shapes{{\[}}%[[SHAPE0_I32]]{{\]}}
+    // CHECK-SAME: {row_major}
     %0 = tt.descriptor_load %desc[%batch_idx, %c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<1x64x32xf16> -> tensor<64x32xf16, #dot0>
     tt.return %0 : tensor<64x32xf16, #dot0>
   }
@@ -227,5 +245,34 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %b_k = tt.descriptor_load %k_desc[%c0_i32, %c0_i32] {ttig.block_io = "column_major", ttig.desc_padding = 1 : i32} : !tt.tensordesc<64x64xbf16> -> tensor<64x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
 
     tt.return
+  }
+}
+
+// -----
+
+// COM: Rank-4 descriptor load, rank-reducing to 2. With two batch dims the operand
+// COM: ORDER becomes observable: both lists must be outermost-first, so that entry i
+// COM: of each describes the same descriptor dim (issue #7922). The dims are distinct
+// COM: SSA values so a reversed list cannot match.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [4, 2], repCluster = [1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  // CHECK-LABEL: tt.func @descriptor_load_two_batch_dims
+  tt.func @descriptor_load_two_batch_dims(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i64, %bi0: i32, %bi1: i32) -> tensor<64x32xf16, #dot0> {
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg2, %arg3, %arg4], [%arg5, %arg5, %c1_i64, %c1_i64] : <f16>, <1x1x64x32xf16>
+    // CHECK: %[[SHAPE0:.*]] = ttig.extract_desc %{{.*}}[0] : <1x1x64x32xf16> -> i64
+    // CHECK: %[[SHAPE1:.*]] = ttig.extract_desc %{{.*}}[1] : <1x1x64x32xf16> -> i64
+    // CHECK: %[[S0:.*]] = arith.trunci %[[SHAPE0]] : i64 to i32
+    // CHECK: %[[S1:.*]] = arith.trunci %[[SHAPE1]] : i64 to i32
+    // CHECK: ttig.2d_block_load
+    // COM: `AttrSizedOperandSegments` must not leak its attribute into printed IR.
+    // CHECK-NOT: operandSegmentSizes
+    // CHECK-SAME: batch_offsets{{\[}}%arg6, %arg7{{\]}}
+    // CHECK-SAME: batch_shapes{{\[}}%[[S0]], %[[S1]]{{\]}}
+    // CHECK-SAME: {row_major}
+    %0 = tt.descriptor_load %desc[%bi0, %bi1, %c0_i32, %c0_i32] {ttig.block_io = "row_major"} : !tt.tensordesc<1x1x64x32xf16> -> tensor<64x32xf16, #dot0>
+    tt.return %0 : tensor<64x32xf16, #dot0>
   }
 }

--- a/test/TritonIntelGPU/tritonintelgpu-invalid.mlir
+++ b/test/TritonIntelGPU/tritonintelgpu-invalid.mlir
@@ -228,3 +228,33 @@ tt.func @invalid_desc_scatter_src_rank(%arg0: !tt.tensordesc<1x128xbf16>, %arg1:
   ttig.descriptor_scatter %arg0[%arg1, %arg2], %arg3 : !tt.tensordesc<1x128xbf16>, tensor<32xi32>, i32, tensor<128xbf16>
   tt.return
 }
+
+// -----
+
+// COM: `batch_offsets` and `batch_shapes` are the descriptor index and its
+// COM: declared extent for the same batch dim, so they only bounds-check when
+// COM: they come in pairs.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4, 2], repCluster = [1, 1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  tt.func @mismatched_batch_offsets_shapes(%base_ptr: !tt.ptr<f16>, %width: i32, %height: i32, %pitch: i32, %x: i32, %y: i32, %batch_stride: i64, %batch_offset: i32, %batch_shape0: i32, %batch_shape1: i32) -> tensor<2x64x32xf16, #dot0> {
+    // expected-error @below {{'ttig.2d_block_load' op expected the same number of batch offsets and batch shapes, got 1 and 2}}
+    %0 = ttig.2d_block_load %base_ptr, %width, %height, %pitch[%x, %y] batch_strides[%batch_stride] batch_offsets[%batch_offset] batch_shapes[%batch_shape0, %batch_shape1] {row_major} : !tt.ptr<f16> -> tensor<2x64x32xf16, #dot0>
+    tt.return %0 : tensor<2x64x32xf16, #dot0>
+  }
+}
+
+// -----
+
+// COM: Every descriptor batch dim escapes the hardware surface clamp once its
+// COM: offset is folded into the base pointer, so the descriptor must supply at
+// COM: least as many batch offsets as the result has batch strides.
+#dpas = #ttig.dpas<{repeatCount = 8, systolicDepth = 8, executionSize = 16, opsPerChan = 2, threadsPerWarp = 16, warpsPerCTA = [1, 4, 2], repCluster = [1, 1, 1], A = [8, 16], B = [16, 16], C = [8, 16]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #dpas, kWidth = 1}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 16 : i32, ttig.support_2d_block_io} {
+  tt.func @too_few_batch_offsets(%base_ptr: !tt.ptr<f16>, %width: i32, %height: i32, %pitch: i32, %x: i32, %y: i32, %batch_stride: i64) -> tensor<2x64x32xf16, #dot0> {
+    // expected-error @below {{'ttig.2d_block_load' op expected at least 1 batch offset(s), one per descriptor batch dimension, got 0}}
+    %0 = ttig.2d_block_load %base_ptr, %width, %height, %pitch[%x, %y] batch_strides[%batch_stride] {row_major} : !tt.ptr<f16> -> tensor<2x64x32xf16, #dot0>
+    tt.return %0 : tensor<2x64x32xf16, #dot0>
+  }
+}

--- a/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
+++ b/third_party/intel/include/Dialect/TritonIntelGPU/IR/TritonIntelGPUOps.td
@@ -208,7 +208,9 @@ def TTIG_ExtractDescOp : TTIG_Op<"extract_desc", [Pure]> {
   let assemblyFormat = "$desc `[` $index `]` attr-dict `:` type($desc) `->` type($result)";
 }
 
-def TTIG_Subgroup2DBlockLoadOp : TTIG_Op<"2d_block_load"> {
+def TTIG_Subgroup2DBlockLoadOp : TTIG_Op<"2d_block_load", [
+  AttrSizedOperandSegments
+]> {
   let summary = "2D block load from a descriptor-based surface";
   let description = [{
     Loads a 2D tile from a memory surface described by decomposed parameters.
@@ -234,6 +236,17 @@ def TTIG_Subgroup2DBlockLoadOp : TTIG_Op<"2d_block_load"> {
     / `base_pitch` (those describe a single 2D surface only), so they must be
     supplied by the producer of this op.
 
+    `batch_offsets` and `batch_shapes` carry the index and the declared extent
+    of every batch dimension of the *descriptor*, outermost first. They are used
+    only to bounds-check those dimensions: `base_ptr` already includes every
+    batch offset, so a batch index escapes the hardware's `base_width` x
+    `base_height` clamp and cannot be checked by the hardware. Unlike
+    `batch_strides`, which describes only what the result layout walks
+    (`rank - 2` entries), these describe the descriptor (`descriptor_rank - 2`
+    entries) and so also cover the leading dimensions a rank-reducing load
+    drops. The dropped dimensions are therefore the first
+    `batch_offsets.size() - batch_strides.size()` entries.
+
     When `pad_nan` is set, the LLVM lowering builds boundary masks from
     the surface dimensions and fills out-of-bounds elements with NaN.
     Otherwise, the hardware zero-fills out-of-bounds elements.
@@ -248,6 +261,8 @@ def TTIG_Subgroup2DBlockLoadOp : TTIG_Op<"2d_block_load"> {
     I32:$offset_x,
     I32:$offset_y,
     Variadic<I64>:$batch_strides,
+    Variadic<I32>:$batch_offsets,
+    Variadic<I32>:$batch_shapes,
     OptionalAttr<UnitAttr>:$pad_nan,
     TTIG_BlockIOMode:$memory_layout
   );
@@ -257,6 +272,8 @@ def TTIG_Subgroup2DBlockLoadOp : TTIG_Op<"2d_block_load"> {
     $base_ptr `,` $base_width `,` $base_height `,` $base_pitch
     `[` $offset_x `,` $offset_y `]`
     (`batch_strides` `[` $batch_strides^ `]`)?
+    (`batch_offsets` `[` $batch_offsets^ `]`)?
+    (`batch_shapes` `[` $batch_shapes^ `]`)?
     `{` $memory_layout (`,` `pad_nan` $pad_nan^)? `}`
     attr-dict `:` type($base_ptr) `->` type($result)
   }];

--- a/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
+++ b/third_party/intel/lib/Dialect/TritonIntelGPU/IR/Ops.cpp
@@ -138,6 +138,19 @@ LogicalResult Subgroup2DBlockLoadOp::verify() {
            << (rank - 2) << " batch stride(s) for a rank-" << rank
            << " result, got " << getBatchStrides().size();
 
+  if (getBatchOffsets().size() != getBatchShapes().size())
+    return emitOpError("expected the same number of batch offsets and batch "
+                       "shapes, got ")
+           << getBatchOffsets().size() << " and " << getBatchShapes().size();
+
+  // A rank-reducing load drops leading descriptor dimensions from the result,
+  // so the descriptor has at least as many batch dimensions as the result.
+  if (getBatchOffsets().size() < getBatchStrides().size())
+    return emitOpError("expected at least ")
+           << getBatchStrides().size()
+           << " batch offset(s), one per descriptor batch dimension, got "
+           << getBatchOffsets().size();
+
   return success();
 }
 

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -4547,6 +4547,8 @@ struct Subgroup2DBlockLoadOpConversion
     Value baseOffsetX = adaptor.getOffsetX();
     Value baseOffsetY = adaptor.getOffsetY();
     ValueRange batchStrides = adaptor.getBatchStrides();
+    ValueRange batchOffsets = adaptor.getBatchOffsets();
+    ValueRange batchShapes = adaptor.getBatchShapes();
 
     Value elemBytes = b.i32_val(elemSizeInBits / 8);
 
@@ -4581,28 +4583,6 @@ struct Subgroup2DBlockLoadOpConversion
       baseOffsetX = b.add(baseOffsetX, misalignElems);
     }
 
-    // Build NaN masks if pad_nan is set.
-    SmallVector<Value> nanMaskElems;
-    if (op.getPadNan()) {
-      SmallVector<Value> resultOffsets(rank, b.i32_val(0));
-      SmallVector<Value> resultShapes(rank);
-      for (unsigned i = 0; i < rank; ++i) {
-        if (static_cast<int>(i) == cfg.rowDim)
-          resultShapes[i] = baseHeight;
-        else if (static_cast<int>(i) == cfg.colDim)
-          resultShapes[i] = b.udiv(baseWidth, elemBytes);
-        else
-          resultShapes[i] = b.i32_val(tensorType.getDimSize(i));
-      }
-      unsigned surfaceColDim = contiguousDim;
-      unsigned surfaceRowDim =
-          (contiguousDim == rank - 1) ? rank - 2 : rank - 1;
-      resultOffsets[surfaceColDim] = baseOffsetX;
-      resultOffsets[surfaceRowDim] = baseOffsetY;
-      nanMaskElems =
-          buildNaNMasks(loc, resultOffsets, resultShapes, tensorType, rewriter);
-    }
-
     unsigned blockRowIdx = cfg.isTransposeRequired ? cfg.colDim : cfg.rowDim;
     unsigned blockColIdx = cfg.isTransposeRequired ? cfg.rowDim : cfg.colDim;
 
@@ -4619,12 +4599,73 @@ struct Subgroup2DBlockLoadOpConversion
         std::max(blockRowIdx, blockColIdx) != rank - 1)
       return failure();
 
+    // Descriptor batch dimensions the result layout does not span, because a
+    // rank-reducing load dropped them. They are the leading entries of
+    // `batch_offsets`/`batch_shapes`, so descriptor batch dimension
+    // `rankDelta + d` corresponds to result batch dimension `d`.
+    unsigned rankDelta = batchOffsets.size() - batchStrides.size();
+
+    auto andPred = [&](Value acc, Value pred) -> Value {
+      return acc ? Value(b.and_(acc, pred)) : pred;
+    };
+
+    // A batch index is folded into the base pointer, so it escapes the
+    // hardware's base_width x base_height clamp and needs an explicit check.
+    // Compare signed: a negative descriptor index is out of bounds, and an
+    // overflowing sum wraps negative rather than becoming spuriously in range.
+    auto inDescBounds = [&](Value index, Value shape) -> Value {
+      Value isNonNegative = b.icmp_sge(index, b.i32_val(0));
+      Value isBelowShape = b.icmp_slt(index, shape);
+      return b.and_(isNonNegative, isBelowShape);
+    };
+
+    // Dropped dimensions are not spanned by the result layout, so their bounds
+    // check is the same for every sub-tile. Emit it once here rather than
+    // rebuilding it inside `computeAddress`.
+    Value droppedDimPred;
+    for (unsigned d = 0; d < rankDelta; ++d)
+      droppedDimPred = andPred(droppedDimPred,
+                               inDescBounds(batchOffsets[d], batchShapes[d]));
+
+    // Build NaN masks if pad_nan is set.
+    SmallVector<Value> nanMaskElems;
+    if (op.getPadNan()) {
+      SmallVector<Value> resultOffsets(rank, b.i32_val(0));
+      SmallVector<Value> resultShapes(rank);
+      for (unsigned i = 0; i < rank; ++i) {
+        if (static_cast<int>(i) == cfg.rowDim)
+          resultShapes[i] = baseHeight;
+        else if (static_cast<int>(i) == cfg.colDim)
+          resultShapes[i] = b.udiv(baseWidth, elemBytes);
+        else {
+          // Batch dimension: bound it by the descriptor's declared extent at
+          // the descriptor's index. The tile extent at index 0 would mark every
+          // element in range and pad nothing.
+          resultShapes[i] = batchShapes[i + rankDelta];
+          resultOffsets[i] = batchOffsets[i + rankDelta];
+        }
+      }
+      unsigned surfaceColDim = contiguousDim;
+      unsigned surfaceRowDim =
+          (contiguousDim == rank - 1) ? rank - 2 : rank - 1;
+      resultOffsets[surfaceColDim] = baseOffsetX;
+      resultOffsets[surfaceRowDim] = baseOffsetY;
+      nanMaskElems =
+          buildNaNMasks(loc, resultOffsets, resultShapes, tensorType, rewriter);
+      // Dropped dimensions have no result dimension for the mask to iterate, so
+      // gate every element on their bounds check instead.
+      if (droppedDimPred)
+        for (Value &mask : nanMaskElems)
+          mask = b.and_(droppedDimPred, mask);
+    }
+
     // Per-sub-tile: combine base offsets with linear layout offsets.
     auto computeAddress =
         [&](unsigned /*registerIdx*/,
             ArrayRef<std::pair<StringAttr, Value>> offsets) -> SubTileAddress {
       Value addrElem = basePtr;
       Value offsetX, offsetY;
+      Value pred = droppedDimPred;
       unsigned surfaceColDim = contiguousDim;
       unsigned surfaceRowDim =
           (contiguousDim == rank - 1) ? rank - 2 : rank - 1;
@@ -4647,10 +4688,14 @@ struct Subgroup2DBlockLoadOpConversion
           Value offset64 = b.zext(int_ty(64), adjustedOffset);
           Value batchOffset = b.mul(offset64, batchStrides[dim]);
           addrElem = b.gep(ptr_ty(ctx, 1), eltTy, addrElem, batchOffset);
+          // The descriptor index is already in `basePtr`, so the coordinate to
+          // bounds-check is that index plus this sub-tile's layout offset.
+          unsigned descDim = dim + rankDelta;
+          Value index = b.add(batchOffsets[descDim], adjustedOffset);
+          pred = andPred(pred, inDescBounds(index, batchShapes[descDim]));
         }
       }
-      return {addrElem,        offsetX, offsetY, baseWidth, baseHeight,
-              /*pred=*/Value()};
+      return {addrElem, offsetX, offsetY, baseWidth, baseHeight, pred};
     };
 
     return lowerBlockLoad2D(op, cfg, *llEncoding, pitch, computeAddress,

--- a/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
+++ b/third_party/intel/lib/TritonIntelGPUTransforms/LowerTo2DBlockLoad.cpp
@@ -311,13 +311,23 @@ private:
     for (unsigned d = 0; d + 2 < rank; ++d)
       batchStrides.push_back(strides[d + (descRank - rank)]);
 
+    // Batch indices folded into base_ptr re-base the 2D surface, so they
+    // escape the hardware's clamp; the lowering needs each index and its
+    // declared extent to predicate the load. For that check only -- never for
+    // addressing, since base_ptr already carries the offsets.
+    SmallVector<Value> batchOffsets, batchShapes;
+    for (unsigned d = 0; d < numBatchDims; ++d) {
+      batchOffsets.push_back(indices[d]);
+      batchShapes.push_back(toI32(shapes[d]));
+    }
+
     // Determine padding mode from the descriptor.
     bool padNan = padding == tt::PaddingOption::PAD_NAN;
     UnitAttr padNanAttr = padNan ? builder.getUnitAttr() : UnitAttr();
 
     auto blockLoadOp = ttgi::Subgroup2DBlockLoadOp::create(
         builder, loc, op.getType(), basePtr, baseWidth, baseHeight, basePitch,
-        offsetX, offsetY, batchStrides, padNanAttr,
+        offsetX, offsetY, batchStrides, batchOffsets, batchShapes, padNanAttr,
         ttgi::BlockIOModeAttr::get(builder.getContext(), memLayout));
 
     // Propagate one_matrix_per_load attribute if present.


### PR DESCRIPTION

Fixes #7922

`Subgroup2DBlockLoadOpConversion::computeAddress` returned a null predicate
unconditionally, so batch dimensions were never bounds-checked. Batch offsets are
folded into the base pointer, which escapes the hardware's `base_width` x
`base_height` clamp, so an out-of-range batch index read out of bounds instead of
returning the descriptor's padding value. `pad_nan` was broken the same way, bounding
batch dimensions by the tile extent instead of the declared extent.

Adds `batch_offsets` and `batch_shapes` (both `Variadic<I32>`, arity `descRank - 2`)
to `ttig.2d_block_load`, used only for the predicate `index >= 0 && index < extent`;
the address computation is unchanged. Arity differs from `batch_strides`
(`resultRank - 2`), the difference being how many dimensions a rank-reducing load
dropped; those dropped dimensions are uniform across sub-tiles so their check is
emitted once. Rank-2 emits no batch operands and its codegen is unchanged.

Covered by lit assertions for rank-3, rank-4, mixed rank-reducing and `pad_nan`, two
verifier negative cases, producer checks, and an end-to-end `test_block_io.py` case
under both padding modes.
