### PR TITLE
[TritonIntelGPU] Enable AnnotateCacheControl by default on Windows too

### DIFF
--- a/python/test/unit/intel/test_regressions.py
+++ b/python/test/unit/intel/test_regressions.py
@@ -2060,3 +2060,21 @@ module {
     temp_file = tmp_path / "test_regression_7022.ttir"
     temp_file.write_text(ir)
     triton.compile(str(temp_file))
+
+
+def test_regression_7945_annotate_cache_control_enabled_on_every_os(fresh_knobs):
+    """`TRITON_INTEL_DISABLE_ANNOTATE_CACHE_CONTROL` used to default to
+    `os.name == "nt"`, keeping the `AnnotateCacheControl` pass off on Windows
+    after the regressions reported in
+    https://github.com/intel/intel-xpu-backend-for-triton/issues/7495. The
+    harmful `cg`-to-`!nontemporal` lowering, which IGC turns into an
+    L3-bypassing LSC access, was removed in #7901, so the pass is enabled on
+    every OS again (#7945). Windows CI observes the flip here.
+    """
+    assert fresh_knobs.intel.disable_annotate_cache_control is False
+
+
+@pytest.mark.parametrize("value, expected", [("1", True), ("0", False)])
+def test_regression_7945_annotate_cache_control_env_override(fresh_knobs, monkeypatch, value, expected):
+    monkeypatch.setenv("TRITON_INTEL_DISABLE_ANNOTATE_CACHE_CONTROL", value)
+    assert fresh_knobs.intel.disable_annotate_cache_control is expected

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -593,9 +593,10 @@ class intel_knobs(base_knobs):
     gen_native_code: env_bool = env_bool("TRITON_XPU_GEN_NATIVE_CODE", False)
     opt_reduction_locality: env_bool = env_bool("TRITON_INTEL_OPTIMIZE_REDUCTION_LOCALITY", False)
     disable_igc_opt: env_bool = env_bool("TRITON_INTEL_DISABLE_IGC_OPT", False)
-    # Enable the AnnotateCacheControl pass by default everywhere except Windows,
-    # where it triggers E2E performance regressions (see issue #7495).
-    disable_annotate_cache_control: env_bool = env_bool("TRITON_INTEL_DISABLE_ANNOTATE_CACHE_CONTROL", os.name == "nt")
+    # Disabled on Windows after the regressions tracked in issue #7495. The harmful
+    # `cg`-to-`!nontemporal` lowering (an L3 bypass) was removed in issue #7901, so
+    # the pass is enabled on every OS again. See issue #7945.
+    disable_annotate_cache_control: env_bool = env_bool("TRITON_INTEL_DISABLE_ANNOTATE_CACHE_CONTROL", False)
     enable_code_sinking: env_bool = env_bool("TRITON_INTEL_ENABLE_CODE_SINKING", False)
     disable_canonicalize_pointers: env_bool = env_bool("TRITON_INTEL_DISABLE_CANONICALIZE_POINTERS", True)
     enable_loop_distribution: env_bool = env_bool("TRITON_INTEL_ENABLE_LOOP_DISTRIBUTION", False)


### PR DESCRIPTION
Removes the `os.name == "nt"` default from `TRITON_INTEL_DISABLE_ANNOTATE_CACHE_CONTROL`, so `AnnotateCacheControl` runs on Windows too. Adds a regression test pinning the default.

- The carve-out was added in #7717 **only** to preserve the workaround for #7495, with no revisit condition recorded. The mechanism it guarded — `cg` lowering to `!nontemporal`, which IGC turns into an L3-bypassing access — was removed in #7901.
- Windows was never special here: the two lowering paths are selected by `ttig.support_predicated_io`, a driver-derived target capability, not by the OS.
- Measured on Arc B580 / Windows (driver `32.0.101.9999`): ten inference workloads all under a 1.05 one-sided 95% upper bound on the latency ratio, and the original #7495 configuration at a **0.30%** cost (upper bound 1.00355).
- Escape hatch unchanged: `TRITON_INTEL_DISABLE_ANNOTATE_CACHE_CONTROL=1`.

Closes #7945

<details>
<summary>Why the #7495 mechanism is gone</summary>

The pass annotates loads with the `cg` cache modifier and `EVICT_LAST`. `cg` used to lower to LLVM `!nontemporal`, which IGC turns into an LSC `.uc.uc` access — bypassing L3, not just L1. #7843 measured that at 1.58x on Linux, and #7901 removed it: on the non-predicated path `cg`/`cs` now emit nothing at all, and on the predicated path the hint travels as an explicit per-cache-level SPIR-V decoration that keeps **L3 cached**.

The pass emits only `CG` and `EVICT_LAST`, never `CS` — and #7901's predicated-path change touched only `CS` — so #7755's measurement of that path (4.63 ms with the pass vs 4.64 ms without) still describes the current code.

</details>

<details>
<summary>What was measured on Windows</summary>

**Codegen** — enabling the pass changed the inspected kernels only by adding L1-uncached / L3-cached decorations to selected masked loads. No `!nontemporal` metadata and no L3-uncached decoration appeared in any generated IR.

**Resources** — across 66 paired Inductor kernels, compiler-reported register count, spill count, shared memory and GRF mode were unchanged in every pair.

**Inference** — ten workloads, each confirmed to actually receive new annotations before being timed; all had a one-sided 95% upper bound below 1.05 after counterbalanced re-runs. Host instability was observed during the campaign, and an A-vs-A control showed noise of comparable scale.

**Accuracy (inference)** — no pass-to-fail case: five models passed both with and without the pass; five failed identically in both configurations during fp64-reference module loading.

**The #7495 configuration** — `DebertaV2ForQuestionAnswering`, training, AMP bfloat16, batch size 2. Enabling the pass added the `cg` decoration to six loads and changed nothing else: kernel count, predicated-load count, `evict_last` count, `!nontemporal` count (zero) and L3-uncached count (zero) were all identical. Over five counterbalanced pairs the median latency ratio was 1.0030. `UR_RESULT_ERROR_OUT_OF_RESOURCES` was not observed in either arm.

</details>

<details>
<summary>Limitations worth knowing</summary>

- **The training A/B ran on an older build.** Current `main` cannot execute a training graph on this driver at all: #7809 offers `SPV_EXT_long_vector` to any non-LTS driver, and this one does not implement it, so every attempt failed identically with and without the pass at device module load. The A/B therefore used `9fa71f9d5`, which contains #7901 and predates #7809. That extension-selection problem is unrelated to this change and is reported separately.
- **Effects at or below ~0.4% are not attributable to this change.** Measured drift was roughly 0.2% over fifteen minutes with identical binaries, and the two arms require separate cache directories.
- **This campaign cannot compare failure rates between arms** — one arm-B attempt was excluded and retried after an eager-path `UR_RESULT_ERROR_DEVICE_LOST`.
- **Training accuracy stayed untestable**, not neutral: both arms aborted identically in host-side `deepcopy` with an out-of-memory error, before any kernel compiled.
- **A DeBERTa inference A/B would be vacuous.** Inductor already emits `evict_last` on its loads and that lowering is not gated by this knob, so both configurations produce identical cache-control output — a neutral result there would mean nothing.
- Results apply to the tested CI driver rather than to customer drivers.

</details>