### PR TITLE
[vLLM] Fix KDA test collection: drop non-argument `NC` from autotune key

### DIFF
--- a/scripts/vllm/vllm-fix.patch
+++ b/scripts/vllm/vllm-fix.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/kernels/attention/test_cascade_flash_attn.py b/tests/kernels/attention/test_cascade_flash_attn.py
-index 80c5c853de..e6ef4c1833 100755
+index 80c5c853d..e6ef4c183 100755
 --- a/tests/kernels/attention/test_cascade_flash_attn.py
 +++ b/tests/kernels/attention/test_cascade_flash_attn.py
 @@ -21,6 +21,8 @@ except ImportError:
@@ -12,7 +12,7 @@ index 80c5c853de..e6ef4c1833 100755
  NUM_HEADS = [(4, 4), (8, 2), (16, 2)]
  HEAD_SIZES = [128, 192, 256]
 diff --git a/tests/kernels/mamba/test_mamba_mixer2.py b/tests/kernels/mamba/test_mamba_mixer2.py
-index 973e7885c6..e474275f57 100644
+index 973e7885c..e474275f5 100644
 --- a/tests/kernels/mamba/test_mamba_mixer2.py
 +++ b/tests/kernels/mamba/test_mamba_mixer2.py
 @@ -12,6 +12,7 @@ from vllm.distributed.parallel_state import (
@@ -57,7 +57,7 @@ index 973e7885c6..e474275f57 100644
          mixer_single_gpu = Mixer2RMSNormGated(
              full_hidden_size=hidden_size,
 diff --git a/tests/kernels/mamba/utils.py b/tests/kernels/mamba/utils.py
-index b82c4d82c3..483672927a 100644
+index b82c4d82c..483672927 100644
 --- a/tests/kernels/mamba/utils.py
 +++ b/tests/kernels/mamba/utils.py
 @@ -66,10 +66,9 @@ def selective_state_update_ref(
@@ -75,7 +75,7 @@ index b82c4d82c3..483672927a 100644
          out += (x * D).to(out.dtype)
      out = (out if z is None else out * F.silu(z)).to(x.dtype)
 diff --git a/tests/kernels/moe/test_moe.py b/tests/kernels/moe/test_moe.py
-index 26e0370a3e..b7d097959c 100644
+index a288e0557..f9d270bde 100644
 --- a/tests/kernels/moe/test_moe.py
 +++ b/tests/kernels/moe/test_moe.py
 @@ -380,6 +380,20 @@ def test_fused_moe(
@@ -135,7 +135,7 @@ index 26e0370a3e..b7d097959c 100644
  @pytest.mark.usefixtures("default_vllm_config")
  @pytest.mark.parametrize("m", [1, 64, 256])
  @pytest.mark.parametrize("n,k", [(1024, 1024), (2048, 2048)])
-@@ -1686,7 +1709,10 @@ def _batched_fused_marlin_moe_cases() -> list[Any]:
+@@ -1945,7 +1968,10 @@ def _batched_fused_marlin_moe_cases() -> list[Any]:
      ("m,n,k,e,topk,max_tokens_per_batch,dtype,quant_dtype,input_type,atol"),
      _batched_fused_marlin_moe_cases(),
  )
@@ -148,10 +148,10 @@ index 26e0370a3e..b7d097959c 100644
      m: int,
      n: int,
 diff --git a/tests/utils.py b/tests/utils.py
-index 71f9d4b669..c2a2924524 100644
+index 0c2cfeb6a..bdb9d9427 100644
 --- a/tests/utils.py
 +++ b/tests/utils.py
-@@ -1923,7 +1923,12 @@ def spawn_new_process_for_each_test(f: Callable[_P, None]) -> Callable[_P, None]
+@@ -1947,7 +1947,12 @@ def spawn_new_process_for_each_test(f: Callable[_P, None]) -> Callable[_P, None]
  
              repo_root = str(VLLM_PATH.resolve())
              env = os.environ.copy()
@@ -166,7 +166,7 @@ index 71f9d4b669..c2a2924524 100644
  
              result = subprocess.run(
 diff --git a/vllm/model_executor/warmup/minimax_m3_msa_warmup.py b/vllm/model_executor/warmup/minimax_m3_msa_warmup.py
-index 18bf142491..c47cbf80ff 100644
+index 18bf14249..c47cbf80f 100644
 --- a/vllm/model_executor/warmup/minimax_m3_msa_warmup.py
 +++ b/vllm/model_executor/warmup/minimax_m3_msa_warmup.py
 @@ -4,7 +4,6 @@
@@ -202,8 +202,21 @@ index 18bf142491..c47cbf80ff 100644
  
      logger.info("Warming up MiniMax M3 MSA kernels.")
  
+diff --git a/vllm/models/kimi_k3/amd/ops/third_party/kda/chunk_intra.py b/vllm/models/kimi_k3/amd/ops/third_party/kda/chunk_intra.py
+index ca3bc8f75..325350b1e 100644
+--- a/vllm/models/kimi_k3/amd/ops/third_party/kda/chunk_intra.py
++++ b/vllm/models/kimi_k3/amd/ops/third_party/kda/chunk_intra.py
+@@ -452,7 +452,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
+         for num_warps in [1, 2, 4, 8]
+         for num_stages in [2, 3, 4]
+     ],
+-    key=["BK", "NC", "BT", "HV"],
++    key=["BK", "BT", "HV"],
+ )
+ @triton.jit(do_not_specialize=["B", "T"])
+ def chunk_kda_fwd_kernel_intra_sub_chunk(
 diff --git a/vllm/models/kimi_k3/nvidia/ops/recoverssm.py b/vllm/models/kimi_k3/nvidia/ops/recoverssm.py
-index c603ec7ed1..26375a877f 100644
+index c603ec7ed..26375a877 100644
 --- a/vllm/models/kimi_k3/nvidia/ops/recoverssm.py
 +++ b/vllm/models/kimi_k3/nvidia/ops/recoverssm.py
 @@ -855,7 +855,7 @@ class KDARecoverSSMCommitContext:
@@ -215,8 +228,21 @@ index c603ec7ed1..26375a877f 100644
                  device=device,
              )
  
+diff --git a/vllm/models/kimi_k3/nvidia/ops/third_party/kda/chunk_intra.py b/vllm/models/kimi_k3/nvidia/ops/third_party/kda/chunk_intra.py
+index 087197d10..0dce2c732 100644
+--- a/vllm/models/kimi_k3/nvidia/ops/third_party/kda/chunk_intra.py
++++ b/vllm/models/kimi_k3/nvidia/ops/third_party/kda/chunk_intra.py
+@@ -358,7 +358,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
+         for num_warps in [1, 2, 4, 8]
+         for num_stages in [2, 3, 4]
+     ],
+-    key=['BK', 'NC', 'BT', 'HV'],
++    key=['BK', 'BT', 'HV'],
+ )
+ @triton.jit(do_not_specialize=['B', 'T'])
+ def chunk_kda_fwd_kernel_intra_sub_chunk(
 diff --git a/vllm/third_party/flash_linear_attention/ops/kda.py b/vllm/third_party/flash_linear_attention/ops/kda.py
-index 1701cd47ac..4d47e5d020 100644
+index 1701cd47a..4d47e5d02 100644
 --- a/vllm/third_party/flash_linear_attention/ops/kda.py
 +++ b/vllm/third_party/flash_linear_attention/ops/kda.py
 @@ -455,79 +455,8 @@ def rms_norm_gated(


### PR DESCRIPTION
Some `kda` tests were failing at collection.

The latest Triton merge (https://github.com/intel/intel-xpu-backend-for-triton/pull/7988) pulled in https://github.com/triton-lang/triton/commit/20e6ba864830b88f56b907fef85cab5097cf3892. This change rejects `@triton.autotune` keys that aren't kernel args, and the `kda` kernel `chunk_kda_fwd_kernel_intra_sub_chunk` keys on `NC`. `NC` is a grid var and not a kernel arg so it is not a valid autotune key.

This PR patches the `kda` kernel to remove the `NC` autotune key.

Closes https://github.com/intel/intel-xpu-backend-for-triton/issues/8033.