### PR TITLE
[CI] Run SGLang benchmarks on max1100 instead of max1550

### DIFF
--- a/.github/workflows/on-label.yml
+++ b/.github/workflows/on-label.yml
@@ -154,5 +154,5 @@ jobs:
       needs.select-benchmark-platforms.outputs.run-pvc-benchmarks == 'true'
     uses: ./.github/workflows/sglang-benchmarks.yml
     with:
-      runner_label: max1550
+      runner_label: max1100
     secrets: inherit

--- a/.github/workflows/sglang-benchmarks-pvc.yml
+++ b/.github/workflows/sglang-benchmarks-pvc.yml
@@ -34,5 +34,5 @@ jobs:
     if: always() && !cancelled()
     uses: ./.github/workflows/sglang-benchmarks.yml
     with:
-      runner_label: max1550
+      runner_label: max1100
     secrets: inherit

--- a/.github/workflows/sglang-benchmarks.yml
+++ b/.github/workflows/sglang-benchmarks.yml
@@ -43,7 +43,7 @@ jobs:
     name: SGLang benchmarks
     runs-on:
       - linux
-      - ${{ inputs.runner_label || 'max1550' }}
+      - ${{ inputs.runner_label || 'max1100' }}
     timeout-minutes: 720
     defaults:
       run:


### PR DESCRIPTION
The max1550 machines are failed, so every PR touching scripts/sglang queued a benchmarks job that could never be scheduled, and the nightly run never started. Switches the PVC workflow, the on-label job and the sglang-benchmarks.yml default to max1100.