### PR TITLE
[TritonIntelGPU] Disable sub-group reinterpret cast on LTS drivers

### DIFF
--- a/third_party/intel/include/Analysis/Utility.h
+++ b/third_party/intel/include/Analysis/Utility.h
@@ -29,9 +29,9 @@ bool cvtIsSubGroupShuffle(RankedTensorType srcTy, RankedTensorType dstTy);
 /// Return whether the layout conversion from `srcTy` to `dstTy` can be
 /// performed as a sub-group transpose through local memory.
 bool cvtIsSubGroupTranspose(RankedTensorType srcTy, RankedTensorType dstTy);
-/// Return whether the layout conversion from `srcTy` to `dstTy` can be
-/// performed as a sub-group bitcast shuffle (reinterpret cast).
-bool cvtIsSubGroupReinterpret(RankedTensorType srcTy, RankedTensorType dstTy);
+/// Return whether the layout conversion performed by `op` can be performed as a
+/// sub-group bitcast shuffle (reinterpret cast).
+bool cvtIsSubGroupReinterpret(ConvertLayoutOp op);
 /// Return whether `type` is a valid element type for a fast sub-group
 /// transpose.
 bool isValidElementTypeForSubGroupTranspose(Type type);

--- a/third_party/intel/lib/Analysis/Allocation.cpp
+++ b/third_party/intel/lib/Analysis/Allocation.cpp
@@ -31,7 +31,7 @@ unsigned allocationAnalysisScratchSizeFn(gpu::ConvertLayoutOp convertLayout) {
     unsigned numMatrixCells = (numElements / subGroupSize) * (subGroupSize + 1);
     return numMatrixCells * bytesPerElement;
   }
-  if (gpu::intel::cvtIsSubGroupReinterpret(srcTy, dstTy))
+  if (gpu::intel::cvtIsSubGroupReinterpret(convertLayout))
     return 0;
   return invalidSize;
 }

--- a/third_party/intel/lib/Analysis/Utility.cpp
+++ b/third_party/intel/lib/Analysis/Utility.cpp
@@ -1,5 +1,6 @@
 #include "intel/include/Analysis/Utility.h"
 #include "intel/include/Dialect/TritonIntelGPU/IR/Attributes.h"
+#include "intel/include/Dialect/TritonIntelGPU/IR/Dialect.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -376,7 +377,15 @@ getSubGroupReinterpretPackInfo(MLIRContext *ctx,
   return std::nullopt;
 }
 
-bool cvtIsSubGroupReinterpret(RankedTensorType srcTy, RankedTensorType dstTy) {
+bool cvtIsSubGroupReinterpret(ConvertLayoutOp op) {
+  // The sub-group bitcast shuffle operation is lowered to a GenISA intrinsic
+  // not implemented by the LTS driver.
+  auto mod = op->getParentOfType<ModuleOp>();
+  if (mod && mod->hasAttr(TritonIntelGPUDialect::getIsLTSAttrName()))
+    return false;
+
+  RankedTensorType srcTy = op.getSrc().getType();
+  RankedTensorType dstTy = op.getType();
   MLIRContext *ctx = srcTy.getContext();
   StringAttr kRegister = str_attr("register");
   StringAttr kLane = str_attr("lane");

--- a/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/intel/lib/TritonIntelGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -50,7 +50,7 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
         performSubGroupTranspose(op, srcLayout, dstLayout, adaptor, rewriter);
         return success();
       }
-      if (intel::cvtIsSubGroupReinterpret(srcTy, dstTy)) {
+      if (intel::cvtIsSubGroupReinterpret(op)) {
         performSubGroupReinterpret(op, srcLayout, dstLayout, adaptor, rewriter);
         return success();
       }
@@ -407,9 +407,8 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
                                   const LinearLayout &dstLayout,
                                   OpAdaptor adaptor,
                                   ConversionPatternRewriter &rewriter) const {
-    assert(
-        intel::cvtIsSubGroupReinterpret(op.getSrc().getType(), op.getType()) &&
-        "Expecting sub-group reinterpret cast");
+    assert(intel::cvtIsSubGroupReinterpret(op) &&
+           "Expecting sub-group reinterpret cast");
 
     Location loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -627,7 +626,7 @@ struct ConvertLayoutOpGuard : public ConvertOpToLLVMPattern<ConvertLayoutOp> {
     assert(!intel::cvtIsSubGroupTranspose(srcTy, dstTy) &&
            "Failed to lower layout conversion through sub-group transpose");
     assert(
-        !intel::cvtIsSubGroupReinterpret(srcTy, dstTy) &&
+        !intel::cvtIsSubGroupReinterpret(op) &&
         "Failed to lower layout conversion through sub-group reinterpret cast");
     return failure();
   }


### PR DESCRIPTION
The sub-group reinterpret cast lowering added in 1d2e9f722 emits TritonGEN::SubGroupBitcastShuffleOp, which lowers to the GenISA intrinsic llvm.genx.GenISA.SubgroupBitcastShuffle. That intrinsic is not implemented by the LTS driver, so any kernel taking this path fails there.