### PR TITLE
Install Level Zero SDK on Windows CI

### DIFF
--- a/.github/WINDOWS.md
+++ b/.github/WINDOWS.md
@@ -45,6 +45,24 @@ Install Microsoft Visual Studio 2022 and make sure the following [components](ht
 Install [Intel® Deep Learning Essentials 2026.1](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html?packages=dl-essentials&dl-essentials-os=windows&dl-win=offline).
 By default, it is installed to `C:\Program Files (x86)\Intel\oneAPI`.
 
+### Level Zero SDK
+
+Intel® Deep Learning Essentials does not include Level Zero headers, which Triton needs to compile
+its device utilities. Download `level-zero-win-sdk-<version>.zip` from
+[Level Zero releases](https://github.com/oneapi-src/level-zero/releases) and unpack it, for example
+to `C:\level-zero-sdk`:
+
+```
+Expand-Archive -Path level-zero-win-sdk-1.33.1.zip -DestinationPath C:\level-zero-sdk
+```
+
+Point `LEVEL_ZERO_V1_SDK_PATH` at that directory and make it available in new PowerShell sessions:
+
+```
+$env:LEVEL_ZERO_V1_SDK_PATH = "C:\level-zero-sdk"
+[Environment]::SetEnvironmentVariable("LEVEL_ZERO_V1_SDK_PATH", $env:LEVEL_ZERO_V1_SDK_PATH, "User")
+```
+
 ### Chocolatey
 
 ```
@@ -168,6 +186,15 @@ Initialize environment variables:
 ```
 .venv\Scripts\activate.ps1
 Invoke-BatchFile "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+```
+
+Check that `LEVEL_ZERO_V1_SDK_PATH` points to a usable Level Zero SDK, otherwise Triton fails to
+compile its device utilities with
+`sycl_functions.h: fatal error: 'level_zero/ze_api.h' file not found`:
+
+```
+Test-Path "$env:LEVEL_ZERO_V1_SDK_PATH\include\level_zero\ze_api.h"
+Test-Path "$env:LEVEL_ZERO_V1_SDK_PATH\lib\ze_loader.lib"
 ```
 
 Check that PyTorch and Triton are available:

--- a/.github/actions/install-level-zero-sdk/action.yml
+++ b/.github/actions/install-level-zero-sdk/action.yml
@@ -1,0 +1,56 @@
+name: install-level-zero-sdk
+description: Install the Level Zero SDK on Windows and export LEVEL_ZERO_V1_SDK_PATH
+
+# The Intel® Deep Learning Essentials package does not ship Level Zero headers or import
+# libraries, so on Windows nothing provides `level_zero/ze_api.h` and `ze_loader.lib`. Without
+# them the runtime build of `spirv_utils` fails with
+# `sycl_functions.h: fatal error: 'level_zero/ze_api.h' file not found`.
+
+inputs:
+  version:
+    description: Level Zero SDK version
+    default: 1.33.1
+  sha256:
+    description: SHA256 checksum of level-zero-win-sdk-<version>.zip
+    default: ff845844b1a57a22abf646ebffb32cd07839249e0e2b962d0d5684a7a70689c1
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Level Zero SDK
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        $ProgressPreference = "SilentlyContinue"
+
+        $root = Join-Path $env:RUNNER_TOOL_CACHE "level-zero-sdk\${{ inputs.version }}"
+        $header = Join-Path $root "include\level_zero\ze_api.h"
+        $lib = Join-Path $root "lib\ze_loader.lib"
+
+        if (-not ((Test-Path $header) -and (Test-Path $lib))) {
+          $zip = Join-Path $env:RUNNER_TEMP "level-zero-win-sdk-$(New-Guid).zip"
+          $url = "https://github.com/oneapi-src/level-zero/releases/download/v${{ inputs.version }}/level-zero-win-sdk-${{ inputs.version }}.zip"
+          try {
+            Invoke-WebRequest -Uri $url -OutFile $zip
+
+            $hash = (Get-FileHash -Algorithm SHA256 $zip).Hash
+            if ($hash -ne "${{ inputs.sha256 }}") {
+              throw "Checksum mismatch for $url : expected ${{ inputs.sha256 }}, got $hash"
+            }
+
+            Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction Ignore
+            Expand-Archive -LiteralPath $zip -DestinationPath $root
+          }
+          finally {
+            Remove-Item -LiteralPath $zip -Force -ErrorAction Ignore
+          }
+        }
+
+        foreach ($path in @($header, $lib)) {
+          if (-not (Test-Path $path)) {
+            throw "Level Zero SDK is incomplete: $path not found"
+          }
+        }
+
+        Write-Output "LEVEL_ZERO_V1_SDK_PATH=$root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        Write-Output "Level Zero SDK ${{ inputs.version }}: $root"

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -209,6 +209,10 @@ jobs:
         run: |
           rm -rf ~/.triton/cache
 
+      # Triton compiles `spirv_utils` at runtime and needs Level Zero headers to do so.
+      - name: Install Level Zero SDK
+        uses: ./.github/actions/install-level-zero-sdk
+
       # `capture_runtime_env` in scripts/pytest-utils.sh reads the Triton commit id from `dist/*.whl`.
       - name: Download Triton wheels
         uses: actions/download-artifact@v8

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -136,6 +136,10 @@ jobs:
         run: |
           rm -rf ~/.triton/cache
 
+      # Triton compiles `spirv_utils` at runtime and needs Level Zero headers to do so.
+      - name: Install Level Zero SDK
+        uses: ./.github/actions/install-level-zero-sdk
+
       # We need ninja >= 1.12.0 to support long names on Windows. At the moment there is no required
       # version in pypi, so instead of installing ninja with pip we use a preinstalled 1.12.1 on the
       # runner.

--- a/.github/workflows/inductor-tests-windows.yml
+++ b/.github/workflows/inductor-tests-windows.yml
@@ -106,6 +106,10 @@ jobs:
         run: |
           rm -rf ~/.triton/cache
 
+      # Triton compiles `spirv_utils` at runtime and needs Level Zero headers to do so.
+      - name: Install Level Zero SDK
+        uses: ./.github/actions/install-level-zero-sdk
+
       # We need ninja >= 1.12.0 to support long names on Windows. At the moment there is no required
       # version in pypi, so instead of installing ninja with pip we use a preinstalled 1.12.1 on the
       # runner.

--- a/.github/workflows/pip-test-windows.yml
+++ b/.github/workflows/pip-test-windows.yml
@@ -82,6 +82,10 @@ jobs:
         run: |
           rm -rf ~/.triton/cache
 
+      # Triton compiles `spirv_utils` at runtime and needs Level Zero headers to do so.
+      - name: Install Level Zero SDK
+        uses: ./.github/actions/install-level-zero-sdk
+
       # We need ninja >= 1.12.0 to support long names on Windows. At the moment there is no required
       # version in pypi, so instead of installing ninja with pip we use a preinstalled 1.12.1 on the
       # runner.


### PR DESCRIPTION
Intel Deep Learning Essentials does not ship Level Zero headers or import libraries, and nothing else on a Windows runner provides them or sets LEVEL_ZERO_V1_SDK_PATH. The Level Zero root therefore falls back to the Unix default /usr/local and the runtime build of spirv_utils fails with

    sycl_functions.h:12:10: fatal error: 'level_zero/ze_api.h' file not found

Add a composite action that downloads the official level-zero-win-sdk archive, verifies its checksum and exports LEVEL_ZERO_V1_SDK_PATH, and use it in the Windows workflows that compile device utilities at runtime. Document the same prerequisite for local Windows builds.

Fixes #5879 